### PR TITLE
Fix handle email magic link for Woo Passwordless

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1226,11 +1226,13 @@
 		}
 
 		.login__header-subtitle,
-		.formatted-header__subtitle {
+		.formatted-header__subtitle,
+		.verification-code-form__help-text {
 			font-size: $font-body-large;
 			font-weight: 400;
 			line-height: 27px;
 			letter-spacing: -0.025px;
+			color: var(--studio-gray-60);
 			-webkit-font-smoothing: initial;
 
 			a {
@@ -1579,6 +1581,24 @@
 		.auth-form__separator + .auth-form__social.card {
 			border: 0;
 			padding: 0;
+		}
+
+		.two-factor-authentication__verification-code-form-wrapper {
+			padding: 0;
+
+			.two-factor-authentication__verification-code-form {
+				margin-bottom: 32px;
+				padding: 0;
+
+				.form-fieldset {
+					margin: 48px auto 8px;
+					max-width: 327px;
+				}
+
+				.form-button {
+					max-width: 327px;
+				}
+			}
 		}
 	}
 }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1211,10 +1211,7 @@
 			padding: 48px 0 0;
 		}
 
-		.login__form-header {
-			margin-bottom: 12px;
-		}
-
+		.login__form-header,
 		.formatted-header__title {
 			margin-bottom: 12px;
 
@@ -1227,7 +1224,8 @@
 
 		.login__header-subtitle,
 		.formatted-header__subtitle,
-		.verification-code-form__help-text {
+		.verification-code-form__help-text,
+		.security-key-form__help-text {
 			font-size: $font-body-large;
 			font-weight: 400;
 			line-height: 27px;
@@ -1253,6 +1251,7 @@
 				max-width: 327px;
 				margin: 0 auto;
 				width: 100%;
+				text-align: left;
 			}
 		}
 
@@ -1586,18 +1585,59 @@
 		.two-factor-authentication__verification-code-form-wrapper {
 			padding: 0;
 
+			.button,
+			.form-fieldset,
+			.auth-form__separator {
+				max-width: 327px !important;
+			}
+
 			.two-factor-authentication__verification-code-form {
 				margin-bottom: 32px;
 				padding: 0;
+				display: flex;
+				flex-direction: column;
+				align-items: center;
 
 				.form-fieldset {
 					margin: 48px auto 8px;
-					max-width: 327px;
+					width: 100%;
 				}
 
-				.form-button {
-					max-width: 327px;
+				.security-key-form__help-text,
+				.security-key-form__add-wait-for-key {
+					margin-bottom: 48px;
+
+					p:first-child {
+						margin-bottom: 12px;
+					}
 				}
+			}
+
+			.two-factor-authentication__actions.card {
+				padding: 0;
+				border: 0;
+				margin-bottom: 32px;
+				clip-path: none;
+
+				.button {
+					min-height: 48px;
+					font-style: normal;
+					font-weight: 500;
+					color: var(--studio-gray-100);
+					margin: 0 auto;
+					max-width: 327px !important;
+				}
+			}
+		}
+
+		.login__two-factor-footer {
+			p {
+				max-width: 327px;
+				text-align: center;
+			}
+
+			@media screen and ( max-width: 660px ) {
+				align-items: center;
 			}
 		}
 	}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -5,6 +5,7 @@ import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
+import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import HandleEmailedLinkFormJetpackConnect from './magic-login/handle-emailed-link-form-jetpack-connect';
@@ -109,10 +110,14 @@ export async function login( context, next ) {
 			return next( error );
 		}
 
-		try {
-			await context.store.dispatch( fetchOAuth2ClientData( client_id ) );
-		} catch ( error ) {
-			return next( error );
+		const OAuth2Client = getOAuth2Client( context.store.getState(), client_id );
+		if ( ! OAuth2Client ) {
+			// Only fetch the OAuth2 client data if it's not already in the store. This is to avoid unnecessary requests and re-renders.
+			try {
+				await context.store.dispatch( fetchOAuth2ClientData( client_id ) );
+			} catch ( error ) {
+				return next( error );
+			}
 		}
 	}
 

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -10,7 +10,11 @@ import EmptyContent from 'calypso/components/empty-content';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
-import { isGravPoweredOAuth2Client, isWPJobManagerOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isGravPoweredOAuth2Client,
+	isWPJobManagerOAuth2Client,
+	isWooOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -30,10 +34,12 @@ import {
 	getTwoFactorNotificationSent,
 	isTwoFactorEnabled,
 } from 'calypso/state/login/selectors';
+import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
 import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
 import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
+import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
 import EmailedLoginLinkExpired from './emailed-login-link-expired';
 
@@ -71,6 +77,7 @@ class HandleEmailedLinkForm extends Component {
 
 	state = {
 		hasSubmitted: false,
+		isRedirecting: false,
 	};
 
 	constructor( props ) {
@@ -111,7 +118,13 @@ class HandleEmailedLinkForm extends Component {
 	// Lifted from `blocks/login`
 	// @TODO move to `state/login/actions` & use both places
 	handleValidToken = () => {
-		const { redirectToSanitized, twoFactorEnabled, twoFactorNotificationSent } = this.props;
+		const {
+			redirectToSanitized,
+			twoFactorEnabled,
+			twoFactorNotificationSent,
+			oauth2Client,
+			wccomFrom,
+		} = this.props;
 
 		if ( ! twoFactorEnabled ) {
 			this.props.rebootAfterLogin( { magic_login: 1 } );
@@ -121,8 +134,14 @@ class HandleEmailedLinkForm extends Component {
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: twoFactorNotificationSent.replace( 'none', 'authenticator' ),
 					redirectTo: redirectToSanitized,
+					oauth2ClientId: oauth2Client.id,
+					wccomFrom,
 				} )
 			);
+
+			this.setState( {
+				isRedirecting: true,
+			} );
 		}
 	};
 
@@ -130,7 +149,7 @@ class HandleEmailedLinkForm extends Component {
 	UNSAFE_componentWillUpdate( nextProps, nextState ) {
 		const { authError, isAuthenticated, isFetching } = nextProps;
 
-		if ( ! nextState.hasSubmitted || isFetching ) {
+		if ( ! nextState.hasSubmitted || isFetching || nextState.isRedirecting ) {
 			// Don't do anything here unless the browser has received the `POST` response
 			return;
 		}
@@ -140,7 +159,6 @@ class HandleEmailedLinkForm extends Component {
 			this.props.showMagicLoginLinkExpiredPage();
 			return;
 		}
-
 		this.handleValidToken();
 	}
 
@@ -157,6 +175,8 @@ class HandleEmailedLinkForm extends Component {
 			transition,
 			token,
 			activate,
+			wccomFrom,
+			isWoo,
 		} = this.props;
 		const isWooDna = wooDnaConfig( initialQuery ).isWooDnaFlow();
 		const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
@@ -182,6 +202,10 @@ class HandleEmailedLinkForm extends Component {
 			buttonLabel = translate( 'Confirm Login to WordPress.com' );
 		} else if ( isWooDna ) {
 			buttonLabel = translate( 'Connect' );
+		} else if ( wccomFrom === 'nux' ) {
+			buttonLabel = translate( 'Continue to Woo Express' );
+		} else if ( isWoo ) {
+			buttonLabel = translate( 'Continue to Woo.com' );
 		} else {
 			buttonLabel = translate( 'Continue to WordPress.com' );
 		}
@@ -232,9 +256,8 @@ class HandleEmailedLinkForm extends Component {
 			);
 		}
 
-		const illustration = isWooDna
-			? '/calypso/images/illustrations/illustration-woo-magic-link.svg'
-			: '';
+		const illustration =
+			isWoo || isWooDna ? '/calypso/images/illustrations/illustration-woo-magic-link.svg' : '';
 
 		this.props.recordTracksEvent( 'calypso_login_email_link_handle_click_view' );
 
@@ -256,7 +279,7 @@ class HandleEmailedLinkForm extends Component {
 		}
 
 		// transition is a GET parameter for when the user is transitioning from email user to WPCom user
-		if ( isFetching || transition ) {
+		if ( isFetching || transition || this.state.isRedirecting ) {
 			return <WordPressLogo size={ 72 } className="wpcom-site__logo" />;
 		}
 
@@ -280,7 +303,7 @@ class HandleEmailedLinkForm extends Component {
 const mapState = ( state ) => {
 	const redirectToOriginal = getRedirectToOriginal( state ) || '';
 	const clientId = new URLSearchParams( redirectToOriginal.split( '?' )[ 1 ] ).get( 'client_id' );
-	const oauth2Client = state.oauth2Clients?.clients?.[ clientId ] || {};
+	const oauth2Client = getOAuth2Client( state, clientId ) || {};
 
 	return {
 		redirectToOriginal,
@@ -295,6 +318,8 @@ const mapState = ( state ) => {
 		twoFactorEnabled: isTwoFactorEnabled( state ),
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 		initialQuery: getInitialQueryArguments( state ),
+		isWoo: isWooOAuth2Client( oauth2Client ),
+		wccomFrom: getWccomFrom( state ),
 		oauth2Client,
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88148#pullrequestreview-1915975046

We're showing the WP confirmation screen when the user clicks on the magic link and we're also redirecting user to the WP 2FA screen without the oauth2ClientId, which is confusing for the user.

This PR fixes the issue by redirecting the user to the Woo branded confirmation screen with the oauth2ClientId and also updates the handle email screen to use the Woo branded illustration and button label.

## Proposed Changes

* Adds oauth2ClientId to 2FA URL
* Updates the button label and illustration (Using the existing styles of Woo DNA.)
* Update style of passwordless 2FA screens 


Before:
<img width="800" alt="Screenshot 2024-03-12 at 16 09 27" src="https://github.com/Automattic/wp-calypso/assets/4344253/756245a3-8988-4d06-bb61-0e6e7a82ff7c">

After:
<img width="800" alt="Screenshot 2024-03-12 at 15 11 12" src="https://github.com/Automattic/wp-calypso/assets/4344253/3784a6ce-e01f-4772-a60a-0dd4f5e10fbf">

**When 2FA is enabled:**

Before:
<img width="800" alt="Screenshot 2024-03-12 at 16 08 27" src="https://github.com/Automattic/wp-calypso/assets/4344253/dd8f0aac-bb85-4afb-b65b-052b6d225972">

After:
<img width="800" alt="Screenshot 2024-03-12 at 16 08 09" src="https://github.com/Automattic/wp-calypso/assets/4344253/af2eafea-96b4-4e2b-8a9c-376ee201a1fd">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**2FA is off**

* Create a non-a8c account
* Go to https://wordpress.com/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dcc209140df814f02119fcc56e3662fbb82d946f1631feeca2c5290f408c83029%26redirect_uri%3Dhttps%253A%252F%252Fwoo.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&woo-passwordless=yes
* Enter an email or username (non-a8c account) and click "Send link"
* Go to your inbox and find the `Log in to Woo Express` email
* Click on `Log in to Woo Express` button
* Confirm it shows `Continue to Woo Express` button and a woo magic link illustration

**2FA is on**

* Enable 2FA for your non-a8c account
* Logout your WP account
* Go to https://wordpress.com/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dcc209140df814f02119fcc56e3662fbb82d946f1631feeca2c5290f408c83029%26redirect_uri%3Dhttps%253A%252F%252Fwoo.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&woo-passwordless=yes
* Enter an email or username and click "Send link"
* Go to your inbox and find the `Log in to Woo Express` email
* Click on `Log in to Woo Express` button
* Confirm you're redirected to Woo's 2FA screen.
* Confirm the screen looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?