### PR TITLE
Site Migration: Key retrieval UI

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -98,7 +98,6 @@ const SiteMigrationInstructions: Step = function () {
 											{
 												components: {
 													a: <a href={ destSiteUrl } target="_blank" rel="noreferrer" />,
-													strong: <strong />,
 												},
 											}
 										) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { ClipboardButton } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
@@ -6,16 +7,22 @@ import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
 import type { Step } from '../../types';
 import './style.scss';
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
-	const siteMigrationKey = 'Yjx3xUYYTm89s9xBFe7jitNA94noUg6tzgjnpx9zPVwGdbewfL';
+	const site = useSite();
+	const siteId = site?.ID;
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const sourceSiteUrl = fromUrl
 		? addQueryArgs( fromUrl + '/wp-admin/admin.php', { page: 'migrateguru' } )
+		: '';
+	const destSiteUrl = fromUrl
+		? addQueryArgs( site?.URL + '/wp-admin/admin.php', { page: 'migrateguru' } )
 		: '';
 	const [ buttonTextCopy, setButtonTextCopy ] = useState( false );
 	const onCopy = () => {
@@ -24,6 +31,26 @@ const SiteMigrationInstructions: Step = function () {
 		setTimeout( () => {
 			setButtonTextCopy( false );
 		}, 2000 );
+	};
+	const [ siteMigrationKey, setSiteMigrationKey ] = useState< string | null >( null );
+	const [ siteMigrationKeyError, setSiteMigrationKeyError ] = useState< string | null >( null );
+	const [ hideSiteMigrationKey, setHideSiteMigrationKey ] = useState( true );
+
+	const getMigrationKey = async () => {
+		try {
+			const response = await wpcom.req.get(
+				`/sites/${ siteId }/atomic-migration-status/migrate-guru-key?http_envelope=1`,
+				{
+					apiNamespace: 'wpcom/v2',
+				}
+			);
+
+			setSiteMigrationKey( response?.migration_key );
+			recordTracksEvent( 'calypso_migration_instructions_key_retrieved' );
+		} catch ( error ) {
+			setSiteMigrationKeyError( error as string );
+			recordTracksEvent( 'calypso_migration_instructions_key_error', { error } );
+		}
 	};
 
 	const stepContent = (
@@ -43,23 +70,77 @@ const SiteMigrationInstructions: Step = function () {
 					} ) }
 				</li>
 				<li>
