### PR TITLE
Plugins update manager: Adapt create/edit form supporting time format from the site settings

### DIFF
--- a/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
@@ -23,11 +23,11 @@ export function useSiteDateTimeFormat( siteSlug: string ) {
 		return phpToMomentDatetimeFormat( moment( ts ), format );
 	};
 
-	const isAmPmPhpTimeFormat = ( formatString: string ) => {
+	const isAmPmPhpTimeFormat = () => {
 		// Regular expression to check for AM/PM indicators
 		const ampmRegex = /(a|A)/;
 
-		return ampmRegex.test( formatString );
+		return ampmRegex.test( timeFormat );
 	};
 
 	return {

--- a/client/blocks/plugins-update-manager/schedule-form.const.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.const.ts
@@ -94,6 +94,58 @@ export const HOUR_OPTIONS = [
 	},
 ];
 
+export const HOUR_OPTIONS_24 = [
+	{
+		label: '00',
+		value: '0',
+	},
+	...HOUR_OPTIONS,
+	{
+		label: '13',
+		value: '13',
+	},
+	{
+		label: '14',
+		value: '14',
+	},
+	{
+		label: '15',
+		value: '15',
+	},
+	{
+		label: '16',
+		value: '16',
+	},
+	{
+		label: '17',
+		value: '17',
+	},
+	{
+		label: '18',
+		value: '18',
+	},
+	{
+		label: '19',
+		value: '19',
+	},
+	{
+		label: '20',
+		value: '20',
+	},
+	{
+		label: '21',
+		value: '21',
+	},
+	{
+		label: '22',
+		value: '22',
+	},
+	{
+		label: '23',
+		value: '23',
+	},
+];
+
 export const PERIOD_OPTIONS = [
 	{
 		label: translate( 'AM' ),

--- a/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
@@ -41,8 +41,8 @@ export function ScheduleFormFrequency( props: Props ) {
 
 	const [ frequency, setFrequency ] = useState< 'daily' | 'weekly' >( initFrequency );
 	const [ day, setDay ] = useState< string >( initDate.weekday().toString() );
-	const [ hour, setHour ] = useState< string >( ( initDate.hour() % 12 ).toString() );
-	const [ period, setPeriod ] = useState< string >( initDate.hours() < 12 ? 'am' : 'pm' );
+	const [ hour, setHour ] = useState< string >( initDate.format( 'h' ) ); // 'h' is for 12-hour format
+	const [ period, setPeriod ] = useState< string >( initDate.format( 'a' ) ); // 'a' is for am/pm
 
 	const [ timestamp, setTimestamp ] = useState( prepareTimestamp( frequency, day, hour, period ) );
 	const [ fieldTouched, setFieldTouched ] = useState( false );

--- a/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
@@ -10,15 +10,9 @@ import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import { ScheduleFormTime } from 'calypso/blocks/plugins-update-manager/schedule-form.time';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import {
-	DAILY_OPTION,
-	DAY_OPTIONS,
-	DEFAULT_HOUR,
-	HOUR_OPTIONS,
-	PERIOD_OPTIONS,
-	WEEKLY_OPTION,
-} from './schedule-form.const';
+import { DAILY_OPTION, DAY_OPTIONS, DEFAULT_HOUR, WEEKLY_OPTION } from './schedule-form.const';
 import { prepareTimestamp } from './schedule-form.helper';
 
 type Frequency = 'daily' | 'weekly';
@@ -69,24 +63,14 @@ export function ScheduleFormFrequency( props: Props ) {
 				{ frequency === 'daily' && (
 					<Flex gap={ 6 }>
 						<FlexBlock>
-							<div className="form-field">
-								<div className="time-controls">
-									<SelectControl
-										__next40pxDefaultSize
-										name="hour"
-										value={ hour }
-										options={ HOUR_OPTIONS }
-										onChange={ setHour }
-									/>
-									<SelectControl
-										__next40pxDefaultSize
-										name="period"
-										value={ period }
-										options={ PERIOD_OPTIONS }
-										onChange={ setPeriod }
-									/>
-								</div>
-							</div>
+							<ScheduleFormTime
+								initHour={ hour }
+								initPeriod={ period }
+								onChange={ ( hour, period ) => {
+									setHour( hour );
+									setPeriod( period );
+								} }
+							/>
 						</FlexBlock>
 					</Flex>
 				) }
@@ -113,24 +97,14 @@ export function ScheduleFormFrequency( props: Props ) {
 							</div>
 						</FlexItem>
 						<FlexBlock>
-							<div className="form-field">
-								<div className="time-controls">
-									<SelectControl
-										__next40pxDefaultSize
-										name="hour"
-										value={ hour }
-										options={ HOUR_OPTIONS }
-										onChange={ setHour }
-									/>
-									<SelectControl
-										__next40pxDefaultSize
-										name="period"
-										value={ period }
-										options={ PERIOD_OPTIONS }
-										onChange={ setPeriod }
-									/>
-								</div>
-							</div>
+							<ScheduleFormTime
+								initHour={ hour }
+								initPeriod={ period }
+								onChange={ ( hour, period ) => {
+									setHour( hour );
+									setPeriod( period );
+								} }
+							/>
 						</FlexBlock>
 					</Flex>
 				) }

--- a/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.frequency.tsx
@@ -10,10 +10,12 @@ import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { ScheduleFormTime } from 'calypso/blocks/plugins-update-manager/schedule-form.time';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useSiteDateTimeFormat } from './hooks/use-site-date-time-format';
+import { useSiteSlug } from './hooks/use-site-slug';
 import { DAILY_OPTION, DAY_OPTIONS, DEFAULT_HOUR, WEEKLY_OPTION } from './schedule-form.const';
 import { prepareTimestamp } from './schedule-form.helper';
+import { ScheduleFormTime } from './schedule-form.time';
 
 type Frequency = 'daily' | 'weekly';
 
@@ -26,9 +28,12 @@ interface Props {
 	onChange?: ( frequency: Frequency, timestamp: number ) => void;
 }
 export function ScheduleFormFrequency( props: Props ) {
+	const siteSlug = useSiteSlug();
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 	const { initTimestamp, initFrequency = 'daily', error, showError, onChange, onTouch } = props;
+	const { isAmPmPhpTimeFormat } = useSiteDateTimeFormat( siteSlug );
+	const isAmPmFormat = isAmPmPhpTimeFormat();
 
 	const initDate = initTimestamp
 		? moment( initTimestamp )
@@ -66,6 +71,7 @@ export function ScheduleFormFrequency( props: Props ) {
 							<ScheduleFormTime
 								initHour={ hour }
 								initPeriod={ period }
+								isAmPmFormat={ isAmPmFormat }
 								onChange={ ( hour, period ) => {
 									setHour( hour );
 									setPeriod( period );
@@ -100,6 +106,7 @@ export function ScheduleFormFrequency( props: Props ) {
 							<ScheduleFormTime
 								initHour={ hour }
 								initPeriod={ period }
+								isAmPmFormat={ isAmPmFormat }
 								onChange={ ( hour, period ) => {
 									setHour( hour );
 									setPeriod( period );

--- a/client/blocks/plugins-update-manager/schedule-form.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.helper.ts
@@ -40,6 +40,24 @@ export const prepareTimestamp = (
 	return event.getTime() / 1000;
 };
 
+export const convertHourTo24 = ( hour: string, period: string ): string => {
+	if ( period === 'pm' ) {
+		return hour === '12' ? '12' : ( parseInt( hour, 10 ) + 12 ).toString();
+	}
+
+	return hour;
+};
+
+export const convertHourTo12 = ( hour: string ): string => {
+	const _hour = parseInt( hour, 10 );
+
+	if ( _hour === 0 ) {
+		return '12';
+	}
+
+	return _hour > 12 ? ( _hour - 12 ).toString() : _hour.toString();
+};
+
 type TimeSlot = {
 	frequency: string;
 	timestamp: number;

--- a/client/blocks/plugins-update-manager/schedule-form.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.helper.ts
@@ -41,7 +41,9 @@ export const prepareTimestamp = (
 };
 
 export const convertHourTo24 = ( hour: string, period: string ): string => {
-	if ( period === 'pm' ) {
+	if ( period === 'am' ) {
+		return hour === '12' ? '0' : hour;
+	} else if ( period === 'pm' ) {
 		return hour === '12' ? '12' : ( parseInt( hour, 10 ) + 12 ).toString();
 	}
 

--- a/client/blocks/plugins-update-manager/schedule-form.time.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.time.tsx
@@ -1,0 +1,42 @@
+import { SelectControl } from '@wordpress/components';
+import { useState } from 'react';
+import { HOUR_OPTIONS, PERIOD_OPTIONS } from './schedule-form.const';
+
+interface Props {
+	initHour: string;
+	initPeriod: string;
+	onChange: ( hour: string, period: string ) => void;
+}
+export function ScheduleFormTime( props: Props ) {
+	const { initHour, initPeriod, onChange } = props;
+
+	const [ hour, setHour ] = useState( initHour );
+	const [ period, setPeriod ] = useState( initPeriod );
+
+	return (
+		<div className="form-field">
+			<div className="time-controls">
+				<SelectControl
+					__next40pxDefaultSize
+					name="hour"
+					value={ hour }
+					options={ HOUR_OPTIONS }
+					onChange={ ( hour ) => {
+						setHour( hour );
+						onChange?.( hour, period );
+					} }
+				/>
+				<SelectControl
+					__next40pxDefaultSize
+					name="period"
+					value={ period }
+					options={ PERIOD_OPTIONS }
+					onChange={ ( period ) => {
+						setPeriod( period );
+						onChange?.( hour, period );
+					} }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/client/blocks/plugins-update-manager/schedule-form.time.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.time.tsx
@@ -1,16 +1,23 @@
 import { SelectControl } from '@wordpress/components';
 import { useState } from 'react';
-import { HOUR_OPTIONS, PERIOD_OPTIONS } from './schedule-form.const';
+import {
+	convertHourTo12,
+	convertHourTo24,
+} from 'calypso/blocks/plugins-update-manager/schedule-form.helper';
+import { HOUR_OPTIONS, HOUR_OPTIONS_24, PERIOD_OPTIONS } from './schedule-form.const';
 
 interface Props {
 	initHour: string;
 	initPeriod: string;
+	isAmPmFormat: boolean;
 	onChange: ( hour: string, period: string ) => void;
 }
 export function ScheduleFormTime( props: Props ) {
-	const { initHour, initPeriod, onChange } = props;
+	const { initHour, initPeriod, isAmPmFormat, onChange } = props;
 
-	const [ hour, setHour ] = useState( initHour );
+	const [ hour, setHour ] = useState(
+		isAmPmFormat ? initHour : convertHourTo24( initHour, initPeriod )
+	);
 	const [ period, setPeriod ] = useState( initPeriod );
 
 	return (
@@ -20,22 +27,33 @@ export function ScheduleFormTime( props: Props ) {
 					__next40pxDefaultSize
 					name="hour"
 					value={ hour }
-					options={ HOUR_OPTIONS }
+					options={ isAmPmFormat ? HOUR_OPTIONS : HOUR_OPTIONS_24 }
 					onChange={ ( hour ) => {
 						setHour( hour );
-						onChange?.( hour, period );
+
+						if ( isAmPmFormat ) {
+							onChange?.( hour, period );
+						} else {
+							const _hour = convertHourTo12( hour );
+							const _period = parseInt( hour ) < 12 ? 'am' : 'pm';
+
+							setPeriod( _period );
+							onChange?.( _hour, _period );
+						}
 					} }
 				/>
-				<SelectControl
-					__next40pxDefaultSize
-					name="period"
-					value={ period }
-					options={ PERIOD_OPTIONS }
-					onChange={ ( period ) => {
-						setPeriod( period );
-						onChange?.( hour, period );
-					} }
-				/>
+				{ isAmPmFormat && (
+					<SelectControl
+						__next40pxDefaultSize
+						name="period"
+						value={ period }
+						options={ PERIOD_OPTIONS }
+						onChange={ ( period ) => {
+							setPeriod( period );
+							onChange?.( hour, period );
+						} }
+					/>
+				) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88417

## Proposed Changes

* Created ScheduleFormTime component for better control of time formats
* Supported time picker format based on site settings
* Fixed an edge case in edit mode when time is 12 am

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Site Settings page: `/settings/writing/{SITE}`
* Update Date and Time format
* Go to `/plugins/scheduled-updates/{SITE}`
* Create or edit a schedule
* Check if there is 12 or 24 hours format

<img width="661" alt="Screenshot 2024-03-17 at 21 21 56" src="https://github.com/Automattic/wp-calypso/assets/1241413/99a775a4-de6c-4bff-a127-b25bc8d8dc4c">
<img width="743" alt="Screenshot 2024-03-17 at 21 22 24" src="https://github.com/Automattic/wp-calypso/assets/1241413/c2bdf08b-7733-4384-b743-5eb34daa2930">
<img width="727" alt="Screenshot 2024-03-17 at 21 22 47" src="https://github.com/Automattic/wp-calypso/assets/1241413/6c52e744-3771-4eb0-9a56-90d930d02b15">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?