### PR TITLE
Add Akismet meta pixel on checkout page init

### DIFF
--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -234,8 +234,14 @@ function initFacebook() {
 	// Also initialize the FB pixel for Jetpack & Akismet.
 	// However, disable auto-config for this secondary pixel ID.
 	// See: <https://developers.facebook.com/docs/facebook-pixel/api-reference#automatic-configuration>
-	window.fbq( 'set', 'autoConfig', false, TRACKING_IDS.facebookJetpackInit );
-	window.fbq( 'set', 'autoConfig', false, TRACKING_IDS.facebookAkismetInit );
-	window.fbq( 'init', TRACKING_IDS.facebookJetpackInit, advancedMatching );
-	window.fbq( 'init', TRACKING_IDS.facebookAkismetInit, advancedMatching );
+	if ( isJetpackCheckout() ) {
+		window.fbq( 'set', 'autoConfig', false, TRACKING_IDS.facebookJetpackInit );
+		window.fbq( 'init', TRACKING_IDS.facebookJetpackInit, advancedMatching );
+		window.fbq( 'track', 'PageView' ); // When autoConfig=false, page view tracking must be manually triggered
+	}
+	if ( isAkismetCheckout() ) {
+		window.fbq( 'set', 'autoConfig', false, TRACKING_IDS.facebookAkismetInit );
+		window.fbq( 'init', TRACKING_IDS.facebookAkismetInit, advancedMatching );
+		window.fbq( 'track', 'PageView' ); // When autoConfig=false, page view tracking must be manually triggered
+	}
 }

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -230,10 +230,12 @@ function initFacebook() {
 	// WP Facebook pixel
 	window.fbq( 'init', TRACKING_IDS.facebookInit, advancedMatching );
 
-	// Jetpack Facebook pixel
-	// Also initialize the FB pixel for Jetpack.
+	// Jetpack & Akismet Facebook pixel
+	// Also initialize the FB pixel for Jetpack & Akismet.
 	// However, disable auto-config for this secondary pixel ID.
 	// See: <https://developers.facebook.com/docs/facebook-pixel/api-reference#automatic-configuration>
 	window.fbq( 'set', 'autoConfig', false, TRACKING_IDS.facebookJetpackInit );
+	window.fbq( 'set', 'autoConfig', false, TRACKING_IDS.facebookAkismetInit );
 	window.fbq( 'init', TRACKING_IDS.facebookJetpackInit, advancedMatching );
+	window.fbq( 'init', TRACKING_IDS.facebookAkismetInit, advancedMatching );
 }

--- a/client/lib/analytics/ad-tracking/record-add-to-cart.js
+++ b/client/lib/analytics/ad-tracking/record-add-to-cart.js
@@ -1,4 +1,6 @@
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import { debug, TRACKING_IDS } from './constants';
 import { recordInCriteo } from './criteo';
@@ -52,28 +54,32 @@ export async function recordAddToCart( cartItem ) {
 		window.fbq( ...params );
 
 		// Jetpack
-		params = [
-			'trackSingle',
-			TRACKING_IDS.facebookJetpackInit,
-			'AddToCart',
-			{
-				product_slug: cartItem.product_slug,
-			},
-		];
-		debug( 'recordAddToCart: [Jetpack]', params );
-		window.fbq( ...params );
+		if ( isJetpackCheckout() ) {
+			params = [
+				'trackSingle',
+				TRACKING_IDS.facebookJetpackInit,
+				'AddToCart',
+				{
+					product_slug: cartItem.product_slug,
+				},
+			];
+			debug( 'recordAddToCart: [Jetpack]', params );
+			window.fbq( ...params );
+		}
 
 		// Akismet
-		params = [
-			'trackSingle',
-			TRACKING_IDS.facebookAkismetInit,
-			'AddToCart',
-			{
-				product_slug: cartItem.product_slug,
-			},
-		];
-		debug( 'recordAddToCart: [Akismet]', params );
-		window.fbq( ...params );
+		if ( isAkismetCheckout() ) {
+			params = [
+				'trackSingle',
+				TRACKING_IDS.facebookAkismetInit,
+				'AddToCart',
+				{
+					product_slug: cartItem.product_slug,
+				},
+			];
+			debug( 'recordAddToCart: [Akismet]', params );
+			window.fbq( ...params );
+		}
 	}
 
 	// Bing

--- a/client/lib/analytics/ad-tracking/record-add-to-cart.js
+++ b/client/lib/analytics/ad-tracking/record-add-to-cart.js
@@ -62,6 +62,18 @@ export async function recordAddToCart( cartItem ) {
 		];
 		debug( 'recordAddToCart: [Jetpack]', params );
 		window.fbq( ...params );
+
+		// Akismet
+		params = [
+			'trackSingle',
+			TRACKING_IDS.facebookAkismetInit,
+			'AddToCart',
+			{
+				product_slug: cartItem.product_slug,
+			},
+		];
+		debug( 'recordAddToCart: [Akismet]', params );
+		window.fbq( ...params );
 	}
 
 	// Bing


### PR DESCRIPTION
## Proposed Changes

* We have tracked Akismet purchases via Meta pixel only as purchase conversion
* We want to also gather informations on checkout page performance - so we install Meta pixel on page init (similar to existing WPCOM and Jetpack implementations)

## Testing Instructions

* Go to the checkout page of any Akismet product with tracking flags enabled e.g. `/checkout/akismet/ak_pro5h_yearly:-q-1?flags=ad-tracking,cookie-banner`
* If in GDPR region, accept the cookie banner
* With `Meta Pixel Helper` (Chrome extension), make sure that Akismet pixel is detected (ID: 485349158311379) but not Jetpack one (ID: 919484458159593)
* Go to checkout page of any Jetpack product with tracking flags enabled e.g. `/checkout/jetpack/jetpack_creator_monthly?flags=ad-tracking,cookie-banner`
* With `Meta Pixel Helper` (Chrome extension), make sure that Jetpack pixel is detected (ID: 919484458159593) but not Akismet one (ID: 485349158311379)

In both cases WPCOIM pixel is expected to be detected
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?