-					{ translate(
-						'Click {{strong}}Copy key{{/strong}} below to get your migration key - you will need that in a few minutes to start the migration.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-					<div className="site-migration-instructions__migration-key">
-						<code className="site-migration-instructions__key">{ siteMigrationKey }</code>
-						<ClipboardButton
-							text={ siteMigrationKey }
-							className="site-migration-instructions__copy-key-button is-primary"
-							onCopy={ onCopy }
-						>
-							{ buttonTextCopy ? translate( 'Copied!' ) : translate( 'Copy key' ) }
-						</ClipboardButton>
+					<div
+						className={ `site-migration-instructions__list-migration-key-item ${
+							siteMigrationKey ? 'expanded' : ''
+						}${ siteMigrationKeyError ? 'error' : '' }` }
+					>
+						{ ! siteMigrationKey && (
+							<>
+								{ ! siteMigrationKeyError && (
+									<Button
+										primary
+										compact
+										className="site-migration-instructions__get-key-button component-button"
+										onClick={ getMigrationKey }
+									>
+										{ translate( 'Get migration key', {
+											components: {
+												strong: <strong />,
+											},
+										} ) }
+									</Button>
+								) }
+								{ siteMigrationKeyError && (
+									<>
+										{ translate(
+											'We were unable to retrieve your migration key. To get the key manually, go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}}.',
+											{
+												components: {
+													a: <a href={ destSiteUrl } target="_blank" rel="noreferrer" />,
+													strong: <strong />,
+												},
+											}
+										) }
+									</>
+								) }
+							</>
+						) }
+						{ siteMigrationKey && ! siteMigrationKeyError && (
+							<>
+								{ translate(
+									'Click {{strong}}Copy key{{/strong}} below to copy your migration key - you will need that in a few minutes to start the migration. This key is unique to your site and will only be available once.',
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+								<div className="site-migration-instructions__migration-key">
+									<code className="site-migration-instructions__key">
+										{ hideSiteMigrationKey
+											? '*'.repeat( siteMigrationKey.length - 5 )
+											: siteMigrationKey }
+									</code>
+									<Button
+										primary
+										onClick={ () => {
+											setHideSiteMigrationKey( ! hideSiteMigrationKey );
+										} }
+										className="site-migration-instructions__show-key-button components-button"
+									>
+										{ hideSiteMigrationKey ? translate( 'Show key' ) : translate( 'Hide key' ) }
+									</Button>
+									<ClipboardButton
+										text={ siteMigrationKey }
+										className="site-migration-instructions__copy-key-button is-primary"
+										onCopy={ onCopy }
+									>
+										{ buttonTextCopy ? translate( 'Copied!' ) : translate( 'Copy key' ) }
+									</ClipboardButton>
+								</div>
+							</>
+						) }
 					</div>
 				</li>
 				<li>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -9,6 +9,27 @@
 		margin-top: 1.5rem;
 	}
 
+	.site-migration-instructions__list-migration-key-item {
+		height: 30px;
+		overflow: hidden;
+		transition: height 0.75s ease;
+
+		&.expanded {
+			height: 130px;
+		}
+
+		&.error {
+			height: 55px;
+		}
+	}
+
+	.site-migration-instructions__show-key-button,
+	.site-migration-instructions__copy-key-button {
+		display: inline-block;
+		width: 100px;
+		margin-right: 0.5rem;
+	}
+
 	.site-migration-instructions__migration-key {
 		display: flex;
 		justify-content: space-between;
@@ -21,7 +42,7 @@
 		display: inline-block;
 		margin-right: 0.75rem;
 		padding: 0.75rem 1rem;
-		width: 400px;
+		width: 375px;
 		overflow-x: scroll;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -31,6 +31,7 @@
 		display: inline-block;
 		width: 100px;
 		margin-right: 0.5rem;
+		padding: 6px 12px;
 	}
 
 	.site-migration-instructions__migration-key {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/variables";
+
 .site-migration-instructions {
 	.site-migration-instructions__list {
 		li {
@@ -20,6 +22,7 @@
 
 		&.error {
 			height: 55px;
+			color: $alert-red;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87393

## Proposed Changes

Updates site migration instructions for key retrieval
    
When the user first lands on the page, there is a "Get migration key" button. Clicking the button retrieves the key from the API and displays it (hidden) along with "Show key" and "Copy key" buttons.
    
In the event that there's an API error (either because of a lack of permissions or the key has already been retrieved), we show instructions and a link for manually retrieving the key instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Either checkout this branch locally or use the calypso.live url.
* Visit http://calypso.localhost:3000/start
* Go through the setup flow, picking any plan.
* On the "Goals" step, add `&flags=onboarding/new-migration-flow` to the url and refresh the page.
* Select the "Import existing content or website" goal and click "Continue"
<img width="1283" alt="CleanShot 2024-03-11 at 14 20 33@2x" src="https://github.com/Automattic/wp-calypso/assets/917632/e742c89f-4a6c-4af7-8fb0-62db58bd46d3">
* On the "Where will you import from?" step, enter the url of any WordPress site. You won't actually be migrating it.
* On the "What do you want to migrate?" step, select "Everything" and click "Continue".
* Upgrade your plan (or select the free trial), if necessary. This step will be skipped if you already have a Creator plan.
* After the "Processing" step completes, you should land on the "Site Migration Instructions" step.
<img width="1291" alt="CleanShot 2024-03-11 at 14 23 48@2x" src="https://github.com/Automattic/wp-calypso/assets/917632/cd19d6e6-81ff-408a-82d7-e4338b74de4a">
* Click the "Get migration key" button. 
* You should see the "Copy key" UI.
<img width="820" alt="CleanShot 2024-03-11 at 14 24 11@2x" src="https://github.com/Automattic/wp-calypso/assets/917632/aec14468-8f7e-4379-a873-32631ef47b54">
* Now refresh the page (**NOTE: You will most likely need to re-add `&flags=onboarding/new-migration-flow` to the URL first).
* Click the "Get migration key" button again.
* You should see the following error text.
<img width="693" alt="CleanShot 2024-03-11 at 14 25 21@2x" src="https://github.com/Automattic/wp-calypso/assets/917632/53d1ed6a-ac5a-4d96-82ec-546ea5672623">
* Verify that the link takes you to the MigrateGuru page on the wp-admin for your site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?