### PR TITLE
Plugins update manager: Account for the site's time format settings

### DIFF
--- a/client/blocks/plugins-update-manager/config.ts
+++ b/client/blocks/plugins-update-manager/config.ts
@@ -1,3 +1,2 @@
 export const MAX_SCHEDULES = 2;
 export const MAX_SELECTABLE_PLUGINS = 10;
-export const MOMENT_TIME_FORMAT = 'MMM D h:mm A zz';

--- a/client/blocks/plugins-update-manager/hooks/use-prepare-schedule-name.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-prepare-schedule-name.ts
@@ -1,14 +1,18 @@
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useSiteDateTimeFormat } from './use-site-date-time-format';
+import { useSiteSlug } from './use-site-slug';
 import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 
 export function usePrepareScheduleName() {
 	const moment = useLocalizedMoment();
+	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
+	const { prepareTime } = useSiteDateTimeFormat( siteSlug );
 
 	function prepareScheduleName( schedule: ScheduleUpdates ) {
 		const tm = moment( schedule.timestamp * 1000 );
-		const translateArgs = { time: tm.format( 'LT' ) };
+		const translateArgs = { time: prepareTime( schedule.timestamp ) };
 
 		if ( schedule.schedule === 'daily' ) {
 			/* translators: Daily at 10 am. */

--- a/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
@@ -1,9 +1,19 @@
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { phpToMomentDatetimeFormat } from 'calypso/my-sites/site-settings/date-time-format/utils';
 import { useSiteSettings } from './use-site-settings';
 
 export function useSiteDateTimeFormat( siteSlug: string ) {
+	const moment = useLocalizedMoment();
 	const { getSiteSetting } = useSiteSettings( siteSlug );
 	const dateFormat = getSiteSetting( 'date_format' );
 	const timeFormat = getSiteSetting( 'time_format' );
+
+	const prepareTimestamp = ( unixTimestamp: number ) => {
+		const ts = unixTimestamp * 1000;
+		const format = `${ dateFormat } ${ timeFormat }`;
+
+		return phpToMomentDatetimeFormat( moment( ts ), format );
+	};
 
 	const isAmPmPhpTimeFormat = ( formatString: string ) => {
 		// Regular expression to check for AM/PM indicators
@@ -15,6 +25,7 @@ export function useSiteDateTimeFormat( siteSlug: string ) {
 	return {
 		dateFormat,
 		timeFormat,
+		prepareTimestamp,
 		isAmPmPhpTimeFormat,
 	};
 }

--- a/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
@@ -9,6 +9,13 @@ export function useSiteDateTimeFormat( siteSlug: string ) {
 	const timeFormat = getSiteSetting( 'time_format' );
 
 	// Prepare timestamp based on site settings
+	const prepareTime = ( unixTimestamp: number ) => {
+		const ts = unixTimestamp * 1000;
+
+		return phpToMomentDatetimeFormat( moment( ts ), timeFormat );
+	};
+
+	// Prepare timestamp based on site settings
 	const prepareDateTime = ( unixTimestamp: number ) => {
 		const ts = unixTimestamp * 1000;
 		const format = `${ dateFormat } ${ timeFormat }`;
@@ -26,6 +33,7 @@ export function useSiteDateTimeFormat( siteSlug: string ) {
 	return {
 		dateFormat,
 		timeFormat,
+		prepareTime,
 		prepareDateTime,
 		isAmPmPhpTimeFormat,
 	};

--- a/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
@@ -1,0 +1,20 @@
+import { useSiteSettings } from './use-site-settings';
+
+export function useSiteDateTimeFormat( siteSlug: string ) {
+	const { getSiteSetting } = useSiteSettings( siteSlug );
+	const dateFormat = getSiteSetting( 'date_format' );
+	const timeFormat = getSiteSetting( 'time_format' );
+
+	const isAmPmPhpTimeFormat = ( formatString: string ) => {
+		// Regular expression to check for AM/PM indicators
+		const ampmRegex = /(a|A)/;
+
+		return ampmRegex.test( formatString );
+	};
+
+	return {
+		dateFormat,
+		timeFormat,
+		isAmPmPhpTimeFormat,
+	};
+}

--- a/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
@@ -8,7 +8,8 @@ export function useSiteDateTimeFormat( siteSlug: string ) {
 	const dateFormat = getSiteSetting( 'date_format' );
 	const timeFormat = getSiteSetting( 'time_format' );
 
-	const prepareTimestamp = ( unixTimestamp: number ) => {
+	// Prepare timestamp based on site settings
+	const prepareDateTime = ( unixTimestamp: number ) => {
 		const ts = unixTimestamp * 1000;
 		const format = `${ dateFormat } ${ timeFormat }`;
 
@@ -25,7 +26,7 @@ export function useSiteDateTimeFormat( siteSlug: string ) {
 	return {
 		dateFormat,
 		timeFormat,
-		prepareTimestamp,
+		prepareDateTime,
 		isAmPmPhpTimeFormat,
 	};
 }

--- a/client/blocks/plugins-update-manager/hooks/use-site-settings.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-settings.ts
@@ -1,0 +1,34 @@
+import { SiteSettings } from '@automattic/data-stores';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { requestSiteSettings } from 'calypso/state/site-settings/actions';
+import { getSiteSettings } from 'calypso/state/site-settings/selectors';
+import getSiteId from 'calypso/state/sites/selectors/get-site-id';
+import { SiteSlug } from 'calypso/types';
+
+export function useSiteSettings( siteSlug: SiteSlug ) {
+	const dispatch = useDispatch();
+	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
+	const settings = useSelector( ( state ) => siteId && getSiteSettings( state, siteId ) ) as
+		| SiteSettings
+		| undefined;
+
+	// Dispatch action to request the site settings.
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		dispatch( requestSiteSettings( siteId ) );
+	}, [ dispatch, siteId ] );
+
+	function getSiteSetting( option: string ): any {
+		if ( ! settings || Object.keys( settings ).length === 0 ) {
+			return '';
+		}
+
+		return settings[ option ] || '';
+	}
+
+	return { getSiteSetting };
+}

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -64,6 +64,7 @@ export const ScheduleListCards = ( props: Props ) => {
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
 							{ schedule.last_run_timestamp && prepareDateTime( schedule.last_run_timestamp ) }
+							{ ! schedule.last_run_status && ! schedule.last_run_timestamp && '-' }
 						</span>
 					</div>
 

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -22,7 +22,7 @@ export const ScheduleListCards = ( props: Props ) => {
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
-	const { prepareTimestamp } = useSiteDateTimeFormat( siteSlug );
+	const { prepareDateTime } = useSiteDateTimeFormat( siteSlug );
 
 	return (
 		<div className="schedule-list--cards">
@@ -63,13 +63,13 @@ export const ScheduleListCards = ( props: Props ) => {
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
-							{ schedule.last_run_timestamp && prepareTimestamp( schedule.last_run_timestamp ) }
+							{ schedule.last_run_timestamp && prepareDateTime( schedule.last_run_timestamp ) }
 						</span>
 					</div>
 
 					<div className="schedule-list--card-label">
 						<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
-						<span id="next-update">{ prepareTimestamp( schedule.timestamp ) }</span>
+						<span id="next-update">{ prepareDateTime( schedule.timestamp ) }</span>
 					</div>
 
 					<div className="schedule-list--card-label">

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -1,10 +1,9 @@
 import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { MOMENT_TIME_FORMAT } from 'calypso/blocks/plugins-update-manager/config';
 import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-manager/hooks/use-prepare-plugins-tooltip-info';
+import { useSiteDateTimeFormat } from 'calypso/blocks/plugins-update-manager/hooks/use-site-date-time-format';
 import { ellipsis } from 'calypso/blocks/plugins-update-manager/icons';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { Badge } from './badge';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
@@ -18,12 +17,12 @@ interface Props {
 export const ScheduleListCards = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
-	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
+	const { prepareTimestamp } = useSiteDateTimeFormat( siteSlug );
 
 	return (
 		<div className="schedule-list--cards">
@@ -64,16 +63,13 @@ export const ScheduleListCards = ( props: Props ) => {
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
-							{ schedule.last_run_timestamp &&
-								moment( schedule.last_run_timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
+							{ schedule.last_run_timestamp && prepareTimestamp( schedule.last_run_timestamp ) }
 						</span>
 					</div>
 
 					<div className="schedule-list--card-label">
 						<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
-						<span id="next-update">
-							{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
-						</span>
+						<span id="next-update">{ prepareTimestamp( schedule.timestamp ) }</span>
 					</div>
 
 					<div className="schedule-list--card-label">

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -58,6 +58,7 @@ export const ScheduleListTable = ( props: Props ) => {
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
 							{ schedule.last_run_timestamp && prepareDateTime( schedule.last_run_timestamp ) }
+							{ ! schedule.last_run_status && ! schedule.last_run_timestamp && '-' }
 						</td>
 						<td>{ prepareDateTime( schedule.timestamp ) }</td>
 						<td>

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -1,10 +1,9 @@
 import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useSiteDateTimeFormat } from 'calypso/blocks/plugins-update-manager/hooks/use-site-date-time-format';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { Badge } from './badge';
-import { MOMENT_TIME_FORMAT } from './config';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
 import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
@@ -18,13 +17,13 @@ interface Props {
 export const ScheduleListTable = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
+	const { prepareTimestamp } = useSiteDateTimeFormat( siteSlug );
 
 	/**
 	 * NOTE: If you update the table structure,
@@ -58,10 +57,9 @@ export const ScheduleListTable = ( props: Props ) => {
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
-							{ schedule.last_run_timestamp &&
-								moment( schedule.last_run_timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
+							{ schedule.last_run_timestamp && prepareTimestamp( schedule.last_run_timestamp ) }
 						</td>
-						<td>{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }</td>
+						<td>{ prepareTimestamp( schedule.timestamp ) }</td>
 						<td>
 							{
 								{

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -23,7 +23,7 @@ export const ScheduleListTable = ( props: Props ) => {
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
-	const { prepareTimestamp } = useSiteDateTimeFormat( siteSlug );
+	const { prepareDateTime } = useSiteDateTimeFormat( siteSlug );
 
 	/**
 	 * NOTE: If you update the table structure,
@@ -57,9 +57,9 @@ export const ScheduleListTable = ( props: Props ) => {
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
-							{ schedule.last_run_timestamp && prepareTimestamp( schedule.last_run_timestamp ) }
+							{ schedule.last_run_timestamp && prepareDateTime( schedule.last_run_timestamp ) }
 						</td>
-						<td>{ prepareTimestamp( schedule.timestamp ) }</td>
+						<td>{ prepareDateTime( schedule.timestamp ) }</td>
 						<td>
 							{
 								{

--- a/client/my-sites/site-settings/date-time-format/time-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/time-format-option.jsx
@@ -61,7 +61,9 @@ export const TimeFormatOption = ( {
 			/>
 			<FormSettingExplanation>
 				<ExternalLink
-					href={ localizeUrl( 'https://wordpress.com/support/settings/time-settings/' ) }
+					href={ localizeUrl(
+						'https://wordpress.org/documentation/article/customize-date-and-time-format/'
+					) }
 					icon
 					target="_blank"
 				>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88417

## Proposed Changes

* Introduced hook for getting site settings
* Rely on date and time formats from the site settings and apply them on date/time value presentations.
* Added dash char when the last update value is empty
* Updated dead link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Site Settings page: `/settings/writing/{SITE}`
* Update Date and Time format
* Go to `/plugins/scheduled-updates/{SITE}`
* Check if the dateTime format is changed in the list of schedules based on the site settings
* Try different combinations

| Before | After |
|--------|--------|
| <img width="657" alt="Screenshot 2024-03-14 at 11 28 30" src="https://github.com/Automattic/wp-calypso/assets/1241413/7c4dc08d-ad84-4c75-99cf-c8d2bde9c04f"> | <img width="649" alt="Screenshot 2024-03-14 at 11 28 36" src="https://github.com/Automattic/wp-calypso/assets/1241413/d651fea8-8d6f-42c4-bf40-b2ab5acb5410"> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?