### PR TITLE
Github Deployment: Fetch log details when a long entry show more is clicked

### DIFF
--- a/client/my-sites/github-deployments/deployment-run-logs/deployment-run-logs.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployment-run-logs.tsx
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import { useI18n } from '@wordpress/react-i18n';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -12,18 +12,22 @@ interface DeploymentRunLogsProps {
 }
 
 const DeploymentRunLog = ( { entry, run }: { entry: LogEntry; run: DeploymentRun } ) => {
+	const { __ } = useI18n();
 	const [ detailExpanded, setDetailExpanded ] = useState( false );
 	const siteId = useSelector( getSelectedSiteId );
 	const deployment = run.code_deployment!;
 	const openDetail = () => setDetailExpanded( ( v ) => ! v );
 
+	const commandIdentifier = entry.context?.command.command_identifier;
+	const hasDetail = !! commandIdentifier;
+
 	const { data: logDetail, isLoading } = useCodeDeploymentsRunLogDetailQuery(
 		siteId,
 		deployment.id,
 		run.id,
-		entry.context?.command.command_identifier || null,
+		commandIdentifier ?? null,
 		{
-			enabled: detailExpanded,
+			enabled: detailExpanded && hasDetail,
 			refetchInterval: 5000,
 		}
 	);
@@ -51,19 +55,19 @@ const DeploymentRunLog = ( { entry, run }: { entry: LogEntry; run: DeploymentRun
 		<div>
 			<button
 				css={ {
-					cursor: entry.context?.command.command_identifier ? 'pointer' : undefined,
+					cursor: hasDetail ? 'pointer' : undefined,
 					margin: 0,
 					padding: 0,
 					fontFamily: '"Courier 10 Pitch", Courier, monospace',
 				} }
-				onClick={ entry.context?.command.command_identifier ? openDetail : undefined }
+				onClick={ hasDetail ? openDetail : undefined }
 			>
 				{ entry.timestamp } { entry.level.toUpperCase() } { entry.message }
-				{ entry.context?.command.command_identifier && (
+				{ hasDetail && (
 					<>
 						…{ ' ' }
 						<span className="show-more">
-							{ detailExpanded ? translate( 'show less' ) : translate( 'show more' ) }
+							{ detailExpanded ? __( 'show less' ) : __( 'show more' ) }
 						</span>
 					</>
 				) }

--- a/client/my-sites/github-deployments/deployment-run-logs/deployment-run-logs.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployment-run-logs.tsx
@@ -28,7 +28,6 @@ const DeploymentRunLog = ( { entry, run }: { entry: LogEntry; run: DeploymentRun
 		commandIdentifier ?? null,
 		{
 			enabled: detailExpanded && hasDetail,
-			refetchInterval: 5000,
 		}
 	);
 

--- a/client/my-sites/github-deployments/deployment-run-logs/deployment-run-logs.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployment-run-logs.tsx
@@ -15,7 +15,6 @@ const DeploymentRunLog = ( { entry, run }: { entry: LogEntry; run: DeploymentRun
 	const { __ } = useI18n();
 	const [ detailExpanded, setDetailExpanded ] = useState( false );
 	const siteId = useSelector( getSelectedSiteId );
-	const deployment = run.code_deployment!;
 	const openDetail = () => setDetailExpanded( ( v ) => ! v );
 
 	const commandIdentifier = entry.context?.command.command_identifier;
@@ -23,7 +22,7 @@ const DeploymentRunLog = ( { entry, run }: { entry: LogEntry; run: DeploymentRun
 
 	const { data: logDetail, isLoading } = useCodeDeploymentsRunLogDetailQuery(
 		siteId,
-		deployment.id,
+		run.code_deployment_id,
 		run.id,
 		commandIdentifier ?? null,
 		{

--- a/client/my-sites/github-deployments/deployment-run-logs/deployments-run-item.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployments-run-item.tsx
@@ -80,7 +80,7 @@ export const DeploymentsRunItem = ( { run }: DeploymentsListItemProps ) => {
 						) : logEntries.length === 0 ? (
 							<p>{ __( 'No logs available for this deployment run.' ) }</p>
 						) : (
-							<DeploymentRunLogs logEntries={ logEntries } />
+							<DeploymentRunLogs logEntries={ logEntries } run={ run } />
 						) }
 					</td>
 				</tr>

--- a/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-log-query.ts
+++ b/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-log-query.ts
@@ -16,10 +16,14 @@ export interface Context {
 }
 
 export interface Command {
-	command: string;
+	command_identifier: string;
 	exit_code: number;
-	stdout: string;
-	stderr: string;
+}
+
+export interface LogEntryDetail {
+	exit_code: number;
+	stdout: Array< string >;
+	stderr: Array< string >;
 }
 
 export const useCodeDeploymentsRunLogQuery = (
@@ -40,6 +44,34 @@ export const useCodeDeploymentsRunLogQuery = (
 		queryFn: (): LogEntry[] =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/code-deployments/${ deploymentId }/runs/${ runId }/logs`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		meta: {
+			persist: false,
+		},
+		...options,
+	} );
+};
+export const useCodeDeploymentsRunLogDetailQuery = (
+	siteId: number | null,
+	deploymentId: number,
+	runId: number,
+	commandIdentifier: string | null,
+	options?: Partial< UseQueryOptions< LogEntryDetail > >
+) => {
+	return useQuery< LogEntryDetail >( {
+		enabled: !! siteId && !! commandIdentifier,
+		queryKey: [
+			GITHUB_DEPLOYMENTS_QUERY_KEY,
+			CODE_DEPLOYMENTS_RUN_LOG_QUERY_KEY,
+			siteId,
+			deploymentId,
+			runId,
+			commandIdentifier,
+		],
+		queryFn: (): LogEntryDetail =>
+			wp.req.get( {
+				path: `/sites/${ siteId }/hosting/code-deployments/${ deploymentId }/runs/${ runId }/logs/${ commandIdentifier }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		meta: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/6014. Closes https://github.com/Automattic/dotcom-forge/issues/5852.

## Proposed Changes

* fetch log details from the new endpoint when the `show more` is expanded

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to deployment logs expand the logs and click `show more`

![image](https://github.com/Automattic/wp-calypso/assets/47489215/d26ca2e2-1091-4169-9e5f-68b79263fab5)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?