### PR TITLE
Patterns: fix category-pill-navigation padding

### DIFF
--- a/client/my-sites/patterns/pages/category/style.scss
+++ b/client/my-sites/patterns/pages/category/style.scss
@@ -13,7 +13,10 @@
 
 	@media ( max-width: $break-wide ) {
 		.category-pill-navigation {
-			padding: 24px;
+			padding: 24px 0;
+			.category-pill-navigation__list-inner {
+				padding: 0 24px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes
We have category-pill-navigation component on /patterns/:category page. We should avoid having left/right padding when scroll is active.
Details: p1710412649815179/1710410455.293899-slack-C06ELHR6L9J

## Testing Instructions
1) Open `http://calypso.localhost:3000/patterns/testimonials`
2) Scroll the category-pill-navigation
3) Assert that on **mobile** the scroll takes whole the window width <br /> ![Screenshot 2024-03-14 at 11 53 32](https://github.com/Automattic/wp-calypso/assets/5598437/8c64e226-0065-4eb7-bdb4-742e23c1afbd)
