### PR TITLE
Checkout: Show introductory offer details for price increases

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -221,6 +221,8 @@ function LineItemIntroOfferCostOverrideDetail( { product }: { product: ResponseC
 		return null;
 	}
 
+	const shouldShowDueDate = doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product );
+
 	return (
 		<div>
 			<div>
@@ -234,17 +236,18 @@ function LineItemIntroOfferCostOverrideDetail( { product }: { product: ResponseC
 				} ) }
 			</div>
 			<div>
-				{ translate( 'Billed %(dueDate)s: %(price)s', {
-					args: {
-						dueDate: new Date( dueDate ).toLocaleDateString( undefined, {
-							dateStyle: 'long',
-						} ),
-						price: formatCurrency( dueAmount, product.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-					},
-				} ) }
+				{ shouldShowDueDate &&
+					translate( 'Billed %(dueDate)s: %(price)s', {
+						args: {
+							dueDate: new Date( dueDate ).toLocaleDateString( undefined, {
+								dateStyle: 'long',
+							} ),
+							price: formatCurrency( dueAmount, product.currency, {
+								isSmallestUnit: true,
+								stripZeros: true,
+							} ),
+						},
+					} ) }
 			</div>
 			<div>
 				<LineItemBillingInterval product={ product } />{ ' ' }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -267,6 +267,13 @@ function LineItemCostOverride( {
 	product: ResponseCartProduct;
 } ) {
 	const isPriceIncrease = doesIntroductoryOfferHavePriceIncrease( product );
+	if ( isPriceIncrease ) {
+		return (
+			<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
+				<LineItemIntroOfferCostOverrideDetail product={ product } />
+			</div>
+		);
+	}
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 			<span

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -1,3 +1,10 @@
+import {
+	isBiennially,
+	isDIFMProduct,
+	isMonthlyProduct,
+	isTriennially,
+	isYearly,
+} from '@automattic/calypso-products';
 import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import {
@@ -7,7 +14,6 @@ import {
 	useShoppingCart,
 } from '@automattic/shopping-cart';
 import {
-	LineItemBillingInterval,
 	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
 	doesIntroductoryOfferHavePriceIncrease,
 } from '@automattic/wpcom-checkout';
@@ -250,7 +256,7 @@ function LineItemIntroOfferCostOverrideDetail( { product }: { product: ResponseC
 					} ) }
 			</div>
 			<div>
-				<LineItemBillingInterval product={ product } />{ ' ' }
+				<IntroOfferBillingInterval product={ product } />{ ' ' }
 				<span>
 					{ formatCurrency( renewAmount, product.currency, {
 						isSmallestUnit: true,
@@ -260,6 +266,34 @@ function LineItemIntroOfferCostOverrideDetail( { product }: { product: ResponseC
 			</div>
 		</div>
 	);
+}
+
+export function IntroOfferBillingInterval( { product }: { product: ResponseCartProduct } ) {
+	const translate = useTranslate();
+
+	if ( isDIFMProduct( product ) ) {
+		return <span>{ translate( 'One-time fee' ) }</span>;
+	}
+
+	if ( product.is_included_for_100yearplan ) {
+		return null;
+	}
+
+	if ( isMonthlyProduct( product ) ) {
+		return <span>{ translate( 'Billed every month' ) }</span>;
+	}
+
+	if ( isYearly( product ) ) {
+		return <span>{ translate( 'Billed every year' ) }</span>;
+	}
+
+	if ( isBiennially( product ) ) {
+		return <>{ translate( 'Billed every two years' ) }</>;
+	}
+
+	if ( isTriennially( product ) ) {
+		return <>{ translate( 'Billed every three years' ) }</>;
+	}
 }
 
 function LineItemCostOverride( {

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -55,7 +55,7 @@ const CostOverridesListStyle = styled.div`
 		color: #787c82;
 	}
 
-	& .cost-overrides-list-item__reason {
+	& .cost-overrides-list-item__reason--is-discount {
 		color: #008a20;
 	}
 
@@ -99,9 +99,16 @@ export function CostOverridesList( {
 		<CostOverridesListStyle>
 			{ ! showOnlyCoupons &&
 				nonCouponOverrides.map( ( costOverride ) => {
+					const isPriceIncrease = costOverride.discountAmount < 0;
 					return (
 						<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
-							<span className="cost-overrides-list-item__reason">
+							<span
+								className={
+									isPriceIncrease
+										? 'cost-overrides-list-item__reason'
+										: 'cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount'
+								}
+							>
 								{ costOverride.humanReadableReason }
 							</span>
 							<span className="cost-overrides-list-item__discount">
@@ -117,7 +124,7 @@ export function CostOverridesList( {
 				couponOverrides.map( ( costOverride ) => {
 					return (
 						<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
-							<span className="cost-overrides-list-item__reason">
+							<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 								{ couponCode.length > 0
 									? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
 									: costOverride.humanReadableReason }
@@ -138,12 +145,12 @@ export function CostOverridesList( {
 							className="cost-overrides-list-item cost-overrides-list-item--coupon"
 							key={ costOverride.humanReadableReason }
 						>
-							<span className="cost-overrides-list-item__reason">
+							<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 								{ couponCode.length > 0
 									? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
 									: costOverride.humanReadableReason }
 							</span>
-							<span className="cost-overrides-list-item__discount">
+							<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 								{ formatCurrency( -costOverride.discountAmount, currency, {
 									isSmallestUnit: true,
 									signForPositive: true,
@@ -259,9 +266,18 @@ function LineItemCostOverride( {
 	costOverride: LineItemCostOverrideForDisplay;
 	product: ResponseCartProduct;
 } ) {
+	const isPriceIncrease = doesIntroductoryOfferHavePriceIncrease( product );
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
-			<span className="cost-overrides-list-item__reason">{ costOverride.humanReadableReason }</span>
+			<span
+				className={
+					isPriceIncrease
+						? 'cost-overrides-list-item__reason'
+						: 'cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount'
+				}
+			>
+				{ costOverride.humanReadableReason }
+			</span>
 			<span className="cost-overrides-list-item__discount">
 				{ costOverride.discountAmount &&
 					formatCurrency( -costOverride.discountAmount, product.currency, {

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -9,6 +9,7 @@ import {
 import {
 	LineItemBillingInterval,
 	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
+	doesIntroductoryOfferHavePriceIncrease,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -167,14 +168,26 @@ export function CostOverridesList( {
 	);
 }
 
-function LineItemCostOverrideIntroOfferDueDate( { product }: { product: ResponseCartProduct } ) {
+/**
+ * Introductory offers sometimes have complex pricing plans that are not easy
+ * to display as a simple discount. This component displays more details about
+ * certain offers.
+ */
+function LineItemIntroOfferCostOverrideDetail( { product }: { product: ResponseCartProduct } ) {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const translate = useTranslate();
 	if ( ! product.introductory_offer_terms?.enabled ) {
 		return null;
 	}
-	if ( ! doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product ) ) {
+
+	// We only want to display this info for introductory offers which have
+	// pricing that is difficult to display as a simple discount. Currently
+	// that is offers with different term lengths or price increases.
+	if (
+		! doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product ) &&
+		! doesIntroductoryOfferHavePriceIncrease( product )
+	) {
 		return null;
 	}
 
@@ -256,7 +269,7 @@ function LineItemCostOverride( {
 						signForPositive: true,
 					} ) }
 			</span>
-			<LineItemCostOverrideIntroOfferDueDate product={ product } />
+			<LineItemIntroOfferCostOverrideDetail product={ product } />
 		</div>
 	);
 }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -279,13 +279,7 @@ function LineItemCostOverride( {
 	}
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
-			<span
-				className={
-					isPriceIncrease
-						? 'cost-overrides-list-item__reason'
-						: 'cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount'
-				}
-			>
+			<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 				{ costOverride.humanReadableReason }
 			</span>
 			<span className="cost-overrides-list-item__discount">

--- a/client/my-sites/checkout/src/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/src/hooks/product-variants.tsx
@@ -160,57 +160,57 @@ function getTermText(
 	switch ( term ) {
 		case TERM_DECENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Ten years' ) : translate( 'Billed every ten years' )
+				! shouldUseCheckoutV2 ? translate( 'Ten years' ) : translate( 'Renews every ten years' )
 			);
 
 		case TERM_NOVENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Nine years' ) : translate( 'Billed every nine years' )
+				! shouldUseCheckoutV2 ? translate( 'Nine years' ) : translate( 'Renews every nine years' )
 			);
 
 		case TERM_OCTENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Eight years' ) : translate( 'Billed every eight years' )
+				! shouldUseCheckoutV2 ? translate( 'Eight years' ) : translate( 'Renews every eight years' )
 			);
 
 		case TERM_SEPTENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Seven years' ) : translate( 'Billed every seven years' )
+				! shouldUseCheckoutV2 ? translate( 'Seven years' ) : translate( 'Renews every seven years' )
 			);
 
 		case TERM_SEXENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Six years' ) : translate( 'Billed every six years' )
+				! shouldUseCheckoutV2 ? translate( 'Six years' ) : translate( 'Renews every six years' )
 			);
 
 		case TERM_QUINQUENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Five years' ) : translate( 'Billed every five years' )
+				! shouldUseCheckoutV2 ? translate( 'Five years' ) : translate( 'Renews every five years' )
 			);
 
 		case TERM_QUADRENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Four years' ) : translate( 'Billed every four years' )
+				! shouldUseCheckoutV2 ? translate( 'Four years' ) : translate( 'Renews every four years' )
 			);
 
 		case TERM_TRIENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Three years' ) : translate( 'Billed every three years' )
+				! shouldUseCheckoutV2 ? translate( 'Three years' ) : translate( 'Renews every three years' )
 			);
 
 		case TERM_BIENNIALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'Two years' ) : translate( 'Billed every two years' )
+				! shouldUseCheckoutV2 ? translate( 'Two years' ) : translate( 'Renews every two years' )
 			);
 
 		case TERM_ANNUALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'One year' ) : translate( 'Billed every year' )
+				! shouldUseCheckoutV2 ? translate( 'One year' ) : translate( 'Renews every year' )
 			);
 
 		case TERM_MONTHLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'One month' ) : translate( 'Billed every month' )
+				! shouldUseCheckoutV2 ? translate( 'One month' ) : translate( 'Renews every month' )
 			);
 
 		default:

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -926,19 +926,19 @@ export function LineItemBillingInterval( { product }: { product: ResponseCartPro
 	}
 
 	if ( isMonthlyProduct( product ) ) {
-		return <span>{ translate( 'Billed every month' ) }</span>;
+		return <span>{ translate( 'Renews every month' ) }</span>;
 	}
 
 	if ( isYearly( product ) ) {
-		return <span>{ translate( 'Billed every year' ) }</span>;
+		return <span>{ translate( 'Renews every year' ) }</span>;
 	}
 
 	if ( isBiennially( product ) ) {
-		return <>{ translate( 'Billed every two years' ) }</>;
+		return <>{ translate( 'Renews every two years' ) }</>;
 	}
 
 	if ( isTriennially( product ) ) {
-		return <>{ translate( 'Billed every three years' ) }</>;
+		return <>{ translate( 'Renews every three years' ) }</>;
 	}
 }
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -41,6 +41,7 @@ import { getPartnerCoupon } from './partner-coupon';
 import IonosLogo from './partner-logo-ionos';
 import {
 	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
+	doesIntroductoryOfferHavePriceIncrease,
 	getSubtotalWithoutDiscountsForProduct,
 } from './transformations';
 import type { LineItemType } from './types';
@@ -1386,6 +1387,28 @@ function CheckoutLineItem( {
 		  } )
 		: undefined;
 
+	const isPriceIncrease = doesIntroductoryOfferHavePriceIncrease( product );
+
+	const formattedAmountToDisplayV2 = ( () => {
+		if ( isIntroductoryOfferWithDifferentLength ) {
+			return formattedAmountWithIntroductoryOfferOnly;
+		}
+		if ( isPriceIncrease ) {
+			return actualAmountDisplay;
+		}
+		return formatCurrency( costBeforeDiscounts, product.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
+	} )();
+
+	const crossedOutAmountToDisplayV2 = isIntroductoryOfferWithDifferentLength
+		? formatCurrency( costBeforeDiscounts, product.currency, {
+				isSmallestUnit: true,
+				stripZeros: true,
+		  } )
+		: undefined;
+
 	return (
 		<div
 			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
@@ -1411,22 +1434,8 @@ function CheckoutLineItem( {
 			</LineItemTitle>
 			{ shouldUseCheckoutV2 ? (
 				<LineItemPrice
-					actualAmount={
-						isIntroductoryOfferWithDifferentLength
-							? formattedAmountWithIntroductoryOfferOnly
-							: formatCurrency( costBeforeDiscounts, product.currency, {
-									isSmallestUnit: true,
-									stripZeros: true,
-							  } )
-					}
-					crossedOutAmount={
-						isIntroductoryOfferWithDifferentLength
-							? formatCurrency( costBeforeDiscounts, product.currency, {
-									isSmallestUnit: true,
-									stripZeros: true,
-							  } )
-							: undefined
-					}
+					actualAmount={ formattedAmountToDisplayV2 }
+					crossedOutAmount={ crossedOutAmountToDisplayV2 }
 					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 				/>
 			) : (

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -275,9 +275,9 @@ export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 	product: ResponseCartProduct
 ): boolean {
 	if (
-		product.cost_overrides?.some( ( costOverride ) => {
-			costOverride.override_code !== 'introductory-offer';
-		} )
+		product.cost_overrides?.some(
+			( costOverride ) => costOverride.override_code !== 'introductory-offer'
+		)
 	) {
 		return false;
 	}
@@ -295,16 +295,16 @@ export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 }
 
 export function doesIntroductoryOfferHavePriceIncrease( product: ResponseCartProduct ): boolean {
-	const introOffer = product.cost_overrides?.find( ( costOverride ) => {
-		costOverride.override_code !== 'introductory-offer';
-	} );
+	const introOffer = product.cost_overrides?.find(
+		( costOverride ) => costOverride.override_code === 'introductory-offer'
+	);
 	if ( ! introOffer ) {
 		return false;
 	}
 	if ( ! product.introductory_offer_terms?.enabled ) {
 		return false;
 	}
-	if ( introOffer.old_subtotal_integer < introOffer.new_subtotal_integer ) {
+	if ( introOffer.old_subtotal_integer >= introOffer.new_subtotal_integer ) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
## Proposed Changes

Introductory offers which increase the price (eg: Premium domains) cannot easily be displayed as a simple amount in the list of price changes because they don't have enough context (eg: "An additional $100 for the first year? What?") and people generally want more context for price increases than for discounts.

In this PR we change introductory offer cost overrides that increase the price to display the same details we display for offers that have a different term length than the product's term length (see https://github.com/Automattic/wp-calypso/pull/87732) which includes explicitly stating the **current price** and the **renewal price**. 

To prevent the sidebar math from being misleading, we also show the main price for the item (in checkout v2) as the price _after_ the introductory offer has been applied. This also applies to the "Subtotal before discounts" line items in checkout v1.

> [!NOTE]
> This is related to https://github.com/Automattic/wp-calypso/pull/88318 which updated how we display price increases in general. This change only affects introductory offers with price increases; other cost override price increases will still use the UI shown in that PR because the terms of those increases cannot be easily determined from data like introductory offers. Hopefully the description of other price increases already includes more information about their terms.

Before (v1 checkout)             |  After (v1 checkout)
:-------------------------:|:-------------------------:
<img width="1014" alt="Screenshot 2024-03-13 at 3 58 40 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c000337b-1d7f-4471-970c-a8521ab37d9c"> | <img width="1009" alt="Screenshot 2024-03-13 at 3 58 54 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/3aad11a2-1c53-44bf-9f2b-df6d6f21c79f">

Before (v2 checkout)             |  After (v2 checkout)
:-------------------------:|:-------------------------:
<img width="310" alt="premium-domain-v2-before" src="https://github.com/Automattic/wp-calypso/assets/2036909/e7cbf759-0eaa-4c53-9023-f4939c34a695">| <img width="315" alt="premium-domain-v2-after" src="https://github.com/Automattic/wp-calypso/assets/2036909/cc5178de-bd9a-4673-a5fa-ce18f19e410b">

## Testing Instructions

- Add a premium domain to your shopping cart (eg: `ping.global`).
- Visit checkout and verify that the price for the domain _in the sidebar_ shows up as the higher total (the price you pay today).
- Repeat the above steps after adding `?checkoutVersion=2` to the URL.
- Next, add a Professional Email product to your cart and verify that it still displays the same in checkout v2 as it did before this PR:

<img width="317" alt="Screenshot 2024-03-13 at 4 09 51 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/1fdf0030-dc79-43c6-88d0-264df5b63225">
