### PR TITLE
GitHub Deployments: include link to workflow recipes

### DIFF
--- a/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
@@ -65,10 +65,20 @@ export const AdvancedWorkflowStyle = ( {
 
 	return (
 		<div>
-			<p css={ { marginTop: 16, marginBottom: 0 } }>
+			<WorkflowPicker
+				isLoading={ isLoading || isFetching }
+				workflows={ workflows }
+				onChange={ onChooseWorkflow }
+				value={ workflowPath }
+			/>
+
+			<p
+				css={ { marginTop: 16, marginBottom: 0 } }
+				className="github-deployments-deployment-style__workflow-recipes"
+			>
 				{ createInterpolateElement(
 					translate(
-						'You can start with our basic workflow file then extend it. Looking for inspiration? See our <a>workflow recipes</a>.'
+						'You can start with our basic workflow file and extend it. Looking for inspiration? Check out our <a>workflow recipes</a>.'
 					),
 					{
 						a: (
@@ -77,13 +87,6 @@ export const AdvancedWorkflowStyle = ( {
 					}
 				) }
 			</p>
-
-			<WorkflowPicker
-				isLoading={ isLoading || isFetching }
-				workflows={ workflows }
-				onChange={ onChooseWorkflow }
-				value={ workflowPath }
-			/>
 
 			{ isLoading ? null : <div css={ { marginTop: '16px' } }>{ getContent() }</div> }
 		</div>

--- a/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
@@ -1,3 +1,6 @@
+import { ExternalLink } from '@automattic/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { translate } from 'i18n-calypso';
 import { useWorkflowTemplate } from 'calypso/my-sites/github-deployments/components/deployment-style/use-get-workflow-template-query';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
 import { NewWorkflowWizard } from './new-workflow-wizard';
@@ -62,6 +65,19 @@ export const AdvancedWorkflowStyle = ( {
 
 	return (
 		<div>
+			<p css={ { marginTop: 16, marginBottom: 0 } }>
+				{ createInterpolateElement(
+					translate(
+						'You can start with our basic workflow file then extend it. Looking for inspiration? See our <a>workflow recipes</a>.'
+					),
+					{
+						a: (
+							<ExternalLink href="https://developer.wordpress.com/docs/developer-tools/github-deployments/create-github-deployment-source-files/" />
+						),
+					}
+				) }
+			</p>
+
 			<WorkflowPicker
 				isLoading={ isLoading || isFetching }
 				workflows={ workflows }

--- a/client/my-sites/github-deployments/components/deployment-style/new-workflow-wizard.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/new-workflow-wizard.tsx
@@ -57,10 +57,6 @@ export const NewWorkflowWizard = ( {
 
 	return (
 		<div className="github-deployments-new-workflow-wizard">
-			<p css={ { marginBottom: 0 } }>
-				{ __( 'Use our suggested workflow which you can install and then extend at GitHub.' ) }
-			</p>
-
 			<div className="github-deployments-new-workflow-wizard__workflow-file">
 				<div className="github-deployments-new-workflow-wizard__workflow-file-name">
 					<span>{ RECOMMENDED_WORKFLOW_PATH }</span>

--- a/client/my-sites/github-deployments/components/deployment-style/style.scss
+++ b/client/my-sites/github-deployments/components/deployment-style/style.scss
@@ -197,6 +197,17 @@
 			font-weight: normal;
 		}
 	}
+
+	&__workflow-recipes {
+		font-style: italic;
+		color: var(--color-text-subtle);
+		margin-top: 5px;
+
+		a {
+			color: var(--color-text-subtle);
+			text-decoration: underline;
+		}
+	}
 }
 
 .github-deployments-new-workflow-wizard {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/6062


**Before** 

<img width="604" alt="Screenshot 2567-03-18 at 09 35 21" src="https://github.com/Automattic/wp-calypso/assets/6851384/edb2e8bd-2019-4152-906d-06e185b0a4cb">

**After** 

<img width="590" alt="Screenshot 2567-03-18 at 10 32 55" src="https://github.com/Automattic/wp-calypso/assets/6851384/08cab2ba-331f-4746-9979-d353431cc6ae">


## Proposed Changes


* Add a link to workflow recipes
* Remove the previous hint about extending workflow which was combined in this change

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new deployment and choose "advanced" mode
* Check link works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?