### PR TITLE
Stats: Sort UTM metrics in descending order to guarantee "Views" orders

### DIFF
--- a/client/state/stats/utm-metrics/reducer.ts
+++ b/client/state/stats/utm-metrics/reducer.ts
@@ -60,43 +60,47 @@ const metricsParser = (
 	// or set to an empty object.
 	const stopFurtherRequest = !! topPosts;
 
-	return combinedKeys.map( ( combinedKey: string ) => {
-		const parsedKeys = isValidJSONArray( combinedKey )
-			? JSON.parse( combinedKey )
-			: [ combinedKey ];
-		const value = UTMValues[ combinedKey ];
-		const posts = topPosts && combinedKey in topPosts ? topPosts[ combinedKey ] : [];
+	return combinedKeys
+		.sort( ( keyA: string, keyB: string ) => {
+			return UTMValues[ keyB ] - UTMValues[ keyA ];
+		} )
+		.map( ( combinedKey: string ) => {
+			const parsedKeys = isValidJSONArray( combinedKey )
+				? JSON.parse( combinedKey )
+				: [ combinedKey ];
+			const value = UTMValues[ combinedKey ];
+			const posts = topPosts && combinedKey in topPosts ? topPosts[ combinedKey ] : [];
 
-		const data = {
-			label: parsedKeys[ 0 ],
-			value,
-		} as UTMMetricItem;
+			const data = {
+				label: parsedKeys[ 0 ],
+				value,
+			} as UTMMetricItem;
 
-		// Show the label for two UTM parameters: `utm_source,utm_medium`.
-		if ( parsedKeys[ 1 ] ) {
-			data.label += ` / ${ parsedKeys[ 1 ] }`;
-		}
+			// Show the label for two UTM parameters: `utm_source,utm_medium`.
+			if ( parsedKeys[ 1 ] ) {
+				data.label += ` / ${ parsedKeys[ 1 ] }`;
+			}
 
-		// Show the label for three UTM parameters: `utm_campaign,utm_source,utm_medium`.
-		if ( parsedKeys[ 2 ] ) {
-			data.label += ` / ${ parsedKeys[ 2 ] }`;
-		}
+			// Show the label for three UTM parameters: `utm_campaign,utm_source,utm_medium`.
+			if ( parsedKeys[ 2 ] ) {
+				data.label += ` / ${ parsedKeys[ 2 ] }`;
+			}
 
-		// Prepare top posts of each UTM parameter value.
-		if ( posts.length ) {
-			data.children = topPostsParser( posts, siteSlug );
-		}
+			// Prepare top posts of each UTM parameter value.
+			if ( posts.length ) {
+				data.children = topPostsParser( posts, siteSlug );
+			}
 
-		// Set no `paramValues` to prevent top post requests.
-		if ( stopFurtherRequest ) {
-			return data;
-		}
+			// Set no `paramValues` to prevent top post requests.
+			if ( stopFurtherRequest ) {
+				return data;
+			}
 
-		return {
-			...data,
-			paramValues: combinedKey,
-		};
-	} );
+			return {
+				...data,
+				paramValues: combinedKey,
+			};
+		} );
 };
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88636#pullrequestreview-1945278960

## Proposed Changes

* Sort UTM metrics in descending view amount order to guarantee orders rather than relying on the key order of the returned object.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live link.
* Navigate to the UTM module summary page with the feature flag: `stats/utm-module`.
* Ensure the UTM metrics list is displayed in descending order of views amount under any circumstances.

|Before|After|
|-|-|
|<img width="1023" alt="截圖 2024-03-19 下午10 40 42" src="https://github.com/Automattic/wp-calypso/assets/6869813/ff56f0b6-cc13-4344-8482-40563d015c98">|<img width="1018" alt="截圖 2024-03-19 下午10 40 21" src="https://github.com/Automattic/wp-calypso/assets/6869813/766e78f6-72e8-4b58-8d68-55306468c28b">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?