### PR TITLE
Hide whats new for new users

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -41,6 +41,7 @@ import {
 	getShouldShowGlobalSidebar,
 	getShouldShowGlobalSiteSidebar,
 } from 'calypso/state/global-sidebar/selectors';
+import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -346,7 +347,7 @@ class Layout extends Component {
 		return (
 			<div className={ sectionClass }>
 				<WhatsNewLoader
-					loadWhatsNew={ loadHelpCenter && ! this.props.sidebarIsHidden }
+					loadWhatsNew={ loadHelpCenter && ! this.props.sidebarIsHidden && ! this.props.isNewUser }
 					siteId={ this.props.siteId }
 				/>
 				<HelpCenterLoader
@@ -537,6 +538,7 @@ export default withCurrentRoute(
 				isGlobalSiteSidebarVisible: shouldShowGlobalSiteSidebar && ! sidebarIsHidden,
 				currentRoutePattern: getCurrentRoutePattern( state ),
 				userCapabilities: state.currentUser.capabilities,
+				isNewUser: isUserNewerThan( state, WEEK_IN_MILLISECONDS ),
 			};
 		},
 		{

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -538,7 +538,7 @@ export default withCurrentRoute(
 				isGlobalSiteSidebarVisible: shouldShowGlobalSiteSidebar && ! sidebarIsHidden,
 				currentRoutePattern: getCurrentRoutePattern( state ),
 				userCapabilities: state.currentUser.capabilities,
-				isNewUser: isUserNewerThan( state, WEEK_IN_MILLISECONDS ),
+				isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS )( state ),
 			};
 		},
 		{


### PR DESCRIPTION
see discussion p1709762884683639-slack-C06DN6QQVAQ

Hides the whats new modal for new users.

### Testing instructions

Create a new user.
They should not see the whats new modal.
As an existing user, you can clear the "has seen" ids from a sandbox like so:
`wp user meta delete $USER_ID seen_whats_new_announcement_ids`
Reload and you should still see the whats-new modal