### PR TITLE
Revert "Disable /home to wc-admin redirect when nav redesign is enabled"

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
@@ -8,11 +7,7 @@ import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { isSiteOnWooExpressEcommerceTrial } from 'calypso/state/sites/plans/selectors';
-import {
-	canCurrentUserUseCustomerHome,
-	getSiteOption,
-	getSiteUrl,
-} from 'calypso/state/sites/selectors';
+import { canCurrentUserUseCustomerHome, getSiteUrl } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSiteSlug,
 	getSelectedSiteId,
@@ -46,15 +41,10 @@ export async function maybeRedirect( context, next ) {
 
 	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
-	const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' );
-
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	let fetchPromise;
 
-	if (
-		isSiteOnWooExpressEcommerceTrial( state, siteId ) &&
-		! ( isEnabled( 'layout/dotcom-nav-redesign' ) && adminInterface === 'wp-admin' )
-	) {
+	if ( isSiteOnWooExpressEcommerceTrial( state, siteId ) ) {
 		// Pre-fetch plugins and modules to avoid flashing content prior deciding whether to redirect.
 		fetchPromise = Promise.allSettled( [
 			context.store.dispatch( fetchSitePlugins( siteId ) ),


### PR DESCRIPTION
Reverts Automattic/wp-calypso#87531

No longer required, related https://github.com/Automattic/wc-calypso-bridge/pull/1449/commits/c789eb1f173434dfb82adecd4ed20d7486828e81#diff-d3dacd94d523a5a28e530092ce9b5a84d861f8d3d1064814d74f0c8e202a5cb9R243-R263