### PR TITLE
Stop showing colour variations for two themes

### DIFF
--- a/packages/design-preview/src/constants.ts
+++ b/packages/design-preview/src/constants.ts
@@ -4,10 +4,12 @@ export const COLOR_VARIATIONS_BLOCK_LIST = [
 	'pub/calyx',
 	'pub/entry',
 	'pub/eventual',
+	'pub/feelingood',
 	'pub/foam',
 	'pub/jinjang',
 	'pub/loudness',
 	'pub/nested',
+	'pub/ritratto',
 	'pub/tenaz',
 	'premium/skivers',
 ];

--- a/packages/design-preview/src/constants.ts
+++ b/packages/design-preview/src/constants.ts
@@ -10,6 +10,7 @@ export const COLOR_VARIATIONS_BLOCK_LIST = [
 	'pub/loudness',
 	'pub/nested',
 	'pub/ritratto',
+	'pub/spiel',
 	'pub/tenaz',
 	'premium/skivers',
 ];


### PR DESCRIPTION
Added Feelin' Good, Ritratto and Spiel to the block list for generic colour variations in onboarding. They're opionated themes and the variations don't make a significant enough change.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdKhl6-3ds-p2#comment-5685

## Proposed Changes

Stop showing colour choices for Feelin' Good and Ritratto themes during onboarding. The colour choices don't really do anything for these opinionated themes.


Here's what they looked like with color selection

https://github.com/Automattic/wp-calypso/assets/93301/6d7d8825-9364-45ff-acf0-9f0306ef8ba3


https://github.com/Automattic/wp-calypso/assets/93301/f727fd19-515f-4ec6-a044-2704ea189de7



https://github.com/Automattic/wp-calypso/assets/93301/b256f199-ade0-477e-b9d3-e53b53e15c3e


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use calypso live link
 2. Go to /start and go through onboarding until the design picker screen
 3. Click Feelin' Good, it shouldn't offer a choice of colors
 4. Go back and choose Ritratto, it shouldn't offer a choice of colors.
 5. Go back and choose Spiel, it shouldn't offer a choice of colors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?