### PR TITLE
Jetpack Manage: Changing the pricing banner manage pricing link function to prevent cross domain issues

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import page from '@automattic/calypso-router';
 import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -95,7 +94,9 @@ const IntroPricingBanner: React.FC = () => {
 							className="intro-pricing-banner__item-label is-link"
 							onClick={ () => {
 								recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' );
-								page.show( localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale ) );
+								window.location.replace(
+									localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale )
+								);
 							} }
 						>
 							{ preventWidows( translate( 'Explore bulk pricing' ) ) }

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -94,7 +94,7 @@ const IntroPricingBanner: React.FC = () => {
 							className="intro-pricing-banner__item-label is-link"
 							onClick={ () => {
 								recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' );
-								window.location.replace(
+								window.location.assign(
 									localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale )
 								);
 							} }


### PR DESCRIPTION
Previous PR: https://github.com/Automattic/wp-calypso/pull/88423

## Proposed Changes

* Due to cross-domain issues (the IntroPricingBanner where `page.show` is used in this case is used outside of `cloud.jetpack.com` as well), the function used to redirect to a new URL is changed in this PR from `page.show` to ~`window.location.replace`~. `window.location.assign`.

Notes - see Slack alert here: p1710326897341489-slack-C04U5A26MJB

Additional conversation in Slack here: p1710345885544499-slack-CTXBP902X

## Testing Instructions

* To test the fix, check out this PR in a development environment and then visit the pricing page - `https://jetpack.cloud.com:3000/pricing`.
* Click on the 'Explore bulk pricing' link. It should open the manage pricing page on the same page: `https://jetpack.cloud.com:3000/manage/pricing`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?