### PR TITLE
Update domain messaging in paid media flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -135,7 +135,7 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomains: PropTypes.array,
 		forceExactSuggestion: PropTypes.bool,
 		checkDomainAvailabilityPromises: PropTypes.array,
-		isOnboardingPaidMediaFlow: PropTypes.bool,
+		useAlternateDomainMessaging: PropTypes.bool,
 
 		/**
 		 * If an override is not provided we generate 1 suggestion per 1 other subdomain
@@ -173,7 +173,7 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomains: null,
 		hasPendingRequests: false,
 		forceExactSuggestion: false,
-		isOnboardingPaidMediaFlow: false,
+		useAlternateDomainMessaging: false,
 	};
 
 	constructor( props ) {
@@ -1436,7 +1436,7 @@ class RegisterDomainStep extends Component {
 	};
 
 	renderBestNamesPrompt() {
-		const { translate, promptText, isOnboardingPaidMediaFlow } = this.props;
+		const { translate, promptText, useAlternateDomainMessaging } = this.props;
 		const icon = <Icon icon={ tip } size={ 20 } />;
 		const defaultPrompt = (
 			<>
@@ -1453,7 +1453,7 @@ class RegisterDomainStep extends Component {
 					{ promptText }
 				</>
 			);
-		} else if ( isOnboardingPaidMediaFlow ) {
+		} else if ( useAlternateDomainMessaging ) {
 			prompt = translate(
 				'{{p}}{{icon/}}Think of your domain name as a welcome mat for your website. Choose from hundreds of top-level domains (e.g. .com or .net), and claim your corner of the web with a custom site address.{{/p}}{{p}}Your first year of domain registration is free when you choose an annual, 2-year, or 3-year plan.{{/p}}',
 				{
@@ -1468,7 +1468,7 @@ class RegisterDomainStep extends Component {
 		return (
 			<div
 				className={ classNames( 'register-domain-step__example-prompt', {
-					[ 'register-domain-step__example-prompt--stacked' ]: isOnboardingPaidMediaFlow,
+					[ 'register-domain-step__example-prompt--stacked' ]: useAlternateDomainMessaging,
 				} ) }
 			>
 				{ prompt }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -135,6 +135,7 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomains: PropTypes.array,
 		forceExactSuggestion: PropTypes.bool,
 		checkDomainAvailabilityPromises: PropTypes.array,
+		promptText: PropTypes.array,
 
 		/**
 		 * If an override is not provided we generate 1 suggestion per 1 other subdomain
@@ -1434,11 +1435,43 @@ class RegisterDomainStep extends Component {
 	};
 
 	renderBestNamesPrompt() {
-		const { translate, promptText } = this.props;
+		const { translate, promptText, flowName } = this.props;
+		const icon = <Icon icon={ tip } size={ 20 } />;
+		const isPaidMediaFlow = flowName === 'onboarding-pm';
+		const defaultPrompt = (
+			<>
+				{ icon }
+				{ translate( 'The best names are short and memorable' ) }
+			</>
+		);
+		let prompt = defaultPrompt;
+
+		if ( promptText ) {
+			prompt = (
+				<>
+					{ icon }
+					{ promptText }
+				</>
+			);
+		} else if ( isPaidMediaFlow ) {
+			prompt = translate(
+				'{{p}}{{icon/}}Think of your domain name as a welcome mat for your website. Choose from hundreds of top-level domains (e.g. .com or .net), and claim your corner of the web with a custom site address.{{/p}}{{p}}Your first year of domain registration is free when you choose an annual, 2-year, or 3-year plan.{{/p}}',
+				{
+					components: {
+						icon,
+						p: <p />,
+					},
+				}
+			);
+		}
+
 		return (
-			<div className="register-domain-step__example-prompt">
-				<Icon icon={ tip } size={ 20 } />
-				{ promptText ?? translate( 'The best names are short and memorable' ) }
+			<div
+				className={ classNames( 'register-domain-step__example-prompt', {
+					[ 'register-domain-step__example-prompt--stacked' ]: isPaidMediaFlow,
+				} ) }
+			>
+				{ prompt }
 			</div>
 		);
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -135,7 +135,7 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomains: PropTypes.array,
 		forceExactSuggestion: PropTypes.bool,
 		checkDomainAvailabilityPromises: PropTypes.array,
-		promptText: PropTypes.array,
+		isOnboardingPaidMediaFlow: PropTypes.bool,
 
 		/**
 		 * If an override is not provided we generate 1 suggestion per 1 other subdomain
@@ -173,6 +173,7 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomains: null,
 		hasPendingRequests: false,
 		forceExactSuggestion: false,
+		isOnboardingPaidMediaFlow: false,
 	};
 
 	constructor( props ) {
@@ -1435,9 +1436,8 @@ class RegisterDomainStep extends Component {
 	};
 
 	renderBestNamesPrompt() {
-		const { translate, promptText, flowName } = this.props;
+		const { translate, promptText, isOnboardingPaidMediaFlow } = this.props;
 		const icon = <Icon icon={ tip } size={ 20 } />;
-		const isPaidMediaFlow = flowName === 'onboarding-pm';
 		const defaultPrompt = (
 			<>
 				{ icon }
@@ -1453,7 +1453,7 @@ class RegisterDomainStep extends Component {
 					{ promptText }
 				</>
 			);
-		} else if ( isPaidMediaFlow ) {
+		} else if ( isOnboardingPaidMediaFlow ) {
 			prompt = translate(
 				'{{p}}{{icon/}}Think of your domain name as a welcome mat for your website. Choose from hundreds of top-level domains (e.g. .com or .net), and claim your corner of the web with a custom site address.{{/p}}{{p}}Your first year of domain registration is free when you choose an annual, 2-year, or 3-year plan.{{/p}}',
 				{
@@ -1468,7 +1468,7 @@ class RegisterDomainStep extends Component {
 		return (
 			<div
 				className={ classNames( 'register-domain-step__example-prompt', {
-					[ 'register-domain-step__example-prompt--stacked' ]: isPaidMediaFlow,
+					[ 'register-domain-step__example-prompt--stacked' ]: isOnboardingPaidMediaFlow,
 				} ) }
 			>
 				{ prompt }

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -161,6 +161,11 @@
 	@include break-xlarge {
 		margin: 0;
 	}
+
+	&--stacked {
+		flex-direction: column;
+		align-items: start;
+	}
 }
 
 .register-domain-step__placeholder.empty-content {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -165,6 +165,10 @@
 	&--stacked {
 		flex-direction: column;
 		align-items: start;
+
+		svg {
+			float: left;
+		}
 	}
 }
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -201,7 +201,7 @@ export function generateFlows( {
 			optionalDependenciesInQuery: [ 'coupon' ],
 			props: {
 				domains: {
-					isOnboardingPaidMediaFlow: true,
+					useAlternateDomainMessaging: true,
 				},
 				plans: {
 					/**

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -200,6 +200,9 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],
 			props: {
+				domains: {
+					isOnboardingPaidMediaFlow: true,
+				},
 				plans: {
 					/**
 					 * This intent is geared towards customizations related to the paid media flow

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -98,7 +98,7 @@ export class RenderDomainsStep extends Component {
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
 		isReskinned: PropTypes.bool,
-		isOnboardingPaidMediaFlow: PropTypes.bool,
+		useAlternateDomainMessaging: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -1046,7 +1046,7 @@ export class RenderDomainsStep extends Component {
 				forceExactSuggestion={ this.props?.queryObject?.source === 'general-settings' }
 				replaceDomainFailedMessage={ this.state.replaceDomainFailedMessage }
 				dismissReplaceDomainFailed={ this.dismissReplaceDomainFailed }
-				isOnboardingPaidMediaFlow={ this.props.isOnboardingPaidMediaFlow }
+				useAlternateDomainMessaging={ this.props.useAlternateDomainMessaging }
 			/>
 		);
 	};
@@ -1109,7 +1109,7 @@ export class RenderDomainsStep extends Component {
 		const {
 			flowName,
 			isAllDomains,
-			isOnboardingPaidMediaFlow,
+			useAlternateDomainMessaging,
 			isReskinned,
 			stepSectionName,
 			translate,
@@ -1159,7 +1159,7 @@ export class RenderDomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( isOnboardingPaidMediaFlow ) {
+			if ( useAlternateDomainMessaging ) {
 				return translate(
 					"Find a unique web address that's easy to remember and even easier to share."
 				);
@@ -1182,7 +1182,7 @@ export class RenderDomainsStep extends Component {
 			flowName,
 			headerText,
 			isAllDomains,
-			isOnboardingPaidMediaFlow,
+			useAlternateDomainMessaging,
 			isReskinned,
 			stepSectionName,
 			translate,
@@ -1205,7 +1205,7 @@ export class RenderDomainsStep extends Component {
 				return ! stepSectionName && translate( 'Choose your domains' );
 			}
 
-			if ( isOnboardingPaidMediaFlow ) {
+			if ( useAlternateDomainMessaging ) {
 				return translate( 'Claim your domain name' );
 			}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1150,6 +1150,12 @@ export class RenderDomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
+			if ( flowName === 'onboarding-pm' ) {
+				return translate(
+					"Find a unique web address that's easy to remember and even easier to share."
+				);
+			}
+
 			return (
 				! stepSectionName &&
 				'domain-transfer' !== flowName &&
@@ -1182,6 +1188,11 @@ export class RenderDomainsStep extends Component {
 			if ( shouldUseMultipleDomainsInCart( flowName ) ) {
 				return ! stepSectionName && translate( 'Choose your domains' );
 			}
+
+			if ( flowName === 'onboarding-pm' ) {
+				return translate( 'Claim your domain name' );
+			}
+
 			return ! stepSectionName && translate( 'Choose a domain' );
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -98,6 +98,7 @@ export class RenderDomainsStep extends Component {
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
 		isReskinned: PropTypes.bool,
+		isOnboardingPaidMediaFlow: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -1045,6 +1046,7 @@ export class RenderDomainsStep extends Component {
 				forceExactSuggestion={ this.props?.queryObject?.source === 'general-settings' }
 				replaceDomainFailedMessage={ this.state.replaceDomainFailedMessage }
 				dismissReplaceDomainFailed={ this.dismissReplaceDomainFailed }
+				isOnboardingPaidMediaFlow={ this.props.isOnboardingPaidMediaFlow }
 			/>
 		);
 	};
@@ -1104,7 +1106,14 @@ export class RenderDomainsStep extends Component {
 	isHostingFlow = () => isHostingSignupFlow( this.props.flowName );
 
 	getSubHeaderText() {
-		const { flowName, isAllDomains, stepSectionName, isReskinned, translate } = this.props;
+		const {
+			flowName,
+			isAllDomains,
+			isOnboardingPaidMediaFlow,
+			isReskinned,
+			stepSectionName,
+			translate,
+		} = this.props;
 
 		if ( isAllDomains ) {
 			return translate( 'Find the domain that defines you' );
@@ -1150,7 +1159,7 @@ export class RenderDomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( flowName === 'onboarding-pm' ) {
+			if ( isOnboardingPaidMediaFlow ) {
 				return translate(
 					"Find a unique web address that's easy to remember and even easier to share."
 				);
@@ -1169,8 +1178,15 @@ export class RenderDomainsStep extends Component {
 	}
 
 	getHeaderText() {
-		const { headerText, isAllDomains, isReskinned, stepSectionName, translate, flowName } =
-			this.props;
+		const {
+			flowName,
+			headerText,
+			isAllDomains,
+			isOnboardingPaidMediaFlow,
+			isReskinned,
+			stepSectionName,
+			translate,
+		} = this.props;
 
 		if ( stepSectionName === 'use-your-domain' || 'domain-transfer' === flowName ) {
 			return '';
@@ -1189,7 +1205,7 @@ export class RenderDomainsStep extends Component {
 				return ! stepSectionName && translate( 'Choose your domains' );
 			}
 
-			if ( flowName === 'onboarding-pm' ) {
+			if ( isOnboardingPaidMediaFlow ) {
 				return translate( 'Claim your domain name' );
 			}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/martech/issues/2792

## Proposed Changes

This updates messaging on the domain selection screen for the paid media flow. The motivation for the changes from the project thread (peP6yB-1YG-p2):

> By improving copy and messaging on the Domain step to better convey what a domain is, why it matters for users, and instill some urgency; conversions will increase.

| Before | After |
| -- | -- |
![CleanShot 2024-03-15 at 13 56 25@2x](https://github.com/Automattic/wp-calypso/assets/69198925/4c707f95-68dc-49f3-9286-9c911fe22498)|![CleanShot 2024-03-15 at 13 56 32@2x](https://github.com/Automattic/wp-calypso/assets/69198925/99ec3218-8744-4862-869a-9e514d7ac3ec)|


## Testing Instructions

- Visit `/start/onboarding-pm/domains` and verify the messaging changes.
- We don't want the changes to be applied to the logged-in `/domains` page which shares the same components, so please verify that no changes are present on that page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?