### PR TITLE
Reader: Remove AppPromo

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -6,7 +6,6 @@ import { createRef, Component, Fragment } from 'react';
 import * as React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-import AppPromo from 'calypso/blocks/app-promo';
 import InfiniteList from 'calypso/components/infinite-list';
 import ListEnd from 'calypso/components/list-end';
 import SectionNav from 'calypso/components/section-nav';
@@ -424,26 +423,6 @@ class ReaderStream extends Component {
 		} );
 	};
 
-	renderAppPromo = ( index ) => {
-		const { isDiscoverStream } = this.props;
-		// Only show it once in the 4th position.
-		if ( index !== 3 ) {
-			return;
-		}
-
-		return (
-			isDiscoverStream && (
-				<AppPromo
-					iconSize={ 40 }
-					campaign="calypso-reader-stream"
-					title={ this.props.translate( 'Read on the go with the Jetpack Mobile App' ) }
-					hasQRCode={ true }
-					hasGetAppButton={ false }
-				/>
-			)
-		);
-	};
-
 	getPostRef = ( postKey ) => {
 		return keyToString( postKey );
 	};
@@ -462,7 +441,6 @@ class ReaderStream extends Component {
 
 		return (
 			<Fragment key={ itemKey }>
-				{ this.renderAppPromo( index ) }
 				<PostLifecycle
 					ref={ itemKey /* The ref is stored into `InfiniteList`'s `this.ref` map */ }
 					isSelected={ isSelected }


### PR DESCRIPTION
This PR removed the low performing App Promo Banner from the Discover tab. 




## Testing Instructions

Navigate to the discover tab. Notice that you don't see the App Promo Banner any more. 
This banner should be removed from the loggedout and logged in reader discover feed. So please test both versions. 

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?