### PR TITLE
Import site flow: don't record the same invalid URL submission multiple times

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -5,7 +5,7 @@ import { createElement, createInterpolateElement } from '@wordpress/element';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
-import React, { ChangeEvent, FormEvent, useState, useEffect } from 'react';
+import React, { ChangeEvent, FormEvent, useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -35,6 +35,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const [ urlValue, setUrlValue ] = useState( '' );
 	const [ isValid, setIsValid ] = useState( false );
 	const [ submitted, setSubmitted ] = useState( false );
+	const lastInvalidValue = useRef< string | undefined >();
 	const exampleInputWebsite = 'artfulbaker.blog';
 	const showValidationMsg = hasError || ( submitted && ! isValid );
 	const { search } = useLocation();
@@ -77,7 +78,8 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		isValid && onInputEnter( urlValue );
 		setSubmitted( true );
 
-		if ( ! isValid && urlValue?.length > 4 ) {
+		if ( ! isValid && urlValue?.length > 4 && urlValue !== lastInvalidValue.current ) {
+			lastInvalidValue.current = urlValue;
 			recordTracksEvent( 'calypso_importer_capture_input_invalid', {
 				url: urlValue,
 			} );

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -48,7 +48,7 @@ describe( 'CaptureInput', () => {
 
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
-		// enter a value URL and resubmit
+		// Now, enter a valid URL and confirm we can submit ok
 		await userEvent.clear( screen.getByLabelText( /Enter the URL of the site/ ) );
 		await userEvent.type(
 			screen.getByLabelText( /Enter the URL of the site/ ),

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -1,12 +1,17 @@
 /**
  * @jest-environment jsdom
  */
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import CaptureInput from '../capture-input';
+
+const mockedRecordTracksEvent = jest.fn();
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: ( ...args ) => mockedRecordTracksEvent( ...args ),
+} ) );
 
 describe( 'CaptureInput', () => {
 	it( 'captures the site url', async () => {
@@ -25,5 +30,35 @@ describe( 'CaptureInput', () => {
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
 		expect( onInputEnter ).toHaveBeenCalledWith( 'https://example.wordpress.com' );
+	} );
+
+	it( 'only records invalid urls once', async () => {
+		const onInputEnter = jest.fn();
+		render(
+			<MemoryRouter>
+				<CaptureInput onInputEnter={ onInputEnter } />
+			</MemoryRouter>
+		);
+
+		// enter an invalid URL
+		await userEvent.type( screen.getByLabelText( /Enter the URL of the site/ ), 'not a url' );
+
+		// try to submit the same value twice
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		// enter a value URL and resubmit
+		await userEvent.clear( screen.getByLabelText( /Enter the URL of the site/ ) );
+		await userEvent.type(
+			screen.getByLabelText( /Enter the URL of the site/ ),
+			'https://example.wordpress.com'
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( onInputEnter ).toHaveBeenCalledWith( 'https://example.wordpress.com' );
+
+		expect( mockedRecordTracksEvent.mock.calls.length ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdDR7T-1oU-p2#comment-1757

## Proposed Changes

* If the URL is invalid and didn't change, don't record `calypso_importer_capture_input_invalid` as this adds noise to our funnels that makes analysis difficult. See P2 link above for more context. 

I think it would have been better to disable the input but the way the component is designed it would require a bit of reworking, so I kept it simple. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try it on Calypso Live
* Go to /setup/import-hosted-site/import?source=sites-dashboard&ref=hosting-flow
* Enter an invalid URL longer than four characters
* Submit and notice that `calypso_importer_capture_input_invalid`  fires
* Try submitting again and you should not see `calypso_importer_capture_input_invalid` 
* Compare with prod and note that `calypso_importer_capture_input_invalid` fires every time

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?