### PR TITLE
Remove old Calypso subteams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,6 @@
 #
 # See https://help.github.com/en/articles/about-code-owners for details on the format of this file
 
-# Repository configuration
-.github @Automattic/team-calypso-platform
-
 # Comments management
 /client/my-sites/comment* @Automattic/serenity
 
@@ -71,9 +68,6 @@
 /client/lib/explat @Automattic/experimentation-platform
 /packages/explat-* @Automattic/experimentation-platform
 
-# TeamCity configuration
-/.teamcity @Automattic/team-calypso-platform
-
 # I18n
 /bin/build-languages.js @Automattic/i18n
 /build-tools/webpack/generate-chunks-map-plugin.js @Automattic/i18n
@@ -95,13 +89,6 @@
 /packages/i18n-utils @Automattic/i18n
 /packages/language-picker @Automattic/i18n
 /packages/languages @Automattic/i18n
-
-# E2E specs
-/test/e2e @Automattic/team-calypso-platform
-/packages/calypso-e2e @Automattic/team-calypso-platform
-
-# Node updates
-/.nvmrc @Automattic/team-calypso-platform
 
 # Domains
 /client/components/data/domain-management @Automattic/nomado

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -210,7 +210,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				name = "Post Failure Message to Slack"
 				executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
 				path = "./bin/post-threaded-slack-message.sh"
-				arguments = "%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID% %GB_E2E_ANNOUNCEMENT_THREAD_TS% \"The $buildName failed! Could you have a look? @calypso-platform-team! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" %GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%"
+				arguments = "%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID% %GB_E2E_ANNOUNCEMENT_THREAD_TS% \"The $buildName failed! Could you have a look?! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" %GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%"
 			}
 		},
 		buildFeatures = {

--- a/docs/component-libraries.md
+++ b/docs/component-libraries.md
@@ -12,4 +12,4 @@ When figuring out which `<Button>` component to use, here are some guidelines yo
 
 There may also be a more specific component library for the project you're working on (e.g. `@automattic/jetpack-components` and `@woocommerce/components`).
 
-Ultimately, the correct `<Button>` component to use is dependent on the context, use case, constraints, and end goals. There isn't necessarily a correct answer. If you found it difficult to come to the right answer, feel free to ping @Automattic/team-calypso-components or @Automattic/team-calypso-frameworks, and then include your insights here for the next person.
+Ultimately, the correct `<Button>` component to use is dependent on the context, use case, constraints, and end goals. There isn't necessarily a correct answer. If you found it difficult to come to the right answer, feel free to ping @Automattic/team-calypso, and then include your insights here for the next person.

--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -11,4 +11,4 @@ without further notice.
 Second, we want to think very carefully about what functions to add and which not. A lot of Lodash
 functionality these days can be replaced by native JavaScript code and that should be the premise.
 In case you still want to add a function here please open a Pull Request which describes your use-case
-and ping @Automattic/team-calypso-frameworks for a review.
+and ping @Automattic/team-calypso for a review.

--- a/renovate.json5
+++ b/renovate.json5
@@ -121,7 +121,7 @@
 
 	// --- Metadata settings for git ---
 	labels: [ 'Framework', '[Type] Task', 'dependencies' ],
-	reviewers: [ 'team:team-calypso-platform', 'team:team-calypso-frameworks' ],
+	reviewers: [ 'team:team-calypso' ],
 	branchPrefix: 'renovate/',
 	gitAuthor: 'Renovate Bot (self-hosted) <bot@renovateapp.com>',
 	platform: 'github',


### PR DESCRIPTION
## Proposed Changes

As part of the recent team changes, I've been cleaning up the unused Calypso subteams and I'm cleaning them up the repo code as well.

## Testing Instructions

No testing is needed. This affects either the repo config or docs.
