### PR TITLE
WIP: Adds Razorpay icon to subscription list payment method display

### DIFF
--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -8,6 +8,7 @@ import creditCardPlaceholderImage from 'calypso/assets/images/upgrades/cc-placeh
 import creditCardUnionPayImage from 'calypso/assets/images/upgrades/cc-unionpay.svg';
 import creditCardVisaImage from 'calypso/assets/images/upgrades/cc-visa.svg';
 import payPalImage from 'calypso/assets/images/upgrades/paypal.svg';
+import razorpayImage from 'calypso/assets/images/upgrades/upi.svg';
 
 export const PARTNER_PAYPAL_EXPRESS = 'paypal_express';
 export const PAYMENT_AGREEMENTS_PARTNERS = [ PARTNER_PAYPAL_EXPRESS ];
@@ -108,6 +109,7 @@ const CREDIT_CARD_SELECTED_PATHS: ImagePathsMap = {
 	visa: creditCardVisaImage,
 	paypal_express: payPalImage,
 	paypal: payPalImage,
+	razorpay: razorpayImage,
 };
 
 const CREDIT_CARD_DEFAULT_PATH = creditCardPlaceholderImage;

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -18,6 +18,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
 import payPalImage from 'calypso/assets/images/upgrades/paypal-full.svg';
+import razorpayImage from 'calypso/assets/images/upgrades/upi.svg';
 import SiteIcon from 'calypso/blocks/site-icon';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -536,6 +537,16 @@ class PurchaseItem extends Component {
 						src={ payPalImage }
 						alt={ purchase.payment.type }
 						className="purchase-item__paypal"
+					/>
+				);
+			}
+
+			if ( purchase.payment.type === 'razorpay' ) {
+				return (
+					<img
+						src={ razorpayImage }
+						alt={ purchase.payment.type }
+						className="purchase-item__razorpay"
 					/>
 				);
 			}


### PR DESCRIPTION
Closes https://github.com/Automattic/payments-florin/issues/466. 
Requires UPI icon that's added in https://github.com/Automattic/wp-calypso/pull/88320

## Proposed Changes

When viewing a subscription purchased via Razorpay, the generic credit card icon is shown as the payment method.  This PR changes that so the UPI logo is displayed instead.

Before:
![generic](https://github.com/Automattic/wp-calypso/assets/1138631/37d3f804-ce9c-439f-85a2-d5175703a6c3)

After:
![upi-razorpay](https://github.com/Automattic/wp-calypso/assets/1138631/b2751d3a-88d5-47a9-8bf9-277031773657)


## Testing Instructions

* (a12s) Enable store sandbox and billing sandbox.
* Change your user's currency to INR.
* Purchase a subscription using Razorpay's UPI method.  Use `success@razorpay` for testing.
* After purchase, go to the "Purchases" page (`me/purchases`) and make sure that the UPI logo appears next to this new subscription.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?