### PR TITLE
New layout to support evergreen campaigns / weekly budget

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -51,6 +51,7 @@ export type CampaignResponse = {
 		total: number;
 		card_name: string;
 	};
+	is_evergreen?: boolean;
 };
 
 const useCampaignsQuery = ( siteId: number, campaignId: number, queryOptions = {} ) => {

--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -56,23 +56,43 @@ export type CampaignResponse = {
 };
 
 export type Order = {
-	order_id: number;
-	order_key: string;
-	customer_id: number;
-	status: string;
+	id: number;
+	orderKey: string;
+	userId: number;
+	customerId: number;
+	status: 'COMPLETED' | 'PENDING' | 'FAILED' | string;
 	currency: string;
 	total: string;
-	total_tax: string;
-	payment_method: string;
-	failed_payment_counter: number;
-	payment_method_title: string;
-	date_created_gmt: string | null;
-	date_modified_gmt: string | null;
-	date_completed_gmt: string | null;
-	date_paid_gmt: string | null;
-	created_at: string;
-	updated_at: string;
-	user_id: number;
+	totalTax: string;
+	paymentMethod: string;
+	failedPaymentCounter: number;
+	paymentMethodTitle: string;
+	dateCreatedGmt: string;
+	dateModifiedGmt: string;
+	dateCompletedGmt: string;
+	datePaidGmt: string;
+	createdAt: string;
+	updatedAt: string;
+	lineItems: LineItem[];
+	feeItems: FeeItem[];
+	credits: number;
+	subtotal: number;
+};
+
+type LineItem = {
+	id: number;
+	orderId: number;
+	campaignId: number;
+	name: string;
+	subtotal: string;
+	total: string;
+};
+
+type FeeItem = {
+	id: number;
+	orderId: number;
+	name: string;
+	total: string;
 };
 
 const useCampaignsQuery = ( siteId: number, campaignId: number, queryOptions = {} ) => {

--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -50,8 +50,29 @@ export type CampaignResponse = {
 		currency: string;
 		total: number;
 		card_name: string;
+		orders: Order[];
 	};
 	is_evergreen?: boolean;
+};
+
+export type Order = {
+	order_id: number;
+	order_key: string;
+	customer_id: number;
+	status: string;
+	currency: string;
+	total: string;
+	total_tax: string;
+	payment_method: string;
+	failed_payment_counter: number;
+	payment_method_title: string;
+	date_created_gmt: string | null;
+	date_modified_gmt: string | null;
+	date_completed_gmt: string | null;
+	date_paid_gmt: string | null;
+	created_at: string;
+	updated_at: string;
+	user_id: number;
 };
 
 const useCampaignsQuery = ( siteId: number, campaignId: number, queryOptions = {} ) => {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -115,7 +115,7 @@ export default function CampaignItemDetails( props: Props ) {
 		format,
 		budget_cents,
 		type,
-		is_evergreen = true,
+		is_evergreen = false,
 	} = campaign || {};
 
 	const {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -754,7 +754,7 @@ export default function CampaignItemDetails( props: Props ) {
 						{ canDisplayPaymentSection ? (
 							<div className="campaign-item-details__payment-container">
 								<div className="campaign-item-details__payment">
-									<div className="campaign-item-details__payment-row">
+									<div className="campaign-item-details__payment-row ">
 										{ orders && orders.length > 0 && (
 											<div className="campaign-item-details__weekly-orders-row">
 												<div className="campaign-item-details__weekly-label"></div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -473,10 +473,7 @@ export default function CampaignItemDetails( props: Props ) {
 
 				<section className="campaign-item-details__wrapper">
 					<div className="campaign-item-details__main">
-						<div
-							className="campaign-item-details__main-stats-container"
-							style={ { display: is_evergreen && ! shouldShowStats ? 'none' : '' } }
-						>
+						<div className="campaign-item-details__main-stats-container">
 							{ shouldShowStats && (
 								<div className="campaign-item-details__main-stats campaign-item-details__impressions">
 									<div className="campaign-item-details__main-stats-row ">
@@ -584,65 +581,63 @@ export default function CampaignItemDetails( props: Props ) {
 								</div>
 							) }
 
-							{ ! is_evergreen && shouldShowStats && (
-								<div className="campaign-item-details__main-stats-row">
+							<div className="campaign-item-details__main-stats-row">
+								<div>
+									<span className="campaign-item-details__label">
+										{ is_evergreen && status === 'active'
+											? __( 'Duration so far' )
+											: __( 'Duration' ) }
+									</span>
+									<span className="campaign-item-details__text wp-brand-font">
+										{ ! isLoading ? durationDateFormatted : <FlexibleSkeleton /> }
+									</span>
+									<span className="campaign-item-details__details">
+										{ ! isLoading ? durationFormatted : <FlexibleSkeleton /> }
+									</span>
+								</div>
+								{ is_evergreen ? (
 									<div>
-										<span className="campaign-item-details__label">
-											{ is_evergreen && status === 'active'
-												? __( 'Duration so far' )
-												: __( 'Duration' ) }
-										</span>
+										<span className="campaign-item-details__label">{ __( 'Weekly spend' ) }</span>
 										<span className="campaign-item-details__text wp-brand-font">
-											{ ! isLoading ? durationDateFormatted : <FlexibleSkeleton /> }
+											{ ! isLoading ? (
+												<>
+													{ weeklySpendFormatted }{ ' ' }
+													<span className="campaign-item-details__details">
+														/ { totalBudgetFormatted }
+													</span>
+												</>
+											) : (
+												<FlexibleSkeleton />
+											) }
 										</span>
 										<span className="campaign-item-details__details">
-											{ ! isLoading ? durationFormatted : <FlexibleSkeleton /> }
+											{ ! isLoading ? weeklySpendingPercentageFormatted : <FlexibleSkeleton /> }
 										</span>
 									</div>
-									{ is_evergreen ? (
-										<div>
-											<span className="campaign-item-details__label">{ __( 'Weekly spend' ) }</span>
-											<span className="campaign-item-details__text wp-brand-font">
-												{ ! isLoading ? (
-													<>
-														{ weeklySpendFormatted }{ ' ' }
-														<span className="campaign-item-details__details">
-															/ { totalBudgetFormatted }
-														</span>
-													</>
-												) : (
-													<FlexibleSkeleton />
-												) }
-											</span>
-											<span className="campaign-item-details__details">
-												{ ! isLoading ? weeklySpendingPercentageFormatted : <FlexibleSkeleton /> }
-											</span>
-										</div>
-									) : (
-										<div>
-											<span className="campaign-item-details__label">{ __( 'Budget' ) }</span>
-											<span className="campaign-item-details__text wp-brand-font">
-												{ ! isLoading ? totalBudgetFormatted : <FlexibleSkeleton /> }
-											</span>
-											<span className="campaign-item-details__details">
-												{ ! isLoading ? (
-													`${ budgetRemainingFormatted } remaining`
-												) : (
-													<FlexibleSkeleton />
-												) }
-											</span>
-										</div>
-									) }
+								) : (
 									<div>
-										<span className="campaign-item-details__label">
-											{ translate( 'Overall spending' ) }
-										</span>
+										<span className="campaign-item-details__label">{ __( 'Budget' ) }</span>
 										<span className="campaign-item-details__text wp-brand-font">
-											{ ! isLoading ? overallSpendingFormatted : <FlexibleSkeleton /> }
+											{ ! isLoading ? totalBudgetFormatted : <FlexibleSkeleton /> }
+										</span>
+										<span className="campaign-item-details__details">
+											{ ! isLoading ? (
+												`${ budgetRemainingFormatted } remaining`
+											) : (
+												<FlexibleSkeleton />
+											) }
 										</span>
 									</div>
+								) }
+								<div>
+									<span className="campaign-item-details__label">
+										{ translate( 'Overall spending' ) }
+									</span>
+									<span className="campaign-item-details__text wp-brand-font">
+										{ ! isLoading ? overallSpendingFormatted : <FlexibleSkeleton /> }
+									</span>
 								</div>
-							) }
+							</div>
 						</div>
 
 						<div className="campaign-item-details__main-stats-container">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -280,9 +280,7 @@ export default function CampaignItemDetails( props: Props ) {
 			  );
 
 	const shouldShowStats =
-		! is_evergreen &&
-		!! ui_status &&
-		! [ 'created', 'rejected', 'scheduled' ].includes( ui_status );
+		!! ui_status && ! [ 'created', 'rejected', 'scheduled' ].includes( ui_status );
 
 	const buttons = [
 		{

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -181,7 +181,7 @@ export default function CampaignItemDetails( props: Props ) {
 		start_date,
 		end_date,
 		is_evergreen,
-		campaign?.status
+		campaign?.ui_status
 	);
 	const durationFormatted = duration_days
 		? sprintf(
@@ -276,6 +276,11 @@ export default function CampaignItemDetails( props: Props ) {
 			: __(
 					"If you continue, an approval request for your ad will be canceled, and the campaign won't start."
 			  );
+
+	const shouldShowStats =
+		! is_evergreen &&
+		!! ui_status &&
+		! [ 'created', 'rejected', 'scheduled' ].includes( ui_status );
 
 	const buttons = [
 		{
@@ -466,8 +471,11 @@ export default function CampaignItemDetails( props: Props ) {
 
 				<section className="campaign-item-details__wrapper">
 					<div className="campaign-item-details__main">
-						<div className="campaign-item-details__main-stats-container">
-							{ !! status && ! [ 'created', 'rejected' ].includes( status ) && (
+						<div
+							className="campaign-item-details__main-stats-container"
+							style={ { display: is_evergreen && ! shouldShowStats ? 'none' : '' } }
+						>
+							{ shouldShowStats && (
 								<div className="campaign-item-details__main-stats campaign-item-details__impressions">
 									<div className="campaign-item-details__main-stats-row ">
 										<div>
@@ -573,63 +581,66 @@ export default function CampaignItemDetails( props: Props ) {
 									</div>
 								</div>
 							) }
-							<div className="campaign-item-details__main-stats-row">
-								<div>
-									<span className="campaign-item-details__label">
-										{ is_evergreen && status === 'active'
-											? __( 'Duration so far' )
-											: __( 'Duration' ) }
-									</span>
-									<span className="campaign-item-details__text wp-brand-font">
-										{ ! isLoading ? durationDateFormatted : <FlexibleSkeleton /> }
-									</span>
-									<span className="campaign-item-details__details">
-										{ ! isLoading ? durationFormatted : <FlexibleSkeleton /> }
-									</span>
-								</div>
-								{ is_evergreen ? (
+
+							{ ! is_evergreen && shouldShowStats && (
+								<div className="campaign-item-details__main-stats-row">
 									<div>
-										<span className="campaign-item-details__label">{ __( 'Weekly spend' ) }</span>
+										<span className="campaign-item-details__label">
+											{ is_evergreen && status === 'active'
+												? __( 'Duration so far' )
+												: __( 'Duration' ) }
+										</span>
 										<span className="campaign-item-details__text wp-brand-font">
-											{ ! isLoading ? (
-												<>
-													{ weeklySpendFormatted }{ ' ' }
-													<span className="campaign-item-details__details">
-														/ { totalBudgetFormatted }
-													</span>
-												</>
-											) : (
-												<FlexibleSkeleton />
-											) }
+											{ ! isLoading ? durationDateFormatted : <FlexibleSkeleton /> }
 										</span>
 										<span className="campaign-item-details__details">
-											{ ! isLoading ? weeklySpendingPercentageFormatted : <FlexibleSkeleton /> }
+											{ ! isLoading ? durationFormatted : <FlexibleSkeleton /> }
 										</span>
 									</div>
-								) : (
+									{ is_evergreen ? (
+										<div>
+											<span className="campaign-item-details__label">{ __( 'Weekly spend' ) }</span>
+											<span className="campaign-item-details__text wp-brand-font">
+												{ ! isLoading ? (
+													<>
+														{ weeklySpendFormatted }{ ' ' }
+														<span className="campaign-item-details__details">
+															/ { totalBudgetFormatted }
+														</span>
+													</>
+												) : (
+													<FlexibleSkeleton />
+												) }
+											</span>
+											<span className="campaign-item-details__details">
+												{ ! isLoading ? weeklySpendingPercentageFormatted : <FlexibleSkeleton /> }
+											</span>
+										</div>
+									) : (
+										<div>
+											<span className="campaign-item-details__label">{ __( 'Budget' ) }</span>
+											<span className="campaign-item-details__text wp-brand-font">
+												{ ! isLoading ? totalBudgetFormatted : <FlexibleSkeleton /> }
+											</span>
+											<span className="campaign-item-details__details">
+												{ ! isLoading ? (
+													`${ budgetRemainingFormatted } remaining`
+												) : (
+													<FlexibleSkeleton />
+												) }
+											</span>
+										</div>
+									) }
 									<div>
-										<span className="campaign-item-details__label">{ __( 'Budget' ) }</span>
-										<span className="campaign-item-details__text wp-brand-font">
-											{ ! isLoading ? totalBudgetFormatted : <FlexibleSkeleton /> }
+										<span className="campaign-item-details__label">
+											{ translate( 'Overall spending' ) }
 										</span>
-										<span className="campaign-item-details__details">
-											{ ! isLoading ? (
-												`${ budgetRemainingFormatted } remaining`
-											) : (
-												<FlexibleSkeleton />
-											) }
+										<span className="campaign-item-details__text wp-brand-font">
+											{ ! isLoading ? overallSpendingFormatted : <FlexibleSkeleton /> }
 										</span>
 									</div>
-								) }
-								<div>
-									<span className="campaign-item-details__label">
-										{ translate( 'Overall spending' ) }
-									</span>
-									<span className="campaign-item-details__text wp-brand-font">
-										{ ! isLoading ? overallSpendingFormatted : <FlexibleSkeleton /> }
-									</span>
 								</div>
-							</div>
+							) }
 						</div>
 
 						<div className="campaign-item-details__main-stats-container">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -797,6 +797,11 @@ export default function CampaignItemDetails( props: Props ) {
 													);
 											  } )
 											: [] }
+										{ orders && orders.length > 0 && (
+											<div className="campaign-item-details__weekly-orders-row">
+												<div className="campaign-item-details__weekly-orders-seperator"></div>
+											</div>
+										) }
 										<div className="campaign-item-details__secondary-payment-row">
 											{ payment_method && card_name && (
 												<>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -115,7 +115,7 @@ export default function CampaignItemDetails( props: Props ) {
 		format,
 		budget_cents,
 		type,
-		is_evergreen = false,
+		is_evergreen = true,
 	} = campaign || {};
 
 	const {
@@ -152,11 +152,8 @@ export default function CampaignItemDetails( props: Props ) {
 	// Formatted labels
 	const ctrFormatted = clickthrough_rate ? `${ clickthrough_rate.toFixed( 2 ) }%` : '-';
 	const clicksFormatted = clicks_total && clicks_total > 0 ? clicks_total : '-';
-	const totalBudgetWeekly = budget_cents ? ( budget_cents / 100 ) * 7 : 0;
-	const displayBudget = is_evergreen ? totalBudgetWeekly : total_budget;
-	const totalBudgetFormatted = `$${ formatCents( displayBudget || 0, 2 ) }`;
-
 	const weeklyBudget = budget_cents ? ( budget_cents / 100 ) * 7 : 0;
+
 	const weeklyBudgetFormatted = `$${ formatCents( weeklyBudget || 0, 2 ) }`;
 	const weeklySpend =
 		total_budget_used && billing_data ? total_budget_used - billing_data?.total : 0;
@@ -172,6 +169,9 @@ export default function CampaignItemDetails( props: Props ) {
 				args: { weeklySpendingPercentage },
 		  } )
 		: '';
+
+	const displayBudget = is_evergreen ? weeklyBudget : total_budget;
+	const totalBudgetFormatted = `$${ formatCents( displayBudget || 0, 2 ) }`;
 
 	const deliveryEstimateFormatted = getCampaignEstimatedImpressions( display_delivery_estimate );
 	const campaignTitleFormatted = title || __( 'Untitled' );

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -389,6 +389,34 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		.campaign-item-details__secondary-stats-interests-mobile {
 			display: none;
 		}
+
+		.campaign-item-details__weekly-orders-row {
+			display: grid;
+			grid-template-columns: 42% 43% 15%;
+			flex-grow: 1;
+			justify-content: space-between;
+			width: 100%;
+
+			> div {
+				display: flex;
+				flex-direction: column;
+				padding: 16px;
+
+				> span {
+					display: flex;
+					align-items: center;
+				}
+			}
+
+			.campaign-item-details__weekly-amount {
+				text-align: right;
+
+				> span {
+					text-align: right;
+				}
+			}
+		}
+
 		.campaign-item-details__secondary-payment-row {
 			display: grid;
 			grid-template-columns: 42% 58%;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -394,18 +394,15 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			display: grid;
 			grid-template-columns: 42% 43% 15%;
 			flex-grow: 1;
+			margin-top: 8px;
 			justify-content: space-between;
 			width: 100%;
 
 			> div {
 				display: flex;
 				flex-direction: column;
-				padding: 16px;
+				padding: 8px 16px 0;
 
-				> span {
-					display: flex;
-					align-items: center;
-				}
 			}
 
 			.campaign-item-details__weekly-amount {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -292,6 +292,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			}
 		}
 
+		.campaign-item-details__impressions .campaign-item-details__main-stats-row {
+			border-bottom: 1px solid #ddd;
+		}
+
 		.campaign-item-details__main-stats-row-bottom {
 			display: flex;
 			flex-direction: row;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -405,7 +405,6 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				display: flex;
 				flex-direction: column;
 				padding: 8px 16px 0;
-
 			}
 
 			@media (max-width: ($break-medium + 425)) {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -390,11 +390,14 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			display: none;
 		}
 
+		.campaign-item-details__payment-row {
+			margin: 24px 0;
+		}
+
 		.campaign-item-details__weekly-orders-row {
 			display: grid;
 			grid-template-columns: 42% 43% 15%;
 			flex-grow: 1;
-			margin-top: 8px;
 			justify-content: space-between;
 			width: 100%;
 
@@ -403,6 +406,24 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				flex-direction: column;
 				padding: 8px 16px 0;
 
+			}
+
+			@media (max-width: ($break-medium + 425)) {
+				grid-template-columns: 60% 40%;
+			}
+
+			.campaign-item-details__weekly-label {
+				@media (max-width: ($break-medium + 425)) {
+					display: none;
+				}
+			}
+
+			.campaign-item-details__weekly-orders-seperator {
+				background: #dcdcde;
+				height: 1px;
+				margin: 24px 16px 8px;
+				padding: 0;
+				grid-column: 1 / 4; /* Span across all columns */
 			}
 
 			.campaign-item-details__weekly-amount {

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -109,25 +109,35 @@ export const getCampaignDurationDays = ( start_date: string, end_date: string ) 
 	return calculateDurationDays( dateStart, dateEnd );
 };
 
-export const getCampaignDurationFormatted = ( start_date?: string, end_date?: string ) => {
+export const getCampaignDurationFormatted = (
+	start_date?: string,
+	end_date?: string,
+	is_evergreen = false,
+	status: string = ''
+) => {
 	if ( ! start_date || ! end_date ) {
 		return '-';
 	}
 
 	const campaignDays = getCampaignDurationDays( start_date, end_date );
 
-	let durationFormatted;
 	if ( campaignDays === 0 ) {
-		durationFormatted = '-';
-	} else {
-		// translators: Moment.js date format, `MMM` refers to short month name (e.g. `Sep`), `D`` refers to day of month (e.g. `5`). Wrap text [] to be displayed as is, for example `D [de] MMM` will be formatted as `5 de sep.`.
-		const format = _x( 'MMM D', 'shorter date format' );
-		const dateStartFormatted = moment.utc( start_date ).format( format );
-		const dateEndFormatted = moment.utc( end_date ).format( format );
-		durationFormatted = `${ dateStartFormatted } - ${ dateEndFormatted }`;
+		return '-';
 	}
 
-	return durationFormatted;
+	// translators: Moment.js date format, `MMM` refers to short month name (e.g. `Sep`), `D`` refers to day of month (e.g. `5`). Wrap text [] to be displayed as is, for example `D [de] MMM` will be formatted as `5 de sep.`.
+	const format = _x( 'MMM D', 'shorter date format' );
+	const dateStartFormatted = moment.utc( start_date ).format( format );
+
+	// A campaign without an "end date", show start -> today (if not ended)
+	if ( is_evergreen && status === 'active' ) {
+		const todayFormatted = moment.utc().format( format );
+		return `${ dateStartFormatted } - ${ todayFormatted }`;
+	}
+
+	// Else show start -> end
+	const dateEndFormatted = moment.utc( end_date ).format( format );
+	return `${ dateStartFormatted } - ${ dateEndFormatted }`;
 };
 
 export const getCampaignActiveDays = ( start_date?: string, end_date?: string ) => {

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -130,9 +130,15 @@ export const getCampaignDurationFormatted = (
 	const dateStartFormatted = moment.utc( start_date ).format( format );
 
 	// A campaign without an "end date", show start -> today (if not ended)
-	if ( is_evergreen && status === 'active' ) {
+	if ( is_evergreen ) {
 		const todayFormatted = moment.utc().format( format );
-		return `${ dateStartFormatted } - ${ todayFormatted }`;
+		if ( status === 'active' ) {
+			return `${ dateStartFormatted } - ${ todayFormatted }`;
+		}
+
+		if ( status === 'scheduled' ) {
+			return '-';
+		}
 	}
 
 	// Else show start -> end


### PR DESCRIPTION
Related to #



## Proposed Changes
**Before**
![Screenshot 2024-03-11 at 15 57 48](https://github.com/Automattic/wp-calypso/assets/6440498/8d9778c8-1bb2-4e66-a644-c3213cdea50b)

**After (left traditional, right evergreen)**
![Screenshot 2024-03-11 at 15 57 08](https://github.com/Automattic/wp-calypso/assets/6440498/f9d14d0a-c008-4259-9245-53fb91974718)

**Design**
![Screenshot 2024-03-12 at 16 10 18](https://github.com/Automattic/wp-calypso/assets/6440498/b29e7cb1-280c-4093-9768-bc64cc5f949a)


## Testing Instructions

Check the page using the live  link below, this should let you check a traditional campaign.

To test an evergreen campaign, you will need to load calypso locally, then force `is_evergreen` to `true`, see this commit for an example:
https://github.com/Automattic/wp-calypso/pull/88379/commits/ee1428a577ed6590efc33324c772feffb29b5d9c


Note: 

- "Duration so far" will only show when campaign is active too.
- Weekly spend summary will be in a follow on PR, I need to add this info to the campaign endpoint
- I've hidden stats when evergreen campaign is scheduled, Since "spent so far" values are all empty and so is impressions
![Screenshot 2024-03-12 at 17 33 11](https://github.com/Automattic/wp-calypso/assets/6440498/375ecd71-d1ac-46fc-b53a-64848945f9bf)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
