### PR TITLE
Continue with Google: Include nonce

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -6,9 +6,9 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { cloneElement, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import wpcomRequest from 'wpcom-proxy-request';
 import GoogleIcon from 'calypso/components/social-icons/google';
 import { preventWidows } from 'calypso/lib/formatting';
-import wpcom from 'calypso/lib/wp';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/utils';
@@ -56,16 +56,15 @@ class GoogleSocialButton extends Component {
 		this.hideError = this.hideError.bind( this );
 	}
 
-	async fetchNonce() {
-		return wpcom.req.get( `/generate-authorization-nonce`, {
-			apiNamespace: 'wpcom/v2',
-		} );
-	}
-
 	componentDidMount() {
 		const initialize = async () => {
 			try {
-				const response = await this.fetchNonce();
+				const response = await wpcomRequest( {
+					path: '/generate-authorization-nonce',
+					apiNamespace: 'wpcom/v2',
+					apiVersion: '2',
+					method: 'GET',
+				} );
 				const nonce = response.nonce;
 				this.setState( { nonce } );
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -18,6 +18,7 @@ import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-
 import './style.scss';
 
 const noop = () => {};
+const isNonceEnabled = config.isEnabled( 'login/google-login-update' );
 
 class GoogleSocialButton extends Component {
 	static propTypes = {
@@ -57,36 +58,47 @@ class GoogleSocialButton extends Component {
 	}
 
 	componentDidMount() {
-		const initialize = async () => {
-			try {
-				const response = await wpcomRequest( {
-					path: '/generate-authorization-nonce',
-					apiNamespace: 'wpcom/v2',
-					apiVersion: '2',
-					method: 'GET',
-				} );
-				const nonce = response.nonce;
-				this.setState( { nonce } );
-
-				if ( this.props.authCodeFromRedirect && this.props.serviceFromRedirect !== 'github' ) {
-					this.handleAuthorizationCode( {
-						auth_code: this.props.authCodeFromRedirect,
-						redirect_uri: this.props.redirectUri,
-						state: nonce,
+		if ( isNonceEnabled ) {
+			const initialize = async () => {
+				try {
+					const response = await wpcomRequest( {
+						path: '/generate-authorization-nonce',
+						apiNamespace: 'wpcom/v2',
+						apiVersion: '2',
+						method: 'GET',
 					} );
+					const nonce = response.nonce;
+					this.setState( { nonce } );
+
+					if ( this.props.authCodeFromRedirect && this.props.serviceFromRedirect !== 'github' ) {
+						this.handleAuthorizationCode( {
+							auth_code: this.props.authCodeFromRedirect,
+							redirect_uri: this.props.redirectUri,
+							state: nonce,
+						} );
+					}
+
+					await this.initializeGoogleSignIn();
+				} catch ( error ) {
+					this.props.showErrorNotice(
+						this.props.translate(
+							'Error fetching nonce or initializing Google sign-in. Please try again.'
+						)
+					);
 				}
+			};
 
-				await this.initializeGoogleSignIn();
-			} catch ( error ) {
-				this.props.showErrorNotice(
-					this.props.translate(
-						'Error fetching nonce or initializing Google sign-in. Please try again.'
-					)
-				);
+			initialize();
+		} else {
+			if ( this.props.authCodeFromRedirect && this.props.serviceFromRedirect !== 'github' ) {
+				this.handleAuthorizationCode( {
+					auth_code: this.props.authCodeFromRedirect,
+					redirect_uri: this.props.redirectUri,
+				} );
 			}
-		};
 
-		initialize();
+			this.initializeGoogleSignIn();
+		}
 	}
 
 	async initializeGoogleSignIn() {
@@ -105,7 +117,7 @@ class GoogleSocialButton extends Component {
 			scope: this.props.scope,
 			ux_mode: this.props.uxMode,
 			redirect_uri: this.props.redirectUri,
-			state: this.state.nonce,
+			state: isNonceEnabled ? this.state.nonce : undefined,
 			callback: ( response ) => {
 				if ( response.error ) {
 					this.props.recordTracksEvent( 'calypso_social_button_failure', {
@@ -117,7 +129,11 @@ class GoogleSocialButton extends Component {
 					return;
 				}
 
-				this.handleAuthorizationCode( { auth_code: response.code, state: response.state } );
+				if ( isNonceEnabled ) {
+					this.handleAuthorizationCode( { auth_code: response.code, state: response.state } );
+				} else {
+					this.handleAuthorizationCode( { auth_code: response.code } );
+				}
 			},
 		} );
 

--- a/config/development.json
+++ b/config/development.json
@@ -125,7 +125,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,
-		"login/google-login-update": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/development.json
+++ b/config/development.json
@@ -125,6 +125,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,
+		"login/google-login-update": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,6 +76,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/social-first": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,

--- a/config/production.json
+++ b/config/production.json
@@ -101,6 +101,7 @@
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -95,6 +95,7 @@
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,6 +93,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/social-first": true,
 		"logmein": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/88633.

## Proposed Changes

* introduce new `login/google-login-update` feature flag
* get nonce from newly-introduced endpoint and pass it to Google as a `state` parameter
* receive `state` parameter from Google's response

The PR is meant to work together with D142283-code. 

## Testing Instructions

The PR cannot be fully tested before merging due to limitations outlined in D142283-code.

Please review the code itself to notice any potential issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?