### PR TITLE
Untangle: all envs are no longer auto opted-in to global site view

### DIFF
--- a/client/state/sites/selectors/is-global-site-view-enabled.ts
+++ b/client/state/sites/selectors/is-global-site-view-enabled.ts
@@ -4,7 +4,6 @@ import type { AppState } from 'calypso/types';
 
 /**
  * Returns true if site has the nav redesign Global Site view enabled, false if it is not enabled.
- *
  * @param  {Object}    state  Global state tree
  * @param  {?number}   siteId Site ID
  * @returns {?boolean}        Whether site has the nav redesign enabled
@@ -18,12 +17,5 @@ export default function isGlobalSiteViewEnabled( state: AppState, siteId: number
 		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
 	const isClassicEarlyRelease = !! getSiteOption( state, siteId, 'wpcom_classic_early_release' );
 
-	// A site is eliglible if:
-	// 1. The Calypso environment has the feature flag "layout/docom-nav-redesign-early-release".
-	//    This flag is not meant to be enabled in production and it serves as a faux proxy mechanism.
-	// 2. The site has the site option "wpcom_classic_early_release".
-	const isNavRedesignEligible =
-		isEnabled( 'layout/dotcom-nav-redesign-early-release' ) || isClassicEarlyRelease;
-
-	return isAdminInterfaceWPAdmin && isNavRedesignEligible;
+	return isAdminInterfaceWPAdmin && isClassicEarlyRelease;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -117,7 +117,6 @@
 		"launchpad/new-task-definition-parser/videopress": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
-		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/production.json
+++ b/config/production.json
@@ -93,7 +93,6 @@
 		"launchpad/new-task-definition-parser/newsletter": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
-		"layout/dotcom-nav-redesign-early-release": false,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/test.json
+++ b/config/test.json
@@ -72,7 +72,6 @@
 		"launchpad/new-task-definition-parser/build": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
-		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -86,7 +86,6 @@
 		"launchpad-updates": false,
 		"launchpad/navigator": false,
 		"layout/app-banner": true,
-		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6121

## Proposed Changes

This PR removes the `layout/dotcom-nav-redesign-early-release` check for showing the "global site view".

## Testing Instructions

1. Prepare an Atomic site.
2. Set Hosting Configuration -> Admin interface style setting to Classic.
3. Unset the early release flag from `/_cli` if it's ever set (`wp option delete wpcom_classic_early_release`)
4. Go to `<Calypso Live URL>/home/:site`
5. Verify that you see the nav-unified My Home (instead of the new global site view).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?