### PR TITLE
Signup flow: Remove "Back" button from domain step if user has no sites

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1308,7 +1308,12 @@ export class RenderDomainsStep extends Component {
 		let backLabelText;
 		let isExternalBackUrl = false;
 
-		const hideBack = flowName === 'domain' || ! userSiteCount;
+		// Hide "Back" button in domains step if the user has no sites.
+		const shouldHideBack =
+			! userSiteCount &&
+			this.props.positionInFlow === 1 &&
+			[ 'onboarding', 'onboarding-pm' ].includes( flowName );
+		const hideBack = flowName === 'domain' || shouldHideBack;
 
 		const previousStepBackUrl = this.getPreviousStepUrl();
 		const [ sitesBackLabelText, defaultBackUrl ] =

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -42,7 +42,11 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { getStepUrl, isPlanSelectionAvailableLaterInFlow } from 'calypso/signup/utils';
+import {
+	getStepUrl,
+	isPlanSelectionAvailableLaterInFlow,
+	getPreviousStepName,
+} from 'calypso/signup/utils';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -1300,6 +1304,7 @@ export class RenderDomainsStep extends Component {
 			translate,
 			isReskinned,
 			userSiteCount,
+			previousStepName,
 		} = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
 		const siteSlug = this.props.queryObject?.siteSlug;
@@ -1309,10 +1314,7 @@ export class RenderDomainsStep extends Component {
 		let isExternalBackUrl = false;
 
 		// Hide "Back" button in domains step if the user has no sites.
-		const shouldHideBack =
-			! userSiteCount &&
-			this.props.positionInFlow === 1 &&
-			[ 'onboarding', 'onboarding-pm' ].includes( flowName );
+		const shouldHideBack = ! userSiteCount && previousStepName?.startsWith( 'user' );
 		const hideBack = flowName === 'domain' || shouldHideBack;
 
 		const previousStepBackUrl = this.getPreviousStepUrl();
@@ -1428,12 +1430,13 @@ const submitDomainStepSelection = ( suggestion, section ) => {
 };
 
 const RenderDomainsStepConnect = connect(
-	( state, { steps, flowName } ) => {
+	( state, { steps, flowName, stepName } ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
 		const isPlanStepSkipped = isPlanStepExistsAndSkipped( state );
 		const selectedSite = getSelectedSite( state );
 		const multiDomainDefaultPlan = planItem( PLAN_PERSONAL );
+		const userLoggedIn = isUserLoggedIn( state );
 
 		return {
 			designType: getDesignType( state ),
@@ -1446,8 +1449,9 @@ const RenderDomainsStepConnect = connect(
 			isPlanSelectionAvailableLaterInFlow:
 				( ! isPlanStepSkipped && isPlanSelectionAvailableLaterInFlow( steps ) ) ||
 				[ 'pro', 'starter' ].includes( flowName ),
-			userLoggedIn: isUserLoggedIn( state ),
+			userLoggedIn,
 			multiDomainDefaultPlan,
+			previousStepName: getPreviousStepName( flowName, stepName, userLoggedIn ),
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1308,6 +1308,8 @@ export class RenderDomainsStep extends Component {
 		let backLabelText;
 		let isExternalBackUrl = false;
 
+		const hideBack = flowName === 'domain' || ! userSiteCount;
+
 		const previousStepBackUrl = this.getPreviousStepUrl();
 		const [ sitesBackLabelText, defaultBackUrl ] =
 			userSiteCount && userSiteCount === 1
@@ -1360,7 +1362,7 @@ export class RenderDomainsStep extends Component {
 
 		return (
 			<StepWrapper
-				hideBack={ flowName === 'domain' }
+				hideBack={ hideBack }
 				flowName={ flowName }
 				stepName={ stepName }
 				backUrl={ backUrl }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* This removes the "Back" button from the `onboarding` signup flow's domain step under certain conditions. The Back navigation is removed if the user has no sites and the step before the domains step is a user step.
* Fixes the issue in 1982-martech-gh and p58i-gS9-p2.

<img width="1510" alt="Screenshot 2024-03-19 at 12 09 28 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/88125884-8f8d-4c17-8aef-a5b20e200260">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` and `/start/personal` and signup for a new account. Verify that the Back button in the domains step is not present.
* Go to `/start/domain` and verify that the Back button is not present.
* On a logged-in account, click on "Add a new site" and verify that the back button is present.

