### PR TITLE
Checkout: Make it clear before billing step that taxes may be added

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -109,7 +109,6 @@ export default function BeforeSubmitCheckoutHeader() {
 		} ),
 	};
 
-	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const subtotalBeforeDiscounts = getSubtotalWithoutDiscounts( responseCart );
 	const subTotalLineItemWithoutCoupon: LineItemType = {
 		id: 'subtotal-without-coupon',

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -9,11 +9,13 @@ import {
 	getSubtotalWithoutDiscounts,
 	getTotalDiscountsWithoutCredits,
 	filterAndGroupCostOverridesForDisplay,
+	isBillingInfoEmpty,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
+import { TaxNotCalculatedLineItem } from './wp-checkout-order-summary';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
 
 const CheckoutTermsWrapper = styled.div`
@@ -67,7 +69,7 @@ const NonTotalPrices = styled.div`
 `;
 const TotalPrice = styled.div`
 	font-size: 14px;
-	padding: 16px 0;
+	padding-top: 16px;
 `;
 
 export default function BeforeSubmitCheckoutHeader() {
@@ -89,6 +91,7 @@ export default function BeforeSubmitCheckoutHeader() {
 		} ),
 	};
 
+	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const subtotalBeforeDiscounts = getSubtotalWithoutDiscounts( responseCart );
 	const subTotalLineItemWithoutCoupon: LineItemType = {
 		id: 'subtotal-without-coupon',
@@ -108,7 +111,6 @@ export default function BeforeSubmitCheckoutHeader() {
 			<CheckoutTermsWrapper>
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsWrapper>
-
 			<WPOrderReviewSection>
 				<NonTotalPrices>
 					<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
@@ -125,6 +127,7 @@ export default function BeforeSubmitCheckoutHeader() {
 				<TotalPrice>
 					<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
 				</TotalPrice>
+				{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
 			</WPOrderReviewSection>
 		</>
 	);

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -68,7 +68,7 @@ const NonTotalPrices = styled.div`
 `;
 const TotalPrice = styled.div`
 	font-size: 14px;
-	padding-top: 16px;
+	padding: 16px 0 6px;
 `;
 
 const TaxNotCalculatedLineItemWrapper = styled.div`

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -15,7 +15,6 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
-import { TaxNotCalculatedLineItem } from './wp-checkout-order-summary';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
 
 const CheckoutTermsWrapper = styled.div`
@@ -71,6 +70,25 @@ const TotalPrice = styled.div`
 	font-size: 14px;
 	padding-top: 16px;
 `;
+
+const TaxNotCalculatedLineItemWrapper = styled.div`
+	font-size: 14px;
+	text-wrap: pretty;
+	line-height: 1em;
+	color: ${ ( { theme } ) => theme.colors.textColorLight };
+	margin-bottom: 8px;
+`;
+
+export function TaxNotCalculatedLineItem() {
+	const translate = useTranslate();
+	return (
+		<TaxNotCalculatedLineItemWrapper>
+			{ translate( 'Tax: to be calculated', {
+				textOnly: true,
+			} ) }
+		</TaxNotCalculatedLineItemWrapper>
+	);
+}
 
 export default function BeforeSubmitCheckoutHeader() {
 	const cartKey = useCartKey();

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -221,12 +221,7 @@ function CheckoutSummaryPriceList() {
 				</CheckoutSubtotalSection>
 
 				<CheckoutSummaryTotal>
-					<span className="wp-checkout-order-summary__label">
-						{ translate( 'Total', {
-							context: 'The label of the total line item in checkout',
-							textOnly: true,
-						} ) }
-					</span>
+					<span className="wp-checkout-order-summary__label">{ translate( 'Total' ) }</span>
 					<span className="wp-checkout-order-summary__total-price">
 						{ totalLineItem.formattedAmount }
 					</span>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -167,16 +167,16 @@ export function CheckoutSummaryFeaturedList( {
 }
 
 const TaxNotCalculatedLineItemWrapper = styled.div`
-	margin-top: 8px;
-	font-size: 12px;
+	font-size: 14px;
 	text-wrap: pretty;
+	line-height: 1em;
 `;
 
 export function TaxNotCalculatedLineItem() {
 	const translate = useTranslate();
 	return (
 		<TaxNotCalculatedLineItemWrapper>
-			{ translate( 'Taxes may be added once billing information is provided', {
+			{ translate( 'Tax: to be calculated', {
 				textOnly: true,
 			} ) }
 		</TaxNotCalculatedLineItemWrapper>
@@ -211,6 +211,7 @@ function CheckoutSummaryPriceList() {
 							<span>{ taxLineItem.formattedAmount }</span>
 						</CheckoutSummaryLineItem>
 					) ) }
+					{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
 					{ creditsLineItem && responseCart.sub_total_integer > 0 && (
 						<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + creditsLineItem.id }>
 							<span>{ creditsLineItem.label }</span>
@@ -230,7 +231,6 @@ function CheckoutSummaryPriceList() {
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
-				{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
 			</CheckoutSummaryAmountWrapper>
 		</>
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -172,7 +172,7 @@ const TaxNotCalculatedLineItemWrapper = styled.div`
 	line-height: 1em;
 `;
 
-export function TaxNotCalculatedLineItem() {
+function TaxNotCalculatedLineItem() {
 	const translate = useTranslate();
 	return (
 		<TaxNotCalculatedLineItemWrapper>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -34,6 +34,7 @@ import {
 } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
+	isBillingInfoEmpty,
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
 	getCreditsLineItemFromCart,
@@ -164,6 +165,24 @@ export function CheckoutSummaryFeaturedList( {
 		</>
 	);
 }
+
+const TaxNotCalculatedLineItemWrapper = styled.div`
+	margin-top: 8px;
+	font-size: 12px;
+	text-wrap: pretty;
+`;
+
+export function TaxNotCalculatedLineItem() {
+	const translate = useTranslate();
+	return (
+		<TaxNotCalculatedLineItemWrapper>
+			{ translate( 'Taxes may be added once billing information is provided', {
+				textOnly: true,
+			} ) }
+		</TaxNotCalculatedLineItemWrapper>
+	);
+}
+
 function CheckoutSummaryPriceList() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -201,11 +220,17 @@ function CheckoutSummaryPriceList() {
 				</CheckoutSubtotalSection>
 
 				<CheckoutSummaryTotal>
-					<span className="wp-checkout-order-summary__label">{ translate( 'Total' ) }</span>
+					<span className="wp-checkout-order-summary__label">
+						{ translate( 'Total', {
+							context: 'The label of the total line item in checkout',
+							textOnly: true,
+						} ) }
+					</span>
 					<span className="wp-checkout-order-summary__total-price">
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
+				{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
 			</CheckoutSummaryAmountWrapper>
 		</>
 	);

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -120,7 +120,7 @@ describe( 'CheckoutMain', () => {
 		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
-				.getAllByLabelText( 'Estimated total' )
+				.getAllByLabelText( 'Total' )
 				.map( ( element ) => expect( element ).toHaveTextContent( 'R$156' ) );
 		} );
 	} );

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
+import { ResponseCart } from '@automattic/shopping-cart';
 import { render, screen, within, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
@@ -115,8 +116,27 @@ describe( 'CheckoutMain', () => {
 		} );
 	} );
 
-	it( 'renders the total amount', async () => {
+	it( 'renders the total estimated amount when no billing info has been added', async () => {
 		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
+		await waitFor( () => {
+			screen
+				.getAllByLabelText( 'Estimated total' )
+				.map( ( element ) => expect( element ).toHaveTextContent( 'R$156' ) );
+		} );
+	} );
+
+	it( 'renders the total amount when billing info has been added', async () => {
+		const cart: ResponseCart = {
+			...initialCart,
+			tax: {
+				display_taxes: true,
+				location: {
+					country_code: 'US',
+					postal_code: '90210',
+				},
+			},
+		};
+		render( <MockCheckout initialCart={ cart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
 				.getAllByLabelText( 'Total' )

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -1,6 +1,7 @@
 import { CheckoutProvider, Button } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import { isBillingInfoEmpty } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -76,6 +77,29 @@ const HiddenText = styled.span`
 	white-space: nowrap;
 	width: 1px;
 `;
+
+const TaxNotCalculatedLineItemWrapper = styled.div`
+	font-size: 12px;
+	text-wrap: pretty;
+`;
+
+function TaxNotCalculatedLineItem() {
+	const { __ } = useI18n();
+	return (
+		<TaxNotCalculatedLineItemWrapper>
+			{ __( 'Taxes may be added once billing information is provided' ) }
+		</TaxNotCalculatedLineItemWrapper>
+	);
+}
+
+function TaxAddedLineItem() {
+	const { __ } = useI18n();
+	return (
+		<TaxNotCalculatedLineItemWrapper>
+			{ __( 'Includes applicable taxes' ) }
+		</TaxNotCalculatedLineItemWrapper>
+	);
+}
 
 function MiniCartTotal( { responseCart }: { responseCart: ResponseCart } ) {
 	const { __ } = useI18n();
@@ -170,6 +194,10 @@ export function MiniCart( {
 				/>
 				{ shouldRenderEmptyCart && emptyCart }
 				{ ! shouldRenderEmptyCart && <MiniCartTotal responseCart={ responseCart } /> }
+				{ ! shouldRenderEmptyCart && isBillingInfoEmpty( responseCart ) && (
+					<TaxNotCalculatedLineItem />
+				) }
+				{ ! shouldRenderEmptyCart && ! isBillingInfoEmpty( responseCart ) && <TaxAddedLineItem /> }
 				<MiniCartFooter className="mini-cart__footer">
 					{ ! shouldRenderEmptyCart && (
 						<Button

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -81,13 +81,14 @@ const HiddenText = styled.span`
 const TaxNotCalculatedLineItemWrapper = styled.div`
 	font-size: 12px;
 	text-wrap: pretty;
+	line-height: 1em;
 `;
 
 function TaxNotCalculatedLineItem() {
 	const { __ } = useI18n();
 	return (
 		<TaxNotCalculatedLineItemWrapper>
-			{ __( 'Taxes may be added once billing information is provided' ) }
+			{ __( 'Tax: to be calculated' ) }
 		</TaxNotCalculatedLineItemWrapper>
 	);
 }

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -78,7 +78,7 @@ const HiddenText = styled.span`
 	width: 1px;
 `;
 
-const TaxNotCalculatedLineItemWrapper = styled.div`
+const TaxCalculationLineItemWrapper = styled.div`
 	font-size: 12px;
 	text-wrap: pretty;
 	line-height: 1em;
@@ -87,18 +87,16 @@ const TaxNotCalculatedLineItemWrapper = styled.div`
 function TaxNotCalculatedLineItem() {
 	const { __ } = useI18n();
 	return (
-		<TaxNotCalculatedLineItemWrapper>
-			{ __( 'Tax: to be calculated' ) }
-		</TaxNotCalculatedLineItemWrapper>
+		<TaxCalculationLineItemWrapper>{ __( 'Tax: to be calculated' ) }</TaxCalculationLineItemWrapper>
 	);
 }
 
 function TaxAddedLineItem() {
 	const { __ } = useI18n();
 	return (
-		<TaxNotCalculatedLineItemWrapper>
+		<TaxCalculationLineItemWrapper>
 			{ __( 'Includes applicable taxes' ) }
-		</TaxNotCalculatedLineItemWrapper>
+		</TaxCalculationLineItemWrapper>
 	);
 }
 

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -6,6 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { translate, useTranslate } from 'i18n-calypso';
+import { getContactDetailsType } from './get-contact-details-type';
 import { getIntroductoryOfferIntervalDisplay } from './introductory-offer';
 import type { LineItemType } from './types';
 import type {
@@ -21,8 +22,10 @@ export function getTotalLineItemFromCart( cart: ResponseCart ): LineItemType {
 	return {
 		id: 'total',
 		type: 'total',
-		// translators: The label of the total line item in checkout
-		label: String( translate( 'Total' ) ),
+		label: translate( 'Total', {
+			context: 'The label of the total line item in checkout',
+			textOnly: true,
+		} ),
 		formattedAmount: formatCurrency( cart.total_cost_integer, cart.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
@@ -648,4 +651,18 @@ export function isOverrideCodeIntroductoryOffer( overrideCode: string ): boolean
 			return true;
 	}
 	return false;
+}
+
+/**
+ * True if the billing/contact info is not filled in on a shopping cart (and it
+ * needs to be filled in).
+ */
+export function isBillingInfoEmpty( responseCart: ResponseCart ): boolean {
+	if ( getContactDetailsType( responseCart ) === 'none' ) {
+		return false;
+	}
+	if ( responseCart.tax.location.country_code ) {
+		return false;
+	}
+	return true;
 }

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -22,10 +22,8 @@ export function getTotalLineItemFromCart( cart: ResponseCart ): LineItemType {
 	return {
 		id: 'total',
 		type: 'total',
-		label: translate( 'Total', {
-			context: 'The label of the total line item in checkout',
-			textOnly: true,
-		} ),
+		// translators: The label of the total line item in checkout
+		label: String( translate( 'Total' ) ),
 		formattedAmount: formatCurrency( cart.total_cost_integer, cart.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,


### PR DESCRIPTION
## Proposed Changes

When you enter checkout, if the shopping cart does not yet have a tax location set, the taxes will not yet be calculated and will not be displayed nor included in the total price. For some customers, particularly those in countries outside the US where price-exclusive taxes are uncommon, this may be misleading.

In this PR we add "Tax: to be calculated" as a note where the taxes would normally be displayed when we do not yet know if we will add taxes or not.

Fixes https://github.com/Automattic/payments-shilling/issues/2575

Before             |  After
:-------------------------:|:-------------------------:
<img width="319" alt="Screenshot 2024-05-28 at 6 05 13 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/40612860-6420-473e-8580-6c62c339bb30"> | <img width="313" alt="Screenshot 2024-05-28 at 6 10 28 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/22c2843d-2d31-48c7-a3ce-772ffac21b73">
<img width="581" alt="Screenshot 2024-05-28 at 6 05 17 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c52d30e4-6e3a-451d-a868-c07aec31d2df"> | <img width="578" alt="Screenshot 2024-05-28 at 6 27 31 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/7fc64f0e-0c46-427f-92f2-1a8fb17020dd">
<img width="493" alt="Screenshot 2024-05-28 at 6 15 29 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c10fa7ef-9829-40ff-810e-cc4de692c19a"> | <img width="489" alt="Screenshot 2024-05-28 at 6 12 51 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/be1e6c49-037f-4a96-8fd7-312f5f5e4197">

Because the mini-cart does not mention taxes normally, this PR also adds a notice to the mini-cart when the taxes have been added.

<img width="504" alt="Screenshot 2024-05-28 at 6 18 09 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/761283d7-f2fd-45e6-91df-18a730a8f5cd">

Note that if taxes are calculated and there is no tax applied, you will instead see a regular tax line.

<img width="326" alt="Screenshot 2024-05-28 at 6 17 22 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/08f17d03-e6cc-475c-b1ae-5ee8888f15fb">


## Testing Instructions

First make sure that you don't have taxes already saved on your shopping cart. A simple way is to use an account that has never made a purchase. If you are using an account that has purchased something before, this will require disabling the billing info autocomplete in checkout and any tax data already in the cart which you can do by sandboxing the API and applying the changes in D142087-code.

- Next, add a product to your cart and visit checkout.
- Verify that you see "Tax: to be calculated" displayed in the sidebar and the footer.
- **If you broke the endpoints as mentioned above, you will need to revert those changes now.**
- Change the billing info step to a location that does not charge taxes (eg: UAE).
- Verify that taxes _are not present_ and "Tax: to be calculated"  is NOT displayed.
- Change the billing info step to a location that charges taxes (eg: US, 10001)
- Verify that taxes _are present_ and "Tax: to be calculated"  is NOT displayed.
