### PR TITLE
GitHub deployments: Add repository picker Tracks events

### DIFF
--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -85,8 +85,15 @@ export const GitHubDeploymentCreationForm = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const reduxDispatch = useDispatch();
 	const { createDeployment } = useCreateCodeDeployment( siteId, {
-		onSuccess: () => {
+		onSuccess: ( data ) => {
 			reduxDispatch( successNotice( __( 'Deployment created.' ), noticeOptions ) );
+			reduxDispatch(
+				recordTracksEvent( 'calypso_hosting_github_create_deployment_success', {
+					deployment_type: data ? getDeploymentTypeFromPath( data.target_dir ) : null,
+					is_automated: data?.is_automated,
+					workflow_path: data?.workflow_path,
+				} )
+			);
 			onConnected();
 		},
 		onError: ( error ) => {
@@ -103,16 +110,6 @@ export const GitHubDeploymentCreationForm = ( {
 						...noticeOptions,
 					}
 				)
-			);
-		},
-		onSettled: ( data, error ) => {
-			reduxDispatch(
-				recordTracksEvent( 'calypso_hosting_github_create_deployment_success', {
-					connected: ! error,
-					deployment_type: data ? getDeploymentTypeFromPath( data.target_dir ) : null,
-					is_automated: data?.is_automated,
-					workflow_path: data?.workflow_path,
-				} )
 			);
 		},
 	} );

--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -121,7 +121,10 @@ export const GitHubDeploymentCreationForm = ( {
 				key={ repository?.id ?? 'none' }
 				repository={ repository }
 				initialValues={ initialValues }
-				changeRepository={ () => dispatch( { type: 'open-repository-picker' } ) }
+				changeRepository={ () => {
+					reduxDispatch( recordTracksEvent( 'calypso_hosting_github_repository_picker_click' ) );
+					dispatch( { type: 'open-repository-picker' } );
+				} }
 				onSubmit={ ( {
 					externalRepositoryId,
 					branchName,
@@ -143,6 +146,7 @@ export const GitHubDeploymentCreationForm = ( {
 			<RepositorySelectionDialog
 				isVisible={ isRepositoryPickerOpen }
 				onChange={ ( installation, repository ) => {
+					reduxDispatch( recordTracksEvent( 'calypso_hosting_github_select_repository_click' ) );
 					dispatch( { type: 'select-repository', installation, repository } );
 				} }
 				onClose={ () => dispatch( { type: 'close-repository-picker' } ) }

--- a/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
+++ b/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
@@ -37,8 +37,15 @@ export const GitHubDeploymentManagementForm = ( {
 	const siteId = useSelector( getSelectedSiteId );
 
 	const { updateDeployment } = useUpdateCodeDeployment( siteId, codeDeployment.id, {
-		onSuccess: () => {
+		onSuccess: ( data ) => {
 			dispatch( successNotice( __( 'Deployment updated.' ), noticeOptions ) );
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_github_update_deployment_success', {
+					deployment_type: data ? getDeploymentTypeFromPath( data.target_dir ) : null,
+					is_automated: data?.is_automated,
+					workflow_path: data?.workflow_path,
+				} )
+			);
 			onUpdated();
 		},
 		onError: ( error ) => {
@@ -55,16 +62,6 @@ export const GitHubDeploymentManagementForm = ( {
 						...noticeOptions,
 					}
 				)
-			);
-		},
-		onSettled: ( data, error ) => {
-			dispatch(
-				recordTracksEvent( 'calypso_hosting_github_update_deployment_success', {
-					connected: ! error,
-					deployment_type: data ? getDeploymentTypeFromPath( data.target_dir ) : null,
-					is_automated: data?.is_automated,
-					workflow_path: data?.workflow_path,
-				} )
 			);
 		},
 	} );

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -42,6 +42,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 		deployment.id,
 		{
 			onSuccess: () => {
+				dispatch( recordTracksEvent( 'calypso_hosting_github_manual_deployment_run_success' ) );
 				dispatch( successNotice( __( 'Deployment run created.' ), noticeOptions ) );
 			},
 			onError: ( error ) => {
@@ -60,13 +61,6 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 							...noticeOptions,
 						}
 					)
-				);
-			},
-			onSettled: ( _, error ) => {
-				dispatch(
-					recordTracksEvent( 'calypso_hosting_github_manual_deployment_run_success', {
-						connected: ! error,
-					} )
 				);
 			},
 		}


### PR DESCRIPTION
Title. We should dispatch some events when the repository picker's been opened and a repository has been picked too.

I also moved the mutation related events to the appropriate handler. We should only dispatch successful Tracks events in case the mutation has been successful.