### PR TITLE
A4A: Update A4Aa layout to support multiple columns and use it in Sites Dashboard

### DIFF
--- a/client/a8c-for-agencies/components/layout/column.tsx
+++ b/client/a8c-for-agencies/components/layout/column.tsx
@@ -1,0 +1,28 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import Main from 'calypso/components/main';
+
+import './style.scss';
+
+type Props = {
+	children: ReactNode;
+	className?: string;
+	wide?: boolean;
+	withBorder?: boolean;
+	compact?: boolean;
+};
+
+export default function LayoutColumn( { children, className, wide, withBorder, compact }: Props ) {
+	return (
+		<Main
+			className={ classNames( 'a4a-layout-column', className, {
+				'is-with-border': withBorder,
+				'is-compact': compact,
+			} ) }
+			fullWidthLayout={ wide }
+			wideLayout={ ! wide } // When we set to full width, we want to set this to false.
+		>
+			<div className="a4a-layout-column__container">{ children }</div>
+		</Main>
+	);
+}

--- a/client/a8c-for-agencies/components/layout/index.tsx
+++ b/client/a8c-for-agencies/components/layout/index.tsx
@@ -28,9 +28,9 @@ export default function Layout( {
 	const hasLayoutColumns = React.Children.toArray( children ).some(
 		( child ) => React.isValidElement( child ) && child.type === LayoutColumn
 	);
-	const layoutContainerClassname = ! hasLayoutColumns
-		? 'a4a-layout__container'
-		: 'a4a-layout-with-columns__container';
+	const layoutContainerClassname = hasLayoutColumns
+		? 'a4a-layout-with-columns__container'
+         : 'a4a-layout__container';
 
 	return (
 		<Main

--- a/client/a8c-for-agencies/components/layout/index.tsx
+++ b/client/a8c-for-agencies/components/layout/index.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import LayoutColumn from './column';
 
 import './style.scss';
 
@@ -24,6 +25,13 @@ export default function Layout( {
 	compact,
 	sidebarNavigation,
 }: Props ) {
+	const hasLayoutColumns = React.Children.toArray( children ).some(
+		( child ) => React.isValidElement( child ) && child.type === LayoutColumn
+	);
+	const layoutContainerClassname = ! hasLayoutColumns
+		? 'a4a-layout__container'
+		: 'a4a-layout-with-columns__container';
+
 	return (
 		<Main
 			className={ classNames( 'a4a-layout', className, {
@@ -36,7 +44,7 @@ export default function Layout( {
 			<DocumentHead title={ title } />
 			{ sidebarNavigation }
 
-			<div className="a4a-layout__container">{ children }</div>
+			<div className={ layoutContainerClassname }>{ children }</div>
 		</Main>
 	);
 }

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -6,6 +6,7 @@ html,
 	overflow: auto;
 }
 
+.main.a4a-layout-column,
 .main.a4a-layout {
 	background: var(--color-surface);
 	margin: 0;
@@ -25,13 +26,27 @@ html,
 	padding-block-start: 28px;
 }
 
+.a4a-layout-with-columns__container,
 .a4a-layout__container {
 	max-width: 100%;
 	max-height: 100%;
 	display: flex;
-	flex-direction: column;
 	margin: auto;
 	padding: 0;
+}
+
+.a4a-layout__container {
+	flex-direction: column;
+}
+
+.a4a-layout-with-columns__container {
+	flex-direction: row;
+	flex-wrap: nowrap;
+	gap: 16px;
+}
+
+.a4a-layout-column {
+	flex: 1;
 }
 
 .a4a-layout__body {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import React, { useContext, useEffect, useState, useMemo, useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 	LayoutHeaderActions as Actions,
@@ -179,66 +180,66 @@ export default function SitesDashboard() {
 	return (
 		<Layout
 			title="Sites"
-			className="sites-dashboard"
+			className={ classNames(
+				'sites-dashboard',
+				'sites-dashboard__layout',
+				! sitesViewState.selectedSite && 'preview-hidden'
+			) }
 			wide
 			withBorder={ ! sitesViewState.selectedSite }
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 		>
-			<div
-				className={ classNames(
-					'sites-dashboard__layout',
-					! sitesViewState.selectedSite && 'preview-hidden'
-				) }
-			>
-				<div className="sites-overview">
-					<LayoutTop withNavigation>
-						<LayoutHeader>
-							<Title>{ translate( 'Sites' ) }</Title>
-							<Actions>
-								{ /* TODO: This component is from Jetpack Manage and it was not ported yet, just using it here as a placeholder, it looks broken but it is enough for our purposes at the moment. */ }
-								<SiteTopHeaderButtons />
-							</Actions>
-						</LayoutHeader>
-						<LayoutNavigation { ...selectedItemProps }>
-							<NavigationTabs { ...selectedItemProps } items={ navItems } />
-						</LayoutNavigation>
-					</LayoutTop>
+			<LayoutColumn className="sites-overview" wide>
+				<LayoutTop withNavigation>
+					<LayoutHeader>
+						<Title>{ translate( 'Sites' ) }</Title>
+						<Actions>
+							{ /* TODO: This component is from Jetpack Manage and it was not ported yet, just using it here as a placeholder, it looks broken but it is enough for our purposes at the moment. */ }
+							<SiteTopHeaderButtons />
+						</Actions>
+					</LayoutHeader>
+					<LayoutNavigation { ...selectedItemProps }>
+						<NavigationTabs { ...selectedItemProps } items={ navItems } />
+					</LayoutNavigation>
+				</LayoutTop>
 
-					<DashboardDataContext.Provider
-						value={ {
-							verifiedContacts: {
-								emails: verifiedContacts?.emails ?? [],
-								phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
-								refetchIfFailed: () => {
-									if ( fetchContactFailed ) {
-										refetchContacts();
-									}
-									return;
-								},
+				<DashboardDataContext.Provider
+					value={ {
+						verifiedContacts: {
+							emails: verifiedContacts?.emails ?? [],
+							phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+							refetchIfFailed: () => {
+								if ( fetchContactFailed ) {
+									refetchContacts();
+								}
+								return;
 							},
-							products: products ?? [],
-							isLargeScreen: isLargeScreen || false,
-						} }
-					>
-						<SitesDataViews
-							className="sites-overview__content"
-							data={ data }
-							isLoading={ isLoading }
-							isLargeScreen={ isLargeScreen || false }
-							onSitesViewChange={ onSitesViewChange }
-							sitesViewState={ sitesViewState }
-						/>
-					</DashboardDataContext.Provider>
-				</div>
-				{ sitesViewState.selectedSite && (
+						},
+						products: products ?? [],
+						isLargeScreen: isLargeScreen || false,
+					} }
+				>
+					<SitesDataViews
+						className="sites-overview__content"
+						data={ data }
+						isLoading={ isLoading }
+						isLargeScreen={ isLargeScreen || false }
+						onSitesViewChange={ onSitesViewChange }
+						sitesViewState={ sitesViewState }
+					/>
+				</DashboardDataContext.Provider>
+			</LayoutColumn>
+
+			{ sitesViewState.selectedSite && (
+				<LayoutColumn wide>
 					<JetpackPreviewPane
 						site={ sitesViewState.selectedSite }
 						closeSitePreviewPane={ closeSitePreviewPane }
 						isSmallScreen={ ! isLargeScreen }
 						hasError={ isError }
 					/>
-				) }
-			</div>
+				</LayoutColumn>
+			) }
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -6,17 +6,17 @@
 	padding-block-start: 0;
 
 	@media (min-width: $break-large) {
-		.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-title {
+		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-title {
 			font-size: 1.25rem;
 			font-weight: 500;
 		}
-		.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-subtitle {
+		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-subtitle {
 			display: none;
 		}
 	}
 
 	@media (max-width: $break-large) {
-		.sites-dashboard__layout {
+		&.sites-dashboard__layout {
 			.sites-overview {
 				overflow: hidden;
 
@@ -86,7 +86,11 @@
 		}
 
 		.dataviews-filters__view-actions {
-			padding: 8px;
+			padding-bottom: 8px;
+
+			& > :first-child {
+				margin-left: 8px;
+			}
 
 			.components-input-control {
 				flex-grow: 1;
@@ -142,7 +146,7 @@
 	}
 
 	@media (max-width: $break-wide) {
-		.sites-dashboard__layout:not(.preview-hidden) {
+		&.sites-dashboard__layout:not(.preview-hidden) {
 			flex-direction: column;
 			gap: 0;
 
@@ -162,8 +166,7 @@
 	}
 
 	@media (min-width: $break-wide) {
-		.sites-dashboard__layout:not(.preview-hidden) {
-
+		&.sites-dashboard__layout:not(.preview-hidden) {
 			.sites-overview {
 				padding: 0;
 				overflow-y: hidden;
@@ -286,21 +289,14 @@
 		max-width: none;
 	}
 
-	.sites-dashboard__layout:not(.preview-hidden) {
+	&.sites-dashboard__layout:not(.preview-hidden) {
 
 		.section-nav {
 			display: none;
 		}
 	}
 
-	.sites-dashboard__layout {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: nowrap;
-		gap: 16px;
-		max-height: calc(100vh - 32px);
-		min-height: calc(100vh - 32px);
-
+	&.sites-dashboard__layout {
 		.activity-card-list .activity-card .activity-card__time {
 			background: none;
 		}
@@ -351,10 +347,6 @@
 			}
 		}
 
-		.a4a-layout__container {
-			width: 100%;
-		}
-
 		.sites-overview {
 			width: 400px;
 			flex-shrink: 0;
@@ -369,8 +361,7 @@
 			}
 
 			.sites-overview__content {
-				margin-top: 16px;
-				padding-inline: 64px;
+				margin-top: 24px;
 			}
 		}
 
@@ -413,6 +404,16 @@
 				.sites-overview {
 					padding: 0;
 					overflow-x: auto;
+
+					.dataviews-filters__view-actions {
+						& > :first-child {
+							margin-left: 64px;
+						}
+
+						& > :last-child {
+							margin-right: 64px;
+						}
+					}
 				}
 			}
 		}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -349,7 +349,7 @@
 
 		.sites-overview {
 			width: 400px;
-			flex-shrink: 0;
+			flex: unset;
 			overflow-x: auto;
 			overflow-y: hidden;
 			transition: all 0.2s;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -89,7 +89,7 @@
 			padding-bottom: 8px;
 
 			& > :first-child {
-				margin-left: 8px;
+				margin-inline-start: 8px;
 			}
 
 			.components-input-control {
@@ -120,11 +120,11 @@
 		}
 
 		tr td:first-child {
-			padding-left: 8px;
+			padding-inline-start: 8px;
 		}
 
 		tr td:last-child {
-			padding-right: 8px;
+			padding-inline-end: 8px;
 		}
 
 		.dataviews-view-table-wrapper {
@@ -407,11 +407,11 @@
 
 					.dataviews-filters__view-actions {
 						& > :first-child {
-							margin-left: 64px;
+							margin-inline-start: 64px;
 						}
 
 						& > :last-child {
-							margin-right: 64px;
+							margin-inline-end: 64px;
 						}
 					}
 				}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -109,7 +109,7 @@
 }
 
 .dataviews-filters__view-actions {
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 }
 
 .sites-dataviews__site {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/75

## Proposed Changes

* This PR adds the LayoutColumn component, which can be used as a child of the Layout component. This new component makes it possible to add multiple columns to a single layout, each column behaves as a Layout.
* This PR also updates the SitesDashboard component to use the new component.

## Testing Instructions

* Review the new LayoutColumn component's code
* Make sure A4A existing pages work the same way as before
* Check the SitesDashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?