### PR TITLE
Jetpack Cloud: remove themes row in the comparison table

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/links.ts
+++ b/client/jetpack-cloud/sections/comparison/table/links.ts
@@ -34,7 +34,6 @@ export const links = {
 	social: localizeUrl( 'https://jetpack.com/social/' ),
 	stats: localizeUrl( 'https://jetpack.com/stats/' ),
 	subscriptions: 'https://jetpack.com/features/discussion/subscriptions/',
-	themes: 'https://jetpack.com/features/design/themes/',
 	transaction_fees: 'https://jetpack.com/support/jetpack-earn-transaction-fees/',
 	videopress: 'https://jetpack.com/features/writing/video-hosting/',
 } as const;

--- a/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
@@ -348,16 +348,6 @@ export const useComparisonData = () => {
 				icon: DesignIcon,
 				features: [
 					{
-						id: 'themes',
-						name: translate( 'Themes' ),
-						url: links.themes,
-						info: {
-							FREE: { content: translate( 'Starter Themes' ) },
-							SECURITY: { content: translate( 'Starter Themes' ) },
-							COMPLETE: { content: translate( 'Starter Themes' ) },
-						},
-					},
-					{
 						id: 'related_posts',
 						name: translate( 'Related posts' ),
 						url: links.related_posts,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1710183825709389-slack-C0CMN0V97

## Proposed Changes

* Remove the "Themes" row on the Jetpack Cloud comparison page

## Testing Instructions
* Visit the Jetpack Cloud live link
* Go to `/features/comparison`
* Confirm that the "Themes" row has been removed in the "Design" section

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?