### PR TITLE
Checkout: Clarify promotional period messaging some more

### DIFF
--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -82,13 +82,21 @@ function getMessageForTermsOfServiceRecordUnknown(
 		const numberOfDays = args.subscription_pre_renew_reminder_days || 7;
 		const renewalDate = moment( args.subscription_auto_renew_date ).format( 'll' );
 
-		const nextRenewalText = translate(
-			'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. You will next be charged %(renewalPrice)s on %(renewalDate)s.',
+		const termLengthText = translate(
+			'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s.',
 			{
 				args: {
 					productName,
 					startDate,
 					endDate,
+				},
+			}
+		);
+
+		const nextRenewalText = translate(
+			'You will next be charged %(renewalPrice)s on %(renewalDate)s.',
+			{
+				args: {
 					renewalPrice,
 					renewalDate,
 				},
@@ -139,8 +147,9 @@ function getMessageForTermsOfServiceRecordUnknown(
 
 		return (
 			<>
-				{ nextRenewalText } { shouldShowEndOfPromotionText && endOfPromotionChargeText }{ ' ' }
-				{ regularPriceNoticeText } { emailNoticesText }{ ' ' }
+				{ termLengthText } { nextRenewalText }{ ' ' }
+				{ shouldShowEndOfPromotionText && endOfPromotionChargeText } { regularPriceNoticeText }{ ' ' }
+				{ emailNoticesText }{ ' ' }
 			</>
 		);
 	}

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -121,7 +121,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 		} );
 
 		const emailNoticesText = translate(
-			'You will receive email notices %(numberOfDays)d days before renewals, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+			'You will receive an email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 			{
 				args: {
 					numberOfDays,

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -141,6 +141,8 @@ function getMessageForTermsOfServiceRecordUnknown(
 			}
 		);
 
+		const taxesNotIncludedText = translate( 'Prices do not include applicable taxes.' );
+
 		const shouldShowRegularPriceNoticeText = regularPrice !== renewalPrice;
 
 		const shouldShowEndOfPromotionText =
@@ -151,7 +153,8 @@ function getMessageForTermsOfServiceRecordUnknown(
 			<>
 				{ termLengthText } { nextRenewalText }{ ' ' }
 				{ shouldShowEndOfPromotionText && endOfPromotionChargeText }{ ' ' }
-				{ shouldShowRegularPriceNoticeText && regularPriceNoticeText } { emailNoticesText }{ ' ' }
+				{ shouldShowRegularPriceNoticeText && regularPriceNoticeText } { taxesNotIncludedText }{ ' ' }
+				{ emailNoticesText }{ ' ' }
 			</>
 		);
 	}

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -143,11 +143,19 @@ function getMessageForTermsOfServiceRecordUnknown(
 
 		const taxesNotIncludedText = translate( 'Prices do not include applicable taxes.' );
 
-		const shouldShowRegularPriceNoticeText = regularPrice !== renewalPrice;
-
 		const shouldShowEndOfPromotionText =
 			args.subscription_auto_renew_date !== args.subscription_end_of_promotion_date ||
 			args.maybe_prorated_regular_renewal_price_integer !== args.renewal_price_integer;
+
+		const shouldShowRegularPriceNoticeText = ( () => {
+			if ( regularPrice === renewalPrice ) {
+				return false;
+			}
+			if ( shouldShowEndOfPromotionText && regularPrice === maybeProratedRegularPrice ) {
+				return false;
+			}
+			return true;
+		} )();
 
 		return (
 			<>

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -184,7 +184,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 	}
 
 	return translate(
-		'At the end of the promotional period your %(productName)s will renew for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+		'At the end of the promotional period your %(productName)s subscription will renew for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 		{
 			args: {
 				productName,

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -141,6 +141,8 @@ function getMessageForTermsOfServiceRecordUnknown(
 			}
 		);
 
+		const shouldShowRegularPriceNoticeText = regularPrice !== renewalPrice;
+
 		const shouldShowEndOfPromotionText =
 			args.subscription_auto_renew_date !== args.subscription_end_of_promotion_date ||
 			args.maybe_prorated_regular_renewal_price_integer !== args.renewal_price_integer;
@@ -148,8 +150,8 @@ function getMessageForTermsOfServiceRecordUnknown(
 		return (
 			<>
 				{ termLengthText } { nextRenewalText }{ ' ' }
-				{ shouldShowEndOfPromotionText && endOfPromotionChargeText } { regularPriceNoticeText }{ ' ' }
-				{ emailNoticesText }{ ' ' }
+				{ shouldShowEndOfPromotionText && endOfPromotionChargeText }{ ' ' }
+				{ shouldShowRegularPriceNoticeText && regularPriceNoticeText } { emailNoticesText }{ ' ' }
 			</>
 		);
 	}

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -83,7 +83,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 		const renewalDate = moment( args.subscription_auto_renew_date ).format( 'll' );
 
 		const nextRenewalText = translate(
-			'The promotional period for your %(productName)s lasts from %(startDate)s to %(endDate)s. You will next be charged %(renewalPrice)s on %(renewalDate)s.',
+			'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. You will next be charged %(renewalPrice)s on %(renewalDate)s.',
 			{
 				args: {
 					productName,

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -143,14 +143,30 @@ function getMessageForTermsOfServiceRecordUnknown(
 
 		const taxesNotIncludedText = translate( 'Prices do not include applicable taxes.' );
 
+		// No need to show the endOfPromotionChargeText if the price and date
+		// we are already showing as the next renewal info is the same as the
+		// end of promotion renewal info.
 		const shouldShowEndOfPromotionText =
-			args.subscription_auto_renew_date !== args.subscription_end_of_promotion_date ||
-			args.maybe_prorated_regular_renewal_price_integer !== args.renewal_price_integer;
+			// Show the endOfPromotionChargeText if the endDate differs from
+			// the renewalDate because it is about the endDate.
+			renewalDate !== endDate ||
+			// Show the endOfPromotionChargeText if the
+			// maybeProratedRegularPrice differs from the renewalPrice because
+			// it is about the maybeProratedRegularPrice.
+			renewalPrice !== maybeProratedRegularPrice;
 
 		const shouldShowRegularPriceNoticeText = ( () => {
-			if ( regularPrice === renewalPrice ) {
+			// No need to show the regularPriceNoticeText if the price we are
+			// already showing as the next renewal price is the same as the
+			// regular renewal price, as long as there is no end of promotion
+			// text to mislead the reader into thinking it referrs to all
+			// renewals.
+			if ( ! shouldShowEndOfPromotionText && regularPrice === renewalPrice ) {
 				return false;
 			}
+			// No need to show the regularPriceNoticeText if the price we are
+			// already showing as the end of promotion renewal price is the
+			// same as the regular renewal price.
 			if ( shouldShowEndOfPromotionText && regularPrice === maybeProratedRegularPrice ) {
 				return false;
 			}


### PR DESCRIPTION
## Proposed Changes

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/88328 to further clarify the "promotional period" text in the checkout footer based on the suggestions made in https://github.com/Automattic/wp-calypso/pull/88328#issuecomment-1992287741

Specifically:

- It restores the word "subscription" after the product name.
- It adjusts the wording of the "You will receive an email notification before renewal" text to be more clear.
- It hides the "Subsequent renewals will be $X" text if the renewal price for subsequent renewals is already shown.
- It adds "Prices do not include applicable taxes".

Type | Before              | After
:---:|:-------------------------:|:-------------------------:
Jetpack | <img width="563" alt="Screenshot 2024-03-15 at 1 16 52 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/625993e0-06da-4be7-a485-a96c957d3988"> | <img width="563" alt="Screenshot 2024-03-15 at 1 17 10 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/afb1dd61-48a3-4134-83f7-a9850fe47538">
Domain | <img width="570" alt="Screenshot 2024-03-15 at 4 03 24 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/ceec8862-22e6-40f7-ac22-b78e13c55218"> | <img width="545" alt="Screenshot 2024-03-15 at 4 00 04 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/b1b83ff2-f491-42eb-a947-fb09b8d280f6">
Email | <img width="557" alt="Screenshot 2024-03-15 at 1 22 34 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/2d1987fd-0152-4f88-a5de-793506273cac"> | <img width="558" alt="Screenshot 2024-03-15 at 4 00 31 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/73066902-363e-45fa-92c6-ae5d22204c0c">
Akismet | <img width="560" alt="Screenshot 2024-03-15 at 1 27 05 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/6256b35b-3711-4502-b1d1-583f6c5dfaba"> | <img width="564" alt="Screenshot 2024-03-15 at 4 12 46 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/7475140c-35dd-404b-9cd0-86a121aaa010">

## Testing Instructions

Add various types of products with promotional periods to your shopping cart; not just introductory offers but also bundled domains and products on sale. Verify that the "promotional period" messaging at the bottom of checkout makes sense for each one.

To test a promotional period with a recurring introductory offer (the "Akismet" screenshots above), follow the instructions in D140488-code