### PR TITLE
Plugins update manager: Fix button busy state colors

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -37,7 +37,7 @@ export const ScheduleCreate = ( props: Props ) => {
 	);
 
 	const pendingMutations = useMutationState( {
-		filters: { mutationKey: [ 'edit-update-schedule', siteSlug ], status: 'pending' },
+		filters: { mutationKey: [ 'create-update-schedule', siteSlug ], status: 'pending' },
 	} );
 	const isBusy = pendingMutations.length > 0;
 	const [ syncError, setSyncError ] = useState( '' );

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -16,6 +16,7 @@
 
 	.components-button.is-primary.is-busy {
 		background-image: linear-gradient(-45deg, var(--color-accent) 28%, var(--color-accent-60) 28%, var(--color-accent-60) 72%, var(--color-accent) 72%);
+		background-size: 100px 100%;
 	}
 
 	.components-text {

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -14,6 +14,10 @@
 		min-height: 2.25rem;
 	}
 
+	.components-button.is-primary.is-busy {
+		background-image: linear-gradient(-45deg, var(--color-accent) 28%, var(--color-accent-60) 28%, var(--color-accent-60) 72%, var(--color-accent) 72%);
+	}
+
 	.components-text {
 		color: var(--studio-gray-60);
 		font-size: 0.875rem;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88231

## Proposed Changes

* Fixed button busy state color

| Before | Now |
|--------|--------|
| ![Screen Capture on 2024-03-11 at 17-53-29](https://github.com/Automattic/wp-calypso/assets/1241413/83007821-2d4c-4e00-9ff7-70ff34f41a03) | ![Screen Capture on 2024-03-11 at 17-54-17](https://github.com/Automattic/wp-calypso/assets/1241413/56a9b70f-36a6-4f19-a5a0-5ba60c6e34eb) | 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates`
* Select the site
* Create or edit a schedule
* Check the button color (see gifs above)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?