### PR TITLE
Stats: Handle the number type of UTM metrics label

### DIFF
--- a/client/state/stats/utm-metrics/reducer.ts
+++ b/client/state/stats/utm-metrics/reducer.ts
@@ -20,20 +20,11 @@ import {
 import { schema } from './schema';
 import type { Reducer, AnyAction } from 'redux';
 
-const isValidNumber = ( string: string ): boolean => {
-	return ! isNaN( Number( string ) );
-};
-
-const isValidJSON = ( string: string ) => {
-	// Handle the case when the string is a number.
-	if ( isValidNumber( string ) ) {
-		return false;
-	}
-
+const isValidJSONArray = ( string: string ) => {
 	try {
-		JSON.parse( string );
+		const parsed = JSON.parse( string );
 
-		return true;
+		return Array.isArray( parsed );
 	} catch ( e ) {
 		return false;
 	}
@@ -70,7 +61,9 @@ const metricsParser = (
 	const stopFurtherRequest = !! topPosts;
 
 	return combinedKeys.map( ( combinedKey: string ) => {
-		const parsedKeys = isValidJSON( combinedKey ) ? JSON.parse( combinedKey ) : [ combinedKey ];
+		const parsedKeys = isValidJSONArray( combinedKey )
+			? JSON.parse( combinedKey )
+			: [ combinedKey ];
 		const value = UTMValues[ combinedKey ];
 		const posts = topPosts && combinedKey in topPosts ? topPosts[ combinedKey ] : [];
 

--- a/client/state/stats/utm-metrics/reducer.ts
+++ b/client/state/stats/utm-metrics/reducer.ts
@@ -20,7 +20,16 @@ import {
 import { schema } from './schema';
 import type { Reducer, AnyAction } from 'redux';
 
+const isValidNumber = ( string: string ): boolean => {
+	return ! isNaN( Number( string ) );
+};
+
 const isValidJSON = ( string: string ) => {
+	// Handle the case when the string is a number.
+	if ( isValidNumber( string ) ) {
+		return false;
+	}
+
 	try {
 		JSON.parse( string );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88619
Related to #88537

## Proposed Changes

* Check if the metric label is a type number and parse it correctly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Refer to the `Odd behaviour and a question` section of https://github.com/Automattic/wp-calypso/pull/88619.
* Ensure the number label of metrics is displayed correctly.

|Before|After|
|-|-|
|![image](https://github.com/Automattic/wp-calypso/assets/6869813/18afbc02-71f4-4d5e-a393-80d8c8b60197)|<img width="1095" alt="截圖 2024-03-19 上午1 19 07" src="https://github.com/Automattic/wp-calypso/assets/6869813/77d1662b-a78e-45cd-a8a8-314e6430d250">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?