### PR TITLE
GitHub deployments: rework new workflow wizard

### DIFF
--- a/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
@@ -13,7 +13,6 @@ type AdvancedWorkflowStyleProps = {
 	isFetching: boolean;
 	useComposerWorkflow: boolean;
 	onWorkflowCreation( path: string ): void;
-	onNewWorkflowVerification( path: string ): void;
 	onChooseWorkflow( path: string ): void;
 };
 
@@ -25,7 +24,6 @@ export const AdvancedWorkflowStyle = ( {
 	branchName,
 	workflowPath,
 	onWorkflowCreation,
-	onNewWorkflowVerification,
 	onChooseWorkflow,
 	useComposerWorkflow,
 }: AdvancedWorkflowStyleProps ) => {
@@ -35,11 +33,9 @@ export const AdvancedWorkflowStyle = ( {
 		if ( ! workflow ) {
 			return (
 				<NewWorkflowWizard
-					isLoadingWorkflows={ isLoading || isFetching }
 					workflows={ workflows }
 					repository={ repository }
 					repositoryBranch={ branchName }
-					onWorkflowVerification={ onNewWorkflowVerification }
 					onWorkflowCreated={ onWorkflowCreation }
 					useComposerWorkflow={ useComposerWorkflow }
 				/>

--- a/client/my-sites/github-deployments/components/deployment-style/index.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/index.tsx
@@ -1,9 +1,6 @@
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import SupportInfo from 'calypso/components/support-info/index';
-import { useDispatch } from 'calypso/state';
-import { errorNotice } from 'calypso/state/notices/actions';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
 import { AdvancedWorkflowStyle } from './advanced-workflow-style';
 import { DeploymentStyleContext, DeploymentStyleContextProps } from './context';
@@ -33,7 +30,6 @@ export const DeploymentStyle = ( {
 	useComposerWorkflow,
 }: DeploymentStyleProps ) => {
 	const { __ } = useI18n();
-	const dispatch = useDispatch();
 
 	const {
 		data: workflows,
@@ -101,26 +97,6 @@ export const DeploymentStyle = ( {
 						repository={ repository }
 						branchName={ branchName }
 						workflowPath={ workflowPath }
-						onNewWorkflowVerification={ async ( path: string ) => {
-							const { data: newWorkflows } = await refetch();
-
-							if ( ! newWorkflows?.find( ( workflow ) => workflow.workflow_path === path ) ) {
-								dispatch(
-									errorNotice(
-										// translators: workflowPath is the GitHub repo workflow path
-										sprintf( __( 'Could not find workflow with path %(workflowPath)s' ), {
-											workflowPath: path,
-										} ),
-										{
-											duration: 5000,
-										}
-									)
-								);
-								return;
-							}
-
-							onChooseWorkflow( path );
-						} }
 						onWorkflowCreation={ async ( path ) => {
 							await refetch();
 							onChooseWorkflow( path );

--- a/client/my-sites/github-deployments/components/deployment-style/new-workflow-wizard.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/new-workflow-wizard.tsx
@@ -1,11 +1,8 @@
-import { Button, FormInputValidation, FormLabel } from '@automattic/components';
+import { Button, FormInputValidation } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { ChangeEvent, useEffect, useState } from 'react';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormTextInput from '../../../../components/forms/form-text-input';
+import { useEffect, useState } from 'react';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
 import { CodeHighlighter } from '../code-highlighter';
-import { useDeploymentStyleContext } from './context';
 import { useCreateWorkflow } from './use-create-workflow';
 import { Workflow } from './use-deployment-workflows-query';
 import { newComposerWorkflowExample, newWorkflowExample } from './workflow-yaml-examples';
@@ -15,10 +12,8 @@ import './style.scss';
 interface NewWorkflowWizardProps {
 	repository: Pick< GitHubRepositoryData, 'id' | 'owner' | 'name' >;
 	repositoryBranch: string;
-	isLoadingWorkflows: boolean;
 	workflows?: Workflow[];
 	useComposerWorkflow: boolean;
-	onWorkflowVerification( path: string ): void;
 	onWorkflowCreated( path: string ): void;
 }
 
@@ -28,30 +23,15 @@ const RECOMMENDED_WORKFLOW_PATH = WORKFLOWS_DIRECTORY + 'wpcom.yml';
 export const NewWorkflowWizard = ( {
 	repository,
 	workflows,
-	isLoadingWorkflows,
 	repositoryBranch,
-	onWorkflowVerification,
 	onWorkflowCreated,
 	useComposerWorkflow,
 }: NewWorkflowWizardProps ) => {
 	const { __ } = useI18n();
 
-	const { isCheckingWorkflow } = useDeploymentStyleContext();
-	const [ workflowPath, setWorkflowPath ] = useState( () => {
-		const existingWorkflow = workflows?.find(
-			( workflow ) => workflow.workflow_path === RECOMMENDED_WORKFLOW_PATH
-		);
-
-		if ( ! existingWorkflow ) {
-			return RECOMMENDED_WORKFLOW_PATH;
-		}
-
-		return existingWorkflow.workflow_path;
-	} );
-
 	const { createWorkflow, isPending } = useCreateWorkflow( {
 		onSuccess: () => {
-			onWorkflowCreated( workflowPath );
+			onWorkflowCreated( RECOMMENDED_WORKFLOW_PATH );
 		},
 	} );
 
@@ -59,30 +39,20 @@ export const NewWorkflowWizard = ( {
 
 	useEffect( () => {
 		const existingWorkflow = !! workflows?.find(
-			( workflow ) => workflow.workflow_path === workflowPath
+			( workflow ) => workflow.workflow_path === RECOMMENDED_WORKFLOW_PATH
 		);
 
 		if ( existingWorkflow ) {
-			setError( __( 'A workflow file with this name already exist' ) );
-			return;
-		}
-
-		const notEndingInYml = ! /\.ya?ml$/.test( workflowPath );
-
-		if ( notEndingInYml ) {
-			setError( __( 'The workflow file path must end with .yml' ) );
-			return;
-		}
-
-		const notStartingWithWorkflowDir = ! workflowPath.startsWith( WORKFLOWS_DIRECTORY );
-
-		if ( notStartingWithWorkflowDir ) {
-			setError( __( 'The workflow file must live under the .github/workflows directory' ) );
+			setError(
+				__(
+					'A workflow file with this name already exists. Installing this workflow will overwrite it.'
+				)
+			);
 			return;
 		}
 
 		setError( undefined );
-	}, [ workflows, workflowPath, __ ] );
+	}, [ workflows, __ ] );
 
 	const workflowContent = useComposerWorkflow
 		? newComposerWorkflowExample( repositoryBranch )
@@ -91,42 +61,26 @@ export const NewWorkflowWizard = ( {
 	return (
 		<div className="github-deployments-new-workflow-wizard">
 			<p css={ { marginBottom: 0 } }>
-				{ __(
-					'Create a new workflow file in your repository with the following content and then click ‘Verify workflow’ or let us install it for you.'
-				) }
+				{ __( 'Use our suggested workflow which you can install and then extend at GitHub.' ) }
 			</p>
 
-			<FormFieldset>
-				<FormLabel htmlFor="workflow-file-name">{ __( 'Workflow file name' ) }</FormLabel>
-				<FormTextInput
-					id="workflow-file-name"
-					placeholder={ __( 'Enter the workflow file name' ) }
-					onChange={ ( e: ChangeEvent< HTMLInputElement > ) => {
-						setWorkflowPath( e.target.value );
-					} }
-					value={ workflowPath }
-				/>
-				{ error && (
-					<FormInputValidation css={ { paddingBottom: '0 !important' } } isError text={ error } />
-				) }
-			</FormFieldset>
+			<div className="github-deployments-new-workflow-wizard__workflow-file">
+				<div className="github-deployments-new-workflow-wizard__workflow-file-name">
+					<span>{ RECOMMENDED_WORKFLOW_PATH }</span>
+				</div>
 
-			<CodeHighlighter content={ workflowContent } />
+				<CodeHighlighter content={ workflowContent } />
+			</div>
+
+			{ error && (
+				<FormInputValidation css={ { paddingBottom: '0 !important' } } isError text={ error } />
+			) }
 
 			<div css={ { marginTop: '16px' } }>
 				<Button
 					type="button"
 					className="button form-button"
-					onClick={ () => onWorkflowVerification( workflowPath ) }
-					disabled={ isCheckingWorkflow || isLoadingWorkflows || !! error }
-					busy={ isCheckingWorkflow || isLoadingWorkflows }
-				>
-					{ __( 'Verify workflow' ) }
-				</Button>
-				<Button
-					type="button"
-					className="button form-button"
-					disabled={ !! error || isPending }
+					disabled={ isPending }
 					busy={ isPending }
 					onClick={ () =>
 						createWorkflow( {
@@ -134,7 +88,7 @@ export const NewWorkflowWizard = ( {
 							repositoryOwner: repository.owner,
 							repositoryName: repository.name,
 							branchName: repositoryBranch,
-							fileName: workflowPath,
+							fileName: RECOMMENDED_WORKFLOW_PATH,
 							fileContent: workflowContent,
 						} )
 					}

--- a/client/my-sites/github-deployments/components/deployment-style/style.scss
+++ b/client/my-sites/github-deployments/components/deployment-style/style.scss
@@ -203,6 +203,30 @@
 	.code-highlighter {
 		border: 1px solid var(--gray-gray-5, #dcdcde);
 	}
+
+	&__workflow-file {
+		border: 1px solid var(--gray-gray-5, #dcdcde);
+		border-radius: 2px;
+	}
+
+	&__workflow-file-name {
+		height: 48px;
+		display: flex;
+		align-items: center;
+		padding-left: 16px;
+		background-color: var(--studio-white);
+		border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
+
+		span {
+			color: var(--Gray-Gray-100, #101517);
+			font-family: monospace;
+			font-size: $font-body-extra-small;
+			font-style: normal;
+			font-weight: 400;
+			line-height: normal;
+			letter-spacing: -0.15px;
+		}
+	}
 }
 
 .github-deployments-deployments-style-popover {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/5954

<img width="576" alt="Screenshot 2567-03-11 at 14 19 51" src="https://github.com/Automattic/wp-calypso/assets/6851384/0804fb9d-7ac0-48ae-a8f7-6e9e6a5fe5af">


## Proposed Changes

* Don't let users edit the default workflow file name. This simplifies validation.
* Restyle the workflow preview UI to match Figma.
* If a file exists from a previous setup, just overwrite it.
* Don't verify the standard workflow. It's ours, so we know it works.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply patch D141423-code
* Go to set up a new workflow
    * Try with a repo with no workflows
    * Try with a repo with a workflow other than ours and confirm it can be used
    * Try with a repo that already has a `wpcom.yml` file. Confirm it can be reused or overwritten

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?