### PR TITLE
add background back to whats-new modal. also make modal more resistan…

### DIFF
--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -13,20 +13,19 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 // Core modal style overrides
 .whats-new-guide__main {
 	&.components-guide-overlay {
-		background-color: transparent;
-		pointer-events: none;
+		background-color: rgba(0, 0, 0, 0.45);
 	}
 
 	&.components-modal__frame {
 		overflow: auto;
 		max-height: 80vh;
-		pointer-events: auto;
 
 		@media ( max-width: $wpcom-modal-breakpoint ) {
 			width: 90vw;
 			min-width: 90vw;
 			left: 5vw;
 			right: 5vw;
+			height: 615px;
 		}
 
 		@media ( min-width: $wpcom-modal-breakpoint ) {
@@ -59,18 +58,19 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 		background: var(--studio-white);
 		border-top: none;
 		box-sizing: border-box;
+		position: absolute;
+		bottom: 0;
+
 
 		@media ( min-width: $wpcom-modal-breakpoint ) {
-			position: absolute;
 			width: $wpcom-modal-inner-content-width;
 			height: auto;
-			bottom: 0;
 			left: 0;
 			padding: $wpcom-modal-content-spacing;
 		}
 
 		@media ( max-width: $wpcom-modal-breakpoint ) {
-			padding: 16px;
+			padding: 20px 16px;
 		}
 
 		.guide__buttons {
@@ -140,7 +140,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 		justify-content: flex-start;
 		position: relative;
 		height: 100%;
-		min-height: $wpcom-modal-content-min-height;
+		height: $wpcom-modal-content-min-height;
 		bottom: 0;
 	}
 }
@@ -156,14 +156,16 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 }
 
 .whats-new-page__text {
-	padding: 16px 16px 0;
+	padding: 16px 16px 72px;
 	min-height: 222px;
 	height: fit-content;
 
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		overflow: auto;
-		padding: $wpcom-modal-content-spacing $wpcom-modal-content-spacing 0;
+		padding: 0 $wpcom-modal-content-spacing;
 		margin-bottom: $wpcom-modal-footer-height;
+		margin-top: $wpcom-modal-content-spacing;
+		height: calc(400px - $wpcom-modal-footer-height - $wpcom-modal-content-spacing);
 	}
 }
 .whats-new-page__visual {

--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -19,6 +19,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 	&.components-modal__frame {
 		overflow: auto;
 		max-height: 80vh;
+		cursor: auto;
 
 		@media ( max-width: $wpcom-modal-breakpoint ) {
 			width: 90vw;


### PR DESCRIPTION
Add the clickable background back onto the whats new modal. Without the background you have to find the little "X" to dismiss it.

builds on top of https://github.com/Automattic/wp-calypso/pull/88438

I also tidied up some handling of long text, and loading images. The buttons will no longer jump around and the height of the modal and button position will no longer change between slides if one slide has very long text.

Before:
<img width="1728" alt="Screenshot 2024-03-13 at 10 44 55 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/641fc90e-39da-4a48-95f5-2384bf3d0e02">

After:
<img width="1726" alt="Screenshot 2024-03-13 at 10 44 03 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/a72015e2-fc27-4444-99a7-bc5f2a72b2ab">


https://github.com/Automattic/wp-calypso/assets/22446385/2cd040a0-8912-4510-a2b1-9c00aa465736

**Mobile with long text before**
Notice the changing position of the buttons and height of the modal and jump during loading.
https://github.com/Automattic/wp-calypso/assets/22446385/64be39a7-3e79-48e7-9807-ab99625c74d7

** Mobile with long text after **
Everything just stays where it was :) 


https://github.com/Automattic/wp-calypso/assets/22446385/bf8eaff1-69fd-4ab4-8a35-13410f3d083c
### Testing instructions

Open that whats new modal on the home page and editor. from `help menu`-> `what's new`