### PR TITLE
Automattic for Agencies: Implement API changes to the marketplace

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -10,3 +10,4 @@ export const A4A_BILLING_LINK = `${ A4A_PURCHASES_LINK }/billing`;
 export const A4A_INVOICES_LINK = `${ A4A_PURCHASES_LINK }/invoices`;
 export const A4A_PAYMENT_METHODS_LINK = `${ A4A_PURCHASES_LINK }/payment-methods`;
 export const A4A_PAYMENT_METHODS_ADD_LINK = `${ A4A_PURCHASES_LINK }/payment-methods/add`;
+export const A4A_DOWNLOAD_PRODUCTS_LINK = `${ A4A_PURCHASES_LINK }/download-products`;

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -16,6 +16,7 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import {
 	A4A_DOWNLOAD_PRODUCTS_LINK,
 	A4A_LICENSES_LINK,
+	A4A_SITES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import FormRadio from 'calypso/components/forms/form-radio';
 import Pagination from 'calypso/components/pagination';
@@ -150,7 +151,7 @@ export default function AssignLicense( { sites, currentPage, search }: Props ) {
 
 		const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
 		if ( fromDashboard ) {
-			return page.redirect( '/sites' );
+			return page.redirect( A4A_SITES_LINK );
 		}
 
 		return page.redirect( A4A_LICENSES_LINK );

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -13,12 +13,15 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import {
+	A4A_DOWNLOAD_PRODUCTS_LINK,
+	A4A_LICENSES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import FormRadio from 'calypso/components/forms/form-radio';
 import Pagination from 'calypso/components/pagination';
 import SearchCard from 'calypso/components/search-card';
 import areLicenseKeysAssignableToMultisite from 'calypso/jetpack-cloud/sections/partner-portal/lib/are-license-keys-assignable-to-multisite';
 import isWooCommerceProduct from 'calypso/jetpack-cloud/sections/partner-portal/lib/is-woocommerce-product';
-import { a4aPurchasesBasePath } from 'calypso/lib/a8c-for-agencies/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -112,11 +115,11 @@ export default function AssignLicense( { sites, currentPage, search }: Props ) {
 
 	const onClickAssignLater = useCallback( () => {
 		if ( licenseKeysArray.length > 1 ) {
-			page.redirect( a4aPurchasesBasePath( '/licenses' ) );
+			page.redirect( A4A_LICENSES_LINK );
 		}
 
 		const licenseKey = licenseKeysArray[ 0 ];
-		page.redirect( addQueryArgs( { highlight: licenseKey }, a4aPurchasesBasePath( '/licenses' ) ) );
+		page.redirect( addQueryArgs( { highlight: licenseKey }, A4A_LICENSES_LINK ) );
 	}, [ licenseKeysArray ] );
 
 	const onClickAssignLicenses = useCallback( async () => {
@@ -140,7 +143,7 @@ export default function AssignLicense( { sites, currentPage, search }: Props ) {
 			return page.redirect(
 				addQueryArgs(
 					{ products: licenseKeysArray.join( ',' ), attachedSiteId: selectedSite?.ID },
-					a4aPurchasesBasePath( '/download-products' )
+					A4A_DOWNLOAD_PRODUCTS_LINK
 				)
 			);
 		}
@@ -150,7 +153,7 @@ export default function AssignLicense( { sites, currentPage, search }: Props ) {
 			return page.redirect( '/sites' );
 		}
 
-		return page.redirect( a4aPurchasesBasePath( '/licenses' ) );
+		return page.redirect( A4A_LICENSES_LINK );
 	}, [ assignLicensesToSite, dispatch, licenseKeysArray, selectedSite?.ID ] );
 
 	return (

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-assign-license-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-assign-license-mutation.ts
@@ -1,0 +1,33 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getCurrentAgencyUserId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { APILicense } from 'calypso/state/partner-portal/types';
+
+interface MutationAssignLicenseVariables {
+	licenseKey: string;
+	selectedSite: number | boolean;
+}
+
+function mutationAssignLicense( {
+	licenseKey,
+	selectedSite,
+	agencyId,
+}: MutationAssignLicenseVariables & { agencyId: number } ): Promise< APILicense > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/jetpack-licensing/license/${ licenseKey }/site`,
+		body: { site: selectedSite, agency_id: agencyId },
+	} );
+}
+
+export default function useAssignLicenseMutation< TContext = unknown >(
+	options?: UseMutationOptions< APILicense, Error, MutationAssignLicenseVariables, TContext >
+): UseMutationResult< APILicense, Error, MutationAssignLicenseVariables, TContext > {
+	const agencyId = useSelector( getCurrentAgencyUserId );
+
+	return useMutation< APILicense, Error, MutationAssignLicenseVariables, TContext >( {
+		...options,
+		mutationFn: ( args ) => mutationAssignLicense( { ...args, agencyId } ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-issue-license-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-issue-license-mutation.ts
@@ -1,0 +1,33 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getCurrentAgencyUserId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { APIError, APILicense } from 'calypso/state/partner-portal/types';
+
+export interface MutationIssueLicenseVariables {
+	product: string;
+	quantity: number;
+}
+
+function mutationIssueLicense( {
+	product,
+	quantity,
+	agencyId,
+}: MutationIssueLicenseVariables & { agencyId: number } ): Promise< APILicense > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-licensing/license',
+		body: { product, quantity, agency_id: agencyId },
+	} );
+}
+
+export default function useIssueLicenseMutation< TContext = unknown >(
+	options?: UseMutationOptions< APILicense, APIError, MutationIssueLicenseVariables, TContext >
+): UseMutationResult< APILicense, APIError, MutationIssueLicenseVariables, TContext > {
+	const agencyId = useSelector( getCurrentAgencyUserId );
+
+	return useMutation< APILicense, APIError, MutationIssueLicenseVariables, TContext >( {
+		...options,
+		mutationFn: ( args ) => mutationIssueLicense( { ...args, agencyId } ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-assign-licenses-to-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-assign-licenses-to-site.ts
@@ -1,0 +1,108 @@
+import { useCallback } from 'react';
+import {
+	getProductSlugFromLicenseKey,
+	getProductTitle,
+} from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import useAssignLicenseMutation from '../../hooks/use-assign-license-mutation';
+import type {
+	ProductInfo,
+	PurchasedProductsInfo,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+const NO_OP = () => {
+	/* Do nothing */
+};
+
+type UseAssignLicensesToSiteOptions = {
+	onError?: ( ( error: Error ) => void ) | ( () => void );
+};
+const useAssignLicensesToSite = (
+	selectedSite?: { ID: number; domain: string } | null,
+	options: UseAssignLicensesToSiteOptions = {}
+): {
+	assignLicensesToSite: ( licenseKeys: string[] ) => Promise< PurchasedProductsInfo >;
+	isReady: boolean;
+} => {
+	const products = useProductsQuery( true );
+	const assignLicense = useAssignLicenseMutation( {
+		onError: options.onError ?? NO_OP,
+	} );
+
+	const isReady = assignLicense.isIdle;
+	const assignLicensesToSite = useCallback(
+		async ( licenseKeys: string[] ): Promise< PurchasedProductsInfo > => {
+			// Only proceed if the mutation is in a fresh/ready state
+			if ( ! assignLicense.isIdle ) {
+				throw new Error( 'The mutation for assigning licenses is not ready' );
+			}
+
+			// We need a valid site ID in order to assign licenses to a site;
+			// otherwise, we assign nothing
+			const selectedSiteId = selectedSite?.ID;
+			if ( ! selectedSiteId ) {
+				throw new Error( 'A site ID is required for license assignment but was missing' );
+			}
+
+			const keysWithProductNames = licenseKeys
+				.map( ( key ) => {
+					const productSlug = getProductSlugFromLicenseKey( key );
+					const selectedProduct = products?.data?.find?.(
+						// Product slugs are limited to 38 characters in license keys.
+						( p ) => p.slug.substring( 0, 38 ) === productSlug
+					);
+
+					if ( ! selectedProduct ) {
+						return null;
+					}
+
+					return {
+						key,
+						product: selectedProduct,
+					};
+				} )
+				// If we can't determine which product a license is meant for, filter it out.
+				// The Exclude<> usage here is to let Typescript know that the null case has been eliminated.
+				.filter( ( item ): item is Exclude< typeof item, null > => item !== null )
+				// Sort ascending by product id as a quick and dirty way to avoid race conditions between add-on
+				// products and their dependencies. For example, Jetpack Backup Add-on Storage requires that Jetpack
+				// Backup is present on the site, so we need to assign the Jetpack Backup license first.
+				// We rely on the product id because add-ons should practically always have a higher product id
+				// than the product they are an add-on for.
+				.sort( ( a, b ) => b.product.product_id - a.product.product_id )
+				// We only need the product's title/display name
+				.map( ( { key, product } ) => ( {
+					key,
+					name: getProductTitle( ( product as APIProductFamilyProduct ).name ),
+				} ) );
+
+			const apiRequests = [];
+
+			// Purposely catch any error responses and let them through,
+			// so we can pass all their information along as ProductInfo objects
+			// (not currently available via PromiseSettledResult<T>)
+			for ( let i = 0; i < keysWithProductNames.length; i++ ) {
+				const { key, name } = keysWithProductNames[ i ];
+				apiRequests.push(
+					// Assign the products sequentially to guarantee products that depend on other products have their
+					// dependencies assigned first.
+					await assignLicense
+						.mutateAsync( { licenseKey: key, selectedSite: selectedSiteId } )
+						.then( () => ( { key, name, status: 'fulfilled' } ) as ProductInfo )
+						.catch( () => ( { key, name, status: 'rejected' } ) as ProductInfo )
+				);
+			}
+
+			return {
+				selectedSite: selectedSite?.domain || '',
+				selectedProducts: apiRequests,
+			};
+		},
+		[ selectedSite, assignLicense, products ]
+	);
+
+	return { assignLicensesToSite, isReady };
+};
+
+export default useAssignLicensesToSite;

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-issue-and-assign-licenses.tsx
@@ -2,7 +2,10 @@ import page from '@automattic/calypso-router';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import { A4A_LICENSES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_LICENSES_LINK,
+	A4A_SITES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setPurchasedLicense, resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -127,7 +130,7 @@ function useIssueAndAssignLicenses(
 			// let's politely send them back there
 			const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
 			if ( fromDashboard ) {
-				page.redirect( '/sites' );
+				page.redirect( A4A_SITES_LINK );
 				return;
 			}
 

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-issue-and-assign-licenses.tsx
@@ -1,0 +1,150 @@
+import page from '@automattic/calypso-router';
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { a4aPurchasesBasePath } from 'calypso/lib/a8c-for-agencies/paths';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { setPurchasedLicense, resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import { type APIError } from 'calypso/state/partner-portal/types';
+import useAssignLicensesToSite from './use-assign-licenses-to-site';
+import useIssueLicenses, {
+	type IssueLicenseRequest,
+	type FulfilledIssueLicenseResult,
+} from './use-issue-licenses';
+
+const NO_OP = () => {
+	/* Do nothing */
+};
+
+const useGetLicenseIssuedMessage = () => {
+	const translate = useTranslate();
+	const products = useProductsQuery( true );
+
+	return useCallback(
+		( licenses: FulfilledIssueLicenseResult[] ) => {
+			if ( licenses.length === 0 ) {
+				return;
+			}
+
+			// Only one individual license; let's be more specific
+			if ( licenses.length === 1 && ( licenses[ 0 ].quantity ?? 1 ) === 1 ) {
+				const productName =
+					products?.data?.find?.( ( p ) => p.slug === licenses[ 0 ].slug )?.name ?? '';
+				return translate(
+					'Thanks for your purchase! Below you can view and assign your new {{strong}}%(productName)s{{/strong}} license to a website.',
+					{
+						args: {
+							productName,
+						},
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			}
+
+			// Multiple licenses and/or bundles? A generic thanks will suffice.
+			return translate(
+				'Thanks for your purchase! Below you can view and assign your new product licenses to your websites.'
+			);
+		},
+		[ products?.data, translate ]
+	);
+};
+
+type UseIssueAndAssignLicensesOptions = {
+	onIssueError?: ( ( error: APIError ) => void ) | ( () => void );
+	onAssignError?: ( ( error: Error ) => void ) | ( () => void );
+};
+function useIssueAndAssignLicenses(
+	selectedSite?: { ID: number; domain: string } | null,
+	options: UseIssueAndAssignLicensesOptions = {}
+) {
+	const dispatch = useDispatch();
+
+	const { isReady: isIssueReady, issueLicenses } = useIssueLicenses( {
+		onError: options.onIssueError ?? NO_OP,
+	} );
+
+	const { isReady: isAssignReady, assignLicensesToSite } = useAssignLicensesToSite( selectedSite, {
+		onError: options.onAssignError ?? NO_OP,
+	} );
+
+	const getLicenseIssuedMessage = useGetLicenseIssuedMessage();
+
+	return useMemo( () => {
+		const isReady = isIssueReady && isAssignReady;
+
+		const issueAndAssignLicenses = async ( selectedLicenses: IssueLicenseRequest[] ) => {
+			if ( ! isReady || selectedLicenses.length === 0 ) {
+				return;
+			}
+
+			const issuedLicenses = ( await issueLicenses( selectedLicenses ) ).filter(
+				( r ): r is FulfilledIssueLicenseResult => r.status === 'fulfilled'
+			);
+
+			// Exit early if we don't see any issued licenses matching a product we know
+			if ( issuedLicenses.length === 0 ) {
+				return;
+			}
+
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_multiple_licenses_issued', {
+					products: issuedLicenses
+						.map( ( license ) => `${ license.slug }:${ license.quantity ?? 1 }` )
+						.join( ',' ),
+				} )
+			);
+
+			const issuedKeys = issuedLicenses.map( ( { license_key } ) => license_key );
+
+			// TODO: Move dispatch events and redirects outside this function
+			//
+			// If no site is selected, announce that licenses were issued;
+			// then, redirect to somewhere more appropriate
+			const selectedSiteId = selectedSite?.ID;
+			if ( ! selectedSiteId ) {
+				const issuedMessage = getLicenseIssuedMessage( issuedLicenses );
+				dispatch( successNotice( issuedMessage, { displayOnNextPage: true } ) );
+
+				page.redirect( a4aPurchasesBasePath( '/licenses' ) );
+				return;
+			}
+
+			// If a specific site is already selected,
+			// let's assign the licenses we just issued to it
+			const assignLicensesStatus = await assignLicensesToSite( issuedKeys );
+
+			// TODO: Move dispatch events and redirects outside this function
+			dispatch( resetSite() );
+			dispatch( setPurchasedLicense( assignLicensesStatus ) );
+
+			// If we know this person came from the dashboard,
+			// let's politely send them back there
+			const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
+			if ( fromDashboard ) {
+				page.redirect( '/sites' );
+				return;
+			}
+
+			// Otherwise, send them to the overview of all licenses
+			page.redirect( a4aPurchasesBasePath( '/licenses' ) );
+		};
+
+		return { issueAndAssignLicenses, isReady };
+	}, [
+		assignLicensesToSite,
+		dispatch,
+		getLicenseIssuedMessage,
+		isAssignReady,
+		isIssueReady,
+		issueLicenses,
+		selectedSite?.ID,
+	] );
+}
+
+export default useIssueAndAssignLicenses;

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-issue-and-assign-licenses.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import { a4aPurchasesBasePath } from 'calypso/lib/a8c-for-agencies/paths';
+import { A4A_LICENSES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setPurchasedLicense, resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -111,7 +111,7 @@ function useIssueAndAssignLicenses(
 				const issuedMessage = getLicenseIssuedMessage( issuedLicenses );
 				dispatch( successNotice( issuedMessage, { displayOnNextPage: true } ) );
 
-				page.redirect( a4aPurchasesBasePath( '/licenses' ) );
+				page.redirect( A4A_LICENSES_LINK );
 				return;
 			}
 
@@ -132,7 +132,7 @@ function useIssueAndAssignLicenses(
 			}
 
 			// Otherwise, send them to the overview of all licenses
-			page.redirect( a4aPurchasesBasePath( '/licenses' ) );
+			page.redirect( A4A_LICENSES_LINK );
 		};
 
 		return { issueAndAssignLicenses, isReady };

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-issue-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/hooks/use-issue-licenses.tsx
@@ -1,0 +1,68 @@
+import { APIError, APILicense } from 'calypso/state/partner-portal/types';
+import useIssueLicenseMutation from '../../hooks/use-issue-license-mutation';
+
+const NO_OP = () => {
+	/* Do nothing */
+};
+
+export type IssueLicenseRequest = {
+	slug: string;
+	quantity: number;
+};
+
+export type FulfilledIssueLicenseResult = APILicense & {
+	status: 'fulfilled';
+	slug: string;
+};
+export type RejectedIssueLicenseResult = {
+	status: 'rejected';
+	slug: string;
+};
+
+export type IssueLicenseResult = FulfilledIssueLicenseResult | RejectedIssueLicenseResult;
+
+type UseIssueLicensesOptions = {
+	onError?: ( ( error: APIError ) => void ) | ( () => void );
+};
+const useIssueLicenses = ( options: UseIssueLicensesOptions = {} ) => {
+	const paymentMethodRequired = false; // FIXME: Fix this with actual data
+
+	const { mutateAsync, isIdle } = useIssueLicenseMutation( {
+		onError: options.onError ?? NO_OP,
+		retry: ( errorCount, error ) => {
+			// There's a slight delay before the license creation API is made
+			// aware when a user adds a payment method and will allow creation
+			// of a license.
+			// To make this a smoother experience, we silently retry a couple of
+			// times if the error is missing_valid_payment_method but the
+			// local state shows that a payment method exists.
+			if ( ! paymentMethodRequired && error?.code === 'missing_valid_payment_method' ) {
+				return errorCount < 5;
+			}
+
+			return false;
+		},
+	} );
+
+	const issueLicenses = (
+		selectedLicenses: IssueLicenseRequest[]
+	): Promise< IssueLicenseResult[] > => {
+		const requests: Promise< IssueLicenseResult >[] = selectedLicenses.map(
+			( { slug, quantity } ) =>
+				mutateAsync( { product: slug, quantity } )
+					.then(
+						( value ): FulfilledIssueLicenseResult => ( { slug, status: 'fulfilled', ...value } )
+					)
+					.catch( (): RejectedIssueLicenseResult => ( { slug, status: 'rejected' } ) )
+		);
+
+		return Promise.all( requests );
+	};
+
+	return {
+		isReady: isIdle,
+		issueLicenses,
+	};
+};
+
+export default useIssueLicenses;

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
@@ -1,6 +1,7 @@
 // FIXME: Lets decide later if we need to move the calypso/jetpack-cloud imports to a shared common folder.
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -25,6 +26,7 @@ import getSites from 'calypso/state/selectors/get-sites';
 import AssignLicenseStepProgress from '../assign-license-step-progress';
 import IssueLicenseContext from './context';
 import LicensesForm from './licenses-form';
+import useSubmitForm from './licenses-form/hooks/use-submit-form';
 import type { SelectedLicenseProp } from './types';
 import type { AssignLicenseProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -44,7 +46,14 @@ export default function IssueLicense( { siteId, suggestedProduct }: AssignLicens
 		.reduce( ( a, b ) => a + b, 0 );
 
 	const { selectedSize, setSelectedSize, availableSizes } = useProductBundleSize( true );
-	const isReady = true; // FIXME: Fix this with actual form ready state
+
+	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
+	// track if the user purchases a different set of products.
+	const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
+		?.toString()
+		.split( ',' );
+
+	const { isReady, submitForm } = useSubmitForm( selectedSite, suggestedProductSlugs );
 
 	const onShowReviewLicensesModal = useCallback( () => {
 		setShowReviewLicenses( true );
@@ -211,8 +220,8 @@ export default function IssueLicense( { siteId, suggestedProduct }: AssignLicens
 					onClose={ onDismissReviewLicensesModal }
 					selectedLicenses={ getGroupedLicenses() }
 					selectedSite={ selectedSite }
-					isFormReady={ true } // FIXME: Fix this with actual form ready state
-					submitForm={ () => {} } // FIXME: Fix this with actual form submit
+					isFormReady={ isReady }
+					submitForm={ submitForm }
 				/>
 			) }
 		</>

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/hooks/use-submit-form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/hooks/use-submit-form.tsx
@@ -2,9 +2,9 @@ import page from '@automattic/calypso-router';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import { A4A_PAYMENT_METHODS_ADD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { serializeQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
 import { containEquivalentItems } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-submit-form';
-import { a4aPurchasesBasePath } from 'calypso/lib/a8c-for-agencies/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -28,11 +28,7 @@ const useSubmitForm = ( selectedSite?: SiteDetails | null, suggestedProductSlugs
 								'A primary payment method is required.{{br/}} {{a}}Try adding a new payment method{{/a}} or contact support.',
 								{
 									components: {
-										a: (
-											<a
-												href={ a4aPurchasesBasePath( '/payment-methods/add?return=/marketplace' ) }
-											/>
-										),
+										a: <a href={ `${ A4A_PAYMENT_METHODS_ADD_LINK }?return=/marketplace` } />,
 										br: <br />,
 									},
 								}
@@ -95,7 +91,7 @@ const useSubmitForm = ( selectedSite?: SiteDetails | null, suggestedProductSlugs
 						...( selectedSite?.ID && { site_id: selectedSite?.ID } ),
 						...( fromDashboard && { source: 'dashboard' } ),
 					},
-					a4aPurchasesBasePath( '/payment-methods/add' )
+					A4A_PAYMENT_METHODS_ADD_LINK
 				);
 
 				page( nextStep );

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
@@ -16,6 +16,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import IssueLicenseContext from '../context';
 import { PRODUCT_FILTER_ALL } from './constants';
+import useSubmitForm from './hooks/use-submit-form';
 import ProductFilterSearch from './product-filter-search';
 import ProductFilterSelect from './product-filter-select';
 import LicensesFormSection from './sections';
@@ -54,6 +55,7 @@ export default function LicensesForm( {
 		products,
 		wooExtensions,
 		data,
+		suggestedProductSlugs,
 	} = useProductAndPlans( {
 		selectedSite,
 		selectedProductFilter,
@@ -186,7 +188,7 @@ export default function LicensesForm( {
 		[ dispatch, handleSelectBundleLicense, quantity, selectedLicenses, setSelectedLicenses ]
 	);
 
-	const isReady = true; // FIXME: Fix this with actual form ready state
+	const { isReady } = useSubmitForm( selectedSite, suggestedProductSlugs );
 
 	const isSelected = useCallback(
 		( slug: string | string[] ) =>

--- a/client/lib/a8c-for-agencies/paths.ts
+++ b/client/lib/a8c-for-agencies/paths.ts
@@ -1,0 +1,1 @@
+export const a4aPurchasesBasePath = ( path = '' ) => `/purchases${ path }`;

--- a/client/lib/a8c-for-agencies/paths.ts
+++ b/client/lib/a8c-for-agencies/paths.ts
@@ -1,1 +1,0 @@
-export const a4aPurchasesBasePath = ( path = '' ) => `/purchases${ path }`;

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -1,0 +1,3 @@
+export function getCurrentAgencyUserId(): number {
+	return 123; // FIXME: Replace with actual implementation
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/279

## Proposed Changes

This PR implements API changes to the marketplace.

## Testing Instructions

- Switch to the branch `git checkout add/implement-marketplace-api-changes`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Follow the steps here to get the agency ID: D139529-code
- Set the agency ID to the value you get from the above step to `getCurrentAgencyUserId` selector.
- Click the Marketplace menu item > Select `Jetpack Complete` and issue it > Verify that the selected licenses are issued > Assign the issued licenses to a site by selecting one from the Assign License page > Verify that the licenses are assigned to the selected site.

<img width="723" alt="Screenshot 2024-03-15 at 3 28 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c1662818-03cf-45c4-8430-305dfe034675">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?