### PR TITLE
Patterns: show always only list view for mobile

### DIFF
--- a/client/my-sites/patterns/components/pattern-gallery/style.scss
+++ b/client/my-sites/patterns/components/pattern-gallery/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .pattern-gallery {
 	display: grid;
 	gap: 48px;
@@ -5,4 +7,8 @@
 .pattern-gallery--grid {
 	gap: 16px 24px;
 	grid-template-columns: repeat(3, 1fr);
+
+	@media ( max-width: $break-medium ) {
+		grid-template-columns: 1fr;
+	}
 }


### PR DESCRIPTION
## Proposed Changes
We have grid / list view switcher. But when the screen is very narrow - it should be rendered only as list view and additionally the switcher should be hidden. We already hide the switcher, and with this PR - we are fixing the rendering list view for narrow screens, even if it's grid view mode.

## Testing Instructions
1) Open `http://calypso.localhost:3000/patterns/about?grid=1`
2) Open dev tools and slowly decrease the width of the screen
3) Assert that when the switcher is hidden - the view is always rendered as list (even if grid was selected).