### PR TITLE
Checkout: Convert DomainRegistrationAgreement to TypeScript

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -592,6 +592,10 @@ export interface CartLocation {
 	city?: string;
 }
 
+export type DomainLegalAgreementUrl = string;
+export type DomainLegalAgreementTitle = string;
+export type DomainLegalAgreements = Record< DomainLegalAgreementUrl, DomainLegalAgreementTitle >;
+
 export interface ResponseCartProductExtra {
 	context?: string;
 	source?: string;
@@ -603,7 +607,7 @@ export interface ResponseCartProductExtra {
 	google_apps_registration_data?: DomainContactDetails;
 	receipt_for_domain?: number;
 	domain_registration_agreement_url?: string;
-	legal_agreements?: never[] | Record< string, string >;
+	legal_agreements?: never[] | DomainLegalAgreements;
 
 	/**
 	 * Set to 'renewal' if requesting a renewal.

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -602,6 +602,8 @@ export interface ResponseCartProductExtra {
 	google_apps_users?: GSuiteProductUser[];
 	google_apps_registration_data?: DomainContactDetails;
 	receipt_for_domain?: number;
+	domain_registration_agreement_url?: string;
+	legal_agreements?: never[] | Record< string, string >;
 
 	/**
 	 * Set to 'renewal' if requesting a renewal.


### PR DESCRIPTION
## Proposed Changes

This PR converts `DomainRegistrationAgreement` to TypeScript with minimal changes.

## Screenshot

<img width="545" alt="Screenshot 2024-03-19 at 11 36 00 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/067c0fbd-f29c-465f-abc0-262dd6f9711b">

## Testing Instructions

Add a domain to the cart that includes a legal agreement and verify that the agreement is displayed in checkout.

From D130520-code it looks like this includes `.de` and `.br` domains. You may need to modify your sandbox to allow these domains to be added to the cart (ping me for help).