### PR TITLE
Pattern Library: Add `PatternsPageViewTracker`

### DIFF
--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -54,7 +54,7 @@ export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageV
 		path = `/patterns/${ category }`;
 	}
 
-	if ( searchTerm ) {
+	if ( debouncedSeachTerm ) {
 		path += '/:search';
 	}
 

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -15,25 +15,26 @@ export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageV
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
 	useEffect( () => {
-		const commonProperties = {
-			is_logged_in: isLoggedIn,
-			user_is_dev_account: isDevAccount ? '1' : '0',
-		};
+		if ( category ) {
+			recordTracksEvent( 'calypso_pattern_library_filter', {
+				category,
+				is_logged_in: isLoggedIn,
+				user_is_dev_account: isDevAccount ? '1' : '0',
+			} );
+		}
+	}, [ category, isDevAccount, isLoggedIn ] );
 
+	useEffect( () => {
 		if ( searchTerm ) {
 			recordTracksEvent( 'calypso_pattern_library_search', {
-				...commonProperties,
+				category,
+				is_logged_in: isLoggedIn,
+				user_is_dev_account: isDevAccount ? '1' : '0',
 				search_term: searchTerm,
 			} );
 		}
-
-		if ( category ) {
-			recordTracksEvent( 'calypso_pattern_library_filter', {
-				...commonProperties,
-				category,
-			} );
-		}
-	}, [ category, isDevAccount, isLoggedIn, searchTerm ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isDevAccount, isLoggedIn, searchTerm ] );
 
 	let path: string = '';
 	const properties: Record< string, string | boolean > = {

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -14,32 +14,40 @@ export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageV
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
-	// `PageViewTracker` pushes a new event only when `path` changes, so we track
-	// `calypso_pattern_library_search` to have accurate data on which search terms are used
 	useEffect( () => {
+		const commonProperties = {
+			is_logged_in: isLoggedIn,
+			user_is_dev_account: isDevAccount ? '1' : '0',
+		};
+
 		if ( searchTerm ) {
 			recordTracksEvent( 'calypso_pattern_library_search', {
-				is_logged_in: isLoggedIn ? '1' : '0',
+				...commonProperties,
 				search_term: searchTerm,
-				user_is_dev_account: isDevAccount ? '1' : '0',
 			} );
 		}
-	}, [ isDevAccount, isLoggedIn, searchTerm ] );
+
+		if ( category ) {
+			recordTracksEvent( 'calypso_pattern_library_filter', {
+				...commonProperties,
+				category: category,
+			} );
+		}
+	}, [ category, isDevAccount, isLoggedIn, searchTerm ] );
 
 	let path: string = '';
-	const properties: Record< string, string > = {
-		is_logged_in: isLoggedIn ? '1' : '0',
+	const properties: Record< string, string | boolean > = {
+		is_logged_in: isLoggedIn,
 	};
 
 	if ( ! category ) {
-		path = searchTerm ? '/patterns/:search' : '/patterns';
+		path = '/patterns';
 	} else {
-		path = searchTerm ? '/patterns/:category/:search' : '/patterns/:category';
-		properties.category = category;
+		path = `/patterns/${ category }`;
 	}
 
 	if ( searchTerm ) {
-		properties.search_term = searchTerm;
+		path += '/:search';
 	}
 
 	return <PageViewTracker path={ path } properties={ properties } title="Pattern Library" />;

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from 'react';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
 
 type PatternsPageViewTrackerProps = {
 	category: string;
@@ -9,6 +12,19 @@ type PatternsPageViewTrackerProps = {
 
 export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageViewTrackerProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+
+	// `PageViewTracker` pushes a new event only when `path` changes, so we track
+	// `calypso_pattern_library_search` to have accurate data on which search terms are used
+	useEffect( () => {
+		if ( searchTerm ) {
+			recordTracksEvent( 'calypso_pattern_library_search', {
+				is_logged_in: isLoggedIn ? '1' : '0',
+				search_term: searchTerm,
+				user_is_dev_account: isDevAccount ? '1' : '0',
+			} );
+		}
+	}, [ isDevAccount, isLoggedIn, searchTerm ] );
 
 	let path: string = '';
 	const properties: Record< string, string > = {
@@ -26,9 +42,5 @@ export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageV
 		properties.search_term = searchTerm;
 	}
 
-	const key = path + category + searchTerm;
-
-	return (
-		<PageViewTracker key={ key } path={ path } properties={ properties } title="Pattern Library" />
-	);
+	return <PageViewTracker path={ path } properties={ properties } title="Pattern Library" />;
 }

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -1,0 +1,34 @@
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+
+type PatternsPageViewTrackerProps = {
+	category: string;
+	searchTerm: string;
+};
+
+export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageViewTrackerProps ) {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	let path: string = '';
+	const properties: Record< string, string > = {
+		is_logged_in: isLoggedIn ? '1' : '0',
+	};
+
+	if ( ! category ) {
+		path = searchTerm ? '/patterns/:search' : '/patterns';
+	} else {
+		path = searchTerm ? '/patterns/:category/:search' : '/patterns/:category';
+		properties.category = category;
+	}
+
+	if ( searchTerm ) {
+		properties.search_term = searchTerm;
+	}
+
+	const key = path + category + searchTerm;
+
+	return (
+		<PageViewTracker key={ key } path={ path } properties={ properties } title="Pattern Library" />
+	);
+}

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -33,6 +33,9 @@ export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageV
 				search_term: searchTerm,
 			} );
 		}
