### PR TITLE
Rollback hosting trial CTA for logged in plugins page

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -1,4 +1,3 @@
-import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import HostingActivateStatus from 'calypso/my-sites/hosting/hosting-activate-status';
 import { TrialAcknowledgeModal } from 'calypso/my-sites/plans/trials/trial-acknowledge/acknowlege-modal';
@@ -90,11 +89,9 @@ const PluginsDiscoveryPage = ( props ) => {
 	} );
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const { __ } = useI18n();
 
 	const {
 		isTrialAcknowledgeModalOpen,
-		setIsTrialAcknowledgeModalOpen,
 		isTransferring,
 		hasRequestedTrial,
 		trialRequested,
@@ -104,24 +101,10 @@ const PluginsDiscoveryPage = ( props ) => {
 		isAtomic,
 	} = useTrialHelpers( props );
 
-	const onStartTrialUpsellClick = () => {
-		if ( ! isEligibleForHostingTrial ) {
-			return;
-		}
-		setIsTrialAcknowledgeModalOpen( true );
-	};
-
-	const secondaryCallToAction = isEligibleForHostingTrial ? __( 'Try for free' ) : null;
-
 	return (
 		<>
 			{ ! isTransferring && ! hasRequestedTrial && (
-				<UpgradeNudge
-					{ ...props }
-					secondaryCallToAction={ secondaryCallToAction }
-					secondaryOnClick={ onStartTrialUpsellClick }
-					paidPlugins={ true }
-				/>
+				<UpgradeNudge { ...props } paidPlugins={ true } />
 			) }
 			{ ! isTrialAcknowledgeModalOpen && ! isAtomic && (
 				<HostingActivateStatus


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6023-gh-Automattic/dotcom-forge

## Proposed Changes

Removes the **Try for free** CTA in the upgrade nudge for logged-in users viewing `/plugins`. For now we aren't removing the underlying logic, just focusing on disabling the CTA itself. If needed, we can remove the logic in a followup PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using a free plan site that does not already support plugins, navigate to `/plugins` using the link in the calypso nav menu
- When the page loads, confirm that there is only one CTA labeled **Upgrade to Creator**, and there is no longer a second **Try for free** CTA
- Confirm that **Upgrade to Creator** takes you to an upgrade page listing **Creator** and **Entrepreneur** plans (we didn't touch this button in this PR, but better to be sure)

**Before**
![logged-in wpcom plugins page with a free trial CTA reading "Try for free"](https://github.com/Automattic/wp-calypso/assets/13856531/d73d5e3a-dc87-4b53-b8bd-87c74149afa8)

**After**
![logged-in wpcom plugins page without the secondary free trial CTA button reading "Try for free"](https://github.com/Automattic/wp-calypso/assets/13856531/0485d934-8385-4f9d-a6be-a1c6b0170f20)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?