### PR TITLE
Add tracks events to Razorpay checkout flow

### DIFF
--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -13,6 +13,7 @@ import {
 } from '@automattic/composite-checkout';
 import {
 	ManagedContactDetails,
+	WPCOMTransactionEndpointRequestPayload,
 	WPCOMTransactionEndpointResponseRedirect,
 } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
@@ -97,18 +98,29 @@ export default async function razorpayProcessor(
 					response as WPCOMTransactionEndpointResponseRedirect,
 					( result ) => {
 						transactionOptions.reduxDispatch(
-							recordTracksEvent( 'calypso_checkout_razorpay_modal_complete', {
-								transactionData: formattedTransactionData,
-							} )
+							recordTracksEvent(
+								'calypso_checkout_razorpay_modal_complete',
+								constructTracksProps( formattedTransactionData, {} )
+							)
 						);
 						return resolve( { bd_order_id: response.order_id.toString(), ...result } );
+					},
+					() => {
+						transactionOptions.reduxDispatch(
+							recordTracksEvent(
+								'calypso_checkout_razorpay_modal_dismissed',
+								constructTracksProps( formattedTransactionData, {} )
+							)
+						);
+						return resolve( {} );
 					}
 				);
 				debug( 'Opening Razorpay modal with options', razorpayOptions );
 				transactionOptions.reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_razorpay_modal_open', {
-						transactionData: formattedTransactionData,
-					} )
+					recordTracksEvent(
+						'calypso_checkout_razorpay_modal_open',
+						constructTracksProps( formattedTransactionData, {} )
+					)
 				);
 				const razorpay = new window.Razorpay( razorpayOptions );
 				razorpay.open();
@@ -140,9 +152,10 @@ export default async function razorpayProcessor(
 
 			if ( confirmationResult.success === true ) {
 				transactionOptions.reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_razorpay_confirmation_success', {
-						confirmationResult,
-					} )
+					recordTracksEvent(
+						'calypso_checkout_razorpay_confirmation_success',
+						constructTracksProps( formattedTransactionData, confirmationResult )
+					)
 				);
 				return makeSuccessResponse( confirmationResult );
 			}
@@ -180,7 +193,8 @@ function combineRazorpayOptions(
 	razorpayConfiguration: RazorpayConfiguration,
 	contactDetails: ManagedContactDetails | undefined,
 	txnResponse: WPCOMTransactionEndpointResponseRedirect,
-	handler: ( response: RazorpayModalResponse ) => void
+	handler: ( response: RazorpayModalResponse ) => void,
+	ondismiss: () => void
 ): RazorpayOptions {
 	if ( ! txnResponse.razorpay_order_id ) {
 		throw new Error( 'Missing order_id for razorpay transaction' );
@@ -195,7 +209,7 @@ function combineRazorpayOptions(
 
 	options.handler = handler;
 	const modal = options.modal ?? {};
-	modal.ondismiss = handler;
+	modal.ondismiss = ondismiss;
 	options.modal = modal;
 
 	debug( 'Constructing Razorpay prefill object using contact details', contactDetails );
@@ -206,4 +220,18 @@ function combineRazorpayOptions(
 	options.prefill = prefill;
 
 	return options;
+}
+
+function constructTracksProps(
+	transactionData: WPCOMTransactionEndpointRequestPayload,
+	confirmationResult: object
+): object {
+	const tracksProps = {
+		blog_id: transactionData.cart.blog_id,
+		price_integer:
+			'price_integer' in confirmationResult ? confirmationResult.price_integer : 'unset',
+		receipt_id: 'receipt_id' in confirmationResult ? confirmationResult.receipt_id : 'unset',
+		success: 'success' in confirmationResult ? confirmationResult.success : 'unset',
+	};
+	return tracksProps;
 }

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -98,6 +98,11 @@ export default async function razorpayProcessor(
 					( result ) => resolve( { bd_order_id: response.order_id.toString(), ...result } )
 				);
 				debug( 'Opening Razorpay modal with options', razorpayOptions );
+				transactionOptions.reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_razorpay_open_modal', {
+						transactionData: formattedTransactionData,
+					} )
+				);
 				const razorpay = new window.Razorpay( razorpayOptions );
 				razorpay.open();
 			} );


### PR DESCRIPTION
## Proposed Changes

* Fire a new tracks event when the Razorpay modal window is opened, when the modal calls the success handler, and when confirmation succeeds.

## Testing Instructions

* (a12s): Set your currency to INR, enter checkout, and set your billing contact location to India. Select Razorpay and click to submit, opening the modal window. Close the modal to return to the checkout screen. Click to submit, this time complete the transaction.
* (a12s): Search the tracks live view for your test user. It may take several minutes for events to appear in the feed. Look for these events in order (not consecutive):

    * `calypso_checkout_switch_to_razorpay`
    * `calypso_checkout_composite_razorpay_submit_clicked`
    * `calypso_checkout_razorpay_modal_open`
    * `calypso_checkout_razorpay_modal_dismissed`
    * `calypso_checkout_composite_razorpay_submit_clicked`
    * `calypso_checkout_razorpay_modal_open`
    * `calypso_checkout_razorpay_modal_complete`
    * `calypso_checkout_razorpay_confirmation_success`

On the confirmation success event, we should also see `price_integer` and `receipt_id` properties:

<img width="289" alt="Screenshot 2024-03-22 at 3 27 26 PM" src="https://github.com/Automattic/wp-calypso/assets/9310939/6b005ef2-f990-479c-b336-6b9fac51cf47">

* (a12s): Enter checkout again and select Razorpay. Click to submit. This time, do something to make the confirmation fail (e.g. disconnect from your api sandbox) before completing the transaction.
* (a12s): Look for these tracks events in order:

    * `calypso_checkout_switch_to_razorpay`
    * `calypso_checkout_composite_razorpay_submit_clicked`
    * `calypso_checkout_razorpay_modal_open`
    * `calypso_checkout_razorpay_modal_complete`
    * `calypso_checkout_razorpay_transaction_error`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
