### PR TITLE
Jetpack Connection: Fix redirect for My Jetpack on free plans

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -7,6 +7,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { useSelector } from 'calypso/state';
 import getJetpackRecommendationsUrl from 'calypso/state/selectors/get-jetpack-recommendations-url';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 type SiteId = number | null;
@@ -59,14 +60,30 @@ export default function useJetpackFreeButtonProps(
 	siteId: SiteId,
 	urlQueryArgs: QueryArgs = {}
 ): Props {
+	const site = useSelector( getSelectedSite );
 	const recommendationsUrl = useSelector( getJetpackRecommendationsUrl );
-	const siteWpAdminUrl = urlQueryArgs?.admin_url
+
+	let siteWpAdminUrl = urlQueryArgs?.admin_url
 		? getUrlFromParts( {
 				...getUrlParts( urlQueryArgs.admin_url + 'admin.php' ),
 				search: '?page=jetpack',
 				hash: '/recommendations',
 		  } ).href
 		: recommendationsUrl;
+
+	if (
+		! siteWpAdminUrl &&
+		urlQueryArgs?.redirect &&
+		urlQueryArgs.redirect.toLowerCase().includes( 'wp-admin/admin.php?page=my-jetpack' )
+	) {
+		if ( site?.options?.admin_url ) {
+			siteWpAdminUrl = getUrlFromParts( {
+				...getUrlParts( site.options.admin_url + 'admin.php' ),
+				search: '?page=my-jetpack',
+			} ).href;
+		}
+	}
+
 	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpfree_click', {
 		site_id: siteId || undefined,
 	} );


### PR DESCRIPTION
## Proposed Changes
"Start with Jetpack Free" button on the "Plans" page does not return users back to "My Jetpack" after connection if Jetpack-the-plugin is missing.
Instead, it sends users to the `/jetpack/connect` page, which doesn't make sense since the site has just been connected.

The PR fixes the issue, allowing the users to return back to "My Jetpack".

Props to @fgiannar for discovering the problem.

## Testing Instructions
1. Install Jetpack and a standalone plugin (e.g. Backup). Better to start with a clean site so it wouldn't have any purchased products (even expired).
2. Deactivate Jetpack, disconnect if connected. Leave the standalone plugin active.
3. Go to "My Jetpack" and initiate the connection, but don't click "Approve" just yet.
4. On the "Approve" page, replace the `wordpress.com` with the Calypso Live one (see comment below), and click approve when it loads.
5. On the "Plans" page click the "Start with Jetpack Free" button. You should get redirected to "My Jetpack".
6. Disconnect and activate the Jetpack plugin.
7. Repeat steps 3-5, except that now you should get redirected to the Jetpack Dashboard's "Recommendations" tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
