### PR TITLE
wp-admin Command Palette: Prioritize contextual commands

### DIFF
--- a/apps/command-palette-wp-admin/src/index.js
+++ b/apps/command-palette-wp-admin/src/index.js
@@ -21,7 +21,7 @@ function CommandPaletteApp() {
 		return;
 	}
 
-	const currentRoute = window.location.pathname;
+	const currentRoute = window.location.pathname + window.location.search;
 
 	const navigate = ( path, openInNewTab ) => {
 		let url = path;

--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -199,7 +199,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'see site', 'Keyword for the Visit site dashboard command', __i18n_text_domain__ ),
 				_x( 'browse site', 'Keyword for the Visit site dashboard command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/:site' ],
+			context: [ '/wp-admin' ],
 			callback: commandNavigation( ':site' ),
 			icon: seenIcon,
 		},
@@ -215,7 +215,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'admin', 'Keyword for the Open site dashboard command', __i18n_text_domain__ ),
 				_x( 'wp-admin', 'Keyword for the Open site dashboard command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			callback: commandNavigation( '/wp-admin' ),
 			icon: dashboardIcon,
 		},
@@ -263,10 +262,8 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				),
 				_x( 'wp-cli', 'Keyword for the Open hosting configuration command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			callback: commandNavigation( '/hosting-config/:site' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
-			siteType: SiteType.ATOMIC,
 			filterP2: true,
 			icon: settingsIcon,
 		},
@@ -291,7 +288,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 					__i18n_text_domain__
 				),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			callback: commandNavigation( '/hosting-config/:site#database-access' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			siteType: SiteType.ATOMIC,
@@ -306,7 +302,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'display name', 'Keyword for the Open my profile command', __i18n_text_domain__ ),
 				_x( 'gravatar', 'Keyword for the Open my profile command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			callback: commandNavigation( `/me` ),
 			icon: profileIcon,
 		},
@@ -398,7 +393,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'add new site', 'Keyword for the Add new site command', __i18n_text_domain__ ),
 				_x( 'create site', 'Keyword for the Add new site command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			callback: commandNavigation( 'https://wordpress.com/start/domains?source=command-palette' ),
 			icon: plusIcon,
 		},
@@ -434,14 +428,12 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'subscriptions', 'Keyword for the View my purchases command', __i18n_text_domain__ ),
 				_x( 'upgrades', 'Keyword for the View my purchases command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			callback: commandNavigation( `/me/purchases` ),
 			icon: creditCardIcon,
 		},
 		{
 			name: 'registerDomain',
 			label: __( 'Register new domain', __i18n_text_domain__ ),
-			context: [ '/sites' ],
 			callback: commandNavigation( `/start/domain/domain-only?ref=command-palette` ),
 			icon: domainsIcon,
 		},
@@ -459,7 +451,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'subdomains', 'Keyword for the Manage domains command', __i18n_text_domain__ ),
 				_x( 'whois', 'Keyword for the Manage domains command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			callback: commandNavigation( `/domains/manage` ),
 			icon: domainsIcon,
 		},
