### PR TITLE
Checkout: Round corners of checkout inputs

### DIFF
--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -9,6 +9,17 @@ import type { CountryListItem, ContactDetailsType } from '@automattic/wpcom-chec
 const BillingFormFields = styled.div`
 	margin-bottom: 16px;
 
+	& input[type='text'].form-text-input,
+	input[type='url'].form-text-input,
+	input[type='password'].form-text-input,
+	input[type='email'].form-text-input,
+	input[type='tel'].form-text-input,
+	input[type='number'].form-text-input,
+	input[type='search'].form-text-input,
+	.form-fieldset.contact-details-form-fields select {
+		border-radius: 3px;
+	}
+
 	& .form-input-validation {
 		padding: 6px 6px 11px;
 	}

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -24,8 +24,8 @@ const RadioButtonWrapper = styled.div<
 		content: '';
 		border: ${ ( props ) => ( props.checked ? '1px solid ' + getBorderColor( props ) : 'none' ) };
 		border-bottom: ${ ( props ) => '1px solid ' + getBorderColor( props ) };
-		border-radius: ${ ( props ) => ( props.checked ? '3px' : '0px' ) };
 		box-sizing: border-box;
+		border-radius: 3px;
 
 		.rtl & {
 			right: 0;


### PR DESCRIPTION
It seems we have a mixture of round and square corners in our checkout fields, this PR changes all inputs to use a 3px border-radius.

Reported here pbOQVh-45k-p2#comment-5580

Related to https://github.com/Automattic/wp-calypso/issues/88437

## Testing Instructions

* Go to Checkout and edit the Contact Information
* Check that all fields use a 3px border-radius
* Check that coupon field is 3px border-radius
* Go to Payment Method section
* Hover mouse over different methods and ensure the hover effect has a 3px border-radius
