### PR TITLE
Plugins update manager: Unload the form component and move frequency/timestamp control logic to the separate component

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
@@ -1,0 +1,146 @@
+import {
+	__experimentalText as Text,
+	Flex,
+	FlexBlock,
+	FlexItem,
+	RadioControl,
+	SelectControl,
+} from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import {
+	DAILY_OPTION,
+	DAY_OPTIONS,
+	DEFAULT_HOUR,
+	HOUR_OPTIONS,
+	PERIOD_OPTIONS,
+	WEEKLY_OPTION,
+} from './schedule-form.const';
+import { prepareTimestamp } from './schedule-form.helper';
+
+type Frequency = 'daily' | 'weekly';
+
+interface Props {
+	initTimestamp?: number;
+	initFrequency: Frequency;
+	error?: string;
+	showError?: boolean;
+	onTouch?: ( touched: boolean ) => void;
+	onChange?: ( frequency: Frequency, timestamp: number ) => void;
+}
+export function ScheduleFormFrequency( props: Props ) {
+	const moment = useLocalizedMoment();
+	const translate = useTranslate();
+	const { initTimestamp, initFrequency = 'daily', error, showError, onChange, onTouch } = props;
+
+	const initDate = initTimestamp
+		? moment( initTimestamp * 1000 )
+		: moment( new Date() ).hour( DEFAULT_HOUR );
+
+	const [ frequency, setFrequency ] = useState< 'daily' | 'weekly' >( initFrequency );
+	const [ day, setDay ] = useState< string >( initDate.weekday().toString() );
+	const [ hour, setHour ] = useState< string >( ( initDate.hour() % 12 ).toString() );
+	const [ period, setPeriod ] = useState< string >( initDate.hours() < 12 ? 'am' : 'pm' );
+
+	const [ timestamp, setTimestamp ] = useState( prepareTimestamp( frequency, day, hour, period ) );
+	const [ fieldTouched, setFieldTouched ] = useState( false );
+
+	useEffect(
+		() => setTimestamp( prepareTimestamp( frequency, day, hour, period ) ),
+		[ frequency, day, hour, period ]
+	);
+	useEffect( () => onTouch?.( fieldTouched ), [ fieldTouched ] );
+	useEffect( () => onChange?.( frequency, timestamp ), [ frequency, timestamp ] );
+
+	return (
+		<div className="form-field">
+			<label htmlFor="frequency">{ translate( 'Update every' ) }</label>
+			<div className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
+				<RadioControl
+					name="frequency"
+					options={ [ DAILY_OPTION ] }
+					selected={ frequency }
+					onChange={ ( f ) => setFrequency( f as 'daily' ) }
+					onBlur={ () => setFieldTouched( true ) }
+				></RadioControl>
+				{ frequency === 'daily' && (
+					<Flex gap={ 6 }>
+						<FlexBlock>
+							<div className="form-field">
+								<div className="time-controls">
+									<SelectControl
+										__next40pxDefaultSize
+										name="hour"
+										value={ hour }
+										options={ HOUR_OPTIONS }
+										onChange={ setHour }
+									/>
+									<SelectControl
+										__next40pxDefaultSize
+										name="period"
+										value={ period }
+										options={ PERIOD_OPTIONS }
+										onChange={ setPeriod }
+									/>
+								</div>
+							</div>
+						</FlexBlock>
+					</Flex>
+				) }
+			</div>
+			<div className={ classnames( 'radio-option', { selected: frequency === 'weekly' } ) }>
+				<RadioControl
+					name="frequency"
+					options={ [ WEEKLY_OPTION ] }
+					selected={ frequency }
+					onChange={ ( f ) => setFrequency( f as 'weekly' ) }
+					onBlur={ () => setFieldTouched( true ) }
+				></RadioControl>
+				{ frequency === 'weekly' && (
+					<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>
+						<FlexItem>
+							<div className="form-field">
+								<SelectControl
+									__next40pxDefaultSize
+									name="day"
+									value={ day }
+									options={ DAY_OPTIONS }
+									onChange={ setDay }
+								/>
+							</div>
+						</FlexItem>
+						<FlexBlock>
+							<div className="form-field">
+								<div className="time-controls">
+									<SelectControl
+										__next40pxDefaultSize
+										name="hour"
+										value={ hour }
+										options={ HOUR_OPTIONS }
+										onChange={ setHour }
+									/>
+									<SelectControl
+										__next40pxDefaultSize
+										name="period"
+										value={ period }
+										options={ PERIOD_OPTIONS }
+										onChange={ setPeriod }
+									/>
+								</div>
+							</div>
+						</FlexBlock>
+					</Flex>
+				) }
+			</div>
+			{ ( ( showError && error ) || ( fieldTouched && error ) ) && (
+				<Text className="validation-msg">
+					<Icon className="icon-info" icon={ info } size={ 16 } />
+					{ error }
+				</Text>
+			) }
+		</div>
+	);
+}

--- a/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
@@ -37,7 +37,7 @@ export function ScheduleFormFrequency( props: Props ) {
 	const { initTimestamp, initFrequency = 'daily', error, showError, onChange, onTouch } = props;
 
 	const initDate = initTimestamp
-		? moment( initTimestamp * 1000 )
+		? moment( initTimestamp )
 		: moment( new Date() ).hour( DEFAULT_HOUR );
 
 	const [ frequency, setFrequency ] = useState< 'daily' | 'weekly' >( initFrequency );

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -52,7 +52,9 @@ export const ScheduleForm = ( props: Props ) => {
 	const [ frequency, setFrequency ] = useState< 'daily' | 'weekly' >(
 		scheduleForEdit?.schedule || 'daily'
 	);
-	const [ timestamp, setTimestamp ] = useState< number >( scheduleForEdit?.timestamp );
+	const [ timestamp, setTimestamp ] = useState< number >(
+		scheduleForEdit ? scheduleForEdit?.timestamp * 1000 : Date.now()
+	);
 	const scheduledTimeSlots = schedules.map( ( schedule ) => ( {
 		timestamp: schedule.timestamp,
 		frequency: schedule.schedule,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88417

## Proposed Changes

- The form logic became large and I tried to unload the timeslot picker logic and move it to a separate component for easier maintenance in the future.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-plugins`
* Select an atomic site
* Check if everything works as it was before the change

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?