### PR TITLE
GitHub Deployments: Fixed GHD submit button

### DIFF
--- a/client/my-sites/github-deployments/components/github-connection-form/style.scss
+++ b/client/my-sites/github-deployments/components/github-connection-form/style.scss
@@ -62,6 +62,10 @@
 		gap: 8px;
 		margin-top: 40px;
 
+		.button {
+			overflow: visible;
+		}
+
 		.form-setting-explanation {
 			margin: 0;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Although we're not prioritizing mobile navigation on GHD yet, let's ensure not full screen will also show the main CTA as expected:

## Proposed Changes

| Before | After |
|--------|--------|
| <img width="817" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/c76a6c24-4676-4d33-8415-5553ea05aee6"> | <img width="789" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/c678dfc5-bd04-46c9-8337-001b241c4d83"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?