### PR TITLE
Rollback hosting trial banner from theme upload page

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -46,7 +46,6 @@ import {
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
@@ -487,8 +486,9 @@ const mapStateToProps = ( state ) => {
 		siteHasFeature( state, siteId, FEATURE_UPLOAD_THEMES ) ||
 		siteHasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS );
 
-	const isEligibleForHostingTrial =
-		isUserEligibleForFreeHostingTrial( state ) && site?.plan?.is_free;
+	// This value is hardcoded to 'false' to disable the free trial banner
+	// see https://github.com/Automattic/wp-calypso/pull/88490
+	const isEligibleForHostingTrial = false;
 
 	const showEligibility =
 		canUploadThemesOrPlugins && ! isAtomic && ( hasEligibilityMessages || ! isEligible );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6027-gh-Automattic/dotcom-forge

## Proposed Changes

Remove the **Start your free Creator plan trial to access the theme install features** CTA in the upgrade nudge banner for logged-in users viewing `/themes/upload`, in favor of a standard upgrade nudge. For now we aren't removing the underlying logic, just focusing on disabling the CTA itself. If needed, we can remove the logic in a followup PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using a free plan site that does not already support uploading themes, navigate to `/themes/upload` 
- When the page loads, confirm that CTA banner encourages an upgrade to the Creator plan, rather than offering a free trial
- Confirm that clicking on the banner opens a checkout modal with the Creator plan already added to the cart.
- Confirm that clicking on the banner does not open a free trial modal

**Before**
<img width="1101" alt="Upsell banner on theme upload page that reads 'Start your free Creator plan trial to access the theme install features'" src="https://github.com/Automattic/wp-calypso/assets/13856531/16d9143d-0d04-4b9f-8771-18f4dcd429b0">

**After**
<img width="1103" alt="Upsell banner on theme upload page that reads 'Upgrade to the Creator plan to access the theme install features'" src="https://github.com/Automattic/wp-calypso/assets/13856531/558ead0d-8e5d-45c1-91b8-db39b5fb653e">
