### PR TITLE
Fix: Subscribers to use Global Site Nav

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -369,6 +369,7 @@ body.is-mobile-app-view {
 // Only apply the no-masterbar rule to logged in sections
 // This is done since most has-no-masterbar section have their own padding set already that we don't want to overwrite
 .layout.has-no-masterbar.is-group-me,
+.layout.has-no-masterbar.is-group-jetpack-cloud,
 .layout.has-no-masterbar.is-group-sites,
 .layout.has-no-masterbar.is-group-sites-dashboard,
 .layout.has-no-masterbar.is-section-reader {

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -20,5 +20,9 @@ export const getShouldShowGlobalSiteSidebar = (
 	sectionGroup: string
 ) => {
 	// Global Site View should be limited to classic interface users only for now.
-	return isGlobalSiteViewEnabled( state, siteId ) && sectionGroup === 'sites' && !! siteId;
+	return (
+		isGlobalSiteViewEnabled( state, siteId ) &&
+		( sectionGroup === 'sites' || sectionGroup === 'jetpack-cloud' ) &&
+		!! siteId
+	);
 };


### PR DESCRIPTION
Slack: 

## Proposed Changes

As we added `subscribers` to Jetpack Cloud and the URL is the same as Calypso, it's getting `jetpack-cloud` as `sectionGroup` instead of `sites`.
We changed the condition to make `jetpack-cloud` to show the Global Site Nav.
We can remove this when we enable Subscribers to Jetpack Cloud on production.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/36175d93-dc12-4da7-9739-560d8cec6495) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/f5eef253-00d5-48ac-9f43-9cde03b45ca6) |

## Testing Instructions

* Go to `/subscribers/:YOUR_SITE`
* You should see the Global Site Nav.