### PR TITLE
useExperiment: Fix initial loading state bug

### DIFF
--- a/packages/explat-client-react-helpers/CHANGELOG.md
+++ b/packages/explat-client-react-helpers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0
+
+- Fix bug with late loading of initial render of useExperiment
+
 ## 0.0.6
 
 - Bump explat-client version to latest that includes a fix for the experiment name validation to match server side validation: [a-z0-9_]*

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -33,6 +33,7 @@
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/react": "^14.2.1",
+		"jest": "^29.7.0",
 		"react-dom": "^18.2.0",
 		"typescript": "^5.3.3"
 	}

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/explat-client-react-helpers",
-	"version": "0.0.6",
+	"version": "0.1.0",
 	"description": "Standalone ExPlat Client: React Helpers.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useReducer } from 'react';
+import { useRef, useEffect, useReducer } from 'react';
 import * as React from 'react';
 import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-client';
 
@@ -67,7 +67,7 @@ export default function createExPlatClientReactHelpers(
 		// Manual updates to ensure rerendering when we want it:
 		// https://legacy.reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
 		const [ , forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
-		const [ previousExperimentName ] = useState( experimentName );
+		const previousExperimentNameRef = useRef( experimentName );
 
 		useEffect( () => {
 			let isSubscribed = true;
@@ -84,8 +84,8 @@ export default function createExPlatClientReactHelpers(
 		}, [ experimentName, options.isEligible ] );
 
 		if (
-			experimentName !== previousExperimentName &&
-			! previousExperimentName.startsWith( 'explat_test' )
+			experimentName !== previousExperimentNameRef.current &&
+			! previousExperimentNameRef.current.startsWith( 'explat_test' )
 		) {
 			exPlatClient.config.logError( {
 				message: '[ExPlat] useExperiment: experimentName should never change between renders!',

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -66,8 +66,7 @@ export default function createExPlatClientReactHelpers(
 
 		// Manual updates to ensure rerendering when we want it:
 		// https://legacy.reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const [ _ignored, forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
+		const [ , forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
 		const [ previousExperimentName ] = useState( experimentName );
 
 		useEffect( () => {

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -99,7 +99,7 @@ export default function createExPlatClientReactHelpers(
 
 		const maybeExperimentAssignment =
 			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment( experimentName );
-		return [ !! maybeExperimentAssignment, maybeExperimentAssignment ];
+		return [ ! maybeExperimentAssignment, maybeExperimentAssignment ];
 	};
 
 	const Experiment = ( {

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -10,6 +10,7 @@ import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-clie
 const createMockExPlatClient = ( isDevelopmentMode = false ): ExPlatClient => ( {
 	loadExperimentAssignment: jest.fn(),
 	dangerouslyGetExperimentAssignment: jest.fn(),
+	dangerouslyGetMaybeLoadedExperimentAssignment: jest.fn( () => null ),
 	config: {
 		isDevelopmentMode,
 		logError: jest.fn(),
@@ -51,6 +52,11 @@ describe( 'useExperiment', () => {
 		expect( result.current ).toEqual( [ true, null ] );
 		expect( exPlatClient.loadExperimentAssignment ).toHaveBeenCalledTimes( 1 );
 		act( () => controllablePromise1.resolve( validExperimentAssignment ) );
+		(
+			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
+				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
+			>
+		 ).mockImplementation( () => validExperimentAssignment );
 		await waitFor( () => expect( result.current ).toEqual( [ true, null ] ) );
 		rerender();
 		expect( result.current ).toEqual( [ false, validExperimentAssignment ] );
@@ -81,6 +87,11 @@ describe( 'useExperiment', () => {
 		rerender();
 		expect( result.current ).toEqual( [ true, null ] );
 		expect( exPlatClient.loadExperimentAssignment ).toHaveBeenCalledTimes( 1 );
+		(
+			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
+				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
+			>
+		 ).mockImplementation( () => validExperimentAssignment );
 		act( () => controllablePromise1.resolve( validExperimentAssignment ) );
 		await waitFor( () => expect( result.current ).toEqual( [ true, null ] ) );
 		rerender();
@@ -125,6 +136,11 @@ describe( 'Experiment', () => {
 			/>
 		);
 		expect( container.textContent ).toBe( 'loading-2' );
+		(
+			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
+				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
+			>
+		 ).mockImplementation( () => validExperimentAssignment );
 		await act( async () => controllablePromise1.resolve( validExperimentAssignment ) );
 		await waitFor( () => expect( container.textContent ).toBe( 'treatment-1' ) );
 		rerender(
@@ -158,9 +174,13 @@ describe( 'Experiment', () => {
 			/>
 		);
 		expect( container.textContent ).toBe( 'loading' );
-		await act( async () =>
-			controllablePromise1.resolve( { ...validExperimentAssignment, variationName: null } )
-		);
+		const resolvedExperimentAssignment = { ...validExperimentAssignment, variationName: null };
+		(
+			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
+				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
+			>
+		 ).mockImplementation( () => resolvedExperimentAssignment );
+		await act( async () => controllablePromise1.resolve( resolvedExperimentAssignment ) );
 		await waitFor( () => expect( container.textContent ).toBe( 'default-1' ) );
 		rerender(
 			<Experiment
@@ -198,6 +218,11 @@ describe( 'ProvideExperimentData', () => {
 		expect( capture.mock.calls[ 0 ] ).toEqual( [ true, null ] );
 		capture.mockReset();
 		const experimentAssignment = { ...validExperimentAssignment, variationName: null };
+		(
+			exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment as jest.MockedFunction<
+				typeof exPlatClient.dangerouslyGetMaybeLoadedExperimentAssignment
+			>
+		 ).mockImplementation( () => experimentAssignment );
 		await act( async () => controllablePromise1.resolve( experimentAssignment ) );
 		await waitFor( () => {
 			expect( capture ).toHaveBeenCalledTimes( 1 );

--- a/packages/explat-client/CHANGELOG.md
+++ b/packages/explat-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0
+
+- Add dangerouslyGetMaybeLoadedExperimentAssignment for use in useExperiment
+
 ## 0.0.5
 
 - Changed runtime experiment name validation to match server side validation: [a-z0-9_]*

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/explat-client",
-	"version": "0.0.5",
+	"version": "0.1.0",
 	"description": "Standalone ExPlat Client.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -30,6 +30,7 @@
 	"devDependencies": {
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"jest": "^29.7.0",
 		"typescript": "^5.3.3"
 	}
 }

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -37,6 +37,15 @@ export interface ExPlatClient {
 	dangerouslyGetExperimentAssignment: ( experimentName: string ) => ExperimentAssignment;
 
 	/**
+	 * Get an experiment assignment, return null if it hasn't been loaded.
+	 *
+	 * Only intended for use in useExperiment hook.
+	 */
+	dangerouslyGetMaybeLoadedExperimentAssignment: (
+		experimentName: string
+	) => null | ExperimentAssignment;
+
+	/**
 	 * INTERNAL USE ONLY
 	 */
 	config: Config;
@@ -212,6 +221,31 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 				return createFallbackExperimentAssignment( experimentName );
 			}
 		},
+		dangerouslyGetMaybeLoadedExperimentAssignment: (
+			experimentName: string
+		): ExperimentAssignment | null => {
+			try {
+				if ( ! Validation.isName( experimentName ) ) {
+					throw new Error( `Invalid experimentName: ${ experimentName }` );
+				}
+
+				const storedExperimentAssignment = retrieveExperimentAssignment( experimentName );
+				if ( ! storedExperimentAssignment ) {
+					return null;
+				}
+
+				return storedExperimentAssignment;
+			} catch ( error ) {
+				if ( config.isDevelopmentMode ) {
+					safeLogError( {
+						message: ( error as Error ).message,
+						experimentName,
+						source: 'dangerouslyGetExperimentAssignment-error',
+					} );
+				}
+				return createFallbackExperimentAssignment( experimentName );
+			}
+		},
 		config,
 	};
 }
@@ -230,6 +264,13 @@ export function createSsrSafeDummyExPlatClient( config: Config ): ExPlatClient {
 			return createFallbackExperimentAssignment( experimentName );
 		},
 		dangerouslyGetExperimentAssignment: ( experimentName: string ) => {
+			config.logError( {
+				message: 'Attempting to dangerously get ExperimentAssignment in SSR context',
+				experimentName,
+			} );
+			return createFallbackExperimentAssignment( experimentName );
+		},
+		dangerouslyGetMaybeLoadedExperimentAssignment: ( experimentName: string ) => {
 			config.logError( {
 				message: 'Attempting to dangerously get ExperimentAssignment in SSR context',
 				experimentName,

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -240,7 +240,7 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 					safeLogError( {
 						message: ( error as Error ).message,
 						experimentName,
-						source: 'dangerouslyGetExperimentAssignment-error',
+						source: 'dangerouslyGetMaybeLoadedExperimentAssignment-error',
 					} );
 				}
 				return createFallbackExperimentAssignment( experimentName );

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,6 +968,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-polyfills": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    jest: "npm:^29.7.0"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/explat-client": "workspace:^"
     "@testing-library/react": "npm:^14.2.1"
+    jest: "npm:^29.7.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     tslib: "npm:>=2.3.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See pbmo2S-2sV-p2

## Proposed Changes

* Get the initial state directly from the experiment store.
* Use manual re-rendering.

## Testing Instructions

First, apply the following changes on top of this diff so that we can use the query string method to simulate an actual assignment and to disable the fix from https://github.com/Automattic/wp-calypso/pull/88426:


```diff
diff --git a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
index 32b76a0f6f3..62096ad720f 100644
--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -19,11 +19,11 @@ export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {

        const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
                'calypso_launch_checkout_v2',
-               { isEligible: isCheckoutSection && ! hasCheckoutVersion( '2' ) }
+               { isEligible: isCheckoutSection }
        );

        if ( cachedExperimentAssignment ) {
-               return cachedExperimentAssignment;
+               // return cachedExperimentAssignment;
        }

        // Is loading experiment assignment
```

Next, add a product to your cart that has variants (eg: a 1 year wpcom plan) and visit checkout.

Alter the checkout URL to add `?checkoutVersion=2` and load checkout again.

Pay attention to the dropdown in the sidebar; make sure there is no flickering of the price as it loads. See https://github.com/Automattic/wp-calypso/pull/88426 for a video of what to be looking for; it's subtle.