### PR TITLE
Checkout: Cache result of useCheckoutV2

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -3,6 +3,17 @@ import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
+// The `isLoadingExperimentAssignment` return value of useExperiment is not
+// stable across multiple calls; each instance runs its own `useEffect` which
+// means that there are full renders before they return the value of the
+// assignment. This can cause flickering if different components call
+// `useExperiment` on the page since some components might be in their
+// "loading" state and others may have an assignment.
+//
+// To compensate, here we cache the assignment once it has been made, as
+// assignments do not change on the same calypso load.
+let cachedExperimentAssignment: 'treatment' | 'control' | undefined;
+
 export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {
 	const isCheckoutSection = useSelector( getSectionName ) === 'checkout';
 
@@ -11,14 +22,20 @@ export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {
 		{ isEligible: isCheckoutSection && ! hasCheckoutVersion( '2' ) }
 	);
 
+	if ( cachedExperimentAssignment ) {
+		return cachedExperimentAssignment;
+	}
+
 	// Is loading experiment assignment
 	if ( isLoadingExperimentAssignment ) {
 		return 'loading';
 	}
 	// Done loading experiment assignment, and treatment assignment found
 	if ( experimentAssignment?.variationName === 'treatment' || hasCheckoutVersion( '2' ) ) {
+		cachedExperimentAssignment = 'treatment';
 		return 'treatment';
 	}
 	// Done loading experiment assignment, and control or null assignment found
+	cachedExperimentAssignment = 'control';
 	return 'control';
 }


### PR DESCRIPTION
Recently we've seen flickering in some components of the checkout v2 experiment. It turns out this was being caused by the `useExperiment` hook itself.

The `isLoadingExperimentAssignment` return value of `useExperiment` is not stable across multiple calls; each instance runs its own `useEffect` which means that there are full renders before they return the value of the assignment. This can cause flickering if different components call `useExperiment` on the page since some components might be in their "loading" state (waiting for the `useEffect`) and others may have an assignment.

## Proposed Changes

To compensate, in this PR we globally cache the assignment once it has been made, as assignments do not change on the same calypso load.

Before:

https://github.com/Automattic/wp-calypso/assets/2036909/a4db7e2f-6797-42d2-8cca-f56d4300d5b1 

After:

https://github.com/Automattic/wp-calypso/assets/2036909/f08820f9-b3d1-4696-871d-5217fa7dc4c5


## Testing Instructions

First, apply the following changes on top of this diff so that we can use the query string method to simulate an actual assignment:

```
diff --git a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
index 32b76a0f6f3..8ac5c7af80d 100644
--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -19,7 +19,7 @@ export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {

        const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
                'calypso_launch_checkout_v2',
-               { isEligible: isCheckoutSection && ! hasCheckoutVersion( '2' ) }
+               { isEligible: isCheckoutSection }
        );

        if ( cachedExperimentAssignment ) {
```

Next, add a product to your cart that has variants (eg: a 1 year wpcom plan) and visit checkout.

Alter the checkout URL to add `?checkoutVersion=2` and load checkout again.

Pay attention to the dropdown in the sidebar; make sure there is no flickering of the price as it loads. (If you remove the caching, you can reproduce the flickering.)