### PR TITLE
Jetpack Search Congrats page: fix typo/spacing

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -49,16 +49,12 @@ export default function JetpackSearchThankYou( { purchase }: JetpackSearchThankY
 			title={ translate( 'Welcome to Jetpack Search!' ) }
 			subtitle={
 				<>
-					<>
+					<p>{ translate( 'We are currently indexing your site.' ) }</p>
+					<p>
 						{ translate(
-							'{{paragraph}}We are currently indexing your site.{{/paragraph}}{{paragraph}}In the meantime, we have configured Jetpack Search on your site — you should try customizing it in your traditional WordPress dashboard.{{/paragraph}}',
-							{
-								components: {
-									paragraph: <p />,
-								},
-							}
+							'In the meantime, we have configured Jetpack Search on your site — you should try customizing it in your traditional WordPress dashboard.'
 						) }
-					</>
+					</p>
 				</>
 			}
 			products={ <ThankYouJetpackSearchProduct siteId={ siteId } purchase={ purchase } /> }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -49,10 +49,14 @@ export default function JetpackSearchThankYou( { purchase }: JetpackSearchThankY
 			title={ translate( 'Welcome to Jetpack Search!' ) }
 			subtitle={
 				<>
-					<>{ translate( 'We are currently indexing your site.' ) }</>
 					<>
 						{ translate(
-							'In the meantime, we have configured Jetpack Search on your site — you should try customizing it in your traditional WordPress dashboard.'
+							'{{paragraph}}We are currently indexing your site.{{/paragraph}}{{paragraph}}In the meantime, we have configured Jetpack Search on your site — you should try customizing it in your traditional WordPress dashboard.{{/paragraph}}',
+							{
+								components: {
+									paragraph: <p />,
+								},
+							}
 						) }
 					</>
 				</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88262

## Proposed Changes

- Add markup to header text to fix a spacing issue between the two sentences in the content.

**Before**
<img width="717" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13856531/bacbeaf4-d0dc-464a-bf3e-74571170cea8">

**After**
<img width="781" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13856531/2e3d2596-b60e-46bd-b30f-2942b85dc2b5">

Previously there was no space between "...indexing your site" and "In the meantime..."

adding some vertical spacing via paragraph tags is more in line with the layout of the previous design.

## Testing Instructions

Purchase Jetpack Search and confirm that the text is properly formatted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
