### PR TITLE
Plugins: Prevent Style Bleed for Toggle Colour

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
@@ -52,6 +52,9 @@
 		min-width: 50%;
 		vertical-align: middle;
 	}
+	.components-form-toggle.is-checked .components-form-toggle__track {
+		background-color: var(--studio-jetpack-green-50);
+	}
 	&.has-bulk-management-active {
 		thead {
 			display: none;
@@ -87,10 +90,6 @@ td.plugin-common-table__actions {
 	@include break-huge() {
 		max-width: 150px;
 	}
-}
-
-.components-form-toggle.is-checked .components-form-toggle__track {
-	background-color: var(--studio-jetpack-green-50);
 }
 
 .plugin-common-table__plugin-icon {


### PR DESCRIPTION
## Proposed Changes

If you load `/plugins` and then load a toggle anywhere else in Calypso (eg. navigate to Me > Developer), there is a style bleed and the toggle remains green. This PR makes those styles more specific.

<img width="839" alt="Screenshot 2024-03-17 at 17 44 09" src="https://github.com/Automattic/wp-calypso/assets/43215253/0b4282d1-48b9-4aa9-8450-64d9a2a24f45">

@yashwin @vitozev it looks like this style was introduced in #66219 but I can't find where the toggle appears now - could you help with me that? 
