### PR TITLE
Stats: Fetch all-time UTM metrics for the post details page

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -216,7 +216,7 @@ class StatsPostDetail extends Component {
 
 					{ config.isEnabled( 'stats/utm-module' ) && (
 						<div className="stats-module-utm__post-detail">
-							<StatsModuleUTM siteId={ siteId } postId={ postId } />
+							<StatsModuleUTM siteId={ siteId } postId={ postId } query={ { num: -1 } } />
 						</div>
 					) }
 

--- a/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
+++ b/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
@@ -26,7 +26,7 @@ const daysInYearFromDate = ( date: string ) => {
 };
 
 export const fetch = ( action: AnyAction ) => {
-	const { siteId, utmParam, postId, query } = action;
+	const { siteId, utmParam, postId, query = {} } = action;
 
 	// `num` is only for the period `day`.
 	const num = query.num || 1;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88524

## Proposed Changes

* Fetch all-time UTM metrics with `query.num = -1` for the post details page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live branch.
* Prepare a Jetpack site with a purchased Stats commercial license.
* Navigate to the post details page with the feature flag: `/stats/post/{post-id}/{site-slug}?flags=stats/utm-module`.
* Ensure the UTM module on the post details page shows the all-time metrics.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?