### PR TITLE
Jetpack Manage: Changing the pricing banner manage pricing link to open the page correctly

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -95,7 +95,9 @@ const IntroPricingBanner: React.FC = () => {
 							className="intro-pricing-banner__item-label is-link"
 							onClick={ () => {
 								recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' );
-								page.replace( localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale ) );
+								page.show(
+									localizeUrl( 'http://jetpack.cloud.localhost:3000/manage/pricing', locale )
+								);
 							} }
 						>
 							{ preventWidows( translate( 'Explore bulk pricing' ) ) }

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
 import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -90,16 +91,15 @@ const IntroPricingBanner: React.FC = () => {
 					</div>
 					<div className="intro-pricing-banner__item is-agencies">
 						<img className="intro-pricing-banner__item-icon" src={ people } alt="" />
-						<a
+						<button
 							className="intro-pricing-banner__item-label is-link"
-							onClick={ () =>
-								recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' )
-							}
-							href={ localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale ) }
-							rel="noreferrer"
+							onClick={ () => {
+								recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' );
+								page.replace( localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale ) );
+							} }
 						>
 							{ preventWidows( translate( 'Explore bulk pricing' ) ) }
-						</a>
+						</button>
 					</div>
 					{ shouldShowCart && hasCrossed && (
 						<CloudCart cartStyle={ isSmallScreen ? {} : { left: clientRect.left } } />

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -95,9 +95,7 @@ const IntroPricingBanner: React.FC = () => {
 							className="intro-pricing-banner__item-label is-link"
 							onClick={ () => {
 								recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' );
-								page.show(
-									localizeUrl( 'http://jetpack.cloud.localhost:3000/manage/pricing', locale )
-								);
+								page.show( localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale ) );
 							} }
 						>
 							{ preventWidows( translate( 'Explore bulk pricing' ) ) }

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -60,6 +60,7 @@
 	text-decoration: underline;
 	// This works in all major browsers except for Firefox for Android. It is also not imperative that this works
 	text-underline-offset: 3px;
+	cursor: pointer;
 }
 
 .is-section-jetpack-connect .intro-pricing-banner.is-sticky,


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/363

## Proposed Changes

* This PR changes the link method on the pricing page in the pricing banner, to ensure it opens. Previously the page would need refreshing after clicking on the link.

## Testing Instructions

* To replicate the issue, visit `https://cloud.jetpack.com/pricing` and click on the 'Explore bulk pricing' link in the pricing page header. Notice the URL changes to `https://cloud.jetpack.com/manage/pricing/` but the page content does not change. Refresh the page and the new page content should be visible.
* To test the fix, check out this PR in a development environment and modify the link to be `https://jetpack.cloud.com:3000/manage/pricing`. From the pricing page - `https://jetpack.cloud.com:3000/pricing` -  click on the 'Explore bulk pricing' link. It should open the manage pricing page on the same page: `https://jetpack.cloud.com:3000/manage/pricing`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?