### PR TITLE
Backup: Add track event when backup failed component is rendered

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
 import { getBackupErrorCode } from 'calypso/lib/jetpack/backup-utils';
@@ -40,6 +40,10 @@ const BackupFailed = ( { backup } ) => {
 			} )
 		);
 	}, [ dispatch, mayBeBlockedByHost ] );
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_failed_view' ) );
+	}, [ dispatch ] );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88098 and p1HpG7-rqN-p2#comment-70566

We want to compare how many users see the backup failed view vs. how many of them click on `Contact support`.

## Proposed Changes

* Add `calypso_jetpack_backup_failed_view` track event when the backup failed component is rendered.

## Testing Instructions
* The easy way to test it is locally, by adding the following code to the line 112 of `client/components/jetpack/daily-backup-status/index.jsx`:

```javascript
return <BackupFailed backup={ backup } />;
```
* Open the Network tab in your developer tools 
* Navigate to Jetpack Cloud > Backup
* Pick a site with backups completed
* You should see the `Backup failed` card
* Ensure you see a request to `t.gif` with the `calypso_jetpack_backup_failed_view` event.

![CleanShot 2024-03-15 at 16 13 01@2x](https://github.com/Automattic/wp-calypso/assets/1488641/f1ccf6c2-8acb-4ef3-ac6f-996401927a2f)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?