### PR TITLE
Stats: Query UTM metrics along with top posts in a single request

### DIFF
--- a/client/my-sites/stats/hooks/use-utm-metrics-query.ts
+++ b/client/my-sites/stats/hooks/use-utm-metrics-query.ts
@@ -1,14 +1,16 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { requestMetrics } from 'calypso/state/stats/utm-metrics/actions';
 import { getMetrics, isLoading } from 'calypso/state/stats/utm-metrics/selectors';
 
 export default function useUTMMetricsQuery( siteId: number, UTMParam: string, postId?: number ) {
 	const dispatch = useDispatch();
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 
 	useEffect( () => {
-		dispatch( requestMetrics( siteId, UTMParam, postId ) );
-	}, [ dispatch, siteId, UTMParam, postId ] );
+		dispatch( requestMetrics( siteId, UTMParam, postId, siteSlug ) );
+	}, [ dispatch, siteId, UTMParam, postId, siteSlug ] );
 
 	const isFetching = useSelector( ( state ) => isLoading( state, siteId ) );
 	const metrics = useSelector( ( state ) => getMetrics( state, siteId, postId ) );

--- a/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
+++ b/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
@@ -25,6 +25,8 @@ export const fetch = ( action: AnyAction ) => {
 					date: new Date().toISOString().split( 'T' )[ 0 ],
 					days: 7,
 					post_id: postId || '',
+					// Only query top posts if postId is not provided or 0.
+					query_top_posts: ! postId ? true : false,
 				},
 			},
 			action
@@ -58,12 +60,12 @@ registerHandlers( 'state/data-layer/wpcom/sites/stats/utm-metrics/index.js', {
 	[ STATS_UTM_METRICS_REQUEST ]: [
 		dispatchRequest( {
 			fetch,
-			onSuccess: ( { siteId, postId }: AnyAction, data: object ) => {
+			onSuccess: ( { siteId, postId, siteSlug }: AnyAction, data: object ) => {
 				if ( postId ) {
 					return receiveMetricsByPost( siteId, postId, data );
 				}
 
-				return receiveMetrics( siteId, data );
+				return receiveMetrics( siteId, data, siteSlug );
 			},
 			onError: ( { siteId }: AnyAction ) => requestMetricsFail( siteId ),
 			// fromApi,

--- a/client/state/stats/utm-metrics/actions.ts
+++ b/client/state/stats/utm-metrics/actions.ts
@@ -16,12 +16,18 @@ import 'calypso/state/stats/init';
  * @returns {Object}  Action object
  */
 
-export function requestMetrics( siteId: number, utmParam: string, postId?: number ) {
+export function requestMetrics(
+	siteId: number,
+	utmParam: string,
+	postId?: number,
+	siteSlug?: string
+) {
 	return {
 		type: STATS_UTM_METRICS_REQUEST,
 		siteId,
-		postId,
 		utmParam,
+		postId,
+		siteSlug,
 	};
 }
 
@@ -39,11 +45,12 @@ export function requestMetricsFail( siteId: number ) {
  * @param {Object} data   API response
  * @returns {Object}  Action object
  */
-export function receiveMetrics( siteId: number, data: object ) {
+export function receiveMetrics( siteId: number, data: object, siteSlug: string ) {
 	return {
 		type: STATS_UTM_METRICS_RECEIVE,
 		siteId,
 		data,
+		siteSlug,
 	};
 }
 

--- a/client/state/stats/utm-metrics/types.ts
+++ b/client/state/stats/utm-metrics/types.ts
@@ -1,12 +1,22 @@
 export interface UTMMetricItem {
 	label: string;
 	value: number;
+	children?: Array< UTMMetricItemTopPost >;
 	paramValues?: string;
+}
+
+export interface UTMMetricItemTopPostRaw {
+	id: number;
+	title: string;
+	views: number;
+	href: string;
 }
 
 export interface UTMMetricItemTopPost {
 	id: number;
-	title: string;
+	label: string;
+	value: number;
 	href: string;
-	views: number;
+	page: string | null;
+	actions: Array< { data: string; type: string } >;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1710305728393389/1709906996.434119-slack-C82FZ5T4G

## Proposed Changes

* Query UTM metrics with the parameter `query_top_posts` to fetch the top posts at the same time. This avoids a bunch of queries for the top posts of each UTM parameter value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live branch.
* Navigate to Stats > Traffic page for a Jetpack site with a purchased Stats commercial license.
* Ensure the UTM module works as previously without extra API queries for top posts.
* Click on the `View all` link in the UTM module.
* Ensure the UTM summary page works as previously without extra API queries for top posts.
* Navigate to a specific post details page.
* Ensure the UTM module works as previously.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?