### PR TITLE
Do not exclude boost from unlinked checkout

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -602,10 +602,7 @@ export function siteSelection( context, next ) {
 
 	const siteId = getSiteId( getState(), siteFragment );
 
-	const isUnlinkedCheckoutNotBoost =
-		isUnlinkedCheckout && ! context.pathname.includes( 'jetpack_boost' );
-
-	if ( siteId && ! isUnlinkedCheckoutNotBoost ) {
+	if ( siteId && ! isUnlinkedCheckout ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 		// to wp-admin. In that case, don't continue handling the route.
 		dispatch( setSelectedSiteId( siteId ) );
@@ -654,7 +651,7 @@ export function siteSelection( context, next ) {
 
 				// If the user is presumably not connected to WPCOM, we ignore the site ID we found.
 				// Details: p9dueE-6Hf-p2
-				if ( freshSiteId && ! isUnlinkedCheckoutNotBoost ) {
+				if ( freshSiteId && ! isUnlinkedCheckout ) {
 					// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 					// to wp-admin. In that case, don't continue handling the route.
 					dispatch( setSelectedSiteId( freshSiteId ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/jetpack#35285

## Proposed Changes
* Do not exclude Boost from unlinked checkout

## Testing Instructions
* Get a new JN site. (Also works on non-JN sites).
* Activate Jetpack Boost (doesn’t matter if Jetpack is active or not).
* Go to the admin.php?page=jetpack-boost#/getting-started and click “Get Boost”. Connect the user, but don’t go through with Checkout.
* Go to “My Jetpack” and disconnect the site.
* Go to admin.php?page=jetpack-boost#/getting-started once more and click on “Get Boost” again.
* Checkout should work nicely

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?