### PR TITLE
i18n: Localize `None` option in podcasting topics selector

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/topics-selector.jsx
+++ b/client/my-sites/site-settings/podcasting-details/topics-selector.jsx
@@ -1,12 +1,14 @@
+import { useTranslate } from 'i18n-calypso';
 import FormSelect from 'calypso/components/forms/form-select';
 import useTopics from './use-topics';
 
 function TopicsSelector( props ) {
+	const translate = useTranslate();
 	const podcastingTopics = useTopics();
 
 	return (
 		<FormSelect { ...props }>
-			<option value="0">None</option>
+			<option value="0">{ translate( 'None', { context: 'podcast topic selector' } ) }</option>
 			{ podcastingTopics.map( ( topic ) => {
 				// The keys for podcasting in Apple Podcasts use &amp;
 				const topicKey = topic.key.replace( '&', '&amp;' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 761-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap the `None` option in the podcasting topics selector component in `translate()` call.

![wWa8psEkeb2K1fB9](https://github.com/Automattic/wp-calypso/assets/2722412/2f3f8aae-64fb-4c96-b5eb-86ab87007564)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
