### PR TITLE
Jetpack cloud: Enable subscriber CSV upload

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -75,6 +75,7 @@
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
+		"subscriber-csv-upload": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -67,6 +67,7 @@
 		"oauth": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,
+		"subscriber-csv-upload": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -72,6 +72,7 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
+		"subscriber-csv-upload": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false


### PR DESCRIPTION
Slack: p1710271743858989-slack-C06DN6QQVAQ

## Proposed Changes

Enable CSV Upload on Subscribers import to Jetpack Cloud / Calypso Green.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/557991c2-65f0-4bdd-b371-36434818b84b) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/4b7e44cf-4ace-4ec1-9d21-1a22c1d675a9) |

#### TO DO
- [ ] Test with JN Site.

## Testing Instructions

* Run `yarn start-jetpack-cloud`
* Go to `/subscribers/YOUR_ATOMIC_OR_JETPACK_SITE`
* Click on Import
* You should see the CSV upload option (screenshot)
* Test with Atomic and self-hosted Jetpack sites

