### PR TITLE
Automattic for Agencies: Create a skeleton for the sign up page

### DIFF
--- a/client/a8c-for-agencies/sections/signup/controller.tsx
+++ b/client/a8c-for-agencies/sections/signup/controller.tsx
@@ -1,0 +1,23 @@
+import { Context, type Callback } from '@automattic/calypso-router';
+import page from '@automattic/calypso-router';
+import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import AgencySignUp from './primary/agency-signup';
+
+export function requireNoPartnerRecordContext( context: Context, next: () => void ): void {
+	const state = context.store.getState();
+	const partner = getActiveAgency( state );
+
+	// Users who already have a partner record should be redirected away from the signup form.
+	if ( partner ) {
+		page.redirect( A4A_SITES_LINK );
+		return;
+	}
+
+	next();
+}
+
+export const signUpContext: Callback = ( context, next ) => {
+	context.primary = <AgencySignUp />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/signup/index.ts
+++ b/client/a8c-for-agencies/sections/signup/index.ts
@@ -1,0 +1,13 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import * as controller from './controller';
+
+export default function () {
+	page(
+		'/signup',
+		controller.requireNoPartnerRecordContext,
+		controller.signUpContext,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx
@@ -1,11 +1,21 @@
-import DocumentHead from 'calypso/components/data/document-head';
-import Main from 'calypso/components/main';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 
 export default function AgencySignup() {
 	return (
-		<Main className="agency-signup">
-			<DocumentHead title="Sign up for Automattic for Agencies" />
-			<h2>Sign up for Automattic for Agencies</h2>
-		</Main>
+		<Layout title="Sign Up" wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>Sign up for Automattic for Agencies</Title>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<div>Form</div>
+			</LayoutBody>
+		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx
@@ -1,0 +1,11 @@
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+
+export default function AgencySignup() {
+	return (
+		<Main className="agency-signup">
+			<DocumentHead title="Sign up for Automattic for Agencies" />
+			<h2>Sign up for Automattic for Agencies</h2>
+		</Main>
+	);
+}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -101,6 +101,13 @@
 	}
 }
 
+// Various screens dont use a sidebar.
+.theme-a8c-for-agencies .layout.has-no-sidebar {
+	.layout__content {
+		padding-left: 16px;
+	}
+}
+
 .theme-a8c-for-agencies .layout__secondary {
 	border-inline-end: initial;
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -753,6 +753,12 @@ const sections = [
 		group: 'a8c-for-agencies',
 		enableLoggedOut: true,
 	},
+	{
+		name: 'a8c-for-agencies-signup',
+		paths: [ '/signup' ],
+		module: 'calypso/a8c-for-agencies/sections/signup',
+		group: 'a8c-for-agencies',
+	},
 ];
 
 module.exports = sections;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -163,6 +163,7 @@
 		"a8c-for-agencies-sites": false,
 		"a8c-for-agencies-marketplace": false,
 		"a8c-for-agencies-purchases": false,
+		"a8c-for-agencies-signup": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -25,7 +25,8 @@
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
-		"a8c-for-agencies-purchases": true
+		"a8c-for-agencies-purchases": true,
+		"a8c-for-agencies-signup": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -19,7 +19,8 @@
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
-		"a8c-for-agencies-purchases": true
+		"a8c-for-agencies-purchases": true,
+		"a8c-for-agencies-signup": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -21,7 +21,8 @@
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
-		"a8c-for-agencies-purchases": true
+		"a8c-for-agencies-purchases": true,
+		"a8c-for-agencies-signup": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
## Proposed Changes

* This PR creates the skeleton that will be used for building up the signup for for A4A.

## Testing Instructions

- Switch to the current branch by running `git checkout add/a4a/signup-form-skeleton`
- When logged out, visit agencies.localhost:3000/signup and confirm you are redirected to log in.
- When logged in, visit agencies.localhost:3000/signup and confirm you can see blank page similar to the one below.

<img width="1503" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1749918/a8ca8867-6938-4d57-9948-4c2bf6fd14a0">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?