### PR TITLE
Checkout: adjust placement of coupon field

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -83,7 +83,7 @@ import { GoogleDomainsCopy } from './google-transfers-copy';
 import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-sidebar-plan-upsell';
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
-import WPCheckoutOrderReview from './wp-checkout-order-review';
+import WPCheckoutOrderReview, { CouponFieldArea } from './wp-checkout-order-review';
 import { CheckoutSummaryFeaturedList, WPCheckoutOrderSummary } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
@@ -352,6 +352,8 @@ export default function CheckoutMainContent( {
 		updateLocation,
 		replaceProductInCart,
 		isPendingUpdate: isCartPendingUpdate,
+		removeCoupon,
+		couponStatus,
 	} = useShoppingCart( cartKey );
 	const translate = useTranslate();
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
@@ -428,6 +430,15 @@ export default function CheckoutMainContent( {
 	const [ is3PDAccountConsentAccepted, setIs3PDAccountConsentAccepted ] = useState( false );
 	const [ is100YearPlanTermsAccepted, setIs100YearPlanTermsAccepted ] = useState( false );
 	const [ isSubmitted, setIsSubmitted ] = useState( false );
+	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
+
+	const isPurchaseFree = responseCart.total_cost_integer === 0;
+
+	const removeCouponAndClearField = () => {
+		couponFieldStateProps.setCouponFieldValue( '' );
+		setCouponFieldVisible( false );
+		return removeCoupon();
+	};
 
 	const updateCachedContactDetails = useUpdateCachedContactDetails();
 
@@ -543,6 +554,9 @@ export default function CheckoutMainContent( {
 									<WPCheckoutOrderReview
 										removeProductFromCart={ removeProductFromCart }
 										couponFieldStateProps={ couponFieldStateProps }
+										removeCouponAndClearField={ removeCouponAndClearField }
+										isCouponFieldVisible={ isCouponFieldVisible }
+										setCouponFieldVisible={ setCouponFieldVisible }
 										onChangeSelection={ changeSelection }
 										siteUrl={ siteUrl }
 										createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -584,6 +598,9 @@ export default function CheckoutMainContent( {
 									removeProductFromCart={ removeProductFromCart }
 									replaceProductInCart={ replaceProductInCart }
 									couponFieldStateProps={ couponFieldStateProps }
+									removeCouponAndClearField={ removeCouponAndClearField }
+									isCouponFieldVisible={ isCouponFieldVisible }
+									setCouponFieldVisible={ setCouponFieldVisible }
 									onChangeSelection={ changeSelection }
 									siteUrl={ siteUrl }
 									createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -715,6 +732,15 @@ export default function CheckoutMainContent( {
 							return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
 						} }
 					/>
+					{ ! isAkismetCheckout() && ! shouldUseCheckoutV2 && (
+						<CouponFieldArea
+							isCouponFieldVisible={ isCouponFieldVisible }
+							setCouponFieldVisible={ setCouponFieldVisible }
+							isPurchaseFree={ isPurchaseFree }
+							couponStatus={ couponStatus }
+							couponFieldStateProps={ couponFieldStateProps }
+						/>
+					) }
 					<CheckoutTermsAndCheckboxes
 						is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }
 						setIs3PDAccountConsentAccepted={ setIs3PDAccountConsentAccepted }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -43,11 +43,9 @@ import type {
 } from '@automattic/shopping-cart';
 import type { PropsWithChildren } from 'react';
 
-const WPOrderReviewList = styled.ul< {
-	shouldUseCheckoutV2?: boolean;
-} >`
+const WPOrderReviewList = styled.ul`
 	box-sizing: border-box;
-	${ ( props ) => ( props.shouldUseCheckoutV2 ? 'margin: 24px 0 0 0;' : 'margin: 24px 0;' ) }
+	margin: 24px 0 0 0;
 	padding: 0;
 `;
 
@@ -173,10 +171,7 @@ export function WPOrderReviewLineItems( {
 	);
 
 	return (
-		<WPOrderReviewList
-			className={ joinClasses( [ className, 'order-review-line-items' ] ) }
-			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
-		>
+		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ responseCart.products.map( ( product ) => (
 				<LineItemWrapper
 					key={ product.uuid }

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -84,6 +84,10 @@ export type RemoveProductFromCart = ( uuidToRemove: string ) => Promise< Respons
 
 export type UpdateTaxLocationInCart = ( location: CartLocation ) => Promise< ResponseCart >;
 
+export type SetCouponFieldVisible = ( couponFieldVisible: boolean ) => void;
+
+export type RemoveCouponAndClearField = () => Promise< ResponseCart< ResponseCartProduct > >;
+
 /**
  * The custom hook keeps a cached version of the server cart, as well as a
  * cache status.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2753

## Proposed Changes

* Adjust the placement of the coupon field on checkout by moving it between the Payments Step and ToS section.

### Screenshots
| Description | Image |
|--------|--------|
| New placement |<img width="1506" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/91ce81ea-0250-4961-ab4f-73950720e8d4">|
| Focussed state |<img width="1509" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/3a095dc4-0381-4d6c-a34a-7fb271fe82b1"> |
| Mobile |<img width="311" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/c6a81e1b-f919-4d18-8cfd-80bf203f1162"> |
| Mobile focussed |<img width="313" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b29f1dfa-b5ee-4d7f-ac28-547c5c1b2c13"> | 
| Tablet (Ipad mini) | <img width="384" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/ebd9ac3b-f114-48d0-95f6-2d28948f4afc">|
| RTL field |<img width="1509" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/0e9816f1-40c7-47f6-8429-ae140a2575e2"> |
| RTL field focussed | <img width="1512" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/4a863b3a-5ad3-4cae-ba08-d63a28cef0c5">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add any product to the cart and go to checkout.
* Confirm that the coupon field is visible below the payments box.
* Apply a coupon and confirm that the discount is applied.
* Remove the applied coupon and confirm that the discount is removed.
* Test in a variety of screen sizes and confirm that the field displays correctly.
* Append `?checkoutVersion=2` to the URL to switch to checkout v2. Re-check the above scenarios.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?