### PR TITLE
Checkout: Allow showing intro offers for Jetpack Social

### DIFF
--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -181,21 +181,11 @@ export interface LineItemCostOverrideForDisplay {
 	discountAmount?: number;
 }
 
-function isUserVisibleCostOverride(
-	costOverride: ResponseCartCostOverride,
-	product: ResponseCartProduct
-): boolean {
+function isUserVisibleCostOverride( costOverride: ResponseCartCostOverride ): boolean {
 	if ( costOverride.does_override_original_cost ) {
 		// We won't display original cost overrides since they are
 		// included in the original cost that's being displayed. They
 		// are not discounts.
-		return false;
-	}
-
-	if (
-		'introductory-offer' === costOverride.override_code &&
-		! canDisplayIntroductoryOfferDiscountForProduct( product )
-	) {
 		return false;
 	}
 	return true;
@@ -312,7 +302,7 @@ export function filterCostOverridesForLineItem(
 
 	return (
 		costOverrides
-			.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride, product ) )
+			.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride ) )
 			// Hide coupon overrides because they will be displayed separately.
 			.filter( ( costOverride ) => costOverride.override_code !== 'coupon-discount' )
 			.map( ( costOverride ) => makeSaleCostOverrideUnique( costOverride, product, translate ) )
@@ -393,7 +383,7 @@ export function filterAndGroupCostOverridesForDisplay(
 		const costOverrides = product?.cost_overrides ?? [];
 
 		costOverrides
-			.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride, product ) )
+			.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride ) )
 			.map( ( costOverride ) => makeSaleCostOverrideUnique( costOverride, product, translate ) )
 			.map( ( costOverride ) =>
 				makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate, false )
@@ -442,19 +432,6 @@ function getCreditsUsedByCart( responseCart: ResponseCart ): number {
 
 function getYearlyVariantFromProduct( product: ResponseCartProduct ) {
 	return product.product_variants.find( ( variant ) => 12 === variant.bill_period_in_months );
-}
-
-/**
- * Introductory offer discounts can sometimes be misleading. If we want to hide
- * them for a product in checkout, we can do so in this function.
- */
-function canDisplayIntroductoryOfferDiscountForProduct( product: ResponseCartProduct ): boolean {
-	// Social Advanced has free trial that we don't consider an introductory
-	// offer. See https://github.com/Automattic/wp-calypso/pull/86353
-	if ( isJetpackSocialAdvancedSlug( product.product_slug ) ) {
-		return false;
-	}
-	return true;
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/86353#pullrequestreview-1818790561 it was pointed out that displaying the introductory offer cost override for Jetpack Social was confusing,

> I think this could come off confusing since it's not really a $178.40 discount, it's more of a $13.95 discount since it's only for one month

To fix this, they decided to hide that cost override entirely. This creates other UI challenges, though, because the override is still present even if it's hidden. For example, it was pointed out that the price still gets crossed out in v2 checkout without an explanation.

Since that original diff, we changed how we display introductory offer cost overrides that have billing terms which are difficult to describe as a simple discount. https://github.com/Automattic/wp-calypso/pull/87732 adds quite a lot of detail to the override instead. This detail would be displayed for Jetpack Social except that we are still hiding it, but I believe that the original reason for hiding it is no longer relevant.

In this diff we remove the logic that hides Jetpack Social intro offer cost overrides.

Before             |  After
:-------------------------:|:-------------------------:
<img width="338" alt="Screenshot 2024-03-13 at 12 22 48 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/69f824d1-3be8-4a13-8974-ae7414fd262e"> | <img width="325" alt="Screenshot 2024-03-13 at 12 23 08 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/f69b3847-b7f6-4841-b25d-2e0e04016224">


## Testing Instructions

- Visit `/checkout/jetpack/jetpack_social_advanced_yearly?checkoutVersion=2` on this branch.
- Verify that you see details about the introductory offer in the sidebar.