### PR TITLE
Codeowners: add lib/checkout to Shilling's owner list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 /client/state/gsuite-users @Automattic/letero
 
 # Payments
+/client/lib/checkout/ @Automattic/shilling
 /client/me/purchases/add-new-payment-method/ @Automattic/shilling
 /client/me/purchases/billing-history/ @Automattic/shilling
 /client/me/purchases/manage-purchase/ @Automattic/shilling


### PR DESCRIPTION
This adds `/client/lib/checkout/` to @Automattic/shilling's ownership list, given its use with the Payment Method management pages.