### PR TITLE
A4A: Update the overview header title to "Agency HQ Overview"

### DIFF
--- a/client/a8c-for-agencies/sections/overview/controller.tsx
+++ b/client/a8c-for-agencies/sections/overview/controller.tsx
@@ -2,7 +2,6 @@ import { type Callback } from '@automattic/calypso-router';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
-	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
@@ -15,8 +14,7 @@ export const overviewContext: Callback = ( context, next ) => {
 		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>Overview</Title>
-					<Subtitle>Overview of your agency</Subtitle>
+					<Title>Agency HQ Overview</Title>
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>

--- a/client/a8c-for-agencies/sections/overview/controller.tsx
+++ b/client/a8c-for-agencies/sections/overview/controller.tsx
@@ -1,27 +1,10 @@
 import { type Callback } from '@automattic/calypso-router';
-import Layout from 'calypso/a8c-for-agencies/components/layout';
-import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
-import LayoutHeader, {
-	LayoutHeaderTitle as Title,
-} from 'calypso/a8c-for-agencies/components/layout/header';
-import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
-import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import MainSidebar from '../../components/sidebar-menu/main';
+import Overview from './overview';
 
 export const overviewContext: Callback = ( context, next ) => {
 	context.secondary = <MainSidebar path={ context.path } />;
-	context.primary = (
-		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
-			<LayoutTop>
-				<LayoutHeader>
-					<Title>Agency HQ Overview</Title>
-				</LayoutHeader>
-			</LayoutTop>
-			<LayoutBody>
-				<div>test</div>
-			</LayoutBody>
-		</Layout>
-	);
+	context.primary = <Overview />;
 
 	next();
 };

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -9,12 +9,13 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 
 export default function Overview() {
 	const translate = useTranslate();
+	const title = translate( 'Agency HQ Overview' );
 
 	return (
-		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>{ translate( 'Agency HQ Overview' ) }</Title>
+					<Title>{ title }</Title>
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+
+export default function Overview() {
+	const translate = useTranslate();
+
+	return (
+		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ translate( 'Agency HQ Overview' ) }</Title>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<div>test</div>
+			</LayoutBody>
+		</Layout>
+	);
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolve: https://github.com/Automattic/jetpack-genesis/issues/289

## Proposed Changes

* Adds `Overview` component to support using `translate()` for the header title.
* Updates the title to "Agency HQ Overview".
* Removes the subtitle.
* Note: keeps the tab/layout title as "Overview".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the updated header in the `/overview` page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1056" alt="Screenshot 2024-03-18 at 11 42 24 AM" src="https://github.com/Automattic/wp-calypso/assets/10933065/bf489583-6360-47f0-860a-2a400c80332b">
