### PR TITLE
Checkout: Convert DomainRegistrationHsts to TypeScript

### DIFF
--- a/client/my-sites/checkout/src/components/domain-registration-hsts.tsx
+++ b/client/my-sites/checkout/src/components/domain-registration-hsts.tsx
@@ -1,6 +1,5 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { localize } from 'i18n-calypso';
-import { isEmpty, merge, reduce } from 'lodash';
+import { LocalizeProps, localize } from 'i18n-calypso';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { getDomainRegistrations, getDomainTransfers } from 'calypso/lib/cart-values/cart-items';
@@ -8,33 +7,39 @@ import { getTld, isHstsRequired } from 'calypso/lib/domains';
 import { HTTPS_SSL } from 'calypso/lib/url/support';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import type { ResponseCart } from '@automattic/shopping-cart';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
+export interface DomainRegistrationHstsProps {
+	cart: ResponseCart;
+}
 
-class DomainRegistrationHsts extends PureComponent {
+export interface DomainRegistrationConnectedHstsProps {
+	productsList: Record< string, ProductListItem >;
+}
+
+class DomainRegistrationHsts extends PureComponent<
+	DomainRegistrationHstsProps & DomainRegistrationConnectedHstsProps & LocalizeProps
+> {
 	getHstsTlds = () => {
 		const { cart, productsList } = this.props;
-		const domains = merge( getDomainRegistrations( cart ), getDomainTransfers( cart ) );
+		const domains = [ ...getDomainRegistrations( cart ), ...getDomainTransfers( cart ) ];
 
-		if ( isEmpty( domains ) ) {
+		if ( domains.length === 0 ) {
 			return null;
 		}
 
-		const hstsTlds = reduce(
-			domains,
-			( tlds, domain ) => {
-				if ( isHstsRequired( domain.product_slug, productsList ) ) {
-					const tld = '.' + getTld( domain.meta );
+		const hstsTlds = domains.reduce( ( tlds: string[], domain ) => {
+			if ( isHstsRequired( domain.product_slug, productsList ) ) {
+				const tld = '.' + getTld( domain.meta );
 
-					if ( tlds.indexOf( tld ) === -1 ) {
-						tlds.push( tld );
-					}
+				if ( tlds.indexOf( tld ) === -1 ) {
+					tlds.push( tld );
 				}
+			}
 
-				return tlds;
-			},
-			[]
-		);
+			return tlds;
+		}, [] );
 
 		return hstsTlds.join( ', ' );
 	};

--- a/client/my-sites/checkout/src/components/domain-registration-hsts.tsx
+++ b/client/my-sites/checkout/src/components/domain-registration-hsts.tsx
@@ -14,7 +14,7 @@ export interface DomainRegistrationHstsProps {
 	cart: ResponseCart;
 }
 
-export interface DomainRegistrationConnectedHstsProps {
+interface DomainRegistrationConnectedHstsProps {
 	productsList: Record< string, ProductListItem >;
 }
 


### PR DESCRIPTION
## Proposed Changes

This just converts the `DomainRegistrationHsts` form to TypeScript with minimal changes.

## Testing Instructions

Visual check should be sufficient.