### PR TITLE
Patterns: fix UI for rendering sides of PillNavigation on mobile

### DIFF
--- a/client/components/category-pill-navigation/style.scss
+++ b/client/components/category-pill-navigation/style.scss
@@ -65,7 +65,8 @@
 		}
 
 		@media ( max-width: $break-wide ) {
-			display: none;
+			width: 0;
+			padding: 0;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes
With this PR we are improving UX for CategoryPillNavigation on mobile. Specifically - we are rendering gradients from both sides, to highlight that it's possible to scroll it.
Some conversation: p1710767693614239-slack-C06ELHR6L9J

## Testing Instructions
1) Open `http://calypso.localhost:3000/patterns/about`
2) Open dev tools to test out mobile version
3) Decrease the width of website screen
4) Assert that you see gradients <br />  ![Screenshot 2024-03-18 at 16 24 23](https://github.com/Automattic/wp-calypso/assets/5598437/038b4c5c-fa2f-42c9-b9be-fe155444c375)


