### PR TITLE
Migration: Import user update viewer/subscriber filtering

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/import-users/utils.ts
+++ b/client/blocks/importer/wordpress/import-everything/import-users/utils.ts
@@ -94,41 +94,37 @@ export const getRoleBadgeText = ( role: string | undefined ) => {
 	return text;
 };
 
-export const getRoleFilterValues = [
+export const getRoleFilterValues: { value: string[]; label: string }[] = [
 	{
-		value: 'super-admin',
+		value: [ 'super-admin' ],
 		label: translate( 'Super Admin' ),
 	},
 	{
-		value: 'administrator',
+		value: [ 'administrator' ],
 		label: translate( 'Admin' ),
 	},
 	{
-		value: 'editor',
+		value: [ 'editor' ],
 		label: translate( 'Editor' ),
 	},
 	{
-		value: 'author',
+		value: [ 'author' ],
 		label: translate( 'Author' ),
 	},
 	{
-		value: 'contributor',
+		value: [ 'contributor' ],
 		label: translate( 'Contributor' ),
 	},
 	{
-		value: 'subscriber',
-		label: translate( 'Viewer' ),
-	},
-	{
-		value: 'follower',
+		value: [ 'follower' ],
 		label: translate( 'Follower' ),
 	},
 	{
-		value: 'email-subscriber',
+		value: [ 'email-subscriber' ],
 		label: translate( 'Email subscriber' ),
 	},
 	{
-		value: 'viewer',
+		value: [ 'viewer', 'subscriber' ],
 		label: translate( 'Viewer' ),
 	},
 ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Combine viewer and subscriber role filters for consistent UI experience

<img width="805" alt="CleanShot 2024-03-15 at 11 52 20@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/489a6dbc-365d-4ae5-a92f-0f950a02f41b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/sites?hosting-flow=true` and click `Migrate a site`.
* Go through the migration flow until you reach the import user screen.
* Verify the viewer filter is working correctly. It should filter for both subscriber and viewer roles.
* Verify you can filter by searching or user roles. Try to break it with different filter combinations.
* Verify the `select all users` toggle and invitations are still working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?