### PR TITLE
Stats: Introduce badge "New" to the UTM metrics module

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -135,6 +135,7 @@ const StatsListCard = ( {
 			}
 			emptyMessage={ emptyMessage }
 			isEmpty={ ! loader && ( ! data || ! data?.length ) }
+			isNew={ [ 'utm' ].includes( moduleType ) }
 			className={ classNames( `list-${ moduleType }`, className ) }
 			headerClassName={ listItemClassName }
 			metricLabel={ metricLabel }

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -99,6 +99,7 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 				<StatsCard
 					title="UTM"
 					className={ classNames( className, 'stats-module-utm', 'stats-module__card', 'utm' ) }
+					isNew
 				>
 					<StatsModulePlaceholder isLoading />
 				</StatsCard>
@@ -108,6 +109,7 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 				<StatsCard
 					title="UTM"
 					className={ classNames( className, 'stats-module-utm', 'stats-module__card', 'utm' ) }
+					isNew
 				>
 					<StatsCardUpsellJetpack className="stats-module__upsell" siteSlug={ siteSlug } />
 				</StatsCard>

--- a/packages/components/src/horizontal-bar-list/sideElements/badge-new/index.tsx
+++ b/packages/components/src/horizontal-bar-list/sideElements/badge-new/index.tsx
@@ -2,6 +2,10 @@ import { Badge } from '@automattic/components';
 
 import './style.scss';
 
-const BadgeNew = () => <Badge type="success">New</Badge>;
+const BadgeNew = () => (
+	<Badge type="success" className="stats-card__badge--success">
+		New
+	</Badge>
+);
 
 export default BadgeNew;

--- a/packages/components/src/horizontal-bar-list/sideElements/badge-new/index.tsx
+++ b/packages/components/src/horizontal-bar-list/sideElements/badge-new/index.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/components';
+import { Badge } from '../../../.';
 
 import './style.scss';
 

--- a/packages/components/src/horizontal-bar-list/sideElements/badge-new/index.tsx
+++ b/packages/components/src/horizontal-bar-list/sideElements/badge-new/index.tsx
@@ -1,0 +1,7 @@
+import { Badge } from '@automattic/components';
+
+import './style.scss';
+
+const BadgeNew = () => <Badge type="success">New</Badge>;
+
+export default BadgeNew;

--- a/packages/components/src/horizontal-bar-list/sideElements/badge-new/style.scss
+++ b/packages/components/src/horizontal-bar-list/sideElements/badge-new/style.scss
@@ -1,0 +1,18 @@
+@import "@automattic/typography/styles/variables";
+
+:root {
+	--jp-green-40: #069e08;
+}
+
+.badge--success {
+	font-family: Inter, $sans;
+	height: auto;
+	padding: 2px 8px;
+	font-weight: 500;
+	font-size: $font-body-extra-small;
+	line-height: 16px;
+	color: var(--color-success-40);
+	background-color: var(--color-text-inverted);
+	border: 1px solid var(--jp-green-40);
+	border-radius: 4px;
+}

--- a/packages/components/src/horizontal-bar-list/sideElements/badge-new/style.scss
+++ b/packages/components/src/horizontal-bar-list/sideElements/badge-new/style.scss
@@ -4,7 +4,7 @@
 	--jp-green-40: #069e08;
 }
 
-.badge--success {
+.badge--success.stats-card__badge--success {
 	font-family: Inter, $sans;
 	height: auto;
 	padding: 2px 8px;

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -32,6 +32,15 @@
 		align-items: center;
 		padding: 0 $padding-outside $header-spacer $padding-outside;
 
+		.stats-card-header__title {
+			display: flex;
+			align-items: center;
+
+			& > :first-child {
+				margin-left: 10px;
+			}
+		}
+
 		.stats-card-header__title,
 		.stats-card-header__title:visited {
 			font-size: $header-font-size;

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import BadgeNew from './sideElements/badge-new';
 import type { StatsCardProps } from './types';
 
 import './stats-card.scss';
@@ -14,6 +15,7 @@ const StatsCard = ( {
 	titleAriaLevel = 4,
 	footerAction,
 	isEmpty,
+	isNew,
 	emptyMessage,
 	heroElement,
 	splitHeader,
@@ -37,6 +39,7 @@ const StatsCard = ( {
 			aria-level={ titleAriaLevel }
 		>
 			{ title }
+			{ isNew && <BadgeNew /> }
 		</div>
 	);
 

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -70,6 +70,7 @@ export type StatsCardProps = {
 		url?: string;
 	};
 	isEmpty?: boolean;
+	isNew?: boolean;
 	emptyMessage?: string;
 	/**
 	 * @property {string} metricLabel - a label to use for the values on the right side of the bars - `Views` by default


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87580

## Proposed Changes

* Introduce the badge `New` based on the `Badge` component.
* Add the badge `New` to the UTM metrics module.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with a Jetpack site purchased a Stats commercial license.
* Navigate to Stats > Traffic page.
* Ensure the UTM metric module has a badge `New` next to the title.

<img width="762" alt="截圖 2024-03-12 下午11 57 07" src="https://github.com/Automattic/wp-calypso/assets/6869813/32eed38b-0a38-4f13-a551-52f94aec38d1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?