### PR TITLE
Patterns: fix preserving layout view after changing category

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -187,7 +187,9 @@ export const PatternLibrary = ( {
 								isBlock
 								label=""
 								onChange={ ( value ) => {
-									const href = getCategoryUrlPath( category, value as PatternTypeFilter );
+									const href =
+										getCategoryUrlPath( category, value as PatternTypeFilter ) +
+										( isGridView ? '?grid=1' : '' );
 									page( href );
 								} }
 								value={ patternTypeFilter }


### PR DESCRIPTION
## Proposed Changes
We have switcher for `Patterns/Page layout`. When we click on some of them - we don't preserve `grid / list view` status. This PR fixes it.

## Testing Instructions
1) Open `http://calypso.localhost:3000/patterns/about`
2) Select `Grid view`
3) Select `Page layout`
4) Assert that you still see everything as grid view <br / > ![Screenshot 2024-03-18 at 16 35 32](https://github.com/Automattic/wp-calypso/assets/5598437/552bb39f-b58c-4d49-b813-eac394424eec)