### PR TITLE
Onboarding: Fix requesting to change site domain before the site is created

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -20,7 +20,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import useChangeSiteDomain from '../../../../hooks/use-change-site-domain';
+import useChangeSiteDomainIfNeeded from '../../../../hooks/use-change-site-domain-if-needed';
 import type { Step } from '../../types';
 import type { OnboardSelect, DomainSuggestion } from '@automattic/data-stores';
 import './style.scss';
@@ -43,7 +43,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		useState< DomainSuggestion >();
 	const site = useSite();
 
-	const changeSiteDomain = useChangeSiteDomain();
+	const changeSiteDomainIfNeeded = useChangeSiteDomainIfNeeded();
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
@@ -97,7 +97,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		}
 
 		if ( suggestion?.is_free && suggestion?.domain_name ) {
-			changeSiteDomain( suggestion?.domain_name );
+			changeSiteDomainIfNeeded( suggestion?.domain_name );
 		}
 
 		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -33,7 +33,7 @@ import {
 	recordAddDomainButtonClickInMapDomain,
 	recordAddDomainButtonClickInTransferDomain,
 } from 'calypso/state/domains/actions';
-import useChangeSiteDomain from '../../../../hooks/use-change-site-domain';
+import useChangeSiteDomainIfNeeded from '../../../../hooks/use-change-site-domain-if-needed';
 import { ONBOARD_STORE } from '../../../../stores';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import { DomainFormControl } from './domain-form-control';
@@ -53,7 +53,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const dispatch = useReduxDispatch();
 
-	const changeSiteDomain = useChangeSiteDomain();
+	const changeSiteDomainIfNeeded = useChangeSiteDomainIfNeeded();
 
 	const { submit, exitFlow, goBack } = navigation;
 
@@ -126,7 +126,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		}
 
 		if ( suggestion?.is_free && suggestion?.domain_name ) {
-			changeSiteDomain( suggestion?.domain_name );
+			changeSiteDomainIfNeeded( suggestion?.domain_name );
 		}
 
 		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );

--- a/client/landing/stepper/hooks/use-change-site-domain-if-needed.ts
+++ b/client/landing/stepper/hooks/use-change-site-domain-if-needed.ts
@@ -5,12 +5,12 @@ import { useSiteData } from './use-site-data';
 
 const FREE_DOMAIN_SUFFIX = '.wordpress.com';
 
-const useChangeSiteDomain = () => {
+const useChangeSiteDomainIfNeeded = () => {
 	const dispatch = useDispatch();
 	const { siteId, siteSlug } = useSiteData();
 
-	const changeSiteDomain = async ( domain: string ) => {
-		if ( domain === siteSlug || ! domain.endsWith( FREE_DOMAIN_SUFFIX ) ) {
+	const changeSiteDomainIfNeeded = async ( domain: string ) => {
+		if ( ! siteSlug || domain === siteSlug || ! domain.endsWith( FREE_DOMAIN_SUFFIX ) ) {
 			return;
 		}
 
@@ -28,7 +28,7 @@ const useChangeSiteDomain = () => {
 		);
 	};
 
-	return changeSiteDomain;
+	return changeSiteDomainIfNeeded;
 };
 
-export default useChangeSiteDomain;
+export default useChangeSiteDomainIfNeeded;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1710793587010049-slack-C03N25JPCE4

## Proposed Changes

* Fix the error notice when we send a request to change the site domain before the creation since the site id is incorrect

![image](https://github.com/Automattic/wp-calypso/assets/13596067/9dca7350-c9c3-44c6-a534-38989191c2a4)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Ecommerce Flow**

* Go to /setup/ecommerce/storeProfiler
* On the domain step, pick the domain with `.wordpress.com` suffix
* Continue to finish the site creation
* Make sure you won't see the error notice "Invalid site specified"

**Newsletter Flow**

* Go to /setup/newsletter/newsletterSetup
* On the domain step, pick the domain with `.wordpress.com` suffix
* Continue to finish the site creation
* Make sure you won't see the error notice "Invalid site specified"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?