### PR TITLE
Notifications - resolve conflict with shortkeys in calypso

### DIFF
--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -164,6 +164,7 @@ class Layout extends Component {
 
 	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.redraw );
+		window.removeEventListener( 'keydown', this.handleKeyDown );
 	}
 
 	navigateByDirection = ( direction ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/165

## Proposed Changes

* Ensures keydown handler is removed when the Layout component unmounts.
* This should not have an effect on the notification bell in masterbars and other locations, as the panel does not unmount and remount in those circumstances. However (before this change), if you visit /read/notifications, navigate away and come back, etc. the panel unmounts and remounts. Since the keyDown handler wasn't being removed on unmount this resulted in duplicate and outdated event handlers that were causing conflicts as seen in the issue.
* NOTE - there is another issue on /read/notifications where the shortkeys do not work on initial load. This will be investigated and handled separately.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test calypso:
* Test this build of calypso and verify that the bug in the linked issue no longer happens.

Smoke test site front-end:
* Install this build of the notifications app on your sandbox using the install command in the comment below.
* sandbox widgets and a test site (NOT the public-api).
* visit the front-end of your site and smoke test, there should be no observable changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
