### PR TITLE
A4A: Update sites dashboard URL for preview pane

### DIFF
--- a/client/a8c-for-agencies/sections/sites/constants.js
+++ b/client/a8c-for-agencies/sections/sites/constants.js
@@ -1,1 +1,2 @@
 export const A4A_SITES_DASHBOARD_DEFAULT_CATEGORY = 'overview';
+export const A4A_SITES_DASHBOARD_DEFAULT_FEATURE = 'jetpack_boost';

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -1,13 +1,14 @@
 import { Context, type Callback } from '@automattic/calypso-router';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import SitesSidebar from '../../components/sidebar-menu/sites';
+import { A4A_SITES_DASHBOARD_DEFAULT_FEATURE } from './constants';
 import SitesDashboard from './sites-dashboard';
 import { SitesDashboardProvider } from './sites-dashboard-provider';
 
 function configureSitesContext( isFavorites: boolean, context: Context ) {
 	const category = context.params.category;
 	const siteUrl = context.params.siteUrl;
-	const siteFeature = context.params.feature;
+	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
 	const hideListingInitialState = !! siteUrl;
 
 	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -153,13 +153,13 @@ export default function SitesDashboard() {
 			selectedSiteFeature !== A4A_SITES_DASHBOARD_DEFAULT_FEATURE // If the selected feature is the default one, we can leave the url a little cleaner.
 		) {
 			page.replace(
-				'/sites/' + category + '/' + sitesViewState.selectedSite.url + '/' + selectedSiteFeature
+				`/sites/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }`
 			);
 		} else if ( category && sitesViewState.selectedSite ) {
-			page.replace( '/sites/' + category + '/' + sitesViewState.selectedSite.url );
+			page.replace( `/sites/${ category }/${ sitesViewState.selectedSite.url }` );
 		} else if ( category && category !== A4A_SITES_DASHBOARD_DEFAULT_CATEGORY ) {
 			// If the selected category is the default one, we can leave the url a little cleaner, that's why we are comparing to the default category in the condition above.
-			page.replace( '/sites/' + category );
+			page.replace( `/sites/${ category }` );
 		} else {
 			page.replace( '/sites' );
 		}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -27,10 +27,11 @@ import {
 	AgencyDashboardFilterMap,
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
 	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
@@ -42,6 +43,7 @@ import './style.scss';
 export default function SitesDashboard() {
 	useQueryJetpackPartnerPortalPartner();
 	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
+	const dispatch = useDispatch();
 
 	const {
 		selectedSiteUrl,
@@ -160,7 +162,11 @@ export default function SitesDashboard() {
 		} else {
 			page.replace( '/sites' );
 		}
-	}, [ sitesViewState.selectedSite, selectedSiteFeature, category, setCategory ] );
+
+		if ( sitesViewState.selectedSite ) {
+			dispatch( setSelectedSiteId( sitesViewState.selectedSite.blog_id ) );
+		}
+	}, [ sitesViewState.selectedSite, selectedSiteFeature, category, setCategory, dispatch ] );
 
 	const closeSitePreviewPane = useCallback( () => {
 		if ( sitesViewState.selectedSite ) {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -114,6 +114,7 @@ export default function SitesDashboard() {
 			setSitesViewState( ( prevState ) => ( {
 				...prevState,
 				selectedSite: site,
+				type: 'list',
 			} ) );
 		}
 	}, [ data, isError, isLoading, selectedSiteUrl ] );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -46,6 +46,7 @@ export default function SitesDashboard() {
 	const {
 		selectedSiteUrl,
 		selectedSiteFeature,
+		setSelectedSiteFeature,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
 	} = useContext( SitesDashboardContext );
@@ -164,8 +165,10 @@ export default function SitesDashboard() {
 	const closeSitePreviewPane = useCallback( () => {
 		if ( sitesViewState.selectedSite ) {
 			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
+			// We reset the feature to its default upon closing, instead of setting it to undefined. This way, when users switch sites while a site is selected, the feature remains consistent.
+			setSelectedSiteFeature( A4A_SITES_DASHBOARD_DEFAULT_FEATURE );
 		}
-	}, [ sitesViewState, setSitesViewState ] );
+	}, [ sitesViewState, setSelectedSiteFeature ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import { A4A_SITES_DASHBOARD_DEFAULT_FEATURE } from 'calypso/a8c-for-agencies/sections/sites/constants';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
@@ -21,6 +21,7 @@ export function JetpackPreviewPane( {
 	className,
 	isSmallScreen = false,
 	hasError = false,
+	initialSelectedFeatureId = A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
 }: SitePreviewPaneProps ) {
 	const translate = useTranslate();
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
@@ -41,7 +42,7 @@ export function JetpackPreviewPane( {
 		[ recordEvent ]
 	);
 
-	const { selectedSiteFeature, setSelectedSiteFeature } = useContext( SitesDashboardContext );
+	const [ selectedFeatureId, setSelectedFeatureId ] = useState( initialSelectedFeatureId );
 
 	// Jetpack features: Boost, Backup, Monitor, Stats
 	const features = useMemo(
@@ -50,40 +51,40 @@ export function JetpackPreviewPane( {
 				'jetpack_boost',
 				'Boost',
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedFeatureId,
+				setSelectedFeatureId,
 				<JetpackBoostPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_backup',
 				'Backup',
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedFeatureId,
+				setSelectedFeatureId,
 				<JetpackBackupPreview />
 			),
 			createFeaturePreview(
 				'jetpack_scan',
 				'Scan',
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedFeatureId,
+				setSelectedFeatureId,
 				<JetpackScanPreview sideId={ site.blog_id } />
 			),
 			createFeaturePreview(
 				'jetpack_monitor',
 				'Monitor',
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedFeatureId,
+				setSelectedFeatureId,
 				<JetpackMonitorPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_plugins',
 				translate( 'Plugins' ),
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedFeatureId,
+				setSelectedFeatureId,
 				<JetpackPluginsPreview
 					link={ '/plugins/manage/' + site.url }
 					linkLabel={ translate( 'Manage Plugins' ) }
@@ -96,28 +97,20 @@ export function JetpackPreviewPane( {
 				'jetpack_stats',
 				'Stats',
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedFeatureId,
+				setSelectedFeatureId,
 				<JetpackStatsPreview site={ site } trackEvent={ trackEvent } />
 			),
 			createFeaturePreview(
 				'jetpack_activity',
 				translate( 'Activity' ),
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedFeatureId,
+				setSelectedFeatureId,
 				<JetpackActivityPreview isLoading={ ! selectedSiteId } />
 			),
 		],
-		[
-			selectedSiteFeature,
-			setSelectedSiteFeature,
-			site,
-			trackEvent,
-			hasError,
-			translate,
-			selectedSiteId,
-		]
+		[ selectedFeatureId, site, trackEvent, hasError, translate, selectedSiteId ]
 	);
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
@@ -37,7 +38,7 @@ export function JetpackPreviewPane( {
 		recordEvent( eventName );
 	};
 
-	const [ selectedFeatureId, setSelectedFeatureId ] = useState( 'jetpack_boost' );
+	const { selectedSiteFeature, setSelectedSiteFeature } = useContext( SitesDashboardContext );
 
 	// Jetpack features: Boost, Backup, Monitor, Stats
 	const features = useMemo(
@@ -46,40 +47,40 @@ export function JetpackPreviewPane( {
 				'jetpack_boost',
 				'Boost',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackBoostPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_backup',
 				'Backup',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackBackupPreview />
 			),
 			createFeaturePreview(
 				'jetpack_scan',
 				'Scan',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackScanPreview sideId={ site.blog_id } />
 			),
 			createFeaturePreview(
 				'jetpack_monitor',
 				'Monitor',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackMonitorPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_plugins',
 				translate( 'Plugins' ),
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackPluginsPreview
 					link={ '/plugins/manage/' + site.url }
 					linkLabel={ translate( 'Manage Plugins' ) }
@@ -92,20 +93,28 @@ export function JetpackPreviewPane( {
 				'jetpack_stats',
 				'Stats',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackStatsPreview site={ site } trackEvent={ trackEvent } />
 			),
 			createFeaturePreview(
 				'jetpack_activity',
 				translate( 'Activity' ),
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackActivityPreview isLoading={ ! selectedSiteId } />
 			),
 		],
-		[ site, selectedFeatureId, translate ]
+		[
+			selectedSiteFeature,
+			setSelectedSiteFeature,
+			site,
+			trackEvent,
+			hasError,
+			translate,
+			selectedSiteId,
+		]
 	);
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
@@ -32,11 +32,14 @@ export function JetpackPreviewPane( {
 		if ( site ) {
 			dispatch( setSelectedSiteId( site.blog_id ) );
 		}
-	}, [ site ] );
+	}, [ dispatch, site ] );
 
-	const trackEvent = ( eventName: string ) => {
-		recordEvent( eventName );
-	};
+	const trackEvent = useCallback(
+		( eventName: string ) => {
+			recordEvent( eventName );
+		},
+		[ recordEvent ]
+	);
 
 	const { selectedSiteFeature, setSelectedSiteFeature } = useContext( SitesDashboardContext );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { A4A_SITES_DASHBOARD_DEFAULT_FEATURE } from 'calypso/a8c-for-agencies/sections/sites/constants';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
@@ -21,7 +21,6 @@ export function JetpackPreviewPane( {
 	className,
 	isSmallScreen = false,
 	hasError = false,
-	initialSelectedFeatureId = A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
 }: SitePreviewPaneProps ) {
 	const translate = useTranslate();
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
@@ -42,7 +41,7 @@ export function JetpackPreviewPane( {
 		[ recordEvent ]
 	);
 
-	const [ selectedFeatureId, setSelectedFeatureId ] = useState( initialSelectedFeatureId );
+	const { selectedSiteFeature, setSelectedSiteFeature } = useContext( SitesDashboardContext );
 
 	// Jetpack features: Boost, Backup, Monitor, Stats
 	const features = useMemo(
@@ -51,40 +50,40 @@ export function JetpackPreviewPane( {
 				'jetpack_boost',
 				'Boost',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackBoostPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_backup',
 				'Backup',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackBackupPreview />
 			),
 			createFeaturePreview(
 				'jetpack_scan',
 				'Scan',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackScanPreview sideId={ site.blog_id } />
 			),
 			createFeaturePreview(
 				'jetpack_monitor',
 				'Monitor',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackMonitorPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_plugins',
 				translate( 'Plugins' ),
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackPluginsPreview
 					link={ '/plugins/manage/' + site.url }
 					linkLabel={ translate( 'Manage Plugins' ) }
@@ -97,20 +96,28 @@ export function JetpackPreviewPane( {
 				'jetpack_stats',
 				'Stats',
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackStatsPreview site={ site } trackEvent={ trackEvent } />
 			),
 			createFeaturePreview(
 				'jetpack_activity',
 				translate( 'Activity' ),
 				true,
-				selectedFeatureId,
-				setSelectedFeatureId,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
 				<JetpackActivityPreview isLoading={ ! selectedSiteId } />
 			),
 		],
-		[ selectedFeatureId, site, trackEvent, hasError, translate, selectedSiteId ]
+		[
+			selectedSiteFeature,
+			setSelectedSiteFeature,
+			site,
+			trackEvent,
+			hasError,
+			translate,
+			selectedSiteId,
+		]
 	);
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -10,7 +10,7 @@ export const createFeaturePreview = (
 	id: string,
 	label: string,
 	enabled: boolean,
-	selectedFeatureId: string,
+	selectedFeatureId: string | undefined,
 	setSelectedFeatureId: ( id: string ) => void,
 	preview: React.ReactNode
 ): FeaturePreviewInterface => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
@@ -25,5 +25,4 @@ export interface SitePreviewPaneProps {
 	className?: string;
 	isSmallScreen?: boolean;
 	hasError?: boolean;
-	initialSelectedFeatureId?: string;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
@@ -25,4 +25,5 @@ export interface SitePreviewPaneProps {
 	className?: string;
 	isSmallScreen?: boolean;
 	hasError?: boolean;
+	initialSelectedFeatureId?: string;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/76

## Proposed Changes

* This PR updates the URL control for the site dashboard's preview pane. Now, when a user selects a site, the browser's URL is automatically updated to reflect this choice. This means that if a user bookmarks this URL or revisits it later, they're taken directly to the preview pane of the selected site, preserving the pane's state and position.

## Testing Instructions

* Go to the site dashboard (http://agencies.localhost:3000/sites).
* Make sure the mock data is displayed correctly.
* Select any of the sites.
* Make sure the pane is displayed and the URL is updated.
* Copy the URL.
* Paste it into a new window.
* Make sure it displays the correct site and feature (boost, scan, etc.).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?