### PR TITLE
A4A: Add to the Sites Dashboard the query to retrieve the sites from the Manage endpoint

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -13,17 +13,15 @@ import LayoutNavigation, {
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { mockedSites } from 'calypso/a8c-for-agencies/data/sites';
+import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
+import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import SitesOverviewContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/context';
 import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
 import { JetpackPreviewPane } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane';
 import SiteTopHeaderButtons from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons';
 import SitesDataViews from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews';
-import {
-	SitesDataResponse,
-	SitesViewState,
-} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import { AgencyDashboardFilterMap } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { useSelector } from 'calypso/state';
 import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
@@ -35,6 +33,7 @@ import SitesDashboardContext from '../sites-dashboard-context';
 import './style.scss';
 
 export default function SitesDashboard() {
+	useQueryJetpackPartnerPortalPartner();
 	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
 
 	//const { hideListing } = useContext( SitesDashboardContext );
@@ -89,25 +88,14 @@ export default function SitesDashboard() {
 		layout: {},
 		selectedSite: undefined,
 	} );
-	/*const { data, isError, isLoading, refetch } = useFetchDashboardSites(
+	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
 		search,
 		sitesViewState.page,
 		filter,
 		sort,
 		sitesViewState.perPage
-	);*/
-	//-- Mock data --// todo: fetch the sites from the API endpoint
-	const data: SitesDataResponse = {
-		sites: mockedSites,
-		total: 5,
-		perPage: 50,
-		totalFavorites: 2,
-	};
-	const isError = false;
-	const refetch = () => {};
-	const isLoading = false;
-	//-- End Mock data --//
+	);
 
 	const onSitesViewChange = useCallback(
 		( sitesViewData: SitesViewState ) => {
@@ -121,7 +109,6 @@ export default function SitesDashboard() {
 		if ( isLoading || isError ) {
 			return;
 		}
-
 		const filtersSelected =
 			sitesViewState.filters?.map( ( filter ) => {
 				const filterType =


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/81

## Proposed Changes

This PR adds the OAuth capability to be able to query the Manage endpoint `/jetpack-agency/sites`. This is a temporary code to be able to retrieve the sites, as an old Partner Agency way.

In a follow-up PR, this will be changed to use the A4A authorization scheme instead of the JP Manage Partner way

## Testing Instructions

- Check the code
- Check that you see your sites in A4A the same way you see them in Jetpack Manage.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
