### PR TITLE
GitHub deployments/batch of small UI changes (WIP)

### DIFF
--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -138,85 +138,87 @@ export const GitHubConnectionForm = ( {
 				}
 			} }
 		>
-			<div className="github-deployments-connect-repository__configs">
-				<FormFieldset className="github-deployments-connect-repository__repository">
-					<FormLabel>{ __( 'Repository' ) }</FormLabel>
-					<div
-						className={ classNames( 'github-deployments-connect-repository__repository-input', {
-							'github-deployments-connect-repository__repository-input--has-error':
-								displayMissingRepositoryError,
-						} ) }
-					>
-						{ repository ? (
-							<ExternalLink
-								href={ `https://github.com/${ repository.owner }/${ repository.name }` }
-							>
-								{ repository.owner }/{ repository.name }
-							</ExternalLink>
-						) : (
-							<FormSettingExplanation css={ { margin: '0 !important' } }>
-								{ __( 'No repository selected' ) }
-							</FormSettingExplanation>
-						) }
-						{ changeRepository && (
-							<Button compact onClick={ changeRepository }>
-								{ __( 'Select repository' ) }
-							</Button>
-						) }
-					</div>
-					{ displayMissingRepositoryError && (
-						<FormInputValidation isError text={ __( 'Please select a repository' ) } />
-					) }
-				</FormFieldset>
-				<FormFieldset>
-					<FormLabel htmlFor="branch">{ __( 'Deployment branch' ) }</FormLabel>
-					<div className="github-deployments-connect-repository__branch-select">
-						<FormSelect
-							id="branch"
-							disabled={ isFetchingBranches }
-							onChange={ ( event: ChangeEvent< HTMLSelectElement > ) =>
-								setBranch( event.target.value )
-							}
-							value={ branch }
+			<div className="github-deployments-connect-repository__content">
+				<div className="github-deployments-connect-repository__configs">
+					<FormFieldset className="github-deployments-connect-repository__repository">
+						<FormLabel>{ __( 'Repository' ) }</FormLabel>
+						<div
+							className={ classNames( 'github-deployments-connect-repository__repository-input', {
+								'github-deployments-connect-repository__repository-input--has-error':
+									displayMissingRepositoryError,
+							} ) }
 						>
-							{ branchOptions.map( ( branchOption ) => (
-								<option key={ branchOption } value={ branchOption }>
-									{ branchOption }
-								</option>
-							) ) }
-						</FormSelect>
-						{ isFetchingBranches && <Spinner /> }
-					</div>
-				</FormFieldset>
-				<TargetDirInput onChange={ setDestPath } value={ destPath } />
-				<AutomatedDeploymentsToggle
-					onChange={ setIsAutoDeploy }
-					value={ isAutoDeploy }
-					hasWorkflowPath={ !! workflowPath }
-				/>
-				<div className="github-deployments-connect-repository__submit">
-					<Button type="submit" primary busy={ isPending } disabled={ isPending || submitDisabled }>
-						{ deploymentId ? __( 'Update' ) : __( 'Connect' ) }
-					</Button>
-
-					{ deploymentId && (
-						<FormSettingExplanation>
-							{ __( 'Changes will be applied in the next deployment run.' ) }
-						</FormSettingExplanation>
-					) }
+							{ repository ? (
+								<ExternalLink
+									href={ `https://github.com/${ repository.owner }/${ repository.name }` }
+								>
+									{ repository.owner }/{ repository.name }
+								</ExternalLink>
+							) : (
+								<FormSettingExplanation css={ { margin: '0 !important' } }>
+									{ __( 'No repository selected' ) }
+								</FormSettingExplanation>
+							) }
+							{ changeRepository && (
+								<Button compact onClick={ changeRepository }>
+									{ __( 'Select repository' ) }
+								</Button>
+							) }
+						</div>
+						{ displayMissingRepositoryError && (
+							<FormInputValidation isError text={ __( 'Please select a repository' ) } />
+						) }
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="branch">{ __( 'Deployment branch' ) }</FormLabel>
+						<div className="github-deployments-connect-repository__branch-select">
+							<FormSelect
+								id="branch"
+								disabled={ isFetchingBranches }
+								onChange={ ( event: ChangeEvent< HTMLSelectElement > ) =>
+									setBranch( event.target.value )
+								}
+								value={ branch }
+							>
+								{ branchOptions.map( ( branchOption ) => (
+									<option key={ branchOption } value={ branchOption }>
+										{ branchOption }
+									</option>
+								) ) }
+							</FormSelect>
+							{ isFetchingBranches && <Spinner /> }
+						</div>
+					</FormFieldset>
+					<TargetDirInput onChange={ setDestPath } value={ destPath } />
+					<AutomatedDeploymentsToggle
+						onChange={ setIsAutoDeploy }
+						value={ isAutoDeploy }
+						hasWorkflowPath={ !! workflowPath }
+					/>
 				</div>
