### PR TITLE
Untangle: update several command palette links for classic view sites

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -43,13 +43,18 @@ import {
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import wpcom from 'calypso/lib/wp';
 import { useOpenPhpMyAdmin } from 'calypso/my-sites/hosting/phpmyadmin-card';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { clearWordPressCache } from 'calypso/state/hosting/actions';
 import { createNotice, removeNotice } from 'calypso/state/notices/actions';
 import { NoticeStatus } from 'calypso/state/notices/types';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { generateSiteInterfaceLink, isCustomDomain, isNotAtomicJetpack, isP2Site } from '../utils';
+import {
+	generateSiteInterfaceLink,
+	isCustomDomain,
+	isNotAtomicJetpack,
+	isP2Site,
+	siteUsesWpAdminInterface,
+} from '../utils';
 import type {
 	Command,
 	CommandCallBackParams,
@@ -280,10 +285,6 @@ export const useCommandsArrayWpcom = ( {
 		'disable-gpt': 'true',
 		'source-command-palette': 'true',
 	} ).toString() }`;
-
-	const isAtomic = useSelector( ( state ) => {
-		return ( siteId: number ) => isSiteWpcomAtomic( state, siteId );
-	} );
 
 	const commands: Command[] = [
 		{
@@ -689,7 +690,13 @@ export const useCommandsArrayWpcom = ( {
 			label: __( 'Open Jetpack Stats' ),
 			callback: setStateCallback( 'openJetpackStats', __( 'Select site to open Jetpack Stats' ) ),
 			siteFunctions: {
-				onClick: ( param ) => commandNavigation( `/stats/${ param.site.slug }` )( param ),
+				onClick: ( param ) => {
+					const link = generateSiteInterfaceLink( param.site, {
+						calypso: '/stats',
+						wpAdmin: '/admin.php?page=stats',
+					} );
+					commandNavigation( link )( param );
+				},
 			},
 			icon: statsIcon,
 		},
@@ -703,7 +710,12 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'openActivityLog', __( 'Select site to open activity log' ) ),
 			siteFunctions: {
-				onClick: ( param ) => commandNavigation( `/activity-log/${ param.site.slug }` )( param ),
+				onClick: ( param ) =>
+					commandNavigation(
+						`${
+							siteUsesWpAdminInterface( param.site ) ? 'https://cloud.jetpack.com' : ''
+						}/activity-log/${ param.site.slug }`
+					)( param ),
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
 				filterNotice: __( 'Only listing sites hosted on WordPress.com.' ),
 			},
@@ -717,9 +729,9 @@ export const useCommandsArrayWpcom = ( {
 				capabilityFilter: SiteCapabilities.MANAGE_OPTIONS,
 				onClick: ( param ) =>
 					commandNavigation(
-						`${ isAtomic( param.site.ID ) ? 'https://cloud.jetpack.com' : '' }/backup/${
-							param.site.slug
-						}`
+						`${
+							siteUsesWpAdminInterface( param.site ) ? 'https://cloud.jetpack.com' : ''
+						}/backup/${ param.site.slug }`
 					)( param ),
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
 				filterNotice: __( 'Only listing sites with Jetpack Backup enabled.' ),
@@ -1338,8 +1350,13 @@ export const useCommandsArrayWpcom = ( {
 			),
 			siteFunctions: {
 				capabilityFilter: SiteCapabilities.MANAGE_OPTIONS,
-				onClick: ( param ) =>
-					commandNavigation( `/settings/newsletter/${ param.site.slug }` )( param ),
+				onClick: ( param ) => {
+					const link = generateSiteInterfaceLink( param.site, {
+						calypso: '/settings/newsletter',
+						wpAdmin: '/admin.php?page=jetpack#/newsletter',
+					} );
+					commandNavigation( link )( param );
+				},
 			},
 			icon: settingsIcon,
 		},

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -713,8 +713,10 @@ export const useCommandsArrayWpcom = ( {
 				onClick: ( param ) =>
 					commandNavigation(
 						`${
-							siteUsesWpAdminInterface( param.site ) ? 'https://cloud.jetpack.com' : ''
-						}/activity-log/${ param.site.slug }`
+							siteUsesWpAdminInterface( param.site )
+								? 'https://jetpack.com/redirect/?source=calypso-activity-log&site='
+								: '/activity-log/'
+						}${ param.site.slug }`
 					)( param ),
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
 				filterNotice: __( 'Only listing sites hosted on WordPress.com.' ),
