### PR TITLE
Add DIFM label to /sites table

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -11,6 +11,7 @@ import TimeSince from 'calypso/components/time-since';
 import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
 import { hasSiteStatsQueryFailed } from 'calypso/state/stats/lists/selectors';
 import {
@@ -112,6 +113,11 @@ const StatsColumnStyled = styled( Column )`
 	text-align: center;
 `;
 
+const BadgeDIFM = styled.span`
+	color: var( --studio-gray-100 );
+	white-space: break-spaces;
+`;
+
 const StatsOffIndicator = () => {
 	const [ showPopover, setShowPopover ] = useState( false );
 	const tooltipRef = useRef( null );
@@ -143,6 +149,8 @@ const StatsOffIndicator = () => {
 };
 
 export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
+	const isDIFMInProgress = useSelector( ( state ) => isDIFMLiteInProgress( state, site.ID ) );
+
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const { ref, inView } = useInView( { triggerOnce: true } );
@@ -217,6 +225,9 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							<>
 								{ translatedStatus }
 								<SiteLaunchNag site={ site } />
+								{ isDIFMInProgress && (
+									<BadgeDIFM className="site__badge">{ __( 'Built By Express' ) }</BadgeDIFM>
+								) }
 							</>
 						)
 					}

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -223,8 +223,10 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							<TransferNoticeWrapper { ...result } />
 						) : (
 							<>
-								{ translatedStatus }
-								<SiteLaunchNag site={ site } />
+								<div>
+									{ translatedStatus }
+									<SiteLaunchNag site={ site } />
+								</div>
 								{ isDIFMInProgress && (
 									<BadgeDIFM className="site__badge">{ __( 'Built By Express' ) }</BadgeDIFM>
 								) }


### PR DESCRIPTION
fixes 5937-gh-Automattic/dotcom-forge

Originally we misunderstood the issue as the label being missing on the site card, but that is working correctly. The complaint was originally that the label does not appear on the sites table:

pdtkmj-2rq-p2#comment-4589

<img width="1690" alt="Screenshot 2024-03-14 at 3 08 31 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/d6bb76df-4508-480e-a4e4-823b6273d736">

This adds the label to the /sites page.

### Test instructions

Go to Blog RC for a site and enable the `difm-lite-in-progress` option for the site.
Go to the /sites page and the badge should be shown
