### PR TITLE
Untangle: Add GA settings to Connections page

### DIFF
--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -6,11 +6,18 @@ import QueryPublicizeConnections from 'calypso/components/data/query-publicize-c
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import GoogleAnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-google-analytics';
+import { useSelector } from 'calypso/state';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
+import { isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
 import SharingServicesGroup from './services-group';
 
 const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.POST_SHARING_ENABLED );
+
+	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
+		getIsGlobalSiteViewEnabled( state, siteId )
+	);
 
 	return (
 		<div className="connections__sharing-settings connections__sharing-connections">
@@ -42,6 +49,8 @@ const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 				title={ translate( 'Manage connections' ) }
 				numberOfPlaceholders={ isP2Hub ? 2 : undefined }
 			/>
+
+			{ isGlobalSiteViewEnabled && <GoogleAnalyticsSettings /> }
 		</div>
 	);
 };


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6105

## Proposed Changes

For Atomic sites with classic view, this PR adds the Google Analytics settings, previously found under Tools -> Marketing -> Traffic, to Global Site View -> Connections.

<img width="1045" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/697cd5bd-69cc-4266-b1b0-5da9fff1a85d">


## Testing Instructions

1. Prepare an Atomic site.
2. Go to Settings -> Hosting Configuration and set Admin interface style to classic.
3. Go to the site's _cli and run `wp option update wpcom_classic_early_release 1`.
4. Go to `/marketing/connections/:site`
5. Verify you can see the Google Analytics form as screenshot above.
6. Verify you can get and update the settings correctly.
    - (Both the settings in here and Tools -> Marketing -> Traffic should match)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?