### PR TITLE
A4A: Implement the Volume price selector on the Marketplace page.

### DIFF
--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -46,7 +46,7 @@ export default function A4ASlider( { className, options, onChange, value, label,
 						return (
 							<div
 								className="a4a-slider__marker"
-								key={ `slider-option-${ index }` }
+								key={ `slider-option-${ option.value }` }
 								role="button"
 								tabIndex={ -1 }
 								onClick={ () => onChange?.( options[ index ] ) }

--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -1,0 +1,58 @@
+import classNames from 'classnames';
+
+import './style.scss';
+
+export type Option = {
+	label: string;
+	value: number;
+};
+
+type Props = {
+	className?: string;
+	options: Option[];
+	key?: string;
+	onChange?: ( value: Option ) => void;
+	value: number;
+};
+
+export default function A4ASlider( {
+	className,
+	options,
+	key = 'generic',
+	onChange,
+	value,
+}: Props ) {
+	const dataListKey = `a4a-slider-datalist-${ key }`;
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const onSliderChange = ( event: any ) => {
+		onChange?.( options[ event.target.value ] );
+	};
+
+	return (
+		<div className={ classNames( 'a4a-slider', className ) }>
+			<input
+				type="range"
+				min="0"
+				max={ options.length - 1 }
+				list={ dataListKey }
+				onChange={ onSliderChange }
+				value={ value }
+			/>
+
+			<datalist className="a4a-slider__marker-container" id={ dataListKey }>
+				{ options.map( ( option, index ) => {
+					return (
+						<option
+							className="a4a-slider__marker"
+							key={ `slider-option-${ index }` }
+							value={ option.value }
+						>
+							{ option.label }
+						</option>
+					);
+				} ) }
+			</datalist>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -44,7 +44,18 @@ export default function A4ASlider( { className, options, onChange, value, label,
 				<div className="a4a-slider__marker-container">
 					{ options.map( ( option, index ) => {
 						return (
-							<div className="a4a-slider__marker" key={ `slider-option-${ index }` }>
+							<div
+								className="a4a-slider__marker"
+								key={ `slider-option-${ index }` }
+								role="button"
+								tabIndex={ -1 }
+								onClick={ () => onChange?.( options[ index ] ) }
+								onKeyDown={ ( event ) => {
+									if ( event.key === 'Enter' ) {
+										onChange?.( options[ index ] );
+									}
+								} }
+							>
 								<div className="a4a-slider__marker-line"></div>
 								<div className="a4a-slider__marker-label">{ option.label }</div>
 								{ option.sub && <div className="a4a-slider__marker-sub">{ option.sub }</div> }

--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -10,20 +10,12 @@ export type Option = {
 type Props = {
 	className?: string;
 	options: Option[];
-	key?: string;
 	onChange?: ( value: Option ) => void;
 	value: number;
+	label?: string;
 };
 
-export default function A4ASlider( {
-	className,
-	options,
-	key = 'generic',
-	onChange,
-	value,
-}: Props ) {
-	const dataListKey = `a4a-slider-datalist-${ key }`;
-
+export default function A4ASlider( { className, options, onChange, value, label }: Props ) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const onSliderChange = ( event: any ) => {
 		onChange?.( options[ event.target.value ] );
@@ -31,28 +23,28 @@ export default function A4ASlider( {
 
 	return (
 		<div className={ classNames( 'a4a-slider', className ) }>
-			<input
-				type="range"
-				min="0"
-				max={ options.length - 1 }
-				list={ dataListKey }
-				onChange={ onSliderChange }
-				value={ value }
-			/>
+			{ label && <div className="a4a-slider__label">{ label }</div> }
 
-			<datalist className="a4a-slider__marker-container" id={ dataListKey }>
-				{ options.map( ( option, index ) => {
-					return (
-						<option
-							className="a4a-slider__marker"
-							key={ `slider-option-${ index }` }
-							value={ option.value }
-						>
-							{ option.label }
-						</option>
-					);
-				} ) }
-			</datalist>
+			<div className="a4a-slider__input">
+				<input
+					type="range"
+					min="0"
+					max={ options.length - 1 }
+					onChange={ onSliderChange }
+					value={ value }
+				/>
+
+				<div className="a4a-slider__marker-container">
+					{ options.map( ( option, index ) => {
+						return (
+							<div className="a4a-slider__marker" key={ `slider-option-${ index }` }>
+								<div className="a4a-slider__marker-line"></div>
+								<div className="a4a-slider__marker-label">{ option.label }</div>
+							</div>
+						);
+					} ) }
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -5,6 +5,7 @@ import './style.scss';
 export type Option = {
 	label: string;
 	value: number;
+	sub?: string;
 };
 
 type Props = {
@@ -13,9 +14,10 @@ type Props = {
 	onChange?: ( value: Option ) => void;
 	value: number;
 	label?: string;
+	sub?: string;
 };
 
-export default function A4ASlider( { className, options, onChange, value, label }: Props ) {
+export default function A4ASlider( { className, options, onChange, value, label, sub }: Props ) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const onSliderChange = ( event: any ) => {
 		onChange?.( options[ event.target.value ] );
@@ -23,7 +25,12 @@ export default function A4ASlider( { className, options, onChange, value, label 
 
 	return (
 		<div className={ classNames( 'a4a-slider', className ) }>
-			{ label && <div className="a4a-slider__label">{ label }</div> }
+			{ label && (
+				<div className="a4a-slider__label-container">
+					<div className="a4a-slider__label">{ label }</div>
+					<div className="a4a-slider__sub">{ sub }</div>
+				</div>
+			) }
 
 			<div className="a4a-slider__input">
 				<input
@@ -40,6 +47,7 @@ export default function A4ASlider( { className, options, onChange, value, label 
 							<div className="a4a-slider__marker" key={ `slider-option-${ index }` }>
 								<div className="a4a-slider__marker-line"></div>
 								<div className="a4a-slider__marker-label">{ option.label }</div>
+								{ option.sub && <div className="a4a-slider__marker-sub">{ option.sub }</div> }
 							</div>
 						);
 					} ) }

--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -59,6 +59,7 @@
 	position: relative;
 	margin-block-start: -4px;
 	display: flex;
+	align-items: flex-start;
 	justify-content: space-between;
 }
 
@@ -69,6 +70,7 @@
 	align-items: center;
 	flex-direction: column;
 	justify-content: center;
+	gap: 4px;
 }
 
 .a4a-slider__marker-line {
@@ -77,9 +79,24 @@
 	background-color: var(--color-neutral-10);
 }
 
+.a4a-slider__label-container {
+	text-align: right;
+}
+
+.a4a-slider__sub {
+	margin-block-start: 4px;
+}
+
 .a4a-slider__label,
+.a4a-slider__sub,
 .a4a-slider__marker {
 	font-size: 0.875rem;
 	font-weight: 500;
 	line-height: 1.1;
+}
+
+
+.a4a-slider__sub,
+.a4a-slider__marker-sub {
+	color: var(--color-success);
 }

--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -1,6 +1,17 @@
 
 
-.a4a-slider [type="range"] {
+.a4a-slider {
+	display: flex;
+	flex-direction: row;
+	gap: 24px;
+	align-items: flex-end;
+}
+
+.a4a-slider__input {
+	flex-grow: 1;
+}
+
+.a4a-slider__input [type="range"] {
 	-webkit-appearance: none;
 	appearance: none;
 	background: transparent;
@@ -10,7 +21,7 @@
 
 	@mixin slider-track-style {
 		background: var(--color-primary-40);
-		height: 10px;
+		height: 6px;
 		border-radius: 4px;
 	}
 
@@ -22,7 +33,9 @@
 		width: 16px;
 		border-radius: 50%;
 		border: 2.62px solid var(--studio-white);
-		margin-block-start: -3px;
+		margin-block-start: -5px;
+		cursor: pointer;
+		z-index: 2;
 	}
 
 	&::-webkit-slider-runnable-track {
@@ -56,13 +69,17 @@
 	align-items: center;
 	flex-direction: column;
 	justify-content: center;
-	font-size: 0.875rem;
-	font-weight: 500;
-	line-height: 1.1;
 }
 
 .a4a-slider__marker-line {
 	height: 10px;
-	width: 10px;
+	width: 0.5px;
 	background-color: var(--color-neutral-10);
+}
+
+.a4a-slider__label,
+.a4a-slider__marker {
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1.1;
 }

--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -15,6 +15,7 @@
 	-webkit-appearance: none;
 	appearance: none;
 	background: transparent;
+	height: 50px;
 	width: 100%;
 	margin: 0;
 	padding: 0;
@@ -57,7 +58,7 @@
 
 .a4a-slider__marker-container {
 	position: relative;
-	margin-block-start: -4px;
+	margin-block-start: -24px;
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;

--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -1,0 +1,68 @@
+
+
+.a4a-slider [type="range"] {
+	-webkit-appearance: none;
+	appearance: none;
+	background: transparent;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+
+	@mixin slider-track-style {
+		background: var(--color-primary-40);
+		height: 10px;
+		border-radius: 4px;
+	}
+
+	@mixin slider-thumb-style {
+		-webkit-appearance: none;
+		appearance: none;
+		background-color: var(--studio-black);
+		height: 16px;
+		width: 16px;
+		border-radius: 50%;
+		border: 2.62px solid var(--studio-white);
+		margin-block-start: -3px;
+	}
+
+	&::-webkit-slider-runnable-track {
+		@include slider-track-style;
+	}
+
+	&::-moz-range-track {
+		@include slider-track-style;
+	}
+
+	&::-webkit-slider-thumb {
+		@include slider-thumb-style;
+	}
+
+	&::-moz-range-thumb {
+		@include slider-thumb-style;
+	}
+}
+
+.a4a-slider__marker-container {
+	position: relative;
+	margin-block-start: -4px;
+	display: flex;
+	justify-content: space-between;
+}
+
+.a4a-slider__marker {
+	width: 16px;
+	max-width: 16px;
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	justify-content: center;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1.1;
+}
+
+.a4a-slider__marker-line {
+	height: 10px;
+	width: 10px;
+	background-color: var(--color-neutral-10);
+}

--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -1,4 +1,6 @@
 
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .a4a-slider {
 	display: flex;
@@ -81,7 +83,12 @@
 }
 
 .a4a-slider__label-container {
+	display: none;
 	text-align: right;
+
+	@include break-medium {
+		display: block;
+	}
 }
 
 .a4a-slider__sub {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -14,7 +14,6 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { useProductBundleSize } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
 import { useSelector } from 'calypso/state';
 import getSites from 'calypso/state/selectors/get-sites';
 import { ShoppingCartContext } from '../context';
@@ -32,8 +31,6 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 	const { selectedCartItems, setSelectedCartItems, onRemoveCartItem } = useShoppingCart();
 
 	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
-
-	const { selectedSize } = useProductBundleSize( true );
 
 	const sites = useSelector( getSites );
 
@@ -72,11 +69,7 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 
 			<LayoutBody>
 				<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
-					<ProductListing
-						selectedSite={ selectedSite }
-						suggestedProduct={ suggestedProduct }
-						quantity={ selectedSize }
-					/>
+					<ProductListing selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
 				</ShoppingCartContext.Provider>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
@@ -197,6 +197,7 @@ export default function MultiProductCard( props: Props ) {
 							<Button
 								className="product-card__select-button"
 								variant={ isSelected ? 'secondary' : 'primary' }
+								tabIndex={ -1 }
 							>
 								{ isSelected && <Icon icon={ check } /> }
 								{ isSelected ? translate( 'Added' ) : translate( 'Add to cart' ) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
@@ -143,6 +143,7 @@ export default function ProductCard( props: Props ) {
 							<Button
 								className="product-card__select-button"
 								variant={ isSelected ? 'secondary' : 'primary' }
+								tabIndex={ -1 }
 							>
 								{ isSelected && <Icon icon={ check } /> }
 								{ isSelected ? translate( 'Added' ) : translate( 'Add to cart' ) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
@@ -35,6 +35,12 @@
 		background: var(--studio-white);
 		box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 	}
+
+	.components-button.is-primary {
+		background-color: var(--color-accent-60);
+		border-color: var(--color-accent-60);
+		color: var(--color-text-inverted);
+	}
 }
 
 button.product-card__select-button {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
@@ -4,7 +4,6 @@
 .product-card {
 	display: flex;
 	justify-content: stretch;
-
 	&.disabled {
 		opacity: 0.5;
 
@@ -80,36 +79,11 @@ button.product-card__select-button {
 	}
 }
 
-@mixin product-card-block__main {
-	justify-content: space-between;
-	gap: 0.5rem;
-}
-
-@mixin product-card-line__main {
-	justify-content: flex-start;
-}
-
 .product-card__main {
 	display: flex;
 	width: 100%;
-
-	@include product-card-block__main;
-
-	@include break-mobile {
-		@include product-card-line__main;
-	}
-
-	@include breakpoint-deprecated( ">660px" ) {
-		@include product-card-block__main;
-	}
-
-	@include break-medium {
-		@include product-card-line__main;
-	}
-
-	@include break-xlarge {
-		@include product-card-block__main;
-	}
+	justify-content: space-between;
+	gap: 0.5rem;
 }
 
 .product-card__heading {
@@ -172,7 +146,6 @@ button.product-card__select-button {
 }
 
 .product-card__pricing:not(.is-compact) {
-	white-space: nowrap;
 	@include product-card-block__pricing;
 
 	@include break-mobile {
@@ -194,6 +167,7 @@ button.product-card__select-button {
 
 .product-card__pricing.is-compact {
 	margin: 1rem 0 0;
+	max-width: 200px;
 }
 
 .product-card .multiple-choice-question {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
@@ -35,12 +35,10 @@
 		background: var(--studio-white);
 		box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 	}
+}
 
-	.components-button.is-primary {
-		background-color: var(--color-accent-60);
-		border-color: var(--color-accent-60);
-		color: var(--color-text-inverted);
-	}
+.product-card:focus-visible .components-button {
+	box-shadow: inset 0 0 0 1px var(--color-surface), 0 0 0 var(--wp-admin-border-width-focus) var(--color-accent);
 }
 
 button.product-card__select-button {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-product-bundle-size.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-product-bundle-size.tsx
@@ -1,0 +1,69 @@
+import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+const BUNDLE_SIZE_PARAM_KEY = 'bundle_size';
+
+// Parse the location hash to get the selected product bundle size
+// If the hash is not found, return the default size (1)
+const parseLocationHash = ( supportedBundleSizes: number[], value: string ) => {
+	return supportedBundleSizes.find( ( size ) => value === `${ size }` ) || 1;
+};
+
+export const getSupportedBundleSizes = ( products?: APIProductFamilyProduct[] ) => {
+	if ( ! products ) {
+		return [ 1 ];
+	}
+
+	const supported = new Set( [
+		1,
+		...products.flatMap( ( p ) => p.supported_bundles?.map( ( { quantity } ) => quantity ) ),
+	] );
+
+	return [ ...supported ];
+};
+
+export function useProductBundleSize( isPublicFacing = false ) {
+	const { data: products } = useProductsQuery( isPublicFacing );
+
+	const supportedBundleSizes = getSupportedBundleSizes( products );
+
+	const [ selectedSize, setSelectedSize ] = useState< number | undefined >( undefined );
+
+	// When products are changed, we need to reevaluate if selected bundle size is still valid
+	useEffect( () => {
+		const { [ BUNDLE_SIZE_PARAM_KEY ]: bundleSize } = getQueryArgs( window.location.href );
+		setSelectedSize( parseLocationHash( supportedBundleSizes, bundleSize?.toString() ) );
+	}, [ supportedBundleSizes ] );
+
+	const setSelectedSizeAndLocationHash = useCallback(
+		( size: number ) => {
+			if ( size === selectedSize ) {
+				return;
+			}
+
+			const queryArgs =
+				size === 1
+					? removeQueryArgs( window.location.href, BUNDLE_SIZE_PARAM_KEY )
+					: addQueryArgs( window.location.href, {
+							...getQueryArgs( window.location.href ),
+							[ BUNDLE_SIZE_PARAM_KEY ]: `${ size }`,
+					  } );
+
+			window.history.pushState( null, '', queryArgs );
+
+			setSelectedSize( size );
+		},
+		[ selectedSize ]
+	);
+
+	return useMemo( () => {
+		return {
+			selectedSize: selectedSize ?? 1,
+			setSelectedSize: setSelectedSizeAndLocationHash,
+			availableSizes: supportedBundleSizes,
+			fetchingAvailableSizes: ! selectedSize, // We know we are still fetching if our selected size is undefined.
+		};
+	}, [ selectedSize, setSelectedSizeAndLocationHash, supportedBundleSizes ] );
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -5,7 +5,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { parseQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
-import { getSupportedBundleSizes } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
+import {
+	getSupportedBundleSizes,
+	useProductBundleSize,
+} from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
 import {
 	getIncompatibleProducts,
 	isIncompatibleProduct,
@@ -19,6 +22,7 @@ import useProductAndPlans from './hooks/use-product-and-plans';
 import useSubmitForm from './hooks/use-submit-form';
 import ProductFilterSearch from './product-filter-search';
 import ProductListingSection from './sections';
+import VolumePriceSelector from './volume-price-selector';
 import type { ShoppingCartItem } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -27,20 +31,21 @@ import './style.scss';
 interface ProductListingProps {
 	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;
-	quantity?: number;
 }
 
-export default function ProductListing( {
-	selectedSite,
-	suggestedProduct,
-	quantity = 1,
-}: ProductListingProps ) {
+export default function ProductListing( { selectedSite, suggestedProduct }: ProductListingProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const { selectedCartItems, setSelectedCartItems } = useContext( ShoppingCartContext );
 
 	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
+
+	const {
+		selectedSize: quantity,
+		availableSizes: availableBundleSizes,
+		setSelectedSize: setSelectedBundleSize,
+	} = useProductBundleSize( true );
 
 	const {
 		filteredProductsAndBundles,
@@ -278,6 +283,12 @@ export default function ProductListing( {
 				<ProductFilterSearch
 					onProductSearch={ onProductSearch }
 					onClick={ trackClickCallback( 'search' ) }
+				/>
+
+				<VolumePriceSelector
+					selectedBundleSize={ quantity }
+					availableBundleSizes={ availableBundleSizes }
+					onBundleSizeChange={ setSelectedBundleSize }
 				/>
 			</div>
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -6,10 +6,6 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'r
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { parseQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
 import {
-	getSupportedBundleSizes,
-	useProductBundleSize,
-} from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
-import {
 	getIncompatibleProducts,
 	isIncompatibleProduct,
 } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/incompatible-products';
@@ -19,6 +15,7 @@ import { ShoppingCartContext } from '../../context';
 import MultiProductCard from '../multi-product-card';
 import ProductCard from '../product-card';
 import useProductAndPlans from './hooks/use-product-and-plans';
+import { getSupportedBundleSizes, useProductBundleSize } from './hooks/use-product-bundle-size';
 import useSubmitForm from './hooks/use-submit-form';
 import ProductFilterSearch from './product-filter-search';
 import ProductListingSection from './sections';
@@ -28,6 +25,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
+
 interface ProductListingProps {
 	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;
@@ -45,7 +43,7 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 		selectedSize: quantity,
 		availableSizes: availableBundleSizes,
 		setSelectedSize: setSelectedBundleSize,
-	} = useProductBundleSize( true );
+	} = useProductBundleSize();
 
 	const {
 		filteredProductsAndBundles,
@@ -285,11 +283,13 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 					onClick={ trackClickCallback( 'search' ) }
 				/>
 
-				<VolumePriceSelector
-					selectedBundleSize={ quantity }
-					availableBundleSizes={ availableBundleSizes }
-					onBundleSizeChange={ setSelectedBundleSize }
-				/>
+				{ availableBundleSizes.length > 1 && (
+					<VolumePriceSelector
+						selectedBundleSize={ quantity }
+						availableBundleSizes={ availableBundleSizes }
+						onBundleSizeChange={ setSelectedBundleSize }
+					/>
+				) }
 			</div>
 
 			{ plans.length > 0 && (

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -159,5 +159,9 @@ p.product-listing__description {
 }
 
 .product-listing__volume-price-selector {
-	min-width: 430px;
+	min-width: 100%;
+
+	@include break-medium {
+		min-width: 430px;
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -41,7 +41,7 @@ p.product-listing__section-description {
 	gap: 16px;
 	grid-template-columns: 1fr;
 
-	@include break-xlarge {
+	@include break-large {
 		grid-template-columns: repeat(2, 1fr);
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -79,6 +79,7 @@ p.product-listing__description {
 	flex-wrap: wrap;
 	gap: 16px;
 	margin: 16px 0 32px;
+	justify-content: space-between;
 }
 
 .select-dropdown.is-compact.product-listing__product-filter-select {
@@ -155,4 +156,8 @@ p.product-listing__description {
 		font-weight: 400;
 		color: var(--color-text);
 	}
+}
+
+.product-listing__volume-price-selector {
+	min-width: 430px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
@@ -7,6 +7,18 @@ type Props = {
 	selectedBundleSize: number;
 };
 
+const getDiscountPercentage = ( bundleSize: number ) => {
+	// FIXME: Need to calculate based on average discount per bundle size.
+	return {
+		1: '',
+		5: '8%',
+		10: '20%',
+		20: '40%',
+		50: '70%',
+		100: '80%',
+	}[ bundleSize ];
+};
+
 export default function VolumePriceSelector( {
 	availableBundleSizes,
 	onBundleSizeChange,
@@ -17,6 +29,7 @@ export default function VolumePriceSelector( {
 	const options = availableBundleSizes.map( ( size ) => {
 		return {
 			label: `${ size }`,
+			sub: getDiscountPercentage( size ),
 			value: size,
 		};
 	} );
@@ -28,6 +41,7 @@ export default function VolumePriceSelector( {
 	return (
 		<A4ASlider
 			label={ translate( 'Volume pricing' ) }
+			sub={ translate( 'Discount' ) }
 			className="product-listing__volume-price-selector"
 			value={ options.findIndex( ( { value } ) => selectedBundleSize === value ) }
 			options={ options }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
@@ -1,0 +1,33 @@
+import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
+
+type Props = {
+	onBundleSizeChange: ( value: number ) => void;
+	availableBundleSizes: number[];
+	selectedBundleSize: number;
+};
+
+export default function VolumePriceSelector( {
+	availableBundleSizes,
+	onBundleSizeChange,
+	selectedBundleSize,
+}: Props ) {
+	const options = availableBundleSizes.map( ( size ) => {
+		return {
+			label: `${ size }`,
+			value: size,
+		};
+	} );
+
+	const onChange = ( { value }: Option ) => {
+		onBundleSizeChange( value as number );
+	};
+
+	return (
+		<A4ASlider
+			className="product-listing__volume-price-selector"
+			value={ options.findIndex( ( { value } ) => selectedBundleSize === value ) }
+			options={ options }
+			onChange={ onChange }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
 
 type Props = {
@@ -11,6 +12,8 @@ export default function VolumePriceSelector( {
 	onBundleSizeChange,
 	selectedBundleSize,
 }: Props ) {
+	const translate = useTranslate();
+
 	const options = availableBundleSizes.map( ( size ) => {
 		return {
 			label: `${ size }`,
@@ -24,6 +27,7 @@ export default function VolumePriceSelector( {
 
 	return (
 		<A4ASlider
+			label={ translate( 'Volume pricing' ) }
 			className="product-listing__volume-price-selector"
 			value={ options.findIndex( ( { value } ) => selectedBundleSize === value ) }
 			options={ options }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
@@ -41,3 +41,20 @@
 	@include licensing-portal-bottom-action-bar;
 	padding: 14px;
 }
+
+
+.products-overview .a4a-layout__header {
+	.a4a-layout__header-actions {
+		justify-content: flex-end;
+
+		& > * {
+			flex-grow: 0;
+		}
+	}
+
+	@include breakpoint-deprecated( "<1280px" ) {
+		flex-wrap: nowrap;
+		justify-content: space-between;
+
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/style.scss
@@ -1,5 +1,10 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .shopping-cart {
-	margin-inline-end: 32px;
+	@include break-large {
+		margin-inline-end: 32px;
+	}
 }
 
 .badge.shopping-cart__button-badge {


### PR DESCRIPTION
This PR implements the Volume price selector component on the Marketplace page.

<img width="698" alt="Screenshot 2024-03-19 at 7 18 45 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e4ca61df-da9a-44de-abca-c09400a74828">


Closes https://github.com/Automattic/jetpack-genesis/issues/299


## Proposed Changes

* Implement the A4A Slider component, which is reusable. This will be reused in the Pressable page later.
* Implement the `VolumePriceSelector` component that switches bundle size similar to the Jetpack Manage Bundle size tab.

## Testing Instructions
* Switch branch: `git checkout add/a4a/marketplace-volume-pricing`.
* Since the PR now points to Jetpack Licensing API, and we don't have complete products yet for that API. We will need to use the public API to test this PR properly. To do this, follow the steps below.
    * Update the following line (https://github.com/Automattic/wp-calypso/pull/88664/files#diff-7b904678f91e762c73c08df920bfbff7e446449959f4a77b7d1d204a754f980dR46)  to 
    ```
    } = useProductBundleSize( true );
    ```
    * Add the following line to https://github.com/Automattic/wp-calypso/pull/88664/files#diff-7b904678f91e762c73c08df920bfbff7e446449959f4a77b7d1d204a754f980dR48
    ```
		productSearchQuery,
		usePublicQuery: true,
	} );
    ```
     * Update the following line in the [useShoppingCart](https://github.com/Automattic/wp-calypso/blob/trunk/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts#L11) hook to 
     ```
     const { data } = useProductsQuery( true );
     ```
    
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to`/marketplace`
* Confirm that the Volume Price selector is visible and works correctly, similar to the Jetpack Manage bundle size tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?