### PR TITLE
Revert "Plugins update manager: Add translation (#88300)"

### DIFF
--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -1,7 +1,6 @@
 import { WPCOM_FEATURES_SCHEDULED_UPDATES } from '@automattic/calypso-products';
 import { Button, Spinner } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -34,7 +33,6 @@ interface Props {
 }
 
 export const PluginsUpdateManager = ( props: Props ) => {
-	const translate = useTranslate();
 	const { siteSlug, context, scheduleId, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const siteId = useSelector( getSelectedSiteId );
 	const hasScheduledUpdatesFeature = useSelector( ( state ) =>
@@ -71,15 +69,15 @@ export const PluginsUpdateManager = ( props: Props ) => {
 					onEditSchedule={ onEditSchedule }
 				/>
 			),
-			title: translate( 'List schedules' ),
+			title: 'List schedules',
 		},
 		create: {
 			component: <ScheduleCreate onNavBack={ onNavBack } />,
-			title: translate( 'Set up a new schedule' ),
+			title: 'Create a new schedule',
 		},
 		edit: {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
-			title: translate( 'Edit schedule' ),
+			title: 'Edit schedule',
 		},
 	}[ context ];
 
@@ -93,8 +91,8 @@ export const PluginsUpdateManager = ( props: Props ) => {
 			<MainComponent wideLayout>
 				<NavigationHeader
 					navigationItems={ [] }
-					title={ translate( 'Plugins update scheduler' ) }
-					subtitle={ translate( 'Schedule automatic plugin updates' ) }
+					title="Plugin updates manager"
+					subtitle="Effortlessly schedule plugin auto-updates with built-in rollback logic."
 				>
 					{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
 						<Button
@@ -104,7 +102,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 							onClick={ onCreateNewSchedule }
 							disabled={ ! canCreateSchedules }
 						>
-							{ translate( 'Set up a new schedule' ) }
+							Create a new schedule
 						</Button>
 					) }
 				</NavigationHeader>

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -10,7 +10,6 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { arrowLeft, info } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { MAX_SCHEDULES } from './config';
@@ -25,7 +24,6 @@ interface Props {
 }
 export const ScheduleCreate = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const translate = useTranslate();
 	const { createMonitor } = useCreateMonitor( siteSlug );
 	const isEligibleForFeature = useIsEligibleForFeature();
 	const { onNavBack } = props;
@@ -67,11 +65,11 @@ export const ScheduleCreate = ( props: Props ) => {
 				<div className="ch-placeholder">
 					{ onNavBack && (
 						<Button icon={ arrowLeft } onClick={ onNavBack }>
-							{ translate( 'Back' ) }
+							Back
 						</Button>
 					) }
 				</div>
-				<Text>{ translate( 'New Schedule' ) }</Text>
+				<Text>New Schedule</Text>
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody>
@@ -85,7 +83,7 @@ export const ScheduleCreate = ( props: Props ) => {
 					disabled={ ! canCreateSchedules }
 					isBusy={ isBusy }
 				>
-					{ translate( 'Create' ) }
+					Create
 				</Button>
 				{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
 					<Text as="p" className="validation-msg">

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -10,7 +10,6 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { arrowLeft, info } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
@@ -24,10 +23,8 @@ interface Props {
 }
 export const ScheduleEdit = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const translate = useTranslate();
-
-	const { scheduleId, onNavBack } = props;
 	const isEligibleForFeature = useIsEligibleForFeature();
+	const { scheduleId, onNavBack } = props;
 	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
 		siteSlug,
 		isEligibleForFeature
@@ -67,11 +64,11 @@ export const ScheduleEdit = ( props: Props ) => {
 				<div className="ch-placeholder">
 					{ onNavBack && (
 						<Button icon={ arrowLeft } onClick={ onNavBack }>
-							{ translate( 'Back' ) }
+							Back
 						</Button>
 					) }
 				</div>
-				<Text>{ translate( 'Edit Schedule' ) }</Text>
+				<Text>Edit Schedule</Text>
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody>
@@ -91,7 +88,7 @@ export const ScheduleEdit = ( props: Props ) => {
 					isBusy={ isBusy }
 					disabled={ ! canCreateSchedules }
 				>
-					{ translate( 'Save' ) }
+					Save
 				</Button>
 				{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
 					<Text as="p" className="validation-msg">

--- a/client/blocks/plugins-update-manager/schedule-form.const.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.const.ts
@@ -1,44 +1,42 @@
-import { translate } from 'i18n-calypso';
-
 export const DEFAULT_HOUR = 9;
 
 export const DAILY_OPTION = {
-	label: translate( 'Daily' ),
+	label: 'Daily',
 	value: 'daily',
 };
 
 export const WEEKLY_OPTION = {
-	label: translate( 'Weekly' ),
+	label: 'Weekly',
 	value: 'weekly',
 };
 
 export const DAY_OPTIONS = [
 	{
-		label: translate( 'Monday' ),
+		label: 'Monday',
 		value: '1',
 	},
 	{
-		label: translate( 'Tuesday' ),
+		label: 'Tuesday',
 		value: '2',
 	},
 	{
-		label: translate( 'Wednesday' ),
+		label: 'Wednesday',
 		value: '3',
 	},
 	{
-		label: translate( 'Thursday' ),
+		label: 'Thursday',
 		value: '4',
 	},
 	{
-		label: translate( 'Friday' ),
+		label: 'Friday',
 		value: '5',
 	},
 	{
-		label: translate( 'Saturday' ),
+		label: 'Saturday',
 		value: '6',
 	},
 	{
-		label: translate( 'Sunday' ),
+		label: 'Sunday',
 		value: '0',
 	},
 ];
@@ -96,11 +94,11 @@ export const HOUR_OPTIONS = [
 
 export const PERIOD_OPTIONS = [
 	{
-		label: translate( 'AM' ),
+		label: 'AM',
 		value: 'am',
 	},
 	{
-		label: translate( 'PM' ),
+		label: 'PM',
 		value: 'pm',
 	},
 ];

--- a/client/blocks/plugins-update-manager/schedule-form.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.helper.ts
@@ -1,5 +1,3 @@
-import { translate } from 'i18n-calypso';
-
 /**
  * Prepare unix timestamp in seconds
  * based on selected frequency, day, hour and period
@@ -40,6 +38,22 @@ export const prepareTimestamp = (
 	return event.getTime() / 1000;
 };
 
+/**
+ * Validate name
+ * - required
+ * - max length 120
+ */
+export const validateName = ( name: string ) => {
+	let error = '';
+	if ( ! name ) {
+		error = 'Please provide a name to this plugin update schedule.';
+	} else if ( name.length > 120 ) {
+		error = 'Please provide a shorter name.';
+	}
+
+	return error;
+};
+
 type TimeSlot = {
 	frequency: string;
 	timestamp: number;
@@ -68,14 +82,14 @@ export const validateTimeSlot = ( newSchedule: TimeSlot, existingSchedules: Time
 			( newSchedule.frequency === 'daily' || schedule.frequency === 'daily' ) &&
 			existingDate.getHours() === newDate.getHours()
 		) {
-			error = translate( 'Please choose another time, as this slot is already scheduled.' );
+			error = 'Please choose another time, as this slot is already scheduled.';
 		} else if (
 			newSchedule.frequency === 'weekly' &&
 			schedule.frequency === 'weekly' &&
 			newDate.getDay() === existingDate.getDay() &&
 			newDate.getHours() === existingDate.getHours()
 		) {
-			error = translate( 'Please choose another time, as this slot is already scheduled.' );
+			error = 'Please pick another time for optimal performance, as this slot is already taken.';
 		}
 	} );
 
@@ -90,15 +104,13 @@ export const validatePlugins = ( plugins: string[], existingPlugins: Array< stri
 	let error = '';
 
 	if ( plugins.length === 0 ) {
-		error = translate( 'Please select at least one plugin to update.' );
+		error = 'Please select at least one plugin to update.';
 	} else if ( existingPlugins.length ) {
 		const _plugins = [ ...plugins ].sort();
 
 		existingPlugins.forEach( ( existing ) => {
 			if ( JSON.stringify( _plugins ) === JSON.stringify( [ ...existing ].sort() ) ) {
-				error = translate(
-					'Please select a different set of plugins, as this one has already been chosen.'
-				);
+				error = 'Please select a different set of plugins, as this one has already been chosen.';
 			}
 		} );
 	}

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -11,7 +11,6 @@ import {
 } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState, useCallback, useEffect } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useCorePluginsQuery, type CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
@@ -44,9 +43,8 @@ interface Props {
 	onSyncError?: ( error: string ) => void;
 }
 export const ScheduleForm = ( props: Props ) => {
-	const siteSlug = useSiteSlug();
-	const translate = useTranslate();
 	const moment = useLocalizedMoment();
+	const siteSlug = useSiteSlug();
 	const isEligibleForFeature = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
 	const initDate = scheduleForEdit
@@ -181,7 +179,7 @@ export const ScheduleForm = ( props: Props ) => {
 			>
 				<FlexItem>
 					<div className="form-field">
-						<label htmlFor="frequency">{ translate( 'Update every' ) }</label>
+						<label htmlFor="frequency">Update every</label>
 						<div className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
 							<RadioControl
 								name="frequency"
@@ -269,7 +267,7 @@ export const ScheduleForm = ( props: Props ) => {
 				</FlexItem>
 				<FlexItem>
 					<div className="form-field">
-						<label htmlFor="plugins">{ translate( 'Select plugins' ) }</label>
+						<label htmlFor="plugins">Select plugins</label>
 						<span className="plugin-select-stats">
 							{ selectedPlugins.length }/
 							{ plugins.length < MAX_SELECTABLE_PLUGINS ? plugins.length : MAX_SELECTABLE_PLUGINS }
@@ -281,9 +279,7 @@ export const ScheduleForm = ( props: Props ) => {
 							</Text>
 						) : (
 							<Text className="info-msg">
-								{ translate(
-									'Plugins not listed below are managed and updated by WordPress.com for you.'
-								) }
+								Plugins not listed below are managed by WordPress.com and update automatically.
 							</Text>
 						) }
 						<div className="checkbox-options">
@@ -296,7 +292,7 @@ export const ScheduleForm = ( props: Props ) => {
 								{ isPluginsFetching && <Spinner /> }
 								{ isPluginsFetched && plugins.length <= MAX_SELECTABLE_PLUGINS && (
 									<CheckboxControl
-										label={ translate( 'Select all' ) }
+										label="Select all"
 										indeterminate={
 											selectedPlugins.length > 0 && selectedPlugins.length < plugins.length
 										}

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -1,6 +1,5 @@
 import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
 import { MOMENT_TIME_FORMAT } from 'calypso/blocks/plugins-update-manager/config';
 import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-manager/hooks/use-prepare-plugins-tooltip-info';
 import { ellipsis } from 'calypso/blocks/plugins-update-manager/icons';
@@ -19,7 +18,6 @@ export const ScheduleListCards = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const isEligibleForFeature = useIsEligibleForFeature();
 	const moment = useLocalizedMoment();
-	const translate = useTranslate();
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
@@ -33,20 +31,20 @@ export const ScheduleListCards = ( props: Props ) => {
 						className="schedule-list--card-actions"
 						controls={ [
 							{
-								title: translate( 'Edit' ),
+								title: 'Edit',
 								onClick: () => onEditClick( schedule.id ),
 							},
 							{
-								title: translate( 'Remove' ),
+								title: 'Remove',
 								onClick: () => onRemoveClick( schedule.id ),
 							},
 						] }
 						icon={ ellipsis }
-						label={ translate( 'More' ) }
+						label="More"
 					/>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="name">{ translate( 'Name' ) }</label>
+						<label htmlFor="name">Name</label>
 						<strong id="name">
 							<Button
 								className="schedule-name"
@@ -59,7 +57,7 @@ export const ScheduleListCards = ( props: Props ) => {
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="last-update">{ translate( 'Last update' ) }</label>
+						<label htmlFor="last-update">Last Update</label>
 						<span id="last-update">
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
@@ -70,26 +68,26 @@ export const ScheduleListCards = ( props: Props ) => {
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
+						<label htmlFor="next-update">Next update</label>
 						<span id="next-update">
 							{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
 						</span>
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="frequency">{ translate( 'Frequency' ) }</label>
+						<label htmlFor="frequency">Frequency</label>
 						<span id="frequency">
 							{
 								{
-									daily: translate( 'Daily' ),
-									weekly: translate( 'Weekly' ),
+									daily: 'Daily',
+									weekly: 'Weekly',
 								}[ schedule.schedule ]
 							}
 						</span>
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="plugins">{ translate( 'Plugins' ) }</label>
+						<label htmlFor="plugins">Plugins</label>
 						<span id="plugins">
 							{ schedule?.args?.length }
 							<Tooltip

--- a/client/blocks/plugins-update-manager/schedule-list-empty.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-empty.tsx
@@ -1,6 +1,5 @@
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
 
 interface Props {
 	canCreateSchedules: boolean;
@@ -8,16 +7,13 @@ interface Props {
 }
 export const ScheduleListEmpty = ( props: Props ) => {
 	const { onCreateNewSchedule, canCreateSchedules } = props;
-	const translate = useTranslate();
 
 	return (
 		<div className="empty-state">
 			<Text as="p" align="center">
 				{ ! canCreateSchedules
-					? translate( 'This site is unable to schedule auto-updates for plugins.' )
-					: translate(
-							'Keep your site up to date with scheduled automatic plugin updates. Built-in rollback included.'
-					  ) }
+					? 'This site is unable to schedule auto-updates for plugins.'
+					: 'Set up plugin update schedules to ensure your site runs smoothly.' }
 			</Text>
 			{ onCreateNewSchedule && (
 				<Button
@@ -27,7 +23,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 					onClick={ onCreateNewSchedule }
 					disabled={ ! canCreateSchedules }
 				>
-					{ translate( 'Set up a new schedule' ) }
+					Create a new schedule
 				</Button>
 			) }
 		</div>

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -1,6 +1,5 @@
 import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { Badge } from './badge';
@@ -17,10 +16,8 @@ interface Props {
 }
 export const ScheduleListTable = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const isEligibleForFeature = useIsEligibleForFeature();
-
+	const moment = useLocalizedMoment();
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
@@ -34,11 +31,11 @@ export const ScheduleListTable = ( props: Props ) => {
 		<table>
 			<thead>
 				<tr>
-					<th>{ translate( 'Name' ) }</th>
-					<th>{ translate( 'Last update' ) }</th>
-					<th>{ translate( 'Next update' ) }</th>
-					<th>{ translate( 'Frequency' ) }</th>
-					<th>{ translate( 'Plugins' ) }</th>
+					<th>Name</th>
+					<th>Last Update</th>
+					<th>Next Update</th>
+					<th>Frequency</th>
+					<th>Plugins</th>
 					<th></th>
 				</tr>
 			</thead>
@@ -65,8 +62,8 @@ export const ScheduleListTable = ( props: Props ) => {
 						<td>
 							{
 								{
-									daily: translate( 'Daily' ),
-									weekly: translate( 'Weekly' ),
+									daily: 'Daily',
+									weekly: 'Weekly',
 								}[ schedule.schedule ]
 							}
 						</td>
@@ -88,16 +85,16 @@ export const ScheduleListTable = ( props: Props ) => {
 								popoverProps={ { position: 'bottom left' } }
 								controls={ [
 									{
-										title: translate( 'Edit' ),
+										title: 'Edit',
 										onClick: () => onEditClick( schedule.id ),
 									},
 									{
-										title: translate( 'Remove' ),
+										title: 'Remove',
 										onClick: () => onRemoveClick( schedule.id ),
 									},
 								] }
 								icon={ ellipsis }
-								label={ translate( 'More' ) }
+								label="More"
 							/>
 						</td>
 					</tr>

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -9,7 +9,6 @@ import {
 	Spinner,
 } from '@wordpress/components';
 import { Icon, arrowLeft, info } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
@@ -29,9 +28,8 @@ interface Props {
 }
 export const ScheduleList = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const translate = useTranslate();
-	const isMobile = useMobileBreakpoint();
 	const isEligibleForFeature = useIsEligibleForFeature();
+	const isMobile = useMobileBreakpoint();
 
 	const { onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
@@ -86,18 +84,18 @@ export const ScheduleList = ( props: Props ) => {
 				onConfirm={ onRemoveDialogConfirm }
 				onCancel={ closeRemoveConfirm }
 			>
-				{ translate( 'Are you sure you want to delete this schedule?' ) }
+				Are you sure you want to delete this schedule?
 			</ConfirmDialog>
 			<Card className="plugins-update-manager">
 				<CardHeader size="extraSmall">
 					<div className="ch-placeholder">
 						{ onNavBack && (
 							<Button icon={ arrowLeft } onClick={ onNavBack }>
-								{ translate( 'Back' ) }
+								Back
 							</Button>
 						) }
 					</div>
-					<Text>{ translate( 'Schedules' ) }</Text>
+					<Text>Schedules</Text>
 					<div className="ch-placeholder"></div>
 				</CardHeader>
 				<CardBody>
@@ -132,9 +130,7 @@ export const ScheduleList = ( props: Props ) => {
 						canCreateSchedules && (
 							<Text as="p">
 								<Icon className="icon-info" icon={ info } size={ 16 } />
-								{ translate(
-									'The current feature implementation allows to set up two schedules.'
-								) }
+								The current feature implementation only allows to set up two schedules.
 							</Text>
 						) }
 				</CardBody>


### PR DESCRIPTION
## Proposed Changes

* Revert "Plugins update manager: Add translation (#88300)"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?