### PR TITLE
Ensure cmd palette is on top

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -165,11 +165,11 @@ $z-layers: (
 		".popover.info-tooltip__container": 100300,
 		".popover.info-popover__tooltip.plugin-action__disabled-info": 100300,
 		"body .webui-popover": 100300,
-		".commands-commands-menu__overlay": 100300,
 		".fullscreen-fader": 200000,
 		".guided-tours__overlay": 200050,
 		".guided-tours__step": 201000,
 		".support-article-dialog__base.dialog__backdrop": 201001,
+		".commands-commands-menu__overlay": 201100,
 
 		".wpcom-site__global-noscript": 300000,
 

--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -165,6 +165,7 @@ $z-layers: (
 		".popover.info-tooltip__container": 100300,
 		".popover.info-popover__tooltip.plugin-action__disabled-info": 100300,
 		"body .webui-popover": 100300,
+		".commands-commands-menu__overlay": 100300,
 		".fullscreen-fader": 200000,
 		".guided-tours__overlay": 200050,
 		".guided-tours__step": 201000,

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -17,6 +17,7 @@ import {
 	useCommandPalette,
 } from './use-command-palette';
 import type { SiteExcerptData } from '@automattic/sites';
+import './style.scss';
 import '@wordpress/commands/build-style/style.css';
 
 interface CommandMenuGroupProps

--- a/packages/command-palette/src/style.scss
+++ b/packages/command-palette/src/style.scss
@@ -1,3 +1,3 @@
 .commands-command-menu__overlay {
-	z-index: z-index("root", ".dialog__backdrop");
+	z-index: z-index("root", ".commands-commands-menu__overlay");
 }

--- a/packages/command-palette/src/style.scss
+++ b/packages/command-palette/src/style.scss
@@ -1,0 +1,3 @@
+.commands-command-menu__overlay {
+	z-index: z-index("root", ".dialog__backdrop");
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88562

## Proposed Changes

Ensure the command palette is displayed on top of everything else when invoked. Currently it is displayed behind other dialogs.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Have an atomic site
 2. Go to `/github-deployments`
 3. Press "Select repository"
 4. Press ⌘+k to launch the command palette

Alternatively:
 1. Go to `/media/:siteSlug?tour=mediaBasicsTour`
 2. Wait for the tour to pop-up
 3. Press ⌘+k to launch the command palette

Before | After
-------|------
<img width="1457" alt="Screenshot 2024-03-15 at 16 07 22" src="https://github.com/Automattic/wp-calypso/assets/93301/5b5a2d33-80d7-4d02-a096-0774b525cf8e"> |<img width="1457" alt="Screenshot 2024-03-15 at 16 07 43" src="https://github.com/Automattic/wp-calypso/assets/93301/d0553ffe-e304-402c-bf8d-14208806d609">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?