### PR TITLE
Pattern Library: Add performance marks in SSR logic

### DIFF
--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -29,6 +29,7 @@ function fetchCategoriesAndPatterns( context: RouterContext, next: RouterNext ) 
 
 	const { cachedMarkup, queryClient, lang, params, store } = context;
 
+	// Bypasses fetching if the rendered page is cached, or if any query parameters were passed in the URL
 	if ( cachedMarkup || Object.keys( context.query ).length > 0 ) {
 		next();
 		return;

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -66,8 +66,6 @@ function fetchCategoriesAndPatterns( context: RouterContext, next: RouterNext ) 
 			);
 		} )
 		.then( () => {
-			performanceMark( context, 'finished', true );
-
 			next();
 		} )
 		.catch( ( error ) => {

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -1,13 +1,15 @@
 import type { Context } from '@automattic/calypso-router';
 import type { QueryClient } from '@tanstack/react-query';
 import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+import type { PartialContext as PerformanceMarkContext } from 'calypso/server/lib/performance-mark';
 
 export type RouterNext = ( error?: Error ) => void;
 
-export type RouterContext = Context & {
-	cachedMarkup?: string;
-	queryClient: QueryClient;
-};
+export type RouterContext = Context &
+	PerformanceMarkContext & {
+		cachedMarkup?: string;
+		queryClient: QueryClient;
+	};
 
 export type { Pattern };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

@stephanethomas noted that the `/fr/patterns/about` route loaded slowly for him (p1710177806667219-slack-C06ELHR6L9J). This prompted me to investigate the issue. Unsurprisingly, it looks like the data fetching is the main culprit.

To help us diagnose and manage this issue, this PR adds performance marks in the SSR logic. Performance marks are timing markers that will generate terminal output like this:

```
    performanceMarks: {
      "fetchCategoriesAndPatterns": {
        "total_duration": 1652,
        "getPatternCategories": 887,
        "getPatterns": 765
      }
    }
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/fr/patterns/about` in an incognito window
2. Once the request finishes, ensure that you see the `fetchCategoriesAndPatterns` performance marks in your terminal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?