### PR TITLE
Plugins update manager: Add translation

### DIFF
--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -57,11 +57,11 @@ export const PluginsUpdateManager = ( props: Props ) => {
 					onEditSchedule={ onEditSchedule }
 				/>
 			),
-			title: translate( 'List schedules' ),
+			title: translate( 'Scheduled Updates' ),
 		},
 		create: {
 			component: <ScheduleCreate onNavBack={ onNavBack } />,
-			title: translate( 'Set up a new schedule' ),
+			title: translate( 'New schedule' ),
 		},
 		edit: {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
@@ -76,7 +76,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 			<MainComponent wideLayout>
 				<NavigationHeader
 					navigationItems={ [] }
-					title={ translate( 'Plugins update scheduler' ) }
+					title={ translate( 'Plugin Update Manager' ) }
 					subtitle={ translate( 'Schedule automatic plugin updates' ) }
 				>
 					{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
@@ -87,7 +87,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 							onClick={ onCreateNewSchedule }
 							disabled={ ! canCreateSchedules }
 						>
-							{ translate( 'Set up a new schedule' ) }
+							{ translate( 'Add new schedule' ) }
 						</Button>
 					) }
 				</NavigationHeader>

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useIsEligibleForFeature } from 'calypso/blocks/plugins-update-manager/hooks/use-is-eligible-for-feature';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -29,6 +30,7 @@ interface Props {
 }
 
 export const PluginsUpdateManager = ( props: Props ) => {
+	const translate = useTranslate();
 	const { siteSlug, context, scheduleId, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const siteId = useSelector( getSelectedSiteId );
 
@@ -55,15 +57,15 @@ export const PluginsUpdateManager = ( props: Props ) => {
 					onEditSchedule={ onEditSchedule }
 				/>
 			),
-			title: 'List schedules',
+			title: translate( 'List schedules' ),
 		},
 		create: {
 			component: <ScheduleCreate onNavBack={ onNavBack } />,
-			title: 'Create a new schedule',
+			title: translate( 'Set up a new schedule' ),
 		},
 		edit: {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
-			title: 'Edit schedule',
+			title: translate( 'Edit schedule' ),
 		},
 	}[ context ];
 
