### PR TITLE
Tourkit: Update changelog and version

### DIFF
--- a/packages/tour-kit/CHANGELOG.md
+++ b/packages/tour-kit/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2
+
+- Added 'onStepView' callback that's called each time a step is mounted
+- Fixed the value of index that is passed to 'onGoToStep', 'onPreviousStep' and 'onNextStep'
+
 ## 1.1.1
 
 - Added missing configuration passthrough on spotlight live resize component

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/tour-kit",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Tour lib for guided walkthroughs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Bumps the version before updating on NPM.

## Proposed Changes

* Bumps the version and adds changelog

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check if the number and changelog is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?