### PR TITLE
Reader: Fix issue with blinking posts

### DIFF
--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -30,9 +30,11 @@ export function items( state = {}, action ) {
 
 				postsByKey[ global_ID ] = {
 					...post,
-					feed_item_IDs: feed_item_IDs.length
-						? [ ...new Set( [ ...feed_item_IDs, feed_item_ID ] ) ]
-						: [ feed_item_ID ],
+					...( feed_item_ID && {
+						feed_item_IDs: feed_item_IDs.length
+							? [ ...new Set( [ ...feed_item_IDs, feed_item_ID ] ) ]
+							: [ feed_item_ID ],
+					} ),
 				};
 			} );
 

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-case-declarations */
 
-import { keyBy, get, forEach } from 'lodash';
+import { get, forEach } from 'lodash';
 import {
 	READER_POSTS_RECEIVE,
 	READER_POST_SEEN,
@@ -20,19 +20,23 @@ export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case READER_POSTS_RECEIVE:
 			const posts = action.posts || action.payload.posts;
-			const postsByDedupedGlobalId = {};
+			const postsByKey = {};
 
-			// Assign a new key in case of global_ID collision.
-			for ( const [ globalId, post ] of Object.entries( keyBy( posts, 'global_ID' ) ) ) {
-				let key = globalId;
-				if ( state[ globalId ] && state[ globalId ].feed_item_ID !== post.feed_item_ID ) {
-					key = `${ globalId }-${ post.feed_item_ID }`;
-				}
+			// Keep track of all the feed_item_ID that have the same global_ID.
+			// See: https://github.com/Automattic/wp-calypso/pull/88408
+			posts.map( ( post ) => {
+				const { feed_item_IDs = [] } = state[ post.global_ID ] ?? {};
+				const { feed_item_ID, global_ID } = post;
 
-				postsByDedupedGlobalId[ key ] = post;
-			}
+				postsByKey[ global_ID ] = {
+					...post,
+					feed_item_IDs: feed_item_IDs.length
+						? [ ...new Set( [ ...feed_item_IDs, feed_item_ID ] ) ]
+						: [ feed_item_ID ],
+				};
+			} );
 
-			return { ...state, ...postsByDedupedGlobalId };
+			return { ...state, ...postsByKey };
 
 		case READER_SEEN_MARK_AS_SEEN_RECEIVE:
 		case READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE:

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -20,7 +20,19 @@ export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case READER_POSTS_RECEIVE:
 			const posts = action.posts || action.payload.posts;
-			return { ...state, ...keyBy( posts, 'global_ID' ) };
+			const postsByDedupedGlobalId = {};
+
+			// Assign a new key in case of global_ID collision.
+			for ( const [ globalId, post ] of Object.entries( keyBy( posts, 'global_ID' ) ) ) {
+				let key = globalId;
+				if ( state[ globalId ] && state[ globalId ].feed_item_ID !== post.feed_item_ID ) {
+					key = `${ globalId }-${ post.feed_item_ID }`;
+				}
+
+				postsByDedupedGlobalId[ key ] = post;
+			}
+
+			return { ...state, ...postsByDedupedGlobalId };
 
 		case READER_SEEN_MARK_AS_SEEN_RECEIVE:
 		case READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE:

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -24,7 +24,7 @@ export function items( state = {}, action ) {
 
 			// Keep track of all the feed_item_ID that have the same global_ID.
 			// See: https://github.com/Automattic/wp-calypso/pull/88408
-			posts.map( ( post ) => {
+			posts.forEach( ( post ) => {
 				const { feed_item_IDs = [] } = state[ post.global_ID ] ?? {};
 				const { feed_item_ID, global_ID } = post;
 

--- a/client/state/reader/posts/selectors.js
+++ b/client/state/reader/posts/selectors.js
@@ -1,5 +1,5 @@
 import treeSelect from '@automattic/tree-select';
-import { keyBy, some, get } from 'lodash';
+import { some, get } from 'lodash';
 import { keyToString, keyForPost } from 'calypso/reader/post-key';
 import 'calypso/state/reader/init';
 
@@ -15,7 +15,29 @@ export function getPostById( state, postGlobalId ) {
 
 const getPostMapByPostKey = treeSelect(
 	( state ) => [ state.reader.posts.items ],
-	( [ posts ] ) => keyBy( posts, ( post ) => keyToString( keyForPost( post ) ) )
+	( [ posts ] ) => {
+		const postMap = {};
+
+		Object.values( posts ).forEach( ( post ) => {
+			const { feed_item_IDs = [] } = post ?? {};
+
+			// Default case when the post matches only one feed_item_ID, if available.
+			if ( feed_item_IDs.length <= 1 ) {
+				postMap[ keyToString( keyForPost( post ) ) ] = post;
+				return;
+			}
+
+			// Edge case when the post matches multiple feed_item_IDs.
+			// Insert one entry per feed_item_ID to the post map.
+			// See: https://github.com/Automattic/wp-calypso/pull/88408
+			feed_item_IDs.map( ( feed_item_ID ) => {
+				const postKey = keyForPost( { feed_ID: post.feed_ID, feed_item_ID } );
+				postMap[ keyToString( postKey ) ] = post;
+			} );
+		} );
+
+		return postMap;
+	}
 );
 
 export const getPostByKey = ( state, postKey ) => {

--- a/client/state/reader/posts/selectors.js
+++ b/client/state/reader/posts/selectors.js
@@ -30,7 +30,7 @@ const getPostMapByPostKey = treeSelect(
 			// Edge case when the post matches multiple feed_item_IDs.
 			// Insert one entry per feed_item_ID to the post map.
 			// See: https://github.com/Automattic/wp-calypso/pull/88408
-			feed_item_IDs.map( ( feed_item_ID ) => {
+			feed_item_IDs.forEach( ( feed_item_ID ) => {
 				const postKey = keyForPost( { feed_ID: post.feed_ID, feed_item_ID } );
 				postMap[ keyToString( postKey ) ] = post;
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/54866

## Proposed Changes

In the Redux store, reader posts are stored in a map object using the post global ID as key. There are cases where global IDs will collide for the same post available in multiple environments. For instance, compare these posts [A](https://public-api.wordpress.com/rest/v1.2/read/feed/152308815/posts/5123943941) and [B](https://public-api.wordpress.com/rest/v1.2/read/feed/152308815/posts/5139449448). Notice that they are the same payload except for the domain and `feed_item_ID`.

This creates an issue in the reader UI where it displays both posts, but they are endlessly being queried since each one ends up overriding the other in the Redux store. Why? Because every time post A makes a query, the Redux store saves the payload of post A and overrides the one of post B. Then post B needs to make a query since it's no longer available in the Redux store, and ends up overriding the payload of post A.

This PR solves this issue by creating a `feed_item_IDs` to track all feed items that have the same global ID. This way, when doing post lookup, we create additional lookup map entries for all the feed_item_IDs that the post has. Note that this fix is only for the reader UI, it doesn't address what I think it's the root problem which is (1) global IDs should be unique and (2) same post shouldn't be shown twice.


Before:

https://github.com/Automattic/wp-calypso/assets/797888/1a9e0e59-d4d0-4577-9105-f477884147fe

After:

https://github.com/Automattic/wp-calypso/assets/797888/7d684e24-c22a-4958-bf9c-414c8ea433e8


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Not sure how to reproduce this issue, but definitely ensure that the change makes sense and doesn't introduce any regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?