### PR TITLE
Congrats: Add generic congrats page for handling multiple purchases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -587,7 +587,7 @@ export class CheckoutThankYou extends Component<
 		}
 
 		/** REFACTORED REDESIGN */
-		if ( purchases.length > 0 && isRefactoredForThankYouV2( this.props ) ) {
+		if ( this.isDataLoaded() && isRefactoredForThankYouV2( this.props ) ) {
 			let pageContent = null;
 			const domainPurchase = getDomainPurchase( purchases );
 			const gSuiteOrExtraLicenseOrGoogleWorkspace = purchases.find(

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -94,6 +94,7 @@ import ProPlanDetails from './pro-plan-details';
 import MasterbarStyled from './redesign-v2/masterbar-styled';
 import DomainBulkTransferThankYou from './redesign-v2/pages/domain-bulk-transfer';
 import DomainOnlyThankYou from './redesign-v2/pages/domain-only';
+import GenericThankYou from './redesign-v2/pages/generic';
 import JetpackSearchThankYou from './redesign-v2/pages/jetpack-search';
 import PlanOnlyThankYou from './redesign-v2/pages/plan-only';
 import { isRefactoredForThankYouV2 } from './redesign-v2/utils';
@@ -586,7 +587,7 @@ export class CheckoutThankYou extends Component<
 		}
 
 		/** REFACTORED REDESIGN */
-		if ( isRefactoredForThankYouV2( this.props ) ) {
+		if ( purchases.length > 0 && isRefactoredForThankYouV2( this.props ) ) {
 			let pageContent = null;
 			const domainPurchase = getDomainPurchase( purchases );
 			const gSuiteOrExtraLicenseOrGoogleWorkspace = purchases.find(
@@ -636,6 +637,8 @@ export class CheckoutThankYou extends Component<
 				pageContent = (
 					<GoogleWorkspaceSetUpThankYou purchase={ gSuiteOrExtraLicenseOrGoogleWorkspace } />
 				);
+			} else {
+				pageContent = <GenericThankYou purchases={ purchases } emailAddress={ email } />;
 			}
 
 			if ( pageContent ) {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-default-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-default-footer-details.ts
@@ -1,0 +1,24 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { ThankYouFooterDetailProps } from 'calypso/components/thank-you-v2/footer';
+
+export default function getDefaultFooterDetails( context: string ): ThankYouFooterDetailProps[] {
+	const footerDetails = [
+		{
+			key: 'footer-generic-support',
+			title: translate( 'Everything you need to know' ),
+			description: translate( 'Explore our support guides and find an answer to every question.' ),
+			buttonText: translate( 'Explore support resources' ),
+			buttonHref: localizeUrl( 'https://wordpress.com/support/' ),
+			buttonOnClick: () => {
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: context,
+					type: 'generic-support',
+				} );
+			},
+		},
+	];
+
+	return footerDetails;
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details.ts
@@ -1,0 +1,62 @@
+import { translate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
+import { getTitanControlPanelRedirectPath } from 'calypso/my-sites/email/paths';
+import type { ThankYouFooterDetailProps } from 'calypso/components/thank-you-v2/footer';
+
+export default function getTitanFooterDetails(
+	selectedSiteSlug: string,
+	domainName: string,
+	currentRoute: string,
+	context: string,
+	limit?: number
+): ThankYouFooterDetailProps[] {
+	const titanControlPanelUrl = getTitanControlPanelRedirectPath(
+		selectedSiteSlug,
+		domainName,
+		currentRoute,
+		{
+			context: TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP,
+		}
+	);
+
+	const footerDetails = [
+		{
+			key: 'footer-get-the-app',
+			title: translate( 'Manage your email and site from anywhere' ),
+			description: translate(
+				'The Jetpack mobile app for iOS and Android makes managing your email, domain, and website even simpler.'
+			),
+			buttonText: translate( 'Get the app' ),
+			buttonHref: titanControlPanelUrl,
+			buttonOnClick: () => {
+				recordEmailAppLaunchEvent( {
+					provider: 'titan',
+					app: 'app',
+					context: 'checkout-thank-you',
+				} );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context,
+					type: 'get-the-app',
+				} );
+			},
+		},
+		{
+			key: 'footer-questions-email',
+			title: translate( 'Email questions? We have the answers' ),
+			description: translate(
+				'Explore our comprehensive support guides and find solutions to all your email inquiries.'
+			),
+			buttonText: translate( 'Email support resources' ),
+			buttonHref: '/support/category/domains-and-email/email/',
+			buttonOnClick: () => {
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context,
+					type: 'questions-email',
+				} );
+			},
+		},
+	];
+
+	return footerDetails.slice( 0, limit ?? footerDetails.length );
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details.ts
@@ -7,7 +7,7 @@ import { getTitanControlPanelRedirectPath } from 'calypso/my-sites/email/paths';
 import type { ThankYouFooterDetailProps } from 'calypso/components/thank-you-v2/footer';
 
 export default function getTitanFooterDetails(
-	selectedSiteSlug: string,
+	selectedSiteSlug: string | null,
 	domainName: string,
 	currentRoute: string,
 	context: string,

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details.ts
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
@@ -48,7 +49,7 @@ export default function getTitanFooterDetails(
 				'Explore our comprehensive support guides and find solutions to all your email inquiries.'
 			),
 			buttonText: translate( 'Email support resources' ),
-			buttonHref: '/support/category/domains-and-email/email/',
+			buttonHref: localizeUrl( 'https://wordpress.com/support/category/domains-and-email/email/' ),
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
 					context,

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details.ts
@@ -2,6 +2,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
+import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { getTitanControlPanelRedirectPath } from 'calypso/my-sites/email/paths';
 import type { ThankYouFooterDetailProps } from 'calypso/components/thank-you-v2/footer';
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
@@ -1,4 +1,5 @@
 import { isDomainProduct, isPlan, isTitanMail } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
@@ -57,7 +58,17 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 			);
 		}
 
-		return <ThankYouProduct key={ purchase.productSlug } name={ purchase.productName } />;
+		return (
+			<ThankYouProduct
+				key={ purchase.productSlug }
+				name={ purchase.productName }
+				actions={
+					<Button href={ `/purchases/subscriptions/${ siteSlug }` }>
+						{ translate( 'Manage purchase' ) }
+					</Button>
+				}
+			/>
+		);
 	} );
 
 	let footerDetails = [];

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
@@ -13,6 +13,8 @@ import { ThankYouTitanProduct } from '../products/titan-product';
 import getDefaultFooterDetails from './content/get-default-footer-details';
 import getDomainFooterDetails from './content/get-domain-footer-details';
 import getTitanFooterDetails from './content/get-titan-footer-details';
