### PR TITLE
Checkoutv2: Hide upsells if multiple billing terms exist

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -278,39 +278,36 @@ function CheckoutSidebarNudge( {
 	}
 
 	/**
-	 * TODO !hasMonthlyProduct can likely be removed after checkout v2 is merged
-	 * V2 checkout handles monthly products in the CheckoutSidebarPlanUpsell so this condition is not needed
+	 * TODO !hasMonthlyProduct can likely be removed after Jetpack refactors their sidebar nudge
+	 * to account for monthly products like CheckoutSidebarPlanUpsell does
 	 */
-	if ( ! hasMonthlyProduct || shouldUseCheckoutV2 ) {
-		return (
-			<CheckoutSidebarNudgeWrapper>
-				{ ! ( productsWithVariants.length > 1 ) && (
-					<>
-						<CheckoutSidebarPlanUpsell />
-						<JetpackAkismetCheckoutSidebarPlanUpsell />
-					</>
-				) }
-				{ ( isPurchaseRenewal || domainWithoutPlanInCartOrSite ) && (
-					<SecondaryCartPromotions
-						responseCart={ responseCart }
-						addItemToCart={ addItemToCart }
-						isCartPendingUpdate={ isCartPendingUpdate }
-						isPurchaseRenewal={ isPurchaseRenewal }
-					/>
-				) }
-				{ shouldUseCheckoutV2 && (
-					<CheckoutSummaryFeaturedList
-						responseCart={ responseCart }
-						siteId={ siteId }
-						isCartUpdating={ FormStatus.VALIDATING === formStatus }
-						onChangeSelection={ changeSelection }
-					/>
-				) }
-			</CheckoutSidebarNudgeWrapper>
-		);
-	}
 
-	return null;
+	return (
+		<CheckoutSidebarNudgeWrapper>
+			{ ! ( productsWithVariants.length > 1 ) && (
+				<>
+					<CheckoutSidebarPlanUpsell />
+					{ ! hasMonthlyProduct && <JetpackAkismetCheckoutSidebarPlanUpsell /> }
+				</>
+			) }
+			{ ( isPurchaseRenewal || domainWithoutPlanInCartOrSite ) && (
+				<SecondaryCartPromotions
+					responseCart={ responseCart }
+					addItemToCart={ addItemToCart }
+					isCartPendingUpdate={ isCartPendingUpdate }
+					isPurchaseRenewal={ isPurchaseRenewal }
+				/>
+			) }
+			{ shouldUseCheckoutV2 && (
+				<CheckoutSummaryFeaturedList
+					responseCart={ responseCart }
+					siteId={ siteId }
+					isCartUpdating={ FormStatus.VALIDATING === formStatus }
+					onChangeSelection={ changeSelection }
+				/>
+			) }
+		</CheckoutSidebarNudgeWrapper>
+	);
 }
 
 export default function CheckoutMainContent( {

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -253,7 +253,7 @@ function CheckoutSidebarNudge( {
 		areThereDomainProductsInCart && ! hasPlan( responseCart ) && ! siteHasPaidPlan( selectedSite );
 
 	const productsWithVariants = responseCart?.products?.filter(
-		( product ) => product.product_variants?.length > 1 && product.is_bundled === false
+		( product ) => product.product_variants?.length > 1 && product.is_domain_registration === false
 	);
 
 	if ( isWcMobile ) {

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -252,6 +252,10 @@ function CheckoutSidebarNudge( {
 	const domainWithoutPlanInCartOrSite =
 		areThereDomainProductsInCart && ! hasPlan( responseCart ) && ! siteHasPaidPlan( selectedSite );
 
+	const productsWithVariants = responseCart?.products?.filter(
+		( product ) => product.product_variants?.length > 1 && product.is_bundled === false
+	);
+
 	if ( isWcMobile ) {
 		return null;
 	}
@@ -280,8 +284,12 @@ function CheckoutSidebarNudge( {
 	if ( ! hasMonthlyProduct || shouldUseCheckoutV2 ) {
 		return (
 			<CheckoutSidebarNudgeWrapper>
-				<CheckoutSidebarPlanUpsell />
-				<JetpackAkismetCheckoutSidebarPlanUpsell />
+				{ ! ( productsWithVariants.length > 1 ) && (
+					<>
+						<CheckoutSidebarPlanUpsell />
+						<JetpackAkismetCheckoutSidebarPlanUpsell />
+					</>
+				) }
 				{ ( isPurchaseRenewal || domainWithoutPlanInCartOrSite ) && (
 					<SecondaryCartPromotions
 						responseCart={ responseCart }


### PR DESCRIPTION
When multiple products with billing variants are in the v2 cart, the current v1 upsell (seen with Jetpack, not dotcom) is broken and incorrect. It appears that it gets confused by which product is should actually be targeting. See related link below for example.

This quick fix will hide the upsell in any cart that has multiple products with _multiple billing variants_ which are also _not bundled_.

Related to https://github.com/Automattic/wp-calypso/issues/88457

## Testing Instructions

* Go to an atomic site and add multiple Jetpack products to the cart `http://calypso.localhost:3000/checkout/youratomicsite.wpcomstaging.com/jetpack_boost_monthly,jetpack_search_monthly`
* Check that the sidebar upsell does not show
* Remove a product so only one exists, ensure upsell now shows
* Do the same for dotcom and check a variety of cart pairings such as plan/domain bundle, singular plan, monthly vs annual plans - really any combination of products with multiple billing variants
