### PR TITLE
Checkout: Use is_marketplace_product to replace isMarketplaceProduct in checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -58,7 +58,6 @@ import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-su
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
-import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useUpdateCachedContactDetails } from '../hooks/use-cached-contact-details';
@@ -1004,16 +1003,14 @@ function useDoesCartHaveMarketplaceProductRequiringConfirmation(
 	responseCart: ResponseCart
 ): boolean {
 	const excluded3PDAccountProductSlugs = [ 'sensei_pro_monthly', 'sensei_pro_yearly' ];
-	return useSelector( ( state ) => {
-		return responseCart.products
-			.filter(
-				( product ) =>
-					! (
-						product.product_slug && excluded3PDAccountProductSlugs.includes( product.product_slug )
-					)
-			)
-			.some( ( product ) => isMarketplaceProduct( state, product.product_slug ) );
-	} );
+	return responseCart.products
+		.filter(
+			( product ) =>
+				! (
+					product.product_slug && excluded3PDAccountProductSlugs.includes( product.product_slug )
+				)
+		)
+		.some( ( product ) => product.extra.is_marketplace_product );
 }
 
 const JetpackCheckoutSeals = () => {

--- a/client/my-sites/checkout/src/components/third-party-plugins-terms-of-service.jsx
+++ b/client/my-sites/checkout/src/components/third-party-plugins-terms-of-service.jsx
@@ -1,14 +1,12 @@
 import { localize } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
-import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 function ThirdPartyPluginsTermsOfService( { cart, translate } ) {
-	const hasMarketplaceProduct = useSelector( ( state ) => {
-		return cart?.products?.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );
-	} );
+	const hasMarketplaceProduct = cart?.products?.some(
+		( product ) => product.extra.is_marketplace_product
+	);
 
 	if ( ! hasMarketplaceProduct ) {
 		return null;

--- a/client/my-sites/checkout/src/components/third-party-plugins-terms-of-service.tsx
+++ b/client/my-sites/checkout/src/components/third-party-plugins-terms-of-service.tsx
@@ -1,10 +1,10 @@
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
-
-function ThirdPartyPluginsTermsOfService( { cart, translate } ) {
-	const hasMarketplaceProduct = cart?.products?.some(
+export default function ThirdPartyPluginsTermsOfService( { cart }: { cart: ResponseCart } ) {
+	const translate = useTranslate();
+	const hasMarketplaceProduct = cart.products.some(
 		( product ) => product.extra.is_marketplace_product
 	);
 
@@ -29,5 +29,3 @@ function ThirdPartyPluginsTermsOfService( { cart, translate } ) {
 
 	return <CheckoutTermsItem>{ thirdPartyPluginsTerms }</CheckoutTermsItem>;
 }
-
-export default localize( ThirdPartyPluginsTermsOfService );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/65414 added a checkbox to the bottom of checkout that's required if you want to purchase certain Marketplace products. However, [in order to identify marketplace products](https://github.com/Automattic/wp-calypso/blob/1947d2b902432cfef84b25781799ddc992063f4f/client/my-sites/checkout/src/components/checkout-main-content.tsx#L1015), it uses `isMarketplaceProduct()` which requires `state.productsList.items` to be populated in Redux. Since we do not have any code in checkout that populates the Redux products list, this will always return false unless you've reached checkout from another calypso page that does fetch that data.

## Proposed Changes

In this PR we change checkout to use the shopping cart item's `is_marketplace_product` property instead of relying on the Redux data store to identify marketplace products.

Before             |  After
:-------------------------:|:-------------------------:
<img width="628" alt="Screenshot 2024-03-12 at 11 54 14 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/fd14a3cd-db28-44ef-8c13-b5dce760fa3c"> | <img width="606" alt="Screenshot 2024-03-12 at 11 54 39 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/1dcfb6c6-b262-4a14-af86-077fb3e323c2">

Fixes https://github.com/Automattic/payments-shilling/issues/2577

## Testing Instructions

1. Use localhost calypso since sometimes it randomly clears Redux state by design. (You'll get a little notification.)
2. Use a site that has a Business plan.
3. Visit the plugins page from the main sidebar.
4. Select a paid plugin like `AutomateWoo` and click to purchase it.
5. When you reach checkout, scroll down to the bottom of the page.
6. Reload the page until you see the notice that Redux has been cleared.
7. Verify that you see the checkbox that reads `You agree that an account may be created on a third party developer’s site related to the products you have purchased.` just above the submit button. You should also see the TOS line `You agree to our Third-Party Plugins Terms of Service`
