### PR TITLE
Automattic for Agencies: Implement query products for the Marketplace

### DIFF
--- a/client/a8c-for-agencies/data/marketplace/use-products-query.ts
+++ b/client/a8c-for-agencies/data/marketplace/use-products-query.ts
@@ -1,0 +1,99 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import selectAlphabeticallySortedProductOptions from 'calypso/jetpack-cloud/sections/partner-portal/lib/select-alphabetically-sorted-product-options';
+import wpcom from 'calypso/lib/wp';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+function queryProducts(
+	isPublicFacing: boolean,
+	agencyId?: number
+): Promise< APIProductFamily[] > {
+	const productsAPIPath = isPublicFacing
+		? '/jetpack-licensing/public/manage-pricing'
+		: '/jetpack-licensing/partner/product-families';
+
+	return wpcom.req
+		.get(
+			{
+				apiNamespace: 'wpcom/v2',
+				path: productsAPIPath,
+			},
+			{
+				...( agencyId && { agency_id: agencyId } ),
+			}
+		)
+		.then( ( data: APIProductFamily[] ) => {
+			const exclude = [
+				'free',
+				'personal',
+				'premium',
+				'professional',
+				'jetpack-backup-daily',
+				'jetpack-backup-realtime',
+				'jetpack-backup-t0',
+				'jetpack-security-daily',
+				'jetpack-security-realtime',
+			];
+
+			return data
+				.map( ( family ) => {
+					return {
+						...family,
+						products: family.products
+							.filter( ( product ) => {
+								return exclude.indexOf( product.slug ) === -1;
+							} )
+							.map( ( product ) => ( {
+								...product,
+								family_slug: family.slug,
+							} ) ),
+					};
+				} )
+				.filter( ( family ) => {
+					return family.products.length > 0;
+				} );
+		} );
+}
+
+export function usePublicProductsQuery(): UseQueryResult< APIProductFamilyProduct[], unknown > {
+	return useProductsQuery( true );
+}
+
+export default function useProductsQuery(
+	isPublicFacing = false
+): UseQueryResult< APIProductFamilyProduct[], unknown > {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const query = useQuery( {
+		queryKey: [ 'a4a', 'marketplace', 'products', isPublicFacing, agencyId ],
+		queryFn: () => queryProducts( isPublicFacing, agencyId ),
+		select: selectAlphabeticallySortedProductOptions,
+		enabled: isPublicFacing || !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+
+	const { isError } = query;
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice(
+					translate(
+						'We were unable to retrieve your latest product details. Please try again later.'
+					),
+					{
+						id: 'a4a-marketplace-product-families-failure',
+					}
+				)
+			);
+		}
+	}, [ dispatch, translate, isError ] );
+
+	return query;
+}

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -1,6 +1,6 @@
 import { getQueryArg } from '@wordpress/url';
 import { useCallback, useEffect, useState } from 'react';
-import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import type { ShoppingCartItem } from '../types';
 
 const SELECTED_ITEMS_SESSION_STORAGE_KEY = 'shopping-card-selected-items';
