### PR TITLE
A4A: Update Marketplace header and body layout to follow new design.

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -63,14 +63,21 @@ html,
 	}
 }
 
+.a4a-layout__top-wrapper {
+	padding-block-start: 48px;
+}
+
+.main.a4a-layout.is-compact .a4a-layout__top-wrapper {
+	padding-block-start: 28px;
+}
+
 .main.a4a-layout.is-with-border {
 	@include breakpoint-deprecated( ">660px" ) {
 		.a4a-layout__top-wrapper {
 			border-block-end: 1px solid var(--color-neutral-5);
-
 			// If we don't have a navigation, we will require some spacing on the borders.
 			&:not(.has-navigation) {
-				padding-block: 48px;
+				padding-block-end: 48px;
 			}
 		}
 	}
@@ -79,8 +86,9 @@ html,
 .main.a4a-layout.is-with-border.is-compact {
 	@include breakpoint-deprecated( ">660px" ) {
 		.a4a-layout__top-wrapper {
+
 			&:not(.has-navigation) {
-				padding-block: 28px;
+				padding-block-end: 28px;
 			}
 		}
 	}

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -1,11 +1,16 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+html,
+.theme-a8c-for-agencies {
+	overflow: auto;
+}
+
 .main.a4a-layout {
 	background: var(--color-surface);
 	margin: 0;
-	padding-block-start: 48px;
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	height: calc(100vh - 32px);
 
 	header.current-section {
 		margin-block-end: 16px;
@@ -22,7 +27,7 @@
 
 .a4a-layout__container {
 	max-width: 100%;
-	min-height: calc(100vh - 80px);
+	max-height: 100%;
 	display: flex;
 	flex-direction: column;
 	margin: auto;
@@ -31,14 +36,21 @@
 
 .a4a-layout__body {
 	width: 100%;
-	flex: 1 1 100%;
+	overflow-y: auto;
 	padding-block-start: 16px;
 	padding-block-end: 32px;
+
+	-ms-overflow-style: none;
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
 }
 
 .a4a-layout__top-wrapper,
 .a4a-layout__body {
 	margin-inline: 0;
+	max-height: 100%;
 
 	> * {
 		padding-inline: 16px;
@@ -58,7 +70,7 @@
 
 			// If we don't have a navigation, we will require some spacing on the borders.
 			&:not(.has-navigation) {
-				padding-block-end: 48px;
+				padding-block: 48px;
 			}
 		}
 	}
@@ -68,7 +80,7 @@
 	@include breakpoint-deprecated( ">660px" ) {
 		.a4a-layout__top-wrapper {
 			&:not(.has-navigation) {
-				padding-block-end: 28px;
+				padding-block: 28px;
 			}
 		}
 	}

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -39,12 +39,6 @@ html,
 	overflow-y: auto;
 	padding-block-start: 16px;
 	padding-block-end: 32px;
-
-	-ms-overflow-style: none;
-
-	&::-webkit-scrollbar {
-		display: none;
-	}
 }
 
 .a4a-layout__top-wrapper,

--- a/client/a8c-for-agencies/components/layout/top.tsx
+++ b/client/a8c-for-agencies/components/layout/top.tsx
@@ -4,16 +4,21 @@ import LayoutNavigation from './nav';
 
 type Props = {
 	children: ReactNode;
+	withNavigation?: boolean;
 };
 
-export default function LayoutTop( { children }: Props ) {
+export default function LayoutTop( { children, withNavigation }: Props ) {
 	const navigation = Children.toArray( children ).find(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( child: any ) => child.type === LayoutNavigation
 	);
 
 	return (
-		<div className={ classNames( 'a4a-layout__top-wrapper', { 'has-navigation': !! navigation } ) }>
+		<div
+			className={ classNames( 'a4a-layout__top-wrapper', {
+				'has-navigation': withNavigation || !! navigation,
+			} ) }
+		>
 			{ children }
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
@@ -4,17 +4,13 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
-	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
-import LayoutNavigation, {
-	LayoutNavigationTabs,
-} from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { useProductBundleSize } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
@@ -23,7 +19,6 @@ import TotalCost from 'calypso/jetpack-cloud/sections/partner-portal/primary/iss
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSites from 'calypso/state/selectors/get-sites';
-import AssignLicenseStepProgress from '../assign-license-step-progress';
 import IssueLicenseContext from './context';
 import LicensesForm from './licenses-form';
 import useSubmitForm from './licenses-form/hooks/use-submit-form';
@@ -45,7 +40,7 @@ export default function IssueLicense( { siteId, suggestedProduct }: AssignLicens
 		.map( ( license ) => license.quantity )
 		.reduce( ( a, b ) => a + b, 0 );
 
-	const { selectedSize, setSelectedSize, availableSizes } = useProductBundleSize( true );
+	const { selectedSize } = useProductBundleSize( true );
 
 	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
 	// track if the user purchases a different set of products.
@@ -76,65 +71,12 @@ export default function IssueLicense( { siteId, suggestedProduct }: AssignLicens
 
 	const showStickyContent = useBreakpoint( '>660px' ) && selectedLicenses.length > 0;
 
-	const currentStep = showReviewLicenses ? 'reviewLicense' : 'issueLicense';
-
 	useEffect( () => {
 		if ( siteId && sites.length > 0 ) {
 			const site = siteId ? sites.find( ( site ) => site?.ID === parseInt( siteId ) ) : null;
 			setSelectedSite( site );
 		}
 	}, [ siteId, sites ] );
-
-	const subtitle = useMemo( () => {
-		if ( selectedSite?.domain ) {
-			return translate(
-				'Select the products you would like to add to {{strong}}%(selectedSiteDomain)s{{/strong}}:',
-				{
-					args: { selectedSiteDomain: selectedSite.domain },
-					components: { strong: <strong /> },
-				}
-			);
-		}
-
-		return translate( 'Select the products you would like to issue a new license for:' );
-	}, [ selectedSite?.domain, translate ] );
-
-	const selectedText =
-		selectedSize === 1
-			? translate( 'Single license' )
-			: ( translate( '%(size)d licenses', { args: { size: selectedSize } } ) as string );
-
-	const selectedCount = selectedLicenses.filter( ( license ) => license.quantity === selectedSize )
-		?.length;
-
-	const showBundle = ! selectedSite && availableSizes.length > 1;
-
-	const navItems = availableSizes.map( ( size ) => {
-		const count = selectedLicenses.filter( ( license ) => license.quantity === size ).length;
-		return {
-			label:
-				size === 1
-					? translate( 'Single license' )
-					: ( translate( '%(size)d licenses', {
-							args: { size },
-					  } ) as string ),
-			selected: selectedSize === size,
-			onClick: () => {
-				setSelectedSize( size );
-				dispatch(
-					recordTracksEvent( 'calypso_a4a_marketplace_bundle_tab_click', {
-						bundle_size: size,
-					} )
-				);
-			},
-			...( count && { count } ),
-		};
-	} );
-
-	const selectedItemProps = {
-		selectedText,
-		...( selectedCount && { selectedCount } ),
-	};
 
 	// Group licenses by slug and sort them by quantity
 	const getGroupedLicenses = useCallback( () => {
@@ -154,21 +96,14 @@ export default function IssueLicense( { siteId, suggestedProduct }: AssignLicens
 		<>
 			<Layout
 				className={ classNames( 'issue-license' ) }
-				title={ translate( 'Issue a new License' ) }
+				title={ translate( 'Product Marketplace' ) }
 				wide
 				withBorder
 				sidebarNavigation={ <MobileSidebarNavigation /> }
 			>
 				<LayoutTop>
-					<AssignLicenseStepProgress
-						currentStep={ currentStep }
-						selectedSite={ selectedSite }
-						isBundleLicensing
-					/>
-
 					<LayoutHeader showStickyContent={ showStickyContent }>
-						<Title>{ translate( 'Issue product licenses' ) } </Title>
-						<Subtitle>{ subtitle }</Subtitle>
+						<Title>{ translate( 'Marketplace' ) } </Title>
 						{ selectedLicenses.length > 0 && (
 							<Actions>
 								<div className="issue-license__controls">
@@ -197,12 +132,6 @@ export default function IssueLicense( { siteId, suggestedProduct }: AssignLicens
 							</Actions>
 						) }
 					</LayoutHeader>
-
-					{ showBundle && (
-						<LayoutNavigation { ...selectedItemProps }>
-							<LayoutNavigationTabs { ...selectedItemProps } items={ navItems } />
-						</LayoutNavigation>
-					) }
 				</LayoutTop>
 
 				<LayoutBody>

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
@@ -15,10 +15,8 @@ import useProductAndPlans from 'calypso/jetpack-cloud/sections/partner-portal/pr
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import IssueLicenseContext from '../context';
-import { PRODUCT_FILTER_ALL } from './constants';
 import useSubmitForm from './hooks/use-submit-form';
 import ProductFilterSearch from './product-filter-search';
-import ProductFilterSelect from './product-filter-select';
 import LicensesFormSection from './sections';
 import type { SelectedLicenseProp } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -43,10 +41,6 @@ export default function LicensesForm( {
 
 	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
 
-	const [ selectedProductFilter, setSelectedProductFilter ] = useState< string | null >(
-		PRODUCT_FILTER_ALL
-	);
-
 	const {
 		filteredProductsAndBundles,
 		isLoadingProducts,
@@ -58,7 +52,6 @@ export default function LicensesForm( {
 		suggestedProductSlugs,
 	} = useProductAndPlans( {
 		selectedSite,
-		selectedProductFilter,
 		selectedBundleSize: quantity,
 		productSearchQuery,
 		usePublicQuery: true, // FIXME: Fix this when we have the API endpoint for A4A
@@ -200,16 +193,6 @@ export default function LicensesForm( {
 		[ quantity, selectedLicenses ]
 	);
 
-	const onProductFilterSelect = useCallback(
-		( value: string | null ) => {
-			setSelectedProductFilter( value );
-			dispatch(
-				recordTracksEvent( 'calypso_a4a_marketplace_issue_license_filter_submit', { value } )
-			);
-		},
-		[ dispatch ]
-	);
-
 	const onProductSearch = useCallback(
 		( value: string ) => {
 			setProductSearchQuery( value );
@@ -294,12 +277,6 @@ export default function LicensesForm( {
 				<ProductFilterSearch
 					onProductSearch={ onProductSearch }
 					onClick={ trackClickCallback( 'search' ) }
-				/>
-				<ProductFilterSelect
-					selectedProductFilter={ selectedProductFilter }
-					onProductFilterSelect={ onProductFilterSelect }
-					onClick={ trackClickCallback( 'filter' ) }
-					isSingleLicense={ isSingleLicenseView }
 				/>
 			</div>
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -73,7 +73,7 @@ export default function LicensesOverview( {
 			/>
 			{ /*  TODO: <FETCH_LICENSES_HERE /> */ }
 			<LicensesOverviewContext.Provider value={ context }>
-				<LayoutTop>
+				<LayoutTop withNavigation>
 					<LayoutHeader>
 						<Title>{ title } </Title>
 						<Actions>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -324,6 +324,10 @@
 			}
 		}
 
+		.a4a-layout__top-wrapper {
+			padding: 0;
+		}
+
 		.a4a-layout__top-wrapper,
 		.a4a-layout__body {
 			> * {


### PR DESCRIPTION
This PR updates the Marketplace header to follow the new design. Note that the shopping cart toggle will be added to a separate PR. The PR also updates the scrolling behavior for the main layout component.


https://github.com/Automattic/wp-calypso/assets/56598660/a335f3d0-635b-44cb-8da4-992d1a7923e2


Closes https://github.com/Automattic/jetpack-genesis/issues/283

## Proposed Changes

* The PR removes the Stepper, navigation tab, and subtitles in the header to match the new design. The review license CTA is still there, but it will be replaced with a shopping cart toggle later in a separate PR.
* The A4A Layout component was also updated to follow correct scrolling behavior for pages that are longer than the viewport.

## Testing Instructions

* Switch branch: `git checkout update/a4a-marketplace-header`.
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to http://agencies.localhost:3000/marketplace
* Confirm that the Header behaves correctly based on the video sample on this PR.
* Confirm scrolling also works correctly and does not scroll the entire HTML but only within the Layout's body.
* **Also, please test other pages to see if nothing has been broken with the changes made on this PR.** 

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?