### PR TITLE
Stats: Add UTM module overlay with blurred fake data bars

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -13,7 +13,6 @@ import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
 
 interface Props {
 	className: string;
-	statType: string;
 	siteSlug: string;
 	buttonComponent?: ReactNode;
 }

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -102,7 +102,9 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 					<StatsModulePlaceholder isLoading />
 				</StatsCard>
 			) }
-			{ ! isFetching && ! isAdvancedFeatureEnabled && <StatsModuleUTMOverlay siteId={ siteId } /> }
+			{ ! isFetching && ! isAdvancedFeatureEnabled && (
+				<StatsModuleUTMOverlay className={ className } siteId={ siteId } />
+			) }
 			{ ! isFetching && isAdvancedFeatureEnabled && (
 				<StatsModuleDataQuery
 					data={ data }

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -2,17 +2,15 @@ import { StatsCard } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import useUTMMetricTopPostsQuery from '../hooks/use-utm-metric-top-posts-query';
 import useUTMMetricsQuery from '../hooks/use-utm-metrics-query';
-import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleDataQuery from '../stats-module/stats-module-data-query';
 import statsStrings from '../stats-strings';
 import UTMDropdown from './stats-module-utm-dropdown';
+import StatsModuleUTMOverlay from './stats-module-utm-overlay';
 
 const OPTION_KEYS = {
 	SOURCE_MEDIUM: 'utm_source,utm_medium',
@@ -26,7 +24,6 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	const moduleStrings = statsStrings();
 	const translate = useTranslate();
 	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SOURCE_MEDIUM );
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	// Check if blog is internal.
 	const { isFetching: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
@@ -105,16 +102,7 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 					<StatsModulePlaceholder isLoading />
 				</StatsCard>
 			) }
-			{ ! isFetching && ! isAdvancedFeatureEnabled && (
-				// TODO: update the ghost card to only show the module name
-				<StatsCard
-					title="UTM"
-					className={ classNames( className, 'stats-module-utm', 'stats-module__card', 'utm' ) }
-					isNew
-				>
-					<StatsCardUpsellJetpack className="stats-module__upsell" siteSlug={ siteSlug } />
-				</StatsCard>
-			) }
+			{ ! isFetching && ! isAdvancedFeatureEnabled && <StatsModuleUTMOverlay siteId={ siteId } /> }
 			{ ! isFetching && isAdvancedFeatureEnabled && (
 				<StatsModuleDataQuery
 					data={ data }

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.scss
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.scss
@@ -1,0 +1,5 @@
+.stats-module-utm-overlay .stats-card__content {
+	// Prevent blur elements from being interactable.
+	pointer-events: none;
+	user-select: none;
+}

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.scss
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.scss
@@ -1,5 +1,11 @@
-.stats-module-utm-overlay .stats-card__content {
-	// Prevent blur elements from being interactable.
-	pointer-events: none;
-	user-select: none;
+.stats-module-utm-overlay {
+	.stats-card--column-header {
+		filter: blur(10px);
+	}
+
+	.stats-card__content {
+		// Prevent blur elements from being interactable.
+		pointer-events: none;
+		user-select: none;
+	}
 }

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
@@ -9,9 +9,10 @@ import './stats-module-utm-overlay.scss';
 
 type StatsModuleUTMOverlayProps = {
 	siteId: number;
+	className?: string;
 };
 
-const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( { siteId } ) => {
+const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( { siteId, className } ) => {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) || '' );
 
 	const fakeData = [
@@ -49,7 +50,7 @@ const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( { siteId
 		// @ts-expect-error TODO: Refactor StatsListCard with TypeScript.
 		<StatsListCard
 			title="UTM"
-			className={ classNames( 'stats-module-utm-overlay', 'stats-module__card', 'utm' ) }
+			className={ classNames( className, 'stats-module-utm-overlay', 'stats-module__card', 'utm' ) }
 			moduleType="utm"
 			data={ fakeData }
 			mainItemLabel="Posts by Source / Medium"

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
@@ -52,6 +52,8 @@ const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( { siteId
 			className={ classNames( 'stats-module-utm-overlay', 'stats-module__card', 'utm' ) }
 			moduleType="utm"
 			data={ fakeData }
+			mainItemLabel="Posts by Source / Medium"
+			splitHeader
 			showMore={ {
 				label: 'View all',
 			} }

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
@@ -1,0 +1,63 @@
+import classNames from 'classnames';
+import React from 'react';
+import { useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
+import StatsListCard from '../stats-list/stats-list-card';
+
+import './stats-module-utm-overlay.scss';
+
+type StatsModuleUTMOverlayProps = {
+	siteId: number;
+};
+
+const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( { siteId } ) => {
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) || '' );
+
+	const fakeData = [
+		{
+			label: 'google / cpc',
+			value: 102,
+		},
+		{
+			label: 'linkedin / social',
+			value: 15,
+		},
+		{
+			label: 'google / organic',
+			value: 14,
+		},
+		{
+			label: 'facebook.com / social',
+			value: 13,
+		},
+		{
+			label: 'newsletter / email',
+			value: 12,
+		},
+		{
+			label: 'x.com / social',
+			value: 12,
+		},
+		{
+			label: 'rss / rss',
+			value: 10,
+		},
+	];
+
+	return (
+		// @ts-expect-error TODO: Refactor StatsListCard with TypeScript.
+		<StatsListCard
+			title="UTM"
+			className={ classNames( 'stats-module-utm-overlay', 'stats-module__card', 'utm' ) }
+			moduleType="utm"
+			data={ fakeData }
+			showMore={ {
+				label: 'View all',
+			} }
+			overlay={ <StatsCardUpsellJetpack className="stats-module__upsell" siteSlug={ siteSlug } /> }
+		></StatsListCard>
+	);
+};
+
+export default StatsModuleUTMOverlay;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #88055 

## Proposed Changes

* Introduce `StatsModuleUTMOverlay` to utilize `StatsListCard` with overlay and fake bars.
* Remove unused prop `statType` of StatsCardUpsellJetpack.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live branch.
* Prepare a site **_without_** a purchased Stats commercial license.
* Navigate to Stats > Traffic page with the feature flag: `stats/utm-module`.
* Ensure the UTM module is disabled with an overlay aligned with the design.

<img width="1263" alt="截圖 2024-03-19 上午12 28 54" src="https://github.com/Automattic/wp-calypso/assets/6869813/0613e262-c82d-4279-bea3-3d923951d392">

* Navigate to the post details page and the UTM module summary page.
* Ensure the UTM module is disabled with an overlay aligned with the design.

<img width="1266" alt="截圖 2024-03-19 上午12 29 49" src="https://github.com/Automattic/wp-calypso/assets/6869813/18a632f4-177e-407b-98eb-22202dcbdc8a">

<img width="1094" alt="截圖 2024-03-19 上午12 30 13" src="https://github.com/Automattic/wp-calypso/assets/6869813/90a0764b-5546-44ff-b3c2-813a8c31d33f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?