### PR TITLE
Congrats: add progress bar and auto-login to ecomm congrats page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -595,6 +595,10 @@ export class CheckoutThankYou extends Component<
 					<PlanOnlyThankYou
 						primaryPurchase={ purchases[ 0 ] }
 						isEmailVerified={ this.props.isEmailVerified }
+						transferInProgress={
+							! this.props.transferComplete || ! this.props.isWooCommerceInstalled
+						}
+						receiptId={ receiptId }
 					/>
 				);
 			} else if ( purchases.length === 1 && isSearch( purchases[ 0 ] ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -651,7 +651,7 @@ export class CheckoutThankYou extends Component<
 						<MasterbarStyled
 							onClick={ () => page( `/home/${ siteSlug ?? '' }` ) }
 							backText={ translate( 'Back to dashboard' ) }
-							canGoBack={ !! siteId }
+							canGoBack={ !! siteId && ! wasEcommercePlanPurchased }
 							showContact
 						/>
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -203,9 +203,7 @@ const PlanOnlyThankYou = ( {
 				// automatically log the user into the wp-admin.
 				isWpComEcommercePlan( primaryPurchase.productSlug ) &&
 					transferComplete &&
-					isEmailVerified && (
-						<WpAdminAutoLogin site={ { URL: `https://${ siteUrl }` } } delay={ 0 } />
-					)
+					isEmailVerified && <WpAdminAutoLogin site={ { URL: siteUrl } } delay={ 0 } />
 			}
 			<ThankYouV2
 				title={ translate( 'Get the best out of your site' ) }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -13,6 +13,7 @@ import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSiteOptions, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import TransferPending from '../../transfer-pending';
 import ThankYouPlanProduct from '../products/plan-product';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
@@ -27,6 +28,8 @@ interface PlanOnlyThankYouProps {
 	errorNotice: ( text: string, noticeOptions?: object ) => void;
 	removeNotice: ( noticeId: string ) => void;
 	successNotice: ( text: string, noticeOptions?: object ) => void;
+	transferInProgress?: boolean;
+	receiptId?: number;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {
@@ -44,6 +47,8 @@ const PlanOnlyThankYou = ( {
 	errorNotice,
 	removeNotice,
 	successNotice,
+	transferInProgress,
+	receiptId,
 }: PlanOnlyThankYouProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -191,7 +196,9 @@ const PlanOnlyThankYou = ( {
 		},
 	} );
 
-	return (
+	return isWpComEcommercePlan( primaryPurchase.productSlug ) && transferInProgress ? (
+		<TransferPending orderId={ receiptId as number } siteId={ siteId as number } />
+	) : (
 		<ThankYouV2
 			title={ translate( 'Get the best out of your site' ) }
 			subtitle={ preventWidows( subtitle ) }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -14,7 +14,6 @@ import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSiteOptions, getSiteUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import TransferPending from '../../transfer-pending';
 import ThankYouPlanProduct from '../products/plan-product';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
@@ -29,8 +28,7 @@ interface PlanOnlyThankYouProps {
 	errorNotice: ( text: string, noticeOptions?: object ) => void;
 	removeNotice: ( noticeId: string ) => void;
 	successNotice: ( text: string, noticeOptions?: object ) => void;
-	transferInProgress?: boolean;
-	receiptId?: number;
+	transferComplete?: boolean;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {
@@ -48,8 +46,7 @@ const PlanOnlyThankYou = ( {
 	errorNotice,
 	removeNotice,
 	successNotice,
-	transferInProgress,
-	receiptId,
+	transferComplete,
 }: PlanOnlyThankYouProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -199,20 +196,17 @@ const PlanOnlyThankYou = ( {
 
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId as number ) );
 
-	// Display the progress bar if an ecommerce site is still being transferred
-	if ( isWpComEcommercePlan( primaryPurchase.productSlug ) && transferInProgress ) {
-		return <TransferPending orderId={ receiptId as number } siteId={ siteId as number } />;
-	}
-
 	return (
 		<>
-			{ /* If an ecommerce site is verified and completely transferred,
-			     automatically log the user into the wp-admin. */ }
-			{ isWpComEcommercePlan( primaryPurchase.productSlug ) &&
-				! transferInProgress &&
-				isEmailVerified && (
-					<WpAdminAutoLogin site={ { URL: `https://${ siteUrl }` } } delay={ 0 } />
-				) }
+			{
+				// If an ecommerce site is verified and completely transferred,
+				// automatically log the user into the wp-admin.
+				isWpComEcommercePlan( primaryPurchase.productSlug ) &&
+					transferComplete &&
+					isEmailVerified && (
+						<WpAdminAutoLogin site={ { URL: `https://${ siteUrl }` } } delay={ 0 } />
+					)
+			}
 			<ThankYouV2
 				title={ translate( 'Get the best out of your site' ) }
 				subtitle={ preventWidows( subtitle ) }

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -2,13 +2,7 @@
  * @jest-environment jsdom
  */
 
-import {
-	PLAN_ECOMMERCE,
-	PLAN_BUSINESS,
-	PLAN_PREMIUM,
-	isDotComPlan,
-	PLAN_PERSONAL,
-} from '@automattic/calypso-products';
+import { PLAN_BUSINESS, PLAN_PREMIUM, PLAN_PERSONAL } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -29,9 +23,6 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 jest.mock( '../domain-registration-details', () => () => 'component--domain-registration-details' );
 jest.mock( '../google-apps-details', () => () => 'component--google-apps-details' );
 jest.mock( '../jetpack-plan-details', () => () => 'component--jetpack-plan-details' );
-jest.mock( '../atomic-store-thank-you-card', () => () => (
-	<div data-testid="atomic-store-thank-you-card" />
-) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => 'page-view-tracker' );
 jest.mock( '../header', () =>
 	jest.fn( ( { children } ) => <div data-testid="checkout-thank-you-header">{ children }</div> )
@@ -169,62 +160,6 @@ describe( 'CheckoutThankYou', () => {
 				} ),
 				expect.anything()
 			);
-		} );
-	} );
-
-	describe( 'Presence of <AtomicStoreThankYouCard /> in render() output', () => {
-		const props = {
-			...defaultProps,
-			receiptId: 12,
-			selectedSite: {
-				ID: 12,
-			},
-			sitePlans: {
-				hasLoadedFromServer: true,
-			},
-			receipt: {
-				hasLoadedFromServer: true,
-				data: {
-					purchases: [ { productSlug: PLAN_ECOMMERCE }, [] ],
-				},
-			},
-			refreshSitePlans: ( selectedSite ) => selectedSite,
-			planSlug: PLAN_ECOMMERCE,
-		};
-
-		afterAll( () => {
-			isDotComPlan.mockImplementation( () => false );
-		} );
-
-		test( 'Should be there for AT', () => {
-			render(
-				<Provider store={ store }>
-					<CheckoutThankYou
-						{ ...props }
-						transferComplete={ true }
-						isWooCommerceInstalled={ true }
-					/>
-				</Provider>
-			);
-			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).toBeVisible();
-		} );
-
-		test( 'Should not be there for AT', () => {
-			const { rerender } = render(
-				<Provider store={ store }>
-					<CheckoutThankYou { ...props } transferComplete={ false } />
-				</Provider>
-			);
-			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).not.toBeInTheDocument();
-
-			isDotComPlan.mockImplementation( () => true );
-
-			rerender(
-				<Provider store={ store }>
-					<CheckoutThankYou { ...props } />
-				</Provider>
-			);
-			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).not.toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6016-gh-Automattic/dotcom-forge

## Proposed Changes

- Implement site transfer progress bar and wp-admin autologin for ecomm purchase congrats pages

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Purchase an Entrepreneur plan for a fresh (or [reverted](https://mc.a8c.com/automated-transfer/revert.php?blog_id=)) site
- After clicking the **Checkout** button, confirm that the transfer progress bar loads before the congrats page.
- When the congrats. page loads, click the **Create store button** as quickly as possible. We want to confirm that the site is ready _as_ the button renders, and not a few seconds later
- Confirm that the button successfully takes you to the Woo setup wizard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?