### PR TITLE
Stats: Apply period and date to the UTM metrics query

### DIFF
--- a/client/my-sites/stats/hooks/use-utm-metrics-query.ts
+++ b/client/my-sites/stats/hooks/use-utm-metrics-query.ts
@@ -4,13 +4,18 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { requestMetrics } from 'calypso/state/stats/utm-metrics/actions';
 import { getMetrics, isLoading } from 'calypso/state/stats/utm-metrics/selectors';
 
-export default function useUTMMetricsQuery( siteId: number, UTMParam: string, postId?: number ) {
+export default function useUTMMetricsQuery(
+	siteId: number,
+	UTMParam: string,
+	query: object,
+	postId?: number
+) {
 	const dispatch = useDispatch();
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 
 	useEffect( () => {
-		dispatch( requestMetrics( siteId, UTMParam, postId, siteSlug ) );
-	}, [ dispatch, siteId, UTMParam, postId, siteSlug ] );
+		dispatch( requestMetrics( siteId, UTMParam, query, postId, siteSlug ) );
+	}, [ dispatch, siteId, UTMParam, query, postId, siteSlug ] );
 
 	const isFetching = useSelector( ( state ) => isLoading( state, siteId ) );
 	const metrics = useSelector( ( state ) => getMetrics( state, siteId, postId ) );

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -35,6 +35,7 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	const { isFetching: isFetchingUTM, metrics } = useUTMMetricsQuery(
 		siteId,
 		selectedOption,
+		query,
 		postId
 	);
 	// Fetch top posts for all UTM metric items.

--- a/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
+++ b/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
@@ -10,8 +10,37 @@ import {
 } from 'calypso/state/stats/utm-metrics/actions';
 import type { AnyAction } from 'redux';
 
+const getDaysOfMonthFromDate = ( date: string ): number => {
+	const dateObj = new Date( date );
+	const year = dateObj.getFullYear();
+	const month = dateObj.getMonth() + 1;
+
+	return new Date( year, month, 0 ).getDate();
+};
+
+const daysInYearFromDate = ( date: string ) => {
+	const dateObj = new Date( date );
+	const year = dateObj.getFullYear();
+
+	return ( year % 4 === 0 && year % 100 > 0 ) || year % 400 === 0 ? 366 : 365;
+};
+
 export const fetch = ( action: AnyAction ) => {
-	const { siteId, utmParam, postId } = action;
+	const { siteId, utmParam, postId, query } = action;
+
+	// Calculate the number of days to query based on the period.
+	let days = 1;
+	switch ( query.period ) {
+		case 'week':
+			days = 7;
+			break;
+		case 'month':
+			days = getDaysOfMonthFromDate( query.date );
+			break;
+		case 'year':
+			days = daysInYearFromDate( query.date );
+			break;
+	}
 
 	return [
 		http(
@@ -21,9 +50,8 @@ export const fetch = ( action: AnyAction ) => {
 				apiVersion: '1.1',
 				query: {
 					max: 10,
-					// Today's date in yyyy-mm-dd format.
-					date: new Date().toISOString().split( 'T' )[ 0 ],
-					days: 7,
+					date: query.date || new Date().toISOString().split( 'T' )[ 0 ],
+					days: days,
 					post_id: postId || '',
 					// Only query top posts if postId is not provided or 0.
 					query_top_posts: ! postId ? true : false,

--- a/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
+++ b/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
@@ -28,8 +28,11 @@ const daysInYearFromDate = ( date: string ) => {
 export const fetch = ( action: AnyAction ) => {
 	const { siteId, utmParam, postId, query } = action;
 
+	// `num` is only for the period `day`.
+	const num = query.num || 1;
+
 	// Calculate the number of days to query based on the period.
-	let days = 1;
+	let days = num;
 	switch ( query.period ) {
 		case 'week':
 			days = 7;

--- a/client/state/stats/utm-metrics/actions.ts
+++ b/client/state/stats/utm-metrics/actions.ts
@@ -19,6 +19,7 @@ import 'calypso/state/stats/init';
 export function requestMetrics(
 	siteId: number,
 	utmParam: string,
+	query: object,
 	postId?: number,
 	siteSlug?: string
 ) {
@@ -26,6 +27,7 @@ export function requestMetrics(
 		type: STATS_UTM_METRICS_REQUEST,
 		siteId,
 		utmParam,
+		query,
 		postId,
 		siteSlug,
 	};

--- a/client/state/stats/utm-metrics/reducer.ts
+++ b/client/state/stats/utm-metrics/reducer.ts
@@ -106,7 +106,7 @@ const metricsParser = (
 const dataReducer = ( state = {}, action: AnyAction ) => {
 	switch ( action.type ) {
 		case STATS_UTM_METRICS_RECEIVE: {
-			const values = action.data.top_utm_values;
+			const values = action.data.top_utm_values || {};
 			const topPosts = action.data.top_posts;
 			const siteSlug = action.siteSlug;
 
@@ -117,7 +117,7 @@ const dataReducer = ( state = {}, action: AnyAction ) => {
 		}
 
 		case STATS_UTM_METRICS_RECEIVE_BY_POST: {
-			const values = action.data.top_utm_values;
+			const values = action.data.top_utm_values || {};
 
 			const { metricsByPost } = state as {
 				metricsByPost: { [ key: string ]: Array< UTMMetricItem > };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88475#pullrequestreview-1935137017

## Proposed Changes

* Apply the `period` and `date` from the shared `query` object to the UTM metrics query by changing the data period on the Traffic page.

<img width="1361" alt="截圖 2024-03-14 下午11 50 45" src="https://github.com/Automattic/wp-calypso/assets/6869813/74abc1ff-ae36-45e6-b4c1-74d2ed8b43d2">

* Apply the `num` along with the period `day` to the UTM metrics query by changing the data period on the UTM module summary page.

<img width="1095" alt="截圖 2024-03-14 下午11 51 08" src="https://github.com/Automattic/wp-calypso/assets/6869813/35fcd8ac-c66c-4584-aac3-ecc4b259ecf5">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live branch.
* Prepare a Jetpack site with a purchased Stats commercial license.
* Navigate to Stats > Traffic page with the feature flag: `stats/utm-module`.
* Trigger the date period change and ensure the UTM metrics are queried with the corresponding parameters.

<img width="1040" alt="截圖 2024-03-14 下午11 56 53" src="https://github.com/Automattic/wp-calypso/assets/6869813/d44ea968-f971-4bf5-9619-bff8c0adc681">

* Click on the `View all` link to the UTM module summary page.
* Trigger the period change and ensure the UTM metrics are queried with the corresponding parameters.

<img width="1092" alt="截圖 2024-03-14 下午11 58 30" src="https://github.com/Automattic/wp-calypso/assets/6869813/985cb193-a605-40d3-8b66-fddd20b24da1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?