### PR TITLE
HelpCenter Fix article style issues inside editor

### DIFF
--- a/packages/help-center/src/components/help-center-article-content.scss
+++ b/packages/help-center/src/components/help-center-article-content.scss
@@ -11,6 +11,11 @@
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
+	// Temporary fix on the help center article content inside the editor
+	.wp-block-columns-is-layout-flex {
+		display: block !important;
+	}
+
 	h1 {
 		font-size: $font-title-large;
 		font-weight: 600;
@@ -103,6 +108,7 @@
 			margin-top: 12px;
 			margin-bottom: 12px;
 			margin-left: 32px;
+			display: block !important;
 		}
 	}
 
@@ -170,6 +176,7 @@
 		font-size: $font-body-small;
 		text-align: center;
 		color: var(--color-neutral-40);
+		display: block !important;
 	}
 
 	// placeholder for videopress videos


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87340

## Proposed Changes

* When inside the Editor, there are some styles being leaked from Gutenberg into the HelpCenter, this PR temporarily addresses the worst style issues, we are studying how to isolate HelpCenter style and prevent more leaks from happening.
More details in this https://github.com/Automattic/wp-calypso/issues/87340#issuecomment-1956826896

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since this issue only happens inside the editor, it means you need to install the ETK in your atomic to test this PR.
* Download ETK Zip File from the latest [commit/build](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WPComPlugins_Build_Plugins/12062351?buildTab=artifacts#%2Fediting-toolkit.zip)
* Install this zip in your atomic site
* Navigate to Helpcenter inside the editor
* Search for Like and select `add a like button`
* compare with the video in this https://github.com/Automattic/wp-calypso/issues/87340#issuecomment-1956826896

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?