### PR TITLE
Continue with GitHub: Fix missing `redirectTo`

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -116,11 +116,19 @@ class SocialLoginForm extends Component {
 
 	handleGitHubResponse = ( { access_token } ) => {
 		const { onSuccess, socialService } = this.props;
-		const redirectTo = this.props.redirectTo;
 
 		if ( socialService !== 'github' ) {
 			return;
 		}
+
+		let redirectTo = this.props.redirectTo;
+
+		// load persisted redirect_to url from session storage, needed for redirect_to to work with GitHub redirect flow
+		if ( socialService === 'github' && ! redirectTo ) {
+			redirectTo = window.sessionStorage.getItem( 'login_redirect_to' );
+		}
+
+		window.sessionStorage.removeItem( 'login_redirect_to' );
 
 		const socialInfo = {
 			service: 'github',

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -124,7 +124,7 @@ class SocialLoginForm extends Component {
 		let redirectTo = this.props.redirectTo;
 
 		// load persisted redirect_to url from session storage, needed for redirect_to to work with GitHub redirect flow
-		if ( socialService === 'github' && ! redirectTo ) {
+		if ( ! redirectTo ) {
 			redirectTo = window.sessionStorage.getItem( 'login_redirect_to' );
 		}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/88670.

Context: p7DVsv-kfF-p2#comment-49570

## Proposed Changes

* load `redirectTo` from session storage for _Continue with GitHub_ button

## Testing Instructions

0. Check out and build the changes proposed in this PR.
1. Create a Jurassic Ninja test site.
2. Open a new / incognito browser window and make sure you are not logged in to your WordPress.com account there.
3. Log in to your new test site's WP Admin with the provided credentials.
4. Navigate to the Jetpack settings page and click on the "Finish setting up Jetpack" button (and then "Connect your user account") to connect your test site with your WordPress.com account.

![Markup on 2024-03-19 at 14:12:42](https://github.com/Automattic/wp-calypso/assets/25105483/e611a0ab-14ff-4cd2-bd90-9e208a6ab33c)

5. Once you get to the following page: 

![Markup on 2024-03-19 at 14:09:45](https://github.com/Automattic/wp-calypso/assets/25105483/27c809ab-56c0-493d-82a6-4a1acefc7f9f)

Replace `https://wordpress.com/` in the address bar with `http://calypso.localhost:3000/` (also omitting the `s` in `https`).
6. Click on the _Continue with GitHub_ button and follow the steps.
7. You should get logged in and then once you click the green "Approve" button followed by "Start with Jetpack Free", you should be directed to your WordPress.com account with the test site connected. 

If you need to repeat the site reconnection, you can disconnect the site first at Pc9OEs-v-p2 (by clicking on the "Disconnect Jetpack" link).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?