### PR TITLE
Checkout: Validate CPF in Pix processor before submitting

### DIFF
--- a/client/my-sites/checkout/src/lib/pix-processor.ts
+++ b/client/my-sites/checkout/src/lib/pix-processor.ts
@@ -1,6 +1,7 @@
 import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-checkout';
 import { createElement } from 'react';
 import { Root, createRoot } from 'react-dom/client';
+import { isValidCPF } from 'calypso/lib/checkout/processor-specific';
 import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from '../lib/get-domain-details';
@@ -53,6 +54,14 @@ export async function pixProcessor(
 	const paymentMethodId = 'pix';
 
 	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId } ) );
+
+	if ( ! isValidCPF( submitData.document ) ) {
+		return makeErrorResponse(
+			translate( 'Your CPF is invalid. Please verify that you have entered it correctly.', {
+				textOnly: true,
+			} )
+		);
+	}
 
 	const baseURL = new URL(
 		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com'


### PR DESCRIPTION
When paying with the Ebanx Pix payment method, one of the required fields is the CPF (the taxpayer ID number). We submit whatever the user enters to our transactions endpoint, which then validates that the field is set before passing the entry along to Ebanx. If the CPF field is invalid, Ebanx sends back an error message which we display to the user. This leaves a record of a failed transaction in our Ebanx dashboard. It's not desirable to record these failures for data entry validation reasons. (See https://github.com/Automattic/payments-shilling/issues/2490).

## Proposed Changes

This PR uses the existing CPF validation that we apply to the CPF field in the Ebanx credit card form for the Pix form as well.

Fixes https://github.com/Automattic/payments-shilling/issues/2490

Before             |  After
:-------------------------:|:-------------------------:
<img width="942" alt="before-cpf" src="https://github.com/Automattic/wp-calypso/assets/2036909/d4b6a13e-a444-41e1-9a68-1204bab64e59"> | <img width="944" alt="after-cpf" src="https://github.com/Automattic/wp-calypso/assets/2036909/4b563639-7ed7-4b51-9dcf-0a0999f0b244">

## Testing Instructions

- To use Pix as a payment method option in checkout, first you'll need to have BRL as your currency, and then you'll need to select "Brazil" as the country inside checkout (and a Brazilian postal code like `61919-230`).
- Use Ebanx [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/) to fill out the Pix form. 
- Enter an **INCORRECT** CPF number.
- Open your browser devtools to view Network requests.
- Click to submit the payment.
- Verify that you receive an error message that reads `Your CPF is invalid. Please verify that you have entered it correctly.`.
- Using your browser devtools, verify that the `/me/transactions` endpoint **WAS NOT** called. (This is important because before this PR you would also get an error, but it would come from the transactions endpoint rather than calypso.)
- Enter a **CORRECT** CPF number.
- Click to submit the payment.
- Verify that you see the QR code displayed (you don't need to complete the payment).