### PR TITLE
Get billing product slug by theme id

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -54,8 +54,9 @@ jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
 	},
 } ) );
 
-jest.mock( 'calypso/my-sites/themes/helpers', () => ( {
-	marketplaceThemeBillingProductSlug: () => {
+jest.mock( 'calypso/state/products-list/selectors', () => ( {
+	...jest.requireActual( 'calypso/state/products-list/selectors' ),
+	getProductBillingSlugByThemeId: () => {
 		return;
 	},
 } ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -43,10 +43,12 @@ import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgr
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
-import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
-import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
+import {
+	getProductBillingSlugByThemeId,
+	getProductsByBillingSlug,
+} from 'calypso/state/products-list/selectors';
 import { hasPurchasedDomain } from 'calypso/state/purchases/selectors/has-purchased-domain';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -366,7 +368,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const marketplaceThemeProducts =
 		useSelector( ( state ) =>
-			getProductsByBillingSlug( state, marketplaceThemeBillingProductSlug( selectedDesignThemeId ) )
+			getProductsByBillingSlug(
+				state,
+				getProductBillingSlugByThemeId( state, selectedDesignThemeId )
+			)
 		) || [];
 	const marketplaceProductSlug =
 		marketplaceThemeProducts.length !== 0

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -370,7 +370,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		useSelector( ( state ) =>
 			getProductsByBillingSlug(
 				state,
-				getProductBillingSlugByThemeId( state, selectedDesignThemeId )
+				getProductBillingSlugByThemeId( state, selectedDesignThemeId ?? '' )
 			)
 		) || [];
 	const marketplaceProductSlug =

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -31,7 +31,6 @@ import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-a
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wpcom from 'calypso/lib/wp';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
-import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import flows from 'calypso/signup/config/flows';
 import steps from 'calypso/signup/config/steps';
 import {
@@ -49,6 +48,7 @@ import {
 	getProductsByBillingSlug,
 	getProductsList,
 	getMarketplaceProducts,
+	getProductBillingSlugByThemeId,
 } from 'calypso/state/products-list/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
@@ -603,7 +603,10 @@ async function addExternalManagedThemeToCart(
 	callback,
 	providedDependencies
 ) {
-	const products = getProductsByBillingSlug( state, marketplaceThemeBillingProductSlug( themeId ) );
+	const products = getProductsByBillingSlug(
+		state,
+		getProductBillingSlugByThemeId( state, themeId )
+	);
 
 	if ( undefined === products || products.length === 0 ) {
 		// @TODO What kind of logging should we add here? For now it just bails the code.

--- a/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
+++ b/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
@@ -8,15 +8,12 @@ import type { AppState, Theme } from 'calypso/types';
  * @param {string} themeId theme id
  * @returns {string} the corresponding billing product slug
  */
-export function getProductBillingSlugByThemeId(
-	state: AppState,
-	themeId: string | null
-): string | null {
+export function getProductBillingSlugByThemeId( state: AppState, themeId: string ): string {
 	const theme: Theme | undefined = getTheme( state, 'wpcom', themeId );
 
 	if ( theme?.product_details === undefined ) {
 		return `wp-mp-theme-${ themeId }`;
 	}
 
-	return theme?.product_details[ 0 ][ 'billing_product_slug' ];
+	return theme.product_details[ 0 ][ 'billing_product_slug' ];
 }

--- a/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
+++ b/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
@@ -11,9 +11,9 @@ import type { AppState, Theme } from 'calypso/types';
 export function getProductBillingSlugByThemeId( state: AppState, themeId: string ): string {
 	const theme: Theme | undefined = getTheme( state, 'wpcom', themeId );
 
-	if ( theme?.product_details === undefined ) {
-		return `wp-mp-theme-${ themeId }`;
+	if ( theme?.product_details?.[ 0 ]?.billing_product_slug !== undefined ) {
+		return theme.product_details[ 0 ].billing_product_slug;
 	}
 
-	return theme.product_details[ 0 ][ 'billing_product_slug' ];
+	return `wp-mp-theme-${ themeId }`;
 }

--- a/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
+++ b/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
@@ -1,0 +1,22 @@
+import 'calypso/state/products-list/init';
+import { getProductBySlug } from 'calypso/state/products-list/selectors/get-product-by-slug';
+import { getTheme } from 'calypso/state/themes/selectors';
+import type { ProductListItem } from './get-products-list';
+import type { AppState, Theme } from 'calypso/types';
+
+/**
+ * Retrieves the billing product slug give a theme id.
+ * @param {Object} state - global state tree
+ * @param {string} themeId theme id
+ * @returns {string} the corresponding billing product slug
+ */
+export function getProductBillingSlugByThemeId( state: AppState, themeId: string ): string | null {
+	const theme: Theme | undefined = getTheme( state, 'wpcom', themeId );
+	const productSlugs = theme.product_details.map( ( product ) => product.product_slug );
+
+	const products: ProductListItem[] = productSlugs.map( ( productSlug ) => {
+		return getProductBySlug( state, productSlug );
+	} );
+
+	return products[ 0 ].billing_product_slug;
+}

--- a/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
+++ b/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
@@ -1,7 +1,5 @@
 import 'calypso/state/products-list/init';
-import { getProductBySlug } from 'calypso/state/products-list/selectors/get-product-by-slug';
 import { getTheme } from 'calypso/state/themes/selectors';
-import type { ProductListItem } from './get-products-list';
 import type { AppState, Theme } from 'calypso/types';
 
 /**
@@ -12,11 +10,10 @@ import type { AppState, Theme } from 'calypso/types';
  */
 export function getProductBillingSlugByThemeId( state: AppState, themeId: string ): string | null {
 	const theme: Theme | undefined = getTheme( state, 'wpcom', themeId );
-	const productSlugs = theme.product_details.map( ( product ) => product.product_slug );
 
-	const products: ProductListItem[] = productSlugs.map( ( productSlug ) => {
-		return getProductBySlug( state, productSlug );
-	} );
+	if ( theme?.product_details === undefined ) {
+		return `wp-mp-theme-${ themeId }`;
+	}
 
-	return products[ 0 ].billing_product_slug;
+	return theme?.product_details[ 0 ][ 'billing_product_slug' ];
 }

--- a/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
+++ b/client/state/products-list/selectors/get-product-billing-slug-by-theme-id.ts
@@ -8,7 +8,10 @@ import type { AppState, Theme } from 'calypso/types';
  * @param {string} themeId theme id
  * @returns {string} the corresponding billing product slug
  */
-export function getProductBillingSlugByThemeId( state: AppState, themeId: string ): string | null {
+export function getProductBillingSlugByThemeId(
+	state: AppState,
+	themeId: string | null
+): string | null {
 	const theme: Theme | undefined = getTheme( state, 'wpcom', themeId );
 
 	if ( theme?.product_details === undefined ) {

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -18,3 +18,4 @@ export { getProductSaleCouponCost } from './get-product-sale-coupon-cost';
 export { getProductSaleCouponDiscount } from './get-product-sale-coupon-discount';
 export { getProductCurrencyCode } from './get-product-currency-code';
 export { getMarketplaceProducts } from './get-marketplace-products';
+export { getProductBillingSlugByThemeId } from './get-product-billing-slug-by-theme-id';

--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -11,8 +11,8 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import 'calypso/state/themes/init';
 import { marketplaceThemeProduct } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
-import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
+import { getProductBillingSlugByThemeId } from 'calypso/state/products-list/selectors/get-product-billing-slug-by-theme-id';
 import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
@@ -62,7 +62,7 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 
 		const products = getProductsByBillingSlug(
 			state,
-			marketplaceThemeBillingProductSlug( themeId )
+			getProductBillingSlugByThemeId( state, themeId )
 		);
 
 		if ( undefined === products || products.length === 0 ) {

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed-by-user.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed-by-user.ts
@@ -1,5 +1,5 @@
-import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
+import { getProductBillingSlugByThemeId } from 'calypso/state/products-list/selectors/get-product-billing-slug-by-theme-id';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
 /**
@@ -9,7 +9,10 @@ import { getUserPurchases } from 'calypso/state/purchases/selectors';
  * @returns {boolean} true if the site subscribed to the theme
  */
 export function isMarketplaceThemeSubscribedByUser( state = {}, themeId: string ) {
-	const products = getProductsByBillingSlug( state, marketplaceThemeBillingProductSlug( themeId ) );
+	const products = getProductsByBillingSlug(
+		state,
+		getProductBillingSlugByThemeId( state, themeId )
+	);
 	const userPurchases = getUserPurchases( state );
 
 	return !! (

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
@@ -1,5 +1,5 @@
-import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
+import { getProductBillingSlugByThemeId } from 'calypso/state/products-list/selectors/get-product-billing-slug-by-theme-id';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 
 /**
@@ -10,7 +10,10 @@ import { getSitePurchases } from 'calypso/state/purchases/selectors';
  * @returns {boolean} true if the site subscribed to the theme
  */
 export function isMarketplaceThemeSubscribed( state = {}, themeId: string, siteId: number ) {
-	const products = getProductsByBillingSlug( state, marketplaceThemeBillingProductSlug( themeId ) );
+	const products = getProductsByBillingSlug(
+		state,
+		getProductBillingSlugByThemeId( state, themeId )
+	);
 
 	const sitePurchases = getSitePurchases( state, siteId );
 

--- a/client/types.ts
+++ b/client/types.ts
@@ -65,6 +65,7 @@ export interface Theme {
 interface MarketplaceThemeProductDetails {
 	product_id: number;
 	product_slug: string;
+	billing_product_slug: string;
 }
 
 interface ThemeCost {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Replace the function `marketplaceThemeBillingProductSlug` that was returning the billing slug only by concatenating themeId with a hardcoded prefix `wp-mp-theme-${ themeId }`. 

This function is replaced by `getProductBillingSlugByThemeId` which gets the billing slug from the theme product details property for dotcom marketplace themes. 

For themes different from dotcom marketplace themes the `wp-mp-theme-${ themeId }` remains being returned.

## Testing Instructions
- Check out this branch on your local environment
- Go to Appearance - Themes
- Look for the Ornate Decor theme and click on the theme to go to the details
- Click on "Subscribe to Activate"

  <img width="1525" alt="Screenshot 2024-04-24 at 6 01 54 PM" src="https://github.com/Automattic/wp-calypso/assets/351784/79bacc5b-9ff8-4059-8264-991c3e8033c7">

- Complete the checkout
- Check that the Congrats Page shows up and that the "Activate this design" button is enabled

  <img width="1374" alt="Screenshot 2024-04-24 at 6 03 42 PM" src="https://github.com/Automattic/wp-calypso/assets/351784/8b847eea-b652-4f8e-a29c-cc15fedbfebd">

- Click on the "Activate this design" button and check that the "Customize this design" button is displayed.
- Click on "Customize this design" and check that you can customize the Ornate Decor theme.
- Go to Upgrades - Purchases to Cancel the subscription and Remove it. Check there are no errors.
 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?