### PR TITLE
Plugin update manager: empty state when no eligible plugins are installed

### DIFF
--- a/client/blocks/plugins-update-manager/context/index.tsx
+++ b/client/blocks/plugins-update-manager/context/index.tsx
@@ -3,28 +3,20 @@ import type { SiteSlug } from 'calypso/types';
 
 interface PluginUpdateManagerContextProps {
 	siteSlug: SiteSlug;
-	siteHasEligiblePlugins: boolean;
-	siteHasEligiblePluginsLoading: boolean;
 }
 
 const PluginUpdateManagerContext = createContext< PluginUpdateManagerContextProps >( {
 	siteSlug: '',
-	siteHasEligiblePlugins: true,
-	siteHasEligiblePluginsLoading: true,
 } );
 
 const PluginUpdateManagerContextProvider = ( {
 	siteSlug,
-	siteHasEligiblePlugins,
-	siteHasEligiblePluginsLoading,
 	children,
 }: PluginUpdateManagerContextProps & { children: ReactNode } ) => {
 	return (
 		<PluginUpdateManagerContext.Provider
 			value={ {
 				siteSlug,
-				siteHasEligiblePlugins,
-				siteHasEligiblePluginsLoading,
 			} }
 		>
 			{ children }

--- a/client/blocks/plugins-update-manager/context/index.tsx
+++ b/client/blocks/plugins-update-manager/context/index.tsx
@@ -1,35 +1,30 @@
-import React, { createContext, ReactNode, useState } from 'react';
+import React, { createContext, ReactNode } from 'react';
 import type { SiteSlug } from 'calypso/types';
 
 interface PluginUpdateManagerContextProps {
 	siteSlug: SiteSlug;
-}
-
-interface PluginUpdateManagerContextState {
 	siteHasEligiblePlugins: boolean;
-	setSiteHasEligiblePlugins: ( siteHasEligiblePlugins: boolean ) => void;
+	siteHasEligiblePluginsLoading: boolean;
 }
 
-const PluginUpdateManagerContext = createContext<
-	PluginUpdateManagerContextProps & PluginUpdateManagerContextState
->( {
+const PluginUpdateManagerContext = createContext< PluginUpdateManagerContextProps >( {
 	siteSlug: '',
 	siteHasEligiblePlugins: true,
-	setSiteHasEligiblePlugins: () => {},
+	siteHasEligiblePluginsLoading: true,
 } );
 
 const PluginUpdateManagerContextProvider = ( {
 	siteSlug,
+	siteHasEligiblePlugins,
+	siteHasEligiblePluginsLoading,
 	children,
 }: PluginUpdateManagerContextProps & { children: ReactNode } ) => {
-	const [ siteHasEligiblePlugins, setSiteHasEligiblePlugins ] = useState( true );
-
 	return (
 		<PluginUpdateManagerContext.Provider
 			value={ {
 				siteSlug,
 				siteHasEligiblePlugins,
-				setSiteHasEligiblePlugins,
+				siteHasEligiblePluginsLoading,
 			} }
 		>
 			{ children }

--- a/client/blocks/plugins-update-manager/hooks/use-site-has-eligible-plugins.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-has-eligible-plugins.ts
@@ -1,9 +1,14 @@
 import { useContext } from 'react';
+import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import { PluginUpdateManagerContext } from '../context';
 
 export function useSiteHasEligiblePlugins() {
-	const { siteHasEligiblePlugins, siteHasEligiblePluginsLoading } = useContext(
-		PluginUpdateManagerContext
+	const { siteSlug } = useContext( PluginUpdateManagerContext );
+	const { data: plugins = [], isFetched: isPluginsFetched } = useCorePluginsQuery(
+		siteSlug,
+		true,
+		true
 	);
-	return { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading };
+	const siteHasEligiblePlugins = isPluginsFetched && plugins.length > 0;
+	return { siteHasEligiblePlugins, loading: ! isPluginsFetched };
 }

--- a/client/blocks/plugins-update-manager/hooks/use-site-has-eligible-plugins.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-has-eligible-plugins.ts
@@ -2,10 +2,11 @@ import { useContext } from 'react';
 import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import { PluginUpdateManagerContext } from '../context';
 
-export function useSiteHasEligiblePlugins() {
-	const { siteSlug } = useContext( PluginUpdateManagerContext );
+export function useSiteHasEligiblePlugins( siteSlug?: string ) {
+	const { siteSlug: contextSiteSlug } = useContext( PluginUpdateManagerContext );
+	const slug = siteSlug || contextSiteSlug;
 	const { data: plugins = [], isFetched: isPluginsFetched } = useCorePluginsQuery(
-		siteSlug,
+		slug,
 		true,
 		true
 	);

--- a/client/blocks/plugins-update-manager/hooks/use-site-has-eligible-plugins.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-has-eligible-plugins.ts
@@ -1,18 +1,9 @@
-import { useContext, useEffect } from 'react';
-import { CorePluginsResponse } from 'calypso/data/plugins/use-core-plugins-query';
+import { useContext } from 'react';
 import { PluginUpdateManagerContext } from '../context';
 
-export function useSetSiteHasEligiblePlugins( data: CorePluginsResponse, isFetched: boolean ) {
-	const { setSiteHasEligiblePlugins } = useContext( PluginUpdateManagerContext );
-	useEffect( () => {
-		if ( isFetched && ! data.filter( ( plugin ) => ! plugin.is_managed ).length ) {
-			setSiteHasEligiblePlugins( false );
-			return;
-		}
-	}, [ data, isFetched ] );
-}
-
 export function useSiteHasEligiblePlugins() {
-	const { siteHasEligiblePlugins } = useContext( PluginUpdateManagerContext );
-	return siteHasEligiblePlugins;
+	const { siteHasEligiblePlugins, siteHasEligiblePluginsLoading } = useContext(
+		PluginUpdateManagerContext
+	);
+	return { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading };
 }

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -8,7 +8,6 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ScheduledUpdatesGate from 'calypso/components/scheduled-updates/scheduled-updates-gate';
-import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
@@ -41,14 +40,6 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
-	const { data: plugins = [], isFetched: isPluginsFetched } = useCorePluginsQuery(
-		siteSlug,
-		true,
-		true
-	);
-	const siteHasEligiblePlugins =
-		isPluginsFetched && plugins.filter( ( plugin ) => ! plugin.is_managed ).length > 0;
-
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
 	useEffect( () => {
 		recordTracksEvent( 'calypso_scheduled_updates_page_view', {
@@ -79,11 +70,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	}[ context ];
 
 	return (
-		<PluginUpdateManagerContextProvider
-			siteSlug={ siteSlug }
-			siteHasEligiblePlugins={ siteHasEligiblePlugins }
-			siteHasEligiblePluginsLoading={ ! isPluginsFetched }
-		>
+		<PluginUpdateManagerContextProvider siteSlug={ siteSlug }>
 			<DocumentHead title={ title } />
 			{ ! isSitePlansLoaded && <QuerySitePlans siteId={ siteId } /> }
 			<MainComponent wideLayout>
@@ -98,9 +85,9 @@ export const PluginsUpdateManager = ( props: Props ) => {
 						<Button
 							__next40pxDefaultSize
 							icon={ plus }
-							variant={ canCreateSchedules && siteHasEligiblePlugins ? 'primary' : 'secondary' }
+							variant={ canCreateSchedules ? 'primary' : 'secondary' }
 							onClick={ onCreateNewSchedule }
-							disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
+							disabled={ ! canCreateSchedules }
 						>
 							{ translate( 'Add new schedule' ) }
 						</Button>

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -3,6 +3,7 @@ import { plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useIsEligibleForFeature } from 'calypso/blocks/plugins-update-manager/hooks/use-is-eligible-for-feature';
+import { useSiteHasEligiblePlugins } from 'calypso/blocks/plugins-update-manager/hooks/use-site-has-eligible-plugins';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import MainComponent from 'calypso/components/main';
@@ -39,6 +40,8 @@ export const PluginsUpdateManager = ( props: Props ) => {
 
 	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
+
+	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins( siteSlug );
 
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
 	useEffect( () => {
@@ -85,9 +88,9 @@ export const PluginsUpdateManager = ( props: Props ) => {
 						<Button
 							__next40pxDefaultSize
 							icon={ plus }
-							variant={ canCreateSchedules ? 'primary' : 'secondary' }
+							variant={ canCreateSchedules && siteHasEligiblePlugins ? 'primary' : 'secondary' }
 							onClick={ onCreateNewSchedule }
-							disabled={ ! canCreateSchedules }
+							disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
 						>
 							{ translate( 'Add new schedule' ) }
 						</Button>

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -31,7 +31,8 @@ export const ScheduleCreate = ( props: Props ) => {
 	const translate = useTranslate();
 	const { createMonitor } = useCreateMonitor( siteSlug );
 	const { isEligibleForFeature } = useIsEligibleForFeature();
-	const siteHasEligiblePlugins = useSiteHasEligiblePlugins();
+	const { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading } =
+		useSiteHasEligiblePlugins();
 	const { onNavBack } = props;
 	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
 		siteSlug,
@@ -52,6 +53,13 @@ export const ScheduleCreate = ( props: Props ) => {
 			onNavBack && onNavBack();
 		}
 	}, [ isFetched ] );
+
+	// Redirect back to list when no eligible plugins are installed
+	useEffect( () => {
+		if ( ! siteHasEligiblePlugins && ! siteHasEligiblePluginsLoading ) {
+			onNavBack && onNavBack();
+		}
+	}, [ siteHasEligiblePlugins, siteHasEligiblePluginsLoading ] );
 
 	const onSyncSuccess = () => {
 		recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -2,7 +2,6 @@ import { Flex, FlexItem } from '@wordpress/components';
 import { useState, useEffect } from 'react';
 import { ScheduleFormFrequency } from 'calypso/blocks/plugins-update-manager/schedule-form-frequency';
 import { ScheduleFormPlugins } from 'calypso/blocks/plugins-update-manager/schedule-form-plugins';
-import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import {
 	useCreateUpdateScheduleMutation,
 	useEditUpdateScheduleMutation,
@@ -12,7 +11,6 @@ import {
 	ScheduleUpdates,
 } from 'calypso/data/plugins/use-update-schedules-query';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
-import { useSetSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { validatePlugins, validateTimeSlot } from './schedule-form.helper';
 
@@ -27,13 +25,6 @@ export const ScheduleForm = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
-
-	const { data: plugins = [], isFetched: isPluginsFetched } = useCorePluginsQuery(
-		siteSlug,
-		true,
-		true
-	);
-	useSetSiteHasEligiblePlugins( plugins, isPluginsFetched );
 
 	const serverSyncCallbacks = {
 		onSuccess: () => onSyncSuccess && onSyncSuccess(),

--- a/client/blocks/plugins-update-manager/schedule-list-empty.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-empty.tsx
@@ -24,7 +24,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 				{ ( () => {
 					if ( ! siteHasEligiblePlugins && canCreateSchedules ) {
 						return translate(
-							'To set up schedules to manage your plugins, first you need to install plugins that are not managed by the plugin provider.'
+							'To set up schedules to update your plugins, first you need to install plugins that are not managed by the plugin provider.'
 						);
 					} else if ( ! canCreateSchedules ) {
 						return translate( 'This site is unable to schedule auto-updates for plugins.' );

--- a/client/blocks/plugins-update-manager/schedule-list-empty.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-empty.tsx
@@ -39,7 +39,6 @@ export const ScheduleListEmpty = ( props: Props ) => {
 					return (
 						<Button
 							__next40pxDefaultSize
-							icon={ plus }
 							variant={ canCreateSchedules ? 'primary' : 'secondary' }
 							onClick={ () => {
 								window.location.href = managePluginsUrl;

--- a/client/blocks/plugins-update-manager/schedule-list-empty.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-empty.tsx
@@ -1,6 +1,10 @@
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
 
 interface Props {
 	canCreateSchedules: boolean;
@@ -8,28 +12,55 @@ interface Props {
 }
 export const ScheduleListEmpty = ( props: Props ) => {
 	const { onCreateNewSchedule, canCreateSchedules } = props;
+	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const managePluginsUrl = `${ siteAdminUrl }plugins.php`;
 	const translate = useTranslate();
 
 	return (
 		<div className="empty-state">
 			<Text as="p" align="center">
-				{ ! canCreateSchedules
-					? translate( 'This site is unable to schedule auto-updates for plugins.' )
-					: translate(
-							'Take control of your site’s maintenance by choosing when your plugins update—whatever day and time is most convenient. Up to two schedules let you enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind.'
-					  ) }
+				{ ( () => {
+					if ( ! siteHasEligiblePlugins && canCreateSchedules ) {
+						return translate(
+							'To set up schedules to manage your plugins, first you need to install plugins that are not managed by the plugin provider.'
+						);
+					} else if ( ! canCreateSchedules ) {
+						return translate( 'This site is unable to schedule auto-updates for plugins.' );
+					}
+					return translate(
+						"Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Up to two schedules let you enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind."
+					);
+				} )() }
 			</Text>
-			{ onCreateNewSchedule && (
-				<Button
-					__next40pxDefaultSize
-					icon={ plus }
-					variant={ canCreateSchedules ? 'primary' : 'secondary' }
-					onClick={ onCreateNewSchedule }
-					disabled={ ! canCreateSchedules }
-				>
-					{ translate( 'Add new schedule' ) }
-				</Button>
-			) }
+			{ ( () => {
+				if ( ! siteHasEligiblePlugins && canCreateSchedules ) {
+					return (
+						<Button
+							__next40pxDefaultSize
+							icon={ plus }
+							variant={ canCreateSchedules ? 'primary' : 'secondary' }
+							onClick={ () => {
+								window.location.href = managePluginsUrl;
+							} }
+						>
+							{ translate( 'Explore plugins' ) }
+						</Button>
+					);
+				}
+				return (
+					<Button
+						__next40pxDefaultSize
+						icon={ plus }
+						variant={ canCreateSchedules ? 'primary' : 'secondary' }
+						onClick={ onCreateNewSchedule }
+						disabled={ ! canCreateSchedules }
+					>
+						{ translate( 'Add new schedule' ) }
+					</Button>
+				);
+			} )() }
 		</div>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88404

## Proposed Changes

- Checks whether there are eligble plugins installed inside `<PluginsUpdateManager /> ` and sets this on the context
- Shows a message + CTA on the list screen informing the user that they have no eligble plugins
- Minor refactorings

![CleanShot 2024-03-18 at 13 41 38@2x](https://github.com/Automattic/wp-calypso/assets/528287/85819737-2288-4be6-90d2-f7a50a62c726)


## Testing Instructions

1. Apply this PR
2. Check whether you see the message when no eligble plugins are installed (you can mock this by returning `[]` inside the select function of `client/data/plugins/use-core-plugins-query.ts`.
3. Tets for regressions


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?