### PR TITLE
Pattern Library: Wire up `Patterns / Page layouts` switcher

### DIFF
--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -15,7 +15,7 @@ import './style.scss';
 export const CategoryGalleryClient: CategoryGalleryFC = ( {
 	categories,
 	description,
-	patternType,
+	patternTypeFilter,
 	title,
 } ) => {
 	const patternIdsByCategory = {
@@ -36,7 +36,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 				<CategoryGalleryServer
 					categories={ categories }
 					description={ description }
-					patternType={ patternType }
+					patternTypeFilter={ patternTypeFilter }
 					title={ title }
 				/>
 			}
@@ -49,20 +49,20 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 				<PatternsSection title={ title } description={ description }>
 					<div
 						className={ classNames( 'patterns-category-gallery', {
-							'is-regular-patterns': patternType === PatternTypeFilter.REGULAR,
-							'is-page-patterns': patternType === PatternTypeFilter.PAGES,
+							'is-regular-patterns': patternTypeFilter === PatternTypeFilter.REGULAR,
+							'is-page-patterns': patternTypeFilter === PatternTypeFilter.PAGES,
 						} ) }
 					>
 						{ categories?.map( ( category ) => (
 							<LocalizedLink
 								className="patterns-category-gallery__item"
-								href={ getCategorySlug( category.name, patternType, false ) }
+								href={ getCategorySlug( category.name, patternTypeFilter, false ) }
 								key={ category.name }
 							>
 								<div
 									className={ classNames( 'patterns-category-gallery__item-preview', {
 										'patterns-category-gallery__item-preview_page-layouts':
-											patternType === PatternTypeFilter.PAGES,
+											patternTypeFilter === PatternTypeFilter.PAGES,
 										'patterns-category-gallery__item-preview_mirrored': category.name === 'footer',
 									} ) }
 								>
@@ -70,7 +70,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 										<PatternPreview
 											isCategoryPreview
 											pattern={
-												patternType === PatternTypeFilter.PAGES
+												patternTypeFilter === PatternTypeFilter.PAGES
 													? category.pagePreviewPattern
 													: category.regularPreviewPattern
 											}
@@ -81,7 +81,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 
 								<div className="patterns-category-gallery__item-name">{ category.label }</div>
 								<div className="patterns-category-gallery__item-count">
-									{ patternType === PatternTypeFilter.PAGES
+									{ patternTypeFilter === PatternTypeFilter.PAGES
 										? category.pagePatternCount
 										: category.regularPatternCount }{ ' ' }
 									patterns

--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -7,7 +7,7 @@ import {
 	PatternPreview,
 } from 'calypso/my-sites/patterns/components/pattern-preview';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
-import { RENDERER_SITE_ID, getCategorySlug } from 'calypso/my-sites/patterns/controller';
+import { RENDERER_SITE_ID, getCategoryUrlPath } from 'calypso/my-sites/patterns/controller';
 import { PatternTypeFilter, type CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
@@ -56,7 +56,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 						{ categories?.map( ( category ) => (
 							<LocalizedLink
 								className="patterns-category-gallery__item"
-								href={ getCategorySlug( category.name, patternTypeFilter, false ) }
+								href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
 								key={ category.name }
 							>
 								<div

--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -7,8 +7,8 @@ import {
 	PatternPreview,
 } from 'calypso/my-sites/patterns/components/pattern-preview';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
-import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/controller';
-import type { CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
+import { RENDERER_SITE_ID, getCategorySlug } from 'calypso/my-sites/patterns/controller';
+import { PatternTypeFilter, type CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
@@ -49,19 +49,20 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 				<PatternsSection title={ title } description={ description }>
 					<div
 						className={ classNames( 'patterns-category-gallery', {
-							'is-regular-patterns': patternType === 'regular',
-							'is-page-patterns': patternType === 'pages',
+							'is-regular-patterns': patternType === PatternTypeFilter.REGULAR,
+							'is-page-patterns': patternType === PatternTypeFilter.PAGES,
 						} ) }
 					>
 						{ categories?.map( ( category ) => (
 							<LocalizedLink
 								className="patterns-category-gallery__item"
-								href={ `/patterns/${ category.name }` }
+								href={ getCategorySlug( category.name, patternType, false ) }
 								key={ category.name }
 							>
 								<div
 									className={ classNames( 'patterns-category-gallery__item-preview', {
-										'patterns-category-gallery__item-preview_page-layouts': patternType === 'pages',
+										'patterns-category-gallery__item-preview_page-layouts':
+											patternType === PatternTypeFilter.PAGES,
 										'patterns-category-gallery__item-preview_mirrored': category.name === 'footer',
 									} ) }
 								>
@@ -69,7 +70,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 										<PatternPreview
 											isCategoryPreview
 											pattern={
-												patternType === 'pages'
+												patternType === PatternTypeFilter.PAGES
 													? category.pagePreviewPattern
 													: category.regularPreviewPattern
 											}
@@ -80,7 +81,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 
 								<div className="patterns-category-gallery__item-name">{ category.label }</div>
 								<div className="patterns-category-gallery__item-count">
-									{ patternType === 'pages'
+									{ patternType === PatternTypeFilter.PAGES
 										? category.pagePatternCount
 										: category.regularPatternCount }{ ' ' }
 									patterns

--- a/client/my-sites/patterns/components/category-gallery/server.tsx
+++ b/client/my-sites/patterns/components/category-gallery/server.tsx
@@ -2,7 +2,8 @@ import classNames from 'classnames';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview/placeholder';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
-import type { CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
+import { getCategorySlug } from 'calypso/my-sites/patterns/controller';
+import { PatternTypeFilter, type CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
@@ -16,27 +17,28 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 		<PatternsSection title={ title } description={ description }>
 			<div
 				className={ classNames( 'patterns-category-gallery', {
-					'is-regular-patterns': patternType === 'regular',
-					'is-page-patterns': patternType === 'pages',
+					'is-regular-patterns': patternType === PatternTypeFilter.REGULAR,
+					'is-page-patterns': patternType === PatternTypeFilter.PAGES,
 				} ) }
 			>
 				{ categories?.map( ( category ) => (
 					<LocalizedLink
 						className="patterns-category-gallery__item"
-						href={ `/patterns/${ category.name }` }
+						href={ getCategorySlug( category.name, patternType, false ) }
 						key={ category.name }
 					>
 						<div className="patterns-category-gallery__item-preview">
 							<div
 								className={ classNames( 'patterns-category-gallery__item-preview', {
-									'patterns-category-gallery__item-preview_page-layouts': patternType === 'pages',
+									'patterns-category-gallery__item-preview_page-layouts':
+										patternType === PatternTypeFilter.PAGES,
 									'patterns-category-gallery__item-preview_mirrored': category.name === 'footer',
 								} ) }
 							>
 								<div className="patterns-category-gallery__item-preview-inner">
 									<PatternPreviewPlaceholder
 										pattern={
-											patternType === 'pages'
+											patternType === PatternTypeFilter.PAGES
 												? category.pagePreviewPattern
 												: category.regularPreviewPattern
 										}
@@ -47,7 +49,9 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 
 						<div className="patterns-category-gallery__item-name">{ category.label }</div>
 						<div className="patterns-category-gallery__item-count">
-							{ patternType === 'pages' ? category.pagePatternCount : category.regularPatternCount }{ ' ' }
+							{ patternType === PatternTypeFilter.PAGES
+								? category.pagePatternCount
+								: category.regularPatternCount }{ ' ' }
 							patterns
 						</div>
 					</LocalizedLink>

--- a/client/my-sites/patterns/components/category-gallery/server.tsx
+++ b/client/my-sites/patterns/components/category-gallery/server.tsx
@@ -11,34 +11,34 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 	categories,
 	description,
 	title,
-	patternType,
+	patternTypeFilter,
 } ) => {
 	return (
 		<PatternsSection title={ title } description={ description }>
 			<div
 				className={ classNames( 'patterns-category-gallery', {
-					'is-regular-patterns': patternType === PatternTypeFilter.REGULAR,
-					'is-page-patterns': patternType === PatternTypeFilter.PAGES,
+					'is-regular-patterns': patternTypeFilter === PatternTypeFilter.REGULAR,
+					'is-page-patterns': patternTypeFilter === PatternTypeFilter.PAGES,
 				} ) }
 			>
 				{ categories?.map( ( category ) => (
 					<LocalizedLink
 						className="patterns-category-gallery__item"
-						href={ getCategorySlug( category.name, patternType, false ) }
+						href={ getCategorySlug( category.name, patternTypeFilter, false ) }
 						key={ category.name }
 					>
 						<div className="patterns-category-gallery__item-preview">
 							<div
 								className={ classNames( 'patterns-category-gallery__item-preview', {
 									'patterns-category-gallery__item-preview_page-layouts':
-										patternType === PatternTypeFilter.PAGES,
+										patternTypeFilter === PatternTypeFilter.PAGES,
 									'patterns-category-gallery__item-preview_mirrored': category.name === 'footer',
 								} ) }
 							>
 								<div className="patterns-category-gallery__item-preview-inner">
 									<PatternPreviewPlaceholder
 										pattern={
-											patternType === PatternTypeFilter.PAGES
+											patternTypeFilter === PatternTypeFilter.PAGES
 												? category.pagePreviewPattern
 												: category.regularPreviewPattern
 										}
@@ -49,7 +49,7 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 
 						<div className="patterns-category-gallery__item-name">{ category.label }</div>
 						<div className="patterns-category-gallery__item-count">
-							{ patternType === PatternTypeFilter.PAGES
+							{ patternTypeFilter === PatternTypeFilter.PAGES
 								? category.pagePatternCount
 								: category.regularPatternCount }{ ' ' }
 							patterns

--- a/client/my-sites/patterns/components/category-gallery/server.tsx
+++ b/client/my-sites/patterns/components/category-gallery/server.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview/placeholder';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
-import { getCategorySlug } from 'calypso/my-sites/patterns/controller';
+import { getCategoryUrlPath } from 'calypso/my-sites/patterns/controller';
 import { PatternTypeFilter, type CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
@@ -24,7 +24,7 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 				{ categories?.map( ( category ) => (
 					<LocalizedLink
 						className="patterns-category-gallery__item"
-						href={ getCategorySlug( category.name, patternTypeFilter, false ) }
+						href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
 						key={ category.name }
 					>
 						<div className="patterns-category-gallery__item-preview">

--- a/client/my-sites/patterns/controller.tsx
+++ b/client/my-sites/patterns/controller.tsx
@@ -3,7 +3,7 @@ import { PatternTypeFilter } from 'calypso/my-sites/patterns/types';
 
 export const RENDERER_SITE_ID = 226011606; // assemblerdemo
 
-export function getCategorySlug(
+export function getCategoryUrlPath(
 	categorySlug: string,
 	type: PatternTypeFilter,
 	includeLocale = true

--- a/client/my-sites/patterns/controller.tsx
+++ b/client/my-sites/patterns/controller.tsx
@@ -1,1 +1,17 @@
+import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import { PatternTypeFilter } from 'calypso/my-sites/patterns/types';
+
 export const RENDERER_SITE_ID = 226011606; // assemblerdemo
+
+export function getCategorySlug(
+	categorySlug: string,
+	type: PatternTypeFilter,
+	includeLocale = true
+) {
+	const href =
+		type === PatternTypeFilter.PAGES
+			? `/patterns/layouts/${ categorySlug }`
+			: `/patterns/${ categorySlug }`;
+
+	return includeLocale ? addLocaleToPathLocaleInFront( href ) : href;
+}

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -5,11 +5,16 @@ import { CategoryGalleryServer } from 'calypso/my-sites/patterns/components/cate
 import { PatternGalleryServer } from 'calypso/my-sites/patterns/components/pattern-gallery/server';
 import { getPatternCategoriesQueryOptions } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { getPatternsQueryOptions } from 'calypso/my-sites/patterns/hooks/use-patterns';
+import {
+	PatternTypeFilter,
+	type RouterContext,
+	type RouterNext,
+	type Pattern,
+} from 'calypso/my-sites/patterns/types';
 import { PatternsWrapper } from 'calypso/my-sites/patterns/wrapper';
 import { serverRouter } from 'calypso/server/isomorphic-routing';
 import performanceMark from 'calypso/server/lib/performance-mark';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import type { RouterContext, RouterNext, Pattern } from 'calypso/my-sites/patterns/types';
 
 function renderPatterns( context: RouterContext, next: RouterNext ) {
 	performanceMark( context, 'renderPatterns' );
@@ -20,6 +25,9 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 			categoryGallery={ CategoryGalleryServer }
 			isGridView={ !! context.query.grid }
 			patternGallery={ PatternGalleryServer }
+			patternType={
+				context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR
+			}
 		/>
 	);
 
@@ -77,7 +85,12 @@ export default function ( router: ReturnType< typeof serverRouter > ) {
 	const langParam = getLanguageRouteParam();
 
 	router(
-		[ `/${ langParam }/patterns/:category?`, `/patterns/:category?` ],
+		[
+			`/${ langParam }/patterns/:category?`,
+			`/${ langParam }/patterns/:type(layouts)/:category?`,
+			`/patterns/:category?`,
+			`/patterns/:type(layouts)/:category?`,
+		],
 		ssrSetupLocale,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -25,7 +25,7 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 			categoryGallery={ CategoryGalleryServer }
 			isGridView={ !! context.query.grid }
 			patternGallery={ PatternGalleryServer }
-			patternType={
+			patternTypeFilter={
 				context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR
 			}
 		/>

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -25,7 +25,7 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 				categoryGallery={ CategoryGalleryClient }
 				isGridView={ !! context.query.grid }
 				patternGallery={ PatternGalleryClient }
-				patternType={
+				patternTypeFilter={
 					context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR
 				}
 			/>

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -8,10 +8,14 @@ import {
 } from 'calypso/controller/index.web';
 import { CategoryGalleryClient } from 'calypso/my-sites/patterns/components/category-gallery/client';
 import { PatternGalleryClient } from 'calypso/my-sites/patterns/components/pattern-gallery/client';
+import {
+	PatternTypeFilter,
+	type RouterContext,
+	type RouterNext,
+} from 'calypso/my-sites/patterns/types';
 import { PatternsWrapper } from 'calypso/my-sites/patterns/wrapper';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getPatternCategoriesQueryOptions } from './hooks/use-pattern-categories';
-import type { RouterContext, RouterNext } from 'calypso/my-sites/patterns/types';
 
 function renderPatterns( context: RouterContext, next: RouterNext ) {
 	if ( ! context.primary ) {
@@ -21,6 +25,9 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 				categoryGallery={ CategoryGalleryClient }
 				isGridView={ !! context.query.grid }
 				patternGallery={ PatternGalleryClient }
+				patternType={
+					context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR
+				}
 			/>
 		);
 	}
@@ -60,5 +67,12 @@ export default function ( router: typeof clientRouter ) {
 		redirectWithoutLocaleParamInFrontIfLoggedIn,
 		...middleware
 	);
+	router(
+		`/${ langParam }/patterns/:type(layouts)/:category?`,
+		redirectWithoutLocaleParamInFrontIfLoggedIn,
+		...middleware
+	);
+
 	router( `/patterns/:category?`, ...middleware );
+	router( `/patterns/:type(layouts)/:category?`, ...middleware );
 }

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -73,11 +73,18 @@ export const PatternsCategoryPage = ( {
 		}
 	}, [ category ] );
 
-	const categoryNavList = categories?.map( ( category ) => ( {
-		name: category.name || '',
-		label: category.label,
-		link: getCategorySlug( category.name, patternTypeFilter, false ),
-	} ) );
+	const categoryObject = categories?.find( ( { name } ) => name === category );
+
+	const categoryNavList = categories?.map( ( category ) => {
+		const patternTypeFilterFallback =
+			category.pagePatternCount === 0 ? PatternTypeFilter.REGULAR : patternTypeFilter;
+
+		return {
+			name: category.name || '',
+			label: category.label,
+			link: getCategorySlug( category.name, patternTypeFilterFallback, false ),
+		};
+	} );
 
 	return (
 		<>
@@ -128,8 +135,12 @@ export const PatternsCategoryPage = ( {
 						} }
 						value={ patternTypeFilter }
 					>
-						<ToggleGroupControlOption value={ PatternTypeFilter.REGULAR } label="Patterns" />
-						<ToggleGroupControlOption value={ PatternTypeFilter.PAGES } label="Page layouts" />
+						<ToggleGroupControlOption label="Patterns" value={ PatternTypeFilter.REGULAR } />
+						<ToggleGroupControlOption
+							disabled={ categoryObject?.pagePatternCount === 0 }
+							label="Page layouts"
+							value={ PatternTypeFilter.PAGES }
+						/>
 					</ToggleGroupControl>
 
 					<ToggleGroupControl label="" isBlock className="patterns__toggle-view" value="patterns">

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -126,7 +126,7 @@ export const PatternsCategoryPage = ( {
 					<h1 className="patterns-page-category__title">Patterns</h1>
 
 					<ToggleGroupControl
-						className="patterns__toggle-type"
+						className="patterns-page-category__toggle--pattern-type"
 						isBlock
 						label=""
 						onChange={ ( value ) => {
@@ -135,24 +135,34 @@ export const PatternsCategoryPage = ( {
 						} }
 						value={ patternTypeFilter }
 					>
-						<ToggleGroupControlOption label="Patterns" value={ PatternTypeFilter.REGULAR } />
 						<ToggleGroupControlOption
+							className="patterns-page-category__toggle-option"
+							label="Patterns"
+							value={ PatternTypeFilter.REGULAR }
+						/>
+						<ToggleGroupControlOption
+							className="patterns-page-category__toggle-option"
 							disabled={ categoryObject?.pagePatternCount === 0 }
 							label="Page layouts"
 							value={ PatternTypeFilter.PAGES }
 						/>
 					</ToggleGroupControl>
 
-					<ToggleGroupControl label="" isBlock className="patterns__toggle-view" value="patterns">
+					<ToggleGroupControl
+						className="patterns-page-category__toggle--view"
+						label=""
+						isBlock
+						value="patterns"
+					>
 						<ToggleGroupControlOption
-							value="patterns"
+							className="patterns-page-category__toggle-option--list-view"
 							label="List view"
-							className="patterns-button__list-view"
+							value="list"
 						/>
 						<ToggleGroupControlOption
-							value="layouts"
+							className="patterns-page-category__toggle-option--grid-view"
 							label="Grid view"
-							className="patterns-button__grid-view"
+							value="grid"
 						/>
 					</ToggleGroupControl>
 				</div>

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -39,14 +39,14 @@ type PatternsCategoryPageProps = {
 	category: string;
 	isGridView?: boolean;
 	patternGallery: PatternGalleryFC;
-	patternType: PatternTypeFilter;
+	patternTypeFilter: PatternTypeFilter;
 };
 
 export const PatternsCategoryPage = ( {
 	category,
 	isGridView,
 	patternGallery: PatternGallery,
-	patternType,
+	patternTypeFilter,
 }: PatternsCategoryPageProps ) => {
 	const locale = useLocale();
 	// Helps prevent resetting the search input if a search term was provided through the URL
@@ -58,7 +58,7 @@ export const PatternsCategoryPage = ( {
 	const { data: categories } = usePatternCategories( locale );
 	const { data: patterns = [] } = usePatterns( locale, category, {
 		select( patterns ) {
-			const patternsByType = filterPatternsByType( patterns, patternType );
+			const patternsByType = filterPatternsByType( patterns, patternTypeFilter );
 			return filterPatternsByTerm( patternsByType, searchTerm );
 		},
 	} );
@@ -76,7 +76,7 @@ export const PatternsCategoryPage = ( {
 	const categoryNavList = categories?.map( ( category ) => ( {
 		name: category.name || '',
 		label: category.label,
-		link: getCategorySlug( category.name, patternType, false ),
+		link: getCategorySlug( category.name, patternTypeFilter, false ),
 	} ) );
 
 	return (
@@ -126,7 +126,7 @@ export const PatternsCategoryPage = ( {
 							const href = getCategorySlug( category, value as PatternTypeFilter );
 							page( href );
 						} }
-						value={ patternType }
+						value={ patternTypeFilter }
 					>
 						<ToggleGroupControlOption value={ PatternTypeFilter.REGULAR } label="Patterns" />
 						<ToggleGroupControlOption value={ PatternTypeFilter.PAGES } label="Page layouts" />

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -9,7 +9,7 @@ import { CategoryPillNavigation } from 'calypso/components/category-pill-navigat
 import DocumentHead from 'calypso/components/data/document-head';
 import { PatternsGetStarted } from 'calypso/my-sites/patterns/components/get-started';
 import { PatternsHeader } from 'calypso/my-sites/patterns/components/header';
-import { getCategorySlug } from 'calypso/my-sites/patterns/controller';
+import { getCategoryUrlPath } from 'calypso/my-sites/patterns/controller';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import {
 	usePatternSearchTerm,
@@ -82,7 +82,7 @@ export const PatternsCategoryPage = ( {
 		return {
 			name: category.name || '',
 			label: category.label,
-			link: getCategorySlug( category.name, patternTypeFilterFallback, false ),
+			link: getCategoryUrlPath( category.name, patternTypeFilterFallback, false ),
 		};
 	} );
 
@@ -130,7 +130,7 @@ export const PatternsCategoryPage = ( {
 						isBlock
 						label=""
 						onChange={ ( value ) => {
-							const href = getCategorySlug( category, value as PatternTypeFilter );
+							const href = getCategoryUrlPath( category, value as PatternTypeFilter );
 							page( href );
 						} }
 						value={ patternTypeFilter }

--- a/client/my-sites/patterns/pages/category/style.scss
+++ b/client/my-sites/patterns/pages/category/style.scss
@@ -32,6 +32,11 @@
 	padding: 56px 0 48px;
 	align-items: center;
 
+	@media ( max-width: $break-medium ) {
+		display: block;
+		padding: 0 0 24px;
+	}
+
 	.patterns-page-category__title {
 		margin-right: auto;
 		font-family: $font-recoleta;
@@ -45,42 +50,44 @@
 		flex: none;
 		margin-left: 24px;
 		white-space: nowrap;
+	}
 
-		.components-base-control__field,
-		.components-base-control__label {
-			margin-bottom: 0;
-		}
+	.components-base-control__field,
+	.components-base-control__label {
+		margin-bottom: 0;
+	}
 
-		.components-toggle-group-control-option-base {
-			min-width: 118px;
-		}
+	.patterns-page-category__toggle-option {
+		min-width: 118px;
 
-		.patterns-button__list-view,
-		.patterns-button__grid-view {
-			min-width: 34px;
-
-			div {
-				font-size: 0;
-			}
-
-			&[aria-checked="true"] {
-				filter: invert(100%);
-			}
-		}
-
-		.patterns-button__list-view {
-			background: url(./images/list.svg) no-repeat center center;
-		}
-
-		.patterns-button__grid-view {
-			background: url(./images/grid.svg) no-repeat center center;
+		&:disabled {
+			cursor: default;
+			opacity: 0.5;
 		}
 	}
 
-	@media ( max-width: $break-medium  ) {
-		display: block;
-		padding: 0 0 24px;
+	.patterns-page-category__toggle-option--list-view,
+	.patterns-page-category__toggle-option--grid-view {
+		min-width: 34px;
 
+		div {
+			font-size: 0;
+		}
+
+		&[aria-checked="true"] {
+			filter: invert(100%);
+		}
+	}
+
+	.patterns-page-category__toggle-option--list-view {
+		background: url(./images/list.svg) no-repeat center center;
+	}
+
+	.patterns-page-category__toggle-option--grid-view {
+		background: url(./images/grid.svg) no-repeat center center;
+	}
+
+	@media ( max-width: $break-medium ) {
 		.patterns-page-category__title {
 			display: none;
 		}
@@ -89,15 +96,15 @@
 			margin-left: 0;
 		}
 
-		.patterns__toggle-type {
+		.patterns-page-category__toggle--pattern-type {
 			width: 100%;
 		}
 
-		.patterns__toggle-view {
+		.patterns-page-category__toggle--view {
 			display: none;
 		}
 
-		.components-toggle-group-control-option-base {
+		.patterns-page-category__toggle-option {
 			height: 40px;
 		}
 	}

--- a/client/my-sites/patterns/pages/home/index.tsx
+++ b/client/my-sites/patterns/pages/home/index.tsx
@@ -9,11 +9,15 @@ import {
 	filterPatternsByTerm,
 } from 'calypso/my-sites/patterns/hooks/use-pattern-search-term';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
+import {
+	PatternTypeFilter,
+	type CategoryGalleryFC,
+	type PatternGalleryFC,
+} from 'calypso/my-sites/patterns/types';
 import ImgCopyPaste from './images/copy-paste.svg';
 import ImgEdit from './images/edit.svg';
 import ImgResponsive from './images/responsive.svg';
 import ImgStyle from './images/style.svg';
-import type { CategoryGalleryFC, PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
@@ -54,7 +58,7 @@ export const PatternsHomePage = ( {
 				title="Ship faster with patterns"
 				description="Choose from a huge library of patterns to build any page you need."
 				categories={ categories?.filter( ( c ) => c.regularPatternCount ) }
-				patternType="regular"
+				patternType={ PatternTypeFilter.REGULAR }
 			/>
 
 			{ searchTerm && <PatternGallery patterns={ patterns } isGridView={ isGridView } /> }
@@ -112,7 +116,7 @@ export const PatternsHomePage = ( {
 				title="Beautifully curated page layouts"
 				description="Entire pages built of patterns, ready to be added to your site."
 				categories={ categories?.filter( ( c ) => c.pagePatternCount ) }
-				patternType="pages"
+				patternType={ PatternTypeFilter.PAGES }
 			/>
 
 			<PatternsGetStarted />

--- a/client/my-sites/patterns/pages/home/index.tsx
+++ b/client/my-sites/patterns/pages/home/index.tsx
@@ -58,7 +58,7 @@ export const PatternsHomePage = ( {
 				title="Ship faster with patterns"
 				description="Choose from a huge library of patterns to build any page you need."
 				categories={ categories?.filter( ( c ) => c.regularPatternCount ) }
-				patternType={ PatternTypeFilter.REGULAR }
+				patternTypeFilter={ PatternTypeFilter.REGULAR }
 			/>
 
 			{ searchTerm && <PatternGallery patterns={ patterns } isGridView={ isGridView } /> }
@@ -116,7 +116,7 @@ export const PatternsHomePage = ( {
 				title="Beautifully curated page layouts"
 				description="Entire pages built of patterns, ready to be added to your site."
 				categories={ categories?.filter( ( c ) => c.pagePatternCount ) }
-				patternType={ PatternTypeFilter.PAGES }
+				patternTypeFilter={ PatternTypeFilter.PAGES }
 			/>
 
 			<PatternsGetStarted />

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -41,7 +41,7 @@ export type Category = CategoryBase & {
 type CategoryGalleryProps = {
 	categories?: Category[];
 	description: string;
-	patternType: PatternTypeFilter;
+	patternTypeFilter: PatternTypeFilter;
 	title: string;
 };
 

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -13,6 +13,11 @@ export type RouterContext = Context &
 
 export type { Pattern };
 
+export enum PatternTypeFilter {
+	PAGES = 'pages',
+	REGULAR = 'regular',
+}
+
 type CategoryBase = {
 	name: string;
 	label: string;
@@ -36,7 +41,7 @@ export type Category = CategoryBase & {
 type CategoryGalleryProps = {
 	categories?: Category[];
 	description: string;
-	patternType: 'regular' | 'pages';
+	patternType: PatternTypeFilter;
 	title: string;
 };
 

--- a/client/my-sites/patterns/wrapper.tsx
+++ b/client/my-sites/patterns/wrapper.tsx
@@ -17,7 +17,7 @@ type PatternsWrapperProps = {
 	categoryGallery: CategoryGalleryFC;
 	isGridView?: boolean;
 	patternGallery: PatternGalleryFC;
-	patternType: PatternTypeFilter;
+	patternTypeFilter: PatternTypeFilter;
 };
 
 export const PatternsWrapper = ( {
@@ -25,7 +25,7 @@ export const PatternsWrapper = ( {
 	categoryGallery,
 	isGridView,
 	patternGallery,
-	patternType,
+	patternTypeFilter,
 }: PatternsWrapperProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
@@ -45,7 +45,7 @@ export const PatternsWrapper = ( {
 						category={ category }
 						isGridView={ isGridView }
 						patternGallery={ patternGallery }
-						patternType={ patternType }
+						patternTypeFilter={ patternTypeFilter }
 					/>
 				) }
 			</Main>

--- a/client/my-sites/patterns/wrapper.tsx
+++ b/client/my-sites/patterns/wrapper.tsx
@@ -2,9 +2,13 @@ import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-
 import Main from 'calypso/components/main';
 import { PatternsCategoryPage } from 'calypso/my-sites/patterns/pages/category';
 import { PatternsHomePage } from 'calypso/my-sites/patterns/pages/home';
+import {
+	type CategoryGalleryFC,
+	type PatternGalleryFC,
+	PatternTypeFilter,
+} from 'calypso/my-sites/patterns/types';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import type { CategoryGalleryFC, PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
@@ -13,6 +17,7 @@ type PatternsWrapperProps = {
 	categoryGallery: CategoryGalleryFC;
 	isGridView?: boolean;
 	patternGallery: PatternGalleryFC;
+	patternType: PatternTypeFilter;
 };
 
 export const PatternsWrapper = ( {
@@ -20,6 +25,7 @@ export const PatternsWrapper = ( {
 	categoryGallery,
 	isGridView,
 	patternGallery,
+	patternType,
 }: PatternsWrapperProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
@@ -39,6 +45,7 @@ export const PatternsWrapper = ( {
 						category={ category }
 						isGridView={ isGridView }
 						patternGallery={ patternGallery }
+						patternType={ patternType }
 					/>
 				) }
 			</Main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5971

## Proposed Changes

Category pages in the pattern library have a toggle at the top, where users can select if they want to see regular patterns or page layout patterns.

This PR wires up that toggle to filter the displayed patterns as expected. The selection is also persisted to the URL as follows:

- Regular pattern categories: `/patterns/about`
- Page pattern categories: `/patterns/layouts/about`

![toggle](https://github.com/Automattic/wp-calypso/assets/1101677/434f1766-8409-478f-ac3f-917849f4b542)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/about`
2. Click on `Page layouts` in the toggle
3. Ensure that the displayed patterns change as expected
4. Ensure that the URL changes to `/patterns/layouts/about`
5. Refresh the page
6. Ensure that `Page layouts` is still selected in the toggle
7. Click `Headers` in the category pill navigation
8. Ensure that the URL changes to `/patterns/header`
9. Ensure that your cannot select `Page layouts` in the toggle (it's disabled)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?