### PR TITLE
Tour Kit Lib: Add step mount callback, fix indexes sent to callbacks, update docs

### DIFF
--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -68,14 +68,14 @@ function FooBar() {
 				steps,
 				currentStepIndex,
 				setInitialFocusedElement,
-				onNext,
-				onPrevious,
+				onNextStep,
+				onPreviousStep,
 				onDismiss,
 			} ) => {
 				return (
 					<>
-						<button onClick={ onPrevious }>Previous</button>
-						<button onClick={ onNext } ref={ setInitialFocusedElement }>
+						<button onClick={ onPreviousStep }>Previous</button>
+						<button onClick={ onNextStep } ref={ setInitialFocusedElement }>
 							Next
 						</button>
 						<button onClick={ onDismiss( 'close-btn' ) }>Close</button>
@@ -138,8 +138,8 @@ The main API for configuring a tour is the config object. See example usage and 
   - `steps`: The steps defined for the tour.
   - `currentStepIndex`
   - `onDismiss`: Handler that dismissed/closes the tour.
-  - `onNext`: Handler that progresses the tour to the next step.
-  - `onPrevious`: Handler that takes the tour to the previous step.
+  - `onNextStep`: Handler that progresses the tour to the next step.
+  - `onPreviousStep`: Handler that takes the tour to the previous step.
   - `onMinimize`: Handler that minimizes the tour (passes rendering to `tourMinimized`).
   - `setInitialFocusedElement`: A dispatcher that assigns an element to be initially focused when a step renders (see examples).
   - `onGoToStep`: Handler that progresses the tour to a given step index.

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -84,21 +84,27 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 	);
 
 	const handleNextStepProgression = useCallback( () => {
+		let newStepIndex = currentStepIndex;
 		if ( lastStepIndex > currentStepIndex ) {
-			setCurrentStepIndex( currentStepIndex + 1 );
+			newStepIndex = currentStepIndex + 1;
+			setCurrentStepIndex( newStepIndex );
 		}
-		handleCallback( currentStepIndex, config.options?.callbacks?.onNextStep );
+		handleCallback( newStepIndex, config.options?.callbacks?.onNextStep );
 	}, [ config.options?.callbacks?.onNextStep, currentStepIndex, lastStepIndex ] );
 
 	const handlePreviousStepProgression = useCallback( () => {
-		currentStepIndex && setCurrentStepIndex( currentStepIndex - 1 );
-		handleCallback( currentStepIndex, config.options?.callbacks?.onPreviousStep );
+		let newStepIndex = currentStepIndex;
+		if ( currentStepIndex > 0 ) {
+			newStepIndex = currentStepIndex - 1;
+			setCurrentStepIndex( newStepIndex );
+		}
+		handleCallback( newStepIndex, config.options?.callbacks?.onPreviousStep );
 	}, [ config.options?.callbacks?.onPreviousStep, currentStepIndex ] );
 
 	const handleGoToStep = useCallback(
 		( stepIndex: number ) => {
 			setCurrentStepIndex( stepIndex );
-			handleCallback( currentStepIndex, config.options?.callbacks?.onGoToStep );
+			handleCallback( stepIndex, config.options?.callbacks?.onGoToStep );
 		},
 		[ config.options?.callbacks?.onGoToStep, currentStepIndex ]
 	);

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -212,6 +212,12 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 
 	useStepTracking( currentStepIndex, config.options?.callbacks?.onStepViewOnce );
 
+	useEffect( () => {
+		if ( config.options?.callbacks?.onStepView ) {
+			handleCallback( currentStepIndex, config.options?.callbacks?.onStepView );
+		}
+	}, [ config.options?.callbacks?.onStepView, currentStepIndex ] );
+
 	return (
 		<>
 			<KeyboardNavigation

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -62,6 +62,7 @@ export interface Callbacks {
 	onNextStep?: Callback;
 	onPreviousStep?: Callback;
 	onStepViewOnce?: Callback;
+	onStepView?: Callback;
 }
 
 export interface Options {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Add some improvements to `tour-kit` library

## Proposed Changes

- Added a `onStepView` callback that's called when each step is mounted. This is particularly useful when you want something to run whenever a step is on a step.
- When calling the callbacks `onGoToStep`, `onPreviousStep` and `onNextStep`, instead of the actual new index, the previous index was being sent (Because the `setCurrentStepIndex` setter doesn't immediately update the `currentStepIndex` value). We've fixed that.
- Also updated the documentation because some callback function names were different than the actual ones being used in the library.

This is how the previous callback functions behaved. Notice that all the values being printed are from the old index.

https://github.com/Automattic/wp-calypso/assets/6820724/659882a0-3a42-48aa-ac93-f1c4dea17dcb

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As it's just some callbacks and the values being sent from the library, you can't directly test without a consumer that's using this library. So add some callbacks or hold some debuggers from a consumer for the newly added and other callbacks
- Make sure the new callback is being called with the proper index value, and the old callbacks are being called with the current index value now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?