### PR TITLE
e2e: Fix site editor test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
@@ -91,7 +91,10 @@ export class FullSiteEditorNavSidebarComponent {
 	 */
 	async clickNavButtonByExactText( text: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		await editorParent.getByRole( 'button', { name: text, exact: true } ).click();
+		await editorParent
+			.getByLabel( 'Navigation' )
+			.getByRole( 'button', { name: text, exact: true } )
+			.click();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

After probably wordpress/gutenberg#59317 made the editor iframe be considered a button labeled "Edit", a test started failing complaining about there being two such buttons:

```
    locator.click: Error: strict mode violation: locator('body.block-editor-page').getByRole('button', { name: 'Edit', exact: true }) resolved to 2 elements:
        1) <button type="button" aria-label="Edit" class="component…>…</button> aka getByLabel('Navigation').getByLabel('Edit')
        2) <iframe tabindex="0" role="button" aria-label="Edit" nam…></iframe> aka locator('iframe[name="editor-canvas"]')
```

This fixes it by narrowing the search to the "Navigation" section of the page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn workspace wp-e2e-tests build && JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/fse/fse__temp-smoke-test.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?