### PR TITLE
GitHub Deployments: Improved copy for no-deployment state

### DIFF
--- a/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
@@ -13,7 +13,7 @@ export const DeploymentStarterMessage = ( { deployment }: DeploymentStarterMessa
 
 	const getManualDeploymentMessage = () => {
 		if ( ! deployment.workflow_path ) {
-			return __( 'Trigger a deployment from the ellipsis menu.' );
+			return __( 'Trigger a deployment from the menu.' );
 		}
 
 		const workflowName = deployment.workflow_path.replace( '.github/workflows/', '' );
@@ -46,11 +46,16 @@ export const DeploymentStarterMessage = ( { deployment }: DeploymentStarterMessa
 		<td colSpan={ 4 }>
 			<i css={ { color: 'var(--Gray-Gray-40, #50575E)' } }>
 				{ deployment.is_automated
-					? // Translators: %(branch)s is the branch name of the repository, %(repo)s is the repository name
-					  sprintf( __( 'Push something to the ‘%(branch)s’ branch of ‘%(repo)s’.' ), {
-							branch: deployment.branch_name,
-							repo: deployment.repository_name,
-					  } )
+					? sprintf(
+							// Translators: %(branch)s is the branch name of the repository, %(repo)s is the repository name
+							__(
+								'Push something to the ‘%(branch)s’ branch of ‘%(repo)s’ or trigger a deployment from the menu.'
+							),
+							{
+								branch: deployment.branch_name,
+								repo: deployment.repository_name,
+							}
+					  )
 					: getManualDeploymentMessage() }
 			</i>
 		</td>

--- a/client/my-sites/github-deployments/deployments/test/deployment-starter-message.test.tsx
+++ b/client/my-sites/github-deployments/deployments/test/deployment-starter-message.test.tsx
@@ -25,7 +25,9 @@ describe( 'DeploymentStarterMessage', () => {
 		);
 
 		expect(
-			getByText( 'Push something to the ‘trunk’ branch of ‘repository’.' )
+			getByText(
+				'Push something to the ‘trunk’ branch of ‘repository’ or trigger a deployment from the menu.'
+			)
 		).toBeInTheDocument();
 	} );
 
@@ -38,7 +40,7 @@ describe( 'DeploymentStarterMessage', () => {
 			/>
 		);
 
-		expect( getByText( 'Trigger a deployment from the ellipsis menu.' ) ).toBeInTheDocument();
+		expect( getByText( 'Trigger a deployment from the menu.' ) ).toBeInTheDocument();
 	} );
 
 	test( 'instructs the user to create a manual deployment for advanced connections', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the latelinked issue.
-->

Task-related: p1710179224693039/1710178297.118729-slack-C06D9M3CHMK

## Proposed Changes

* We're improving the no-deployment state of GHD


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?