### PR TITLE
Have main checkout component handle progress bar

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -14,7 +14,6 @@ import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSiteOptions, getSiteUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import TransferPending from '../../transfer-pending';
 import ThankYouPlanProduct from '../products/plan-product';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
@@ -29,8 +28,7 @@ interface PlanOnlyThankYouProps {
 	errorNotice: ( text: string, noticeOptions?: object ) => void;
 	removeNotice: ( noticeId: string ) => void;
 	successNotice: ( text: string, noticeOptions?: object ) => void;
-	transferInProgress?: boolean;
-	receiptId?: number;
+	transferComplete?: boolean;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {
@@ -48,8 +46,7 @@ const PlanOnlyThankYou = ( {
 	errorNotice,
 	removeNotice,
 	successNotice,
-	transferInProgress,
-	receiptId,
+	transferComplete,
 }: PlanOnlyThankYouProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -199,20 +196,17 @@ const PlanOnlyThankYou = ( {
 
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId as number ) );
 
-	// Display the progress bar if an ecommerce site is still being transferred
-	if ( isWpComEcommercePlan( primaryPurchase.productSlug ) && transferInProgress ) {
-		return <TransferPending orderId={ receiptId as number } siteId={ siteId as number } />;
-	}
-
 	return (
 		<>
-			{ /* If an ecommerce site is verified and completely transferred,
-			     automatically log the user into the wp-admin. */ }
-			{ isWpComEcommercePlan( primaryPurchase.productSlug ) &&
-				! transferInProgress &&
-				isEmailVerified && (
-					<WpAdminAutoLogin site={ { URL: `https://${ siteUrl }` } } delay={ 0 } />
-				) }
+			{
+				// If an ecommerce site is verified and completely transferred,
+				// automatically log the user into the wp-admin.
+				isWpComEcommercePlan( primaryPurchase.productSlug ) &&
+					transferComplete &&
+					isEmailVerified && (
+						<WpAdminAutoLogin site={ { URL: `https://${ siteUrl }` } } delay={ 0 } />
+					)
+			}
 			<ThankYouV2
 				title={ translate( 'Get the best out of your site' ) }
 				subtitle={ preventWidows( subtitle ) }

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -2,13 +2,7 @@
  * @jest-environment jsdom
  */
 
-import {
-	PLAN_ECOMMERCE,
-	PLAN_BUSINESS,
-	PLAN_PREMIUM,
-	isDotComPlan,
-	PLAN_PERSONAL,
-} from '@automattic/calypso-products';
+import { PLAN_BUSINESS, PLAN_PREMIUM, PLAN_PERSONAL } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -29,9 +23,6 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 jest.mock( '../domain-registration-details', () => () => 'component--domain-registration-details' );
 jest.mock( '../google-apps-details', () => () => 'component--google-apps-details' );
 jest.mock( '../jetpack-plan-details', () => () => 'component--jetpack-plan-details' );
-jest.mock( '../atomic-store-thank-you-card', () => () => (
-	<div data-testid="atomic-store-thank-you-card" />
-) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => 'page-view-tracker' );
 jest.mock( '../header', () =>
 	jest.fn( ( { children } ) => <div data-testid="checkout-thank-you-header">{ children }</div> )
@@ -169,62 +160,6 @@ describe( 'CheckoutThankYou', () => {
 				} ),
 				expect.anything()
 			);
-		} );
-	} );
-
-	describe( 'Presence of <AtomicStoreThankYouCard /> in render() output', () => {
-		const props = {
-			...defaultProps,
-			receiptId: 12,
-			selectedSite: {
-				ID: 12,
-			},
-			sitePlans: {
-				hasLoadedFromServer: true,
-			},
-			receipt: {
-				hasLoadedFromServer: true,
-				data: {
-					purchases: [ { productSlug: PLAN_ECOMMERCE }, [] ],
-				},
-			},
-			refreshSitePlans: ( selectedSite ) => selectedSite,
-			planSlug: PLAN_ECOMMERCE,
-		};
-
-		afterAll( () => {
-			isDotComPlan.mockImplementation( () => false );
-		} );
-
-		test( 'Should be there for AT', () => {
-			render(
-				<Provider store={ store }>
-					<CheckoutThankYou
-						{ ...props }
-						transferComplete={ true }
-						isWooCommerceInstalled={ true }
-					/>
-				</Provider>
-			);
-			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).toBeVisible();
-		} );
-
-		test( 'Should not be there for AT', () => {
-			const { rerender } = render(
-				<Provider store={ store }>
-					<CheckoutThankYou { ...props } transferComplete={ false } />
-				</Provider>
-			);
-			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).not.toBeInTheDocument();
-
-			isDotComPlan.mockImplementation( () => true );
-
-			rerender(
-				<Provider store={ store }>
-					<CheckoutThankYou { ...props } />
-				</Provider>
-			);
-			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).not.toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88572

## Proposed Changes

Instead of lobbing the progress bar into the `<PlanOnlyThankYou>` component and passing a bunch more properties that are only needed for the E-Commerce plan, what if we handle the load bar in the main `<CheckoutThankYou>` component? 

I've also taken the opportunity to remove the legacy code that has been re-worked into different parts of the code.