### PR TITLE
Continue with GitHub: Update GitHub App authorization URL

### DIFF
--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -150,7 +150,7 @@ const GitHubLoginButton = ( {
 		}
 
 		const scope = encodeURIComponent( 'read:user,user:email' );
-		window.location.href = `https://public-api.wordpress.com/wpcom/v2/hosting/github/app-redirect?redirect_uri=${ stripQueryString(
+		window.location.href = `https://public-api.wordpress.com/wpcom/v2/hosting/github/authorize?redirect_uri=${ stripQueryString(
 			redirectUri
 		) }&scope=${ scope }&ux_mode=redirect`;
 	};

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { Popover } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import {
@@ -10,10 +9,8 @@ import {
 	useCallback,
 	useEffect,
 	useRef,
-	useState,
 } from 'react';
 import GitHubIcon from 'calypso/components/social-icons/github';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { isFormDisabled as isFormDisabledSelector } from 'calypso/state/login/selectors';
@@ -61,13 +58,8 @@ const GitHubLoginButton = ( {
 		return currentError;
 	} );
 
-	const isFormDisabled = useSelector( isFormDisabledSelector );
+	const isDisabled = useSelector( isFormDisabledSelector );
 	const dispatch = useDispatch();
-
-	const [ disabledState ] = useState< boolean >( false );
-	const [ errorState ] = useState< string | null >( null );
-	const [ showError, setShowError ] = useState< boolean >( false );
-
 	const errorRef = useRef< EventTarget | null >( null );
 
 	const handleGitHubError = useCallback( () => {
@@ -139,8 +131,6 @@ const GitHubLoginButton = ( {
 		}
 	}, [ authError, handleGitHubError ] );
 
-	const isDisabled = isFormDisabled || disabledState;
-
 	const handleClick = ( e: MouseEvent< HTMLButtonElement > ) => {
 		errorRef.current = e.currentTarget;
 		e.preventDefault();
@@ -195,16 +185,6 @@ const GitHubLoginButton = ( {
 					</span>
 				</button>
 			) }
-			<Popover
-				id="social-buttons__error"
-				className="social-buttons__error"
-				isVisible={ showError }
-				onClose={ () => setShowError( false ) }
-				position="top"
-				context={ errorRef.current }
-			>
-				{ preventWidows( errorState ) }
-			</Popover>
 		</>
 	);
 };

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -150,7 +150,7 @@ const GitHubLoginButton = ( {
 		}
 
 		const scope = encodeURIComponent( 'read:user,user:email' );
-		window.location.href = `https://public-api.wordpress.com/wpcom/v2/hosting/github/authorize?redirect_uri=${ stripQueryString(
+		window.location.href = `https://public-api.wordpress.com/wpcom/v2/hosting/github/app-authorize?redirect_uri=${ stripQueryString(
 			redirectUri
 		) }&scope=${ scope }&ux_mode=redirect`;
 	};

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { Popover } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import {
@@ -9,8 +10,10 @@ import {
 	useCallback,
 	useEffect,
 	useRef,
+	useState,
 } from 'react';
 import GitHubIcon from 'calypso/components/social-icons/github';
+import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { isFormDisabled as isFormDisabledSelector } from 'calypso/state/login/selectors';
@@ -58,8 +61,13 @@ const GitHubLoginButton = ( {
 		return currentError;
 	} );
 
-	const isDisabled = useSelector( isFormDisabledSelector );
+	const isFormDisabled = useSelector( isFormDisabledSelector );
 	const dispatch = useDispatch();
+
+	const [ disabledState ] = useState< boolean >( false );
+	const [ errorState ] = useState< string | null >( null );
+	const [ showError, setShowError ] = useState< boolean >( false );
+
 	const errorRef = useRef< EventTarget | null >( null );
 
 	const handleGitHubError = useCallback( () => {
@@ -131,6 +139,8 @@ const GitHubLoginButton = ( {
 		}
 	}, [ authError, handleGitHubError ] );
 
+	const isDisabled = isFormDisabled || disabledState;
+
 	const handleClick = ( e: MouseEvent< HTMLButtonElement > ) => {
 		errorRef.current = e.currentTarget;
 		e.preventDefault();
@@ -185,6 +195,16 @@ const GitHubLoginButton = ( {
 					</span>
 				</button>
 			) }
+			<Popover
+				id="social-buttons__error"
+				className="social-buttons__error"
+				isVisible={ showError }
+				onClose={ () => setShowError( false ) }
+				position="top"
+				context={ errorRef.current }
+			>
+				{ preventWidows( errorState ) }
+			</Popover>
 		</>
 	);
 };

--- a/client/my-sites/github-deployments/components/installations-dropdown/use-live-installations.ts
+++ b/client/my-sites/github-deployments/components/installations-dropdown/use-live-installations.ts
@@ -18,7 +18,7 @@ interface UseLiveInstallationsParameters {
 const NOTICE_ID = 'github-app-install-notice';
 
 const AUTHORIZATION_URL =
-	'https://public-api.wordpress.com/wpcom/v2/hosting/github/authorize?ux_mode=popup';
+	'https://public-api.wordpress.com/wpcom/v2/hosting/github/app-authorize?ux_mode=popup';
 
 const INSTALLATION_URL = `https://github.com/apps/${ config(
 	'github_app_slug'

--- a/client/my-sites/github-deployments/components/installations-dropdown/use-live-installations.ts
+++ b/client/my-sites/github-deployments/components/installations-dropdown/use-live-installations.ts
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { useI18n } from '@wordpress/react-i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { useLayoutEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { postLoginRequest } from 'calypso/state/login/utils';
@@ -18,9 +17,8 @@ interface UseLiveInstallationsParameters {
 
 const NOTICE_ID = 'github-app-install-notice';
 
-const AUTHORIZATION_URL = addQueryArgs( 'https://github.com/login/oauth/authorize', {
-	client_id: config( 'github_oauth_client_id' ),
-} );
+const AUTHORIZATION_URL =
+	'https://public-api.wordpress.com/wpcom/v2/hosting/github/app-redirect?ux_mode=popup';
 
 const INSTALLATION_URL = `https://github.com/apps/${ config(
 	'github_app_slug'

--- a/client/my-sites/github-deployments/components/installations-dropdown/use-live-installations.ts
+++ b/client/my-sites/github-deployments/components/installations-dropdown/use-live-installations.ts
@@ -18,7 +18,7 @@ interface UseLiveInstallationsParameters {
 const NOTICE_ID = 'github-app-install-notice';
 
 const AUTHORIZATION_URL =
-	'https://public-api.wordpress.com/wpcom/v2/hosting/github/app-redirect?ux_mode=popup';
+	'https://public-api.wordpress.com/wpcom/v2/hosting/github/authorize?ux_mode=popup';
 
 const INSTALLATION_URL = `https://github.com/apps/${ config(
 	'github_app_slug'


### PR DESCRIPTION
**⚠️ Do not merge until ready to deploy together with D140226-code. ⚠️** 

---

Related to D140226-code and https://github.com/Automattic/wp-calypso/pull/88041.

## Proposed Changes

This PR changes the URL for the popup from directly calling `github.com/authorize` to the redirect endpoint. This endpoint takes care of adding the `state` parameter, which is later used in the app callback to verify if the callback originated from us.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply and build the proposed changes.
2. Please test together with D140226-code.
3. Test GitHub deployments and log-in / sign-up flows. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?