### PR TITLE
Pattern Library: Fix `useCx` error in SSR

### DIFF
--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { useLocale, addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import styled from '@emotion/styled';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -25,6 +26,10 @@ import ImgGrid from './images/grid.svg';
 import ImgStar from './images/star.svg';
 
 import './style.scss';
+
+// We use this unstyled Emotion component simply to prevent errors related to the use of Emotion's
+// `useCx` hook in `ToggleGroupControl`
+const PatternsCategoryPageBody = styled.div``;
 
 function filterPatternsByType( patterns: Pattern[], type: PatternTypeFilter ) {
 	return patterns.filter( ( pattern ) => {
@@ -121,7 +126,7 @@ export const PatternsCategoryPage = ( {
 				</div>
 			) }
 
-			<div className="patterns-page-category">
+			<PatternsCategoryPageBody className="patterns-page-category">
 				<div className="patterns-page-category__header">
 					<h1 className="patterns-page-category__title">Patterns</h1>
 
@@ -168,7 +173,7 @@ export const PatternsCategoryPage = ( {
 				</div>
 
 				<PatternGallery patterns={ patterns } isGridView={ isGridView } />
-			</div>
+			</PatternsCategoryPageBody>
 
 			<PatternsGetStarted />
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Previously, when requesting e.g. `/fr/patterns/about`, we would get the following error in the terminal:

```
Error: The `useCx` hook should be only used within a valid Emotion Cache Context
```

This PR fixes that by wrapping the `ToggleGroupControl` component in an unstyled Emotion component. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply this PR locally and **RESTART Calypso** once you've done so
2. Open an incognito window
3. Request `/fr/patterns/about`
4. Ensure that you don't see any error in you terminal
