### PR TITLE
Pattern Library: Add "Copy pattern" buttons

### DIFF
--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -68,7 +68,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 								>
 									<div className="patterns-category-gallery__item-preview-inner">
 										<PatternPreview
-											isCategoryPreview
+											className="pattern-preview--category-gallery"
 											pattern={
 												patternTypeFilter === PatternTypeFilter.PAGES
 													? category.pagePreviewPattern

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -28,11 +28,14 @@ export const PatternGalleryClient: PatternGalleryFC = ( { isGridView, patterns =
 				<div
 					className={ classNames( 'pattern-gallery', {
 						'pattern-gallery--grid': isGridView,
-						'pattern-gallery--list': ! isGridView,
 					} ) }
 				>
 					{ patterns.map( ( pattern ) => (
 						<PatternPreview
+							className={ classNames( {
+								'pattern-preview--grid': isGridView,
+								'pattern-preview--list': ! isGridView,
+							} ) }
 							key={ pattern.ID }
 							pattern={ pattern }
 							viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -6,11 +6,16 @@ import {
 	PatternPreview,
 } from 'calypso/my-sites/patterns/components/pattern-preview';
 import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/controller';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
+const LOGGED_OUT_USERS_CAN_COPY_COUNT = 3;
+
 export const PatternGalleryClient: PatternGalleryFC = ( { isGridView, patterns = [] } ) => {
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const patternIdsByCategory = {
 		first: patterns.map( ( { ID } ) => `${ ID }` ) ?? [],
 	};
@@ -30,8 +35,9 @@ export const PatternGalleryClient: PatternGalleryFC = ( { isGridView, patterns =
 						'pattern-gallery--grid': isGridView,
 					} ) }
 				>
-					{ patterns.map( ( pattern ) => (
+					{ patterns.map( ( pattern, i ) => (
 						<PatternPreview
+							canCopy={ isLoggedIn || i < LOGGED_OUT_USERS_CAN_COPY_COUNT }
 							className={ classNames( {
 								'pattern-preview--grid': isGridView,
 								'pattern-preview--list': ! isGridView,

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -25,7 +25,12 @@ export const PatternGalleryClient: PatternGalleryFC = ( { isGridView, patterns =
 				shouldShufflePosts={ false }
 				siteId={ RENDERER_SITE_ID }
 			>
-				<div className={ classNames( 'pattern-gallery', { 'pattern-gallery--grid': isGridView } ) }>
+				<div
+					className={ classNames( 'pattern-gallery', {
+						'pattern-gallery--grid': isGridView,
+						'pattern-gallery--list': ! isGridView,
+					} ) }
+				>
 					{ patterns.map( ( pattern ) => (
 						<PatternPreview
 							key={ pattern.ID }

--- a/client/my-sites/patterns/components/pattern-gallery/server.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/server.tsx
@@ -6,7 +6,12 @@ import './style.scss';
 
 export const PatternGalleryServer: PatternGalleryFC = ( { isGridView, patterns = [] } ) => {
 	return (
-		<div className={ classNames( 'pattern-gallery', { 'pattern-gallery--grid': isGridView } ) }>
+		<div
+			className={ classNames( 'pattern-gallery', {
+				'pattern-gallery--grid': isGridView,
+				'pattern-gallery--list': ! isGridView,
+			} ) }
+		>
 			{ patterns?.map( ( pattern ) => (
 				<PatternPreviewPlaceholder key={ pattern.ID } pattern={ pattern } />
 			) ) }

--- a/client/my-sites/patterns/components/pattern-gallery/server.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/server.tsx
@@ -9,11 +9,17 @@ export const PatternGalleryServer: PatternGalleryFC = ( { isGridView, patterns =
 		<div
 			className={ classNames( 'pattern-gallery', {
 				'pattern-gallery--grid': isGridView,
-				'pattern-gallery--list': ! isGridView,
 			} ) }
 		>
 			{ patterns?.map( ( pattern ) => (
-				<PatternPreviewPlaceholder key={ pattern.ID } pattern={ pattern } />
+				<PatternPreviewPlaceholder
+					className={ classNames( {
+						'pattern-preview--grid': isGridView,
+						'pattern-preview--list': ! isGridView,
+					} ) }
+					key={ pattern.ID }
+					pattern={ pattern }
+				/>
 			) ) }
 		</div>
 	);

--- a/client/my-sites/patterns/components/pattern-gallery/style.scss
+++ b/client/my-sites/patterns/components/pattern-gallery/style.scss
@@ -1,8 +1,8 @@
 .pattern-gallery {
 	display: grid;
+	gap: 48px;
 }
-
 .pattern-gallery--grid {
-	gap: 24px;
+	gap: 32px 24px;
 	grid-template-columns: repeat(3, 1fr);
 }

--- a/client/my-sites/patterns/components/pattern-gallery/style.scss
+++ b/client/my-sites/patterns/components/pattern-gallery/style.scss
@@ -3,6 +3,6 @@
 	gap: 48px;
 }
 .pattern-gallery--grid {
-	gap: 32px 24px;
+	gap: 16px 24px;
 	grid-template-columns: repeat(3, 1fr);
 }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -79,14 +79,13 @@ export function PatternPreview( {
 
 				{ canCopy && (
 					<ClipboardButton
-						borderless={ ! isPreviewLarge }
 						className="pattern-preview__copy"
 						onCopy={ () => {
 							setIsCopied( true );
 						} }
 						text={ pattern?.html ?? '' }
-						primary={ isPreviewLarge }
-						transparent={ ! isPreviewLarge }
+						primary
+						transparent={ ! canCopy }
 					>
 						{ copyButtonText }
 					</ClipboardButton>

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -1,6 +1,8 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
+import { Button } from '@automattic/components';
 import { useResizeObserver } from '@wordpress/compose';
+import { Icon, lock } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
@@ -14,16 +16,29 @@ export const ASPECT_RATIO = 7 / 4;
 
 type PatternPreviewProps = {
 	className?: string;
+	canCopy?: boolean;
 	pattern: Pattern | null;
 	viewportWidth?: number;
 };
 
-export function PatternPreview( { className, pattern, viewportWidth }: PatternPreviewProps ) {
+export function PatternPreview( {
+	className,
+	canCopy = true,
+	pattern,
+	viewportWidth,
+}: PatternPreviewProps ) {
 	const [ isCopied, setIsCopied ] = useState( false );
 	const { renderedPatterns } = usePatternsRendererContext();
 	const patternId = encodePatternId( pattern?.ID ?? 0 );
 	const renderedPattern = renderedPatterns[ patternId ];
 	const [ resizeObserver, nodeSize ] = useResizeObserver();
+
+	const isPreviewLarge = nodeSize?.width ? nodeSize.width > 960 : true;
+	let copyButtonText = isPreviewLarge ? 'Copy pattern' : 'Copy';
+
+	if ( isCopied ) {
+		copyButtonText = isPreviewLarge ? 'Pattern copied!' : 'Copied';
+	}
 
 	useEffect( () => {
 		if ( ! isCopied ) {
@@ -62,28 +77,26 @@ export function PatternPreview( { className, pattern, viewportWidth }: PatternPr
 			<div className="pattern-preview__header">
 				<div className="pattern-preview__title">{ pattern.title }</div>
 
-				<ClipboardButton
-					className="pattern-preview__copy pattern-preview__copy--large"
-					onCopy={ () => {
-						setIsCopied( true );
-					} }
-					primary
-					text={ pattern?.html ?? '' }
-				>
-					{ isCopied ? 'Pattern copied!' : 'Copy pattern' }
-				</ClipboardButton>
+				{ canCopy && (
+					<ClipboardButton
+						borderless={ ! isPreviewLarge }
+						className="pattern-preview__copy"
+						onCopy={ () => {
+							setIsCopied( true );
+						} }
+						text={ pattern?.html ?? '' }
+						primary={ isPreviewLarge }
+						transparent={ ! isPreviewLarge }
+					>
+						{ copyButtonText }
+					</ClipboardButton>
+				) }
 
-				<ClipboardButton
-					borderless
-					className="pattern-preview__copy pattern-preview__copy--small"
-					onCopy={ () => {
-						setIsCopied( true );
-					} }
-					text={ pattern?.html ?? '' }
-					transparent
-				>
-					{ isCopied ? 'Copied' : 'Copy' }
-				</ClipboardButton>
+				{ ! canCopy && (
+					<Button className="pattern-preview__get-access" borderless transparent>
+						<Icon height={ 18 } icon={ lock } width={ 18 } /> Get access
+					</Button>
+				) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -2,6 +2,8 @@ import { PatternRenderer } from '@automattic/block-renderer';
 import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import { useResizeObserver } from '@wordpress/compose';
 import classNames from 'classnames';
+import { useEffect, useState } from 'react';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
 import type { Pattern } from 'calypso/my-sites/patterns/types';
 
@@ -21,10 +23,25 @@ export function PatternPreview( {
 	pattern,
 	viewportWidth,
 }: PatternPreviewProps ) {
+	const [ isCopied, setIsCopied ] = useState( false );
 	const { renderedPatterns } = usePatternsRendererContext();
 	const patternId = encodePatternId( pattern?.ID ?? 0 );
 	const renderedPattern = renderedPatterns[ patternId ];
 	const [ resizeObserver, nodeSize ] = useResizeObserver();
+
+	useEffect( () => {
+		if ( ! isCopied ) {
+			return;
+		}
+
+		const timeoutId = setTimeout( () => {
+			setIsCopied( false );
+		}, 3500 );
+
+		return () => {
+			clearTimeout( timeoutId );
+		};
+	}, [ isCopied ] );
 
 	if ( ! pattern ) {
 		return null;
@@ -33,7 +50,7 @@ export function PatternPreview( {
 	return (
 		<div
 			className={ classNames( 'pattern-preview', {
-				'pattern-preview_category-gallery': isCategoryPreview,
+				'pattern-preview--category-gallery': isCategoryPreview,
 				'is-loading': ! renderedPattern,
 			} ) }
 		>
@@ -47,7 +64,32 @@ export function PatternPreview( {
 				/>
 			</div>
 
-			<div className="pattern-preview__title">{ pattern.title }</div>
+			<div className="pattern-preview__header">
+				<div className="pattern-preview__title">{ pattern.title }</div>
+
+				<ClipboardButton
+					className="pattern-preview__copy pattern-preview__copy--list"
+					onCopy={ () => {
+						setIsCopied( true );
+					} }
+					primary
+					text={ pattern?.html ?? '' }
+				>
+					{ isCopied ? 'Pattern copied!' : 'Copy pattern' }
+				</ClipboardButton>
+
+				<ClipboardButton
+					borderless
+					className="pattern-preview__copy pattern-preview__copy--grid"
+					onCopy={ () => {
+						setIsCopied( true );
+					} }
+					text={ pattern?.html ?? '' }
+					transparent
+				>
+					{ isCopied ? 'Copied' : 'Copy' }
+				</ClipboardButton>
+			</div>
 		</div>
 	);
 }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -85,14 +85,13 @@ export function PatternPreview( {
 						} }
 						text={ pattern?.html ?? '' }
 						primary
-						transparent={ ! canCopy }
 					>
 						{ copyButtonText }
 					</ClipboardButton>
 				) }
 
 				{ ! canCopy && (
-					<Button className="pattern-preview__get-access" borderless transparent>
+					<Button className="pattern-preview__get-access" transparent>
 						<Icon height={ 18 } icon={ lock } width={ 18 } /> Get access
 					</Button>
 				) }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -47,7 +47,7 @@ export function PatternPreview( {
 
 		const timeoutId = setTimeout( () => {
 			setIsCopied( false );
-		}, 3500 );
+		}, 4500 );
 
 		return () => {
 			clearTimeout( timeoutId );

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -13,16 +13,12 @@ export const DESKTOP_VIEWPORT_WIDTH = 1200;
 export const ASPECT_RATIO = 7 / 4;
 
 type PatternPreviewProps = {
-	isCategoryPreview?: boolean;
+	className?: string;
 	pattern: Pattern | null;
 	viewportWidth?: number;
 };
 
-export function PatternPreview( {
-	isCategoryPreview,
-	pattern,
-	viewportWidth,
-}: PatternPreviewProps ) {
+export function PatternPreview( { className, pattern, viewportWidth }: PatternPreviewProps ) {
 	const [ isCopied, setIsCopied ] = useState( false );
 	const { renderedPatterns } = usePatternsRendererContext();
 	const patternId = encodePatternId( pattern?.ID ?? 0 );
@@ -49,8 +45,7 @@ export function PatternPreview( {
 
 	return (
 		<div
-			className={ classNames( 'pattern-preview', {
-				'pattern-preview--category-gallery': isCategoryPreview,
+			className={ classNames( 'pattern-preview', className, {
 				'is-loading': ! renderedPattern,
 			} ) }
 		>
@@ -68,7 +63,7 @@ export function PatternPreview( {
 				<div className="pattern-preview__title">{ pattern.title }</div>
 
 				<ClipboardButton
-					className="pattern-preview__copy pattern-preview__copy--list"
+					className="pattern-preview__copy pattern-preview__copy--large"
 					onCopy={ () => {
 						setIsCopied( true );
 					} }
@@ -80,7 +75,7 @@ export function PatternPreview( {
 
 				<ClipboardButton
 					borderless
-					className="pattern-preview__copy pattern-preview__copy--grid"
+					className="pattern-preview__copy pattern-preview__copy--small"
 					onCopy={ () => {
 						setIsCopied( true );
 					} }

--- a/client/my-sites/patterns/components/pattern-preview/placeholder.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/placeholder.tsx
@@ -8,7 +8,10 @@ export function PatternPreviewPlaceholder( { pattern }: PatternPreviewPlaceholde
 	return (
 		<div className="pattern-preview is-loading">
 			<div className="pattern-preview__renderer" />
-			<div className="pattern-preview__title">{ pattern?.title }</div>
+
+			<div className="pattern-preview__header">
+				<div className="pattern-preview__title">{ pattern?.title }</div>
+			</div>
 		</div>
 	);
 }

--- a/client/my-sites/patterns/components/pattern-preview/placeholder.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/placeholder.tsx
@@ -1,12 +1,19 @@
+import classNames from 'classnames';
 import type { Pattern } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
-type PatternPreviewPlaceholderProps = { pattern: Pattern | null };
+type PatternPreviewPlaceholderProps = {
+	className?: string;
+	pattern: Pattern | null;
+};
 
-export function PatternPreviewPlaceholder( { pattern }: PatternPreviewPlaceholderProps ) {
+export function PatternPreviewPlaceholder( {
+	className,
+	pattern,
+}: PatternPreviewPlaceholderProps ) {
 	return (
-		<div className="pattern-preview is-loading">
+		<div className={ classNames( 'pattern-preview is-loading', className ) }>
 			<div className="pattern-preview__renderer" />
 
 			<div className="pattern-preview__header">

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -1,9 +1,19 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@automattic/components/src/styles/typography";
+
 .pattern-preview {
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
 	justify-content: space-between;
 	position: relative;
+
+	.pattern-gallery--list & {
+		@include break-huge {
+			flex-direction: column-reverse;
+		}
+	}
 
 	.pattern-preview__renderer {
 		background: var(--color-surface);
@@ -18,18 +28,81 @@
 		aspect-ratio: 7 / 4;
 	}
 
-	.pattern-preview__title {
-		min-height: 3rem;
+	.pattern-preview__header {
+		align-items: center;
+		color: var(--Gray-Gray-100, #101517);
+		display: flex;
+		font-family: $font-sf-pro-display;
+		gap: 16px;
+		justify-content: space-between;
+		line-height: 1.3;
+	}
+
+	.pattern-gallery--list & .pattern-preview__title {
+		@include break-huge {
+			font-size: rem(20px);
+		}
+	}
+
+	.pattern-preview__copy {
+		--default-color: #3858e9;
+		--hover-color: #1d35b4;
+	}
+
+	.pattern-preview__copy--list {
+		background-color: var(--default-color);
+		border-color: var(--default-color);
+		font-size: rem(13px);
+
+		&:enabled:hover,
+		&:focus {
+			background-color: var(--hover-color);
+			border-color: var(--hover-color);
+		}
+	}
+
+	.pattern-preview__copy--grid {
+		color: var(--default-color);
+		font: inherit;
+		padding: 0;
+
+		&:enabled:hover {
+			color: var(--hover-color);
+		}
+	}
+
+	.pattern-gallery--list & .pattern-preview__copy--list {
+		display: none;
+
+		@include break-medium {
+			display: block;
+		}
+	}
+
+	.pattern-gallery--list & .pattern-preview__copy--grid {
+		display: block;
+
+		@include break-medium {
+			display: none;
+		}
+	}
+
+	.pattern-gallery--grid & .pattern-preview__copy--list {
+		display: none;
+	}
+
+	.pattern-gallery--grid & .pattern-preview__copy--grid {
+		display: block;
 	}
 }
 
-.pattern-preview_category-gallery {
+.pattern-preview--category-gallery {
 	.pattern-preview__renderer {
 		border-radius: 0;
 		box-shadow: none;
 	}
 
-	.pattern-preview__title {
+	.pattern-preview__header {
 		display: none;
 	}
 }

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -23,13 +23,19 @@
 	}
 
 	.pattern-preview__header {
-		align-items: center;
-		color: var(--Gray-Gray-100, #101517);
+		align-items: start;
 		display: flex;
 		font-family: $font-sf-pro-display;
 		gap: 16px;
 		justify-content: space-between;
 		line-height: 1.3;
+		// Account for possibility of title wrapping over two rows, in which case we want the
+		// entire `.pattern-gallery--grid` row to align correctly
+		min-height: 3rem;
+	}
+
+	.pattern-preview__title {
+		padding-top: 4px;
 	}
 
 	.pattern-preview__copy,
@@ -76,6 +82,18 @@
 }
 
 .pattern-preview--list {
+	.pattern-preview__header {
+		min-height: auto;
+	}
+
+	.pattern-preview__title {
+		padding-top: 8px;
+
+		@include break-huge {
+			font-size: rem(20px);
+		}
+	}
+
 	.pattern-preview__copy,
 	.pattern-preview__get-access {
 		padding: 8px 14px;
@@ -83,12 +101,6 @@
 
 	.pattern-preview__get-access {
 		padding-left: 12px;
-	}
-
-	.pattern-preview__title {
-		@include break-huge {
-			font-size: rem(20px);
-		}
 	}
 }
 

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -9,12 +9,6 @@
 	justify-content: space-between;
 	position: relative;
 
-	.pattern-gallery--list & {
-		@include break-huge {
-			flex-direction: column-reverse;
-		}
-	}
-
 	.pattern-preview__renderer {
 		background: var(--color-surface);
 		border-radius: 4px;
@@ -38,18 +32,12 @@
 		line-height: 1.3;
 	}
 
-	.pattern-gallery--list & .pattern-preview__title {
-		@include break-huge {
-			font-size: rem(20px);
-		}
-	}
-
 	.pattern-preview__copy {
 		--default-color: #3858e9;
 		--hover-color: #1d35b4;
 	}
 
-	.pattern-preview__copy--list {
+	.pattern-preview__copy--large {
 		background-color: var(--default-color);
 		border-color: var(--default-color);
 		font-size: rem(13px);
@@ -61,7 +49,7 @@
 		}
 	}
 
-	.pattern-preview__copy--grid {
+	.pattern-preview__copy--small {
 		color: var(--default-color);
 		font: inherit;
 		padding: 0;
@@ -70,8 +58,20 @@
 			color: var(--hover-color);
 		}
 	}
+}
 
-	.pattern-gallery--list & .pattern-preview__copy--list {
+.pattern-preview--list {
+	@include break-huge {
+		flex-direction: column-reverse;
+	}
+
+	.pattern-preview__title {
+		@include break-huge {
+			font-size: rem(20px);
+		}
+	}
+
+	.pattern-preview__copy--large {
 		display: none;
 
 		@include break-medium {
@@ -79,19 +79,21 @@
 		}
 	}
 
-	.pattern-gallery--list & .pattern-preview__copy--grid {
+	.pattern-preview__copy--small {
 		display: block;
 
 		@include break-medium {
 			display: none;
 		}
 	}
+}
 
-	.pattern-gallery--grid & .pattern-preview__copy--list {
+.pattern-preview--grid {
+	.pattern-preview__copy--large {
 		display: none;
 	}
 
-	.pattern-gallery--grid & .pattern-preview__copy--grid {
+	.pattern-preview__copy--small {
 		display: block;
 	}
 }

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -32,30 +32,41 @@
 		line-height: 1.3;
 	}
 
-	.pattern-preview__copy {
+	.pattern-preview__copy,
+	.pattern-preview__get-access {
 		--default-color: #3858e9;
 		--hover-color: #1d35b4;
-	}
 
-	.pattern-preview__copy--large {
-		background-color: var(--default-color);
-		border-color: var(--default-color);
-		font-size: rem(13px);
+		&.is-primary {
+			background-color: var(--default-color);
+			border-color: var(--default-color);
+			font-size: rem(13px);
 
-		&:enabled:hover,
-		&:focus {
-			background-color: var(--hover-color);
-			border-color: var(--hover-color);
+			&:enabled:hover,
+			&:focus {
+				background-color: var(--hover-color);
+				border-color: var(--hover-color);
+			}
+		}
+
+		&.is-borderless {
+			color: var(--default-color);
+			font: inherit;
+			padding: 0;
+
+			&:enabled:hover {
+				color: var(--hover-color);
+			}
 		}
 	}
 
-	.pattern-preview__copy--small {
-		color: var(--default-color);
-		font: inherit;
-		padding: 0;
+	.pattern-preview__get-access {
+		align-items: center;
+		display: flex;
+		gap: 4px;
 
-		&:enabled:hover {
-			color: var(--hover-color);
+		path {
+			fill: currentColor;
 		}
 	}
 }
@@ -69,32 +80,6 @@
 		@include break-huge {
 			font-size: rem(20px);
 		}
-	}
-
-	.pattern-preview__copy--large {
-		display: none;
-
-		@include break-medium {
-			display: block;
-		}
-	}
-
-	.pattern-preview__copy--small {
-		display: block;
-
-		@include break-medium {
-			display: none;
-		}
-	}
-}
-
-.pattern-preview--grid {
-	.pattern-preview__copy--large {
-		display: none;
-	}
-
-	.pattern-preview__copy--small {
-		display: block;
 	}
 }
 

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -37,33 +37,37 @@
 		--default-color: #3858e9;
 		--hover-color: #1d35b4;
 
-		&.is-primary {
-			background-color: var(--default-color);
-			border-color: var(--default-color);
-			font-size: rem(13px);
+		flex-shrink: 0;
+		font-size: rem(13px);
+		line-height: 1.6;
+		padding: 4px 8px;
+	}
 
-			&:enabled:hover,
-			&:focus {
-				background-color: var(--hover-color);
-				border-color: var(--hover-color);
-			}
-		}
+	.pattern-preview__copy {
+		background-color: var(--default-color);
+		border-color: var(--default-color);
 
-		&.is-borderless {
-			color: var(--default-color);
-			font: inherit;
-			padding: 0;
-
-			&:enabled:hover {
-				color: var(--hover-color);
-			}
+		&:enabled:hover,
+		&:focus {
+			background-color: var(--hover-color);
+			border-color: var(--hover-color);
 		}
 	}
 
 	.pattern-preview__get-access {
 		align-items: center;
+		border: 1px solid currentColor;
+		color: var(--default-color);
 		display: flex;
+		font-family: inherit;
 		gap: 4px;
+		padding-left: 5px;
+
+		&:enabled:hover,
+		&:focus {
+			border-color: currentColor;
+			color: var(--hover-color);
+		}
 
 		path {
 			fill: currentColor;
@@ -72,8 +76,13 @@
 }
 
 .pattern-preview--list {
-	@include break-huge {
-		flex-direction: column-reverse;
+	.pattern-preview__copy,
+	.pattern-preview__get-access {
+		padding: 8px 14px;
+	}
+
+	.pattern-preview__get-access {
+		padding-left: 12px;
 	}
 
 	.pattern-preview__title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5601

## Proposed Changes

This PR adds `Copy pattern` buttons to the pattern library. Logged-out users can only copy the first **three** patterns in each category. Per the mockups, on mobile and in grid view, we use a smaller version of the copy button. See BnTfb6hzKcRTb2LBtuPwKe-fi-246%3A42915

| List view | Grid view |
| - | - |
| ![list](https://github.com/Automattic/wp-calypso/assets/1101677/f7ada21e-6d8c-4a59-9c02-f8e11052dde3) | ![grid](https://github.com/Automattic/wp-calypso/assets/1101677/7c72643e-95a0-4d00-bb67-a3261aecec48) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Be logged in
2. Navigate to `/patterns/about`
3. Ensure that you see `Copy pattern` buttons for each pattern
4. Click `Copy pattern`
5. Ensure that the text changes to `Pattern copied`
6. Go to the block editor in WordPress and paste the pattern
7. Ensure that it looks as expected
8. On `/patterns/about`, switch to grid view
9. Ensure that you see smaller `Copy` buttons for each pattern
10. Open an incognito window and navigate to `/patterns/about`
11. Ensure that you see `Copy pattern` buttons for just the three first patterns
12. Ensure that the other patterns have `Get access` buttons