### PR TITLE
Subscribers: Update links and remove cards from Jetpack Cloud

### DIFF
--- a/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
@@ -3,8 +3,9 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, chevronRight, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import './style.scss';
 import { useEffect } from 'react';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import './style.scss';
 
 type EmptyListCTALinkProps = {
 	icon: JSX.Element;
@@ -45,6 +46,14 @@ const EmptyListView = () => {
 		recordTracksEvent( 'calypso_subscribers_empty_view_displayed' );
 	}, [] );
 
+	const subscribeBlockUrl = isJetpackCloud()
+		? 'https://jetpack.com/support/jetpack-blocks/subscription-form-block/'
+		: 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/';
+
+	const importSubscribersUrl = isJetpackCloud()
+		? 'https://jetpack.com/support/newsletter/import-subscribers/'
+		: 'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';
+
 	return (
 		<div className="empty-list-view">
 			<h2 className="empty-list-view__title">{ translate( 'Grow your subscribers' ) }</h2>
@@ -56,25 +65,23 @@ const EmptyListView = () => {
 			<EmptyListCTALink
 				icon={ chartBar }
 				text={ translate( 'Turn your visitors into subscribers' ) }
-				url={ localizeUrl(
-					'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
-				) }
+				url={ localizeUrl( subscribeBlockUrl ) }
 				eventName="calypso_subscribers_empty_view_subscribe_block_clicked"
 			/>
 			<EmptyListCTALink
 				icon={ people }
 				text={ translate( 'Import existing subscribers' ) }
-				url={ localizeUrl(
-					'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
-				) }
+				url={ localizeUrl( importSubscribersUrl ) }
 				eventName="calypso_subscribers_empty_view_import_subscribers_clicked"
 			/>
-			<EmptyListCTALink
-				icon={ trendingUp }
-				text={ translate( 'Grow your audience' ) }
-				url={ localizeUrl( 'https://wordpress.com/support/category/grow-your-audience/' ) }
-				eventName="calypso_subscribers_empty_view_grow_your_audience_clicked"
-			/>
+			{ ! isJetpackCloud() && (
+				<EmptyListCTALink
+					icon={ trendingUp }
+					text={ translate( 'Grow your audience' ) }
+					url={ localizeUrl( 'https://wordpress.com/support/category/grow-your-audience/' ) }
+					eventName="calypso_subscribers_empty_view_grow_your_audience_clicked"
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -5,8 +5,11 @@ import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { SectionContainer } from 'calypso/components/section';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 type GrowYourAudienceCardProps = {
@@ -58,7 +61,10 @@ const GrowYourAudienceCard = ( {
 const GrowYourAudience = () => {
 	const locale = useLocale();
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 
 	const statsCardTranslated =
 		englishLocales.includes( locale ) ||
@@ -67,6 +73,14 @@ const GrowYourAudience = () => {
 				'Take a look at your stats and refine your content strategy for better engagement.'
 			) &&
 			hasTranslation( 'Check stats' ) );
+
+	const statsUrl = isJetpackCloud()
+		? `${ siteAdminUrl }admin.php?page=stats#!/stats/subscribers/${ selectedSiteSlug }`
+		: `/stats/subscribers/${ selectedSiteSlug }`;
+
+	const subscribeBlockUrl = isJetpackCloud()
+		? 'https://jetpack.com/support/jetpack-blocks/subscription-form-block/'
+		: 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/';
 
 	return (
 		<SectionContainer className="grow-your-audience">
@@ -82,7 +96,7 @@ const GrowYourAudience = () => {
 						title={ translate( 'Explore your stats' ) }
 						tracksEventCta="stats"
 						ctaLabel={ translate( 'Check stats' ) }
-						url={ `/stats/subscribers/${ selectedSiteSlug }` }
+						url={ statsUrl }
 					/>
 				) : (
 					<GrowYourAudienceCard
@@ -94,34 +108,34 @@ const GrowYourAudience = () => {
 						tracksEventCta="subscribe-block"
 						ctaLabel={ translate( 'Learn more' ) }
 						externalUrl
-						url={ localizeUrl(
-							'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
-						) }
+						url={ localizeUrl( subscribeBlockUrl ) }
 					/>
 				) }
-
-				<GrowYourAudienceCard
-					icon={ trendingUp }
-					text={ translate(
-						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
-					) }
-					title={ translate( 'Start earning' ) }
-					tracksEventCta="earn"
-					ctaLabel={ translate( 'Learn more' ) }
-					url={ `/earn/${ selectedSiteSlug ?? '' }` }
-				/>
-
-				<GrowYourAudienceCard
-					icon={ people }
-					text={ translate(
-						'Create fresh content, publish regularly, and understand your audience with site stats.'
-					) }
-					title={ translate( 'Keep your readers engaged' ) }
-					tracksEventCta="go-content-strategy"
-					ctaLabel={ translate( 'Learn more' ) }
-					externalUrl
-					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
-				/>
+				{ isWPCOMSite && (
+					<GrowYourAudienceCard
+						icon={ trendingUp }
+						text={ translate(
+							'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
+						) }
+						title={ translate( 'Start earning' ) }
+						tracksEventCta="earn"
+						ctaLabel={ translate( 'Learn more' ) }
+						url={ `https://wordpress.com/earn/${ selectedSiteSlug ?? '' }` }
+					/>
+				) }
+				{ ! isJetpackCloud() && (
+					<GrowYourAudienceCard
+						icon={ people }
+						text={ translate(
+							'Create fresh content, publish regularly, and understand your audience with site stats.'
+						) }
+						title={ translate( 'Keep your readers engaged' ) }
+						tracksEventCta="go-content-strategy"
+						ctaLabel={ translate( 'Learn more' ) }
+						externalUrl
+						url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
+					/>
+				) }
 			</div>
 		</SectionContainer>
 	);

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -65,6 +66,10 @@ const MigrateSubscribersModal = () => {
 		return null;
 	}
 
+	const migrateSubscribersUrl = isJetpackCloud()
+		? 'https://jetpack.com/support/newsletter/import-subscribers/#migrate-subscribers-from-a-word-press-com-site'
+		: 'https://wordpress.com/support/migrate-subscribers-from-another-site/';
+
 	const selectionRender = (
 		<div className="migrate-subscribers-modal__content">
 			<div className="migrate-subscribers-modal__form--container">
@@ -95,9 +100,7 @@ const MigrateSubscribersModal = () => {
 								<Button
 									variant="link"
 									target="_blank"
-									href={ localizeUrl(
-										'https://wordpress.com/support/migrate-subscribers-from-another-site/'
-									) }
+									href={ localizeUrl( migrateSubscribersUrl ) }
 								/>
 							),
 						}

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -13,6 +13,7 @@ import QueryMembershipsSettings from 'calypso/components/data/query-memberships-
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import GiftSubscriptionModal from 'calypso/my-sites/subscribers/components/gift-modal/gift-modal';
 import { SubscriberListContainer } from 'calypso/my-sites/subscribers/components/subscriber-list-container';
 import {
@@ -49,16 +50,23 @@ const SubscribersHeader = ( { selectedSiteId, isUnverified }: SubscribersHeaderP
 		setShowSupportDoc( localizeUrl( 'https://wordpress.com/support/paid-newsletters/' ), 168381 );
 	};
 
+	const paidNewsletterUrl = isJetpackCloud()
+		? 'https://jetpack.com/support/newsletter/paid-newsletters/'
+		: 'https://wordpress.com/support/paid-newsletters/';
+
 	const subtitleOptions = {
 		components: {
 			link: (
 				<a
-					href={ localizeUrl( 'https://wordpress.com/support/paid-newsletters/' ) }
+					href={ localizeUrl( paidNewsletterUrl ) }
 					target="blank"
 					onClick={ ( event ) => {
-						event.preventDefault();
-						openHelpCenter();
+						if ( ! isJetpackCloud() ) {
+							event.preventDefault();
+							openHelpCenter();
+						}
 					} }
+					rel="noreferrer"
 				/>
 			),
 		},

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -75,6 +75,7 @@
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
+		"subscriber-csv-upload": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -67,6 +67,7 @@
 		"oauth": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,
+		"subscriber-csv-upload": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -72,6 +72,7 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
+		"subscriber-csv-upload": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -19,6 +19,8 @@ import {
 	useRef,
 	useCallback,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useActiveJobRecognition } from '../../hooks/use-active-job-recognition';
 import { useInProgressState } from '../../hooks/use-in-progress-state';
 import { RecordTrackEvents, useRecordAddFormEvents } from '../../hooks/use-record-add-form-events';
@@ -389,6 +391,10 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			? translate( 'Or upload a CSV file of up to 100 emails from your existing list. Learn more.' )
 			: translate( 'Or upload a CSV file of emails from your existing list. Learn more.' );
 
+		const importSubscribersUrl = isJetpackCloud()
+			? 'https://jetpack.com/support/newsletter/import-subscribers/'
+			: 'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';
+
 		const interpolateElement = {
 			uploadBtn: formFileUploadElement,
 			Button: (
@@ -396,9 +402,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					variant="link"
 					target="_blank"
 					rel="noreferrer"
-					href={ localizeUrl(
-						'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
-					) }
+					href={ localizeUrl( importSubscribersUrl ) }
 				/>
 			),
 		};

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -358,6 +358,10 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	}
 
 	function renderImportCsvDisclaimerMsg() {
+		const importSubscribersUrl = isJetpackCloud()
+			? 'https://jetpack.com/support/newsletter/import-subscribers/'
+			: 'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';
+
 		return (
 			( !! getValidEmails().length || ( isSelectedFileValid && selectedFile ) ) && (
 				<p className="add-subscriber__form--disclaimer">
@@ -374,9 +378,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 								<Button
 									variant="link"
 									target="_blank"
-									href={ localizeUrl(
-										'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
-									) }
+									href={ localizeUrl( importSubscribersUrl ) }
 								/>
 							),
 						}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5961

## Proposed Changes

Update support docs/help from Subscribers on Jetpack cloud.

As some support docs don't exist on Jetpack, we removed the card or item from the list.

| Before / Calypso | After: Atomic | After: Self hosted |
| --- | --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/9656f2ff-2d93-457c-a14a-66de7c7e7138) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/9a373ed5-b936-4dbb-8807-e912255524ae) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/948e676f-fdfa-418c-a42b-fc1aa1cf83a3) |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/a4bae883-0557-454f-ab09-a3bc433be25e) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/0e39af03-e356-4a3d-a6e4-29a22d41029b) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/dc77f0c8-7d4e-4ad6-97d8-2c9b3df144c2) |

## Links at Jetpack Cloud
Turn your visitors into subscribers -> `https://jetpack.com/support/jetpack-blocks/subscription-form-block/`
Import existing subscribers -> `https://jetpack.com/support/newsletter/import-subscribers/`
Check Stats box -> `wp-admin/admin.php?page=stats#!/stats/subscribers/SITE-SLUG`

## Testing Instructions

* Run `yarn start-jetpack-cloud `
* Go to `http://jetpack.cloud.localhost:3000/subscribers/:your-site`
* Check the Items (when 0 subscribers) and Cards (when >0 subscribers) 
* Check if support/help links to Jetpack support docs at Jetpack Cloud and WPcom docs on WPcom.
* Do it with an Atomic site and a self-hosted site.
* Check if nothing is broken on Calypso at `/subscribers/:your-site`

* We also updated the email template to Jetpack in this diff: D141993-code