### PR TITLE
Plugin update manager: make back button work

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -78,7 +78,7 @@ export const ScheduleCreate = ( props: Props ) => {
 						}
 					) }
 					onClick={ () => {
-						page.redirect( `/plugins/${ siteSlug }` );
+						page.show( `/plugins/${ siteSlug }` );
 					} }
 				/>
 			) }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -126,7 +126,7 @@ export function updatesManager( context, next ) {
 			context.primary = createElement( PluginsUpdateManager, {
 				siteSlug,
 				context: 'create',
-				onNavBack: () => page.redirect( `/plugins/scheduled-updates/${ siteSlug }` ),
+				onNavBack: () => page.show( `/plugins/scheduled-updates/${ siteSlug }` ),
 			} );
 			break;
 
@@ -135,7 +135,7 @@ export function updatesManager( context, next ) {
 				siteSlug,
 				scheduleId,
 				context: 'edit',
-				onNavBack: () => page.redirect( `/plugins/scheduled-updates/${ siteSlug }` ),
+				onNavBack: () => page.show( `/plugins/scheduled-updates/${ siteSlug }` ),
 			} );
 			break;
 
@@ -144,10 +144,9 @@ export function updatesManager( context, next ) {
 			context.primary = createElement( PluginsUpdateManager, {
 				siteSlug,
 				context: 'list',
-				onCreateNewSchedule: () =>
-					page.redirect( `/plugins/scheduled-updates/create/${ siteSlug }` ),
+				onCreateNewSchedule: () => page.show( `/plugins/scheduled-updates/create/${ siteSlug }` ),
 				onEditSchedule: ( id ) =>
-					page.redirect( `/plugins/scheduled-updates/edit/${ siteSlug }/${ id }` ),
+					page.show( `/plugins/scheduled-updates/edit/${ siteSlug }/${ id }` ),
 			} );
 			break;
 	}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88544

## Proposed Changes

* Replaces `page.redirect` with `page.show`. `page.redirect` replaces the history entry instead of pushing a new one.

## Testing Instructions

1. Apply this PR
2. Click around, test the back button
3. Check for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?