### PR TITLE
GitHub Deployments: Use run date in deployments run list item

### DIFF
--- a/client/my-sites/github-deployments/deployment-run-logs/deployments-run-item.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployments-run-item.tsx
@@ -59,7 +59,7 @@ export const DeploymentsRunItem = ( { run }: DeploymentsListItemProps ) => {
 					<DeploymentStatus status={ run.status as DeploymentStatusValue } />
 				</td>
 				<td>
-					<span>{ formatDate( locale, new Date( deployment.updated_on ) ) }</span>
+					<span>{ formatDate( locale, new Date( run.created_on ) ) }</span>
 				</td>
 				<td>
 					<DeploymentDuration run={ run } />


### PR DESCRIPTION
We should display the deployment run date instead of the deployment update date in the list.