@@ -730,8 +732,10 @@ export const useCommandsArrayWpcom = ( {
 				onClick: ( param ) =>
 					commandNavigation(
 						`${
-							siteUsesWpAdminInterface( param.site ) ? 'https://cloud.jetpack.com' : ''
-						}/backup/${ param.site.slug }`
+							siteUsesWpAdminInterface( param.site )
+								? 'https://jetpack.com/redirect/?source=calypso-backups&site='
+								: '/backup/'
+						}${ param.site.slug }`
 					)( param ),
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
 				filterNotice: __( 'Only listing sites with Jetpack Backup enabled.' ),

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -82,6 +82,10 @@ export const siteDefaultInterface = ( site: SiteExcerptNetworkData ) => {
 	return site?.options?.wpcom_admin_interface;
 };
 
+export const siteUsesWpAdminInterface = ( site: SiteExcerptNetworkData ) => {
+	return ( site.jetpack && ! site.is_wpcom_atomic ) || siteDefaultInterface( site ) === 'wp-admin';
+};
+
 export interface InterfaceURLFragment {
 	calypso: `/${ string }`;
 	wpAdmin: `/${ string }`;
@@ -91,10 +95,7 @@ export const generateSiteInterfaceLink = (
 	site: SiteExcerptData,
 	urlFragment: InterfaceURLFragment
 ) => {
-	const isWpAdminDefault =
-		( site.jetpack && ! site.is_wpcom_atomic ) || siteDefaultInterface( site ) === 'wp-admin';
-
-	const targetLink = isWpAdminDefault
+	const targetLink = siteUsesWpAdminInterface( site )
 		? `${ site.URL }/wp-admin${ urlFragment.wpAdmin }`
 		: `${ urlFragment.calypso }/${ site.slug }`;
 

--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -499,7 +499,9 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'openJetpackStats',
 			label: __( 'Open Jetpack Stats', __i18n_text_domain__ ),
-			callback: commandNavigation( '/stats/:site' ),
+			callback: commandNavigation(
+				shouldUseWpAdmin ? '/wp-admin/admin.php?page=stats' : '/stats/:site'
+			),
 			icon: statsIcon,
 		},
 		{
@@ -518,7 +520,9 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				),
 				_x( 'audit log', 'Keyword for the Open activity log command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			callback: commandNavigation( '/activity-log/:site' ),
+			callback: commandNavigation(
+				`${ shouldUseWpAdmin ? 'https://cloud.jetpack.com' : '' }/activity-log/:site`
+			),
 			filterP2: true,
 			icon: acitvityLogIcon,
 		},
@@ -526,7 +530,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			name: 'openJetpackBackup',
 			label: __( 'Open Jetpack Backup', __i18n_text_domain__ ),
 			callback: commandNavigation(
-				`${ siteType === SiteType.ATOMIC ? 'https://cloud.jetpack.com' : '' }/backup/:site`
+				`${ shouldUseWpAdmin ? 'https://cloud.jetpack.com' : '' }/backup/:site`
 			),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			filterP2: true,
@@ -935,7 +939,11 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			name: 'manageSettingsNewsletter',
 			label: __( 'Manage newsletter settings', __i18n_text_domain__ ),
 			context: [ '/wp-admin/options-' ],
-			callback: commandNavigation( '/settings/newsletter/:site' ),
+			callback: commandNavigation(
+				shouldUseWpAdmin
+					? '/wp-admin/admin.php?page=jetpack#/newsletter'
+					: '/settings/newsletter/:site'
+			),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			icon: settingsIcon,
 		},

--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -521,7 +521,11 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'audit log', 'Keyword for the Open activity log command', __i18n_text_domain__ ),
 			].join( ' ' ),
 			callback: commandNavigation(
-				`${ shouldUseWpAdmin ? 'https://cloud.jetpack.com' : '' }/activity-log/:site`
+				`${
+					shouldUseWpAdmin
+						? 'https://jetpack.com/redirect/?source=calypso-activity-log&site='
+						: '/activity-log/'
+				}:site`
 			),
 			filterP2: true,
 			icon: acitvityLogIcon,
@@ -530,7 +534,11 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			name: 'openJetpackBackup',
 			label: __( 'Open Jetpack Backup', __i18n_text_domain__ ),
 			callback: commandNavigation(
-				`${ shouldUseWpAdmin ? 'https://cloud.jetpack.com' : '' }/backup/:site`
+				`${
+					shouldUseWpAdmin
+						? 'https://jetpack.com/redirect/?source=calypso-backups&site='
+						: '/backup/'
+				}:site`
 			),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			filterP2: true,


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5733

## Proposed Changes

This PR updates the links of the following commands so that they respect the admin interface style.

|Command|Default style|Classic style|
|-|-|-|
|Manage newsletter settings|`/settings/newsletter/:site`|`/wp-admin/admin.php?page=jetpack#/newsletter`|
|Open Jetpack Stats|`/stats/:site`|`/wp-admin/admin.php?page=stats`|


|Command|Default style<br>OR<br>Classic style without early access option|Classic style with early access option|
|-|-|-|
|Open activity log|`/activity-log/:site`|`cloud.jetpack.com/activity-log/:site`|
|Open Jetpack Backup|`/backup/:site`|`cloud.jetpack.com/backup/:site`|

## Testing Instructions

This command palette can be run in two places: Calypso and wp-admin.

### Testing in Calypso

1. Use the Calypso Live URL.
2. Go to `/home/:site` of a Simple site or Atomic site with admin interface set to Default style.
3. Test the scenario in the above table.
4. Repeat with an Atomic site with admin interface set to Classic style and NOT included in the early release*.
4. Repeat with an Atomic site with admin interface set to Classic style and included in the early release*.

### Testing in wp-admin

1. Sandbox `widgets.wp.com`.
2. Go to your sandbox.
3. Run: ` install-plugin.sh command-palette untangle/cmd-palette`.
4. Go to `/wp-admin` of a Simple site or Atomic site with admin interface set to Default style.
5. Test the scenario in the above table.
6. Repeat with an Atomic site with admin interface set to Classic style and NOT included in the early release*.
4. Repeat with an Atomic site with admin interface set to Classic style and included in the early release*.

* to include an Atomic site in an early release list:

1. Go to `site.com/_cli`
2. Run `wp option update wpcom_classic_early_release 1`
---

### Notes

This PR modifies the behavior introduced by @okmttdhr's PR:

- https://github.com/Automattic/wp-calypso/pull/88018

so that it opens Jetpack Cloud only if the site uses classic view. I think this is the correct intended behavior, as for now we want to "untangle" Jetpack from Calypso when the admin interface is set to classic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?