### PR TITLE
Update woo passwordless screens

### DIFF
--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -49,7 +49,7 @@ function SocialAuthToS( props ) {
 
 	return getToSComponent(
 		props.translate(
-			'If you continue with Google, Apple, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			'If you continue with Google and Apple, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			toSLinks
 		)
 	);

--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -1,7 +1,9 @@
+import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 
 const toSLinks = {
 	components: {
@@ -27,14 +29,33 @@ function getToSComponent( content ) {
 }
 
 function SocialAuthToS( props ) {
-	const content = props.translate(
-		'If you continue with Google, Apple or GitHub, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-		toSLinks
-	);
+	if ( props.isWooPasswordless ) {
+		return getToSComponent(
+			props.translate(
+				'By continuing with any of the options above, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				toSLinks
+			)
+		);
+	}
 
-	return getToSComponent( content );
+	if ( config.isEnabled( 'login/github' ) ) {
+		return getToSComponent(
+			props.translate(
+				'If you continue with Google, Apple or GitHub, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				toSLinks
+			)
+		);
+	}
+
+	return getToSComponent(
+		props.translate(
+			'If you continue with Google, Apple, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			toSLinks
+		)
+	);
 }
 
 export default connect( ( state ) => ( {
 	oauth2Client: getCurrentOAuth2Client( state ),
+	isWooPasswordless: !! getWooPasswordless( state ),
 } ) )( localize( SocialAuthToS ) );

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -8,6 +8,7 @@ import wpcom from 'calypso/lib/wp';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
+
 import './continue-as-user.scss';
 
 // Validate redirect URL using the REST endpoint.

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -7,7 +7,7 @@ import Gravatar from 'calypso/components/gravatar';
 import wpcom from 'calypso/lib/wp';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
-
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 import './continue-as-user.scss';
 
 // Validate redirect URL using the REST endpoint.
@@ -42,6 +42,7 @@ function ContinueAsUser( {
 	redirectPath,
 	isSignUpFlow,
 	isWooOAuth2Client,
+	isWooPasswordless,
 } ) {
 	const translate = useTranslate();
 	const { url: validatedRedirectUrlFromQuery, loading: validatingQueryURL } =
@@ -100,6 +101,36 @@ function ContinueAsUser( {
 	);
 
 	if ( isWooOAuth2Client ) {
+		if ( isWooPasswordless ) {
+			return (
+				<div className="continue-as-user">
+					<div className="continue-as-user__user-info">
+						{ gravatarLink }
+						<div className="continue-as-user__not-you">
+							<button
+								type="button"
+								id="loginAsAnotherUser"
+								className="continue-as-user__change-user-link"
+								onClick={ onChangeAccount }
+							>
+								{ translate( 'Sign in as a different user' ) }
+							</button>
+						</div>
+					</div>
+					<Button
+						primary
+						busy={ isLoading }
+						className="continue-as-user__continue-button"
+						href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
+					>
+						{ `${ translate( 'Continue as', {
+							context: 'Continue as an existing WordPress.com user',
+						} ) } ${ userName }` }
+					</Button>
+				</div>
+			);
+		}
+
 		return (
 			<div className="continue-as-user">
 				<div className="continue-as-user__user-info">
@@ -148,4 +179,5 @@ function ContinueAsUser( {
 export default connect( ( state ) => ( {
 	currentUser: getCurrentUser( state ),
 	redirectUrlFromQuery: get( getCurrentQueryArguments( state ), 'redirect_to', null ),
+	isWooPasswordless: !! getWooPasswordless( state ),
 } ) )( ContinueAsUser );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -49,6 +49,7 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
 import isMagicLoginEmailRequested from 'calypso/state/selectors/is-magic-login-email-requested';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
@@ -421,6 +422,13 @@ class Login extends Component {
 							) }
 						</p>
 					);
+				} else if ( this.showContinueAsUser() && this.props.isWooPasswordless ) {
+					headerText = <h3>{ translate( 'Get started in minutes' ) }</h3>;
+					postHeader = (
+						<p className="login__header-subtitle">
+							{ translate( 'First, select the account you’d like to use.' ) }
+						</p>
+					);
 				} else {
 					headerText = <h3>{ translate( "Let's get started" ) }</h3>;
 					const poweredByWpCom =
@@ -782,7 +790,7 @@ class Login extends Component {
 		if ( this.showContinueAsUser() ) {
 			if ( isWoo ) {
 				return (
-					<Fragment>
+					<div className="login__body login__body--continue-as-user">
 						<ContinueAsUser
 							onChangeAccount={ this.handleContinueAsAnotherUser }
 							isWooOAuth2Client={ isWoo }
@@ -802,7 +810,7 @@ class Login extends Component {
 							showSocialLoginFormOnly={ true }
 							sendMagicLoginLink={ this.sendMagicLoginLink }
 						/>
-					</Fragment>
+					</div>
 				);
 			}
 
@@ -838,11 +846,12 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale, isWoo } = this.props;
+		const { isJetpack, oauth2Client, locale, isWoo, isWooPasswordless } = this.props;
 
 		return (
 			<div
 				className={ classNames( 'login', {
+					'is-woo-passwordless': isWooPasswordless,
 					'is-jetpack': isJetpack,
 					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
 					'is-a4a': isA4AOAuth2Client( oauth2Client ),
@@ -885,6 +894,7 @@ export default connect(
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 		isWooCoreProfilerFlow: isWooCommerceCoreProfilerFlow( state ),
 		wccomFrom: getWccomFrom( state ),
+		isWooPasswordless: !! getWooPasswordless( state ),
 		isAnchorFmSignup: getIsAnchorFmSignup(
 			get( getCurrentQueryArguments( state ), 'redirect_to' )
 		),

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -846,12 +846,11 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale, isWoo, isWooPasswordless } = this.props;
+		const { isJetpack, oauth2Client, locale, isWoo } = this.props;
 
 		return (
 			<div
 				className={ classNames( 'login', {
-					'is-woo-passwordless': isWooPasswordless,
 					'is-jetpack': isJetpack,
 					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
 					'is-a4a': isA4AOAuth2Client( oauth2Client ),

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -859,6 +859,10 @@ class SignupForm extends Component {
 
 	termsOfServiceLink = () => {
 		if ( this.props.isWoo ) {
+			if ( this.props.isWooPasswordless ) {
+				return null;
+			}
+
 			return (
 				<p className="signup-form__terms-of-service-link">
 					{ this.props.translate(
@@ -1236,7 +1240,7 @@ class SignupForm extends Component {
 
 		if (
 			( this.props.isPasswordless &&
-				( 'wpcc' !== this.props.flowName || this.props.wooPasswordless ) ) ||
+				( 'wpcc' !== this.props.flowName || this.props.isWooPasswordless ) ) ||
 			isGravatar
 		) {
 			let formProps = {
@@ -1370,7 +1374,7 @@ export default connect(
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			wccomFrom: getWccomFrom( state ),
-			wooPasswordless: getWooPasswordless( state ),
+			isWooPasswordless: !! getWooPasswordless( state ),
 			isWoo: isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow,
 			isWooCoreProfilerFlow,
 			isP2Flow:

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -25,8 +25,8 @@ class PasswordlessSignupForm extends Component {
 	static propTypes = {
 		locale: PropTypes.string,
 		inputPlaceholder: PropTypes.string,
-		submitButtonLabel: PropTypes.string,
-		submitButtonLoadingLabel: PropTypes.string,
+		submitButtonLabel: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
+		submitButtonLoadingLabel: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 		userEmail: PropTypes.string,
 		labelText: PropTypes.string,
 		isInviteLoggedOutForm: PropTypes.bool,

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -242,7 +242,7 @@ exports[`JetpackSignup should render 1`] = `
             <p
               class="auth-form__social-buttons-tos"
             >
-              If you continue with Google, Apple or GitHub, you agree to our 
+              If you continue with Google and Apple, you agree to our 
               <a
                 href="https://wordpress.com/tos/"
                 rel="noopener noreferrer"
@@ -540,7 +540,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
             <p
               class="auth-form__social-buttons-tos"
             >
-              If you continue with Google, Apple or GitHub, you agree to our 
+              If you continue with Google and Apple, you agree to our 
               <a
                 href="https://wordpress.com/tos/"
                 rel="noopener noreferrer"

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1184,7 +1184,7 @@
 			font-style: normal;
 			font-weight: 400;
 			line-height: 21px;
-			padding: 0 24px 11px 0;
+			padding: 0;
 			margin-top: 8px;
 
 			svg {
@@ -1200,6 +1200,9 @@
 			}
 		}
 
+		.layout__content {
+			padding-top: 80px;
+		}
 
 		.wp-login__container,
 		.magic-login,
@@ -1237,6 +1240,10 @@
 				font-weight: 500;
 				line-height: 27px;
 				letter-spacing: -0.025px;
+
+				&:hover {
+					color: $woo-purple-40;
+				}
 			}
 
 			@media screen and ( max-width: 660px ) {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1448,6 +1448,8 @@
 		}
 
 		.magic-login {
+			margin-top: 0;
+
 			h1.magic-login__form-header {
 				color: var(--studio-gray-100);
 				font-feature-settings: "ss01" on, "salt" on;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1103,7 +1103,7 @@
 	}
 
 
-	.is-woo-passwordless {
+	&.is-woo-passwordless {
 		* {
 			font-family: $woo-inter-font;
 		}
@@ -1200,6 +1200,8 @@
 			}
 		}
 
+
+		.wp-login__container,
 		.magic-login,
 		.step-wrapper,
 		.jetpack-connect__main-logo {
@@ -1528,8 +1530,11 @@
 				margin: 0;
 				max-width: 327px;
 				margin-inline: auto;
+
 				p {
 					color: var(--studio-gray-60);
+					text-align: center;
+
 					font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 					font-size: rem(14px);
 					font-style: normal;
@@ -1567,9 +1572,4 @@
 			padding: 0;
 		}
 	}
-
-	.wp-login__container:has(> .is-woo-passwordless) {
-		padding: 48px 0 0;
-	}
-
 }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -18,6 +18,7 @@
 	$woo-form-divider-border: 1px solid #e6e6e6;
 	$gray-60: #50575e;
 	$gray-50: #646970;
+	$woo-inter-font:  "Inter", -apple-system, system-ui, sans-serif;
 
 	background: #fff;
 	min-height: 100%;
@@ -1100,4 +1101,475 @@
 			line-height: inherit;
 		}
 	}
+
+
+	.is-woo-passwordless {
+		* {
+			font-family: $woo-inter-font;
+		}
+
+		$woo-font-size-input: $font-body;
+		$woo-radius-input: 8px;
+
+		h1,
+		h3 {
+			color: var(--studio-gray-100);
+			font-feature-settings: "ss01" on, "salt" on;
+			font-family: proxima-nova, sans-serif;
+			text-align: center;
+			font-size: 2.25rem;
+			font-weight: 700;
+			line-height: 39.6px;
+			letter-spacing: -0.72px;
+
+			@media screen and ( max-width: 660px ) {
+				text-align: left;
+			}
+		}
+
+		input[type="text"].form-text-input,
+		input[type="email"].form-text-input,
+		input[type="password"].form-text-input,
+		input[type="tel"].form-text-input,
+		textarea.form-text-input {
+			border: 2px solid var(--studio-gray-10);
+			height: 48px;
+			padding: 8px 16px;
+			font-size: $woo-font-size-input;
+			font-style: normal;
+			line-height: 24px;
+			border-radius: $woo-radius-input;
+
+			&:focus,
+			&:hover,
+			&:focus:hover {
+				border: 2px solid $woo-purple-50;
+				box-shadow: none;
+			}
+
+			&:disabled {
+				border: 2px solid var(--studio-gray-5);
+				background: var(--studio-gray-0);
+			}
+		}
+
+		.button.is-primary,
+		.login .button.is-primary,
+		.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
+			background-color: $woo-purple-50;
+			font-family: $woo-inter-font;
+			font-size: 1rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 28px;
+
+			&.is-busy {
+				background-image: none;
+			}
+
+			&:hover {
+				background-color: $woo-purple-70;
+				color: #fff;
+			}
+
+			&:disabled {
+				background-color: var(--studio-gray-0);
+				color: var(--studio-gray-20);
+			}
+		}
+
+		.form-input-validation.is-error {
+			color: #8a2424;
+			font-size: rem(14px);
+			font-style: normal;
+			font-weight: 400;
+			line-height: 21px;
+			padding: 0 24px 11px 0;
+			margin-top: 8px;
+
+			svg {
+				display: none;
+			}
+		}
+
+		.validation-fieldset {
+			&:has(.is-error) {
+				input {
+					border: 2px solid  #e26f56;
+				}
+			}
+		}
+
+		.magic-login,
+		.step-wrapper,
+		.jetpack-connect__main-logo {
+			padding: 48px 0 0;
+		}
+
+		.login__form-header {
+			margin-bottom: 12px;
+		}
+
+		.formatted-header__title {
+			margin-bottom: 12px;
+
+			@media screen and ( max-width: 660px ) {
+				padding: 0;
+				max-width: 327px;
+				margin: 0 auto 16px;
+			}
+		}
+
+		.login__header-subtitle,
+		.formatted-header__subtitle {
+			font-size: $font-body-large;
+			font-weight: 400;
+			line-height: 27px;
+			letter-spacing: -0.025px;
+			-webkit-font-smoothing: initial;
+
+			a {
+				color: $woo-purple-50;
+				font-size: rem(18px);
+				font-style: normal;
+				font-weight: 500;
+				line-height: 27px;
+				letter-spacing: -0.025px;
+			}
+
+			@media screen and ( max-width: 660px ) {
+				padding: 0;
+				max-width: 327px;
+				margin: 0 auto;
+				width: 100%;
+			}
+		}
+
+		.signup-form,
+		.login__body--continue-as-user {
+			width: 100%;
+			margin: 48px auto 0;
+			padding: 0;
+			max-width: 327px;
+			display: flex;
+			flex-direction: column;
+		}
+
+		.signup-form {
+			input[type="email"].form-text-input {
+				margin-bottom: 0;
+			}
+
+			.signup-form__passwordless-form-wrapper .logged-out-form__footer {
+				padding: 0;
+				margin-top: 24px;
+			}
+		}
+
+		.auth-form__social {
+			max-width: 100%;
+			padding: 40px 0 14px;
+			border-top: 0;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+
+			.auth-form__social-buttons {
+				width: 100%;
+
+				.auth-form__social-buttons-container {
+					gap: 16px;
+				}
+
+				.social-buttons__button.button {
+					display: flex;
+					height: 48px;
+					padding: 8px 16px;
+					align-items: center;
+					gap: 60px;
+					align-self: stretch;
+					border-radius: 8px; // stylelint-disable-line scales/radii
+					border: 2px solid var(--studio-gray-10);
+					width: 100%;
+					margin: 0;
+
+					&:hover {
+						background: var(--studio-gray-0, #f6f7f7);
+					}
+
+					svg {
+						margin: 0;
+					}
+				}
+
+				.social-buttons__service-name {
+					font-size: 1rem;
+					font-style: normal;
+					font-weight: 500;
+					line-height: 24px;
+					color: var(--studio-gray-100);
+					margin: 0;
+				}
+
+				.social-icons {
+					border: 0;
+					padding: 0;
+				}
+
+				.login__social-tos {
+					margin: 0 auto 2.5em;
+					max-width: 100%;
+					order: -1;
+
+					a {
+						font-size: inherit;
+						line-height: inherit;
+					}
+				}
+			}
+
+			.auth-form__social-buttons-tos {
+				margin-top: 32px;
+				font-size: $woo-font-size-small;
+				line-height: 18px;
+				color: $gray-50;
+				text-align: center;
+
+				a {
+					color: $gray-50;
+					line-height: 18px;
+					font-size: inherit;
+				}
+			}
+		}
+
+		.auth-form__separator .auth-form__separator-text {
+			padding: 0 27px !important;
+		}
+
+
+		.auth-form__separator {
+			margin: 32px auto;
+			max-width: initial;
+		}
+
+		.continue-as-user {
+			margin: 0;
+			max-width: initial;
+
+			~ .auth-form__separator {
+				margin: 32px auto;
+			}
+
+			.continue-as-user__user-info {
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+				align-items: center;
+				align-self: stretch;
+				border-radius: 8px; // stylelint-disable-line scales/radii
+				border: 2px solid #dcdcde;
+				height: 221px;
+				box-sizing: border-box;
+				padding: 32px 24px 16px 24px;
+			}
+
+			~ .card.auth-form__social.is-login {
+				margin: 0;
+				padding: 0;
+				max-width: initial;
+			}
+
+
+			.continue-as-user__gravatar-link {
+				display: flex;
+				flex-direction: column;
+				margin: 0 0 8px;
+				padding: 0;
+				border: 0;
+				border-radius: 0;
+			}
+
+			.gravatar.continue-as-user__gravatar {
+				width: 80px;
+				height: 80px;
+				box-sizing: border-box;
+			}
+
+			.continue-as-user__username {
+				font-style: normal;
+				margin-top: 8px;
+
+			}
+
+			.continue-as-user__email {
+				font-size: 0.875rem;
+				line-height: 21px;
+				color: $gray-50;
+				text-align: center;
+				margin: 0;
+			}
+		}
+
+		.continue-as-user__not-you {
+			margin-bottom: 0;
+			display: flex;
+			height: 32px;
+			padding: 4px 16px;
+			justify-content: center;
+			align-items: center;
+			gap: 4px;
+		}
+
+		.continue-as-user__change-user-link {
+			text-decoration: none;
+			color: $woo-purple-50;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 21px;
+
+			&:hover {
+				color: $woo-purple-70;
+			}
+		}
+
+		.continue-as-user__continue-button {
+			margin-top: 24px;
+		}
+
+		.magic-login {
+			h1.magic-login__form-header {
+				color: var(--studio-gray-100);
+				font-feature-settings: "ss01" on, "salt" on;
+				font-family: proxima-nova, sans-serif;
+				text-align: center;
+				font-size: 2.25rem;
+				font-weight: 700;
+				line-height: 39.6px;
+				letter-spacing: -0.72px;
+				margin: 0;
+
+				@media screen and ( max-width: 660px ) {
+					text-align: left;
+					max-width: 327px;
+					margin: 0 auto;
+				}
+			}
+
+			.magic-login__form-action {
+				margin-top: 8px;
+			}
+
+			.magic-login__form {
+				border: none;
+				padding: 0;
+
+				p {
+					text-align: center;
+				}
+
+				.logged-out-form {
+					max-width: 100%;
+					padding: 0;
+					box-shadow: none;
+
+					form {
+						max-width: 327px;
+					}
+				}
+
+				label.form-label {
+					color: var(--studio-gray-100);
+					font-size: 1rem;
+					font-style: normal;
+					font-weight: 600;
+					line-height: 24px;
+					margin-bottom: 16px;
+				}
+			}
+
+			.magic-login__form p.magic-login__form-sub-header,
+			.magic-login__form-text {
+				color: var(--studio-gray-60);
+				text-align: center;
+				font-size: rem(18px);
+				font-style: normal;
+				font-weight: 400;
+				line-height: 27px;
+				letter-spacing: -0.025px;
+				margin: 12px auto 48px;
+
+				strong {
+					font-weight: 600;
+				}
+			}
+
+			.magic-login__emails-list {
+				max-width: 327px;
+				margin-inline: auto;
+
+				li {
+					border-radius: 8px; // stylelint-disable-line scales/radii
+					border: 2px solid var(--studio-gray-10);
+				}
+
+				a {
+					color: var(--studio-gray-100);
+					text-decoration: none;
+					font-size: 1rem;
+					font-style: normal;
+					font-weight: 500;
+					line-height: 24px;
+				}
+			}
+
+			.magic-login__footer {
+				margin: 0;
+				max-width: 327px;
+				margin-inline: auto;
+				p {
+					color: var(--studio-gray-60);
+					font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+					font-size: rem(14px);
+					font-style: normal;
+					font-weight: 400;
+					line-height: 20px;
+				}
+
+				a {
+					text-decoration: none;
+					color: $woo-purple-50;
+					font-size: rem(14px);
+					font-style: normal;
+					font-weight: 500;
+					line-height: 20px;
+				}
+			}
+		}
+
+		.logged-out-form {
+			padding: 0;
+			margin: 0;
+
+			label.form-label {
+				color: var(--color-gray-100);
+				font-size: 1rem;
+				font-style: normal;
+				font-weight: 600;
+				line-height: 24px;
+				margin-bottom: 16px;
+			}
+		}
+
+		.auth-form__separator + .auth-form__social.card {
+			border: 0;
+			padding: 0;
+		}
+	}
+
+	.wp-login__container:has(> .is-woo-passwordless) {
+		padding: 48px 0 0;
+	}
+
 }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -60,7 +60,7 @@ function getRedirectToAfterLoginUrl( {
 	signupDependencies,
 	stepName,
 	userLoggedIn,
-	wooPasswordless,
+	isWooPasswordless,
 } ) {
 	if (
 		oauth2Signup &&
@@ -68,7 +68,7 @@ function getRedirectToAfterLoginUrl( {
 		isOauth2RedirectValid( initialContext.query.oauth2_redirect )
 	) {
 		if (
-			wooPasswordless &&
+			isWooPasswordless &&
 			! initialContext.query.oauth2_redirect.includes( 'woo-passwordless' )
 		) {
 			return initialContext.query.oauth2_redirect + '&woo-passwordless=yes';
@@ -566,13 +566,12 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const isWooPasswordLess = this.props.wooPasswordless;
 		const { oauth2Client, isReskinned } = this.props;
 		const isPasswordless =
 			isMobile() ||
 			this.props.isPasswordless ||
 			isNewsletterFlow( this.props?.queryObject?.variationName ) ||
-			isWooPasswordLess;
+			this.props.isWooPasswordless;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -613,7 +612,7 @@ export class UserStep extends Component {
 					isReskinned={ isReskinned }
 					shouldDisplayUserExistsError={ ! isWooOAuth2Client( oauth2Client ) }
 					isSocialFirst={ this.props.isSocialFirst }
-					labelText={ this.props.wooPasswordless ? this.props.translate( 'Your email' ) : null }
+					labelText={ this.props.isWooPasswordless ? this.props.translate( 'Your email' ) : null }
 				/>
 				<div id="g-recaptcha"></div>
 			</>
@@ -745,7 +744,7 @@ const ConnectedUser = connect(
 			oauth2Client: getCurrentOAuth2Client( state ),
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),
-			wooPasswordless: getWooPasswordless( state ),
+			isWooPasswordless: !! getWooPasswordless( state ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

We reverted #87931 in #88260, which not only reverted the  "Continue as Existing user" screen but also reverted the CSS changes of other passwordless screens.

This PR is to bring back the "Continue as Existing user" screen in passwordless feature flag and also fix the other passwordless screens.

## Proposed Changes

* Bring back the new "Continue as Existing user" screen in passwordless feature flag.
* Fix the styles of other passwordless screens to match the design.
* Update Term of Service.
* Change all `wooPasswordless` props name to `isWooPasswordless`.

<img width="750px" alt="03  Social Signup" src="https://github.com/Automattic/wp-calypso/assets/4344253/f06bcb3b-b3fe-41f4-b398-f26b6758a63a">

<img width="780px" alt="03  Existing user - Logged in" src="https://github.com/Automattic/wp-calypso/assets/4344253/6e0d4ca7-9f0f-49a1-af2f-dbb7c9793530">

<img width="1480" alt="03  Social login - Horizontal layout" src="https://github.com/Automattic/wp-calypso/assets/4344253/6abdabd2-b1c9-4707-933f-fb734a226084">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please setup woo start env for testing

**Passwordless signup** 

1. Use incognito mode
2. Go to the Woo Express site creation flow (https://woo.com/start/#/installation > `Try Woo Express for free`)
3. Observe that signup screen matches the design 4ixWMlzrxllx93tSFsCW6k-fi-9483_4315

**Continue as Existing user** 


1. Log in to WP.com but Log out of Woo.com 
2. Go to the Woo Express site creation flow 
3. Observe that the "Continue as Existing user" screen matches the design (4ixWMlzrxllx93tSFsCW6k-fi-9483%3A13771)

 **"Check your email" screen**

* Go to https://wordpress.com/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dcc209140df814f02119fcc56e3662fbb82d946f1631feeca2c5290f408c83029%26redirect_uri%3Dhttps%253A%252F%252Fwoo.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&woo-passwordless=yes
* Enter an email or username (non-a8c account) and click "Send link"
* Observe that the "Check your email" screen matches the design 4ixWMlzrxllx93tSFsCW6k-fi-9483%3A8624
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?