### PR TITLE
Enable woo passwordless feature flag in Stage environment

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -193,7 +193,7 @@
 		"user-management-revamp": true,
 		"videomaker-trial": true,
 		"woop": false,
-		"woo/passwordless": false,
+		"woo/passwordless": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/command-palette": true

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -154,9 +154,14 @@ export class UserSignupPage {
 	 * @returns {NewUserResponse} Response from the REST API.
 	 */
 	async signupWoo( email: string, username: string, password: string ): Promise< NewUserResponse > {
+		const isWooPasswordless = await this.page.evaluate( `configData.features['woo/passwordless']` );
+
 		await this.page.fill( selectors.emailInput, email );
-		await this.page.fill( selectors.usernameInput, username );
-		await this.page.fill( selectors.passwordInput, password );
+
+		if ( ! isWooPasswordless ) {
+			await this.page.fill( selectors.usernameInput, username );
+			await this.page.fill( selectors.passwordInput, password );
+		}
 
 		const [ , response ] = await Promise.all( [
 			this.page.waitForURL( /.*woo\.com*/ ),

--- a/test/e2e/specs/authentication/authentication__totp.ts
+++ b/test/e2e/specs/authentication/authentication__totp.ts
@@ -76,6 +76,11 @@ describe( DataHelper.createSuiteTitle( 'Authentication: TOTP' ), function () {
 		it( 'Enter username', async function () {
 			loginPage = new LoginPage( page );
 			await loginPage.fillUsername( credentials.username );
+
+			const isWooPasswordless = await page.evaluate( `configData.features['woo/passwordless']` );
+			if ( isWooPasswordless ) {
+				await loginPage.clickSubmit();
+			}
 		} );
 
 		it( 'Enter password', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Enable woo passwordless feature flag in Stage environment so that we can test the feature in stage environment.

## Proposed Changes

* Enable the feature flag `woocommerce/passwordless` in stage environment.
* Update e2e tests so when the feature flag is enabled, the tests will run with the feature flag enabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Reviewing the changes in the PR should be enough

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?