### PR TITLE
Scheduled Updates: Show Jetpack users migrate upsell banner

### DIFF
--- a/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
@@ -7,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -15,6 +16,7 @@ const UpsellNudgeNotice = () => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
 	const getWpcomUpgradeNudge = () => {
 		const titleText = translate(
@@ -68,7 +70,7 @@ const UpsellNudgeNotice = () => {
 		);
 	};
 
-	return isJetpack ? getJetpackMigrateNudge() : getWpcomUpgradeNudge();
+	return isJetpack && ! isAtomic ? getJetpackMigrateNudge() : getWpcomUpgradeNudge();
 };
 
 export default UpsellNudgeNotice;

--- a/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
@@ -7,35 +7,68 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const UpsellNudgeNotice = () => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
-	const titleText = translate(
-		'Upgrade to the %(businessPlanName)s plan to install plugins and manage scheduled updates.',
-		{
-			args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-		}
-	);
+	const getWpcomUpgradeNudge = () => {
+		const titleText = translate(
+			'Upgrade to the %(businessPlanName)s plan to install plugins and manage scheduled updates.',
+			{
+				args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+			}
+		);
 
-	const href = addQueryArgs( `/checkout/${ siteSlug }/business`, {
-		redirect_to: `/plugins/scheduled-updates/${ siteSlug }`,
-	} );
+		const href = addQueryArgs( `/checkout/${ siteSlug }/business`, {
+			redirect_to: `/plugins/scheduled-updates/${ siteSlug }`,
+		} );
 
-	return (
-		<UpsellNudge
-			className="scheduled-updates-upsell-nudge"
-			title={ titleText }
-			event="calypso_scheduled_updates_upgrade_click"
-			href={ href }
-			callToAction={ translate( 'Upgrade' ) }
-			plan={ PLAN_BUSINESS }
-			showIcon={ true }
-			feature={ WPCOM_FEATURES_SCHEDULED_UPDATES }
-		/>
-	);
+		return (
+			<UpsellNudge
+				className="scheduled-updates-upsell-nudge"
+				title={ titleText }
+				tracksImpressionName="calypso_scheduled_updates_upgrade_impression"
+				event="calypso_scheduled_updates_upgrade_upsell"
+				tracksClickName="calypso_scheduled_updates_upgrade_click"
+				href={ href }
+				callToAction={ translate( 'Upgrade' ) }
+				plan={ PLAN_BUSINESS }
+				showIcon={ true }
+				feature={ WPCOM_FEATURES_SCHEDULED_UPDATES }
+			/>
+		);
+	};
+
+	const getJetpackMigrateNudge = () => {
+		const titleText = translate(
+			'Thank you for you interest in scheduling plugin updates. Migrate your site to WordPress.com to get started!'
+		);
+
+		const href = addQueryArgs( `/setup/import-hosted-site/import`, {
+			source: 'scheduled-updates-dashboard',
+		} );
+
+		return (
+			<UpsellNudge
+				className="scheduled-updates-upsell-nudge"
+				title={ titleText }
+				tracksImpressionName="calypso_scheduled_updates_migrate_impression"
+				event="calypso_scheduled_updates_migrate_upsell"
+				tracksClickName="calypso_scheduled_updates_migrate_click"
+				href={ href }
+				callToAction={ translate( 'Migrate' ) }
+				showIcon={ true }
+				feature={ WPCOM_FEATURES_SCHEDULED_UPDATES }
+			/>
+		);
+	};
+
+	return isJetpack ? getJetpackMigrateNudge() : getWpcomUpgradeNudge();
 };
 
 export default UpsellNudgeNotice;

--- a/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
@@ -53,6 +53,7 @@ const UpsellNudgeNotice = () => {
 
 		const href = addQueryArgs( `/setup/import-hosted-site/import`, {
 			source: 'scheduled-updates-dashboard',
+			ref: 'scheduled-updates-dashboard',
 		} );
 
 		return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88655

## Proposed Changes

* If a user is coming from a Jetpack site, we show a migration upsell instead and navigate them to the migration flow.
* Adding upsell banner track events:
    * Simple site:
        - show: `calypso_scheduled_updates_upgrade_impression`
        - click: `calypso_scheduled_updates_upgrade_click`
    * Jetpack site:
        - show: `calypso_scheduled_updates_migrate_impression`
        - click: `calypso_scheduled_updates_migrate_click`
       
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new JN site and connect to your WP.com account.
* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/<site-slug>`
* Check and see if the migrate upsell banner shows up
![Screen Shot 2024-03-19 at 5 19 02 PM](https://github.com/Automattic/wp-calypso/assets/4074459/4f837c62-9385-4470-9cd6-17f680626811)
* Click `Migrate` button and see if it redirects you to the `import-hosted-site` flow
* Check in Tracks Vigilante and see if `calypso_scheduled_updates_migrate_impression` and `calypso_scheduled_updates_migrate_click` both gets triggered.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?