### PR TITLE
Stats: Remove support prefill for Jetpack site disputes

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -362,34 +362,14 @@ function StatsCommercialFlowOptOutForm( {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_commercial_update_classification_clicked` );
 
-		// No need to translate this as we'd prefer customer communication to be in English.
-		const subject = 'Jetpack Stats Commercial Classification Dispute';
-		const message = `Hi Jetpack Team,\n
-I'm writing to dispute the classification of my site '${ siteSlug }' as commercial.\n
-I can confirm that,
-- I don't have ads on my site.
-- I don't sell products/services on my site.
-- I don't promote a business on my site.
-- I don't solicit donations or sponsorships on my site.\n
-Could you please take a look at my site and update the classification if necessary?\n
-Thanks\n\n`;
-
-		// For Jetpack sites, link to https://jetpack.com/contact-support/ with pre-filled form.
+		// For Jetpack sites, open the Jetpack support form. Do not prefill.
 		if ( isJetpackSupport ) {
-			window.open(
-				`https://jetpack.com/contact-support/?assistant=false&url=${ siteSlug }&subject=${ encodeURIComponent(
-					subject
-				) }&message=${ encodeURIComponent( message ) }`
-			);
+			window.open( `https://jetpack.com/contact-support/?url=${ siteSlug }` );
 			return;
 		}
 
-		// TODO: Assess whether this is appropriate escalation approach for Dotcom sites.
-		const mailTo = 'help@wordpress.com';
-		const emailHref = `mailto:${ mailTo }?subject=${ encodeURIComponent(
-			subject
-		) }&body=${ encodeURIComponent( message ) }`;
-		window.open( emailHref );
+		// For Dotcom sites, open the Dotcom help page.
+		window.open( 'https://wordpress.com/help' );
 	};
 
 	const isFormSubmissionDisabled = () => {
@@ -413,7 +393,7 @@ Thanks\n\n`;
 				}
 		  )
 		: translate( 'To use a non-commercial license you must agree to the following:' );
-	const formButton = isCommercial ? translate( 'Request update' ) : translate( 'Continue' );
+	const formButton = isCommercial ? translate( 'Contact support' ) : translate( 'Continue' );
 	const formHandler = isCommercial ? handleRequestUpdateClick : handleSwitchToPersonalClick;
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pejTkB-1dH-p2#comment-1147.

## Proposed Changes

* Removes Jetpack support form prefill for commercial dispute process.
* Replace the Dotcom email link with a link to the Dotcom support page. Note that this shouldn't be an active flow at the moment since Dotcom customers are not shown this page in production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For a commercial Jetpack site, ensure that the dispute UX directs you to an unfilled Jetpack support form. 
    * This support form acts as a support documentation search form if the user is not authenticated with their Dotcom account in Jetpack.com.

> <img width="988" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/62068ace-aced-4b22-89c8-94d7e5c7d2cb">

  * This is how the support form looks when the user is logged into their Dotcom account on Jetpack.com.

> <img width="718" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/5d4aaabc-b8f4-4695-97be-a00b29f5bf67">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?