### PR TITLE
A4A: Implement Marketplace checkout page

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -22,10 +22,6 @@ html,
 	}
 }
 
-.main.a4a-layout.is-compact {
-	padding-block-start: 28px;
-}
-
 .a4a-layout-with-columns__container,
 .a4a-layout__container {
 	max-width: 100%;

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -6,6 +6,7 @@ export const A4A_PLUGINS_LINK = '/plugins';
 export const A4A_MARKETPLACE_LINK = '/marketplace';
 export const A4A_MARKETPLACE_PRODUCTS_LINK = `${ A4A_MARKETPLACE_LINK }/products`;
 export const A4A_MARKETPLACE_HOSTING_LINK = `${ A4A_MARKETPLACE_LINK }/hosting`;
+export const A4A_MARKETPLACE_CHECKOUT_LINK = `${ A4A_MARKETPLACE_LINK }/checkout`;
 export const A4A_MARKETPLACE_ASSIGN_LICENSE_LINK = `${ A4A_MARKETPLACE_LINK }/assign-license`;
 export const A4A_PURCHASES_LINK = '/purchases';
 export const A4A_LICENSES_LINK = `${ A4A_PURCHASES_LINK }/licenses`;

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -1,0 +1,30 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+
+export default function Checkout() {
+	const translate = useTranslate();
+
+	return (
+		<Layout
+			className="checkout"
+			title={ translate( 'Product Marketplace' ) }
+			wide
+			withBorder
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ translate( 'Marketplace' ) } </Title>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>checkout</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -16,9 +16,9 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import useSubmitForm from '../products-overview/product-listing/hooks/use-submit-form';
-import { ShoppingCartItem } from '../types';
 import PricingSummary from './pricing-summary';
 import ProductInfo from './product-info';
+import type { ShoppingCartItem } from '../types';
 
 import './style.scss';
 
@@ -26,7 +26,7 @@ export default function Checkout() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { selectedItems, setSelectedItems } = useShoppingCart();
+	const { selectedCartItems, onRemoveCartItem, onClearCart } = useShoppingCart();
 
 	const [ selectedSite ] = useState< SiteDetails | null | undefined >( null ); // FIXME: Need to fetch from state
 
@@ -40,7 +40,7 @@ export default function Checkout() {
 
 	const sortedSelectedItems = useMemo( () => {
 		return Object.values(
-			selectedItems.reduce(
+			selectedCartItems.reduce(
 				( acc: Record< string, ShoppingCartItem[] >, item ) => (
 					( acc[ item.slug ] = ( acc[ item.slug ] || [] ).concat( item ) ), acc
 				),
@@ -49,7 +49,7 @@ export default function Checkout() {
 		)
 			.map( ( group ) => group.sort( ( a, b ) => a.quantity - b.quantity ) )
 			.flat();
-	}, [ selectedItems ] );
+	}, [ selectedCartItems ] );
 
 	const onCheckout = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_checkout_click' ) );
@@ -68,9 +68,9 @@ export default function Checkout() {
 
 	const onEmptyCart = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_empty_cart_click' ) );
-		setSelectedItems( [] );
+		onClearCart();
 		page( A4A_MARKETPLACE_LINK );
-	}, [ dispatch, setSelectedItems ] );
+	}, [ dispatch, onClearCart ] );
 
 	const onContinueShopping = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_continue_shopping_click' ) );
@@ -117,14 +117,7 @@ export default function Checkout() {
 						</div>
 					</div>
 					<div className="checkout__aside">
-						<PricingSummary
-							items={ sortedSelectedItems }
-							onRemoveItem={ ( item: ShoppingCartItem ) => {
-								setSelectedItems(
-									sortedSelectedItems.filter( ( selectedItem ) => selectedItem !== item )
-								);
-							} }
-						/>
+						<PricingSummary items={ sortedSelectedItems } onRemoveItem={ onRemoveCartItem } />
 
 						<div className="checkout__aside-actions">
 							<Button

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -77,6 +77,14 @@ export default function Checkout() {
 		page( A4A_MARKETPLACE_LINK );
 	}, [ dispatch ] );
 
+	const onRemoveItem = useCallback(
+		( item: ShoppingCartItem ) => {
+			dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_remove_item_click' ) );
+			onRemoveCartItem( item );
+		},
+		[ dispatch, onRemoveCartItem ]
+	);
+
 	return (
 		<Layout
 			className="checkout"
@@ -117,7 +125,7 @@ export default function Checkout() {
 						</div>
 					</div>
 					<div className="checkout__aside">
-						<PricingSummary items={ sortedSelectedItems } onRemoveItem={ onRemoveCartItem } />
+						<PricingSummary items={ sortedSelectedItems } onRemoveItem={ onRemoveItem } />
 
 						<div className="checkout__aside-actions">
 							<Button

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -1,7 +1,9 @@
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button } from '@automattic/components';
+import { SiteDetails } from '@automattic/data-stores';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -13,6 +15,7 @@ import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sideba
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useShoppingCart from '../hooks/use-shopping-cart';
+import useSubmitForm from '../products-overview/product-listing/hooks/use-submit-form';
 import { ShoppingCartItem } from '../types';
 import PricingSummary from './pricing-summary';
 import ProductInfo from './product-info';
@@ -25,11 +28,43 @@ export default function Checkout() {
 
 	const { selectedItems, setSelectedItems } = useShoppingCart();
 
+	const [ selectedSite ] = useState< SiteDetails | null | undefined >( null ); // FIXME: Need to fetch from state
+
+	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
+	// track if the user purchases a different set of products.
+	const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
+		?.toString()
+		.split( ',' );
+
+	const { isReady, submitForm } = useSubmitForm( selectedSite, suggestedProductSlugs );
+
+	const sortedSelectedItems = useMemo( () => {
+		return Object.values(
+			selectedItems.reduce(
+				( acc: Record< string, ShoppingCartItem[] >, item ) => (
+					( acc[ item.slug ] = ( acc[ item.slug ] || [] ).concat( item ) ), acc
+				),
+				{}
+			)
+		)
+			.map( ( group ) => group.sort( ( a, b ) => a.quantity - b.quantity ) )
+			.flat();
+	}, [ selectedItems ] );
+
 	const onCheckout = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_checkout_click' ) );
 
-		// FIXME: Issue license
-	}, [ dispatch ] );
+		submitForm( sortedSelectedItems );
+
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_checkout_checkout_click', {
+				total_licenses: sortedSelectedItems.length,
+				items: sortedSelectedItems
+					?.map( ( item ) => `${ item.slug } x ${ item.quantity }` )
+					.join( ',' ),
+			} )
+		);
+	}, [ dispatch, sortedSelectedItems, submitForm ] );
 
 	const onEmptyCart = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_empty_cart_click' ) );
