### PR TITLE
Developer Features: Update developer features support link

### DIFF
--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -20,6 +20,7 @@ export const DeveloperFeatures = () => {
 						{ linkLearnMore && (
 							<div className="developer-features-list__item-learn-more">
 								<a
+									id={ id }
 									href={ linkLearnMore }
 									target="_blank"
 									rel="noopener noreferrer"

--- a/client/me/developer/features/test/use-handle-click-link.js
+++ b/client/me/developer/features/test/use-handle-click-link.js
@@ -21,24 +21,29 @@ describe( 'useHandleClickLink', () => {
 		);
 	} );
 
-	describe( 'ensure track events are recorded without the /support/ prefix', () => {
-		test.each( [
-			[ 'https://wordpress.com/support/feature', 'feature' ],
-			[ 'https://wordpress.com/support/category/feature', 'category/feature' ],
-			[ 'https://wordpress.com/support/feature-with-hyphens', 'feature-with-hyphens' ],
-			[ 'https://wordpress.com/support/supported/feature', 'supported/feature' ],
-		] )(
-			"for the URL %s a tracks event is recorded using the 'feature' value '%s'",
-			( href, feature ) => {
-				const { result } = renderHook( () => useHandleClickLink() );
-				const event = { currentTarget: { href } };
+	describe( 'ensure track events report correct property', () => {
+		it( 'should report element id when defined', () => {
+			const { result } = renderHook( () => useHandleClickLink() );
+			const elementId = 'my-feature';
+			const event = { currentTarget: { id: elementId } };
 
-				act( () => result.current( event ) );
+			act( () => result.current( event ) );
 
-				expect( mockRecordTracksEventWithUserIsDevAccount ).toHaveBeenCalledWith( tracksHandle, {
-					feature,
-				} );
-			}
-		);
+			expect( mockRecordTracksEventWithUserIsDevAccount ).toHaveBeenCalledWith( tracksHandle, {
+				feature: elementId,
+			} );
+		} );
+
+		it( 'should report href when element id is not defined', () => {
+			const { result } = renderHook( () => useHandleClickLink() );
+			const href = 'https://wordpress.com';
+			const event = { currentTarget: { href } };
+
+			act( () => result.current( event ) );
+
+			expect( mockRecordTracksEventWithUserIsDevAccount ).toHaveBeenCalledWith( tracksHandle, {
+				feature: href,
+			} );
+		} );
 	} );
 } );

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -8,7 +8,7 @@ export const useFeaturesList = () => {
 
 	return [
 		{
-			id: 'sftp-ssh-wp-cli',
+			id: 'connect-to-ssh-on-wordpress-com',
 			title: translate( 'SFTP, SSH, and WP-CLI', {
 				comment: 'Feature title',
 			} ),
@@ -21,7 +21,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( 'https://developer.wordpress.com/docs/developer-tools/wp-cli/' ),
 		},
 		{
-			id: 'staging-sites',
+			id: 'how-to-create-a-staging-site',
 			title: translate( 'Staging sites', {
 				comment: 'Feature title',
 			} ),
@@ -36,7 +36,7 @@ export const useFeaturesList = () => {
 			),
 		},
 		{
-			id: 'custom-code',
+			id: 'code',
 			title: translate( 'Custom code', {
 				comment: 'Feature title',
 			} ),
@@ -49,7 +49,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( 'https://wordpress.com/support/code' ),
 		},
 		{
-			id: 'free-ssl-certificates',
+			id: 'https-ssl',
 			title: translate( 'Free SSL certificates', {
 				comment: 'Feature title',
 			} ),
@@ -62,7 +62,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( 'https://wordpress.com/support/domains/https-ssl' ),
 		},
 		{
-			id: 'expert-support',
+			id: 'help-support-options',
 			title: translate( '24/7 expert support', {
 				comment: 'Feature title',
 			} ),

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -110,7 +110,7 @@ export const useFeaturesList = () => {
 							<a
 								id="site-monitoring"
 								href={ localizeUrl(
-									'https://developer.wordpress.com/docs/platform-features/account-security/'
+									'https://developer.wordpress.com/docs/troubleshooting/site-monitoring/'
 								) }
 								target="_blank"
 								rel="noopener noreferrer"

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -18,7 +18,7 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( 'https://wordpress.com/support/connect-to-ssh-on-wordpress-com' ),
+			linkLearnMore: localizeUrl( 'https://developer.wordpress.com/docs/developer-tools/wp-cli/' ),
 		},
 		{
 			id: 'staging-sites',
@@ -31,7 +31,9 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( 'https://wordpress.com/support/how-to-create-a-staging-site/' ),
+			linkLearnMore: localizeUrl(
+				'https://developer.wordpress.com/docs/developer-tools/staging-sites/'
+			),
 		},
 		{
 			id: 'custom-code',
@@ -70,7 +72,7 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( 'https://wordpress.com/support/help-support-options' ),
+			linkLearnMore: localizeUrl( 'https://developer.wordpress.com/docs/support/' ),
 		},
 		{
 			id: 'malware-scanning-removal',
@@ -84,7 +86,10 @@ export const useFeaturesList = () => {
 					components: {
 						backupsLink: (
 							<a
-								href={ localizeUrl( 'https://wordpress.com/support/restore' ) }
+								id="restore"
+								href={ localizeUrl(
+									'https://developer.wordpress.com/docs/platform-features/real-time-backup-restore/'
+								) }
 								target="_blank"
 								rel="noopener noreferrer"
 								onClick={ handleClickLink }
@@ -92,7 +97,10 @@ export const useFeaturesList = () => {
 						),
 						malwareScanningLink: (
 							<a
-								href={ localizeUrl( 'https://wordpress.com/support/malware-and-site-security' ) }
+								id="malware-and-site-security"
+								href={ localizeUrl(
+									'https://developer.wordpress.com/docs/platform-features/jetpack-scan/'
+								) }
 								target="_blank"
 								rel="noopener noreferrer"
 								onClick={ handleClickLink }
@@ -100,7 +108,10 @@ export const useFeaturesList = () => {
 						),
 						siteMonitoringLink: (
 							<a
-								href={ localizeUrl( 'https://wordpress.com/support/site-monitoring' ) }
+								id="site-monitoring"
+								href={ localizeUrl(
+									'https://developer.wordpress.com/docs/platform-features/account-security/'
+								) }
 								target="_blank"
 								rel="noopener noreferrer"
 								onClick={ handleClickLink }

--- a/client/me/developer/features/use-handle-click-link.tsx
+++ b/client/me/developer/features/use-handle-click-link.tsx
@@ -6,16 +6,9 @@ export const useHandleClickLink = () => {
 
 	return useCallback(
 		( event: React.MouseEvent< HTMLAnchorElement > ) => {
-			const prefixToRemove = '/support/';
-			const pathIndex = event.currentTarget.href.indexOf( prefixToRemove );
-
-			let featureSlug = event.currentTarget.href;
-			if ( pathIndex !== -1 ) {
-				featureSlug = featureSlug.substring( pathIndex + prefixToRemove.length );
-			}
-			featureSlug = featureSlug.replace( /^\/|\/$/g, '' );
+			const feature = event.currentTarget.id ? event.currentTarget.id : event.currentTarget.href;
 			recordTracksEventWithUserIsDevAccount( 'calypso_me_developer_learn_more', {
-				feature: featureSlug,
+				feature,
 			} );
 		},
 		[ recordTracksEventWithUserIsDevAccount ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6091

## Proposed Changes

We are updating the support doc links for the developer features to point to the up-to-date docs at https://developer.wordpress.com. These are the link updates:
* SFTP, SSH, and WP-CLI: https://developer.wordpress.com/docs/developer-tools/wp-cli/
* Staging site: https://developer.wordpress.com/docs/developer-tools/staging-sites/
* Custom code (no change): https://wordpress.com/support/code/ 
* Free SSL certificates (no change): https://wordpress.com/support/domains/https-ssl/
* 24/7 expert support: https://developer.wordpress.com/docs/support/
* Real-time backups: https://developer.wordpress.com/docs/platform-features/real-time-backup-restore/
* Malware scanning: https://developer.wordpress.com/docs/platform-features/jetpack-scan/
* Site monitoring: https://developer.wordpress.com/docs/troubleshooting/site-monitoring/

Also, previously, the link tracking logic generates the feature name to track from the URL, which becomes problematic, as we may be supplying different URLs as learn mores links. To provide better flexibility, the logic is updated such that we report the `id` attribute of each anchor tag. These are the expected `feature` property for click tracking:
* SFTP, SSH, and WP-CLI: `connect-to-ssh-on-wordpress-com`
* Staging site: `how-to-create-a-staging-site`
* Custom code: `code`
* Free SSL certificates: `https-ssl` (this used to report `domains/https-ssl`)
* 24/7 expert support: `help-support-options`
* Real-time backups: `restore`
* Malware scanning: `malware-and-site-security`
* Site monitoring: `site-monitoring`

Note that, as a result of this change, we will be reporting different values for the the learn more link of "Free SSL certificates". It's been almost two months since we launched the Developer Features Page. I think we've collected enough data to have a general understanding of user's interests, and it's not a huge deal to "reset" our data with new values at this point.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/me/developer`.
* Click on all links on the page and ensure they take you to the correct support doc.
* Ensure that each link click triggers the `calypso_me_developer_learn_more` event, sending the proper `feature` value.