### PR TITLE
Add VAT notice in pricing banner

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -69,6 +69,11 @@ const IntroPricingBanner: React.FC = () => {
 			<div className="intro-pricing-banner__viewport-sentinel" { ...outerDivProps }></div>
 			<div className="intro-pricing-banner">
 				<div className="intro-pricing-banner__content">
+					<div className="intro-pricing-banner__item is-centered-mobile">
+						<span className="intro-pricing-banner__item-label">
+							{ preventWidows( translate( 'Prices do not include VAT' ) ) }
+						</span>
+					</div>
 					<div className="intro-pricing-banner__item">
 						<img className="intro-pricing-banner__item-icon" src={ rocket } alt="" />
 						<span className="intro-pricing-banner__item-label">

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -4,6 +4,7 @@ import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import CloudCart from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -26,12 +27,23 @@ const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = 47;
 const CONNECT_STORE_HEIGHT = 0;
 
+const useShowNoticeVAT = () => {
+	const query = useGeoLocationQuery();
+	// It's better to show more information rather than hide it. So we don't show notice if we don't have geodata yet.
+	if ( query.isLoading ) {
+		return false;
+	}
+	// If there is an error, we fail safe and show the notice. If we have a country - we show notice if it's not US.
+	return query.isError || 'US' !== query.data?.country_short;
+};
+
 const IntroPricingBanner: React.FC = () => {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const shouldShowCart = useSelector( isJetpackCloudCartEnabled );
 	const clientRect = useBoundingClientRect( '.header__content .header__jetpack-masterbar-cart' );
 	const isSmallScreen = useBreakpoint( '<660px' );
+	const shouldShowNoticeVAT = useShowNoticeVAT();
 
 	const windowBoundaryOffset = useMemo( () => {
 		if ( isJetpackCloud() ) {
@@ -69,11 +81,13 @@ const IntroPricingBanner: React.FC = () => {
 			<div className="intro-pricing-banner__viewport-sentinel" { ...outerDivProps }></div>
 			<div className="intro-pricing-banner">
 				<div className="intro-pricing-banner__content">
-					<div className="intro-pricing-banner__item is-centered-mobile">
-						<span className="intro-pricing-banner__item-label">
-							{ preventWidows( translate( 'Prices do not include VAT' ) ) }
-						</span>
-					</div>
+					{ shouldShowNoticeVAT && (
+						<div className="intro-pricing-banner__item is-centered-mobile">
+							<span className="intro-pricing-banner__item-label">
+								{ preventWidows( translate( 'Prices do not include VAT' ) ) }
+							</span>
+						</div>
+					) }
 					<div className="intro-pricing-banner__item">
 						<img className="intro-pricing-banner__item-icon" src={ rocket } alt="" />
 						<span className="intro-pricing-banner__item-label">

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -28,13 +28,14 @@ const CLOUD_MASTERBAR_HEIGHT = 47;
 const CONNECT_STORE_HEIGHT = 0;
 
 const useShowNoticeVAT = () => {
+	const excludedCountries = [ 'US', 'CA' ];
 	const query = useGeoLocationQuery();
-	// It's better to show more information rather than hide it. So we don't show notice if we don't have geodata yet.
+	// It's better to pop-in more information rather than hide it. So we don't show notice if we don't have geodata yet.
 	if ( query.isLoading ) {
 		return false;
 	}
-	// If there is an error, we fail safe and show the notice. If we have a country - we show notice if it's not US.
-	return query.isError || 'US' !== query.data?.country_short;
+	// If there is an error, we fail safe and show the notice. If we have a country - we show notice if the country is not exceptions list.
+	return query.isError || ! excludedCountries.includes( query.data?.country_short ?? '' );
 };
 
 const IntroPricingBanner: React.FC = () => {

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -21,7 +21,7 @@
 .intro-pricing-banner:not(.is-sticky) .intro-pricing-banner__content {
 	height: 120px;
 	margin-bottom: 2rem;
-	gap: 1.25rem;
+	column-gap: 1.25rem;
 
 	@include break-large {
 		height: 54px;
@@ -34,6 +34,8 @@
 	align-items: flex-start;
 
 	@include break-large {
+		flex-wrap: wrap;
+		justify-content: center;
 		flex-direction: row;
 		align-items: center;
 	}

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -48,6 +48,12 @@
 	&:not(:last-child) {
 		margin-right: 16px;
 	}
+
+	&.is-centered-mobile {
+		@media ( max-width: $break-large ) {
+			align-self: center;
+		}
+	}
 }
 
 .intro-pricing-banner__item-icon {

--- a/client/my-sites/plans/jetpack-plans/product-store/pricing-banner/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/pricing-banner/style.scss
@@ -12,11 +12,12 @@
 
 .jetpack-product-store__pricing-banner .intro-pricing-banner:not(.is-sticky) .intro-pricing-banner__content {
 	height: auto;
-	gap: 12px;
+	gap: 0.75rem;
 
 	@include break-large {
-		gap: 32px;
-		max-height: 32px;
+		row-gap: 1rem;
+		column-gap: 2rem;
+		max-height: 2rem;
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

Show VAT notice on the Jetpack pricing page if a user is connecting from a country other than the US.
The design was discussed here (a12s only): https://github.com/Automattic/jetpack-roadmap/issues/357

![CleanShot 2024-03-13 at 15 45 22@2x](https://github.com/Automattic/wp-calypso/assets/8419292/14d54c10-274a-4665-ab30-43a203c47ef8)

## Testing Instructions

* Go to Jetpack Cloud `/pricing` endpoint
* If you're within the US, connect through another country (e.g. using VPN) or change the country code in hook `useShowNoticeVAT()`
* Check that VAT notice shows up
* Check that the mobile version make sense:
![CleanShot 2024-03-13 at 15 52 26@2x](https://github.com/Automattic/wp-calypso/assets/8419292/4d709e99-1f25-437c-947c-0b59e34b39b6)
* If you're outside of the US, connect through US (e.g. using VPN) or change the country code in the hook to your country
* Vertify that VAT notice doesn't show up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?