### PR TITLE
Signup: Vertically align the Create your account component

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -718,17 +718,22 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	.is-onboarding-pm .signup__step.is-user.is-passwordless-experiment,
 	.signup__step.is-user-social {
 		display: flex;
+		flex-direction: column;
 		align-items: center;
 		justify-content: center;
 		min-height: calc(100vh - 96px);
 
 		.step-wrapper {
-			flex: 1 1 auto;
+			width: 100%;
 			margin-bottom: 48px;
 
 			@media screen and ( max-width: $breakpoint-mobile ) {
 				margin-bottom: 0;
 			}
+		}
+
+		.locale-suggestions {
+			width: 100%;
 		}
 
 		.step-wrapper__header {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -717,7 +717,19 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	// https://github.com/Automattic/wp-calypso/pull/83886
 	.is-onboarding-pm .signup__step.is-user.is-passwordless-experiment,
 	.signup__step.is-user-social {
-		margin-top: 25vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: calc(100vh - 96px);
+
+		.step-wrapper {
+			flex: 1 1 auto;
+			margin-bottom: 48px;
+
+			@media screen and ( max-width: $breakpoint-mobile ) {
+				margin-bottom: 0;
+			}
+		}
 
 		.step-wrapper__header {
 			margin-bottom: 24px !important;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2824-gh-Automattic/martech

## Proposed Changes

* Vertically align the content of `. signup__step` using `display: flex;`.
* Set the minimum height of the `. signup__step` to `100vh` and subtract the `.layout__content` top padding and `.step-wrapper__header` top margin.
* Add margin bottom to `.step-wrapper` to compensate for `.step-wrapper__header` margin top.

**Before:**
![f0e4RFF0AlTPACtq](https://github.com/Automattic/wp-calypso/assets/2722412/ff6d9651-520a-4d83-a824-877f0dc82061)

**After:**
![YF0ZGpwme8KFCav5](https://github.com/Automattic/wp-calypso/assets/2722412/610006c3-a228-45e5-9377-8c47dfda8a91)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Navigate to `https://wordpress.com/start/user-social` and confirm the `Create your account` component is off-center vertically.
* Checkout the branch locally or use calypso.live build.
* Navigate to `start/user-social` and confirm the vertical centering is now fixed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
