### PR TITLE
Command Palette: Wrap it with a context to prevent prop drilling

### DIFF
--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -8,10 +8,10 @@ export interface CommandPaletteContext {
 	currentSiteId: number | null;
 	isOpenGlobal?: boolean;
 	navigate: ( path: string, openInNewTab?: boolean ) => void;
-	onClose: () => void;
+	onClose?: () => void;
 	useCommands: ( options: useCommandsParams ) => PaletteCommand[];
-	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
-	useSites: () => SiteExcerptData[];
+	userCapabilities?: { [ key: number ]: { [ key: string ]: boolean } };
+	useSites?: () => SiteExcerptData[];
 }
 
 const CommandPaletteContext = createContext< CommandPaletteContext | undefined >( undefined );

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -8,10 +8,10 @@ export interface CommandPaletteContext {
 	currentSiteId: number | null;
 	isOpenGlobal?: boolean;
 	navigate: ( path: string, openInNewTab?: boolean ) => void;
-	onClose?: () => void;
+	onClose: () => void;
 	useCommands: ( options: useCommandsParams ) => PaletteCommand[];
 	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
-	useSites?: () => SiteExcerptData[];
+	useSites: () => SiteExcerptData[];
 }
 
 const CommandPaletteContext = createContext< CommandPaletteContext | undefined >( undefined );

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -1,0 +1,85 @@
+import { SiteExcerptData } from '@automattic/sites';
+import { FC, PropsWithChildren, createContext, useContext } from 'react';
+import { Command, CommandMenuGroupProps, useCommandsParams } from '.';
+
+const CommandMenuGroupContext = createContext< CommandMenuGroupProps >( {
+	currentSiteId: null,
+	search: '',
+	selectedCommandName: '',
+	setSelectedCommandName: function ( name: string ): void {
+		throw new Error( 'Function not implemented.' );
+	},
+	navigate: function ( path: string, openInNewTab?: boolean | undefined ): void {
+		throw new Error( 'Function not implemented.' );
+	},
+	useCommands: function ( options: useCommandsParams ): Command[] {
+		throw new Error( 'Function not implemented.' );
+	},
+	currentRoute: null,
+	useSites: function (): SiteExcerptData[] {
+		throw new Error( 'Function not implemented.' );
+	},
+	userCapabilities: {},
+	close: function ( commandName?: string | undefined, isExecuted?: boolean | undefined ): void {
+		throw new Error( 'Function not implemented.' );
+	},
+	setSearch: function ( search: string ): void {
+		throw new Error( 'Function not implemented.' );
+	},
+	setPlaceholderOverride: function ( placeholder: string ): void {
+		throw new Error( 'Function not implemented.' );
+	},
+} );
+
+export const CommandMenuGroupContextProvider: FC< PropsWithChildren< CommandMenuGroupProps > > = ( {
+	children,
+	close,
+	currentRoute,
+	currentSiteId,
+	navigate,
+	search,
+	selectedCommandName,
+	setEmptyListNotice,
+	setFooterMessage,
+	setPlaceholderOverride,
+	setSearch,
+	setSelectedCommandName,
+	useCommands,
+	userCapabilities,
+	useSites,
+} ) => {
+	return (
+		<CommandMenuGroupContext.Provider
+			value={ {
+				close,
+				currentRoute,
+				currentSiteId,
+				navigate,
+				search,
+				selectedCommandName,
+				setEmptyListNotice,
+				setFooterMessage,
+				setPlaceholderOverride,
+				setSearch,
+				setSelectedCommandName,
+				useCommands,
+				userCapabilities,
+				useSites,
+			} }
+		>
+			{ children }
+		</CommandMenuGroupContext.Provider>
+	);
+};
+
+export const useCommandMenuGroupContext = (): CommandMenuGroupProps => {
+	const context = useContext( CommandMenuGroupContext );
+
+	if ( ! context ) {
+		throw new Error(
+			'useCommandMenuGroupContext must be used within a CommandMenuGroupContextProvider'
+		);
+	}
+
+	return context;
+};

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -58,6 +58,7 @@ export const useCommandPaletteContext = () => {
 export interface CommandMenuGroupContext
 	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' > {
 	emptyListNotice: string;
+	placeHolderOverride: string;
 	search: string;
 	selectedCommandName: string;
 	setEmptyListNotice: ( message: string ) => void;
@@ -73,6 +74,7 @@ export const CommandMenuGroupContextProvider: FC<
 	children,
 	close,
 	emptyListNotice,
+	placeHolderOverride,
 	search,
 	selectedCommandName,
 	setEmptyListNotice,
@@ -86,6 +88,7 @@ export const CommandMenuGroupContextProvider: FC<
 			value={ {
 				close,
 				emptyListNotice,
+				placeHolderOverride,
 				search,
 				selectedCommandName,
 				setEmptyListNotice,

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -1,21 +1,23 @@
 import { FC, PropsWithChildren, createContext, useContext } from 'react';
-import { useCommandsParams } from './commands/types';
-import { Command as PaletteCommand, CommandCallBackParams } from './use-command-palette';
-import type { SiteExcerptData } from '@automattic/sites';
+import { CommandCallBackParams } from './use-command-palette';
+import { CommandPaletteProps } from '.';
 
 export interface CommandMenuGroupContext
-	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' > {
-	currentSiteId: number | null;
+	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' >,
+		Pick<
+			CommandPaletteProps,
+			| 'currentRoute'
+			| 'currentSiteId'
+			| 'navigate'
+			| 'useCommands'
+			| 'useSites'
+			| 'userCapabilities'
+		> {
 	search: string;
 	selectedCommandName: string;
-	setSelectedCommandName: ( name: string ) => void;
-	setFooterMessage?: ( message: string ) => void;
 	setEmptyListNotice?: ( message: string ) => void;
-	navigate: ( path: string, openInNewTab?: boolean ) => void;
-	useCommands: ( options: useCommandsParams ) => PaletteCommand[];
-	currentRoute: string | null;
-	useSites: () => SiteExcerptData[];
-	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
+	setFooterMessage?: ( message: string ) => void;
+	setSelectedCommandName: ( name: string ) => void;
 }
 
 const CommandMenuGroupContext = createContext< CommandMenuGroupContext | undefined >( undefined );

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -1,7 +1,6 @@
 import { FC, PropsWithChildren, createContext, useContext } from 'react';
 import { useCommandsParams } from './commands/types';
 import { Command as PaletteCommand, CommandCallBackParams } from './use-command-palette';
-import { CommandPaletteProps } from '.';
 import type { SiteExcerptData } from '@automattic/sites';
 
 export interface CommandPaletteContext {
@@ -22,6 +21,7 @@ export const CommandPaletteContextProvider: FC< PropsWithChildren< CommandPalett
 	currentRoute,
 	currentSiteId,
 	navigate,
+	onClose,
 	useCommands,
 	userCapabilities,
 	useSites,
@@ -32,6 +32,7 @@ export const CommandPaletteContextProvider: FC< PropsWithChildren< CommandPalett
 				currentRoute,
 				currentSiteId,
 				navigate,
+				onClose,
 				useCommands,
 				userCapabilities,
 				useSites,
@@ -42,17 +43,20 @@ export const CommandPaletteContextProvider: FC< PropsWithChildren< CommandPalett
 	);
 };
 
+export const useCommandPaletteContext = () => {
+	const context = useContext( CommandPaletteContext );
+
+	if ( ! context ) {
+		throw new Error(
+			'useCommandPaletteContext must be used within a CommandPaletteContextProvider'
+		);
+	}
+
+	return context;
+};
+
 export interface CommandMenuGroupContext
-	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' >,
-		Pick<
-			CommandPaletteProps,
-			| 'currentRoute'
-			| 'currentSiteId'
-			| 'navigate'
-			| 'useCommands'
-			| 'useSites'
-			| 'userCapabilities'
-		> {
+	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' > {
 	search: string;
 	selectedCommandName: string;
 	setEmptyListNotice?: ( message: string ) => void;
@@ -67,9 +71,6 @@ export const CommandMenuGroupContextProvider: FC<
 > = ( {
 	children,
 	close,
-	currentRoute,
-	currentSiteId,
-	navigate,
 	search,
 	selectedCommandName,
 	setEmptyListNotice,
@@ -77,17 +78,11 @@ export const CommandMenuGroupContextProvider: FC<
 	setPlaceholderOverride,
 	setSearch,
 	setSelectedCommandName,
-	useCommands,
-	userCapabilities,
-	useSites,
 } ) => {
 	return (
 		<CommandMenuGroupContext.Provider
 			value={ {
 				close,
-				currentRoute,
-				currentSiteId,
-				navigate,
 				search,
 				selectedCommandName,
 				setEmptyListNotice,
@@ -95,9 +90,6 @@ export const CommandMenuGroupContextProvider: FC<
 				setPlaceholderOverride,
 				setSearch,
 				setSelectedCommandName,
-				useCommands,
-				userCapabilities,
-				useSites,
 			} }
 		>
 			{ children }

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -1,9 +1,28 @@
 import { FC, PropsWithChildren, createContext, useContext } from 'react';
-import { CommandMenuGroupProps } from '.';
+import { useCommandsParams } from './commands/types';
+import { Command as PaletteCommand, CommandCallBackParams } from './use-command-palette';
+import type { SiteExcerptData } from '@automattic/sites';
 
-const CommandMenuGroupContext = createContext< CommandMenuGroupProps | undefined >( undefined );
+export interface CommandMenuGroupContext
+	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' > {
+	currentSiteId: number | null;
+	search: string;
+	selectedCommandName: string;
+	setSelectedCommandName: ( name: string ) => void;
+	setFooterMessage?: ( message: string ) => void;
+	setEmptyListNotice?: ( message: string ) => void;
+	navigate: ( path: string, openInNewTab?: boolean ) => void;
+	useCommands: ( options: useCommandsParams ) => PaletteCommand[];
+	currentRoute: string | null;
+	useSites: () => SiteExcerptData[];
+	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
+}
 
-export const CommandMenuGroupContextProvider: FC< PropsWithChildren< CommandMenuGroupProps > > = ( {
+const CommandMenuGroupContext = createContext< CommandMenuGroupContext | undefined >( undefined );
+
+export const CommandMenuGroupContextProvider: FC<
+	PropsWithChildren< CommandMenuGroupContext >
+> = ( {
 	children,
 	close,
 	currentRoute,
@@ -44,7 +63,7 @@ export const CommandMenuGroupContextProvider: FC< PropsWithChildren< CommandMenu
 	);
 };
 
-export const useCommandMenuGroupContext = (): CommandMenuGroupProps => {
+export const useCommandMenuGroupContext = () => {
 	const context = useContext( CommandMenuGroupContext );
 
 	if ( ! context ) {

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -1,35 +1,7 @@
-import { SiteExcerptData } from '@automattic/sites';
 import { FC, PropsWithChildren, createContext, useContext } from 'react';
-import { Command, CommandMenuGroupProps, useCommandsParams } from '.';
+import { CommandMenuGroupProps } from '.';
 
-const CommandMenuGroupContext = createContext< CommandMenuGroupProps >( {
-	currentSiteId: null,
-	search: '',
-	selectedCommandName: '',
-	setSelectedCommandName: function ( name: string ): void {
-		throw new Error( 'Function not implemented.' );
-	},
-	navigate: function ( path: string, openInNewTab?: boolean | undefined ): void {
-		throw new Error( 'Function not implemented.' );
-	},
-	useCommands: function ( options: useCommandsParams ): Command[] {
-		throw new Error( 'Function not implemented.' );
-	},
-	currentRoute: null,
-	useSites: function (): SiteExcerptData[] {
-		throw new Error( 'Function not implemented.' );
-	},
-	userCapabilities: {},
-	close: function ( commandName?: string | undefined, isExecuted?: boolean | undefined ): void {
-		throw new Error( 'Function not implemented.' );
-	},
-	setSearch: function ( search: string ): void {
-		throw new Error( 'Function not implemented.' );
-	},
-	setPlaceholderOverride: function ( placeholder: string ): void {
-		throw new Error( 'Function not implemented.' );
-	},
-} );
+const CommandMenuGroupContext = createContext< CommandMenuGroupProps | undefined >( undefined );
 
 export const CommandMenuGroupContextProvider: FC< PropsWithChildren< CommandMenuGroupProps > > = ( {
 	children,

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -1,6 +1,46 @@
 import { FC, PropsWithChildren, createContext, useContext } from 'react';
-import { CommandCallBackParams } from './use-command-palette';
+import { useCommandsParams } from './commands/types';
+import { Command as PaletteCommand, CommandCallBackParams } from './use-command-palette';
 import { CommandPaletteProps } from '.';
+import type { SiteExcerptData } from '@automattic/sites';
+
+export interface CommandPaletteContext {
+	currentRoute: string | null;
+	currentSiteId: number | null;
+	isOpenGlobal?: boolean;
+	navigate: ( path: string, openInNewTab?: boolean ) => void;
+	onClose?: () => void;
+	useCommands: ( options: useCommandsParams ) => PaletteCommand[];
+	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
+	useSites?: () => SiteExcerptData[];
+}
+
+const CommandPaletteContext = createContext< CommandPaletteContext | undefined >( undefined );
+
+export const CommandPaletteContextProvider: FC< PropsWithChildren< CommandPaletteContext > > = ( {
+	children,
+	currentRoute,
+	currentSiteId,
+	navigate,
+	useCommands,
+	userCapabilities,
+	useSites,
+} ) => {
+	return (
+		<CommandPaletteContext.Provider
+			value={ {
+				currentRoute,
+				currentSiteId,
+				navigate,
+				useCommands,
+				userCapabilities,
+				useSites,
+			} }
+		>
+			{ children }
+		</CommandPaletteContext.Provider>
+	);
+};
 
 export interface CommandMenuGroupContext
 	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' >,

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -57,10 +57,11 @@ export const useCommandPaletteContext = () => {
 
 export interface CommandMenuGroupContext
 	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' > {
+	emptyListNotice: string;
 	search: string;
 	selectedCommandName: string;
-	setEmptyListNotice?: ( message: string ) => void;
-	setFooterMessage?: ( message: string ) => void;
+	setEmptyListNotice: ( message: string ) => void;
+	setFooterMessage: ( message: string ) => void;
 	setSelectedCommandName: ( name: string ) => void;
 }
 
@@ -71,6 +72,7 @@ export const CommandMenuGroupContextProvider: FC<
 > = ( {
 	children,
 	close,
+	emptyListNotice,
 	search,
 	selectedCommandName,
 	setEmptyListNotice,
@@ -83,6 +85,7 @@ export const CommandMenuGroupContextProvider: FC<
 		<CommandMenuGroupContext.Provider
 			value={ {
 				close,
+				emptyListNotice,
 				search,
 				selectedCommandName,
 				setEmptyListNotice,

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -201,18 +201,12 @@ function CommandInput( { isOpen, placeholder }: CommandInputProps ) {
 }
 
 interface NotFoundMessageProps {
-	selectedCommandName: string;
-	search: string;
 	emptyListNotice?: string;
-	currentRoute: string | null;
 }
 
-const NotFoundMessage = ( {
-	selectedCommandName,
-	search,
-	emptyListNotice,
-	currentRoute,
-}: NotFoundMessageProps ) => {
+const NotFoundMessage = ( { emptyListNotice }: NotFoundMessageProps ) => {
+	const { selectedCommandName, search } = useCommandMenuGroupContext();
+	const { currentRoute } = useCommandPaletteContext();
 	const trackNotFoundDebounced = useDebounce( () => {
 		recordTracksEvent( 'calypso_hosting_command_palette_not_found', {
 			current_route: currentRoute,
@@ -371,12 +365,7 @@ const CommandPalette = () => {
 						</div>
 						<Command.List ref={ commandListRef }>
 							<StyledCommandsEmpty>
-								<NotFoundMessage
-									selectedCommandName={ selectedCommandName }
-									search={ search }
-									emptyListNotice={ emptyListNotice }
-									currentRoute={ currentRoute }
-								/>
+								<NotFoundMessage emptyListNotice={ emptyListNotice } />
 							</StyledCommandsEmpty>
 							<CommandMenuGroup />
 						</Command.List>

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -89,11 +89,11 @@ export function CommandMenuGroup() {
 	const { commands, filterNotice, emptyListNotice } = useCommandPalette();
 
 	useEffect( () => {
-		setFooterMessage?.( filterNotice ?? '' );
+		setFooterMessage( filterNotice ?? '' );
 	}, [ setFooterMessage, filterNotice ] );
 
 	useEffect( () => {
-		setEmptyListNotice?.( emptyListNotice ?? '' );
+		setEmptyListNotice( emptyListNotice ?? '' );
 	}, [ setEmptyListNotice, emptyListNotice ] );
 
 	if ( ! commands.length ) {

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -210,7 +210,7 @@ interface NotFoundMessageProps {
 	currentRoute: string | null;
 }
 
-interface CommandPaletteProps {
+export interface CommandPaletteProps {
 	currentSiteId: number | null;
 	navigate: ( path: string, openInNewTab?: boolean ) => void;
 	useCommands: ( options: useCommandsParams ) => PaletteCommand[];

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -8,7 +8,6 @@ import { cleanForSlug } from '@wordpress/url';
 import classnames from 'classnames';
 import { Command, useCommandState } from 'cmdk';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useCommandsParams } from './commands/types';
 import useSingleSiteCommands from './commands/use-single-site-commands';
 import {
 	CommandMenuGroupContext,
@@ -19,8 +18,7 @@ import {
 	useCommandPaletteContext,
 } from './context';
 import { COMMAND_SEPARATOR, useCommandFilter } from './use-command-filter';
-import { Command as PaletteCommand, useCommandPalette } from './use-command-palette';
-import type { SiteExcerptData } from '@automattic/sites';
+import { useCommandPalette } from './use-command-palette';
 import './style.scss';
 import '@wordpress/commands/build-style/style.css';
 
@@ -207,17 +205,6 @@ interface NotFoundMessageProps {
 	search: string;
 	emptyListNotice?: string;
 	currentRoute: string | null;
-}
-
-export interface CommandPaletteProps {
-	currentSiteId: number | null;
-	navigate: ( path: string, openInNewTab?: boolean ) => void;
-	useCommands: ( options: useCommandsParams ) => PaletteCommand[];
-	currentRoute: string | null;
-	isOpenGlobal?: boolean;
-	onClose?: () => void;
-	useSites?: () => SiteExcerptData[];
-	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
 }
 
 const NotFoundMessage = ( {

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -172,11 +172,11 @@ export function CommandMenuGroup() {
 
 interface CommandInputProps {
 	isOpen: boolean;
-	placeholder?: string;
 }
 
-function CommandInput( { isOpen, placeholder }: CommandInputProps ) {
-	const { search, setSearch, selectedCommandName } = useCommandMenuGroupContext();
+function CommandInput( { isOpen }: CommandInputProps ) {
+	const { placeHolderOverride, search, selectedCommandName, setSearch } =
+		useCommandMenuGroupContext();
 	const commandMenuInput = useRef< HTMLInputElement >( null );
 	const itemValue = useCommandState( ( state ) => state.value );
 	const itemId = useMemo( () => cleanForSlug( itemValue ), [ itemValue ] );
@@ -194,7 +194,7 @@ function CommandInput( { isOpen, placeholder }: CommandInputProps ) {
 			ref={ commandMenuInput }
 			value={ search }
 			onValueChange={ setSearch }
-			placeholder={ placeholder || __( 'Search for commands', __i18n_text_domain__ ) }
+			placeholder={ placeHolderOverride || __( 'Search for commands', __i18n_text_domain__ ) }
 			aria-activedescendant={ itemId }
 		/>
 	);
@@ -327,6 +327,7 @@ const CommandPalette = () => {
 				reset();
 			} }
 			emptyListNotice={ emptyListNotice }
+			placeHolderOverride={ placeHolderOverride }
 			selectedCommandName={ selectedCommandName }
 			setEmptyListNotice={ setEmptyListNotice }
 			setFooterMessage={ setFooterMessage }
@@ -358,7 +359,7 @@ const CommandPalette = () => {
 							) : (
 								<Icon icon={ inputIcon } />
 							) }
-							<CommandInput isOpen={ isOpen } placeholder={ placeHolderOverride } />
+							<CommandInput isOpen={ isOpen } />
 						</div>
 						<Command.List ref={ commandListRef }>
 							<StyledCommandsEmpty>

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -13,7 +13,10 @@ import useSingleSiteCommands from './commands/use-single-site-commands';
 import {
 	CommandMenuGroupContext,
 	CommandMenuGroupContextProvider,
+	CommandPaletteContext,
+	CommandPaletteContextProvider,
 	useCommandMenuGroupContext,
+	useCommandPaletteContext,
 } from './context';
 import { COMMAND_SEPARATOR, useCommandFilter } from './use-command-filter';
 import { Command as PaletteCommand, useCommandPalette } from './use-command-palette';
@@ -84,7 +87,6 @@ const StyledCommandsFooter = styled.div( {
 
 export function CommandMenuGroup() {
 	const {
-		currentSiteId,
 		search,
 		close,
 		setSearch,
@@ -93,12 +95,9 @@ export function CommandMenuGroup() {
 		setSelectedCommandName,
 		setFooterMessage,
 		setEmptyListNotice,
-		navigate,
-		useCommands,
-		currentRoute,
-		useSites,
-		userCapabilities,
 	} = useCommandMenuGroupContext();
+	const { currentSiteId, navigate, useCommands, currentRoute, useSites, userCapabilities } =
+		useCommandPaletteContext();
 	const { commands, filterNotice, emptyListNotice } = useCommandPalette( {
 		currentSiteId,
 		selectedCommandName,
@@ -245,16 +244,8 @@ const NotFoundMessage = ( {
 	return <>{ emptyListNotice || __( 'No results found.', __i18n_text_domain__ ) }</>;
 };
 
-const CommandPalette = ( {
-	currentSiteId,
-	navigate,
-	useCommands,
-	currentRoute,
-	isOpenGlobal,
-	onClose = () => {},
-	useSites = () => [],
-	userCapabilities = {},
-}: CommandPaletteProps ) => {
+const CommandPalette = () => {
+	const { currentRoute, isOpenGlobal, onClose } = useCommandPaletteContext();
 	const [ placeHolderOverride, setPlaceholderOverride ] = useState( '' );
 	const [ search, setSearch ] = useState( '' );
 	const [ selectedCommandName, setSelectedCommandName ] = useState( '' );
@@ -353,7 +344,6 @@ const CommandPalette = ( {
 
 	return (
 		<CommandMenuGroupContextProvider
-			currentSiteId={ currentSiteId }
 			search={ search }
 			close={ ( commandName, isExecuted ) => {
 				close( commandName, isExecuted );
@@ -365,11 +355,6 @@ const CommandPalette = ( {
 			setSelectedCommandName={ setSelectedCommandName }
 			setFooterMessage={ setFooterMessage }
 			setEmptyListNotice={ setEmptyListNotice }
-			navigate={ navigate }
-			useCommands={ useCommands }
-			currentRoute={ currentRoute }
-			useSites={ useSites }
-			userCapabilities={ userCapabilities }
 		>
 			<Modal
 				className="commands-command-menu"
@@ -416,7 +401,33 @@ const CommandPalette = ( {
 	);
 };
 
-export default CommandPalette;
+const CommandPaletteWithProvider = ( {
+	currentSiteId,
+	navigate,
+	useCommands,
+	currentRoute,
+	isOpenGlobal,
+	onClose = () => {},
+	useSites = () => [],
+	userCapabilities = {},
+}: CommandPaletteContext ) => {
+	return (
+		<CommandPaletteContextProvider
+			currentSiteId={ currentSiteId }
+			navigate={ navigate }
+			useCommands={ useCommands }
+			currentRoute={ currentRoute }
+			isOpenGlobal={ isOpenGlobal }
+			onClose={ onClose }
+			useSites={ useSites }
+			userCapabilities={ userCapabilities }
+		>
+			<CommandPalette />
+		</CommandPaletteContextProvider>
+	);
+};
+
+export default CommandPaletteWithProvider;
 export type { Command, CommandCallBackParams } from './use-command-palette';
 export type { useCommandsParams } from './commands/types';
 export { useSingleSiteCommands };

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -10,31 +10,16 @@ import { Command, useCommandState } from 'cmdk';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useCommandsParams } from './commands/types';
 import useSingleSiteCommands from './commands/use-single-site-commands';
-import { CommandMenuGroupContextProvider, useCommandMenuGroupContext } from './context';
-import { COMMAND_SEPARATOR, useCommandFilter } from './use-command-filter';
 import {
-	Command as PaletteCommand,
-	CommandCallBackParams,
-	useCommandPalette,
-} from './use-command-palette';
+	CommandMenuGroupContext,
+	CommandMenuGroupContextProvider,
+	useCommandMenuGroupContext,
+} from './context';
+import { COMMAND_SEPARATOR, useCommandFilter } from './use-command-filter';
+import { Command as PaletteCommand, useCommandPalette } from './use-command-palette';
 import type { SiteExcerptData } from '@automattic/sites';
 import './style.scss';
 import '@wordpress/commands/build-style/style.css';
-
-export interface CommandMenuGroupProps
-	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' > {
-	currentSiteId: number | null;
-	search: string;
-	selectedCommandName: string;
-	setSelectedCommandName: ( name: string ) => void;
-	setFooterMessage?: ( message: string ) => void;
-	setEmptyListNotice?: ( message: string ) => void;
-	navigate: ( path: string, openInNewTab?: boolean ) => void;
-	useCommands: ( options: useCommandsParams ) => PaletteCommand[];
-	currentRoute: string | null;
-	useSites: () => SiteExcerptData[];
-	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
-}
 
 const StyledCommandsMenuContainer = styled.div( {
 	'[cmdk-root] > [cmdk-list]': {
@@ -283,7 +268,7 @@ const CommandPalette = ( {
 			current_route: currentRoute,
 		} );
 	}, [ currentRoute ] );
-	const close = useCallback< CommandMenuGroupProps[ 'close' ] >(
+	const close = useCallback< CommandMenuGroupContext[ 'close' ] >(
 		( commandName = '', isExecuted = false ) => {
 			setIsOpenLocal( false );
 			onClose();

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -84,29 +84,9 @@ const StyledCommandsFooter = styled.div( {
 } );
 
 export function CommandMenuGroup() {
-	const {
-		search,
-		close,
-		setSearch,
-		setPlaceholderOverride,
-		selectedCommandName,
-		setSelectedCommandName,
-		setFooterMessage,
-		setEmptyListNotice,
-	} = useCommandMenuGroupContext();
-	const { currentSiteId, navigate, useCommands, currentRoute, useSites, userCapabilities } =
-		useCommandPaletteContext();
-	const { commands, filterNotice, emptyListNotice } = useCommandPalette( {
-		currentSiteId,
-		selectedCommandName,
-		setSelectedCommandName,
-		search,
-		navigate,
-		useCommands,
-		currentRoute,
-		useSites,
-		userCapabilities,
-	} );
+	const { search, close, setSearch, setPlaceholderOverride, setFooterMessage, setEmptyListNotice } =
+		useCommandMenuGroupContext();
+	const { commands, filterNotice, emptyListNotice } = useCommandPalette();
 
 	useEffect( () => {
 		setFooterMessage?.( filterNotice ?? '' );

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -243,7 +243,7 @@ const CommandPalette = () => {
 	const close = useCallback< CommandMenuGroupContext[ 'close' ] >(
 		( commandName = '', isExecuted = false ) => {
 			setIsOpenLocal( false );
-			onClose();
+			onClose?.();
 			recordTracksEvent( 'calypso_hosting_command_palette_close', {
 				// For nested commands the command.name would be the siteId
 				// For root commands the selectedCommandName would be empty

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -200,12 +200,8 @@ function CommandInput( { isOpen, placeholder }: CommandInputProps ) {
 	);
 }
 
-interface NotFoundMessageProps {
-	emptyListNotice?: string;
-}
-
-const NotFoundMessage = ( { emptyListNotice }: NotFoundMessageProps ) => {
-	const { selectedCommandName, search } = useCommandMenuGroupContext();
+const NotFoundMessage = () => {
+	const { emptyListNotice, search, selectedCommandName } = useCommandMenuGroupContext();
 	const { currentRoute } = useCommandPaletteContext();
 	const trackNotFoundDebounced = useDebounce( () => {
 		recordTracksEvent( 'calypso_hosting_command_palette_not_found', {
@@ -330,12 +326,13 @@ const CommandPalette = () => {
 				close( commandName, isExecuted );
 				reset();
 			} }
-			setSearch={ setSearch }
-			setPlaceholderOverride={ setPlaceholderOverride }
+			emptyListNotice={ emptyListNotice }
 			selectedCommandName={ selectedCommandName }
-			setSelectedCommandName={ setSelectedCommandName }
-			setFooterMessage={ setFooterMessage }
 			setEmptyListNotice={ setEmptyListNotice }
+			setFooterMessage={ setFooterMessage }
+			setPlaceholderOverride={ setPlaceholderOverride }
+			setSearch={ setSearch }
+			setSelectedCommandName={ setSelectedCommandName }
 		>
 			<Modal
 				className="commands-command-menu"
@@ -365,7 +362,7 @@ const CommandPalette = () => {
 						</div>
 						<Command.List ref={ commandListRef }>
 							<StyledCommandsEmpty>
-								<NotFoundMessage emptyListNotice={ emptyListNotice } />
+								<NotFoundMessage />
 							</StyledCommandsEmpty>
 							<CommandMenuGroup />
 						</Command.List>

--- a/packages/command-palette/src/use-command-palette.tsx
+++ b/packages/command-palette/src/use-command-palette.tsx
@@ -76,8 +76,8 @@ interface useCommandPaletteOptions {
 	navigate: ( path: string, openInNewTab?: boolean ) => void;
 	useCommands: ( options: useCommandsParams ) => Command[];
 	currentRoute: string | null;
-	useSites: () => SiteExcerptData[];
-	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
+	useSites?: () => SiteExcerptData[];
+	userCapabilities?: { [ key: number ]: { [ key: string ]: boolean } };
 }
 
 interface SiteToActionParameters {

--- a/packages/command-palette/src/use-command-palette.tsx
+++ b/packages/command-palette/src/use-command-palette.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { __ } from '@wordpress/i18n';
 import { useCommandState } from 'cmdk';
 import { useCallback } from 'react';
-import { useCommandsParams } from './commands/types';
+import { useCommandMenuGroupContext, useCommandPaletteContext } from './context';
 import { isCustomDomain } from './utils';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -66,18 +66,6 @@ export interface Command {
 
 export interface useExtraCommandsParams {
 	setSelectedCommandName: ( name: string ) => void;
-}
-
-interface useCommandPaletteOptions {
-	currentSiteId: number | null;
-	selectedCommandName: string;
-	setSelectedCommandName: ( name: string ) => void;
-	search: string;
-	navigate: ( path: string, openInNewTab?: boolean ) => void;
-	useCommands: ( options: useCommandsParams ) => Command[];
-	currentRoute: string | null;
-	useSites?: () => SiteExcerptData[];
-	userCapabilities?: { [ key: number ]: { [ key: string ]: boolean } };
 }
 
 interface SiteToActionParameters {
@@ -150,26 +138,19 @@ const useSiteToAction = ( { currentRoute }: { currentRoute: string | null } ) =>
 	return siteToAction;
 };
 
-export const useCommandPalette = ( {
-	currentSiteId,
-	selectedCommandName,
-	setSelectedCommandName,
-	search,
-	navigate,
-	useCommands,
-	currentRoute,
-	useSites = () => [],
-	userCapabilities = {},
-}: useCommandPaletteOptions ): {
+export const useCommandPalette = (): {
 	commands: Command[];
 	filterNotice: string | undefined;
 	emptyListNotice: string | undefined;
 } => {
+	const { search, selectedCommandName, setSelectedCommandName } = useCommandMenuGroupContext();
+	const { currentSiteId, navigate, useCommands, currentRoute, useSites, userCapabilities } =
+		useCommandPaletteContext();
 	const siteToAction = useSiteToAction( { currentRoute } );
 
 	const listVisibleCount = useCommandState( ( state ) => state.filtered.count );
 
-	const sites = useSites();
+	const sites = useSites?.() || [];
 
 	// Call the generateCommandsArray function to get the commands array
 	const commands = useCommands( {
@@ -226,7 +207,7 @@ export const useCommandPalette = ( {
 			let filteredSites = filter ? sites.filter( filter ) : sites;
 			if ( capabilityFilter ) {
 				filteredSites = filteredSites.filter( ( site ) => {
-					const siteCapabilities = userCapabilities[ site.ID ];
+					const siteCapabilities = userCapabilities?.[ site.ID ];
 					return siteCapabilities?.[ capabilityFilter ];
 				} );
 			}

--- a/packages/command-palette/test/use-command-palette.tsx
+++ b/packages/command-palette/test/use-command-palette.tsx
@@ -73,21 +73,6 @@ const commandsWithViewMySiteResult = [
 	},
 ];
 
-const commandsWithViewMySiteOnSitesResult = [
-	{
-		name: 'getHelp',
-		label: 'Get help',
-	},
-	{
-		name: 'clearCache',
-		label: 'Clear cache',
-	},
-	{
-		name: 'enableEdgeCache',
-		label: 'Enable edge cache',
-	},
-];
-
 const commandsWithContext = [
 	{
 		callback,


### PR DESCRIPTION
Fixes #87949

## Proposed Changes

* Wrap the `CommandPalette`  component with a context provider so the props needed on nested children can be accessed with the `useCommandPaletteContext` hook.
* Also add a `CommandMenuGroupContext` to handle the state props passed down to children.

## Testing Instructions

Open the PR preview and check that the command palette works as usual.

Note: The code review is easier by hiding the whitespace on the diff.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?