### PR TITLE
Plugins update manager: Fix unstable tests

### DIFF
--- a/client/blocks/plugins-update-manager/test/schedule-form.helper.test.tsx
+++ b/client/blocks/plugins-update-manager/test/schedule-form.helper.test.tsx
@@ -19,7 +19,6 @@ describe( 'Schedule form validation', () => {
 	test( 'timestamp / time slot', () => {
 		const timestamp = getTwoDaysFutureUTCTime();
 		const ts_3am = timestamp + 3 * 60 * 60;
-		const ts_6pm = timestamp + 18 * 60 * 60;
 		const ts_9pm = timestamp + 21 * 60 * 60;
 
 		const nextMondayMidnight = getNextMondayMidnightUTCTime();
@@ -36,7 +35,7 @@ describe( 'Schedule form validation', () => {
 			{ frequency: 'daily', timestamp: ts_3am }, // daily at 3:00 am
 		];
 		const existingSchedules2 = [
-			{ frequency: 'weekly', timestamp: ts_6pm }, // weekly on Monday at 6:00 pm
+			{ frequency: 'weekly', timestamp: ts_mon_6pm }, // weekly on Monday at 6:00 pm
 		];
 		const existingSchedules3 = [
 			{ frequency: 'weekly', timestamp: ts_mon_6pm }, // weekly on Monday at 6:00 pm
@@ -60,6 +59,9 @@ describe( 'Schedule form validation', () => {
 		expect(
 			validateTimeSlot( { frequency: 'daily', timestamp: ts_mon_6pm }, existingSchedules2 )
 		).toBeTruthy();
+		expect(
+			validateTimeSlot( { frequency: 'weekly', timestamp: ts_fri_6pm }, existingSchedules2 )
+		).toBeFalsy();
 		expect(
 			validateTimeSlot( { frequency: 'daily', timestamp: ts_fri_6pm }, existingSchedules2 )
 		).toBeTruthy();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88442

## Proposed Changes

* Fixed unstable tests
  * The problem was inside the `existingSchedules2` array; the object with "weekly" frequency only specified the time instead of the day and time.

## Testing Instructions

* Run ` npx jest -c=test/client/jest.config.js plugins-update-manager`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?