### PR TITLE
Hide the "use as backup payment method" toggle for UPI methods

### DIFF
--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -10,7 +10,9 @@ import creditCardVisaImage from 'calypso/assets/images/upgrades/cc-visa.svg';
 import payPalImage from 'calypso/assets/images/upgrades/paypal.svg';
 
 export const PARTNER_PAYPAL_EXPRESS = 'paypal_express';
+export const PARTNER_RAZORPAY = 'razorpay';
 export const PAYMENT_AGREEMENTS_PARTNERS = [ PARTNER_PAYPAL_EXPRESS ];
+export const UPI_PARTNERS = [ PARTNER_RAZORPAY ];
 
 /**
  * A saved payment method (card or PayPal agreement).
@@ -75,6 +77,10 @@ export interface StoredPaymentMethodStripeSource extends StoredPaymentMethodBase
 	bic: string;
 }
 
+export interface StoredPaymentMethodRazorpay extends StoredPaymentMethodBase {
+	payment_partner: 'razorpay';
+}
+
 export interface StoredPaymentMethodTaxLocation {
 	country_code?: string;
 	postal_code?: string;
@@ -91,8 +97,11 @@ export const isPaymentAgreement = (
 ): method is StoredPaymentMethodPayPal =>
 	PAYMENT_AGREEMENTS_PARTNERS.includes( method.payment_partner );
 
+export const isUpiMethod = ( method: StoredPaymentMethod ): method is StoredPaymentMethodRazorpay =>
+	UPI_PARTNERS.includes( method.payment_partner );
+
 export const isCreditCard = ( method: StoredPaymentMethod ): method is StoredPaymentMethodCard =>
-	! isPaymentAgreement( method );
+	! isPaymentAgreement( method ) && ! isUpiMethod( method );
 
 interface ImagePathsMap {
 	[ key: string ]: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

In the payment method management screen, users have the ability to designate some stored payment methods as "backups". What this means is that if an autorenewal fails due to a payment error, the subscription engine may attempt to retry using the backup method. This behavior is not appropriate for UPI methods, since they are associated to a specific subscription at the initial purchase.

## Proposed Changes

* We already have logic to hide this toggle for PayPal billing agreements, which also can't be set as backups for similar reasons. This patch extends that to UPI payment methods which at this time means payments using Razorpay. Note that while (currently) all UPI payments are made through Razorpay, not all Razorpay payments use UPI, and this implementation will hide the toggle for non-UPI stored Razorpay methods. However, it is also not clear that regulations in India allow for an open ended billing agreement like this anyway.


## Testing Instructions

1. Have a user with an active mandate. #86197 has instructions about how to do this; be sure to sandbox the API.
2. Visit the payment method management screen at `/me/purchases/payment-methods` and find your Razorpay method. Verify that there is no "set as backup" toggle.
3. (Bonus) If your user also has a stored card, verify that it does have the toggle.

Before:
<img width="875" alt="Screenshot 2024-03-13 at 1 41 25 PM" src="https://github.com/Automattic/wp-calypso/assets/9310939/75b988d1-b488-4b00-bc07-39de24a6f3a0">

After:
<img width="875" alt="Screenshot 2024-03-13 at 1 41 50 PM" src="https://github.com/Automattic/wp-calypso/assets/9310939/d35567f2-0a65-4f6f-a265-eea28ae4a526">

Note that related issue #88320 is aimed at improving the design of the payment method info.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
