### PR TITLE
Rollback hosting trial CTA for logged out plugins page

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -409,10 +409,6 @@ function PrimaryButton( {
 	);
 	const isDisabledForWpcomStaging = isWpcomStaging && isMarketplaceProduct;
 
-	//only show free trial button for free plugins to logged out users
-	const { monthly, yearly } = plugin?.variations ?? {};
-	const shouldStartFreeTrial = ! monthly?.product_id && ! yearly?.product_id;
-
 	const onClick = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_plugin_details_get_started_click', {
@@ -433,7 +429,6 @@ function PrimaryButton( {
 		return (
 			<GetStartedButton
 				onClick={ onClick }
-				startFreeTrial={ shouldStartFreeTrial }
 				plugin={ plugin }
 				isMarketplaceProduct={ isMarketplaceProduct }
 			/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6024-gh-Automattic/dotcom-forge

## Proposed Changes

Removes the **Start your free trial** CTA in the upgrade nudge for logged-out users viewing a plugin listing. Instead, we'll go back to showing a general upgrade CTA. For now we aren't removing the underlying logic for the free trial, just focusing on disabling the CTA itself. If needed, we can remove the logic in a followup PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- When logged out, visit an individual plugin page, e.g. `/plugins/instagram-feed`
- When the page loads, confirm that the CTA rendered is a **Get Started** button, and that the **Start your free trial** CTA is absent
- Confirm that **Get Started** takes you to a signup flow. The URL should contain `with-plugins` and reference the specific plugin you were viewing when you clicked the CTA button (we didn't touch this button in this PR, but better to be sure)

|Before  | After |
| ------------- | ------------- |
| ![logged-out wpcom plugin page with a free trial CTA reading "Start your free trial"](https://github.com/Automattic/wp-calypso/assets/13856531/ae992159-16d7-44f0-9be0-d80963ecaf39)  | ![logged-out wpcom plugins page with an updated "Get Started" CTA button](https://github.com/Automattic/wp-calypso/assets/13856531/5acd0763-c8c4-4e94-af78-2d08907aba35)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?