### PR TITLE
Pattern Library: Split search term and match them separately

### DIFF
--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -57,7 +57,7 @@ export function usePatternSearchTerm(): [ string, Dispatch< SetStateAction< stri
  * Filter patterns by looking at their titles, descriptions and category names
  */
 export function filterPatternsByTerm( patterns: Pattern[], searchTerm: string ) {
-	const lowerCaseSearchTerm = searchTerm.toLowerCase().trim();
+	const lowerCaseSearchTerms = searchTerm.toLowerCase().trim().split( /\s+/ );
 
 	return patterns.filter( ( pattern ) => {
 		const patternCategories = Object.values( pattern.categories ).map(
@@ -68,6 +68,9 @@ export function filterPatternsByTerm( patterns: Pattern[], searchTerm: string ) 
 			( x ): x is NonNullable< typeof x > => Boolean( x )
 		);
 
-		return fields.some( ( field ) => field.toLowerCase().includes( lowerCaseSearchTerm ) );
+		// If any of the fields matches all parts of the search term, return true
+		return fields.some( ( field ) =>
+			lowerCaseSearchTerms.every( ( term ) => field.toLowerCase().includes( term ) )
+		);
 	} );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to #88238

## Proposed Changes

When searching for pattern, we'd previously search for matches of the search term in its entirety. With this PR, we split the search term by whitespace and match the pieces separately.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/posts?grid=1`
2. Search for `posts grid`
3. Ensure that you get two matches