### PR TITLE
Hosting Command Palette: Trim search text to increase matchings

### DIFF
--- a/packages/command-palette/src/use-command-filter.ts
+++ b/packages/command-palette/src/use-command-filter.ts
@@ -3,7 +3,7 @@ export const COMMAND_SEPARATOR = '|~~~|';
 export const useCommandFilter = () => {
 	const commandFilter = ( value: string, search: string ) => {
 		const lowercaseValue = value.toLowerCase();
-		const lowercaseSearch = search.toLowerCase();
+		const lowercaseSearch = search.toLowerCase().trim();
 
 		const [ beforeSeparator, afterSeparator ] = lowercaseValue.split( COMMAND_SEPARATOR );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Fixes p9Jlb4-b8X-p2#comment-10967 

## Proposed Changes

* Trim text that is searched. Ideally we could upstream this change to the `cmdk` library.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using this branch, go to `/sites`
* Press `cmd+k` or `ctrl+k`
* Search for `site `. Notice the final space
* Observe that the `View my sites` is still visible.

### Screencast


https://github.com/Automattic/wp-calypso/assets/779993/996019d1-8dac-4b27-b0b5-484e1c8a881c



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?