### PR TITLE
GitHub deployments: Add support docs links

### DIFF
--- a/client/my-sites/github-deployments/components/deployment-style/index.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/index.tsx
@@ -60,7 +60,8 @@ export const DeploymentStyle = ( {
 				<h3>{ __( 'Pick your deployment mode' ) }</h3>
 				<SupportInfo
 					popoverClassName="github-deployments-deployments-style-popover"
-					link="https://docs.github.com/en/actions/using-workflows"
+					// @todo Move to contextLinks
+					link="https://developer.wordpress.com/docs/developer-tools/github-deployments/github-deployments-workflow-recipes/"
 					privacyLink={ false }
 				>
 					{ supportMessage }

--- a/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
@@ -1,7 +1,11 @@
-import { Dialog } from '@automattic/components';
+import { Dialog, ExternalLink } from '@automattic/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentProps } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { GitHubBrowseRepositories } from '../components/repositories/browse-repositories';
+
+import './style.scss';
 
 interface DeleteDeploymentDialogProps {
 	isVisible: boolean;
@@ -24,8 +28,23 @@ export const RepositorySelectionDialog = ( {
 			shouldCloseOnEsc
 			onClose={ onClose }
 		>
-			<div css={ { width: '622px', height: '470px', display: 'flex', flexDirection: 'column' } }>
-				<h1 css={ { marginBottom: '24px !important' } }>{ __( 'Select repository' ) }</h1>
+			<div className="repository-selection-dialog">
+				<FormattedHeader
+					align="left"
+					headerText={ __( 'Select repository' ) }
+					subHeaderText={ createInterpolateElement(
+						__( 'Pick an existing repository or <docsLink>create a new one</docsLink>.' ),
+						{
+							docsLink: (
+								<ExternalLink
+									href="https://developer.wordpress.com/docs/developer-tools/github-deployments/create-github-deployment-source-files/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						}
+					) }
+				/>
 				<GitHubBrowseRepositories onSelectRepository={ onChange } />
 			</div>
 		</Dialog>

--- a/client/my-sites/github-deployments/deployment-creation/style.scss
+++ b/client/my-sites/github-deployments/deployment-creation/style.scss
@@ -1,0 +1,14 @@
+.repository-selection-dialog {
+	width: 622px;
+	height: 470px;
+	display: flex;
+	flex-direction: column;
+
+	h1 {
+		margin-bottom: 0.25rem !important;
+	}
+
+	.formatted-header {
+		margin-bottom: 24px !important;
+	}
+}


### PR DESCRIPTION
## Proposed Changes

- Link to recipes within deployment style popover
- Link to repository creation from contents within repository picker

![image](https://github.com/Automattic/wp-calypso/assets/26530524/b996bdf0-7a86-4847-b45f-a1558427ebca)

![image](https://github.com/Automattic/wp-calypso/assets/26530524/268e9f1b-7ba4-419d-98c1-dc7c93f1cbcb)