@@ -74,8 +76,8 @@ export const PluginsUpdateManager = ( props: Props ) => {
 			<MainComponent wideLayout>
 				<NavigationHeader
 					navigationItems={ [] }
-					title="Plugin updates manager"
-					subtitle="Effortlessly schedule plugin auto-updates with built-in rollback logic."
+					title={ translate( 'Plugins update scheduler' ) }
+					subtitle={ translate( 'Schedule automatic plugin updates' ) }
 				>
 					{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
 						<Button
@@ -85,7 +87,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 							onClick={ onCreateNewSchedule }
 							disabled={ ! canCreateSchedules }
 						>
-							Create a new schedule
+							{ translate( 'Set up a new schedule' ) }
 						</Button>
 					) }
 				</NavigationHeader>

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -77,7 +77,9 @@ export const PluginsUpdateManager = ( props: Props ) => {
 				<NavigationHeader
 					navigationItems={ [] }
 					title={ translate( 'Plugin Update Manager' ) }
-					subtitle={ translate( 'Streamline your workflow with scheduled updates, timed to suit your needs' ) }
+					subtitle={ translate(
+						'Streamline your workflow with scheduled updates, timed to suit your needs.'
+					) }
 				>
 					{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
 						<Button

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -77,7 +77,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 				<NavigationHeader
 					navigationItems={ [] }
 					title={ translate( 'Plugin Update Manager' ) }
-					subtitle={ translate( 'Schedule automatic plugin updates' ) }
+					subtitle={ translate( 'Streamline your workflow with scheduled updates, timed to suit your needs' ) }
 				>
 					{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
 						<Button

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -11,6 +11,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { arrowLeft, info } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { Banner } from 'calypso/components/banner';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
@@ -27,6 +28,7 @@ interface Props {
 }
 export const ScheduleCreate = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
 	const { createMonitor } = useCreateMonitor( siteSlug );
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const siteHasEligiblePlugins = useSiteHasEligiblePlugins();
@@ -66,8 +68,15 @@ export const ScheduleCreate = ( props: Props ) => {
 		<>
 			{ ! siteHasEligiblePlugins && (
 				<Banner
-					title="No updatable plugins found"
-					description={ `You don't have any plugins that can be updated. Please head over to <a href="https://wordpress.com/plugins/${ siteSlug }">Plugins</a> to install some plugins.` }
+					title={ translate( 'No plugins to update' ) }
+					description={ translate(
+						'You don’t have any plugins that can be updated. Visit the {{a}}Plugins{{/a}} section to explore and install new plugins.',
+						{
+							components: {
+								a: <a href={ `/plugins/${ siteSlug }` } />,
+							},
+						}
+					) }
 					onClick={ () => {
 						page.redirect( `/plugins/${ siteSlug }` );
 					} }
@@ -78,7 +87,7 @@ export const ScheduleCreate = ( props: Props ) => {
 					<div className="ch-placeholder">
 						{ onNavBack && (
 							<Button icon={ arrowLeft } onClick={ onNavBack }>
-								Back
+								{ translate( 'Back' ) }
 							</Button>
 						) }
 					</div>
@@ -96,7 +105,7 @@ export const ScheduleCreate = ( props: Props ) => {
 						disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
 						isBusy={ isBusy }
 					>
-						Create
+						{ translate( 'Create' ) }
 					</Button>
 					{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
 						<Text as="p" className="validation-msg">

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -10,6 +10,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { arrowLeft, info } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
@@ -23,8 +24,10 @@ interface Props {
 }
 export const ScheduleEdit = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const { isEligibleForFeature } = useIsEligibleForFeature();
+	const translate = useTranslate();
+
 	const { scheduleId, onNavBack } = props;
+	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
 		siteSlug,
 		isEligibleForFeature
@@ -64,11 +67,11 @@ export const ScheduleEdit = ( props: Props ) => {
 				<div className="ch-placeholder">
 					{ onNavBack && (
 						<Button icon={ arrowLeft } onClick={ onNavBack }>
-							Back
+							{ translate( 'Back' ) }
 						</Button>
 					) }
 				</div>
-				<Text>Edit Schedule</Text>
+				<Text>{ translate( 'Edit Schedule' ) }</Text>
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody>
@@ -88,7 +91,7 @@ export const ScheduleEdit = ( props: Props ) => {
 					isBusy={ isBusy }
 					disabled={ ! canCreateSchedules }
 				>
-					Save
+					{ translate( 'Save' ) }
 				</Button>
 				{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
 					<Text as="p" className="validation-msg">

--- a/client/blocks/plugins-update-manager/schedule-form.const.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.const.ts
@@ -1,42 +1,44 @@
+import { translate } from 'i18n-calypso';
+
 export const DEFAULT_HOUR = 9;
 
 export const DAILY_OPTION = {
-	label: 'Daily',
+	label: translate( 'Daily' ),
 	value: 'daily',
 };
 
 export const WEEKLY_OPTION = {
-	label: 'Weekly',
+	label: translate( 'Weekly' ),
 	value: 'weekly',
 };
 
 export const DAY_OPTIONS = [
 	{
-		label: 'Monday',
+		label: translate( 'Monday' ),
 		value: '1',
 	},
 	{
-		label: 'Tuesday',
+		label: translate( 'Tuesday' ),
 		value: '2',
 	},
 	{
-		label: 'Wednesday',
+		label: translate( 'Wednesday' ),
 		value: '3',
 	},
 	{
-		label: 'Thursday',
+		label: translate( 'Thursday' ),
 		value: '4',
 	},
 	{
-		label: 'Friday',
+		label: translate( 'Friday' ),
 		value: '5',
 	},
 	{
-		label: 'Saturday',
+		label: translate( 'Saturday' ),
 		value: '6',
 	},
 	{
-		label: 'Sunday',
+		label: translate( 'Sunday' ),
 		value: '0',
 	},
 ];
@@ -94,11 +96,11 @@ export const HOUR_OPTIONS = [
 
 export const PERIOD_OPTIONS = [
 	{
-		label: 'AM',
+		label: translate( 'AM' ),
 		value: 'am',
 	},
 	{
-		label: 'PM',
+		label: translate( 'PM' ),
 		value: 'pm',
 	},
 ];

--- a/client/blocks/plugins-update-manager/schedule-form.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.helper.ts
@@ -1,3 +1,5 @@
+import { translate } from 'i18n-calypso';
+
 /**
  * Prepare unix timestamp in seconds
  * based on selected frequency, day, hour and period
@@ -38,22 +40,6 @@ export const prepareTimestamp = (
 	return event.getTime() / 1000;
 };
 
-/**
- * Validate name
- * - required
- * - max length 120
- */
-export const validateName = ( name: string ) => {
-	let error = '';
-	if ( ! name ) {
-		error = 'Please provide a name to this plugin update schedule.';
-	} else if ( name.length > 120 ) {
-		error = 'Please provide a shorter name.';
-	}
-
-	return error;
-};
-
 type TimeSlot = {
 	frequency: string;
 	timestamp: number;
@@ -82,14 +68,14 @@ export const validateTimeSlot = ( newSchedule: TimeSlot, existingSchedules: Time
 			( newSchedule.frequency === 'daily' || schedule.frequency === 'daily' ) &&
 			existingDate.getHours() === newDate.getHours()
 		) {
-			error = 'Please choose another time, as this slot is already scheduled.';
+			error = translate( 'Please choose another time, as this slot is already scheduled.' );
 		} else if (
 			newSchedule.frequency === 'weekly' &&
 			schedule.frequency === 'weekly' &&
 			newDate.getDay() === existingDate.getDay() &&
 			newDate.getHours() === existingDate.getHours()
 		) {
-			error = 'Please pick another time for optimal performance, as this slot is already taken.';
+			error = translate( 'Please choose another time, as this slot is already scheduled.' );
 		}
 	} );
 
@@ -104,13 +90,15 @@ export const validatePlugins = ( plugins: string[], existingPlugins: Array< stri
 	let error = '';
 
 	if ( plugins.length === 0 ) {
-		error = 'Please select at least one plugin to update.';
+		error = translate( 'Please select at least one plugin to update.' );
 	} else if ( existingPlugins.length ) {
 		const _plugins = [ ...plugins ].sort();
 
 		existingPlugins.forEach( ( existing ) => {
 			if ( JSON.stringify( _plugins ) === JSON.stringify( [ ...existing ].sort() ) ) {
-				error = 'Please select a different set of plugins, as this one has already been chosen.';
+				error = translate(
+					'Please select a different set of plugins, as this one has already been chosen.'
+				);
 			}
 		} );
 	}

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -285,7 +285,7 @@ export const ScheduleForm = ( props: Props ) => {
 						) : (
 							<Text className="info-msg">
 								{ translate(
-									'Plugins not listed below are managed and updated by WordPress.com for you.'
+									'Plugins not listed below are automatically updated by WordPress.com.'
 								) }
 							</Text>
 						) }

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState, useCallback, useEffect } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useCorePluginsQuery, type CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
@@ -44,8 +45,9 @@ interface Props {
 	onSyncError?: ( error: string ) => void;
 }
 export const ScheduleForm = ( props: Props ) => {
-	const moment = useLocalizedMoment();
 	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
 	const initDate = scheduleForEdit
@@ -182,7 +184,7 @@ export const ScheduleForm = ( props: Props ) => {
 			>
 				<FlexItem>
 					<div className="form-field">
-						<label htmlFor="frequency">Update every</label>
+						<label htmlFor="frequency">{ translate( 'Update every' ) }</label>
 						<div className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
 							<RadioControl
 								name="frequency"
@@ -270,7 +272,7 @@ export const ScheduleForm = ( props: Props ) => {
 				</FlexItem>
 				<FlexItem>
 					<div className="form-field">
-						<label htmlFor="plugins">Select plugins</label>
+						<label htmlFor="plugins">{ translate( 'Select plugins' ) }</label>
 						<span className="plugin-select-stats">
 							{ selectedPlugins.length }/
 							{ plugins.length < MAX_SELECTABLE_PLUGINS ? plugins.length : MAX_SELECTABLE_PLUGINS }
@@ -282,7 +284,9 @@ export const ScheduleForm = ( props: Props ) => {
 							</Text>
 						) : (
 							<Text className="info-msg">
-								Plugins not listed below are managed by WordPress.com and update automatically.
+								{ translate(
+									'Plugins not listed below are managed and updated by WordPress.com for you.'
+								) }
 							</Text>
 						) }
 						<div className="checkbox-options">
@@ -295,7 +299,7 @@ export const ScheduleForm = ( props: Props ) => {
 								{ isPluginsFetching && <Spinner /> }
 								{ isPluginsFetched && plugins.length <= MAX_SELECTABLE_PLUGINS && (
 									<CheckboxControl
-										label="Select all"
+										label={ translate( 'Select all' ) }
 										indeterminate={
 											selectedPlugins.length > 0 && selectedPlugins.length < plugins.length
 										}

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -1,5 +1,6 @@
 import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { MOMENT_TIME_FORMAT } from 'calypso/blocks/plugins-update-manager/config';
 import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-manager/hooks/use-prepare-plugins-tooltip-info';
 import { ellipsis } from 'calypso/blocks/plugins-update-manager/icons';
@@ -18,6 +19,7 @@ export const ScheduleListCards = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const moment = useLocalizedMoment();
+	const translate = useTranslate();
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
@@ -31,20 +33,20 @@ export const ScheduleListCards = ( props: Props ) => {
 						className="schedule-list--card-actions"
 						controls={ [
 							{
-								title: 'Edit',
+								title: translate( 'Edit' ),
 								onClick: () => onEditClick( schedule.id ),
 							},
 							{
-								title: 'Remove',
+								title: translate( 'Remove' ),
 								onClick: () => onRemoveClick( schedule.id ),
 							},
 						] }
 						icon={ ellipsis }
-						label="More"
+						label={ translate( 'More' ) }
 					/>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="name">Name</label>
+						<label htmlFor="name">{ translate( 'Name' ) }</label>
 						<strong id="name">
 							<Button
 								className="schedule-name"
@@ -57,7 +59,7 @@ export const ScheduleListCards = ( props: Props ) => {
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="last-update">Last Update</label>
+						<label htmlFor="last-update">{ translate( 'Last update' ) }</label>
 						<span id="last-update">
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
@@ -68,26 +70,26 @@ export const ScheduleListCards = ( props: Props ) => {
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="next-update">Next update</label>
+						<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
 						<span id="next-update">
 							{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
 						</span>
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="frequency">Frequency</label>
+						<label htmlFor="frequency">{ translate( 'Frequency' ) }</label>
 						<span id="frequency">
 							{
 								{
-									daily: 'Daily',
-									weekly: 'Weekly',
+									daily: translate( 'Daily' ),
+									weekly: translate( 'Weekly' ),
 								}[ schedule.schedule ]
 							}
 						</span>
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="plugins">Plugins</label>
+						<label htmlFor="plugins">{ translate( 'Plugins' ) }</label>
 						<span id="plugins">
 							{ schedule?.args?.length }
 							<Tooltip

--- a/client/blocks/plugins-update-manager/schedule-list-empty.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-empty.tsx
@@ -16,7 +16,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 				{ ! canCreateSchedules
 					? translate( 'This site is unable to schedule auto-updates for plugins.' )
 					: translate(
-							'Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Up to two schedules let you enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind.'
+							'Take control of your site’s maintenance by choosing when your plugins update—whatever day and time is most convenient. Up to two schedules let you enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind.'
 					  ) }
 			</Text>
 			{ onCreateNewSchedule && (

--- a/client/blocks/plugins-update-manager/schedule-list-empty.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-empty.tsx
@@ -16,7 +16,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 				{ ! canCreateSchedules
 					? translate( 'This site is unable to schedule auto-updates for plugins.' )
 					: translate(
-							'Keep your site up to date with scheduled automatic plugin updates. Built-in rollback included.'
+							'Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Up to two schedules let you enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind.'
 					  ) }
 			</Text>
 			{ onCreateNewSchedule && (
@@ -27,7 +27,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 					onClick={ onCreateNewSchedule }
 					disabled={ ! canCreateSchedules }
 				>
-					{ translate( 'Set up a new schedule' ) }
+					{ translate( 'Add new schedule' ) }
 				</Button>
 			) }
 		</div>

--- a/client/blocks/plugins-update-manager/schedule-list-empty.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-empty.tsx
@@ -1,5 +1,6 @@
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 
 interface Props {
 	canCreateSchedules: boolean;
@@ -7,13 +8,16 @@ interface Props {
 }
 export const ScheduleListEmpty = ( props: Props ) => {
 	const { onCreateNewSchedule, canCreateSchedules } = props;
+	const translate = useTranslate();
 
 	return (
 		<div className="empty-state">
 			<Text as="p" align="center">
 				{ ! canCreateSchedules
-					? 'This site is unable to schedule auto-updates for plugins.'
-					: 'Set up plugin update schedules to ensure your site runs smoothly.' }
+					? translate( 'This site is unable to schedule auto-updates for plugins.' )
+					: translate(
+							'Keep your site up to date with scheduled automatic plugin updates. Built-in rollback included.'
+					  ) }
 			</Text>
 			{ onCreateNewSchedule && (
 				<Button
@@ -23,7 +27,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 					onClick={ onCreateNewSchedule }
 					disabled={ ! canCreateSchedules }
 				>
-					Create a new schedule
+					{ translate( 'Set up a new schedule' ) }
 				</Button>
 			) }
 		</div>

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -1,5 +1,6 @@
 import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { Badge } from './badge';
@@ -16,8 +17,10 @@ interface Props {
 }
 export const ScheduleListTable = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const { isEligibleForFeature } = useIsEligibleForFeature();
+	const translate = useTranslate();
 	const moment = useLocalizedMoment();
+	const { isEligibleForFeature } = useIsEligibleForFeature();
+
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
@@ -31,11 +34,11 @@ export const ScheduleListTable = ( props: Props ) => {
 		<table>
 			<thead>
 				<tr>
-					<th>Name</th>
-					<th>Last Update</th>
-					<th>Next Update</th>
-					<th>Frequency</th>
-					<th>Plugins</th>
+					<th>{ translate( 'Name' ) }</th>
+					<th>{ translate( 'Last update' ) }</th>
+					<th>{ translate( 'Next update' ) }</th>
+					<th>{ translate( 'Frequency' ) }</th>
+					<th>{ translate( 'Plugins' ) }</th>
 					<th></th>
 				</tr>
 			</thead>
@@ -62,8 +65,8 @@ export const ScheduleListTable = ( props: Props ) => {
 						<td>
 							{
 								{
-									daily: 'Daily',
-									weekly: 'Weekly',
+									daily: translate( 'Daily' ),
+									weekly: translate( 'Weekly' ),
 								}[ schedule.schedule ]
 							}
 						</td>
@@ -85,16 +88,16 @@ export const ScheduleListTable = ( props: Props ) => {
 								popoverProps={ { position: 'bottom left' } }
 								controls={ [
 									{
-										title: 'Edit',
+										title: translate( 'Edit' ),
 										onClick: () => onEditClick( schedule.id ),
 									},
 									{
-										title: 'Remove',
+										title: translate( 'Remove' ),
 										onClick: () => onRemoveClick( schedule.id ),
 									},
 								] }
 								icon={ ellipsis }
-								label="More"
+								label={ translate( 'More' ) }
 							/>
 						</td>
 					</tr>

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -8,13 +8,12 @@ import {
 	CardHeader,
 	Spinner,
 } from '@wordpress/components';
-import { Icon, arrowLeft, info } from '@wordpress/icons';
+import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { MAX_SCHEDULES } from './config';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
@@ -127,17 +126,6 @@ export const ScheduleList = ( props: Props ) => {
 									/>
 								) }
 							</>
-						) }
-					{ isFetched &&
-						! isLoadingCanCreateSchedules &&
-						schedules.length >= MAX_SCHEDULES &&
-						canCreateSchedules && (
-							<Text as="p">
-								<Icon className="icon-info" icon={ info } size={ 16 } />
-								{ translate(
-									'The current feature implementation allows to set up two schedules.'
-								) }
-							</Text>
 						) }
 				</CardBody>
 			</Card>

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -9,6 +9,7 @@ import {
 	Spinner,
 } from '@wordpress/components';
 import { Icon, arrowLeft, info } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
@@ -28,8 +29,9 @@ interface Props {
 }
 export const ScheduleList = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const { isEligibleForFeature, loading: isEligibleForFeatureLoading } = useIsEligibleForFeature();
+	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
+	const { isEligibleForFeature, loading: isEligibleForFeatureLoading } = useIsEligibleForFeature();
 
 	const { onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
@@ -84,18 +86,18 @@ export const ScheduleList = ( props: Props ) => {
 				onConfirm={ onRemoveDialogConfirm }
 				onCancel={ closeRemoveConfirm }
 			>
-				Are you sure you want to delete this schedule?
+				{ translate( 'Are you sure you want to delete this schedule?' ) }
 			</ConfirmDialog>
 			<Card className="plugins-update-manager">
 				<CardHeader size="extraSmall">
 					<div className="ch-placeholder">
 						{ onNavBack && (
 							<Button icon={ arrowLeft } onClick={ onNavBack }>
-								Back
+								{ translate( 'Back' ) }
 							</Button>
 						) }
 					</div>
-					<Text>Schedules</Text>
+					<Text>{ translate( 'Schedules' ) }</Text>
 					<div className="ch-placeholder"></div>
 				</CardHeader>
 				<CardBody>
@@ -132,7 +134,9 @@ export const ScheduleList = ( props: Props ) => {
 						canCreateSchedules && (
 							<Text as="p">
 								<Icon className="icon-info" icon={ info } size={ 16 } />
-								The current feature implementation only allows to set up two schedules.
+								{ translate(
+									'The current feature implementation allows to set up two schedules.'
+								) }
 							</Text>
 						) }
 				</CardBody>


### PR DESCRIPTION
This reverts commit f070f103019cdbf96948628730fe58cd85afaf08.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88300

## Proposed Changes

* Module translation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/{ATOMIC_SITE}`
* Check if everything works fine as before
<img width="1087" alt="Screenshot 2024-03-07 at 17 57 32" src="https://github.com/Automattic/wp-calypso/assets/1241413/a60fad6d-0284-4506-98da-29499a8f55ec">
<img width="1084" alt="Screenshot 2024-03-07 at 17 56 48" src="https://github.com/Automattic/wp-calypso/assets/1241413/3b657865-eb55-4e8a-bf90-54526283c889">
<img width="1090" alt="Screenshot 2024-03-07 at 17 57 41" src="https://github.com/Automattic/wp-calypso/assets/1241413/1747be8b-9a67-4dfc-81cc-631add20a53f">
<img width="1070" alt="Screenshot 2024-03-07 at 17 58 53" src="https://github.com/Automattic/wp-calypso/assets/1241413/12321010-2fc9-4ea8-86b5-5033d4922609">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?