### PR TITLE
GitHub Deployments: Fix repository picker input initial state CSS specificity

### DIFF
--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -154,7 +154,7 @@ export const GitHubConnectionForm = ( {
 								{ repository.owner }/{ repository.name }
 							</ExternalLink>
 						) : (
-							<FormSettingExplanation css={ { margin: 0 } }>
+							<FormSettingExplanation css={ { margin: '0 !important' } }>
 								{ __( 'No repository selected' ) }
 							</FormSettingExplanation>
 						) }


### PR DESCRIPTION
CSS specificity moves the "No repository selected" helper text down within the input if the user is coming from another page. This PR fixes it.