### PR TITLE
Plugin update manager: Make eligibility checks more async

### DIFF
--- a/client/blocks/plugins-update-manager/context/index.tsx
+++ b/client/blocks/plugins-update-manager/context/index.tsx
@@ -3,7 +3,6 @@ import type { SiteSlug } from 'calypso/types';
 
 interface PluginUpdateManagerContextProps {
 	siteSlug: SiteSlug;
-	isEligibleForFeature: boolean;
 }
 
 interface PluginUpdateManagerContextState {
@@ -15,7 +14,6 @@ const PluginUpdateManagerContext = createContext<
 	PluginUpdateManagerContextProps & PluginUpdateManagerContextState
 >( {
 	siteSlug: '',
-	isEligibleForFeature: false,
 	siteHasEligiblePlugins: true,
 	setSiteHasEligiblePlugins: () => {},
 } );
@@ -23,7 +21,6 @@ const PluginUpdateManagerContext = createContext<
 const PluginUpdateManagerContextProvider = ( {
 	siteSlug,
 	children,
-	isEligibleForFeature,
 }: PluginUpdateManagerContextProps & { children: ReactNode } ) => {
 	const [ siteHasEligiblePlugins, setSiteHasEligiblePlugins ] = useState( true );
 
@@ -31,7 +28,6 @@ const PluginUpdateManagerContextProvider = ( {
 		<PluginUpdateManagerContext.Provider
 			value={ {
 				siteSlug,
-				isEligibleForFeature,
 				siteHasEligiblePlugins,
 				setSiteHasEligiblePlugins,
 			} }

--- a/client/blocks/plugins-update-manager/hooks/use-is-eligible-for-feature.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-is-eligible-for-feature.ts
@@ -1,7 +1,33 @@
-import { useContext } from 'react';
-import { PluginUpdateManagerContext } from '../context';
+import { WPCOM_FEATURES_SCHEDULED_UPDATES } from '@automattic/calypso-products';
+import { useSelector } from 'calypso/state';
+import getHasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function useIsEligibleForFeature() {
-	const { isEligibleForFeature } = useContext( PluginUpdateManagerContext );
-	return isEligibleForFeature;
-}
+export const useIsEligibleForFeature = function () {
+	const siteId = useSelector( getSelectedSiteId );
+
+	const isFeaturesLoaded: boolean = useSelector( ( state ) =>
+		getHasLoadedSiteFeatures( state, siteId )
+	);
+
+	const isSitePlansLoaded: boolean = useSelector( ( state ) =>
+		hasLoadedSitePlansFromServer( state, siteId )
+	);
+
+	const hasScheduledUpdatesFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_SCHEDULED_UPDATES )
+	);
+	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
+	const isEligibleForFeature = hasScheduledUpdatesFeature && isAtomic;
+	return {
+		isEligibleForFeature,
+		isAtomic,
+		hasScheduledUpdatesFeature,
+		isFeaturesLoaded,
+		isSitePlansLoaded,
+		loading: ! isFeaturesLoaded || ! isSitePlansLoaded,
+	};
+};

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -28,7 +28,7 @@ interface Props {
 export const ScheduleCreate = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const { createMonitor } = useCreateMonitor( siteSlug );
-	const isEligibleForFeature = useIsEligibleForFeature();
+	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const siteHasEligiblePlugins = useSiteHasEligiblePlugins();
 	const { onNavBack } = props;
 	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 export const ScheduleEdit = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const isEligibleForFeature = useIsEligibleForFeature();
+	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { scheduleId, onNavBack } = props;
 	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
 		siteSlug,

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -46,7 +46,7 @@ interface Props {
 export const ScheduleForm = ( props: Props ) => {
 	const moment = useLocalizedMoment();
 	const siteSlug = useSiteSlug();
-	const isEligibleForFeature = useIsEligibleForFeature();
+	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
 	const initDate = scheduleForEdit
 		? moment( scheduleForEdit?.timestamp * 1000 )

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 export const ScheduleListCards = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const isEligibleForFeature = useIsEligibleForFeature();
+	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const moment = useLocalizedMoment();
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 export const ScheduleListTable = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const isEligibleForFeature = useIsEligibleForFeature();
+	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const moment = useLocalizedMoment();
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -28,7 +28,7 @@ interface Props {
 }
 export const ScheduleList = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-	const isEligibleForFeature = useIsEligibleForFeature();
+	const { isEligibleForFeature, loading: isEligibleForFeatureLoading } = useIsEligibleForFeature();
 	const isMobile = useMobileBreakpoint();
 
 	const { onNavBack, onCreateNewSchedule, onEditSchedule } = props;
@@ -52,7 +52,7 @@ export const ScheduleList = ( props: Props ) => {
 	);
 
 	const showScheduleListEmpty =
-		! isEligibleForFeature ||
+		( ! isEligibleForFeature && ! isEligibleForFeatureLoading ) ||
 		( isFetched &&
 			! isLoadingCanCreateSchedules &&
 			( schedules.length === 0 || ! canCreateSchedules ) );
@@ -99,7 +99,9 @@ export const ScheduleList = ( props: Props ) => {
 					<div className="ch-placeholder"></div>
 				</CardHeader>
 				<CardBody>
-					{ ( isLoading || isLoadingCanCreateSchedules ) && <Spinner /> }
+					{ ( isLoading || isLoadingCanCreateSchedules || isEligibleForFeatureLoading ) && (
+						<Spinner />
+					) }
 					{ showScheduleListEmpty && (
 						<ScheduleListEmpty
 							onCreateNewSchedule={ onCreateNewSchedule }

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -15,21 +15,19 @@ import './style.scss';
 
 interface ScheduledUpdatesGateProps {
 	children: ReactNode;
-	hasScheduledUpdatesFeature: boolean;
-	isAtomic: boolean;
 	siteId: SiteId;
 }
 
-const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
-	children,
-	hasScheduledUpdatesFeature,
-	isAtomic,
-	siteId,
-} ) => {
+const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( { children, siteId } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const transferState = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
-	const isEligibleForFeature = useIsEligibleForFeature();
+	const {
+		isEligibleForFeature,
+		hasScheduledUpdatesFeature,
+		isAtomic,
+		loading: isEligibleForFeatureLoading,
+	} = useIsEligibleForFeature();
 	const [ hasTransfer, setHasTransferring ] = useState(
 		!! (
 			transferState &&
@@ -75,7 +73,7 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 		return null;
 	};
 
-	if ( ! isEligibleForFeature ) {
+	if ( ! isEligibleForFeature && ! isEligibleForFeatureLoading ) {
 		return (
 			<div tabIndex={ -1 } className="scheduled-updates-gate" onFocus={ handleFocus }>
 				{ getNoticeBanner() }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88416

## Proposed Changes

* Extends the useIsEligibleForFeature hook with the logic to calculate if the site is eligble
* Gets rid of the spinner on index.tsx
* Only show the eligibility notice  after everything is loaded


| Atomic | Creator non-atomic | Explorer |
|-|-|-|
| ![CleanShot 2024-03-13 at 10 55 28@2x](https://github.com/Automattic/wp-calypso/assets/528287/e318460d-b0f3-4350-85ee-513f5b5f2a6e) | ![CleanShot 2024-03-13 at 10 55 00@2x](https://github.com/Automattic/wp-calypso/assets/528287/a6fa68ae-f733-4167-92c6-ad015688469f)| ![CleanShot 2024-03-13 at 10 55 38@2x](https://github.com/Automattic/wp-calypso/assets/528287/cfa55727-3fb8-46fd-8f28-5f331e6b226e) | 


## Testing Instructions

1. Apply the PR
2. Check for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?