### PR TITLE
Pattern Library: Updated micro copy

### DIFF
--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -11,6 +11,7 @@ type CategoryPillNavigationProps = {
 		icon: React.ReactElement< typeof Icon >;
 		label: string;
 		link: string;
+		isActive?: boolean;
 	}[];
 	list: {
 		id: string;
@@ -84,7 +85,9 @@ export const CategoryPillNavigation = ( {
 								<LocalizedLink
 									key={ button.label }
 									href={ button.link }
-									className="category-pill-navigation__button"
+									className={ classnames( 'category-pill-navigation__button', {
+										'is-active': button.isActive,
+									} ) }
 								>
 									{ button.icon }
 									{ button.label }

--- a/client/components/category-pill-navigation/style.scss
+++ b/client/components/category-pill-navigation/style.scss
@@ -92,6 +92,10 @@
 	&.is-active {
 		background: var(--Blueberry, #3858e9);
 		color: var(--studio-white);
+
+		svg {
+			fill: var(--studio-white);
+		}
 	}
 }
 

--- a/client/my-sites/patterns/components/copy-paste-info/index.tsx
+++ b/client/my-sites/patterns/components/copy-paste-info/index.tsx
@@ -9,48 +9,57 @@ import './style.scss';
 export function PatternsCopyPasteInfo() {
 	return (
 		<PatternsSection
-			title="Copy. Paste. Customize."
-			description="Build fast while maintaining your sites character."
-			theme="dark"
 			bodyFullWidth
+			description="Pick out a pattern, copy-paste it into your design, and customize it any way you like. No plugins needed."
+			theme="dark"
+			title="Copy, paste, customize—it’s easy like that"
 		>
 			<div className="section-patterns-info">
 				<div className="section-patterns-info__inner">
 					<div className="section-patterns-info__item">
 						<div className="section-patterns-info__item-image">
-							<img src={ ImgCopyPaste } alt="..." />
+							<img src={ ImgCopyPaste } alt="" />
 						</div>
-						<div className="section-patterns-info__item-title">Copy and paste</div>
+
+						<div className="section-patterns-info__item-title">Copy-paste your way</div>
 						<div className="section-patterns-info__item-description">
-							Drop patterns directly into the WordPress editor to build out your pages.
+							Paste patterns directly into the WordPress editor to fully customize them.
 						</div>
 					</div>
+
 					<div className="section-patterns-info__item">
 						<div className="section-patterns-info__item-image">
-							<img src={ ImgStyle } alt="..." />
+							<img src={ ImgStyle } alt="" />
 						</div>
-						<div className="section-patterns-info__item-title">Bring your style</div>
+
+						<div className="section-patterns-info__item-title">Bring your style with you</div>
 						<div className="section-patterns-info__item-description">
-							Patterns inherit typography and color styles from your site to ensure every page looks
-							great.
+							Patterns replicate the typography and color palette from your site to ensure every
+							page is on-brand.
 						</div>
 					</div>
+
 					<div className="section-patterns-info__item">
 						<div className="section-patterns-info__item-image">
-							<img src={ ImgEdit } alt="..." />
+							<img src={ ImgEdit } alt="" />
 						</div>
-						<div className="section-patterns-info__item-title">Edit everything</div>
+
+						<div className="section-patterns-info__item-title">Make it yours</div>
 						<div className="section-patterns-info__item-description">
-							Patterns are collections of regular WordPress blocks. Edit them however you want.
+							Patterns are collections of regular WordPress blocks, so you can edit every detail,
+							however you want.
 						</div>
 					</div>
+
 					<div className="section-patterns-info__item">
 						<div className="section-patterns-info__item-image">
-							<img src={ ImgResponsive } alt="..." />
+							<img src={ ImgResponsive } alt="" />
 						</div>
-						<div className="section-patterns-info__item-title">Fully responsive</div>
+
+						<div className="section-patterns-info__item-title">Responsive by design</div>
 						<div className="section-patterns-info__item-description">
-							All patterns are fully responsive to ensure they look fantastic on any device.
+							All patterns are fully responsive to ensure they look fantastic on any device or
+							screen.
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import ImgBlockPatterns from 'calypso/my-sites/patterns/components/get-started/images/block-patterns.svg';
 import ImgHomePage from 'calypso/my-sites/patterns/components/get-started/images/home-page.svg';
@@ -6,51 +7,50 @@ import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 
 import './style.scss';
 
-export const PatternsGetStarted = () => {
+export function PatternsGetStarted() {
 	return (
 		<PatternsSection
-			title="Get started with patterns"
-			description="Our favorite how-to guides to get you started with patterns."
-			theme="dark"
 			bodyFullWidth
+			description="Take a look at our how-to guides to get started with patterns."
+			theme="dark"
+			title="All about patterns"
 		>
 			<div className="patterns-get-started__buttons">
-				<Button className="patterns-get-started__buttons-build" href="#">
+				<Button className="patterns-get-started__start-button" href="/start">
 					Build a site
 				</Button>
 			</div>
 
 			<div className="patterns-get-started__list">
 				<div className="patterns-get-started__list-inner">
-					<a className="patterns-get-started__item" href="aaa">
-						<img
-							src={ ImgBlockPatterns }
-							alt="VIDEO TUTORIAL"
-							className="patterns-get-started__item-image"
-						/>
-						<div className="patterns-get-started__item-name">VIDEO TUTORIAL</div>
+					<a
+						className="patterns-get-started__item"
+						href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/block-pattern/' ) }
+					>
+						<img src={ ImgBlockPatterns } alt="" className="patterns-get-started__item-image" />
+						<div className="patterns-get-started__item-name">Video tutorial</div>
 						<div className="patterns-get-started__item-description">Block Patterns</div>
 					</a>
-					<a className="patterns-get-started__item" href="aaa">
-						<img
-							src={ ImgPageLayouts }
-							alt="VIDEO TUTORIAL"
-							className="patterns-get-started__item-image"
-						/>
-						<div className="patterns-get-started__item-name">VIDEO TUTORIAL</div>
+
+					<a
+						className="patterns-get-started__item"
+						href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/page-layouts/' ) }
+					>
+						<img src={ ImgPageLayouts } alt="" className="patterns-get-started__item-image" />
+						<div className="patterns-get-started__item-name">Video tutorial</div>
 						<div className="patterns-get-started__item-description">Use Pre-Made Page Layouts</div>
 					</a>
-					<a className="patterns-get-started__item" href="aaa">
-						<img
-							src={ ImgHomePage }
-							alt="FREE COURSE"
-							className="patterns-get-started__item-image"
-						/>
-						<div className="patterns-get-started__item-name">FREE COURSE</div>
+
+					<a
+						className="patterns-get-started__item"
+						href={ localizeUrl( 'https://wordpress.com/learn/webinars/compelling-homepages/' ) }
+					>
+						<img src={ ImgHomePage } alt="" className="patterns-get-started__item-image" />
+						<div className="patterns-get-started__item-name">Free course</div>
 						<div className="patterns-get-started__item-description">Design Your Homepage</div>
 					</a>
 				</div>
 			</div>
 		</PatternsSection>
 	);
-};
+}

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -27,7 +27,7 @@ export function PatternsGetStarted() {
 						className="patterns-get-started__item"
 						href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/block-pattern/' ) }
 					>
-						<img src={ ImgBlockPatterns } alt="" className="patterns-get-started__item-image" />
+						<img className="patterns-get-started__item-image" src={ ImgBlockPatterns } alt="" />
 						<div className="patterns-get-started__item-name">Video tutorial</div>
 						<div className="patterns-get-started__item-description">Block Patterns</div>
 					</a>
@@ -36,7 +36,7 @@ export function PatternsGetStarted() {
 						className="patterns-get-started__item"
 						href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/page-layouts/' ) }
 					>
-						<img src={ ImgPageLayouts } alt="" className="patterns-get-started__item-image" />
+						<img className="patterns-get-started__item-image" src={ ImgPageLayouts } alt="" />
 						<div className="patterns-get-started__item-name">Video tutorial</div>
 						<div className="patterns-get-started__item-description">Use Pre-Made Page Layouts</div>
 					</a>
@@ -45,7 +45,7 @@ export function PatternsGetStarted() {
 						className="patterns-get-started__item"
 						href={ localizeUrl( 'https://wordpress.com/learn/webinars/compelling-homepages/' ) }
 					>
-						<img src={ ImgHomePage } alt="" className="patterns-get-started__item-image" />
+						<img className="patterns-get-started__item-image" src={ ImgHomePage } alt="" />
 						<div className="patterns-get-started__item-name">Free course</div>
 						<div className="patterns-get-started__item-description">Design Your Homepage</div>
 					</a>

--- a/client/my-sites/patterns/components/get-started/style.scss
+++ b/client/my-sites/patterns/components/get-started/style.scss
@@ -7,7 +7,7 @@
 	margin-top: -32px;
 	margin-bottom: 48px;
 
-	.patterns-get-started__buttons-build {
+	.patterns-get-started__start-button {
 		font-family: $font-sf-pro-text;
 		font-size: rem(13px);
 		color: var(--studio-white);

--- a/client/my-sites/patterns/components/header/style.scss
+++ b/client/my-sites/patterns/components/header/style.scss
@@ -30,8 +30,9 @@
 			font-size: rem(18px);
 			letter-spacing: 0.4px;
 			line-height: 1.4;
-			width: 450px;
 			padding-bottom: 32px;
+			text-wrap: pretty;
+			width: 450px;
 		}
 
 		.patterns-header__search-input {

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -148,6 +148,7 @@ export const PatternLibrary = ( {
 							icon: <Icon icon={ iconStar } size={ 30 } />,
 							label: 'Discover',
 							link: addLocaleToPathLocaleInFront( '/patterns' ),
+							isActive: isHomePage,
 						},
 						{
 							icon: <Icon icon={ iconCategory } size={ 26 } />,

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -83,7 +83,7 @@ export const PatternLibrary = ( {
 	const [ searchFormKey, setSearchFormKey ] = useState( category );
 
 	const [ searchTerm, setSearchTerm ] = usePatternSearchTerm( urlQuerySearchTerm ?? '' );
-	const { data: categories } = usePatternCategories( locale );
+	const { data: categories = [] } = usePatternCategories( locale );
 	const { data: patterns = [] } = usePatterns( locale, category, {
 		select( patterns ) {
 			const patternsByType = filterPatternsByType( patterns, patternTypeFilter );
@@ -113,7 +113,7 @@ export const PatternLibrary = ( {
 
 	const categoryObject = categories?.find( ( { name } ) => name === category );
 
-	const categoryNavList = categories?.map( ( category ) => {
+	const categoryNavList = categories.map( ( category ) => {
 		const patternTypeFilterFallback =
 			category.pagePatternCount === 0 ? PatternTypeFilter.REGULAR : patternTypeFilter;
 
@@ -131,44 +131,38 @@ export const PatternLibrary = ( {
 			<DocumentHead title="WordPress Patterns - Category" />
 
 			<PatternsHeader
-				description={
-					category
-						? 'Introduce yourself or your brand to visitors.'
-						: 'Hundreds of expertly designed, fully responsive patterns allow you to craft a beautiful site in minutes.'
-				}
-				key={ searchFormKey }
+				description="Dive into hundreds of expertly designed, fully responsive layouts, and bring any kind of site to life, faster."
 				initialSearchTerm={ searchTerm }
+				key={ searchFormKey }
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }
-				title={ category ? `${ category } patterns` : 'Build your perfect site with patterns' }
+				title="It’s Easier With Patterns"
 			/>
 
-			{ ! isHomePage && categoryNavList && (
-				<div className="pattern-library__pill-navigation">
-					<CategoryPillNavigation
-						selectedCategory={ category }
-						buttons={ [
-							{
-								icon: <Icon icon={ iconStar } size={ 30 } />,
-								label: 'Discover',
-								link: addLocaleToPathLocaleInFront( '/patterns' ),
-							},
-							{
-								icon: <Icon icon={ iconCategory } size={ 26 } />,
-								label: 'All Categories',
-								link: '/222',
-							},
-						] }
-						list={ categoryNavList }
-					/>
-				</div>
-			) }
+			<div className="pattern-library__pill-navigation">
+				<CategoryPillNavigation
+					selectedCategory={ category }
+					buttons={ [
+						{
+							icon: <Icon icon={ iconStar } size={ 30 } />,
+							label: 'Discover',
+							link: addLocaleToPathLocaleInFront( '/patterns' ),
+						},
+						{
+							icon: <Icon icon={ iconCategory } size={ 26 } />,
+							label: 'All Categories',
+							link: '/222',
+						},
+					] }
+					list={ categoryNavList }
+				/>
+			</div>
 
 			{ isHomePage && (
 				<CategoryGallery
-					title="Ship faster with patterns"
-					description="Choose from a huge library of patterns to build any page you need."
+					title="Ship faster, ship more"
+					description="Choose from a library of beautiful, functional design patterns to build exactly the page you—or your client—need, in no time."
 					categories={ categories }
 					patternTypeFilter={ PatternTypeFilter.REGULAR }
 				/>
@@ -236,7 +230,7 @@ export const PatternLibrary = ( {
 			{ isHomePage && (
 				<CategoryGallery
 					title="Beautifully curated page layouts"
-					description="Entire pages built of patterns, ready to be added to your site."
+					description="Start even faster with ready-to-use pages and preassembled patterns. Then tweak the design until it’s just right."
 					categories={ categories?.filter( ( c ) => c.pagePatternCount ) }
 					patternTypeFilter={ PatternTypeFilter.PAGES }
 				/>

--- a/client/my-sites/patterns/components/section/style.scss
+++ b/client/my-sites/patterns/components/section/style.scss
@@ -43,6 +43,7 @@
 		color: #3c434a;
 		font-size: rem(18px);
 		line-height: 1.4;
+		max-width: 520px;
 	}
 }
 

--- a/client/my-sites/patterns/components/section/style.scss
+++ b/client/my-sites/patterns/components/section/style.scss
@@ -44,6 +44,7 @@
 		font-size: rem(18px);
 		line-height: 1.4;
 		max-width: 520px;
+		text-wrap: pretty;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6079

## Proposed Changes

Per the latest design tweaks (see p9Jlb4-b5B-p2#comment-11018), we now have updated micro copy for the pattern library. This PR implements that.

I've also made it so that `CategoryPillNavigation` is now displayed on `/patterns` as well (not just on the category page).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns` and make sure that things look OK