### PR TITLE
Plugins update manager: Unload the form component and move plugins control data to the separate component

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-form.plugins.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.plugins.tsx
@@ -1,0 +1,128 @@
+import {
+	__experimentalText as Text,
+	CheckboxControl,
+	SearchControl,
+	Spinner,
+} from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import { type CorePlugin, useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
+import { MAX_SELECTABLE_PLUGINS } from './config';
+import { useSiteSlug } from './hooks/use-site-slug';
+
+interface Props {
+	initPlugins?: string[];
+	touched?: boolean;
+	error?: string;
+	showError?: boolean;
+	onTouch?: () => void;
+	onChange?: ( value: string[] ) => void;
+}
+export function ScheduleFormPlugins( props: Props ) {
+	const { initPlugins = [], error, showError, onChange, onTouch } = props;
+	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
+
+	const [ pluginSearchTerm, setPluginSearchTerm ] = useState( '' );
+	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( initPlugins );
+	const [ fieldTouched, setFieldTouched ] = useState( false );
+
+	const {
+		data: plugins = [],
+		isLoading: isPluginsFetching,
+		isFetched: isPluginsFetched,
+	} = useCorePluginsQuery( siteSlug, true, true );
+
+	useEffect( () => onTouch?.(), [ fieldTouched ] );
+	useEffect( () => onChange?.( selectedPlugins ), [ selectedPlugins ] );
+
+	const onPluginSelectionChange = useCallback(
+		( plugin: CorePlugin, isChecked: boolean ) => {
+			if ( isChecked ) {
+				const _plugins: string[] = [ ...selectedPlugins ];
+				_plugins.push( plugin.plugin );
+				setSelectedPlugins( _plugins );
+			} else {
+				setSelectedPlugins( selectedPlugins.filter( ( name ) => name !== plugin.plugin ) );
+			}
+		},
+		[ selectedPlugins ]
+	);
+
+	const onPluginSelectAllChange = useCallback(
+		( isChecked: boolean ) => {
+			isChecked
+				? setSelectedPlugins( plugins.map( ( plugin ) => plugin.plugin ) ?? [] )
+				: setSelectedPlugins( [] );
+		},
+		[ plugins ]
+	);
+
+	const isPluginSelectionDisabled = useCallback(
+		( plugin: CorePlugin ) => {
+			return (
+				selectedPlugins.length >= MAX_SELECTABLE_PLUGINS &&
+				! selectedPlugins.includes( plugin.plugin )
+			);
+		},
+		[ selectedPlugins ]
+	);
+
+	return (
+		<div className="form-field">
+			<label htmlFor="plugins">{ translate( 'Select plugins' ) }</label>
+			<span className="plugin-select-stats">
+				{ selectedPlugins.length }/
+				{ plugins.length < MAX_SELECTABLE_PLUGINS ? plugins.length : MAX_SELECTABLE_PLUGINS }
+			</span>
+			{ ( showError && error ) || ( fieldTouched && error ) ? (
+				<Text className="validation-msg">
+					<Icon className="icon-info" icon={ info } size={ 16 } />
+					{ error }
+				</Text>
+			) : (
+				<Text className="info-msg">
+					{ translate( 'Plugins not listed below are automatically updated by WordPress.com.' ) }
+				</Text>
+			) }
+			<div className="checkbox-options">
+				<SearchControl id="plugins" onChange={ setPluginSearchTerm } value={ pluginSearchTerm } />
+				<div className="checkbox-options-container">
+					{ isPluginsFetching && <Spinner /> }
+					{ isPluginsFetched && plugins.length <= MAX_SELECTABLE_PLUGINS && (
+						<CheckboxControl
+							label={ translate( 'Select all' ) }
+							indeterminate={
+								selectedPlugins.length > 0 && selectedPlugins.length < plugins.length
+							}
+							checked={ selectedPlugins.length === plugins.length }
+							onChange={ onPluginSelectAllChange }
+						/>
+					) }
+					{ isPluginsFetched &&
+						plugins.map( ( plugin ) => (
+							<Fragment key={ plugin.plugin }>
+								{ plugin.name.toLowerCase().includes( pluginSearchTerm.toLowerCase() ) && (
+									<CheckboxControl
+										key={ plugin.plugin }
+										label={ plugin.name }
+										checked={ selectedPlugins.includes( plugin.plugin ) }
+										disabled={ isPluginSelectionDisabled( plugin ) }
+										className={ classnames( {
+											disabled: isPluginSelectionDisabled( plugin ),
+										} ) }
+										onChange={ ( isChecked ) => {
+											onPluginSelectionChange( plugin, isChecked );
+											setFieldTouched( true );
+										} }
+									/>
+								) }
+							</Fragment>
+						) ) }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/blocks/plugins-update-manager/schedule-form.plugins.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.plugins.tsx
@@ -17,7 +17,7 @@ interface Props {
 	touched?: boolean;
 	error?: string;
 	showError?: boolean;
-	onTouch?: () => void;
+	onTouch?: ( touched: boolean ) => void;
 	onChange?: ( value: string[] ) => void;
 }
 export function ScheduleFormPlugins( props: Props ) {
@@ -35,7 +35,7 @@ export function ScheduleFormPlugins( props: Props ) {
 		isFetched: isPluginsFetched,
 	} = useCorePluginsQuery( siteSlug, true, true );
 
-	useEffect( () => onTouch?.(), [ fieldTouched ] );
+	useEffect( () => onTouch?.( fieldTouched ), [ fieldTouched ] );
 	useEffect( () => onChange?.( selectedPlugins ), [ selectedPlugins ] );
 
 	const onPluginSelectionChange = useCallback(

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -236,7 +236,7 @@ export const ScheduleForm = ( props: Props ) => {
 				</FlexItem>
 				<FlexItem>
 					<ScheduleFormPlugins
-						initPlugins={ scheduleForEdit?.args }
+						initPlugins={ selectedPlugins }
 						error={ validationErrors?.plugins }
 						showError={ fieldTouched?.plugins }
 						onChange={ setSelectedPlugins }

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -1,20 +1,18 @@
 import {
 	RadioControl,
-	SearchControl,
 	SelectControl,
-	CheckboxControl,
 	__experimentalText as Text,
 	Flex,
 	FlexItem,
 	FlexBlock,
-	Spinner,
 } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useState, useCallback, useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import { ScheduleFormPlugins } from 'calypso/blocks/plugins-update-manager/schedule-form.plugins';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useCorePluginsQuery, type CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
+import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import {
 	useCreateUpdateScheduleMutation,
 	useEditUpdateScheduleMutation,
@@ -23,7 +21,6 @@ import {
 	useUpdateScheduleQuery,
 	ScheduleUpdates,
 } from 'calypso/data/plugins/use-update-schedules-query';
-import { MAX_SELECTABLE_PLUGINS } from './config';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSetSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
 import { useSiteSlug } from './hooks/use-site-slug';
@@ -53,11 +50,11 @@ export const ScheduleForm = ( props: Props ) => {
 	const initDate = scheduleForEdit
 		? moment( scheduleForEdit?.timestamp * 1000 )
 		: moment( new Date() ).hour( DEFAULT_HOUR );
-	const {
-		data: plugins = [],
-		isLoading: isPluginsFetching,
-		isFetched: isPluginsFetched,
-	} = useCorePluginsQuery( siteSlug, true, true );
+	const { data: plugins = [], isFetched: isPluginsFetched } = useCorePluginsQuery(
+		siteSlug,
+		true,
+		true
+	);
 	useSetSiteHasEligiblePlugins( plugins, isPluginsFetched );
 
 	const { data: schedulesData = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
@@ -86,44 +83,11 @@ export const ScheduleForm = ( props: Props ) => {
 		frequency: schedule.schedule,
 	} ) );
 	const scheduledPlugins = schedules.map( ( schedule ) => schedule.args );
-	const [ pluginSearchTerm, setPluginSearchTerm ] = useState( '' );
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {
 		plugins: validatePlugins( selectedPlugins, scheduledPlugins ),
 		timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
 	} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
-
-	const onPluginSelectionChange = useCallback(
-		( plugin: CorePlugin, isChecked: boolean ) => {
-			if ( isChecked ) {
-				const _plugins: string[] = [ ...selectedPlugins ];
-				_plugins.push( plugin.plugin );
-				setSelectedPlugins( _plugins );
-			} else {
-				setSelectedPlugins( selectedPlugins.filter( ( name ) => name !== plugin.plugin ) );
-			}
-		},
-		[ selectedPlugins ]
-	);
-
-	const onPluginSelectAllChange = useCallback(
-		( isChecked: boolean ) => {
-			isChecked
-				? setSelectedPlugins( plugins.map( ( plugin ) => plugin.plugin ) ?? [] )
-				: setSelectedPlugins( [] );
-		},
-		[ plugins ]
-	);
-
-	const isPluginSelectionDisabled = useCallback(
-		( plugin: CorePlugin ) => {
-			return (
-				selectedPlugins.length >= MAX_SELECTABLE_PLUGINS &&
-				! selectedPlugins.includes( plugin.plugin )
-			);
-		},
-		[ selectedPlugins ]
-	);
 
 	const onFormSubmit = () => {
 		const formValid = ! Object.values( validationErrors ).filter( ( e ) => !! e ).length;
@@ -271,65 +235,15 @@ export const ScheduleForm = ( props: Props ) => {
 					</div>
 				</FlexItem>
 				<FlexItem>
-					<div className="form-field">
-						<label htmlFor="plugins">{ translate( 'Select plugins' ) }</label>
-						<span className="plugin-select-stats">
-							{ selectedPlugins.length }/
-							{ plugins.length < MAX_SELECTABLE_PLUGINS ? plugins.length : MAX_SELECTABLE_PLUGINS }
-						</span>
-						{ fieldTouched?.plugins && validationErrors?.plugins ? (
-							<Text className="validation-msg">
-								<Icon className="icon-info" icon={ info } size={ 16 } />
-								{ validationErrors?.plugins }
-							</Text>
-						) : (
-							<Text className="info-msg">
-								{ translate(
-									'Plugins not listed below are automatically updated by WordPress.com.'
-								) }
-							</Text>
-						) }
-						<div className="checkbox-options">
-							<SearchControl
-								id="plugins"
-								onChange={ setPluginSearchTerm }
-								value={ pluginSearchTerm }
-							/>
-							<div className="checkbox-options-container">
-								{ isPluginsFetching && <Spinner /> }
-								{ isPluginsFetched && plugins.length <= MAX_SELECTABLE_PLUGINS && (
-									<CheckboxControl
-										label={ translate( 'Select all' ) }
-										indeterminate={
-											selectedPlugins.length > 0 && selectedPlugins.length < plugins.length
-										}
-										checked={ selectedPlugins.length === plugins.length }
-										onChange={ onPluginSelectAllChange }
-									/>
-								) }
-								{ isPluginsFetched &&
-									plugins.map( ( plugin ) => (
-										<Fragment key={ plugin.plugin }>
-											{ plugin.name.toLowerCase().includes( pluginSearchTerm.toLowerCase() ) && (
-												<CheckboxControl
-													key={ plugin.plugin }
-													label={ plugin.name }
-													checked={ selectedPlugins.includes( plugin.plugin ) }
-													disabled={ isPluginSelectionDisabled( plugin ) }
-													className={ classnames( {
-														disabled: isPluginSelectionDisabled( plugin ),
-													} ) }
-													onChange={ ( isChecked ) => {
-														setFieldTouched( { ...fieldTouched, plugins: true } );
-														onPluginSelectionChange( plugin, isChecked );
-													} }
-												/>
-											) }
-										</Fragment>
-									) ) }
-							</div>
-						</div>
-					</div>
+					<ScheduleFormPlugins
+						initPlugins={ scheduleForEdit?.args }
+						error={ validationErrors?.plugins }
+						showError={ fieldTouched?.plugins }
+						onChange={ setSelectedPlugins }
+						onTouch={ () => {
+							setFieldTouched( { ...fieldTouched, plugins: true } );
+						} }
+					/>
 				</FlexItem>
 			</Flex>
 		</form>

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -240,8 +240,8 @@ export const ScheduleForm = ( props: Props ) => {
 						error={ validationErrors?.plugins }
 						showError={ fieldTouched?.plugins }
 						onChange={ setSelectedPlugins }
-						onTouch={ () => {
-							setFieldTouched( { ...fieldTouched, plugins: true } );
+						onTouch={ ( touched ) => {
+							setFieldTouched( { ...fieldTouched, plugins: touched } );
 						} }
 					/>
 				</FlexItem>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88417

## Proposed Changes

- The form logic became large and I tried to unload the plugin logic and move it to a separate component for easier maintenance in the future.

## Testing Instructions

* Go to `/plugins/scheduled-plugins`
* Select an atomic site
* Check if everything works as it was before the change

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?