### PR TITLE
Stats: Add contact details as commercial reasons

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -342,6 +342,7 @@ function StatsCommercialFlowOptOutForm( {
 		exoclick: 'ExoClick',
 		'live-chat': translate( 'Live Chat' ),
 		'commercial-dext': translate( 'Commercial Domain Extension' ),
+		'contact-details': translate( 'Contact Details' ),
 		'manual-override': translate( 'Manual Override' ),
 	};
 


### PR DESCRIPTION
## Proposed Changes

* `contact-details` was newly introduced early this month, and the PR proposes to sync it to the list on the frontend.

## Testing Instructions

* No need to test only ensure `contact-details` matches fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Swrgcnpx%2Qfvgr%2Qcebsvyrf%2Spbzzrepvny%2Spynff.wrgcnpx%2Qpbzzrepvny%2Qpenjyre.cuc%3Se%3Q633585qo%231246-og

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?