### PR TITLE
Site Migration: Update migration instructions layout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -188,19 +188,14 @@ const SiteMigrationInstructions: Step = function () {
 				className="is-step-site-migration-instructions"
 				hideSkip={ true }
 				hideBack={ true }
-				isHorizontalLayout={ true }
 				formattedHeader={
 					<>
 						<FormattedHeader
 							id="site-migration-instructions-header"
-							headerText={ translate( 'Migrate your site' ) }
-							align="left"
+							headerText={ translate( 'Ready to migrate your site?' ) }
+							align="center"
 						/>
-						<p>
-							{ translate(
-								'Move your existing WordPress site to WordPress.com. Follow these steps to get started.'
-							) }
-						</p>
+						<p>{ translate( 'Follow these steps to get started.' ) }</p>
 					</>
 				}
 				stepContent={ stepContent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -124,7 +124,6 @@ const SiteMigrationInstructions: Step = function () {
 											: siteMigrationKey }
 									</code>
 									<Button
-										primary
 										onClick={ () => {
 											setHideSiteMigrationKey( ! hideSiteMigrationKey );
 										} }
@@ -134,7 +133,7 @@ const SiteMigrationInstructions: Step = function () {
 									</Button>
 									<ClipboardButton
 										text={ siteMigrationKey }
-										className="site-migration-instructions__copy-key-button is-primary"
+										className="site-migration-instructions__copy-key-button is-secondary"
 										onCopy={ onCopy }
 									>
 										{ buttonTextCopy ? translate( 'Copied!' ) : translate( 'Copy key' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { ClipboardButton } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
-import { classNames } from 'classnames';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -50,7 +50,7 @@ const SiteMigrationInstructions: Step = function () {
 			recordTracksEvent( 'calypso_migration_instructions_key_retrieved' );
 		} catch ( error ) {
 			setSiteMigrationKeyError( error as string );
-			recordTracksEvent( 'calypso_migration_instructions_key_error', { error } );
+			recordTracksEvent( 'calypso_migration_instructions_key_error' );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { ClipboardButton } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
+import { classNames } from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -71,9 +72,10 @@ const SiteMigrationInstructions: Step = function () {
 				</li>
 				<li>
 					<div
-						className={ `site-migration-instructions__list-migration-key-item ${
-							siteMigrationKey ? 'expanded' : ''
-						}${ siteMigrationKeyError ? 'error' : '' }` }
+						className={ classNames( 'site-migration-instructions__list-migration-key-item', {
+							expanded: siteMigrationKey,
+							error: siteMigrationKeyError,
+						} ) }
 					>
 						{ ! siteMigrationKey && (
 							<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -42,14 +42,16 @@
 	.site-migration-instructions__migration-key {
 		display: flex;
 		justify-content: space-between;
-		margin-top: 0.5rem 0.75rem 0 0;
+		align-items: center;
+		margin: 0.5rem 0.75rem 0 0;
 		max-width: 100%;
 		background: var(--color-neutral-0);
 		padding: 0.75rem;
 	}
 
 	.site-migration-instructions__migration-key .site-migration-instructions__key {
-		width: 375px;
+		width: 340px;
+		margin-right: 0.5rem;
 		overflow-x: scroll;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -22,7 +22,7 @@
 		transition: height 0.75s ease;
 
 		&.expanded {
-			height: 130px;
+			height: auto;
 		}
 
 		&.error {
@@ -42,15 +42,13 @@
 	.site-migration-instructions__migration-key {
 		display: flex;
 		justify-content: space-between;
-		margin-top: 0.5rem;
+		margin-top: 0.5rem 0.75rem 0 0;
 		max-width: 100%;
+		background: var(--color-neutral-0);
+		padding: 0.75rem;
 	}
 
 	.site-migration-instructions__migration-key .site-migration-instructions__key {
-		background: var(--color-neutral-0);
-		display: inline-block;
-		margin-right: 0.75rem;
-		padding: 0.75rem 1rem;
 		width: 375px;
 		overflow-x: scroll;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -1,6 +1,10 @@
 @import "@wordpress/base-styles/variables";
 
 .site-migration-instructions {
+	.step-container {
+		max-width: 654px;
+	}
+
 	.site-migration-instructions__list {
 		li {
 			margin-bottom: 0.5rem;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -2,6 +2,7 @@
 
 .site-migration-instructions {
 	.step-container {
+		padding: 0 1.5rem;
 		max-width: 654px;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-2uc-p2#comment-4619 

## Proposed Changes

* Update layout of site migration instructions to better align with given design.

**Before**

<img width="1494" alt="Screenshot 2024-03-14 at 9 16 39 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/21f36b26-6cf3-4c8f-bf02-85a6a1f0f00c">

**After**

<img width="1491" alt="Screenshot 2024-03-14 at 9 15 46 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/eddf1be9-5351-4b9d-a71b-ae002a36fa07">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/setup/site-migration/site-migration-instructions?flags=onboarding/new-migration-flow`
* Confirm new layout is visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?