### PR TITLE
Plugin Update Manager: Fix time/period field wrapping/misalignment

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-form.scss
+++ b/client/blocks/plugins-update-manager/schedule-form.scss
@@ -130,6 +130,11 @@
 		}
 	}
 
+	// Change flex to block on mobile to prevent the hour/minute field from wrapping
+	.is-mobile {
+		display: block;
+	}
+
 	.time-controls {
 		& > div {
 			display: inline-block;

--- a/client/blocks/plugins-update-manager/schedule-form.scss
+++ b/client/blocks/plugins-update-manager/schedule-form.scss
@@ -130,11 +130,6 @@
 		}
 	}
 
-	// Change flex to block on mobile to prevent the hour/minute field from wrapping
-	.is-mobile {
-		display: block;
-	}
-
 	.time-controls {
 		& > div {
 			display: inline-block;

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -1,4 +1,3 @@
-import { useMobileBreakpoint } from '@automattic/viewport-react';
 import {
 	RadioControl,
 	SearchControl,
@@ -93,7 +92,6 @@ export const ScheduleForm = ( props: Props ) => {
 		timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
 	} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
-	const isMobile = useMobileBreakpoint();
 
 	const onPluginSelectionChange = useCallback(
 		( plugin: CorePlugin, isChecked: boolean ) => {
@@ -229,7 +227,7 @@ export const ScheduleForm = ( props: Props ) => {
 								onBlur={ () => setFieldTouched( { ...fieldTouched, timestamp: true } ) }
 							></RadioControl>
 							{ frequency === 'weekly' && (
-								<Flex gap={ 6 } className={ classnames( { 'is-mobile': isMobile } ) }>
+								<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>
 									<FlexItem>
 										<div className="form-field">
 											<SelectControl

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -1,3 +1,4 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import {
 	RadioControl,
 	SearchControl,
@@ -92,6 +93,7 @@ export const ScheduleForm = ( props: Props ) => {
 		timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
 	} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
+	const isMobile = useMobileBreakpoint();
 
 	const onPluginSelectionChange = useCallback(
 		( plugin: CorePlugin, isChecked: boolean ) => {
@@ -227,7 +229,7 @@ export const ScheduleForm = ( props: Props ) => {
 								onBlur={ () => setFieldTouched( { ...fieldTouched, timestamp: true } ) }
 							></RadioControl>
 							{ frequency === 'weekly' && (
-								<Flex gap={ 6 }>
+								<Flex gap={ 6 } className={ classnames( { 'is-mobile': isMobile } ) }>
 									<FlexItem>
 										<div className="form-field">
 											<SelectControl


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88491 

## Proposed Changes

* Places the time picker to the next line

| Before | After |
|-|-|
| ![CleanShot 2024-03-14 at 10 40 17@2x](https://github.com/Automattic/wp-calypso/assets/528287/7b26115c-4cfd-4372-a3d8-6b0301b4b1dc) | ![CleanShot 2024-03-14 at 10 37 11@2x](https://github.com/Automattic/wp-calypso/assets/528287/bd6846c5-449e-4e64-b6b0-d736e815c8f0) |

## Testing Instructions

- Test the add/edit schedule screen on a mobile device. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?