### PR TITLE
Settings: Fix the "Invalid site Specified" error

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -31,7 +31,7 @@ import {
 	getSiteSettings,
 } from 'calypso/state/site-settings/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const debug = debugFactory( 'calypso:site-settings' );
 
@@ -352,6 +352,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 	const connectComponent = connect(
 		( state, { fields } ) => {
 			const siteId = getSelectedSiteId( state );
+			const siteSlug = getSelectedSiteSlug( state );
 			let isSavingSettings = isSavingSiteSettings( state, siteId );
 			const isSaveRequestSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
 			let settings = getSiteSettings( state, siteId );
@@ -407,6 +408,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 				settings,
 				settingsFields,
 				siteId,
+				siteSlug,
 				saveInstantSearchRequest,
 			};
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/82856

## Proposed Changes

It fixes the "Invalid site Specified" error on settings pages by passing the `siteSlug` prop to the `WrappedSettingsForm` component.

## Testing Instructions

1. Open the Browser Dev Tools Console
2. Navigate through different settings pages making sure there is no "Invalid site Specified" error in the Console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?