### PR TITLE
GitHub Deployments: Making it clear user can do a manual deployment later

### DIFF
--- a/client/my-sites/github-deployments/components/automated-deployments-toggle/index.tsx
+++ b/client/my-sites/github-deployments/components/automated-deployments-toggle/index.tsx
@@ -3,7 +3,7 @@ import { FormToggle } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import './style.scss';
 
 interface AutomatedDeploymentsToggleProps {
@@ -31,6 +31,9 @@ export const AutomatedDeploymentsToggle = ( {
 					} )
 				}
 			</div>
+			<FormSettingExplanation css={ { marginBottom: '0 !important' } }>
+				{ __( 'You can trigger a manual deployment later' ) }
+			</FormSettingExplanation>
 		</FormFieldset>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1710178958153179-slack-C06D9M3CHMK

## Proposed Changes

* Add a helper text to make it clear that user can make a manual deployment later

![image](https://github.com/Automattic/wp-calypso/assets/1044309/630351e6-5c20-4a7c-b002-2e1655a6f894)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?