### PR TITLE
Rollback hosting free trial CTA on Hosting Settings page

### DIFF
--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -33,12 +33,7 @@ interface HostingUpsellNudgeProps {
 	secondaryOnClick?: () => void;
 }
 
-export function HostingUpsellNudge( {
-	siteId,
-	targetPlan,
-	secondaryCallToAction,
-	secondaryOnClick,
-}: HostingUpsellNudgeProps ) {
+export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgeProps ) {
 	const translate = useTranslate();
 	const features = useFeatureList();
 	const callToActionText = translate( 'Upgrade to %(businessPlanName)s Plan', {
@@ -66,11 +61,8 @@ export function HostingUpsellNudge( {
 			compactButton={ false }
 			title={ title }
 			event="calypso_hosting_configuration_upgrade_click"
-			secondaryEvent="calypso_hosting_configuration_upgrade_free_trial_click"
 			href={ href }
 			callToAction={ callToAction }
-			secondaryCallToAction={ secondaryCallToAction }
-			secondaryOnClick={ secondaryOnClick }
 			plan={ plan as string }
 			feature={ feature }
 			showIcon={ true }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -215,13 +215,6 @@ const Hosting = ( props ) => {
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showHostingActivationBanner = canSiteGoAtomic && ! hasTransfer;
 
-	const onSecondaryCTAClick = () => {
-		if ( ! isEligibleForHostingTrial ) {
-			return;
-		}
-		setIsTrialAcknowledgeModalOpen( true );
-	};
-
 	const setOpenModal = ( isOpen ) => {
 		setIsTrialAcknowledgeModalOpen( isOpen );
 	};
@@ -270,15 +263,7 @@ const Hosting = ( props ) => {
 					href: `/plans/${ siteSlug }?feature=${ encodeURIComponent( FEATURE_SFTP_DATABASE ) }`,
 					title: translate( 'Upgrade your plan to access all hosting features' ),
 			  };
-		const secondaryCallToAction = isEligibleForHostingTrial ? translate( 'Try for free' ) : null;
-		return (
-			<HostingUpsellNudge
-				siteId={ siteId }
-				targetPlan={ targetPlan }
-				secondaryCallToAction={ secondaryCallToAction }
-				secondaryOnClick={ onSecondaryCTAClick }
-			/>
-		);
+		return <HostingUpsellNudge siteId={ siteId } targetPlan={ targetPlan } />;
 	};
 
 	const getAtomicActivationNotice = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6025-gh-Automattic/dotcom-forge

## Proposed Changes

Removes the **Try for free** CTA in the upgrade nudge for logged-in users viewing `/hosting-config/`. For now we aren't removing the underlying logic, just focusing on disabling the CTA itself. If needed, we can remove the logic in a followup PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using a free plan site that does not already support plugins, navigate to `/hosting-config/` 
- When the page loads, confirm that there is only one CTA labeled **Upgrade to Creator Plan**, and there is no longer a second **Try for free** CTA
- Confirm that **Upgrade to Creator** adds the Creator plan to your cart and takes you to the checkout screen (we didn't touch this button in this PR, but better to be sure)

|Before  | After |
| ------------- | ------------- |
| ![wpcom hosting config page with a secondary free trial CTA reading "Try for free"](https://github.com/Automattic/wp-calypso/assets/13856531/de30de0c-7435-42c3-a32e-a4308e6169f1) | ![logged-out wpcom plugins page with just a single "Upgrade to Creator Plan" CTA button](https://github.com/Automattic/wp-calypso/assets/13856531/be0fcb0a-bf88-4ad5-add1-5727a82961ca) |