+
+		// We want to avoid resubmitting the `calypso_pattern_library_search` event whenever
+		// `category` changes, which is why we deliberately don't include it in the dependency array
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isDevAccount, isLoggedIn, searchTerm ] );
 

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -30,7 +30,7 @@ export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageV
 		if ( category ) {
 			recordTracksEvent( 'calypso_pattern_library_filter', {
 				...commonProperties,
-				category: category,
+				category,
 			} );
 		}
 	}, [ category, isDevAccount, isLoggedIn, searchTerm ] );

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -58,5 +58,9 @@ export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageV
 		path += '/:search';
 	}
 
-	return <PageViewTracker path={ path } properties={ properties } title="Pattern Library" />;
+	const key = path + debouncedSeachTerm;
+
+	return (
+		<PageViewTracker key={ key } path={ path } properties={ properties } title="Pattern Library" />
+	);
 }

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -113,7 +113,6 @@ export const PatternLibrary = ( {
 			<PatternsHeader
 				description="Dive into hundreds of expertly designed, fully responsive layouts, and bring any kind of site to life, faster."
 				initialSearchTerm={ searchTerm }
-				key={ searchFormKey }
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -17,6 +17,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { PatternsCopyPasteInfo } from 'calypso/my-sites/patterns/components/copy-paste-info';
 import { PatternsGetStarted } from 'calypso/my-sites/patterns/components/get-started';
 import { PatternsHeader } from 'calypso/my-sites/patterns/components/header';
+import { PatternsPageViewTracker } from 'calypso/my-sites/patterns/components/page-view-tracker';
 import { getCategoryUrlPath } from 'calypso/my-sites/patterns/controller';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import {
@@ -128,6 +129,8 @@ export const PatternLibrary = ( {
 
 	return (
 		<>
+			<PatternsPageViewTracker category={ category } searchTerm={ searchTerm } />
+
 			<DocumentHead title="WordPress Patterns - Category" />
 
 			<PatternsHeader

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -11,7 +11,6 @@ import {
 	category as iconCategory,
 	menu as iconMenu,
 } from '@wordpress/icons';
-import { useEffect, useRef, useState } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import { PatternsCopyPasteInfo } from 'calypso/my-sites/patterns/components/copy-paste-info';
@@ -78,10 +77,6 @@ export const PatternLibrary = ( {
 	searchTerm: urlQuerySearchTerm,
 }: PatternLibraryProps ) => {
 	const locale = useLocale();
-	// Helps prevent resetting the search input if a search term was provided through the URL
-	const isInitialRender = useRef( true );
-	// Helps reset the search input when navigating between categories
-	const [ searchFormKey, setSearchFormKey ] = useState( category );
 
 	const [ searchTerm, setSearchTerm ] = usePatternSearchTerm( urlQuerySearchTerm ?? '' );
 	const { data: categories = [] } = usePatternCategories( locale );
@@ -91,26 +86,6 @@ export const PatternLibrary = ( {
 			return filterPatternsByTerm( patternsByType, searchTerm );
 		},
 	} );
-
-	// Resets the search term when navigating from `/patterns?s=lorem` to `/patterns`
-	useEffect( () => {
-		if ( ! urlQuerySearchTerm ) {
-			setSearchTerm( '' );
-			setSearchFormKey( Math.random().toString() );
-		}
-	}, [ urlQuerySearchTerm ] );
-
-	// Resets the search term whenever the category changes
-	useEffect( () => {
-		if ( isInitialRender.current ) {
-			isInitialRender.current = false;
-		} else {
-			setSearchTerm( '' );
-			setSearchFormKey( category );
-		}
-	}, [ category ] );
-
-	const isHomePage = ! category && ! searchTerm;
 
 	const categoryObject = categories?.find( ( { name } ) => name === category );
 
@@ -126,6 +101,8 @@ export const PatternLibrary = ( {
 				( isGridView ? '?grid=1' : '' ),
 		};
 	} );
+
+	const isHomePage = ! category && ! searchTerm;
 
 	return (
 		<>

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -27,6 +27,7 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 					category={ context.params.category }
 					categoryGallery={ CategoryGalleryClient }
 					isGridView={ !! context.query.grid }
+					key={ context.params.category }
 					patternGallery={ PatternGalleryClient }
 					patternTypeFilter={
 						context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6134

## Proposed Changes

We haven't really observed the analytics guidelines that @wongasy laid out in pcYYuD-1hV-p2 so far. This PR takes a first stab at changing that by tracking the `calypso_page_view` and `calypso_pattern_library_search` events. 

I've added a `PatternsPageViewTracker` component that wraps `PageViewTracker` and also submits `calypso_pattern_library_search` in a `useEffect` callback.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns`
2. Ensure a `calypso_page_view` event is submitted with the path `/patterns`
3. Navigate to `/patterns/about`
4. Ensure a `calypso_page_view` event is submitted with the path `/patterns/:category`
5. Search for something
6. Ensure a `calypso_page_view` event is submitted with the path `/patterns/:category/:search`
7. Ensure a `calypso_pattern_library_search` event is submitted
8. Update the search term
9. Ensure another `calypso_pattern_library_search` event is submitted