@@ -476,7 +467,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'mx', 'Keyword for the Manage DNS records command', __i18n_text_domain__ ),
 				_x( 'txt', 'Keyword for the Manage DNS records command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			isCustomDomain: true,
 			callback: commandNavigation( `/domains/manage/:site/dns/:site` ),
@@ -587,7 +577,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'manageStagingSites',
 			label: __( 'Manage staging sites', __i18n_text_domain__ ),
-			context: [ '/hosting-config' ],
 			searchLabel: [
 				_x(
 					'manage staging sites',
@@ -656,7 +645,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'create post', 'Keyword for the Add new post command', __i18n_text_domain__ ),
 				_x( 'write post', 'Keyword for the Add new post command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/posts' ],
+			context: [ { path: '/wp-admin/edit.php', match: 'exact' } ],
 			callback: commandNavigation( shouldUseWpAdmin ? '/wp-admin/post-new.php' : '/post/:site' ),
 			capability: SiteCapabilities.EDIT_POSTS,
 			icon: plusIcon,
@@ -716,7 +705,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'create page', 'Keyword for the Add new page command', __i18n_text_domain__ ),
 				_x( 'write page', 'Keyword for the Add new page command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/pages' ],
+			context: [ '/wp-admin/edit.php?post_type=page' ],
 			callback: commandNavigation(
 				shouldUseWpAdmin ? '/wp-admin/post-new.php?post_type=page' : '/page/:site'
 			),
@@ -804,7 +793,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'change plan', 'Keyword for the Change site plan command', __i18n_text_domain__ ),
 				_x( 'add plan', 'Keyword for the Change site plan command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/sites' ],
 			callback: commandNavigation( '/plans/:site' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			filterP2: true,
@@ -864,7 +852,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'import subscribers', 'Keyword for the Add subscribers command', __i18n_text_domain__ ),
 				_x( 'upload subscribers', 'Keyword for the Add subscribers command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			context: [ '/subscribers' ],
 			callback: commandNavigation( '/subscribers/:site#add-subscribers' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			icon: subscriberIcon,
@@ -879,7 +866,6 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'downloadSubscribers',
 			label: __( 'Download subscribers as CSV', __i18n_text_domain__ ),
-			context: [ '/subscribers' ],
 			callback: commandNavigation(
 				'https://dashboard.wordpress.com/wp-admin/index.php?page=subscribers&blog=:siteId&blog_subscribers=csv&type=all',
 				{ openInNewTab: true }
@@ -890,7 +876,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'import',
 			label: __( 'Import content to the site', __i18n_text_domain__ ),
-			context: [ '/posts' ],
+			context: [ { path: '/wp-admin/edit.php', match: 'exact' } ],
 			callback: commandNavigation( '/import/:site' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			icon: downloadIcon,
@@ -908,7 +894,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'manageSettingsGeneral',
 			label: __( 'Manage general settings', __i18n_text_domain__ ),
-			context: [ '/settings' ],
+			context: [ '/wp-admin/options-' ],
 			callback: commandNavigation(
 				shouldUseWpAdmin ? '/wp-admin/options-general.php' : '/settings/general/:site'
 			),
@@ -918,7 +904,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'manageSettingsWriting',
 			label: __( 'Manage writing settings', __i18n_text_domain__ ),
-			context: [ '/settings' ],
+			context: [ '/wp-admin/options-' ],
 			callback: commandNavigation(
 				shouldUseWpAdmin ? '/wp-admin/options-writing.php' : '/settings/writing/:site'
 			),
@@ -928,7 +914,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'manageSettingsReading',
 			label: __( 'Manage reading settings', __i18n_text_domain__ ),
-			context: [ '/settings' ],
+			context: [ '/wp-admin/options-' ],
 			callback: commandNavigation(
 				shouldUseWpAdmin ? '/wp-admin/options-reading.php' : '/settings/reading/:site'
 			),
@@ -938,7 +924,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'manageSettingsDiscussion',
 			label: __( 'Manage discussion settings', __i18n_text_domain__ ),
-			context: [ '/settings' ],
+			context: [ '/wp-admin/options-' ],
 			callback: commandNavigation(
 				shouldUseWpAdmin ? '/wp-admin/options-discussion.php' : '/settings/discussion/:site'
 			),
@@ -948,7 +934,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'manageSettingsNewsletter',
 			label: __( 'Manage newsletter settings', __i18n_text_domain__ ),
-			context: [ '/settings' ],
+			context: [ '/wp-admin/options-' ],
 			callback: commandNavigation( '/settings/newsletter/:site' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			icon: settingsIcon,
@@ -956,7 +942,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'manageSettingsPodcast',
 			label: __( 'Manage podcast settings', __i18n_text_domain__ ),
-			context: [ '/settings' ],
+			context: [ '/wp-admin/options-' ],
 			callback: commandNavigation( '/settings/podcasting/:site' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			icon: settingsIcon,
@@ -1052,6 +1038,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			searchLabel: command.searchLabel,
 			callback: command.callback,
 			icon: command.icon,
+			context: command.context,
 		} ) );
 };
 

--- a/packages/command-palette/src/use-command-palette.tsx
+++ b/packages/command-palette/src/use-command-palette.tsx
@@ -58,7 +58,7 @@ export interface Command {
 	subLabel?: string;
 	searchLabel?: string;
 	callback: ( params: CommandCallBackParams ) => void;
-	context?: string[];
+	context?: string[] | { path: string; match: string }[];
 	icon?: JSX.Element;
 	image?: JSX.Element;
 	siteFunctions?: SiteFunctions;
@@ -268,8 +268,19 @@ export const useCommandPalette = ( {
 
 	// Logic for root commands
 	// Filter out commands that have context
-	const commandHasContext = ( paths: string[] = [] ): boolean =>
-		paths.some( ( path ) => currentRoute?.includes( path ) ) ?? false;
+	const commandHasContext = (
+		paths: string[] | { path: string; match: string }[] = []
+	): boolean => {
+		return paths.some( ( pathItem ) => {
+			if ( typeof pathItem === 'string' ) {
+				return currentRoute?.includes( pathItem ) ?? false;
+			}
+
+			return pathItem.match === 'exact'
+				? currentRoute === pathItem.path
+				: currentRoute?.includes( pathItem.path ) ?? false;
+		} );
+	};
 
 	// Sort commands with contextual commands ranking higher than general in a given context
 	const sortedCommands = commands.sort( ( a, b ) => {


### PR DESCRIPTION
## Proposed Changes

This PR ensures that contextual commands appears at the top of the wp-admin command palette, matching the same order than the counterpart Calypso command palette.

**Posts**
Calypso | WP Admin (Before) | WP Admin (After)
--- | --- | ---
<img width="435" alt="Screenshot 2024-03-18 at 16 40 01" src="https://github.com/Automattic/wp-calypso/assets/1233880/6650acab-1e79-4ff6-87b3-a289739a64f8"> | <img width="435" alt="Screenshot 2024-03-18 at 16 40 11" src="https://github.com/Automattic/wp-calypso/assets/1233880/1bbf1cae-0ba8-42df-a4d3-cafbdd43da81"> | <img width="435" alt="Screenshot 2024-03-18 at 21 01 51" src="https://github.com/Automattic/wp-calypso/assets/1233880/b35e84ee-de60-4ed3-bb80-31b6babe3dd4">

**Pages**
Calypso | WP Admin (Before) | WP Admin (After)
--- | --- | ---
<img width="444" alt="Screenshot 2024-03-19 at 09 18 40" src="https://github.com/Automattic/wp-calypso/assets/1233880/6ec8db1d-1055-458e-8418-ed4e396c0590"> | <img width="432" alt="Screenshot 2024-03-19 at 09 18 51" src="https://github.com/Automattic/wp-calypso/assets/1233880/39943fab-657d-486f-9dce-8ff6e5a467bc"> | <img width="444" alt="Screenshot 2024-03-19 at 09 19 26" src="https://github.com/Automattic/wp-calypso/assets/1233880/34c7392e-9679-453c-921e-4cf065dba212">

**General settings**
Calypso | WP Admin (Before) | WP Admin (After)
--- | --- | ---
<img width="444" alt="Screenshot 2024-03-19 at 09 20 21" src="https://github.com/Automattic/wp-calypso/assets/1233880/154a9e00-9251-4352-8330-efd2f5f06a13"> | <img width="442" alt="Screenshot 2024-03-19 at 09 20 51" src="https://github.com/Automattic/wp-calypso/assets/1233880/6ebf1127-1d1f-4a9b-9bce-5b81b8ed7673"> | <img width="439" alt="Screenshot 2024-03-19 at 09 21 04" src="https://github.com/Automattic/wp-calypso/assets/1233880/7bea3afa-a1d1-43c8-acd5-38b61da0b174">


## Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh command-palette update/command-palette-wp-admin-context`
- Sandbox `widgets.wp.com`
- Go to https://wordpress.com/posts and select a site
- Open the command palette and make a note of how commands are sorted
- Switch to the classic view (or go directly yo `/wp-admin/edit.php`)
- Open the command palette
- Make sure the commands have the same order
- Check any other screen with contextual commands (e.g. `/settings/general/:site` and `/wp-admin/options-general.php`, or `/pages/:site` and `/wp-admin/edit.php?post_type=page`)
- Confirm the commands are always sorted in the same way