### PR TITLE
Developer Features: Add GitHub deployment card to developer features page

### DIFF
--- a/client/me/developer/features/github-deployment-card.tsx
+++ b/client/me/developer/features/github-deployment-card.tsx
@@ -17,7 +17,7 @@ export const GitHubDeploymentCard = () => {
 			</div>
 			<div className="developer-features-list__item-description">
 				{ translate(
-					'Connect your GitHub repositories to WordPress.com and develop your sites reliably, predictably, and automatically using version control. Deploy your code directly to your site automatically or on request.'
+					'Speed up your development workflow and take version control further by connecting your WordPress.com sites and GitHub repos. Choose from fully automatic or on-demand deployment.'
 				) }
 			</div>
 			<div className="developer-features-list__item-learn-more">

--- a/client/me/developer/features/github-deployment-card.tsx
+++ b/client/me/developer/features/github-deployment-card.tsx
@@ -1,0 +1,38 @@
+import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useHandleClickLink } from './use-handle-click-link';
+
+import './style.scss';
+
+export const GitHubDeploymentCard = () => {
+	const translate = useTranslate();
+	const handleClickLink = useHandleClickLink();
+
+	return (
+		<Card className="developer-features-list__item developer-features-list__item--full">
+			<div className="developer-features-list__item-tag">{ translate( 'New' ) }</div>
+			<div className="developer-features-list__item-title">
+				{ translate( 'GitHub Deployment' ) }
+			</div>
+			<div className="developer-features-list__item-description">
+				{ translate(
+					'Connect your GitHub repositories to WordPress.com and develop your sites reliably, predictably, and automatically using version control. Deploy your code directly to your site automatically or on request.'
+				) }
+			</div>
+			<div className="developer-features-list__item-learn-more">
+				<a
+					id="github-deployments"
+					href={ localizeUrl(
+						'https://developer.wordpress.com/docs/developer-tools/github-deployments/'
+					) }
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ handleClickLink }
+				>
+					{ translate( 'Learn more' ) }
+				</a>
+			</div>
+		</Card>
+	);
+};

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { GitHubDeploymentCard } from './github-deployment-card';
 import { useFeaturesList } from './use-features-list';
 import { useHandleClickLink } from './use-handle-click-link';
 
@@ -13,6 +14,8 @@ export const DeveloperFeatures = () => {
 	return (
 		<>
 			<div className="developer-features-list">
+				<GitHubDeploymentCard />
+
 				{ features.map( ( { id, title, description, linkLearnMore } ) => (
 					<Card className="developer-features-list__item" key={ id }>
 						<div className="developer-features-list__item-title">{ title }</div>

--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -26,16 +26,29 @@
 			letter-spacing: -0.32px;
 			line-height: 24px;
 		}
+
 		.developer-features-list__item-description {
 			font-size: rem(14px);
 			color: var(--color-text-subtle);
 			line-height: 20px;
 			letter-spacing: -0.15px;
 		}
+
 		.developer-features-list__item-learn-more {
 			padding-top: 8px;
 			margin-top: auto;
 		}
+
+		&--full {
+			grid-column: 1/4;
+		}
+	}
+
+	.developer-features-list__item-tag {
+		color: var(--color-text-subtle);
+		font-size: $font-body-extra-small;
+		line-height: 20px;
+		text-transform: uppercase;
 	}
 
 	@media ( max-width: $break-large ) {

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -122,7 +122,7 @@ class Developer extends Component {
 						className="developer__header"
 					/>
 
-					<form onChange={ this.props.submitForm }>
+					<form className="developer__form" onChange={ this.props.submitForm }>
 						<FormFieldset
 							className={ classnames( 'developer__is_dev_account-fieldset', {
 								'is-loading': this.props.isFetchingUserSettings,

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -37,13 +37,16 @@
 	}
 }
 
+.developer__form {
+	text-align: center;
+}
+
 .form-fieldset.developer__is_dev_account-fieldset {
 	border-radius: 2px;
 	background: var(--color-link-0);
 	padding: 16px;
-	text-align: center;
-	max-width: 750px;
 	margin: 0 auto 30px;
+	display: inline-block;
 
 	.components-toggle-control {
 		font-family: $font-sf-pro-text;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6094

## Proposed Changes

To support GitHub Deployment launch, we are adding a new card to the Developer Features Page to bring awareness to the feature. The tile will be shown to all users, and the learn more link will take users to the latest GitHub Deployments doc: https://developer.wordpress.com/docs/developer-tools/github-deployments/

|Desktop|Mobile|
|------|-----|
|<img width="1170" alt="Screen Shot 2024-03-15 at 10 08 03 AM" src="https://github.com/Automattic/wp-calypso/assets/104910361/51d503d9-b724-4f2f-ab19-b92fc8827c4a">|<img width="379" alt="Screen Shot 2024-03-15 at 10 10 19 AM" src="https://github.com/Automattic/wp-calypso/assets/104910361/2ad5436c-9bfc-4b71-99a7-a56fe323a2bc">|

We're also taking the opportunity to reduce the horizontal padding of the "I am a developer" toggle box to match the mock.

|Before|After|
|------|-----|
|<img width="804" alt="Screen Shot 2024-03-15 at 10 11 07 AM" src="https://github.com/Automattic/wp-calypso/assets/104910361/348ea51c-aefa-4162-9b0a-fec52cd233a7">|<img width="791" alt="Screen Shot 2024-03-15 at 10 10 48 AM" src="https://github.com/Automattic/wp-calypso/assets/104910361/96cab213-e325-4012-a4ea-592c60801c6e">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/me/developer`.
* Assert that the "GitHub Deployment" full width tile renders as per mock on desktop and mobile.
* Assert that the "Learn more" link takes users to the correct doc.
* Assert that link click triggers the `calypso_me_developer_learn_more` event reporting the property `feature: github-deployments`.
* Assert that the horizontal padding for the "I am a developer" box is fixed.
