### PR TITLE
Scheduled Updates: Fix /plugins/scheduled-updates route detection

### DIFF
--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -46,7 +46,7 @@ export default function ( router ) {
 
 	if ( isEnabled( 'plugins/ssr-details' ) ) {
 		router(
-			`/${ langParam }/plugins/:plugin`,
+			`/${ langParam }/plugins/:plugin(^((scheduled-updates)?)*$)`,
 			skipIfLoggedIn,
 			validatePlugin,
 			ssrSetupLocale,

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -141,7 +141,6 @@ export default function ( router ) {
 
 	router(
 		[
-			`/${ langParam }/plugins/scheduled-updates`,
 			`/${ langParam }/plugins/scheduled-updates/:site_slug?`,
 			`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?`,
 			`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?/:schedule_id`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88453

## Proposed Changes

* When navigating to `http://calypso.localhost:3000/plugins/scheduled-updates` you'll see the following error in your terminal.
```
09:24:17.859Z ERROR calypso:  (reqId=41e56800-30bb-416f-a2d1-41dbfbf044bc, url=/plugins/scheduled-updates, env=development, userAgent="Chrome 122", path=/plugins/scheduled-updates, feature=calypso_ssr, message="RequestError: [object ReadableStream]")
09:24:17.859Z  WARN calypso: Route already set up. Ambiguous route definition likely. (reqId=41e56800-30bb-416f-a2d1-41dbfbf044bc, url=/plugins/scheduled-updates, env=development, userAgent="Chrome 122", path=/plugins/scheduled-updates, isLoggedIn=false)
09:24:17.879Z  INFO calypso: request finished (reqId=41e56800-30bb-416f-a2d1-41dbfbf044bc, url=/plugins/scheduled-updates, env=development, userAgent="Chrome 122", path=/plugins/scheduled-updates, method=GET, status=200, length=39742, duration=677.761, httpVersion=1.1, remoteAddr=::1)
    rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36
test here2...
09:25:40.429Z  WARN calypso: Route already set up. Ambiguous route definition likely. (reqId=bef12ddf-a207-4654-aa86-942388080057, url=/plugins/wpforms-lite, env=development, userAgent="Chrome 122", path=/plugins/wpforms-lite, isLoggedIn=false)
09:25:40.438Z  INFO calypso: request finished (reqId=bef12ddf-a207-4654-aa86-942388080057, url=/plugins/wpforms-lite, env=development, userAgent="Chrome 122", path=/plugins/wpforms-lite, method=GET, status=200, length=39610, duration=51.697, httpVersion=1.1, remoteAddr=::1)
    rawUserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36
```
This is because the route gets picked up by `/plugins/:plugin` route in https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plugins/index.node.js#L49. This PR exclude `scheduled-updates` from the check so it gets handle in our index.web.js correctly.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates`. The page should show a site selector as expected.
* Look into your terminal and make sure no Errors like the above coming up.
* Try it with some other plugins like `http://calypso.localhost:3000/plugins/wpforms-lite` and make sure everything shows as expected as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?