### PR TITLE
Checkout: Refine Secure Checkout position

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -931,7 +931,7 @@ a.masterbar__quick-language-switcher {
 		}
 
 		.masterbar--is-jetpack & {
-			transform: none;
+			transform: translateY(0.5px);
 		}
 
 		.masterbar--is-akismet & {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -922,7 +922,7 @@ a.masterbar__quick-language-switcher {
 		font-size: 0.75rem;
 		margin-left: 5px;
 		position: relative;
-		top: 0.5px;
+		top: -0.5px;
 
 		@include breakpoint-deprecated( ">480px" ) {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
@@ -931,11 +931,11 @@ a.masterbar__quick-language-switcher {
 		}
 
 		.masterbar--is-jetpack & {
-			transform: translateY(-0.5px);
+			transform: none;
 		}
 
 		.masterbar--is-akismet & {
-			transform: translateY(3px);
+			transform: translateY(4px);
 		}
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -921,6 +921,8 @@ a.masterbar__quick-language-switcher {
 		line-height: 1.2em;
 		font-size: 0.75rem;
 		margin-left: 5px;
+		position: relative;
+		top: 0.5px;
 
 		@include breakpoint-deprecated( ">480px" ) {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
@@ -929,11 +931,11 @@ a.masterbar__quick-language-switcher {
 		}
 
 		.masterbar--is-jetpack & {
-			transform: translateY(-1px);
+			transform: translateY(-0.5px);
 		}
 
 		.masterbar--is-akismet & {
-			transform: translateY(4px);
+			transform: translateY(3px);
 		}
 	}
 }


### PR DESCRIPTION
This PR adjusts the vertical positioning of the Secure Checkout badge in Checkout for Dotcom, Jetpack, and Akismet.

Reported p58i-gS9-p2#comment-62421

## Testing Instructions

* Go to checkout for all three services and check that the Secure Checkout badge found in the masterbar properly aligns to the bottom of the logo text/
* Since the logos are all images, this will largely be guided by your visual judgement of 'correct' spacing