### PR TITLE
Plugins update manager: Sort list of schedules based on timestamp

### DIFF
--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -17,17 +17,27 @@ export const useUpdateScheduleQuery = (
 	siteSlug: SiteSlug,
 	isEligibleForFeature: boolean
 ): UseQueryResult< ScheduleUpdates[] > => {
+	const select = ( data: ScheduleUpdates[] ) => {
+		return data.sort( ( a, b ) => {
+			if ( a.timestamp === undefined || b.timestamp === undefined ) {
+				return 0;
+			}
+			// Sort other objects based on timestamp
+			return a.timestamp - b.timestamp;
+		} );
+	};
+
 	return useQuery( {
 		queryKey: [ 'schedule-updates', siteSlug ],
 		queryFn: () =>
-			wpcomRequest< { [ key: string ]: Partial< ScheduleUpdates > } >( {
+			wpcomRequest< { [ key: string ]: ScheduleUpdates } >( {
 				path: `/sites/${ siteSlug }/update-schedules`,
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
 			} ).then( ( response ) =>
 				Object.keys( response ).map( ( id ) => ( {
-					id,
 					...response[ id ],
+					id,
 				} ) )
 			),
 		meta: {
@@ -36,13 +46,6 @@ export const useUpdateScheduleQuery = (
 		enabled: !! siteSlug && isEligibleForFeature,
 		retry: false,
 		refetchOnWindowFocus: false,
-		select: ( data: ScheduleUpdates[] ) =>
-			data.sort( ( a, b ) => {
-				if ( a.timestamp === undefined || b.timestamp === undefined ) {
-					return 0;
-				}
-				// Sort other objects based on timestamp
-				return a.timestamp - b.timestamp;
-			} ),
+		select,
 	} );
 };

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -36,5 +36,13 @@ export const useUpdateScheduleQuery = (
 		enabled: !! siteSlug && isEligibleForFeature,
 		retry: false,
 		refetchOnWindowFocus: false,
+		select: ( data: ScheduleUpdates[] ) =>
+			data.sort( ( a, b ) => {
+				if ( a.timestamp === undefined || b.timestamp === undefined ) {
+					return 0;
+				}
+				// Sort other objects based on timestamp
+				return a.timestamp - b.timestamp;
+			} ),
 	} );
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/88656

## Proposed Changes

* Sorts list of schedules based on timestamp
* Improves UX: The list that comes from the server is sorted by timestamp, but the item we manually added as an optimistic update was not before this change.

## Testing Instructions

* Go to `/plugins/scheduled-updates/{ATOMIC_SITE}`
* Add a schedule, for example, at 3am
* Add another, for example, at 2am
* Check if the entry goes in the first place (before this change, it was not sorted)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?