### PR TITLE
A4A: Color styles tweaks

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -5,7 +5,20 @@
 	--a4a-corners-soft: 4px;
 
 	// FIXME: Remove this when we have a proper color scheme
-	--studio-a8c-50: #029cd7;
+	--studio-automattic-0: #ebf4fa;
+	--studio-automattic-5: #c4e2f5;
+	--studio-automattic-10: #88ccf2;
+	--studio-automattic-20: #5ab7e8;
+	--studio-automattic-30: #24a3e0;
+	--studio-automattic-40: #1490c7;
+	--studio-automattic-50: #0277a8;
+	--studio-automattic-60: #036085;
+	--studio-automattic-70: #02506e;
+	--studio-automattic-80: #02384d;
+	--studio-automattic-90: #022836;
+	--studio-automattic-100: #021b24;
+	--studio-automattic: #24a3e0;
+
 	--color-surface-backdrop: #021a23;
 
 	--color-sidebar-background: #021a23;
@@ -24,15 +37,17 @@
 	--color-scary-60: var(--studio-red-60);
 	--color-scary-70: var(--studio-red-70);
 
-	--color-accent: #0088bf;
-	--color-accent-60: #0088bf;
-	--color-accent-70: #006089;
+	--color-primary: var(--studio-automattic-60);
+	--color-primary-40: var(--studio-automattic-40);
+	--color-accent: var(--studio-automattic-60);
+	--color-accent-60: var(--studio-automattic-60);
+	--color-accent-70: var(--studio-automattic-70);
 }
 
 .theme-a8c-for-agencies {
 	.button.is-primary {
-		background-color: var(--studio-a8c-50);
-		border-color: var(--studio-a8c-50);
+		background-color: var(--studio-automattic-60);
+		border-color: var(--studio-automattic-60);
 	}
 
 	.button.is-borderless:focus,
@@ -42,25 +57,25 @@
 	}
 
 	.components-form-toggle.is-checked .components-form-toggle__track {
-		background-color: var(--studio-a8c-50);
-		border-color: var(--studio-a8c-50);
+		background-color: var(--studio-automattic-60);
+		border-color: var(--studio-automattic-60);
 	}
 
 	.components-checkbox-control__input[type="checkbox"]:checked,
 	.components-checkbox-control__input[type="checkbox"]:indeterminate {
-		background: var(--studio-a8c-50);
-		border-color: var(--studio-a8c-50);
+		background: var(--studio-automattic-60);
+		border-color: var(--studio-automattic-60);
 	}
 
 	.components-button.is-tertiary {
-		color: var(--studio-a8c-50);
+		color: var(--studio-automattic-60);
 	}
 
 	.button.is-borderless.is-primary.is-active,
 	.button.is-borderless.is-primary:active,
 	.button.is-borderless.is-primary:focus,
 	.button.is-borderless.is-primary:hover {
-		color: var(--studio-a8c-50);
+		color: var(--studio-automattic-60);
 	}
 
 	// Masterbar
@@ -185,7 +200,7 @@ html {
 
 .button.is-primary:hover,
 .button.is-primary:focus {
-	background-color: var(--color-accent-70);
-	border-color: var(--color-accent-70);
+	background-color: var(--studio-automattic-70);
+	border-color: var(--studio-automattic-70);
 	color: var(--color-text-inverted);
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -35,6 +35,12 @@
 		border-color: var(--studio-a8c-50);
 	}
 
+	.button.is-borderless:focus,
+	.button.is-borderless:hover,
+	.button.is-borderless {
+		background: none;
+	}
+
 	.components-form-toggle.is-checked .components-form-toggle__track {
 		background-color: var(--studio-a8c-50);
 		border-color: var(--studio-a8c-50);
@@ -47,6 +53,13 @@
 	}
 
 	.components-button.is-tertiary {
+		color: var(--studio-a8c-50);
+	}
+
+	.button.is-borderless.is-primary.is-active,
+	.button.is-borderless.is-primary:active,
+	.button.is-borderless.is-primary:focus,
+	.button.is-borderless.is-primary:hover {
 		color: var(--studio-a8c-50);
 	}
 

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -5,7 +5,7 @@
 	--a4a-corners-soft: 4px;
 
 	// FIXME: Remove this when we have a proper color scheme
-	--studio-a8c-20: #029cd7;
+	--studio-a8c-50: #029cd7;
 	--color-surface-backdrop: #021a23;
 
 	--color-sidebar-background: #021a23;
@@ -31,23 +31,23 @@
 
 .theme-a8c-for-agencies {
 	.button.is-primary {
-		background-color: var(--studio-a8c-20);
-		border-color: var(--studio-a8c-20);
+		background-color: var(--studio-a8c-50);
+		border-color: var(--studio-a8c-50);
 	}
 
 	.components-form-toggle.is-checked .components-form-toggle__track {
-		background-color: var(--studio-a8c-20);
-		border-color: var(--studio-a8c-20);
+		background-color: var(--studio-a8c-50);
+		border-color: var(--studio-a8c-50);
 	}
 
 	.components-checkbox-control__input[type="checkbox"]:checked,
 	.components-checkbox-control__input[type="checkbox"]:indeterminate {
-		background: var(--studio-a8c-20);
-		border-color: var(--studio-a8c-20);
+		background: var(--studio-a8c-50);
+		border-color: var(--studio-a8c-50);
 	}
 
 	.components-button.is-tertiary {
-		color: var(--studio-a8c-20);
+		color: var(--studio-a8c-50);
 	}
 
 	// Masterbar

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-import SitePreviewPaneContent from './site-preview-pane-content';
 import SitePreviewPaneHeader from './site-preview-pane-header';
 import SitePreviewPaneTabs from './site-preview-pane-tabs';
 import { FeaturePreviewInterface, SitePreviewPaneProps } from './types';
@@ -54,7 +53,7 @@ export default function SitePreviewPane( {
 		<div className={ classNames( 'site-preview__pane', className ) }>
 			<SitePreviewPaneHeader site={ site } closeSitePreviewPane={ closeSitePreviewPane } />
 			<SitePreviewPaneTabs featureTabs={ featureTabs } />
-			<SitePreviewPaneContent>{ selectedFeature.preview }</SitePreviewPaneContent>
+			{ selectedFeature.preview }
 		</div>
 	);
 }


### PR DESCRIPTION
Resolve: https://github.com/Automattic/automattic-for-agencies-dev/issues/85

## Proposed Changes

A quick CSS style tweaks.

## Testing Instructions

- N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
