### PR TITLE
Design Preview: Override NavigatorProvider CSS to allow for fixed positioning

### DIFF
--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -136,6 +136,14 @@ $design-preview-sidebar-width: 311px;
 		transform: none !important;
 	}
 
+	.components-navigator-provider {
+		contain: none;
+	}
+
+	.components-navigator-screen {
+		will-change: auto;
+	}
+
 	@include break-large {
 		position: relative;
 		width: $design-preview-sidebar-width;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6020

## Proposed Changes

The Gutenberg component NavigatorProvider [added](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/navigator/styles.ts#L6) the CSS rule `contain: content` which prevents the use of fixed positioning as DesignPreview intended.

This PR address the issue by overriding this CSS rule, in addition to overriding `will-change: tranform` which is affects the context for the fixed positioning.

| Before | After |
| --- | --- |
| ![Screenshot 2024-03-13 at 9 10 06 AM](https://github.com/Automattic/wp-calypso/assets/797888/c08027eb-222b-4a6d-90a1-4471b9ac58e1) | ![Screenshot 2024-03-13 at 9 08 50 AM](https://github.com/Automattic/wp-calypso/assets/797888/ef4c3a37-d91f-4596-a4a8-99543d86b383) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/site-setup/designSetup?siteSlug=:site`
* Select any theme without style variations.
* Resize the viewport to mobile.
* Ensure that the UI is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?