### PR TITLE
Patterns: grid and list view functionality

### DIFF
--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -91,9 +91,24 @@ export const PatternsCategoryPage = ( {
 		return {
 			id: category.name || '',
 			label: category.label,
-			link: getCategoryUrlPath( category.name, patternTypeFilterFallback, false ),
+			link:
+				getCategoryUrlPath( category.name, patternTypeFilterFallback, false ) +
+				( isGridView ? '?grid=1' : '' ),
 		};
 	} );
+
+	const handleSettingView = ( value: 'grid' | 'list' ) => {
+		const searchParams = new URLSearchParams( location.search );
+
+		if ( value === 'grid' ) {
+			searchParams.set( 'grid', '1' );
+		} else {
+			searchParams.delete( 'grid' );
+		}
+
+		const paramsString = searchParams.toString().length ? `?${ searchParams.toString() }` : '';
+		page( location.pathname + paramsString );
+	};
 
 	return (
 		<>
@@ -161,17 +176,19 @@ export const PatternsCategoryPage = ( {
 						className="patterns-page-category__toggle--view"
 						label=""
 						isBlock
-						value="patterns"
+						value={ isGridView ? 'grid' : 'list' }
 					>
 						<ToggleGroupControlOption
 							className="patterns-page-category__toggle-option--list-view"
 							label={ ( <Icon icon={ iconMenu } size={ 20 } /> ) as unknown as string }
 							value="list"
+							onClick={ () => handleSettingView( 'list' ) }
 						/>
 						<ToggleGroupControlOption
 							className="patterns-page-category__toggle-option--grid-view"
 							label={ ( <Icon icon={ iconCategory } size={ 20 } /> ) as unknown as string }
 							value="grid"
+							onClick={ () => handleSettingView( 'grid' ) }
 						/>
 					</ToggleGroupControl>
 				</div>

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -44,6 +44,19 @@ function filterPatternsByType( patterns: Pattern[], type: PatternTypeFilter ) {
 	} );
 }
 
+const handleSettingView = ( value: 'grid' | 'list' ) => {
+	const searchParams = new URLSearchParams( location.search );
+
+	if ( value === 'grid' ) {
+		searchParams.set( 'grid', '1' );
+	} else {
+		searchParams.delete( 'grid' );
+	}
+
+	const paramsString = searchParams.toString().length ? `?${ searchParams.toString() }` : '';
+	page( location.pathname + paramsString );
+};
+
 type PatternsCategoryPageProps = {
 	category: string;
 	isGridView?: boolean;
@@ -96,19 +109,6 @@ export const PatternsCategoryPage = ( {
 				( isGridView ? '?grid=1' : '' ),
 		};
 	} );
-
-	const handleSettingView = ( value: 'grid' | 'list' ) => {
-		const searchParams = new URLSearchParams( location.search );
-
-		if ( value === 'grid' ) {
-			searchParams.set( 'grid', '1' );
-		} else {
-			searchParams.delete( 'grid' );
-		}
-
-		const paramsString = searchParams.toString().length ? `?${ searchParams.toString() }` : '';
-		page( location.pathname + paramsString );
-	};
 
 	return (
 		<>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5972

## Proposed Changes
With this PR we are adding handlers for list/grid view button on `/patterns/:category` page

## Testing Instructions
1) Open `http://calypso.localhost:3000/patterns/posts`
2) Assert that `list view` button is selected by default and content has items with list view <br />![Screenshot 2024-03-12 at 12 11 21](https://github.com/Automattic/wp-calypso/assets/5598437/fd229539-3f00-4b3c-b5cb-ac2a16eb34f4)
3) Click on `grid view` button
4) Assert that URL has query `?grid=1`
5) Assert that content has items with grid view
6) Reload the page - assert that everything looks the same and `grid view` button is active
