### PR TITLE
Scheduled Updates: Retry monitor setting when monitor_active is false

### DIFF
--- a/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
+++ b/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
@@ -1,35 +1,21 @@
-import { useTranslate } from 'i18n-calypso';
 import {
 	UpdateMonitorSettings,
 	useCreateMonitorSettingsMutation,
 } from 'calypso/data/plugins/use-monitor-settings-mutation';
-import { useSelector, useDispatch } from 'calypso/state';
+import { useSelector } from 'calypso/state';
 import { JETPACK_MODULE_ACTIVATE_SUCCESS } from 'calypso/state/action-types';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
-import { errorNotice } from 'calypso/state/notices/actions';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { SiteSlug } from 'calypso/types';
 import { CRON_CHECK_INTERVAL } from '../schedule-form.const';
 
 export function useCreateMonitor( siteSlug: SiteSlug ) {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
 	const siteUrl = useSelector( ( state ) =>
 		getSiteUrl( state, getSiteId( state, siteSlug ) as number )
 	);
-	const { createMonitorSettings } = useCreateMonitorSettingsMutation( siteSlug, {
-		onError: () => {
-			dispatch(
-				errorNotice(
-					translate(
-						'We were unable to correctly register the schedule at this time. Please try and re-create a new schedule.'
-					)
-				)
-			);
-		},
-	} );
+	const { createMonitorSettings } = useCreateMonitorSettingsMutation( siteSlug );
 
 	const createMonitor = () => {
 		activateModule(

--- a/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
+++ b/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
@@ -38,23 +38,20 @@ export function useCreateMonitor( siteSlug: SiteSlug ) {
 			true
 		)( ( args: { type: string } ) => {
 			if ( args.type === JETPACK_MODULE_ACTIVATE_SUCCESS ) {
-				createMonitorSettings(
-					{
-						urls: [
-							{
-								// The home URL needs to be one of the URLs monitored.
-								check_interval: CRON_CHECK_INTERVAL,
-								monitor_url: siteUrl,
-							},
-							{
-								// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
-								check_interval: CRON_CHECK_INTERVAL,
-								monitor_url: siteUrl + '/wp-cron.php',
-							},
-						],
-					} as UpdateMonitorSettings,
-					true
-				);
+				createMonitorSettings( {
+					urls: [
+						{
+							// The home URL needs to be one of the URLs monitored.
+							check_interval: CRON_CHECK_INTERVAL,
+							monitor_url: siteUrl,
+						},
+						{
+							// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
+							check_interval: CRON_CHECK_INTERVAL,
+							monitor_url: siteUrl + '/wp-cron.php',
+						},
+					],
+				} as UpdateMonitorSettings );
 			}
 		} );
 	};

--- a/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
+++ b/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
@@ -1,21 +1,35 @@
+import { useTranslate } from 'i18n-calypso';
 import {
 	UpdateMonitorSettings,
 	useCreateMonitorSettingsMutation,
 } from 'calypso/data/plugins/use-monitor-settings-mutation';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
 import { JETPACK_MODULE_ACTIVATE_SUCCESS } from 'calypso/state/action-types';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { SiteSlug } from 'calypso/types';
 import { CRON_CHECK_INTERVAL } from '../schedule-form.const';
 
 export function useCreateMonitor( siteSlug: SiteSlug ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
 	const siteUrl = useSelector( ( state ) =>
 		getSiteUrl( state, getSiteId( state, siteSlug ) as number )
 	);
-	const { createMonitorSettings } = useCreateMonitorSettingsMutation( siteSlug );
+	const { createMonitorSettings } = useCreateMonitorSettingsMutation( siteSlug, {
+		onError: () => {
+			dispatch(
+				errorNotice(
+					translate(
+						'We were unable to correctly register the schedule at this time. Please try and re-create a new schedule.'
+					)
+				)
+			);
+		},
+	} );
 
 	const createMonitor = () => {
 		activateModule(
@@ -24,20 +38,23 @@ export function useCreateMonitor( siteSlug: SiteSlug ) {
 			true
 		)( ( args: { type: string } ) => {
 			if ( args.type === JETPACK_MODULE_ACTIVATE_SUCCESS ) {
-				createMonitorSettings( {
-					urls: [
-						{
-							// The home URL needs to be one of the URLs monitored.
-							check_interval: CRON_CHECK_INTERVAL,
-							monitor_url: siteUrl,
-						},
-						{
-							// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
-							check_interval: CRON_CHECK_INTERVAL,
-							monitor_url: siteUrl + '/wp-cron.php',
-						},
-					],
-				} as UpdateMonitorSettings );
+				createMonitorSettings(
+					{
+						urls: [
+							{
+								// The home URL needs to be one of the URLs monitored.
+								check_interval: CRON_CHECK_INTERVAL,
+								monitor_url: siteUrl,
+							},
+							{
+								// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
+								check_interval: CRON_CHECK_INTERVAL,
+								monitor_url: siteUrl + '/wp-cron.php',
+							},
+						],
+					} as UpdateMonitorSettings,
+					true
+				);
 			}
 		} );
 	};

--- a/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
+++ b/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
@@ -38,20 +38,22 @@ export function useCreateMonitor( siteSlug: SiteSlug ) {
 			true
 		)( ( args: { type: string } ) => {
 			if ( args.type === JETPACK_MODULE_ACTIVATE_SUCCESS ) {
-				createMonitorSettings( {
-					urls: [
-						{
-							// The home URL needs to be one of the URLs monitored.
-							check_interval: CRON_CHECK_INTERVAL,
-							monitor_url: siteUrl,
-						},
-						{
-							// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
-							check_interval: CRON_CHECK_INTERVAL,
-							monitor_url: siteUrl + '/wp-cron.php',
-						},
-					],
-				} as UpdateMonitorSettings );
+				setTimeout( () => {
+					createMonitorSettings( {
+						urls: [
+							{
+								// The home URL needs to be one of the URLs monitored.
+								check_interval: CRON_CHECK_INTERVAL,
+								monitor_url: siteUrl,
+							},
+							{
+								// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
+								check_interval: CRON_CHECK_INTERVAL,
+								monitor_url: siteUrl + '/wp-cron.php',
+							},
+						],
+					} as UpdateMonitorSettings );
+				}, 3000 );
 			}
 		} );
 	};

--- a/client/data/plugins/use-monitor-settings-mutation.ts
+++ b/client/data/plugins/use-monitor-settings-mutation.ts
@@ -52,7 +52,7 @@ interface MonitorSettingVariables {
 }
 
 export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptions = {} ) {
-	const MAX_RETRIES = 1;
+	const MAX_RETRIES = 3;
 	let retryCount = 0;
 
 	const isMonitorNotActive = ( data: UpdateMonitorSettingsCreate ) => {

--- a/client/data/plugins/use-monitor-settings-mutation.ts
+++ b/client/data/plugins/use-monitor-settings-mutation.ts
@@ -51,8 +51,8 @@ export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptio
 	const MAX_RETRIES = 3;
 	const isMonitorNotActiveErrorMsg = 'Monitor is not active.';
 
-	const isMonitorNotActive = ( data: UpdateMonitorSettingsCreate ) => {
-		return data?.settings && data?.settings?.monitor_active === false;
+	const isMonitorActive = ( data: UpdateMonitorSettingsCreate ) => {
+		return data?.settings && data?.settings?.monitor_active === true;
 	};
 
 	const isMonitorNotActiveError = ( error: Error ) => {
@@ -67,7 +67,7 @@ export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptio
 				method: 'POST',
 				body: params,
 			} );
-			if ( isMonitorNotActive( response ) ) {
+			if ( ! isMonitorActive( response ) ) {
 				throw new Error( isMonitorNotActiveErrorMsg );
 			}
 			return response;

--- a/client/data/plugins/use-monitor-settings-mutation.ts
+++ b/client/data/plugins/use-monitor-settings-mutation.ts
@@ -1,6 +1,7 @@
 import { UseQueryResult, useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { SiteSlug } from 'calypso/types';
 
 export type UpdateMonitorURLOptions = {
@@ -75,6 +76,9 @@ export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptio
 		...queryOptions,
 		retry: ( failureCount, error ) => {
 			if ( isMonitorNotActiveError( error ) && failureCount < MAX_RETRIES ) {
+				recordTracksEvent( 'calypso_scheduled_updates_retry_monitor_settings', {
+					site_slug: siteSlug,
+				} );
 				return true;
 			}
 			return false;

--- a/client/data/plugins/use-monitor-settings-mutation.ts
+++ b/client/data/plugins/use-monitor-settings-mutation.ts
@@ -75,11 +75,13 @@ export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptio
 		},
 		...queryOptions,
 		retry: ( failureCount, error ) => {
-			if ( isMonitorNotActiveError( error ) && failureCount < MAX_RETRIES ) {
-				recordTracksEvent( 'calypso_scheduled_updates_retry_monitor_settings', {
+			if ( isMonitorNotActiveError( error ) ) {
+				if ( failureCount < MAX_RETRIES ) {
+					return true;
+				}
+				recordTracksEvent( 'calypso_scheduled_updates_retry_monitor_settings_failed', {
 					site_slug: siteSlug,
 				} );
-				return true;
 			}
 			return false;
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#5996

## Proposed Changes

* Sometimes when we activate the Jetpack monitor module, the `POST /jetpack-monitor-settings` run before the jetpack sync is finished, so the value of `monitor_active` remains `false` from the API and terminates the process of updating the monitoring setting, so the `/wp-cron.php` might not be registered correctly. In this PR, we introduce the retry functionality to the `useCreateMonitorSettingsMutation` hook, if the `monitor_active` returns as `false`, we'll retry the schedule ping again in three seconds and up to three times.
* Add a new event to track for retry `calypso_scheduled_updates_retry_monitor_settings_failed`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/<site-slug>`
* Create a new schedule
* Open your browser Network tab and look for `jetpack-monitor-settings` after your click `Create`.
*  In the response, if `settings.urls` does not contain wp-cron.php it means the ping is not registered correctly.
* Wait for three seconds and there will be another request sent to `/jetpack-monitor-settings` again, this time you should see `wp-cron.php` in your `settings.urls` response.
* If not, it'll continue to retry up to three times.
* Open up [developer console](https://developer.wordpress.com/docs/api/console/ ) and do a `GET wpcom/v2/sites/<your-site-slug>/jetpack-monitor-settings` and make sure `wp-cron.php` is inside the `settings.url`
* If you want to force a fail schedule, you can modify the `MAX_RETRIES` https://github.com/Automattic/wp-calypso/pull/88421/files#diff-8e929ffa22b21550a1165270d72e6a557790f8df30c3994dc7c9a4d85870957dR51 to `1` and remove the check for `isMontiorNotActive` https://github.com/Automattic/wp-calypso/pull/88421/files#diff-8e929ffa22b21550a1165270d72e6a557790f8df30c3994dc7c9a4d85870957dR70
* See if `calypso_scheduled_updates_retry_monitor_settings_failed` is triggered after three retries.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?