+import type { ThankYouFooterDetailProps } from 'calypso/components/thank-you-v2/footer';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 interface GenericThankYouProps {
 	purchases: ReceiptPurchase[];
@@ -76,7 +78,7 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 		);
 	} );
 
-	let footerDetails = [];
+	let footerDetails: ThankYouFooterDetailProps[] = [];
 
 	// Footer details should contain at most two support blurbs. The first support blurb for
 	// each product will be used to populate the footer, with the exception of plan products.

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
@@ -87,7 +87,7 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 			footerDetails = footerDetails.concat( getDomainFooterDetails( 'generic', 1 ) );
 		} else if ( isTitanMail( purchase ) ) {
 			footerDetails = footerDetails.concat(
-				getTitanFooterDetails( siteSlug, purchase.meta, currentRoute, 'generic', 1 )
+				getTitanFooterDetails( siteSlug as string, purchase.meta, currentRoute, 'generic', 1 )
 			);
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
@@ -1,0 +1,94 @@
+import { isDomainProduct, isPlan, isTitanMail } from '@automattic/calypso-products';
+import { translate } from 'i18n-calypso';
+import ThankYouV2 from 'calypso/components/thank-you-v2';
+import ThankYouProduct from 'calypso/components/thank-you-v2/product';
+import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getDomainPurchaseTypeAndPredicate } from '../../utils';
+import ThankYouDomainProduct from '../products/domain-product';
+import ThankYouPlanProduct from '../products/plan-product';
+import { ThankYouTitanProduct } from '../products/titan-product';
+import getDefaultFooterDetails from './content/get-default-footer-details';
+import getDomainFooterDetails from './content/get-domain-footer-details';
+import getTitanFooterDetails from './content/get-titan-footer-details';
+
+interface GenericThankYouProps {
+	purchases: ReceiptPurchase[];
+	emailAddress?: string;
+}
+
+export default function GenericThankYou( { purchases, emailAddress }: GenericThankYouProps ) {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
+	const currentRoute = useSelector( getCurrentRoute );
+	const [ , predicate ] = getDomainPurchaseTypeAndPredicate( purchases );
+	const filteredPurchases = purchases.filter( ( purchase ) => {
+		return ! isDomainProduct( purchase ) || predicate( purchase );
+	} );
+
+	const products = filteredPurchases.map( ( purchase ) => {
+		if ( isDomainProduct( purchase ) ) {
+			return (
+				<ThankYouDomainProduct
+					key={ `domain-${ purchase.meta }` }
+					purchase={ purchase }
+					siteSlug={ siteSlug }
+				/>
+			);
+		} else if ( isPlan( purchase ) ) {
+			return (
+				<ThankYouPlanProduct
+					key={ `plan-${ purchase.productSlug }` }
+					purchase={ purchase }
+					siteSlug={ siteSlug }
+					siteId={ siteId }
+				/>
+			);
+		} else if ( isTitanMail( purchase ) ) {
+			return (
+				<ThankYouTitanProduct
+					key={ `email-${ purchase.meta }` }
+					domainName={ purchase.meta }
+					siteSlug={ siteSlug }
+					emailAddress={ emailAddress }
+					numberOfMailboxesPurchased={ purchase?.newQuantity }
+				/>
+			);
+		}
+
+		return <ThankYouProduct key={ purchase.productSlug } name={ purchase.productName } />;
+	} );
+
+	let footerDetails = [];
+
+	filteredPurchases.some( ( purchase ) => {
+		if ( isDomainProduct( purchase ) ) {
+			footerDetails = footerDetails.concat( getDomainFooterDetails( 'generic', 1 ) );
+		} else if ( isTitanMail( purchase ) ) {
+			footerDetails = footerDetails.concat(
+				getTitanFooterDetails( siteSlug, purchase.meta, currentRoute, 'generic', 1 )
+			);
+		}
+
+		if ( footerDetails.length >= 2 ) {
+			return;
+		}
+	} );
+
+	if ( footerDetails.length < 2 ) {
+		footerDetails = footerDetails.concat( getDefaultFooterDetails( 'generic' ) );
+	}
+
+	const title =
+		filteredPurchases.length > 1 ? translate( 'Great Choices!' ) : translate( 'Great Choice!' );
+
+	return (
+		<ThankYouV2
+			title={ title }
+			subtitle={ translate( 'All set! Ready to take your site even further?' ) }
+			products={ products }
+			footerDetails={ footerDetails.slice( 0, 2 ) }
+		/>
+	);
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
@@ -24,6 +24,11 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 	const siteId = useSelector( getSelectedSiteId );
 	const currentRoute = useSelector( getCurrentRoute );
 	const [ , predicate ] = getDomainPurchaseTypeAndPredicate( purchases );
+
+	// When users purchase a domain registration, we'll have two separate purchase items in the list,
+	// one for domain registration and one for domain mapping. This filter ensures we exclude the redundant
+	// item that should not be listed in the front end. i.e. a purchased domain registration should
+	// only be listed once in the congrats page.
 	const filteredPurchases = purchases.filter( ( purchase ) => {
 		return ! isDomainProduct( purchase ) || predicate( purchase );
 	} );
@@ -73,6 +78,8 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 
 	let footerDetails = [];
 
+	// Footer details should contain at most two support blurbs. The first support blurb for
+	// each product will be used to populate the footer, with the exception of plan products.
 	filteredPurchases.some( ( purchase ) => {
 		if ( isDomainProduct( purchase ) ) {
 			footerDetails = footerDetails.concat( getDomainFooterDetails( 'generic', 1 ) );
@@ -87,6 +94,7 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 		}
 	} );
 
+	// Fallback to the default generic support blurb if there less than two support blurbs in the footer.
 	if ( footerDetails.length < 2 ) {
 		footerDetails = footerDetails.concat( getDefaultFooterDetails( 'generic' ) );
 	}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -1,4 +1,4 @@
-import { isDomainTransfer } from '@automattic/calypso-products';
+import { isDomainMapping, isDomainTransfer } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -93,6 +93,7 @@ export default function ThankYouDomainProduct( {
 	return (
 		<ThankYouProduct
 			name={ domainName }
+			details={ isDomainMapping( purchase ) && translate( 'Domain connection' ) }
 			isFree={ purchase?.priceInteger === 0 }
 			actions={ actions }
 		/>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -90,10 +90,12 @@ export default function ThankYouDomainProduct( {
 		);
 	}
 
+	const isDomainConnection = purchase ? isDomainMapping( purchase as object ) : false;
+
 	return (
 		<ThankYouProduct
 			name={ domainName }
-			details={ isDomainMapping( purchase ) && translate( 'Domain connection' ) }
+			details={ isDomainConnection ? translate( 'Domain connection' ) : undefined }
 			isFree={ purchase?.priceInteger === 0 }
 			actions={ actions }
 		/>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -90,7 +90,7 @@ export default function ThankYouDomainProduct( {
 		);
 	}
 
-	const isDomainConnection = purchase ? isDomainMapping( purchase as object ) : false;
+	const isDomainConnection = purchase && isDomainMapping( purchase );
 
 	return (
 		<ThankYouProduct

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/titan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/titan-product.tsx
@@ -43,6 +43,7 @@ export function ThankYouTitanProduct( {
 
 		actions.push(
 			<Button
+				key="inbox"
 				variant="primary"
 				href={ inboxPath }
 				onClick={ () => {
@@ -58,13 +59,17 @@ export function ThankYouTitanProduct( {
 		);
 
 		actions.push(
-			<Button variant="secondary" href={ emailManagementPath }>
+			<Button key="manage-mail" variant="secondary" href={ emailManagementPath }>
 				{ translate( 'Manage email' ) }
 			</Button>
 		);
 	} else {
 		actions.push(
-			<Button href={ getTitanSetUpMailboxPath( siteSlug, domainName ) } variant="primary">
+			<Button
+				key="set-up-mailbox"
+				href={ getTitanSetUpMailboxPath( siteSlug, domainName ) }
+				variant="primary"
+			>
 				{ translate( 'Set up mailbox' ) }
 			</Button>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
@@ -41,7 +41,7 @@ describe( 'isRefactoredForThankYouV2', () => {
 		expect( isRefactoredForThankYouV2( props ) ).toBe( false );
 	} );
 
-	it( 'should return true if the purchases exists and are not delayed transfer', () => {
+	it( 'should return true if the purchases exist and are not delayed transfer', () => {
 		const props = {
 			receipt: {
 				data: {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
@@ -1,4 +1,3 @@
-import { findPlansKeys, GROUP_WPCOM, TYPE_P2_PLUS } from '@automattic/calypso-products';
 import { domainProductSlugs } from 'calypso/lib/domains/constants';
 import { isRefactoredForThankYouV2 } from '../utils';
 
@@ -18,38 +17,11 @@ describe( 'isRefactoredForThankYouV2', () => {
 		expect( isRefactoredForThankYouV2( props ) ).toBe( false );
 	} );
 
-	it( 'should return true if there are multiple purchases that only contains domains', () => {
+	it( 'should return false if there are no purchases', () => {
 		const props = {
 			receipt: {
 				data: {
-					purchases: [
-						{ productSlug: 'domain_map' },
-						{ productSlug: 'dotblog_domain', isDomainRegistration: true },
-					],
-					failedPurchases: [],
-				},
-			},
-		};
-		expect( isRefactoredForThankYouV2( props ) ).toBe( true );
-	} );
-
-	it( 'should return true if the purchases contain only domain transfers', () => {
-		const props = {
-			receipt: {
-				data: {
-					purchases: [ { productSlug: domainProductSlugs.TRANSFER_IN } ],
-					failedPurchases: [],
-				},
-			},
-		};
-		expect( isRefactoredForThankYouV2( props ) ).toBe( true );
-	} );
-
-	it( 'should return false if the purchase is not supported', () => {
-		const props = {
-			receipt: {
-				data: {
-					purchases: [ { productSlug: 'jetpack-personal' } ],
+					purchases: [],
 					failedPurchases: [],
 				},
 			},
@@ -57,43 +29,23 @@ describe( 'isRefactoredForThankYouV2', () => {
 		expect( isRefactoredForThankYouV2( props ) ).toBe( false );
 	} );
 
-	it( 'should return true for wpcom plans', () => {
-		const wpcomPlans = findPlansKeys( { group: GROUP_WPCOM } );
-		const supportedPlans = [ ...wpcomPlans ];
-		for ( const plan of supportedPlans ) {
-			const props = {
-				receipt: {
-					data: {
-						purchases: [ { productSlug: plan } ],
-						failedPurchases: [],
-					},
-				},
-			};
-			expect( isRefactoredForThankYouV2( props ) ).toBe( true );
-		}
-	} );
-
-	it( 'should return true for p2 plsu plans', () => {
-		const p2PlusPlan = findPlansKeys( { type: TYPE_P2_PLUS } );
-		const supportedPlans = [ ...p2PlusPlan ];
-		for ( const plan of supportedPlans ) {
-			const props = {
-				receipt: {
-					data: {
-						purchases: [ { productSlug: plan } ],
-						failedPurchases: [],
-					},
-				},
-			};
-			expect( isRefactoredForThankYouV2( props ) ).toBe( true );
-		}
-	} );
-
-	it( 'should return true for Jetpack Search', () => {
+	it( 'should return false if the purchases contain delayed domain transfers', () => {
 		const props = {
 			receipt: {
 				data: {
-					purchases: [ { productType: 'search' } ],
+					purchases: [ { productSlug: domainProductSlugs.TRANSFER_IN, delayedProvisioning: true } ],
+					failedPurchases: [],
+				},
+			},
+		};
+		expect( isRefactoredForThankYouV2( props ) ).toBe( false );
+	} );
+
+	it( 'should return true if the purchases exists and are not delayed transfer', () => {
+		const props = {
+			receipt: {
+				data: {
+					purchases: [ { productSlug: 'any_other_product' } ],
 					failedPurchases: [],
 				},
 			},

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -17,6 +17,10 @@ export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps 
 
 	const purchases = getPurchases( props );
 
+	if ( ! purchases.length ) {
+		return false;
+	}
+
 	if ( purchases.find( isDelayedDomainTransfer ) ) {
 		return false;
 	}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -1,17 +1,5 @@
-import {
-	isGSuiteOrExtraLicenseOrGoogleWorkspace,
-	isP2Plus,
-	isTitanMail,
-	isWpComPlan,
-} from '@automattic/calypso-products';
+import { isDelayedDomainTransfer } from '@automattic/calypso-products';
 import { CheckoutThankYouCombinedProps, getFailedPurchases, getPurchases } from '..';
-import {
-	getDomainPurchase,
-	isBulkDomainTransfer,
-	isDomainOnly,
-	isSearch,
-	isTitanWithoutMailboxes,
-} from '../utils';
 
 /**
  * Determines whether the current checkout flow renders a redesigned congrats page
@@ -29,41 +17,9 @@ export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps 
 
 	const purchases = getPurchases( props );
 
-	if ( isBulkDomainTransfer( purchases ) ) {
-		return true;
+	if ( purchases.find( isDelayedDomainTransfer ) ) {
+		return false;
 	}
 
-	if ( isDomainOnly( purchases ) ) {
-		return true;
-	}
-
-	if ( purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace ) ) {
-		return true;
-	}
-
-	if ( isTitanWithoutMailboxes( props.selectedFeature ) && getDomainPurchase( purchases ) ) {
-		return true;
-	}
-
-	if ( purchases.length === 1 ) {
-		const purchase = purchases[ 0 ];
-
-		if ( isWpComPlan( purchase.productSlug ) ) {
-			return true;
-		}
-
-		if ( isP2Plus( purchase ) ) {
-			return true;
-		}
-
-		if ( isTitanMail( purchase ) ) {
-			return true;
-		}
-
-		if ( isSearch( purchase ) ) {
-			return true;
-		}
-	}
-
-	return false;
+	return true;
 };

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -13,6 +13,7 @@ jest.unmock( '@automattic/calypso-products' );
 jest.mock( '@automattic/calypso-products', () => ( {
 	...jest.requireActual( '@automattic/calypso-products' ),
 	shouldFetchSitePlans: () => false,
+	isDotComPlan: jest.fn( () => false ),
 	isDIFMProduct: jest.fn( () => false ),
 } ) );
 
@@ -21,7 +22,6 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 } ) );
 jest.mock( '../domain-registration-details', () => () => 'component--domain-registration-details' );
 jest.mock( '../google-apps-details', () => () => 'component--google-apps-details' );
-jest.mock( '../jetpack-plan-details', () => () => 'component--jetpack-plan-details' );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => 'page-view-tracker' );
 jest.mock( '../header', () =>
 	jest.fn( ( { children } ) => <div data-testid="checkout-thank-you-header">{ children }</div> )
@@ -35,6 +35,9 @@ jest.mock( '../business-plan-details', () => () => <div data-testid="business-pl
 jest.mock( '../transfer-pending/', () => () => 'transfer-pending' );
 jest.mock( '../redesign-v2/pages/plan-only', () => () => (
 	<div data-testid="component--plan-only-thank-you" />
+) );
+jest.mock( '../redesign-v2/pages/generic', () => () => (
+	<div data-testid="component--generic-thank-you" />
 ) );
 
 const translate = ( x ) => x;
@@ -123,6 +126,35 @@ describe( 'CheckoutThankYou', () => {
 		);
 
 		expect( await screen.findByText( /These items could not be added/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the Jetpack plan content if the purchases include a Jetpack plan', async () => {
+		const props = {
+			...defaultProps,
+			receiptId: 12,
+			selectedSite: {
+				ID: 12,
+			},
+			sitePlans: {
+				hasLoadedFromServer: true,
+			},
+			receipt: {
+				hasLoadedFromServer: true,
+				data: {
+					purchases: [ { productSlug: 'jetpack_personal' } ],
+				},
+			},
+			refreshSitePlans: ( selectedSite ) => selectedSite,
+			planSlug: PLAN_PREMIUM,
+		};
+
+		render(
+			<Provider store={ store }>
+				<CheckoutThankYou { ...props } />
+			</Provider>
+		);
+
+		expect( await screen.getByTestId( 'component--plan-only-thank-you' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the <PlanOnlyThankYou> component if the purchases include a Personal plan', async () => {

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -96,73 +96,6 @@ describe( 'CheckoutThankYou', () => {
 		} );
 	} );
 
-	describe( 'Simplified page', () => {
-		const props = {
-			...defaultProps,
-			receiptId: 12,
-			selectedSite: {
-				ID: 12,
-			},
-			sitePlans: {
-				hasLoadedFromServer: true,
-			},
-			receipt: {
-				hasLoadedFromServer: true,
-				data: {
-					purchases: [ { productSlug: PLAN_BUSINESS }, [] ],
-				},
-			},
-			refreshSitePlans: ( selectedSite ) => selectedSite,
-			planSlug: PLAN_BUSINESS,
-		};
-
-		test( 'Should display a full version when isSimplified is missing', () => {
-			render(
-				<Provider store={ store }>
-					<CheckoutThankYou { ...props } />
-				</Provider>
-			);
-			expect( screen.queryByTestId( 'business-plan-details' ) ).toBeVisible();
-			expect( screen.queryByTestId( 'happiness-support' ) ).toBeVisible();
-			expect( CheckoutThankYouHeader ).toHaveBeenCalledWith(
-				expect.objectContaining( { isSimplified: undefined } ),
-				expect.anything()
-			);
-		} );
-
-		test( 'Should display a simplified version when isSimplified is set to true', () => {
-			render(
-				<Provider store={ store }>
-					<CheckoutThankYou { ...props } isSimplified />
-				</Provider>
-			);
-			expect( screen.queryByTestId( 'business-plan-details' ) ).not.toBeInTheDocument();
-			expect( screen.queryByTestId( 'happiness-support' ) ).not.toBeInTheDocument();
-			expect( CheckoutThankYouHeader ).toHaveBeenCalledWith(
-				expect.objectContaining( { isSimplified: true } ),
-				expect.anything()
-			);
-		} );
-
-		test( 'Should pass props down to CheckoutThankYou', () => {
-			render(
-				<CheckoutThankYou
-					{ ...props }
-					isSimplified={ true }
-					siteUnlaunchedBeforeUpgrade={ true }
-					upgradeIntent="plugins"
-				/>
-			);
-			expect( CheckoutThankYouHeader ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					siteUnlaunchedBeforeUpgrade: true,
-					upgradeIntent: 'plugins',
-				} ),
-				expect.anything()
-			);
-		} );
-	} );
-
 	it( 'renders the failed purchases content if there are failed purchases', async () => {
 		const props = {
 			...defaultProps,
@@ -191,35 +124,6 @@ describe( 'CheckoutThankYou', () => {
 		);
 
 		expect( await screen.findByText( /These items could not be added/ ) ).toBeInTheDocument();
-	} );
-
-	it( 'renders the Jetpack plan content if the purchases include a Jetpack plan', async () => {
-		const props = {
-			...defaultProps,
-			receiptId: 12,
-			selectedSite: {
-				ID: 12,
-			},
-			sitePlans: {
-				hasLoadedFromServer: true,
-			},
-			receipt: {
-				hasLoadedFromServer: true,
-				data: {
-					purchases: [ { productSlug: 'jetpack_personal' } ],
-				},
-			},
-			refreshSitePlans: ( selectedSite ) => selectedSite,
-			planSlug: PLAN_PREMIUM,
-		};
-
-		render(
-			<Provider store={ store }>
-				<CheckoutThankYou { ...props } />
-			</Provider>
-		);
-
-		expect( await screen.findByText( 'component--jetpack-plan-details' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the <PlanOnlyThankYou> component if the purchases include a Personal plan', async () => {

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { PLAN_BUSINESS, PLAN_PREMIUM, PLAN_PERSONAL } from '@automattic/calypso-products';
+import { PLAN_PREMIUM, PLAN_PERSONAL } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -13,7 +13,6 @@ jest.unmock( '@automattic/calypso-products' );
 jest.mock( '@automattic/calypso-products', () => ( {
 	...jest.requireActual( '@automattic/calypso-products' ),
 	shouldFetchSitePlans: () => false,
-	isDotComPlan: jest.fn( () => false ),
 	isDIFMProduct: jest.fn( () => false ),
 } ) );
 

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -1,10 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
+import getTitanFooterDetails from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-titan-footer-details';
 import { ThankYouTitanProduct } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/products/titan-product';
-import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
-import { getTitanControlPanelRedirectPath } from 'calypso/my-sites/email/paths';
 import { useSelector } from 'calypso/state';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -27,57 +24,10 @@ const TitanSetUpThankYou = ( {
 	isDomainOnlySite = false,
 	numberOfMailboxesPurchased,
 }: TitanSetUpThankYouProps ) => {
-	const currentRoute = useSelector( getCurrentRoute );
 	const selectedSite = useSelector( getSelectedSite );
+	const currentRoute = useSelector( getCurrentRoute );
 	const selectedSiteSlug = selectedSite?.slug ?? ( isDomainOnlySite ? domainName : null );
 	const translate = useTranslate();
-
-	const titanControlPanelUrl = getTitanControlPanelRedirectPath(
-		selectedSiteSlug,
-		domainName,
-		currentRoute,
-		{
-			context: TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP,
-		}
-	);
-
-	const footerDetails = [
-		{
-			key: 'footer-get-the-app',
-			title: translate( 'Manage your email and site from anywhere' ),
-			description: translate(
-				'The Jetpack mobile app for iOS and Android makes managing your email, domain, and website even simpler.'
-			),
-			buttonText: translate( 'Get the app' ),
-			buttonHref: titanControlPanelUrl,
-			buttonOnClick: () => {
-				recordEmailAppLaunchEvent( {
-					provider: 'titan',
-					app: 'app',
-					context: 'checkout-thank-you',
-				} );
-				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
-					context: 'titan-setup',
-					type: 'get-the-app',
-				} );
-			},
-		},
-		{
-			key: 'footer-questions-email',
-			title: translate( 'Email questions? We have the answers' ),
-			description: translate(
-				'Explore our comprehensive support guides and find solutions to all your email inquiries.'
-			),
-			buttonText: translate( 'Email support resources' ),
-			buttonHref: '/support/category/domains-and-email/email/',
-			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
-					context: 'titan-setup',
-					type: 'questions-email',
-				} );
-			},
-		},
-	];
 
 	let title;
 	let subtitle;
@@ -107,7 +57,12 @@ const TitanSetUpThankYou = ( {
 				title={ title }
 				subtitle={ subtitle }
 				products={ products }
-				footerDetails={ footerDetails }
+				footerDetails={ getTitanFooterDetails(
+					selectedSiteSlug,
+					domainName,
+					currentRoute,
+					'titan-setup'
+				) }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2731

## Proposed Changes

Implement the redesigned generic congrats page for for handling multi-item purchases or any product type that doesn't have a specific congrats page. There's a bunch of legacy code that should be removed, but to ease review, we'll handle clean up in separate PRs.

To ensure the Titan footer blurb is accessible from the generic congrats page, I've refactored that content such that both the TItan and generic congrats page can access the same content from a helper function.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing can be tricky here, since there are many different combinations of purchases users can make. I would suggest focusing on the common flows. If any issues arise for edge cases after this PR goes live, we can address them in followup PRs. Below are a few combination of purchases that we should test:

### Domain and Titan subscription
* These can be purchased via the "Upgrades > Domain" flow
* Assert that the page shows a domain and Titan subscription
* Assert that there's domain and email support blurb bin the footer
<img width="1139" alt="Screen Shot 2024-03-11 at 2 34 18 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/c9386bdf-ba07-4366-91a1-c3ac11ecc78b">

### Plan, domain, and Titan subscription
* Go to "Upgrades > Plan" and add a plan to your shopping cart. On the checkout page, navigate back to your dashboard.
* Go to "Upgrades > Domain" to add a domain and email subscription. You should then be able to checkout 3 items.
* Once the purchase is completed, assert that the congrats page shows all three items.
* Assert that there's domain and email support blurb bin the footer
<img width="1087" alt="Screen Shot 2024-03-11 at 3 15 25 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/3efbc59e-3610-4bc6-86b3-66d265672454">

### Plan and domain connection
* Go to "Upgrades > Domain". Click "Add a domain" then select "Use a domain I own".
* Enter a domain that can be connected to WordPress.com (if you don't have one, feel free to use `awongdemo1.com`, but be sure to remove the connection after testing)
* On checkout, you should see two items: a domain and an Explorer plan
* Once the purchase is completed, assert that the congrats page shows both items. Note that the domain item should say "Domain connection" in the subtext. 
* Assert that there's a domain and generic support blurb in the footer
<img width="958" alt="Screen Shot 2024-03-11 at 3 18 10 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/df93de35-6948-4307-8e53-8a9543fea10d">

### Add-ons
* This can be purchased from "Upgrades > Add-ons" for sites on a free plan
* Assert that you see the purchased product
* Assert that the "Manage purchase" CTA takes users to the site's purchases page
* Assert that there's a generic support blurb in the footer
* Assert that the title says "Great choice!" instead of "Great choices!" when only a single item was purchased
<img width="828" alt="Screen Shot 2024-03-11 at 2 57 20 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/e3000789-3a56-4a59-93ea-30d10e6eddfa">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->
