### PR TITLE
Github Deployments: Show permission notice above pagination component

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/browse-repositories.tsx
+++ b/client/my-sites/github-deployments/components/repositories/browse-repositories.tsx
@@ -60,9 +60,13 @@ export const GitHubBrowseRepositories = ( {
 						margin: 0,
 						textAlign: 'center',
 						gap: '16px',
+						padding: '0',
+						flexGrow: 1,
+						justifyContent: 'center',
+						paddingBottom: '32px',
 					} }
 				>
-					<span css={ { paddingInline: '24px' } }>
+					<span css={ { paddingInline: '32px' } }>
 						{ __(
 							'To access your repositories, install the WordPress.com app on your GitHub account and grant it the necessary permissions.'
 						) }

--- a/client/my-sites/github-deployments/components/repositories/repository-list.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list.tsx
@@ -116,18 +116,18 @@ export const GitHubBrowseRepositoriesList = ( {
 				sortDirection={ direction }
 				onSortChange={ handleSortChange }
 			/>
-			<Pagination
-				page={ page }
-				perPage={ pageSize }
-				total={ filteredRepositories.length }
-				pageClick={ setPage }
-			/>
 			<p className="github-repositories-list-permissions-notice">
 				{ __( 'Missing GitHub repositories?' ) }{ ' ' }
 				<ExternalLink onClick={ openPermissions } href={ installation.management_url }>
 					{ __( 'Adjust permissions on GitHub' ) }
 				</ExternalLink>
 			</p>
+			<Pagination
+				page={ page }
+				perPage={ pageSize }
+				total={ filteredRepositories.length }
+				pageClick={ setPage }
+			/>
 		</div>
 	);
 };

--- a/client/my-sites/github-deployments/components/repositories/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/style.scss
@@ -55,7 +55,6 @@
 
 	.pagination {
 		margin-top: auto;
-		margin-bottom: 16px;
 
 		+ .github-repositories-list-permissions-notice {
 			margin-top: initial;
@@ -69,7 +68,7 @@
 
 .github-deployments-repository-list-table {
 	border-collapse: collapse;
-	margin-bottom: 8px;
+	margin-bottom: 16px;
 
 	th,
 	td {

--- a/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
@@ -29,7 +29,13 @@ export const RepositorySelectionDialog = ( {
 			onClose={ onClose }
 			className="repository-selection-dialog"
 		>
-			<div>
+			<div
+				css={ {
+					display: 'flex',
+					flexDirection: 'column',
+					flexGrow: 1,
+				} }
+			>
 				<FormattedHeader
 					align="left"
 					headerText={ __( 'Select repository' ) }

--- a/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
@@ -27,8 +27,9 @@ export const RepositorySelectionDialog = ( {
 			shouldCloseOnOverlayClick
 			shouldCloseOnEsc
 			onClose={ onClose }
+			className="repository-selection-dialog"
 		>
-			<div className="repository-selection-dialog">
+			<div>
 				<FormattedHeader
 					align="left"
 					headerText={ __( 'Select repository' ) }

--- a/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
@@ -27,6 +27,7 @@ export const RepositorySelectionDialog = ( {
 			shouldCloseOnOverlayClick
 			shouldCloseOnEsc
 			onClose={ onClose }
+			additionalClassNames="github-deployments-dialog"
 			className="repository-selection-dialog"
 		>
 			<div

--- a/client/my-sites/github-deployments/deployment-creation/style.scss
+++ b/client/my-sites/github-deployments/deployment-creation/style.scss
@@ -15,6 +15,8 @@
 
 }
 
-.dialog__action-buttons-close {
-	padding: 32px;
+.github-deployments-dialog .dialog__action-buttons-close {
+	padding: 0;
+	margin-top: 32px;
+	margin-right: 32px;
 }

--- a/client/my-sites/github-deployments/deployment-creation/style.scss
+++ b/client/my-sites/github-deployments/deployment-creation/style.scss
@@ -1,14 +1,20 @@
 .repository-selection-dialog {
 	width: 622px;
-	height: 470px;
+	height: fit-content;
 	display: flex;
 	flex-direction: column;
+	padding: 32px;
 
 	h1 {
-		margin-bottom: 0.25rem !important;
+		margin-bottom: 8px !important;
 	}
 
 	.formatted-header {
 		margin-bottom: 24px !important;
 	}
+
+}
+
+.dialog__action-buttons-close {
+	padding: 32px;
 }

--- a/client/my-sites/github-deployments/deployment-creation/style.scss
+++ b/client/my-sites/github-deployments/deployment-creation/style.scss
@@ -1,6 +1,6 @@
 .repository-selection-dialog {
 	width: 622px;
-	height: fit-content;
+	height: 490px;
 	display: flex;
 	flex-direction: column;
 	padding: 32px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/5952

## Proposed Changes

* Move the permission notice above pagination to match design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to /github-deployments/atomicSite/create
* adjust permissions to all repository
* pagination should be below the notice.

![image](https://github.com/Automattic/wp-calypso/assets/47489215/e82b75b1-5ff2-4d4b-9fa8-9e5c6a94e10d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?