### PR TITLE
Domains: Remove unused `domains/premium-domain-purchases` feature flag

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -818,7 +818,6 @@ class RegisterDomainStep extends Component {
 
 							const isAvailablePremiumDomain = domainAvailability.AVAILABLE_PREMIUM === status;
 							const isAvailableSupportedPremiumDomain =
-								config.isEnabled( 'domains/premium-domain-purchases' ) &&
 								domainAvailability.AVAILABLE_PREMIUM === status &&
 								availabilityResult?.is_supported_premium_domain;
 
@@ -1029,9 +1028,7 @@ class RegisterDomainStep extends Component {
 					const status = get( result, 'status', error );
 					const isAvailable = domainAvailability.AVAILABLE === status;
 					const isAvailableSupportedPremiumDomain =
-						config.isEnabled( 'domains/premium-domain-purchases' ) &&
-						domainAvailability.AVAILABLE_PREMIUM === status &&
-						result?.is_supported_premium_domain;
+						domainAvailability.AVAILABLE_PREMIUM === status && result?.is_supported_premium_domain;
 					resolve( {
 						status: ! isAvailable && ! isAvailableSupportedPremiumDomain ? status : null,
 						trademarkClaimsNoticeInfo: get( result, 'trademark_claims_notice_info', null ),
@@ -1097,9 +1094,7 @@ class RegisterDomainStep extends Component {
 					const isDomainMapped = MAPPED === mappable;
 					const isAvailablePremiumDomain = AVAILABLE_PREMIUM === status;
 					const isAvailableSupportedPremiumDomain =
-						config.isEnabled( 'domains/premium-domain-purchases' ) &&
-						AVAILABLE_PREMIUM === status &&
-						result?.is_supported_premium_domain;
+						AVAILABLE_PREMIUM === status && result?.is_supported_premium_domain;
 
 					/**
 					 * In rare cases we don't get the FQDN as suggestion from the suggestion engine but only

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { getDomainSuggestionsVendor } from '@automattic/domain-picker';
 
 /**
@@ -11,9 +10,9 @@ import { getDomainSuggestionsVendor } from '@automattic/domain-picker';
  * @returns {string} Vendor string to pass as part of the domain suggestions query.
  */
 export const getSuggestionsVendor = ( options = {} ) => {
-	// If the isPremium prop is not given, fallback to the value set in config.
+	// If the isPremium prop is not given, fallback to true.
 	if ( typeof options.isPremium === 'undefined' ) {
-		options.isPremium = config.isEnabled( 'domains/premium-domain-purchases' );
+		options.isPremium = true;
 	}
 
 	return getDomainSuggestionsVendor( options );

--- a/config/development.json
+++ b/config/development.json
@@ -61,7 +61,6 @@
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,7 +31,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/premium-domain-purchases": true,
 		"domains/transfer-to-any-user": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,7 +42,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,7 +40,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,7 +45,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/premium-domain-purchases": true,
 		"domains/transfer-to-any-user": true,
 		"email-accounts/enabled": true,
 		"external-media": true,


### PR DESCRIPTION
## Proposed Changes

This PR removes the `domains/premium-domain-purchases` feature flag as it's no longer needed.

That flag was introduced almost 4 years ago in #44409 and #44869 and was currently always `true`.

## Testing Instructions

- Code inspection

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?