### PR TITLE
Patterns: add controlled width for patterns pages

### DIFF
--- a/client/my-sites/patterns/components/header/style.scss
+++ b/client/my-sites/patterns/components/header/style.scss
@@ -1,16 +1,18 @@
 
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
+@import "calypso/my-sites/patterns/mixins";
 
 .patterns-header {
 	background: #1d2327;
-	padding: 0 26px;
 
 	.patterns-header__inner {
-		padding: 105px 0 64px 84px;
+		@include patterns-page-width;
+		padding-top: 105px;
+		padding-bottom: 64px;
 		background-image: url(./images/background@3x.png);
 		background-repeat: no-repeat;
-		background-position: bottom right 84px;
+		background-position: bottom right 110px;
 		background-size: auto 100%;
 		color: var(--studio-white);
 
@@ -51,10 +53,8 @@
 	}
 
 	@media ( max-width: $break-wide ) {
-		padding: 0 24px;
-
 		.patterns-header__inner {
-			padding: 90px 0 24px;
+			padding: 90px 24px 24px;
 			background: none;
 
 			h1 {

--- a/client/my-sites/patterns/components/section/style.scss
+++ b/client/my-sites/patterns/components/section/style.scss
@@ -1,6 +1,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
+@import "calypso/my-sites/patterns/mixins";
 
 .patterns-section {
 	padding: 90px 0 96px;
@@ -26,7 +27,8 @@
 }
 
 .patterns-section__header {
-	padding: 0 110px 48px;
+	@include patterns-page-width;
+	padding-bottom: 48px;
 
 	h2 {
 		font-family: $font-recoleta;
@@ -45,7 +47,7 @@
 }
 
 .patterns-section__body {
-	padding: 0 110px;
+	@include patterns-page-width;
 }
 
 

--- a/client/my-sites/patterns/mixins.scss
+++ b/client/my-sites/patterns/mixins.scss
@@ -1,0 +1,8 @@
+@mixin patterns-page-width {
+	max-width: 1440px;
+	margin-left: auto;
+	margin-right: auto;
+	padding-left: 110px;
+	padding-right: 110px;
+	box-sizing: border-box;
+}

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -74,22 +74,24 @@ export const PatternsCategoryPage = ( {
 			/>
 
 			{ categoryNavList && (
-				<CategoryPillNavigation
-					selectedCategory={ category }
-					buttons={ [
-						{
-							icon: ImgStar,
-							label: 'Discover',
-							link: addLocaleToPathLocaleInFront( '/patterns' ),
-						},
-						{
-							icon: ImgGrid,
-							label: 'All Categories',
-							link: '/222',
-						},
-					] }
-					list={ categoryNavList }
-				/>
+				<div className="category-pill-navigation__patterns-wrapper">
+					<CategoryPillNavigation
+						selectedCategory={ category }
+						buttons={ [
+							{
+								icon: ImgStar,
+								label: 'Discover',
+								link: addLocaleToPathLocaleInFront( '/patterns' ),
+							},
+							{
+								icon: ImgGrid,
+								label: 'All Categories',
+								link: '/222',
+							},
+						] }
+						list={ categoryNavList }
+					/>
+				</div>
 			) }
 
 			<div className="patterns-page-category">

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -74,7 +74,7 @@ export const PatternsCategoryPage = ( {
 			/>
 
 			{ categoryNavList && (
-				<div className="category-pill-navigation__patterns-wrapper">
+				<div className="patterns-page-category__pill-navigation">
 					<CategoryPillNavigation
 						selectedCategory={ category }
 						buttons={ [

--- a/client/my-sites/patterns/pages/category/style.scss
+++ b/client/my-sites/patterns/pages/category/style.scss
@@ -2,7 +2,7 @@
 @import "@automattic/components/src/styles/typography";
 @import "calypso/my-sites/patterns/mixins";
 
-.category-pill-navigation__patterns-wrapper {
+.patterns-page-category__pill-navigation {
 	background: var(--studio-white);
 
 	.category-pill-navigation {

--- a/client/my-sites/patterns/pages/category/style.scss
+++ b/client/my-sites/patterns/pages/category/style.scss
@@ -1,20 +1,26 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography";
+@import "calypso/my-sites/patterns/mixins";
 
-.is-section-patterns .category-pill-navigation {
-	padding: 32px 110px;
+.category-pill-navigation__patterns-wrapper {
+	background: var(--studio-white);
+
+	.category-pill-navigation {
+		@include patterns-page-width;
+		padding-top: 32px;
+		padding-bottom: 32px;
+	}
 
 	@media ( max-width: $break-wide ) {
-		padding: 24px 0;
-
-		.category-pill-navigation__list .category-pill-navigation__list-inner {
-			padding: 0 24px;
+		.category-pill-navigation {
+			padding: 24px;
 		}
 	}
 }
 
 .patterns-page-category {
-	padding: 0 110px 96px;
+	@include patterns-page-width;
+	padding-bottom: 96px;
 
 	@media ( max-width: $break-wide ) {
 		padding: 24px;

--- a/client/my-sites/patterns/pages/home/style.scss
+++ b/client/my-sites/patterns/pages/home/style.scss
@@ -1,6 +1,5 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
-@import "calypso/my-sites/patterns/mixins";
 
 .section-patterns-info {
 	overflow: auto;

--- a/client/my-sites/patterns/pages/home/style.scss
+++ b/client/my-sites/patterns/pages/home/style.scss
@@ -1,5 +1,6 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
+@import "calypso/my-sites/patterns/mixins";
 
 .section-patterns-info {
 	overflow: auto;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5900

## Proposed Changes
After discussing the design for wide monitors we decided to try to make a limit as 1220px.
Details: p1709646557317429-slack-C06ELHR6L9J

## Testing Instructions
1) Open `http://calypso.localhost:3000/patterns`
2) Resize window and asser that max-width of the sections is 1220 and everything looks good
3) Open `http://calypso.localhost:3000/patterns/posts`
4) Resize window and asser that max-width of the sections is 1220 and everything looks good