### PR TITLE
Help Center: Update help center icon size to compact

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -67,6 +67,7 @@ function HelpCenterContent() {
 				label="Help"
 				aria-pressed={ show ? true : false }
 				aria-expanded={ show ? true : false }
+				size="compact"
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1710519335802189-slack-CNXKTTYCV

## Proposed Changes

* Adds `size="compact"` to the Help Center icon to align size with other icon in FSE toolbar 

Before:
<img width="234" alt="CleanShot 2024-03-15 at 17 48 33@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/0c2c0cc9-eef6-4639-bfaa-2fd931eee48e">

After:
<img width="234" alt="CleanShot 2024-03-15 at 17 57 22@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/ac4aa2ac-5c97-4e50-9514-6dcfd454c4d3">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Sync to WPCOM and upload 
* Verify icon size is correctly aligned with other icons in FSE toolbar (Site editor, post editor, and widget editor).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?