+				<DeploymentStyle
+					isDisabled={ ! repository || isFetchingBranches }
+					branchName={ branch }
+					repository={ repository }
+					workflowPath={ workflowPath }
+					onChooseWorkflow={ ( filePath ) => setWorkflowPath( filePath ) }
+					workflowCheckResult={ workflowCheckResult }
+					isCheckingWorkflow={ isCheckingWorkflow }
+					onWorkflowVerify={ checkWorkflow }
+					useComposerWorkflow={ !! useComposerWorkflow }
+				/>
 			</div>
-			<DeploymentStyle
-				isDisabled={ ! repository || isFetchingBranches }
-				branchName={ branch }
-				repository={ repository }
-				workflowPath={ workflowPath }
-				onChooseWorkflow={ ( filePath ) => setWorkflowPath( filePath ) }
-				workflowCheckResult={ workflowCheckResult }
-				isCheckingWorkflow={ isCheckingWorkflow }
-				onWorkflowVerify={ checkWorkflow }
-				useComposerWorkflow={ !! useComposerWorkflow }
-			/>
+			<div className="github-deployments-connect-repository__submit">
+				<Button type="submit" primary busy={ isPending } disabled={ isPending || submitDisabled }>
+					{ deploymentId ? __( 'Update' ) : __( 'Connect' ) }
+				</Button>
+
+				{ deploymentId && (
+					<FormSettingExplanation>
+						{ __( 'Changes will be applied in the next deployment run.' ) }
+					</FormSettingExplanation>
+				) }
+			</div>
 		</form>
 	);
 };

--- a/client/my-sites/github-deployments/components/github-connection-form/style.scss
+++ b/client/my-sites/github-deployments/components/github-connection-form/style.scss
@@ -63,7 +63,7 @@
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		margin-top: 40px;
+		margin-top: 16px;
 
 		.button {
 			overflow: visible;

--- a/client/my-sites/github-deployments/components/github-connection-form/style.scss
+++ b/client/my-sites/github-deployments/components/github-connection-form/style.scss
@@ -1,10 +1,13 @@
 .github-deployments-connect-repository {
-	display: flex;
-	justify-content: space-between;
-	gap: 58px;
 
-	> * {
-		flex: 1;
+	&__content {
+		display: flex;
+		justify-content: space-between;
+		gap: 58px;
+
+		> div {
+			flex: 1;
+		}
 	}
 
 	.form-label {

--- a/client/my-sites/github-deployments/components/repositories/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/style.scss
@@ -45,6 +45,11 @@
 		p:last-of-type {
 			line-height: 20px;
 		}
+		a.is-primary {
+			svg {
+				margin-left: 4px;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/5904 https://github.com/Automattic/wp-calypso/pull/5909

## Proposed Changes

**Fix primary CTA position** https://github.com/Automattic/wp-calypso/issues/5904
<img width="1192" alt="Screenshot 2567-03-19 at 13 24 52" src="https://github.com/Automattic/wp-calypso/assets/6851384/ec791f67-08cf-4328-ab99-d1dcf58de721">

<img width="1198" alt="Screenshot 2567-03-19 at 13 19 54" src="https://github.com/Automattic/wp-calypso/assets/6851384/602a7957-2187-452c-905e-9bd8ac10e13b">

**Fixes to the "No results found" state** https://github.com/Automattic/wp-calypso/pull/5909
(just the icon gap part as rest done)

<img width="211" alt="Screenshot 2567-03-19 at 13 22 00" src="https://github.com/Automattic/wp-calypso/assets/6851384/9ed8cd2b-bc9b-4a34-ac54-93898a8b84d3">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Testing instructions

- Try it in Calypso Live and compare two issues above are resolved. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?