@@ -73,7 +108,7 @@ export default function Checkout() {
 						<h1 className="checkout__main-title">{ translate( 'Checkout' ) }</h1>
 
 						<div className="checkout__main-list">
-							{ selectedItems.map( ( items ) => (
+							{ sortedSelectedItems.map( ( items ) => (
 								<ProductInfo
 									key={ `product-info-${ items.product_id }-${ items.quantity }` }
 									product={ items }
@@ -83,30 +118,33 @@ export default function Checkout() {
 					</div>
 					<div className="checkout__aside">
 						<PricingSummary
-							items={ selectedItems }
+							items={ sortedSelectedItems }
 							onRemoveItem={ ( item: ShoppingCartItem ) => {
 								setSelectedItems(
-									selectedItems.filter( ( selectedItem ) => selectedItem !== item )
+									sortedSelectedItems.filter( ( selectedItem ) => selectedItem !== item )
 								);
 							} }
 						/>
 
 						<div className="checkout__aside-actions">
-							<Button variant="primary" onClick={ onCheckout } disabled={ ! selectedItems.length }>
+							<Button
+								primary
+								onClick={ onCheckout }
+								disabled={ ! sortedSelectedItems.length || ! isReady }
+								busy={ ! isReady }
+							>
 								{ translate( 'Purchase %(count)d plan', 'Purchase %(count)d plans', {
 									context: 'button label',
-									count: selectedItems.length,
+									count: sortedSelectedItems.length,
 									args: {
-										count: selectedItems.length,
+										count: sortedSelectedItems.length,
 									},
 								} ) }
 							</Button>
 
-							<Button variant="secondary" onClick={ onContinueShopping }>
-								{ translate( 'Continue shopping' ) }
-							</Button>
+							<Button onClick={ onContinueShopping }>{ translate( 'Continue shopping' ) }</Button>
 
-							<Button variant="link" onClick={ onEmptyCart }>
+							<Button borderless onClick={ onEmptyCart }>
 								{ translate( 'Empty cart' ) }
 							</Button>
 						</div>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -1,30 +1,79 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
-	LayoutHeaderTitle as Title,
+	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useShoppingCart from '../hooks/use-shopping-cart';
+import { ShoppingCartItem } from '../types';
+import PricingSummary from './pricing-summary';
+
+import './style.scss';
 
 export default function Checkout() {
 	const translate = useTranslate();
+	const { selectedItems, setSelectedItems } = useShoppingCart();
 
 	return (
 		<Layout
 			className="checkout"
-			title={ translate( 'Product Marketplace' ) }
+			title={ translate( 'Checkout' ) }
 			wide
 			withBorder
+			compact
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 		>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>{ translate( 'Marketplace' ) } </Title>
+					<Breadcrumb
+						items={ [
+							{
+								label: translate( 'Marketplace' ),
+								href: A4A_MARKETPLACE_LINK,
+							},
+							{
+								label: translate( 'Checkout' ),
+							},
+						] }
+					/>
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>checkout</LayoutBody>
+			<LayoutBody>
+				<div className="checkout__container">
+					<div className="checkout__content">Checkout here</div>
+					<div className="checkout__aside">
+						<PricingSummary
+							items={ selectedItems }
+							onRemoveItem={ ( item: ShoppingCartItem ) => {
+								setSelectedItems(
+									selectedItems.filter( ( selectedItem ) => selectedItem !== item )
+								);
+							} }
+						/>
+
+						<div className="checkout__aside-actions">
+							<Button variant="primary">
+								{ translate( 'Purchase %(count)d plan', 'Purchase %(count)d plans', {
+									context: 'button label',
+									count: selectedItems.length,
+									args: {
+										count: selectedItems.length,
+									},
+								} ) }
+							</Button>
+
+							<Button variant="secondary">{ translate( 'Continue shopping' ) }</Button>
+
+							<Button variant="link">{ translate( 'Empty cart' ) }</Button>
+						</div>
+					</div>
+				</div>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -11,6 +11,7 @@ import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sideba
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { ShoppingCartItem } from '../types';
 import PricingSummary from './pricing-summary';
+import ProductInfo from './product-info';
 
 import './style.scss';
 
@@ -45,7 +46,18 @@ export default function Checkout() {
 
 			<LayoutBody>
 				<div className="checkout__container">
-					<div className="checkout__content">Checkout here</div>
+					<div className="checkout__main">
+						<h1 className="checkout__main-title">{ translate( 'Checkout' ) }</h1>
+
+						<div className="checkout__main-list">
+							{ selectedItems.map( ( items ) => (
+								<ProductInfo
+									key={ `product-info-${ items.product_id }-${ items.quantity }` }
+									product={ items }
+								/>
+							) ) }
+						</div>
+					</div>
 					<div className="checkout__aside">
 						<PricingSummary
 							items={ selectedItems }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -1,5 +1,7 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -8,6 +10,8 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { ShoppingCartItem } from '../types';
 import PricingSummary from './pricing-summary';
@@ -17,7 +21,26 @@ import './style.scss';
 
 export default function Checkout() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
 	const { selectedItems, setSelectedItems } = useShoppingCart();
+
+	const onCheckout = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_checkout_click' ) );
+
+		// FIXME: Issue license
+	}, [ dispatch ] );
+
+	const onEmptyCart = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_empty_cart_click' ) );
+		setSelectedItems( [] );
+		page( A4A_MARKETPLACE_LINK );
+	}, [ dispatch, setSelectedItems ] );
+
+	const onContinueShopping = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_continue_shopping_click' ) );
+		page( A4A_MARKETPLACE_LINK );
+	}, [ dispatch ] );
 
 	return (
 		<Layout
@@ -69,7 +92,7 @@ export default function Checkout() {
 						/>
 
 						<div className="checkout__aside-actions">
-							<Button variant="primary">
+							<Button variant="primary" onClick={ onCheckout } disabled={ ! selectedItems.length }>
 								{ translate( 'Purchase %(count)d plan', 'Purchase %(count)d plans', {
 									context: 'button label',
 									count: selectedItems.length,
@@ -79,9 +102,13 @@ export default function Checkout() {
 								} ) }
 							</Button>
 
-							<Button variant="secondary">{ translate( 'Continue shopping' ) }</Button>
+							<Button variant="secondary" onClick={ onContinueShopping }>
+								{ translate( 'Continue shopping' ) }
+							</Button>
 
-							<Button variant="link">{ translate( 'Empty cart' ) }</Button>
+							<Button variant="link" onClick={ onEmptyCart }>
+								{ translate( 'Empty cart' ) }
+							</Button>
 						</div>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -1,0 +1,83 @@
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { getTotalInvoiceValue } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getProductsList } from 'calypso/state/products-list/selectors';
+import ShoppingCartMenuItem from '../shopping-cart/shopping-cart-menu/item';
+import { ShoppingCartItem } from '../types';
+
+type Props = {
+	items: ShoppingCartItem[];
+	onRemoveItem: ( item: ShoppingCartItem ) => void;
+};
+
+export default function PricingSummary( { items, onRemoveItem }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const userProducts = useSelector( getProductsList );
+	const { discountedCost, actualCost } = getTotalInvoiceValue( userProducts, items );
+
+	const currency = items[ 0 ]?.currency ?? 'USD'; // FIXME: Fix if multiple currencies are supported
+
+	const learnMoreLink = ''; //FIXME: Add link for A4A;
+
+	const onClickLearnMore = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_learn_more_click' ) );
+	}, [ dispatch ] );
+
+	return (
+		<div className="checkout__summary">
+			<div className="checkout__summary-pricing">
+				<span className="checkout__summary-pricing-discounted">
+					{ formatCurrency( discountedCost, currency ) }
+				</span>
+				<span className="checkout__summary-pricing-original">
+					{ formatCurrency( actualCost, currency ) }
+				</span>
+				<div className="checkout__summary-pricing-interval">{ translate( '/month' ) }</div>
+			</div>
+
+			<ul className="checkout__summary-items">
+				{ items.map( ( item ) => (
+					<ShoppingCartMenuItem
+						key={ `shopping-cart-item-${ item.product_id }-${ item.quantity }` }
+						item={ item }
+						onRemoveItem={ onRemoveItem }
+					/>
+				) ) }
+			</ul>
+
+			<hr />
+
+			<div className="checkout__summary-total">
+				<span>{ translate( 'Total:' ) }</span>
+				<span>
+					{ translate( '%(total)s/mo', {
+						args: { total: formatCurrency( discountedCost, currency ) },
+					} ) }
+				</span>
+			</div>
+
+			<div className="checkout__summary-notice">
+				{ translate(
+					'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
+					{
+						components: {
+							a: (
+								<a
+									href={ learnMoreLink }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ onClickLearnMore }
+								/>
+							),
+						},
+					}
+				) }
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import ShoppingCartMenuItem from '../shopping-cart/shopping-cart-menu/item';
-import { ShoppingCartItem } from '../types';
+import type { ShoppingCartItem } from '../types';
 
 type Props = {
 	items: ShoppingCartItem[];

--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -1,0 +1,39 @@
+import { useTranslate } from 'i18n-calypso';
+import { useLicenseLightboxData } from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/hooks/use-license-lightbox-data';
+import getProductIcon from 'calypso/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon';
+import type { ShoppingCartItem } from '../types';
+
+export default function ProductInfo( { product }: { product: ShoppingCartItem } ) {
+	const translate = useTranslate();
+
+	const { title, product: productInfo } = useLicenseLightboxData( product );
+
+	if ( ! productInfo ) {
+		return null;
+	}
+
+	return (
+		<div className="product-info">
+			<div className="product-info__icon">
+				<img src={ getProductIcon( { productSlug: productInfo.productSlug } ) } alt={ title } />
+			</div>
+			<div className="product-info__text-content">
+				<div className="product-info__header">
+					<label htmlFor={ title } className="product-info__label">
+						{ title }
+					</label>
+					<span className="product-info__count">
+						{ translate( '%(numLicenses)d plan', '%(numLicenses)d plans', {
+							context: 'button label',
+							count: product.quantity,
+							args: {
+								numLicenses: product.quantity,
+							},
+						} ) }
+					</span>
+				</div>
+				<p className="product-info__description">{ productInfo.lightboxDescription }</p>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -1,0 +1,119 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.checkout .a4a-layout__container,
+.checkout .a4a-layout__body,
+.checkout .a4a-layout__body-wrapper {
+	height: 100%;
+}
+
+.checkout .a4a-layout__body {
+	padding: 0;
+}
+
+.checkout__container {
+	display: flex;
+	flex-direction: row;
+	align-items: stretch;
+	height: 100%;
+
+}
+
+.checkout__content {
+	flex-grow: 1;
+}
+
+.checkout__aside {
+	background: var(--color-neutral-0);
+	padding: 128px 48px;
+	max-width: 443px;
+}
+
+.checkout__summary {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	hr {
+		width: 100%;
+		margin: 0;
+		padding: 0;
+		border: none;
+	}
+}
+
+.checkout__summary-pricing {
+	background-color: var(--studio-white);
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	border: 1px solid var(--color-link);
+	padding: 1rem;
+
+	@media only screen and ( min-width: 782px ) {
+		margin-block-start: 32px;
+	}
+
+	@include break-xlarge {
+		margin-block-start: 24px;
+	}
+
+	.checkout__summary-pricing-discounted {
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: var(--studio-gray-80);
+		line-height: 1;
+
+		@include break-xlarge {
+			font-size: 1.5rem;
+			font-weight: 700;
+			color: var(--studio-black);
+		}
+	}
+
+	.checkout__summary-pricing-original {
+		text-decoration: line-through;
+		font-weight: 400;
+		font-size: 1rem;
+		margin-inline-start: 8px;
+	}
+
+	.checkout__summary-pricing-interval {
+		font-size: 0.75rem;
+		font-weight: 400;
+		color: var(--studio-gray-60);
+		line-height: 2;
+	}
+}
+
+.checkout__summary-items {
+	margin: 0;
+}
+
+.checkout__summary-total {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	font-weight: 500;
+	font-size: 1rem;
+	line-height: 1.5;
+}
+
+
+.checkout__summary-notice {
+	color: var(--color-neutral-50);
+	font-size: rem(12px);
+	margin-block-end: 16px;
+
+	a {
+		text-decoration: underline;
+		color: var(--color-black);
+	}
+}
+
+.checkout__aside-actions {
+	margin-block-start: 32px;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 16px;
+	text-align: center;
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -9,6 +9,10 @@
 
 .checkout .a4a-layout__body {
 	padding: 0;
+
+	@include break-medium {
+		background: linear-gradient(to right, var(--color-surface) 0%, var(--color-surface) 70%, var(--color-neutral-0) 70%, var(--color-neutral-0) 100%);
+	}
 }
 
 .checkout__container {
@@ -116,4 +120,19 @@
 	align-items: stretch;
 	gap: 16px;
 	text-align: center;
+
+	> .components-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 4px;
+		min-height: 40px;
+		font-weight: 600;
+	}
+
+	> .components-button.is-link {
+		color: var(--color-black);
+		text-decoration: underline;
+		font-weight: 400;
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -5,27 +5,37 @@
 .checkout .a4a-layout__body,
 .checkout .a4a-layout__body-wrapper {
 	height: 100%;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 8px;
 }
 
 .checkout .a4a-layout__body {
 	padding: 0;
 
-	@include break-medium {
+	@include break-large {
 		background: linear-gradient(to right, var(--color-surface) 0%, var(--color-surface) 70%, var(--color-neutral-0) 70%, var(--color-neutral-0) 100%);
 	}
 }
 
 .checkout__container {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	align-items: stretch;
-	height: 100%;
+
+
+	@include break-large {
+		flex-direction: row;
+		height: 100%;
+	}
 
 }
 
 .checkout__main {
 	flex-grow: 1;
-	padding: 64px 64px 0 0;
+
+	@include break-large {
+		padding: 64px 64px 0 0;
+	}
 }
 
 .checkout__main-title {
@@ -42,9 +52,13 @@
 }
 
 .checkout__aside {
-	background: var(--color-neutral-0);
-	padding: 128px 48px;
-	max-width: 443px;
+	padding: 32px 0;
+
+	@include break-large {
+		max-width: 443px;
+		padding: 128px 48px;
+		background: var(--color-neutral-0);
+	}
 }
 
 .checkout__summary {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -75,7 +75,7 @@
 }
 
 .checkout__summary-pricing {
-	background-color: var(--studio-white);
+	background-color: var(--color-surface);
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
 	border: 1px solid var(--color-link);
 	padding: 1rem;
@@ -91,13 +91,13 @@
 	.checkout__summary-pricing-discounted {
 		font-size: 1.25rem;
 		font-weight: 600;
-		color: var(--studio-gray-80);
+		color: var(--color-neutral-80);
 		line-height: 1;
 
 		@include break-xlarge {
 			font-size: 1.5rem;
 			font-weight: 700;
-			color: var(--studio-black);
+			color: var(--color-black);
 		}
 	}
 
@@ -111,7 +111,7 @@
 	.checkout__summary-pricing-interval {
 		font-size: 0.75rem;
 		font-weight: 400;
-		color: var(--studio-gray-60);
+		color: var(--color-neutral-60);
 		line-height: 2;
 	}
 }
@@ -206,7 +206,7 @@
 	}
 
 	.product-info__count {
-		background-color: var(--studio-gray-0);
+		background-color: var(--color-neutral-0);
 		padding: 5px 15px;
 		border-radius: 4px;
 		font-weight: 500;
@@ -214,7 +214,7 @@
 	}
 
 	.product-info__description {
-		color: var(--studio-gray-70);
+		color: var(--color-neutral-70);
 		font-size: rem(16px);
 		font-weight: 400;
 		margin-block: 4px 0;

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -23,8 +23,22 @@
 
 }
 
-.checkout__content {
+.checkout__main {
 	flex-grow: 1;
+	padding: 64px 64px 0 0;
+}
+
+.checkout__main-title {
+	margin-block-end: 64px;
+	font-size: 2.25rem;
+	line-height: 1.1;
+	font-weight: 600;
+}
+
+.checkout__main-list {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
 }
 
 .checkout__aside {
@@ -134,5 +148,61 @@
 		color: var(--color-black);
 		text-decoration: underline;
 		font-weight: 400;
+	}
+}
+
+.product-info {
+	display: flex;
+	gap: 14px;
+
+	.product-info__icon {
+		display: none;
+		box-sizing: border-box;
+		width: 48px;
+		height: 48px;
+		background: linear-gradient(159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53%);
+		border-radius: 4px;
+
+		@media only screen and ( min-width: 821px ) {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+	}
+
+	.product-info__icon > img {
+		width: 22px;
+		height: auto;
+	}
+
+
+	.product-info__text-content {
+		width: 100%;
+	}
+
+	.product-info__header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.product-info__label {
+		font-size: rem(16px);
+		font-weight: 700;
+	}
+
+	.product-info__count {
+		background-color: var(--studio-gray-0);
+		padding: 5px 15px;
+		border-radius: 4px;
+		font-weight: 500;
+
+	}
+
+	.product-info__description {
+		color: var(--studio-gray-70);
+		font-size: rem(16px);
+		font-weight: 400;
+		margin-block: 4px 0;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -149,7 +149,7 @@
 	gap: 16px;
 	text-align: center;
 
-	> .components-button {
+	> .button {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -158,7 +158,7 @@
 		font-weight: 600;
 	}
 
-	> .components-button.is-link {
+	> .button.is-link {
 		color: var(--color-black);
 		text-decoration: underline;
 		font-weight: 400;

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -4,6 +4,7 @@ import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/componen
 import getSites from 'calypso/state/selectors/get-sites';
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
+import Checkout from './checkout';
 import HostingOverview from './hosting-overview';
 import ProductsOverview from './products-overview';
 
@@ -21,6 +22,12 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 export const marketplaceHostingContext: Callback = ( context, next ) => {
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = <HostingOverview />;
+	next();
+};
+
+export const checkoutContext: Callback = ( context, next ) => {
+	context.secondary = <MarketplaceSidebar path={ context.path } />;
+	context.primary = <Checkout />;
 	next();
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -71,9 +71,14 @@ export default function useShoppingCart() {
 		[ selectedCartItems, setAndCacheSelectedItems ]
 	);
 
+	const onClearCart = useCallback( () => {
+		setAndCacheSelectedItems( [] );
+	}, [ setAndCacheSelectedItems ] );
+
 	return {
 		selectedCartItems,
 		setSelectedCartItems: setAndCacheSelectedItems,
 		onRemoveCartItem,
+		onClearCart,
 	};
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -8,6 +9,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 
@@ -33,7 +35,7 @@ export default function Hosting() {
 							items={ selectedCartItems }
 							onRemoveItem={ onRemoveCartItem }
 							onCheckout={ () => {
-								/* FIXME: redirect to checkout page */
+								page( A4A_MARKETPLACE_CHECKOUT_LINK );
 							} }
 						/>
 					</Actions>

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import {
 	A4A_MARKETPLACE_ASSIGN_LICENSE_LINK,
+	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
 	A4A_MARKETPLACE_PRODUCTS_LINK,
@@ -8,6 +9,7 @@ import {
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
 	assignLicenseContext,
+	checkoutContext,
 	marketplaceContext,
 	marketplaceHostingContext,
 	marketplaceProductsContext,
@@ -17,5 +19,6 @@ export default function () {
 	page( A4A_MARKETPLACE_LINK, marketplaceContext, makeLayout, clientRender );
 	page( A4A_MARKETPLACE_PRODUCTS_LINK, marketplaceProductsContext, makeLayout, clientRender );
 	page( A4A_MARKETPLACE_HOSTING_LINK, marketplaceHostingContext, makeLayout, clientRender );
+	page( A4A_MARKETPLACE_CHECKOUT_LINK, checkoutContext, makeLayout, clientRender );
 	page( A4A_MARKETPLACE_ASSIGN_LICENSE_LINK, assignLicenseContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -1,10 +1,10 @@
 // FIXME: Lets decide later if we need to move the calypso/jetpack-cloud imports to a shared common folder.
 
+import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -13,44 +13,27 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useProductBundleSize } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
-import ReviewLicenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses';
-import { useDispatch, useSelector } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useSelector } from 'calypso/state';
 import getSites from 'calypso/state/selectors/get-sites';
 import { ShoppingCartContext } from '../context';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import ProductListing from './product-listing';
-import useSubmitForm from './product-listing/hooks/use-submit-form';
-import type { AssignLicenseProps, ShoppingCartItem } from '../types';
+import type { AssignLicenseProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
 export default function ProductsOverview( { siteId, suggestedProduct }: AssignLicenseProps ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	const { selectedCartItems, setSelectedCartItems, onRemoveCartItem } = useShoppingCart();
 
 	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
-	const [ showReviewLicenses, setShowReviewLicenses ] = useState< boolean >( false );
 
 	const { selectedSize } = useProductBundleSize( true );
-
-	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
-	// track if the user purchases a different set of products.
-	const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
-		?.toString()
-		.split( ',' );
-
-	const { isReady, submitForm } = useSubmitForm( selectedSite, suggestedProductSlugs );
-
-	const onDismissReviewLicensesModal = useCallback( () => {
-		setShowReviewLicenses( false );
-		dispatch( recordTracksEvent( 'calypso_a4a_products_overview_review_licenses_dimiss' ) );
-	}, [ dispatch ] );
 
 	const sites = useSelector( getSites );
 
@@ -63,64 +46,39 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 		}
 	}, [ siteId, sites ] );
 
-	// Group licenses by slug and sort them by quantity
-	const getGroupedLicenses = useCallback( () => {
-		return Object.values(
-			selectedCartItems.reduce(
-				( acc: Record< string, ShoppingCartItem[] >, item ) => (
-					( acc[ item.slug ] = ( acc[ item.slug ] || [] ).concat( item ) ), acc
-				),
-				{}
-			)
-		)
-			.map( ( group ) => group.sort( ( a, b ) => a.quantity - b.quantity ) )
-			.flat();
-	}, [ selectedCartItems ] );
-
 	return (
-		<>
-			<Layout
-				className={ classNames( 'products-overview' ) }
-				title={ translate( 'Product Marketplace' ) }
-				wide
-				withBorder
-				sidebarNavigation={ <MobileSidebarNavigation /> }
-			>
-				<LayoutTop>
-					<LayoutHeader showStickyContent={ showStickyContent }>
-						<Title>{ translate( 'Marketplace' ) } </Title>
+		<Layout
+			className={ classNames( 'products-overview' ) }
+			title={ translate( 'Product Marketplace' ) }
+			wide
+			withBorder
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
+			<LayoutTop>
+				<LayoutHeader showStickyContent={ showStickyContent }>
+					<Title>{ translate( 'Marketplace' ) } </Title>
 
-						<Actions>
-							<ShoppingCart
-								items={ selectedCartItems }
-								onRemoveItem={ onRemoveCartItem }
-								onCheckout={ () => {
-									/* FIXME: redirect to checkout page */
-								} }
-							/>
-						</Actions>
-					</LayoutHeader>
-				</LayoutTop>
-
-				<LayoutBody>
-					<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
-						<ProductListing
-							selectedSite={ selectedSite }
-							suggestedProduct={ suggestedProduct }
-							quantity={ selectedSize }
+					<Actions>
+						<ShoppingCart
+							items={ selectedCartItems }
+							onRemoveItem={ onRemoveCartItem }
+							onCheckout={ () => {
+								page( A4A_MARKETPLACE_CHECKOUT_LINK );
+							} }
 						/>
-					</ShoppingCartContext.Provider>
-				</LayoutBody>
-			</Layout>
-			{ showReviewLicenses && (
-				<ReviewLicenses
-					onClose={ onDismissReviewLicensesModal }
-					selectedLicenses={ getGroupedLicenses() }
-					selectedSite={ selectedSite }
-					isFormReady={ isReady }
-					submitForm={ submitForm }
-				/>
-			) }
-		</>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
+					<ProductListing
+						selectedSite={ selectedSite }
+						suggestedProduct={ suggestedProduct }
+						quantity={ selectedSize }
+					/>
+				</ShoppingCartContext.Provider>
+			</LayoutBody>
+		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -63,6 +63,7 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 					<Button
 						className="shopping-cart__menu-checkout-button"
 						onClick={ onCheckout }
+						disabled={ ! items.length }
 						variant="primary"
 					>
 						{ translate( 'Checkout' ) }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -46,8 +46,8 @@
 
 .theme-a8c-for-agencies {
 	.button.is-primary {
-		background-color: var(--studio-automattic-60);
-		border-color: var(--studio-automattic-60);
+		background-color: var(--studio-automattic-40);
+		border-color: var(--studio-automattic-40);
 	}
 
 	.button.is-borderless:focus,

--- a/client/sections.js
+++ b/client/sections.js
@@ -733,6 +733,7 @@ const sections = [
 			'/marketplace',
 			'/marketplace/products',
 			'/marketplace/hosting',
+			'/marketplace/checkout',
 			'/marketplace/assign-license',
 		],
 		module: 'calypso/a8c-for-agencies/sections/marketplace',


### PR DESCRIPTION
This pull request introduces the Marketplace checkout page. The layout closely resembles the original review licenses page from Jetpack Manage, but instead of a modal, it's on a dedicated page.

<img width="1727" alt="Screenshot 2024-03-18 at 8 48 19 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/eb34594f-e6c1-4a68-9cda-977d88d0ab14">


Closes https://github.com/Automattic/jetpack-genesis/issues/286

## Proposed Changes

* Add Checkout page controller context and routing.
* Link the Checkout button in the Shopping cart to the new page.
* Implement the checkout page based on the design specs. Some of the components from the previous Review licenses page have been reused.

## Testing Instructions
* Switch branch: `git checkout add/a4a/marketplace-checkout-page`.
* Start the server by running `yarn start-a8c-for-agencies`.
* Use the live link and go to/marketplace
* Select some items and click the shopping cart toggle to reveal the Checkout button. Press it.
* Confirm that the page is redirected to the Checkout page. The checkout page should display items listed in the shopping cart with the correct price breakdown.
* Confirm that the **Empty cart** and **Continue shopping** buttons are working as expected.

***Note that the Purchase button does not work and will require you to set up an A4A Agency account. This process will be simplified once we have merged the PR that integrates the Agency API to A4A Authentication.***

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?