### PR TITLE
Fix woo express login url

### DIFF
--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -84,6 +84,7 @@ const wooexpress: Flow = {
 				locale,
 				redirectTo,
 				oauth2ClientId: queryParams.get( 'client_id' ) || undefined,
+				wccomFrom: queryParams.get( 'wccom-from' ) || undefined,
 			} );
 
 			if ( aff ) {

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -1,14 +1,15 @@
 import config from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import recordGTMDatalayerEvent from 'calypso/lib/analytics/ad-tracking/woo/record-gtm-datalayer-event';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { login } from 'calypso/lib/paths';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
-import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { AssignTrialResult } from './internals/steps-repository/assign-trial-plan/constants';
@@ -41,8 +42,6 @@ const wooexpress: Flow = {
 		);
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
-		const flowName = this.name;
-
 		// There is a race condition where useLocale is reporting english,
 		// despite there being a locale in the URL so we need to look it up manually.
 		// We also need to support both query param and path suffix localized urls
@@ -62,8 +61,6 @@ const wooexpress: Flow = {
 
 		const queryParams = new URLSearchParams( window.location.search );
 		const profilerData = queryParams.get( 'profilerdata' );
-		const aff = queryParams.get( 'aff' );
-		const vendorId = queryParams.get( 'vid' );
 
 		if ( profilerData ) {
 			try {
@@ -76,40 +73,18 @@ const wooexpress: Flow = {
 			} catch {}
 		}
 
-		const getStartUrl = () => {
-			let hasFlowParams = false;
-			const flowParams = new URLSearchParams();
-			const queryParams = new URLSearchParams();
-
-			if ( vendorId ) {
-				queryParams.set( 'vid', vendorId );
-			}
-
-			if ( aff ) {
-				queryParams.set( 'aff', aff );
-			}
-
-			if ( locale && locale !== 'en' ) {
-				flowParams.set( 'locale', locale );
-				hasFlowParams = true;
-			}
-
-			const redirectTarget =
-				`/setup/wooexpress` +
-				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
-
-			let queryString = `redirect_to=${ redirectTarget }`;
-
-			if ( queryParams.toString() ) {
-				queryString = `${ queryString }&${ queryParams.toString() }`;
-			}
-
-			const logInUrl = getLoginUrl( {
-				variationName: flowName,
-				locale,
+		const getLoginUrl = () => {
+			const redirectTo = addQueryArgs( '/setup/wooexpress', {
+				...Object.fromEntries( queryParams ),
 			} );
 
-			return `${ logInUrl }&${ queryString }`;
+			const logInUrl = login( {
+				locale,
+				redirectTo,
+				oauth2ClientId: queryParams.get( 'client_id' ) || undefined,
+			} );
+
+			return logInUrl;
 		};
 
 		// Despite sending a CHECKING state, this function gets called again with the
@@ -143,7 +118,7 @@ const wooexpress: Flow = {
 			}
 
 			if ( ! userIsLoggedIn ) {
-				const logInUrl = getStartUrl();
+				const logInUrl = getLoginUrl();
 				window.location.assign( logInUrl );
 			}
 		}, [] );

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -61,6 +61,8 @@ const wooexpress: Flow = {
 
 		const queryParams = new URLSearchParams( window.location.search );
 		const profilerData = queryParams.get( 'profilerdata' );
+		const aff = queryParams.get( 'aff' );
+		const vendorId = queryParams.get( 'vid' );
 
 		if ( profilerData ) {
 			try {
@@ -78,12 +80,21 @@ const wooexpress: Flow = {
 				...Object.fromEntries( queryParams ),
 			} );
 
-			const logInUrl = login( {
+			let logInUrl = login( {
 				locale,
 				redirectTo,
 				oauth2ClientId: queryParams.get( 'client_id' ) || undefined,
 			} );
 
+			if ( aff ) {
+				logInUrl = addQueryArgs( logInUrl, { aff } );
+			}
+
+			if ( vendorId ) {
+				logInUrl = addQueryArgs( logInUrl, {
+					vid: vendorId,
+				} );
+			}
 			return logInUrl;
 		};
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -115,6 +115,10 @@ function isOauth2RedirectValid( oauth2Redirect ) {
 		return true;
 	}
 
+	if ( oauth2Redirect.startsWith( '/setup/wooexpress' ) ) {
+		return true;
+	}
+
 	try {
 		const url = new URL( oauth2Redirect );
 		return url.host === 'public-api.wordpress.com';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/woocommerce.com/pull/19925
Fixes  https://github.com/Automattic/wp-calypso/issues/88604

## Proposed Changes

* When user is not logged in, redirect user to Woo login page, instead of WP login page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out https://github.com/Automattic/woocommerce.com/pull/19925 on your local wccom environment.
2. Go to https://woocommerce.test/
2. Log in woo.com
3. Go to wordpress.com and log out
4. Go to https://woo.com/start/#/installation
5. Click on "Try Woo Express for free"
6. Observe that you are redirected to Woo login page
7. Log in and confirm you're redirect to woo express loading screen.
8. Please test around this issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?