### PR TITLE
Subscribers: Fix the error of the import endpoint because of the auth issue

### DIFF
--- a/client/lib/oauth-token/index.d.ts
+++ b/client/lib/oauth-token/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'calypso/lib/oauth-token' {
+	const getToken: () => string | boolean;
+	const setToken: ( token: string ) => void;
+	const clearToken: () => void;
+
+	export { getToken, setToken, clearToken };
+}

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-imports */
-import wpcom from 'calypso/lib/wp'; // Import restricted
+import * as oauthToken from 'calypso/lib/oauth-token'; // Import restricted
 import { wpcomRequest } from '../wpcom-request-controls';
 import {
 	AddSubscribersResponse,
@@ -43,10 +43,11 @@ export function createActions() {
 		yield importCsvSubscribersStart( siteId, file, emails );
 
 		try {
-			const data: ImportSubscribersResponse = yield wpcom.req.post( {
+			const data: ImportSubscribersResponse = yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers/import`,
 				method: 'POST',
 				apiNamespace: 'wpcom/v2',
+				token: oauthToken.getToken(),
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				formData: file && [ [ 'import', file, file.name ] ],
@@ -115,6 +116,7 @@ export function createActions() {
 				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers/import/${ importId }`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
+				token: oauthToken.getToken(),
 			} );
 
 			yield getSubscribersImportSuccess( siteId, data );
@@ -140,6 +142,7 @@ export function createActions() {
 				path: ! status ? path : `${ path }?status=${ encodeURIComponent( status ) }`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
+				token: oauthToken.getToken(),
 			} );
 
 			yield getSubscribersImportsSuccess( siteId, data );

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -43,11 +43,12 @@ export function createActions() {
 		yield importCsvSubscribersStart( siteId, file, emails );
 
 		try {
+			const token = oauthToken.getToken();
 			const data: ImportSubscribersResponse = yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers/import`,
 				method: 'POST',
 				apiNamespace: 'wpcom/v2',
-				token: oauthToken.getToken(),
+				token: typeof token === 'string' ? token : undefined,
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				formData: file && [ [ 'import', file, file.name ] ],
@@ -112,11 +113,12 @@ export function createActions() {
 
 	function* getSubscribersImport( siteId: number, importId: number ) {
 		try {
+			const token = oauthToken.getToken();
 			const data: GetSubscribersImportResponse = yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/subscribers/import/${ importId }`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
-				token: oauthToken.getToken(),
+				token: typeof token === 'string' ? token : undefined,
 			} );
 
 			yield getSubscribersImportSuccess( siteId, data );
@@ -138,11 +140,12 @@ export function createActions() {
 	function* getSubscribersImports( siteId: number, status?: ImportJobStatus ) {
 		try {
 			const path = `/sites/${ encodeURIComponent( siteId ) }/subscribers/import`;
+			const token = oauthToken.getToken();
 			const data: GetSubscribersImportsResponse = yield wpcomRequest( {
 				path: ! status ? path : `${ path }?status=${ encodeURIComponent( status ) }`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
-				token: oauthToken.getToken(),
+				token: typeof token === 'string' ? token : undefined,
 			} );
 
 			yield getSubscribersImportsSuccess( siteId, data );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5962

## Proposed Changes

* This is an auth issue related to https://github.com/Automattic/wp-calypso/pull/87684#issuecomment-1966026408, so we have to use the oauth token to pass the authentication

| Before | After |
| - | - |
| <img width="573" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/d524b120-d59c-4719-96e3-41e9a9347845"> | <img width="570" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/ad400f14-f4f3-49b3-a677-9b4984b1652f"> |

Note that this PR only fixes the warning. There is still an issue that the list of subscribes isn't updated immediately after people add a new subscriber.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run yarn start-jetpack-cloud
* Go to http://jetpack.cloud.localhost:3000/
* Navigate to Subscribers
* Click “Add subscribers” button
* Wait for a second, and make sure yon won't see the warning anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?