### PR TITLE
Global sidebar: Use the support session background color on the global nav footer in support mode

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -243,6 +243,11 @@ $brand-text: "SF Pro Text", $sans;
 			margin-inline-start: auto;
 		}
 
+
+		&:has(.sidebar__footer-language-switcher) {
+			background: var(--studio-orange);
+		}
+
 		.sidebar__item-help,
 		.sidebar__footer-link,
 		.sidebar__footer-wpadmin {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88500

## Proposed Changes

- Use the support session background color on the global nav footer in support mode

|BEFORE|AFTER|
|-|-|
|<img width="296" alt="Screenshot 2567-03-14 at 14 53 16" src="https://github.com/Automattic/wp-calypso/assets/1881481/8438423c-5f4f-4c8f-b71b-d70851b1caa3">|<img width="298" alt="Screenshot 2567-03-14 at 14 43 16" src="https://github.com/Automattic/wp-calypso/assets/1881481/983df21d-0d00-4545-a573-68eed3fcd7a1">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as in #88500


https://github.com/Automattic/wp-calypso/assets/1881481/6ba49f07-d89a-4b44-b68f-26474ed3b147



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?