### PR TITLE
GitHub Deployments: fix for super long branch names 

### DIFF
--- a/client/my-sites/github-deployments/components/github-connection-form/style.scss
+++ b/client/my-sites/github-deployments/components/github-connection-form/style.scss
@@ -52,7 +52,7 @@
 		align-items: center;
 
 		.form-select {
-			flex: 1;
+			width: 100%;
 		}
 	}
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1710469430503659/1710468083.839409-slack-C06D9M3CHMK

<img width="765" alt="Screenshot 2567-03-15 at 13 00 20" src="https://github.com/Automattic/wp-calypso/assets/6851384/df54d4de-c9e9-4fab-acae-6d75b18683cf">

## Proposed Changes

* Stop the left panel from expanding due to very long branch names in the `select`. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try it on prod first and you'll see the issue reported in Slack
* Try again in Calypso Live and you'll see the two columns have equal width


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?