### PR TITLE
GitHub deployments: remove client-side templates and use template name instead

### DIFF
--- a/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
@@ -1,3 +1,4 @@
+import { useWorkflowTemplate } from 'calypso/my-sites/github-deployments/components/deployment-style/use-get-workflow-template-query';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
 import { NewWorkflowWizard } from './new-workflow-wizard';
 import { Workflow } from './use-deployment-workflows-query';
@@ -27,8 +28,14 @@ export const AdvancedWorkflowStyle = ( {
 	onChooseWorkflow,
 	useComposerWorkflow,
 }: AdvancedWorkflowStyleProps ) => {
+	const templateName = useComposerWorkflow ? 'with_composer' : 'simple';
+
+	const { data: template } = useWorkflowTemplate( { branchName, template: templateName } );
+
 	const getContent = () => {
 		const workflow = workflows?.find( ( workflow ) => workflow.workflow_path === workflowPath );
+
+		const templateContents = template?.template ?? '';
 
 		if ( ! workflow ) {
 			return (
@@ -38,6 +45,8 @@ export const AdvancedWorkflowStyle = ( {
 					repositoryBranch={ branchName }
 					onWorkflowCreated={ onWorkflowCreation }
 					useComposerWorkflow={ useComposerWorkflow }
+					templateName={ templateName }
+					exampleTemplate={ templateContents }
 				/>
 			);
 		}
@@ -47,6 +56,7 @@ export const AdvancedWorkflowStyle = ( {
 				repository={ repository }
 				branchName={ branchName }
 				workflow={ workflow }
+				validYamlFile={ templateContents }
 			/>
 		);
 	};

--- a/client/my-sites/github-deployments/components/deployment-style/new-workflow-wizard.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/new-workflow-wizard.tsx
@@ -5,7 +5,6 @@ import { GitHubRepositoryData } from '../../use-github-repositories-query';
 import { CodeHighlighter } from '../code-highlighter';
 import { useCreateWorkflow } from './use-create-workflow';
 import { Workflow } from './use-deployment-workflows-query';
-import { newComposerWorkflowExample, newWorkflowExample } from './workflow-yaml-examples';
 
 import './style.scss';
 
@@ -13,7 +12,8 @@ interface NewWorkflowWizardProps {
 	repository: Pick< GitHubRepositoryData, 'id' | 'owner' | 'name' >;
 	repositoryBranch: string;
 	workflows?: Workflow[];
-	useComposerWorkflow: boolean;
+	templateName: string;
+	exampleTemplate: string;
 	onWorkflowCreated( path: string ): void;
 }
 
@@ -25,7 +25,8 @@ export const NewWorkflowWizard = ( {
 	workflows,
 	repositoryBranch,
 	onWorkflowCreated,
-	useComposerWorkflow,
+	templateName,
+	exampleTemplate,
 }: NewWorkflowWizardProps ) => {
 	const { __ } = useI18n();
 
@@ -54,10 +55,6 @@ export const NewWorkflowWizard = ( {
 		setError( undefined );
 	}, [ workflows, __ ] );
 
-	const workflowContent = useComposerWorkflow
-		? newComposerWorkflowExample( repositoryBranch )
-		: newWorkflowExample( repositoryBranch );
-
 	return (
 		<div className="github-deployments-new-workflow-wizard">
 			<p css={ { marginBottom: 0 } }>
@@ -69,7 +66,7 @@ export const NewWorkflowWizard = ( {
 					<span>{ RECOMMENDED_WORKFLOW_PATH }</span>
 				</div>
 
-				<CodeHighlighter content={ workflowContent } />
+				<CodeHighlighter content={ exampleTemplate } />
 			</div>
 
 			{ error && (
@@ -89,7 +86,7 @@ export const NewWorkflowWizard = ( {
 							repositoryName: repository.name,
 							branchName: repositoryBranch,
 							fileName: RECOMMENDED_WORKFLOW_PATH,
-							fileContent: workflowContent,
+							workflowTemplate: templateName,
 						} )
 					}
 				>

--- a/client/my-sites/github-deployments/components/deployment-style/use-create-workflow.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/use-create-workflow.tsx
@@ -10,7 +10,7 @@ interface MutationVariables {
 	repositoryOwner: string;
 	repositoryName: string;
 	fileName: string;
-	fileContent: string;
+	workflowTemplate: string;
 }
 
 interface MutationResponse {
@@ -34,7 +34,7 @@ export const useCreateWorkflow = (
 			repositoryOwner,
 			repositoryName,
 			fileName,
-			fileContent,
+			workflowTemplate,
 		}: MutationVariables ) =>
 			wp.req.post(
 				{
@@ -47,7 +47,7 @@ export const useCreateWorkflow = (
 					repository_owner: repositoryOwner,
 					repository_name: repositoryName,
 					file_name: fileName,
-					file_content: fileContent,
+					workflow_template: workflowTemplate,
 				}
 			),
 		...options,

--- a/client/my-sites/github-deployments/components/deployment-style/use-get-workflow-template-query.ts
+++ b/client/my-sites/github-deployments/components/deployment-style/use-get-workflow-template-query.ts
@@ -1,0 +1,35 @@
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
+import wp from 'calypso/lib/wp';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/constants';
+
+export const WORKFLOW_TEMPLATES = 'workflow-templates';
+
+type GetWorkflowContentsParams = {
+	template: 'simple' | 'with_composer';
+	branchName: string;
+};
+
+export const useWorkflowTemplate = (
+	{ template, branchName }: GetWorkflowContentsParams,
+	options?: Partial< UseQueryOptions< { template: string } > >
+) => {
+	return useQuery< { template: string } >( {
+		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, WORKFLOW_TEMPLATES, branchName, template ],
+		queryFn: (): { template: string } => {
+			const path = addQueryArgs( '/hosting/github/workflow-templates', {
+				template,
+				branch_name: branchName,
+			} );
+
+			return wp.req.get( {
+				path,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+		meta: {
+			persist: false,
+		},
+		...options,
+	} );
+};

--- a/client/my-sites/github-deployments/components/deployment-style/use-workflow-validations.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/use-workflow-validations.tsx
@@ -1,10 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
-import {
-	codePushExample,
-	uploadArtifactExample,
-	newWorkflowExample,
-} from './workflow-yaml-examples';
+import { codePushExample, uploadArtifactExample } from './workflow-yaml-examples';
 
 interface Validation {
 	label: string;
@@ -14,9 +10,13 @@ interface Validation {
 
 interface UseWorkflowValidationsParams {
 	branchName: string;
+	validYamlFile: string;
 }
 
-export const useWorkflowValidations = ( { branchName }: UseWorkflowValidationsParams ) => {
+export const useWorkflowValidations = ( {
+	branchName,
+	validYamlFile,
+}: UseWorkflowValidationsParams ) => {
 	const { __ } = useI18n();
 
 	const validations: Record< string, Validation > = useMemo( () => {
@@ -26,7 +26,7 @@ export const useWorkflowValidations = ( { branchName }: UseWorkflowValidationsPa
 				description: __(
 					'Ensure that your workflow file contains a valid YAML structure. Here’s an example:'
 				),
-				content: newWorkflowExample( branchName ),
+				content: validYamlFile,
 			},
 			triggered_on_push: {
 				label: __( 'The workflow is triggered on push' ),
@@ -39,7 +39,7 @@ export const useWorkflowValidations = ( { branchName }: UseWorkflowValidationsPa
 				content: uploadArtifactExample(),
 			},
 		};
-	}, [ __, branchName ] );
+	}, [ __, branchName, validYamlFile ] );
 
 	return validations;
 };

--- a/client/my-sites/github-deployments/components/deployment-style/workflow-validation-wizard.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/workflow-validation-wizard.tsx
@@ -13,15 +13,17 @@ interface WorkflowValidationWizardProps {
 	repository: Pick< GitHubRepositoryData, 'owner' | 'name' >;
 	branchName: string;
 	workflow: Workflow;
+	validYamlFile: string;
 }
 
 export const WorkflowValidationWizard = ( {
 	repository,
 	branchName,
 	workflow,
+	validYamlFile,
 }: WorkflowValidationWizardProps ) => {
 	const { __ } = useI18n();
-	const validations = useWorkflowValidations( { branchName } );
+	const validations = useWorkflowValidations( { branchName, validYamlFile } );
 	const { workflowCheckResult, isCheckingWorkflow, onWorkflowVerify } = useDeploymentStyleContext();
 
 	const getWorkflowCheckDescription = () => {

--- a/client/my-sites/github-deployments/components/deployment-style/workflow-yaml-examples.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/workflow-yaml-examples.tsx
@@ -1,96 +1,5 @@
 /* eslint-disable inclusive-language/use-inclusive-words */
 
-export const newWorkflowExample = ( branch: string ) => {
-	return `
-name: Publish Website
-
-on:
-  push:
-    branches:
-      - ${ branch }
-  workflow_dispatch:
-jobs:
-  Build-Artifact-Action:
-    name: Build-Artifact-Action
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Upload the artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wpcom
-        path: |
-          .
-          !.DS_Store 
-          !.stylelintrc.json 
-          !.eslintrc 
-          !.git 
-          !.gitattributes 
-          !.github 
-          !.gitignore 
-          !README.md 
-          !composer.json 
-          !composer.lock 
-          !node_modules 
-          !vendor
-          !package-lock.json 
-          !package.json 
-          !.travis.yml 
-          !phpcs.xml.dist 
-          !sass 
-          !style.css.map 
-          !yarn.lock
-`.trim();
-};
-
-export const newComposerWorkflowExample = ( branch: string ) => {
-	return `
-name: Publish Website
-
-on:
-  push:
-    branches:
-      - ${ branch }
-  workflow_dispatch:
-jobs:
-  Build-Artifact-Action:
-    name: Build-Artifact-Action
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Install PHP dependencies
-      uses: php-actions/composer@v6
-      with:
-        dev: no
-        php_version: 8.2
-    - name: Upload the artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wpcom
-        path: |
-          .
-          !.DS_Store 
-          !.stylelintrc.json 
-          !.eslintrc 
-          !.git 
-          !.gitattributes 
-          !.github 
-          !.gitignore 
-          !README.md 
-          !composer.json 
-          !composer.lock 
-          !node_modules 
-          !vendor
-          !package-lock.json 
-          !package.json 
-          !.travis.yml 
-          !phpcs.xml.dist 
-          !sass 
-          !style.css.map 
-          !yarn.lock
-`.trim();
-};
-
 export const codePushExample = ( branch: string ) => {
 	return `
 on:
@@ -110,24 +19,6 @@ export const uploadArtifactExample = () => {
 		name: wpcom
 		path: |
 			.
-			!.DS_Store 
-			!.stylelintrc.json 
-			!.eslintrc 
 			!.git 
-			!.gitattributes 
-			!.github 
-			!.gitignore 
-			!README.md 
-			!composer.json 
-			!composer.lock 
-			!node_modules 
-			!vendor
-			!package-lock.json 
-			!package.json 
-			!.travis.yml 
-			!phpcs.xml.dist 
-			!sass 
-			!style.css.map 
-			!yarn.lock
 `.trim();
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5590
Related D141572-code

## Proposed Changes

* This diff stops sending workflow scripts from the client to the server and instead uses a `template` param to identify the workflow script, which is now stored on the server. 
* There should be a noticeable change in the UI - templates should continue working like before. This is a change to remove a security issue. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You need to patch this in your sandbox: D141572-code
* Try using workflow templates and verify they work. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?