### PR TITLE
Command Palette: Add GitHub Deployments Command

### DIFF
--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -29,7 +29,6 @@ import {
 	wordpress as wordpressIcon,
 	comment as feedbackIcon,
 } from '@wordpress/icons';
-import classNames from 'classnames';
 import { Command, CommandCallBackParams } from '../use-command-palette';
 import { isCustomDomain } from '../utils';
 import { useCommandsParams } from './types';
@@ -994,15 +993,12 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			siteType: SiteType.ATOMIC,
 			icon: (
 				<svg
-					width={ width }
-					height={ height }
+					width={ 18 }
+					height={ 18 }
 					viewBox="0 0 19 19"
 					fill="none"
 					xmlns="http://www.w3.org/2000/svg"
-					className={ classNames( 'social-icons social-icons__apple', {
-						'social-icons--enabled': ! isDisabled,
-						'social-icons--disabled': !! isDisabled,
-					} ) }
+					className="social-icons--enabled"
 				>
 					<g clipPath="url(#clip0_2014_1339)">
 						<path

--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -29,6 +29,7 @@ import {
 	wordpress as wordpressIcon,
 	comment as feedbackIcon,
 } from '@wordpress/icons';
+import classNames from 'classnames';
 import { Command, CommandCallBackParams } from '../use-command-palette';
 import { isCustomDomain } from '../utils';
 import { useCommandsParams } from './types';
@@ -65,6 +66,7 @@ interface CustomWindow {
 		isWpcomStore: boolean;
 		shouldUseWpAdmin: boolean;
 		siteHostname: string;
+		isGHDeployAvailable: boolean;
 	};
 }
 
@@ -93,6 +95,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		isWpcomStore = false,
 		shouldUseWpAdmin = false,
 		siteHostname,
+		isGHDeployAvailable = false,
 	} = customWindow?.commandPaletteConfig || {};
 
 	let siteType: SiteType | null = null;
@@ -976,6 +979,48 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			icon: feedbackIcon,
 		},
 	];
+
+	if ( isGHDeployAvailable ) {
+		commands.push( {
+			name: 'openGitHubDeployments',
+			label: __( 'Open GitHub Deployments' ),
+			callback: commandNavigation( '/github-deployments/:site' ),
+			searchLabel: [
+				_x( 'open github deployments', 'Keyword for the Open GitHub Deployments command' ),
+				_x( 'github', 'Keyword for the Open GitHub Deployments command' ),
+				_x( 'deployments', 'Keyword for the Open GitHub Deployments command' ),
+			].join( ' ' ),
+			capability: SiteCapabilities.MANAGE_OPTIONS,
+			siteType: SiteType.ATOMIC,
+			icon: (
+				<svg
+					width={ width }
+					height={ height }
+					viewBox="0 0 19 19"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					className={ classNames( 'social-icons social-icons__apple', {
+						'social-icons--enabled': ! isDisabled,
+						'social-icons--disabled': !! isDisabled,
+					} ) }
+				>
+					<g clipPath="url(#clip0_2014_1339)">
+						<path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="M9.47169 0C4.23409 0 0 4.26531 0 9.54207C0 13.7601 2.71293 17.3305 6.47648 18.5942C6.94702 18.6892 7.11938 18.3889 7.11938 18.1363C7.11938 17.9151 7.10387 17.1568 7.10387 16.3668C4.46907 16.9356 3.9204 15.2293 3.9204 15.2293C3.49697 14.1234 2.86958 13.8392 2.86958 13.8392C2.00721 13.2546 2.9324 13.2546 2.9324 13.2546C3.88899 13.3178 4.39094 14.2341 4.39094 14.2341C5.2376 15.6874 6.60192 15.2768 7.15079 15.024C7.22911 14.4078 7.48018 13.9813 7.74677 13.7444C5.64533 13.5232 3.43435 12.7017 3.43435 9.03644C3.43435 7.99377 3.81047 7.1407 4.40645 6.47725C4.31242 6.24034 3.98302 5.26067 4.50067 3.94948C4.50067 3.94948 5.30042 3.69666 7.10367 4.92895C7.87571 4.72008 8.6719 4.61382 9.47169 4.61293C10.2714 4.61293 11.0867 4.72363 11.8395 4.92895C13.643 3.69666 14.4427 3.94948 14.4427 3.94948C14.9604 5.26067 14.6308 6.24034 14.5367 6.47725C15.1484 7.1407 15.509 7.99377 15.509 9.03644C15.509 12.7017 13.2981 13.5073 11.1809 13.7444C11.526 14.0445 11.8238 14.6131 11.8238 15.5137C11.8238 16.7933 11.8083 17.8203 11.8083 18.1361C11.8083 18.3889 11.9809 18.6892 12.4512 18.5944C16.2148 17.3303 18.9277 13.7601 18.9277 9.54207C18.9432 4.26531 14.6936 0 9.47169 0Z"
+							fill="#24292F"
+						/>
+					</g>
+					<defs>
+						<clipPath id="clip0_2014_1339">
+							<rect width="19" height="18.6122" fill="white" />
+						</clipPath>
+					</defs>
+				</svg>
+			),
+		} );
+	}
 
 	return commands
 		.filter( ( command ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to
- https://github.com/Automattic/wp-calypso/issues/88345

## Proposed Changes

* Added the GitHub deployments command to the single site command palette.
* The command is only available on Atomic sites that have the `isGHDeployAvailable` config set to true.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Upload the command palette app to your sandbox.
* Sandbox widgets.wp.com
* [Optional] Follow the instructions in: https://github.com/Automattic/jetpack/pull/36324
* If you don't want to follow the instructions you can open the browser's console and set the `isGHDeployAvailable` property to true before opening the command palette.
* On a simple site, you should not see the command. 
* On an Atomic site the command should be available. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?