### PR TITLE
Pattern Library: Copyable permalinks to patterns (using hashes)

### DIFF
--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -14,7 +14,11 @@ import './style.scss';
 
 const LOGGED_OUT_USERS_CAN_COPY_COUNT = 3;
 
-export const PatternGalleryClient: PatternGalleryFC = ( { isGridView, patterns = [] } ) => {
+export const PatternGalleryClient: PatternGalleryFC = ( {
+	getPatternPermalink,
+	isGridView,
+	patterns = [],
+} ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const patternIdsByCategory = {
 		first: patterns.map( ( { ID } ) => `${ ID }` ) ?? [],
@@ -43,6 +47,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( { isGridView, patterns =
 								'pattern-preview--grid': isGridView,
 								'pattern-preview--list': ! isGridView,
 							} ) }
+							getPatternPermalink={ getPatternPermalink }
 							key={ pattern.ID }
 							pattern={ pattern }
 							viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -63,16 +63,11 @@ function handleSettingView( value: 'grid' | 'list' ) {
 // We intentionally disregard grid view when copying the pattern permalink. Our assumption is that
 // it will be more confusing for users to land in grid view when they have a single-pattern permalink
 function getPatternPermalink(
-	pattern: Pattern | undefined,
+	pattern: Pattern,
 	activeCategory: string,
 	patternTypeFilter: PatternTypeFilter,
 	categories: Category[]
 ) {
-	if ( ! pattern ) {
-		const url = new URL( location.pathname, location.origin );
-		return url.toString();
-	}
-
 	// Get the first pattern category that is also included in the `usePatternCategories` data
 	const patternCategory = Object.keys( pattern.categories ).find( ( categorySlug ) =>
 		categories.find( ( { name } ) => name === categorySlug )

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -40,7 +40,7 @@ function useTimeoutToResetBoolean(
 type PatternPreviewProps = {
 	className?: string;
 	canCopy?: boolean;
-	getPatternPermalink: PatternGalleryProps[ 'getPatternPermalink' ];
+	getPatternPermalink?: PatternGalleryProps[ 'getPatternPermalink' ];
 	isResizable?: boolean;
 	pattern: Pattern | null;
 	viewportWidth?: number;

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -55,13 +55,16 @@ function PatternPreviewFragment( {
 }: PatternPreviewProps ) {
 	const [ isPermalinkCopied, setIsPermalinkCopied ] = useState( false );
 	const [ isPatternCopied, setIsPatternCopied ] = useState( false );
+
+	const idAttr = `pattern-${ pattern?.ID }`;
+
 	const { renderedPatterns } = usePatternsRendererContext();
 	const patternId = encodePatternId( pattern?.ID ?? 0 );
 	const renderedPattern = renderedPatterns[ patternId ];
 	const [ resizeObserver, nodeSize ] = useResizeObserver();
 	const isPreviewLarge = nodeSize?.width ? nodeSize.width > 960 : true;
 
-	const titleTooltipText = isPermalinkCopied ? 'Copied' : 'Copy link';
+	const titleTooltipText = isPermalinkCopied ? 'Copied link to pattern' : 'Copy link to pattern';
 
 	let copyButtonText = isPreviewLarge ? 'Copy pattern' : 'Copy';
 
@@ -80,8 +83,11 @@ function PatternPreviewFragment( {
 		<div
 			className={ classNames( 'pattern-preview', className, {
 				'is-loading': ! renderedPattern,
+				// For some reason, the CSS `:target` selector has trouble with the transition from
+				// SSR markup to client-side React code, which is why we need the `is-targeted` class
+				'is-targeted': window.location.hash === `#${ idAttr }`,
 			} ) }
-			id={ `pattern-${ pattern.ID }` }
+			id={ idAttr }
 		>
 			{ resizeObserver }
 
@@ -94,7 +100,7 @@ function PatternPreviewFragment( {
 			</div>
 
 			<div className="pattern-preview__header">
-				<Tooltip placement="top" text={ titleTooltipText }>
+				<Tooltip delay={ 300 } placement="top" text={ titleTooltipText }>
 					<ClipboardButton
 						borderless
 						className="pattern-preview__title"

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -1,23 +1,46 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import { Button } from '@automattic/components';
-import { ResizableBox } from '@wordpress/components';
+import { ResizableBox, Tooltip } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { Icon, lock } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
-import type { Pattern } from 'calypso/my-sites/patterns/types';
+import type { Pattern, PatternGalleryProps } from 'calypso/my-sites/patterns/types';
+import type { Dispatch, SetStateAction } from 'react';
 
 import './style.scss';
 
 export const DESKTOP_VIEWPORT_WIDTH = 1200;
 export const ASPECT_RATIO = 7 / 4;
 
+// Abstraction for resetting `isPatternCopied` and `isPermalinkCopied` after a given delay
+function useTimeoutToResetBoolean(
+	value: boolean,
+	setter: Dispatch< SetStateAction< boolean > >,
+	timeout = 4500
+) {
+	useEffect( () => {
+		if ( ! value ) {
+			return;
+		}
+
+		const timeoutId = setTimeout( () => {
+			setter( false );
+		}, timeout );
+
+		return () => {
+			clearTimeout( timeoutId );
+		};
+	}, [ value ] );
+}
+
 type PatternPreviewProps = {
 	className?: string;
 	canCopy?: boolean;
+	getPatternPermalink: PatternGalleryProps[ 'getPatternPermalink' ];
 	isResizable?: boolean;
 	pattern: Pattern | null;
 	viewportWidth?: number;
@@ -26,35 +49,28 @@ type PatternPreviewProps = {
 function PatternPreviewFragment( {
 	className,
 	canCopy = true,
+	getPatternPermalink = () => '',
 	pattern,
 	viewportWidth,
 }: PatternPreviewProps ) {
-	const [ isCopied, setIsCopied ] = useState( false );
+	const [ isPermalinkCopied, setIsPermalinkCopied ] = useState( false );
+	const [ isPatternCopied, setIsPatternCopied ] = useState( false );
 	const { renderedPatterns } = usePatternsRendererContext();
 	const patternId = encodePatternId( pattern?.ID ?? 0 );
 	const renderedPattern = renderedPatterns[ patternId ];
 	const [ resizeObserver, nodeSize ] = useResizeObserver();
-
 	const isPreviewLarge = nodeSize?.width ? nodeSize.width > 960 : true;
+
+	const titleTooltipText = isPermalinkCopied ? 'Copied' : 'Copy link';
+
 	let copyButtonText = isPreviewLarge ? 'Copy pattern' : 'Copy';
 
-	if ( isCopied ) {
+	if ( isPatternCopied ) {
 		copyButtonText = isPreviewLarge ? 'Pattern copied!' : 'Copied';
 	}
 
-	useEffect( () => {
-		if ( ! isCopied ) {
-			return;
-		}
-
-		const timeoutId = setTimeout( () => {
-			setIsCopied( false );
-		}, 4500 );
-
-		return () => {
-			clearTimeout( timeoutId );
-		};
-	}, [ isCopied ] );
+	useTimeoutToResetBoolean( isPermalinkCopied, setIsPermalinkCopied );
+	useTimeoutToResetBoolean( isPatternCopied, setIsPatternCopied );
 
 	if ( ! pattern ) {
 		return null;
@@ -65,6 +81,7 @@ function PatternPreviewFragment( {
 			className={ classNames( 'pattern-preview', className, {
 				'is-loading': ! renderedPattern,
 			} ) }
+			id={ `pattern-${ pattern.ID }` }
 		>
 			{ resizeObserver }
 
@@ -77,13 +94,25 @@ function PatternPreviewFragment( {
 			</div>
 
 			<div className="pattern-preview__header">
-				<div className="pattern-preview__title">{ pattern.title }</div>
+				<Tooltip placement="top" text={ titleTooltipText }>
+					<ClipboardButton
+						borderless
+						className="pattern-preview__title"
+						onCopy={ () => {
+							setIsPermalinkCopied( true );
+						} }
+						text={ getPatternPermalink( pattern ) }
+						transparent
+					>
+						{ pattern.title }
+					</ClipboardButton>
+				</Tooltip>
 
 				{ canCopy && (
 					<ClipboardButton
 						className="pattern-preview__copy"
 						onCopy={ () => {
-							setIsCopied( true );
+							setIsPatternCopied( true );
 						} }
 						text={ pattern?.html ?? '' }
 						primary

--- a/client/my-sites/patterns/components/pattern-preview/placeholder.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/placeholder.tsx
@@ -13,7 +13,10 @@ export function PatternPreviewPlaceholder( {
 	pattern,
 }: PatternPreviewPlaceholderProps ) {
 	return (
-		<div className={ classNames( 'pattern-preview is-loading', className ) }>
+		<div
+			className={ classNames( 'pattern-preview is-loading', className ) }
+			id={ `pattern-${ pattern?.ID }` }
+		>
 			<div className="pattern-preview__renderer" />
 
 			<div className="pattern-preview__header">

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -13,6 +13,9 @@
 }
 
 .pattern-preview {
+	--button-color-default: #3858e9;
+	--button-color-hover: #1d35b4;
+
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
@@ -28,12 +31,15 @@
 		overflow: hidden;
 	}
 
-	&:target .pattern-preview__renderer {
+	&:target .pattern-preview__renderer,
+	&.is-targeted .pattern-preview__renderer {
 		animation: 0.8s linear 3.5s backwards pattern-preview-target;
 	}
 
 	&.is-loading .pattern-preview__renderer {
 		aspect-ratio: 7 / 4;
+		animation-play-state: paused;
+		width: 100%;
 	}
 
 	.pattern-preview__header {
@@ -56,15 +62,12 @@
 		text-align: left;
 
 		&:hover {
-			color: inherit;
+			color: var(--button-color-default);
 		}
 	}
 
 	.pattern-preview__copy,
 	.pattern-preview__get-access {
-		--default-color: #3858e9;
-		--hover-color: #1d35b4;
-
 		flex-shrink: 0;
 		font-size: rem(13px);
 		line-height: 1.6;
@@ -72,20 +75,20 @@
 	}
 
 	.pattern-preview__copy {
-		background-color: var(--default-color);
-		border-color: var(--default-color);
+		background-color: var(--button-color-default);
+		border-color: var(--button-color-default);
 
 		&:enabled:hover,
 		&:focus {
-			background-color: var(--hover-color);
-			border-color: var(--hover-color);
+			background-color: var(--button-color-hover);
+			border-color: var(--button-color-hover);
 		}
 	}
 
 	.pattern-preview__get-access {
 		align-items: center;
 		border: 1px solid currentColor;
-		color: var(--default-color);
+		color: var(--button-color-default);
 		display: flex;
 		font-family: inherit;
 		gap: 4px;
@@ -94,7 +97,7 @@
 		&:enabled:hover,
 		&:focus {
 			border-color: currentColor;
-			color: var(--hover-color);
+			color: var(--button-color-hover);
 		}
 
 		path {

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -2,6 +2,16 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/components/src/styles/typography";
 
+@keyframes pattern-preview-target {
+	from {
+		box-shadow: 0 0 0 2px #3858e9;
+	}
+
+	to {
+		box-shadow: 0 0 0 2px #3858e900;
+	}
+}
+
 .pattern-preview {
 	display: flex;
 	flex-direction: column;
@@ -16,6 +26,10 @@
 		display: grid;
 		flex: 1;
 		overflow: hidden;
+	}
+
+	&:target .pattern-preview__renderer {
+		animation: 0.8s linear 3.5s backwards pattern-preview-target;
 	}
 
 	&.is-loading .pattern-preview__renderer {
@@ -35,7 +49,15 @@
 	}
 
 	.pattern-preview__title {
+		font-size: inherit;
+		line-height: inherit;
+		padding-bottom: 0;
 		padding-top: 4px;
+		text-align: left;
+
+		&:hover {
+			color: inherit;
+		}
 	}
 
 	.pattern-preview__copy,

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -15,16 +15,17 @@ export function usePatternSearchTerm(
 
 	// Updates the URL of the page whenever the search term changes
 	useEffect( () => {
-		const params = new URLSearchParams( window.location.search );
+		const url = new URL( window.location.href );
 
 		if ( searchTerm ) {
-			params.set( QUERY_PARAM_SEARCH, searchTerm );
+			url.searchParams.set( QUERY_PARAM_SEARCH, searchTerm );
 		} else {
-			params.delete( QUERY_PARAM_SEARCH );
+			url.searchParams.delete( QUERY_PARAM_SEARCH );
 		}
 
-		const paramsString = params.toString().length ? `?${ params.toString() }` : '';
-		page.redirect( `${ window.location.pathname }${ paramsString }` );
+		if ( url.href !== location.href ) {
+			page.redirect( url.href );
+		}
 	}, [ searchTerm ] );
 
 	// Updates the search term whenever the URL of the page changes

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -47,7 +47,8 @@ type CategoryGalleryProps = {
 
 export type CategoryGalleryFC = React.FC< CategoryGalleryProps >;
 
-type PatternGalleryProps = {
+export type PatternGalleryProps = {
+	getPatternPermalink?( pattern: Pattern ): string;
 	isGridView?: boolean;
 	patterns?: Pattern[];
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5974

## Proposed Changes

Per @matt-west's designs (p9Jlb4-b5B-p2), this PR makes pattern preview titles clickable to copy permalinks to patterns. We use hashes generated from pattern IDs to target single patterns, meaning users will be scrolled to the correct position in the list view of the relevant category.

When the user is viewing a category (e.g., `/patterns/about`) and copies a pattern link from there, we preserve the active category in the link. If they are searching from a global context (e.g., `/patterns?s=about`), we pick the first relevant category from the pattern and use that in the link.

To help users understand that they can click pattern titles to copy the link, I've also included a tooltip that says `Copy link`.

![](https://github.com/Automattic/wp-calypso/assets/1101677/7364f2de-5f9c-47b6-9853-fd6ec9ae0258)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns`
2. Search for `about`
3. Click the first pattern title
4. Ensure that your clipboard now contains a URL that looks like this `http://calypso.localhost:3000/patterns/intro#pattern-14038`
5. Navigate to `/patterns/posts`
6. Click the first pattern title
7. Ensure that your clipboard now contains a URL that looks like this `http://calypso.localhost:3000/patterns/posts#pattern-14048`
8. Navigate to the copied URL in a new tab
9. Ensure that you are scrolled to the relevant pattern and that it initially has a focus outline (which animates away)
