### PR TITLE
Add set primary domain dropdown

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -230,6 +230,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/settings/privacy-settings/#preview-link',
 		post_id: 1507,
 	},
+	'primary-site-address': {
+		link: 'https://wordpress.com/support/domains/set-a-primary-address/',
+		post_id: 197437,
+	},
 	publicize: {
 		link: 'https://wordpress.com/support/post-automatically-to-social-media/',
 		post_id: 216472,

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -10,7 +10,7 @@ type PrimaryDomainSelectorProps = {
 	domains: undefined | DomainData[];
 	userCanSetPrimaryDomains: boolean;
 	site: undefined | null | SiteDetails;
-	onSetPrimaryDomain: ( domain: string, onComplete: () => void ) => void;
+	onSetPrimaryDomain: ( domain: string, onComplete: () => void, type: string ) => void;
 };
 
 const PrimaryDomainSelector = ( {
@@ -64,8 +64,14 @@ const PrimaryDomainSelector = ( {
 
 	const onSelectChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
 		setSelectedDomain( event.target.value );
+
+		const domain = domains.find( ( d ) => d.domain === event.target.value );
+		if ( ! domain ) {
+			return;
+		}
+
 		setIsSettingPrimaryDomain( true );
-		onSetPrimaryDomain( event.target.value, () => setIsSettingPrimaryDomain( false ) );
+		onSetPrimaryDomain( event.target.value, () => setIsSettingPrimaryDomain( false ), domain.type );
 	};
 
 	return (
@@ -84,7 +90,9 @@ const PrimaryDomainSelector = ( {
 				value={ selectedDomain }
 			>
 				{ validPrimaryDomains.map( ( domain ) => (
-					<option key={ domain.domain }>{ domain.domain }</option>
+					<option key={ domain.domain } value={ domain.domain }>
+						{ domain.domain }
+					</option>
 				) ) }
 			</FormSelect>
 		</div>

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -150,7 +150,7 @@ const PrimaryDomainSelector = ( {
 								},
 							}
 						) }
-					{ validPrimaryDomains.length > 1 &&
+					{ validPrimaryDomains.length > 0 &&
 						canUserSetPrimaryDomainOnThisSite &&
 						translate(
 							'You can change it by selecting a different address from the list below. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
@@ -184,7 +184,7 @@ const PrimaryDomainSelector = ( {
 							}
 						) }
 				</p>
-				{ validPrimaryDomains.length > 1 && (
+				{ validPrimaryDomains.length > 0 && (
 					<FormFieldset className="domains-set-primary-address__fieldset">
 						<FormSelect
 							disabled={ isSettingPrimaryDomain || ! canUserSetPrimaryDomainOnThisSite }

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -26,8 +26,8 @@ const PrimaryDomainSelector = ( {
 	site,
 	onSetPrimaryDomain,
 }: PrimaryDomainSelectorProps ) => {
-	const [ selectedDomain, setSelectedDomain ] = useState< undefined | string >( undefined );
-	const [ primaryDomain, setPrimaryDomain ] = useState< undefined | string >( undefined );
+	const [ selectedDomain, setSelectedDomain ] = useState< string >( '' );
+	const [ primaryDomain, setPrimaryDomain ] = useState< string >( '' );
 	const [ isSettingPrimaryDomain, setIsSettingPrimaryDomain ] = useState< boolean >( false );
 
 	const translate = useTranslate();
@@ -43,7 +43,7 @@ const PrimaryDomainSelector = ( {
 			} );
 			if ( primary ) {
 				setPrimaryDomain( primary.domain );
-				setSelectedDomain( undefined );
+				setSelectedDomain( '' );
 			}
 		}
 	}, [ domains ] );
@@ -104,7 +104,7 @@ const PrimaryDomainSelector = ( {
 			selectedDomain,
 			() => {
 				setIsSettingPrimaryDomain( false );
-				setSelectedDomain( undefined );
+				setSelectedDomain( '' );
 			},
 			domain.type
 		);
@@ -115,10 +115,6 @@ const PrimaryDomainSelector = ( {
 			cta_name: isPlanUpgrade ? 'buy_a_plan' : 'add_custom_domain',
 		} );
 	};
-
-	if ( validPrimaryDomains.length > 0 && ! selectedDomain ) {
-		setSelectedDomain( validPrimaryDomains[ 0 ].domain );
-	}
 
 	return (
 		<Card className="domains-set-primary-address">
@@ -175,13 +171,13 @@ const PrimaryDomainSelector = ( {
 								components: {
 									domainSearchLink: (
 										<a
-											href={ '/domains/add/use-my-domain/' + primaryDomain }
+											href={ '/domains/add/' + primaryDomain }
 											onClick={ () => trackUpgradeClick( false ) }
 										/>
 									),
 									mapDomainLink: (
 										<a
-											href={ '/domains/add/' + primaryDomain }
+											href={ '/domains/add/use-my-domain/' + primaryDomain }
 											onClick={ () => trackUpgradeClick( false ) }
 										/>
 									),
@@ -197,6 +193,7 @@ const PrimaryDomainSelector = ( {
 							onChange={ onSelectChange }
 							value={ selectedDomain }
 						>
+							<option value="">Select a domain</option>
 							{ validPrimaryDomains.map( ( domain ) => (
 								<option key={ domain.domain } value={ domain.domain }>
 									{ domain.domain }
@@ -207,7 +204,9 @@ const PrimaryDomainSelector = ( {
 							className="domains-set-primary-address__submit"
 							primary
 							busy={ isSettingPrimaryDomain }
-							disabled={ isSettingPrimaryDomain || ! canUserSetPrimaryDomainOnThisSite }
+							disabled={
+								isSettingPrimaryDomain || ! canUserSetPrimaryDomainOnThisSite || ! selectedDomain
+							}
 							onClick={ onSubmit }
 						>
 							{ translate( 'Set as primary site address' ) }

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { FormLabel } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState, ChangeEvent, useEffect, FormEvent } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
@@ -101,8 +100,6 @@ const PrimaryDomainSelector = ( {
 		onSetPrimaryDomain( selectedDomain, () => setIsSettingPrimaryDomain( false ), domain.type );
 	};
 
-	const supportLink = localizeUrl( 'https://wordpress.com/support/domains/set-a-primary-address/' );
-
 	const trackUpgradeClick = () => {
 		recordTracksEvent( 'calypso_primary_site_address_nudge_cta_click', {
 			cta_name: 'add_custom_domain',
@@ -131,7 +128,7 @@ const PrimaryDomainSelector = ( {
 								{
 									components: {
 										learnMoreLink: (
-											<InlineSupportLink supportLink={ supportLink } showIcon={ false } />
+											<InlineSupportLink supportContext="primary-site-address" showIcon={ false } />
 										),
 									},
 								}

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -43,6 +43,7 @@ const PrimaryDomainSelector = ( {
 			} );
 			if ( primary ) {
 				setPrimaryDomain( primary.domain );
+				setSelectedDomain( undefined );
 			}
 		}
 	}, [ domains ] );
@@ -69,15 +70,12 @@ const PrimaryDomainSelector = ( {
 		return (
 			domain.can_set_as_primary &&
 			! domain.aftermarket_auction &&
-			domain.points_to_wpcom &&
 			! shouldUpgradeToMakeDomainPrimary( domain ) &&
 			! domain.primary_domain
 		);
 	} );
 
-	const hasWpcomStagingDomain = validPrimaryDomains.find(
-		( domain ) => domain.is_wpcom_staging_domain
-	);
+	const hasWpcomStagingDomain = domains.find( ( domain ) => domain.is_wpcom_staging_domain );
 
 	if ( hasWpcomStagingDomain ) {
 		validPrimaryDomains = validPrimaryDomains.filter( ( domain ) => {
@@ -102,7 +100,14 @@ const PrimaryDomainSelector = ( {
 		}
 
 		setIsSettingPrimaryDomain( true );
-		onSetPrimaryDomain( selectedDomain, () => setIsSettingPrimaryDomain( false ), domain.type );
+		onSetPrimaryDomain(
+			selectedDomain,
+			() => {
+				setIsSettingPrimaryDomain( false );
+				setSelectedDomain( undefined );
+			},
+			domain.type
+		);
 	};
 
 	const trackUpgradeClick = ( isPlanUpgrade: boolean = false ) => {

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -1,12 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
-import { FormLabel } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, ChangeEvent, useEffect, FormEvent } from 'react';
+import CardHeading from 'calypso/components/card-heading';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
@@ -116,12 +116,17 @@ const PrimaryDomainSelector = ( {
 	}
 
 	return (
-		<FormFieldset className="domains-set-primary-address">
-			<FormLabel htmlFor="primary-domain-selector" className="domains-set-primary-address__title">
+		<Card className="domains-set-primary-address">
+			<CardHeading
+				className="domains-set-primary-address__title"
+				isBold={ true }
+				size={ 16 }
+				tagName="h2"
+			>
 				{ translate( 'Primary site address' ) }
-			</FormLabel>
-			<div>
-				<FormSettingExplanation className="domains-set-primary-address__subtitle">
+			</CardHeading>
+			<>
+				<p className="domains-set-primary-address__subtitle">
 					{ translate(
 						'The current primary address set for this site is: {{strong}}%(selectedDomain)s{{/strong}}.',
 						{
@@ -178,9 +183,9 @@ const PrimaryDomainSelector = ( {
 								},
 							}
 						) }
-				</FormSettingExplanation>
+				</p>
 				{ validPrimaryDomains.length > 1 && (
-					<>
+					<FormFieldset className="domains-set-primary-address__fieldset">
 						<FormSelect
 							disabled={ isSettingPrimaryDomain || ! canUserSetPrimaryDomainOnThisSite }
 							id="primary-domain-selector"
@@ -193,7 +198,6 @@ const PrimaryDomainSelector = ( {
 								</option>
 							) ) }
 						</FormSelect>
-
 						<FormButton
 							className="domains-set-primary-address__submit"
 							primary
@@ -203,10 +207,10 @@ const PrimaryDomainSelector = ( {
 						>
 							{ translate( 'Set as primary site address' ) }
 						</FormButton>
-					</>
+					</FormFieldset>
 				) }
-			</div>
-		</FormFieldset>
+			</>
+		</Card>
 	);
 };
 

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -210,7 +210,7 @@ const PrimaryDomainSelector = ( {
 							}
 							onClick={ onSubmit }
 						>
-							{ translate( 'Set as primary site address' ) }
+							{ translate( 'Set as primary' ) }
 						</FormButton>
 					</FormFieldset>
 				) }

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -1,0 +1,42 @@
+import { useState, ChangeEvent } from 'react';
+import FormSelect from 'calypso/components/forms/form-select';
+import type { DomainData } from '@automattic/data-stores';
+
+// import './style.scss';
+
+type PrimaryDomainSelectorProps = {
+	domains: undefined | DomainData[];
+};
+
+const PrimaryDomainSelector = ( { domains }: PrimaryDomainSelectorProps ) => {
+	const [ selectedDomain, setSelectedDomain ] = useState< undefined | string >( undefined );
+
+	if ( ! domains ) {
+		return null;
+	}
+
+	const validPrimaryDomains = domains.filter( ( domain ) => {
+		return domain.can_set_as_primary;
+	} );
+
+	// const primaryDomain = validPrimaryDomains.find( ( domain ) => {
+	// 	return domain.primary_domain;
+	// } );
+
+	const changeType = ( event: ChangeEvent< HTMLSelectElement > ) => {
+		setSelectedDomain( event.target.value );
+	};
+
+	return (
+		<div>
+			PRIMARY DOMAIN DROPDOWN
+			<FormSelect onChange={ changeType } value={ selectedDomain }>
+				{ validPrimaryDomains.map( ( domain ) => (
+					<option key={ domain.domain }>{ domain.domain }</option>
+				) ) }
+			</FormSelect>
+		</div>
+	);
+};
+
+export default PrimaryDomainSelector;

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -53,7 +53,7 @@ const PrimaryDomainSelector = ( {
 		);
 	};
 
-	const validPrimaryDomains = domains.filter( ( domain ) => {
+	let validPrimaryDomains = domains.filter( ( domain ) => {
 		return (
 			domain.can_set_as_primary &&
 			! domain.aftermarket_auction &&
@@ -61,6 +61,20 @@ const PrimaryDomainSelector = ( {
 			! shouldUpgradeToMakeDomainPrimary( domain )
 		);
 	} );
+
+	const hasWpcomStagingDomain = validPrimaryDomains.find(
+		( domain ) => domain.is_wpcom_staging_domain
+	);
+
+	if ( hasWpcomStagingDomain ) {
+		validPrimaryDomains = validPrimaryDomains.filter( ( domain ) => {
+			if ( domain.wpcom_domain ) {
+				return domain.is_wpcom_staging_domain;
+			}
+
+			return true;
+		} );
+	}
 
 	const onSelectChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
 		setSelectedDomain( event.target.value );

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -188,12 +188,13 @@ const PrimaryDomainSelector = ( {
 				{ validPrimaryDomains.length > 0 && (
 					<FormFieldset className="domains-set-primary-address__fieldset">
 						<FormSelect
+							className="domains-set-primary-address__select"
 							disabled={ isSettingPrimaryDomain || ! canUserSetPrimaryDomainOnThisSite }
 							id="primary-domain-selector"
 							onChange={ onSelectChange }
 							value={ selectedDomain }
 						>
-							<option value="">Select a domain</option>
+							<option value="">{ translate( 'Select a domain' ) }</option>
 							{ validPrimaryDomains.map( ( domain ) => (
 								<option key={ domain.domain } value={ domain.domain }>
 									{ domain.domain }

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -1,7 +1,12 @@
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import { FormLabel } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState, ChangeEvent, useEffect } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import type { DomainData, SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
@@ -88,28 +93,40 @@ const PrimaryDomainSelector = ( {
 		onSetPrimaryDomain( event.target.value, () => setIsSettingPrimaryDomain( false ), domain.type );
 	};
 
+	const supportLink = localizeUrl( 'https://wordpress.com/support/domains/set-a-primary-address/' );
+
 	return (
-		<div className="domains-set-primary-address">
-			<div className="domains-set-primary-address__title">
+		<FormFieldset className="domains-set-primary-address">
+			<FormLabel htmlFor="primary-domain-selector" className="domains-set-primary-address__title">
 				{ translate( 'Primary site address' ) }
+			</FormLabel>
+			<div>
+				<FormSettingExplanation className="domains-set-primary-address__subtitle">
+					{ translate(
+						'The current primary address set for this site is: {{strong}}%(selectedDomain)s{{/strong}}. You can change it by selecting a different address from the list below. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							args: { selectedDomain: selectedDomain as string },
+							components: {
+								strong: <strong />,
+								learnMoreLink: <InlineSupportLink supportLink={ supportLink } showIcon={ false } />,
+							},
+						}
+					) }
+				</FormSettingExplanation>
+				<FormSelect
+					disabled={ isSettingPrimaryDomain }
+					id="primary-domain-selector"
+					onChange={ onSelectChange }
+					value={ selectedDomain }
+				>
+					{ validPrimaryDomains.map( ( domain ) => (
+						<option key={ domain.domain } value={ domain.domain }>
+							{ domain.domain }
+						</option>
+					) ) }
+				</FormSelect>
 			</div>
-			<div className="domains-set-primary-address__subtitle">
-				{ translate( 'The current primary address set for this site is:' ) }{ ' ' }
-				<b>{ selectedDomain }</b>.{ ' ' }
-				{ translate( 'You can change it by selecting a different address from the list below.' ) }
-			</div>
-			<FormSelect
-				disabled={ isSettingPrimaryDomain }
-				onChange={ onSelectChange }
-				value={ selectedDomain }
-			>
-				{ validPrimaryDomains.map( ( domain ) => (
-					<option key={ domain.domain } value={ domain.domain }>
-						{ domain.domain }
-					</option>
-				) ) }
-			</FormSelect>
-		</div>
+		</FormFieldset>
 	);
 };
 

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -1,27 +1,54 @@
-import { useState, ChangeEvent } from 'react';
+import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import { useState, ChangeEvent, useEffect } from 'react';
 import FormSelect from 'calypso/components/forms/form-select';
-import type { DomainData } from '@automattic/data-stores';
+import type { DomainData, SiteDetails } from '@automattic/data-stores';
 
 // import './style.scss';
 
 type PrimaryDomainSelectorProps = {
 	domains: undefined | DomainData[];
+	userCanSetPrimaryDomains: boolean;
+	site: undefined | null | SiteDetails;
 };
 
-const PrimaryDomainSelector = ( { domains }: PrimaryDomainSelectorProps ) => {
+const PrimaryDomainSelector = ( {
+	domains,
+	site,
+	userCanSetPrimaryDomains,
+}: PrimaryDomainSelectorProps ) => {
 	const [ selectedDomain, setSelectedDomain ] = useState< undefined | string >( undefined );
 
-	if ( ! domains ) {
+	useEffect( () => {
+		if ( domains?.length ) {
+			const primaryDomain = domains.find( ( domain ) => {
+				return domain.primary_domain;
+			} );
+			if ( primaryDomain ) {
+				setSelectedDomain( primaryDomain.domain );
+			}
+		}
+	}, [ domains ] );
+
+	if ( ! domains || ! site ) {
 		return null;
 	}
 
 	const validPrimaryDomains = domains.filter( ( domain ) => {
-		return domain.can_set_as_primary;
+		return (
+			domain.can_set_as_primary &&
+			! domain.aftermarket_auction &&
+			! (
+				( ! userCanSetPrimaryDomains && site?.plan?.is_free ) ??
+				( true &&
+					( domain.type === 'registered' || domain.type === 'mapping' ) &&
+					! domain.current_user_can_create_site_from_domain_only &&
+					! domain.wpcom_domain &&
+					! domain.is_wpcom_staging_domain &&
+					( site?.plan?.features.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false ) )
+			) &&
+			domain.points_to_wpcom
+		);
 	} );
-
-	// const primaryDomain = validPrimaryDomains.find( ( domain ) => {
-	// 	return domain.primary_domain;
-	// } );
 
 	const changeType = ( event: ChangeEvent< HTMLSelectElement > ) => {
 		setSelectedDomain( event.target.value );

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -102,6 +103,12 @@ const PrimaryDomainSelector = ( {
 
 	const supportLink = localizeUrl( 'https://wordpress.com/support/domains/set-a-primary-address/' );
 
+	const trackUpgradeClick = () => {
+		recordTracksEvent( 'calypso_primary_site_address_nudge_cta_click', {
+			cta_name: 'add_custom_domain',
+		} );
+	};
+
 	return (
 		<FormFieldset className="domains-set-primary-address">
 			<FormLabel htmlFor="primary-domain-selector" className="domains-set-primary-address__title">
@@ -130,7 +137,20 @@ const PrimaryDomainSelector = ( {
 								}
 						  )
 						: translate(
-								'If you want to change it you can add a new custom domain for your site'
+								'Before you can change the primary site address you have to add a new custom domain. Buy a {{domainSearchLink}}custom domain{{/domainSearchLink}} or {{mapDomainLink}}map{{/mapDomainLink}} a domain you already own.',
+								{
+									components: {
+										domainSearchLink: (
+											<a
+												href={ '/domains/add/use-my-domain/' + primaryDomain }
+												onClick={ trackUpgradeClick }
+											/>
+										),
+										mapDomainLink: (
+											<a href={ '/domains/add/' + primaryDomain } onClick={ trackUpgradeClick } />
+										),
+									},
+								}
 						  ) }
 				</FormSettingExplanation>
 				{ validPrimaryDomains.length > 1 && (

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -12,7 +12,6 @@
 	&__subtitle.form-setting-explanation {
 		font-style: normal;
 		margin-bottom: 1em;
-		color: var(--color-text-subtle);
 	}
 	&__submit {
 		margin-left: 12px;

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .domains-set-primary-address {
 	&__title {
 		margin-top: 0;
@@ -12,7 +14,13 @@
 		margin-bottom: 0;
 	}
 	&__submit {
-		margin-left: 12px;
 		margin-right: 0;
+		margin-top: 12px;
+		display: block;
+		@media ( min-width: $break-large ) {
+			display: inline-block;
+			margin-top: 0;
+			margin-left: 12px;
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -1,17 +1,17 @@
 .domains-set-primary-address {
-	margin-bottom: 2em;
-	box-shadow: 0 0 0 1px var(--color-border-subtle);
-	padding: 24px;
-	&__title {
-		margin-bottom: 0;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1.5em;
-		font-weight: 600;
-		color: var(--studio-gray-80);
+	&.form-fieldset {
+		margin-bottom: 2em;
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+		padding: 24px;
 	}
-	&__subtitle {
-		font-size: $font-body-small;
+	&__title.form-label {
+		margin-bottom: 0.5em;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+	&__subtitle.form-setting-explanation {
+		font-style: normal;
 		margin-bottom: 1em;
-		color: var(--studio-gray-50);
+		color: var(--color-text-subtle);
 	}
 }

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -1,17 +1,15 @@
 .domains-set-primary-address {
-	&.form-fieldset {
-		margin-bottom: 2em;
-		box-shadow: 0 0 0 1px var(--color-border-subtle);
-		padding: 24px;
+	&__title {
+		margin-top: 0;
 	}
-	&__title.form-label {
-		margin-bottom: 0.5em;
-		font-size: 1rem;
-		font-weight: 600;
+	&__subtitle {
+		color: var(--color-text-subtle);
+		margin-bottom: 0;
+		font-size: 0.875rem;
 	}
-	&__subtitle.form-setting-explanation {
-		font-style: normal;
-		margin-bottom: 1em;
+	&__fieldset.form-fieldset {
+		margin-top: 0.875rem;
+		margin-bottom: 0;
 	}
 	&__submit {
 		margin-left: 12px;

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -14,4 +14,8 @@
 		margin-bottom: 1em;
 		color: var(--color-text-subtle);
 	}
+	&__submit {
+		margin-left: 12px;
+		margin-right: 0;
+	}
 }

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -1,0 +1,17 @@
+.domains-set-primary-address {
+	margin-bottom: 2em;
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+	padding: 24px;
+	&__title {
+		margin-bottom: 0;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		line-height: 1.5em;
+		font-weight: 600;
+		color: var(--studio-gray-80);
+	}
+	&__subtitle {
+		font-size: $font-body-small;
+		margin-bottom: 1em;
+		color: var(--studio-gray-50);
+	}
+}

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -13,6 +13,13 @@
 		margin-top: 0.875rem;
 		margin-bottom: 0;
 	}
+	&__select.form-select {
+		max-width: 100%;
+		width: 100%;
+		@media ( min-width: $break-large ) {
+			width: auto;
+		}
+	}
 	&__submit {
 		margin-right: 0;
 		margin-top: 12px;

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -10,6 +10,7 @@ import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useSelector, useDispatch } from 'calypso/state';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import {
@@ -99,8 +100,29 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					domains={ data?.domains }
 					site={ site }
 					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
-					onSetPrimaryDomain={ async ( domain: string, onComplete: () => void ) => {
+					onSetPrimaryDomain={ async (
+						domain: string,
+						onComplete: () => void,
+						type: string
+					): Promise< void > => {
 						if ( site ) {
+							dispatch(
+								recordGoogleEvent(
+									'Domain Management',
+									'Changed Primary Domain in Site Domains',
+									'Domain Name',
+									domain
+								)
+							);
+							dispatch(
+								recordTracksEvent(
+									'calypso_domain_management_settings_change_primary_domain_dropdown',
+									{
+										section: type,
+										mode: 'dropdown',
+									}
+								)
+							);
 							try {
 								await dispatch( setPrimaryDomain( site.ID, domain ) );
 								dispatch( showUpdatePrimaryDomainSuccessNotice( domain ) );

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -22,6 +22,7 @@ import { isSupportSession } from 'calypso/state/support/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { domainManagementList } from '../../paths';
 import DomainHeader from '../components/domain-header';
+import PrimaryDomainSelector from '../components/primary-domain-selector';
 import {
 	createBulkAction,
 	deleteBulkActionStatus,
@@ -94,6 +95,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				{ ! isLoading && <GoogleDomainOwnerBanner /> }
+				<PrimaryDomainSelector domains={ data?.domains } />
 				<DomainsTable
 					isLoadingDomains={ isLoading }
 					domains={ data?.domains }

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -99,6 +99,18 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					domains={ data?.domains }
 					site={ site }
 					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
+					onSetPrimaryDomain={ async ( domain: string ) => {
+						if ( site ) {
+							try {
+								await dispatch( setPrimaryDomain( site.ID, domain ) );
+								dispatch( showUpdatePrimaryDomainSuccessNotice( domain ) );
+								page.replace( domainManagementList( domain ) );
+								await refetch();
+							} catch ( error ) {
+								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
+							}
+						}
+					} }
 				/>
 				<DomainsTable
 					isLoadingDomains={ isLoading }

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -99,7 +99,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					domains={ data?.domains }
 					site={ site }
 					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
-					onSetPrimaryDomain={ async ( domain: string ) => {
+					onSetPrimaryDomain={ async ( domain: string, onComplete: () => void ) => {
 						if ( site ) {
 							try {
 								await dispatch( setPrimaryDomain( site.ID, domain ) );
@@ -108,6 +108,8 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 								await refetch();
 							} catch ( error ) {
 								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
+							} finally {
+								onComplete();
 							}
 						}
 					} }

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -95,7 +95,11 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				{ ! isLoading && <GoogleDomainOwnerBanner /> }
-				<PrimaryDomainSelector domains={ data?.domains } />
+				<PrimaryDomainSelector
+					domains={ data?.domains }
+					site={ site }
+					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
+				/>
 				<DomainsTable
 					isLoadingDomains={ isLoading }
 					domains={ data?.domains }

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -99,7 +99,6 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 				<PrimaryDomainSelector
 					domains={ data?.domains }
 					site={ site }
-					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
 					onSetPrimaryDomain={ async (
 						domain: string,
 						onComplete: () => void,

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -67,8 +67,7 @@ export const DomainsTableRowActions = ( {
 				isSiteOnFreePlan,
 			} )
 		) &&
-		! isRecentlyRegistered( domain.registrationDate ) &&
-		domain.pointsToWpcom;
+		! isRecentlyRegistered( domain.registrationDate );
 	const canTransferToWPCOM =
 		domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer;
 	const canChangeSiteAddress =


### PR DESCRIPTION
## Proposed Changes

We noticed an increased support requests related to how set a primary domain for a site. This PR adds a new component on site domains page that should make easier to change the primary site address.

![primary-1](https://github.com/Automattic/wp-calypso/assets/2797601/fef3311f-b0d9-4794-875d-235ba0c7a36d)


If the site doesn't have any custom domain we show a message with links to buy and map a custom domain.

![primary-2](https://github.com/Automattic/wp-calypso/assets/2797601/8c1e6b3c-5a19-4f55-87ee-922faa94c46f)


If the site isn't eligible for setting custom domains (free plan and PWPO user) we show a message with a link to the upgrade plan page.

![primary-3](https://github.com/Automattic/wp-calypso/assets/2797601/e44656a8-ce76-4983-a93d-abb2cc6cb939)

## Testing Instructions

This patch should be tested in different scenarios:

**Paid plan (or free plan & exempt PWPO user) with custom domains**
- Verify that the message is `You can change it by selecting a different address from the list below. Learn more.`.
- Verify that you can change the primary domain using the dropdown.

** Paid plan (or free plan & exempt PWPO user) without custom domains**
- Verify that the message is `Before changing your primary site address you must register or connect a new custom domain.`.
- Verify that the dropdown is not rendered.

** Free plan (PWPO user) with custom domains **
** Free plan (PWPO user) without custom domains **
- Verify that the message is `Your site plan doesn't allow to set a custom domain as a primary site address. Upgrade your plan.`.
- Verify that the dropdown is not rendered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?