### PR TITLE
Continue with GitHub: Remove unused code from the `GitHubLoginButton` component

### DIFF
--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { Popover } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import {
@@ -10,10 +9,8 @@ import {
 	useCallback,
 	useEffect,
 	useRef,
-	useState,
 } from 'react';
 import GitHubIcon from 'calypso/components/social-icons/github';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { isFormDisabled as isFormDisabledSelector } from 'calypso/state/login/selectors';
@@ -61,13 +58,8 @@ const GitHubLoginButton = ( {
 		return currentError;
 	} );
 
-	const isFormDisabled = useSelector( isFormDisabledSelector );
+	const isDisabled = useSelector( isFormDisabledSelector );
 	const dispatch = useDispatch();
-
-	const [ disabledState ] = useState< boolean >( false );
-	const [ errorState ] = useState< string | null >( null );
-	const [ showError, setShowError ] = useState< boolean >( false );
-
 	const errorRef = useRef< EventTarget | null >( null );
 
 	const handleGitHubError = useCallback( () => {
@@ -139,8 +131,6 @@ const GitHubLoginButton = ( {
 		}
 	}, [ authError, handleGitHubError ] );
 
-	const isDisabled = isFormDisabled || disabledState;
-
 	const handleClick = ( e: MouseEvent< HTMLButtonElement > ) => {
 		errorRef.current = e.currentTarget;
 		e.preventDefault();
@@ -195,16 +185,6 @@ const GitHubLoginButton = ( {
 					</span>
 				</button>
 			) }
-			<Popover
-				id="social-buttons__error"
-				className="social-buttons__error"
-				isVisible={ showError }
-				onClose={ () => setShowError( false ) }
-				position="top"
-				context={ errorRef.current }
-			>
-				{ preventWidows( errorState ) }
-			</Popover>
 		</>
 	);
 };


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/88467.

## Proposed Changes

* remove unused: `disabledState`, `errorState`, `showError` states and `Popover` component

## Testing Instructions

1. Check out the proposed changes and build them.
2. Navigate to one of the following pages:
  - (as already logged-in user) http://calypso.localhost:3000/me/security/social-login
  - (as logged-out user) http://calypso.localhost:3000/start/user-social
  - (as logged-out user) http://calypso.localhost:3000/log-in
3. Click the GitHub "Connect" button.
4. All of the flows above should work without any regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?