### PR TITLE
Global sidebar: Add quick language switcher when in support mode

### DIFF
--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -3,8 +3,11 @@ import { LocalizeProps } from 'i18n-calypso';
 import { FC } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
+import QuickLanguageSwitcher from 'calypso/layout/masterbar/quick-language-switcher';
 import SidebarFooter from 'calypso/layout/sidebar/footer';
 import { UserData } from 'calypso/lib/user/user';
+import { useSelector } from 'calypso/state';
+import { isSupportSession } from 'calypso/state/support/selectors';
 import { GLOBAL_SIDEBAR_EVENTS } from './events';
 
 const CustomReaderIcon = () => (
@@ -31,6 +34,7 @@ export const GlobalSidebarFooter: FC< {
 	translate: LocalizeProps[ 'translate' ];
 	user?: UserData;
 } > = ( { translate, user } ) => {
+	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
 	return (
 		<SidebarFooter>
 			<a
@@ -62,6 +66,9 @@ export const GlobalSidebarFooter: FC< {
 				}
 				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.HELPCENTER_CLICK ) }
 			/>
+			{ isInSupportSession && (
+				<QuickLanguageSwitcher className="sidebar__footer-language-switcher" shouldRenderAsButton />
+			) }
 		</SidebarFooter>
 	);
 };

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -231,6 +231,18 @@ $brand-text: "SF Pro Text", $sans;
 			}
 		}
 
+		.sidebar__footer-language-switcher {
+			align-items: center;
+			color: var(--studio-gray-5);
+			cursor: pointer;
+			display: flex;
+			height: 32px;
+			gap: 6px;
+			padding: 6px;
+			justify-content: center;
+			margin-inline-start: auto;
+		}
+
 		.sidebar__item-help,
 		.sidebar__footer-link,
 		.sidebar__footer-wpadmin {
@@ -250,6 +262,7 @@ $brand-text: "SF Pro Text", $sans;
 			}
 		}
 
+		.sidebar__footer-language-switcher,
 		.sidebar__footer-link,
 		.sidebar__item-help {
 			&:hover {

--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { Gridicon } from '@automattic/components';
 import languages from '@automattic/languages';
 import { Fragment, useReducer } from 'react';
 import { connect } from 'react-redux';
@@ -22,13 +23,20 @@ function QuickLanguageSwitcher( props ) {
 
 	return (
 		<Fragment>
-			<MasterbarItem
-				icon="globe"
-				className="masterbar__quick-language-switcher"
-				onClick={ toggleLanguagesModal }
-			>
-				{ props.selectedLanguageSlug }
-			</MasterbarItem>
+			{ props.shouldRenderAsButton ? (
+				<button className={ props.className } onClick={ toggleLanguagesModal }>
+					<Gridicon icon="globe" size={ 24 } />
+					{ props.selectedLanguageSlug }
+				</button>
+			) : (
+				<MasterbarItem
+					icon="globe"
+					className="masterbar__quick-language-switcher"
+					onClick={ toggleLanguagesModal }
+				>
+					{ props.selectedLanguageSlug }
+				</MasterbarItem>
+			) }
 			{ isShowingModal && (
 				<LanguagePickerModal
 					languages={ languages }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6066

## Proposed Changes

This PR adds the quick language switcher in the global sidebar when in support mode. See screenshot for reference:
![Screenshot 2024-03-14 at 11 48 41 AM](https://github.com/Automattic/wp-calypso/assets/797888/8812af60-7cca-4213-9978-ed74e9865f51)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the MC tool `/tools/support-user/` and start a session for your non-a11n account.
* Head to `/sites`.
* Ensure that the quick language switcher is available and works as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?