@@ -8,7 +8,7 @@ const SELECTED_ITEMS_SESSION_STORAGE_KEY = 'shopping-card-selected-items';
 export default function useShoppingCart() {
 	const [ selectedCartItems, setSelectedCartItems ] = useState< ShoppingCartItem[] >( [] );
 
-	const { data } = useProductsQuery( true );
+	const { data } = useProductsQuery();
 
 	useEffect( () => {
 		const hasSuggestedProductSlug = getQueryArg( window.location.href, 'product_slug' )

--- a/client/a8c-for-agencies/sections/marketplace/lib/is-pressable-hosting-product.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/is-pressable-hosting-product.ts
@@ -1,0 +1,8 @@
+/**
+ * Provided a license key or a product slug, can we trust that the product is a Pressable hosting product
+ * @param keyOrSlug string
+ * @returns boolean True if Pressable hosting product, false if not
+ */
+export default function isPressableHostingProduct( keyOrSlug: string ) {
+	return keyOrSlug.startsWith( 'pressable-hosting' );
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-assign-licenses-to-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-assign-licenses-to-site.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import {
 	getProductSlugFromLicenseKey,
 	getProductTitle,
 } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
-import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import useAssignLicenseMutation from '../../hooks/use-assign-license-mutation';
 import type {
 	ProductInfo,
@@ -25,7 +25,7 @@ const useAssignLicensesToSite = (
 	assignLicensesToSite: ( licenseKeys: string[] ) => Promise< PurchasedProductsInfo >;
 	isReady: boolean;
 } => {
-	const products = useProductsQuery( true );
+	const products = useProductsQuery();
 	const assignLicense = useAssignLicenseMutation( {
 		onError: options.onError ?? NO_OP,
 	} );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -6,11 +6,11 @@ import {
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setPurchasedLicense, resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { successNotice } from 'calypso/state/notices/actions';
-import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { type APIError } from 'calypso/state/partner-portal/types';
 import useAssignLicensesToSite from './use-assign-licenses-to-site';
 import useIssueLicenses, {
@@ -24,7 +24,7 @@ const NO_OP = () => {
 
 const useGetLicenseIssuedMessage = () => {
 	const translate = useTranslate();
-	const products = useProductsQuery( true );
+	const products = useProductsQuery();
 
 	return useCallback(
 		( licenses: FulfilledIssueLicenseResult[] ) => {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-product-and-plans.tsx
@@ -1,0 +1,188 @@
+import { getQueryArg } from '@wordpress/url';
+import { useMemo } from 'react';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import {
+	isWooCommerceProduct,
+	isWpcomHostingProduct,
+} from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import { isProductMatch } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/filter';
+import { useSelector } from 'calypso/state';
+import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import isPressableHostingProduct from '../../../lib/is-pressable-hosting-product';
+import {
+	PRODUCT_FILTER_ALL,
+	PRODUCT_FILTER_PLANS,
+	PRODUCT_FILTER_PRODUCTS,
+	PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+	PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+} from '../constants';
+import type { SiteDetails } from '@automattic/data-stores';
+
+// Plans and Products that we can merged into 1 card.
+const MERGABLE_PLANS = [ 'jetpack-security' ];
+const MERGABLE_PRODUCTS = [ 'jetpack-backup' ];
+
+type Props = {
+	selectedBundleSize?: number;
+	selectedSite?: SiteDetails | null;
+	selectedProductFilter?: string | null;
+	productSearchQuery?: string;
+	usePublicQuery?: boolean;
+};
+
+const getProductsAndPlansByFilter = (
+	filter: string | null,
+	allProductsAndPlans?: APIProductFamilyProduct[]
+) => {
+	switch ( filter ) {
+		case PRODUCT_FILTER_PRODUCTS:
+			return (
+				allProductsAndPlans?.filter(
+					( { family_slug } ) =>
+						family_slug !== 'jetpack-packs' &&
+						family_slug !== 'jetpack-backup-storage' &&
+						! isWooCommerceProduct( family_slug ) &&
+						! isWpcomHostingProduct( family_slug ) &&
+						! isPressableHostingProduct( family_slug )
+				) || []
+			);
+		case PRODUCT_FILTER_PLANS:
+			return (
+				allProductsAndPlans?.filter( ( { family_slug } ) => family_slug === 'jetpack-packs' ) || []
+			);
+
+		case PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS:
+			return (
+				allProductsAndPlans
+					?.filter( ( { family_slug } ) => family_slug === 'jetpack-backup-storage' )
+					.sort( ( a, b ) => a.product_id - b.product_id ) || []
+			);
+
+		case PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS:
+			return (
+				allProductsAndPlans?.filter( ( { family_slug } ) => isWooCommerceProduct( family_slug ) ) ||
+				[]
+			);
+	}
+
+	return allProductsAndPlans || [];
+};
+
+// This function gets the displayable Plans based on how it should be arranged in the listing.
+const getDisplayablePlans = ( filteredProductsAndBundles: APIProductFamilyProduct[] ) => {
+	const plans = getProductsAndPlansByFilter( PRODUCT_FILTER_PLANS, filteredProductsAndBundles );
+
+	const filteredPlans = MERGABLE_PLANS.map( ( filter ) => {
+		return plans.filter( ( { slug } ) => slug.startsWith( filter ) );
+	} )
+		.filter( ( subArray ) => subArray.length > 0 ) // Remove empty arrays
+		.map( ( mergedPlans ) => ( mergedPlans.length === 1 ? mergedPlans[ 0 ] : mergedPlans ) ); // flat out if only one plan.
+
+	const restOfPlans = plans.filter( ( { slug } ) => {
+		return ! MERGABLE_PLANS.some( ( filter ) => slug.startsWith( filter ) );
+	} );
+
+	return [ ...filteredPlans, ...restOfPlans ] as APIProductFamilyProduct[];
+};
+
+// This function gets the displayable Products based on how it should be arranged in the listing.
+const getDisplayableProducts = ( filteredProductsAndBundles: APIProductFamilyProduct[] ) => {
+	const products = getProductsAndPlansByFilter(
+		PRODUCT_FILTER_PRODUCTS,
+		filteredProductsAndBundles
+	);
+	const filteredProducts = MERGABLE_PRODUCTS.map( ( filter ) => {
+		return products.filter( ( { slug } ) => slug.startsWith( filter ) );
+	} )
+		.filter( ( subArray ) => subArray.length > 0 ) // Remove empty arrays
+		.map( ( mergedProducts ) =>
+			mergedProducts.length === 1 ? mergedProducts[ 0 ] : mergedProducts
+		); // flat out if only one product.
+
+	const restOfProducts = products.filter( ( { slug } ) => {
+		return ! MERGABLE_PRODUCTS.some( ( filter ) => slug.startsWith( filter ) );
+	} );
+
+	return [ ...restOfProducts, ...filteredProducts ].sort( ( a, b ) => {
+		const product_a = Array.isArray( a ) ? a[ 0 ].name : a.name;
+		const product_b = Array.isArray( b ) ? b[ 0 ].name : b.name;
+		return product_a.localeCompare( product_b );
+	} ) as APIProductFamilyProduct[];
+};
+
+export default function useProductAndPlans( {
+	selectedBundleSize = 1,
+	selectedSite,
+	selectedProductFilter = PRODUCT_FILTER_ALL,
+	productSearchQuery,
+	usePublicQuery = false,
+}: Props ) {
+	const { data, isLoading: isLoadingProducts } = useProductsQuery( usePublicQuery );
+
+	const addedPlanAndProducts = useSelector( ( state ) =>
+		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null
+	);
+
+	return useMemo( () => {
+		// List only products that is compatible with current bundle size.
+		const supportedProducts =
+			selectedBundleSize > 1
+				? data?.filter(
+						( { supported_bundles } ) =>
+							supported_bundles?.some?.( ( { quantity } ) => selectedBundleSize === quantity )
+				  )
+				: data;
+
+		// We pre-filter the list by current selected filter
+		let filteredProductsAndBundles = getProductsAndPlansByFilter(
+			selectedProductFilter,
+			supportedProducts
+		);
+
+		// Filter products based on the search term
+		if ( productSearchQuery ) {
+			filteredProductsAndBundles = filteredProductsAndBundles.filter( ( product ) =>
+				isProductMatch( product, productSearchQuery )
+			);
+		}
+
+		// Filter products & plan that are already assigned to a site
+		if ( selectedSite && addedPlanAndProducts && filteredProductsAndBundles ) {
+			filteredProductsAndBundles = filteredProductsAndBundles.filter(
+				( product ) => ! addedPlanAndProducts.includes( product.product_id )
+			);
+		}
+
+		// We need the suggested products (i.e., the products chosen from the dashboard) to properly
+		// track if the user purchases a different set of products.
+		const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
+			?.toString()
+			.split( ',' );
+
+		return {
+			isLoadingProducts,
+			data,
+			filteredProductsAndBundles,
+			plans: getDisplayablePlans( filteredProductsAndBundles ),
+			products: getDisplayableProducts( filteredProductsAndBundles ),
+			backupAddons: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+				filteredProductsAndBundles
+			),
+			wooExtensions: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+				filteredProductsAndBundles
+			),
+			suggestedProductSlugs,
+		};
+	}, [
+		addedPlanAndProducts,
+		data,
+		isLoadingProducts,
+		selectedBundleSize,
+		productSearchQuery,
+		selectedProductFilter,
+		selectedSite,
+	] );
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -10,12 +10,12 @@ import {
 	getIncompatibleProducts,
 	isIncompatibleProduct,
 } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/incompatible-products';
-import useProductAndPlans from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/licenses-form/hooks/use-product-and-plans';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { ShoppingCartContext } from '../../context';
 import MultiProductCard from '../multi-product-card';
 import ProductCard from '../product-card';
+import useProductAndPlans from './hooks/use-product-and-plans';
 import useSubmitForm from './hooks/use-submit-form';
 import ProductFilterSearch from './product-filter-search';
 import ProductListingSection from './sections';
@@ -55,7 +55,6 @@ export default function ProductListing( {
 		selectedSite,
 		selectedBundleSize: quantity,
 		productSearchQuery,
-		usePublicQuery: true, // FIXME: Fix this when we have the API endpoint for A4A
 	} );
 
 	// Create a ref for `filteredProductsAndBundles` to prevent unnecessary re-renders caused by the `useEffect` hook.

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/test/payment-method-add.jsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/test/payment-method-add.jsx
@@ -9,7 +9,7 @@ import { createStore } from 'redux';
 import PaymentMethodAdd from '../index';
 
 describe( '<PaymentMethodAdd>', () => {
-	test( 'should render correctly and match the snapshot', async () => {
+	test( 'should render correctly', async () => {
 		const promise = Promise.resolve();
 		const queryClient = new QueryClient();
 		const initialState = {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/298

## Proposed Changes

This PR implements query products for the Marketplace using the agency ID with a new useProductsQuery hook.

This includes porting of `useProductsQuery` & `useProductAndPlans` from JC to A4A

## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Click the Marketplace menu item -> Verify that some products.

<img width="1332" alt="Screenshot 2024-03-20 at 1 18 09 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/26d11b7c-3907-420e-8944-3f2a386308bd">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?