### PR TITLE
Load created user session into state in userless checkout

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -18,6 +18,7 @@ import {
 	retrieveSignupDestination,
 	setSignupCheckoutPageUnloaded,
 } from 'calypso/signup/storageUtils';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import {
 	getCurrentUser,
 	getCurrentUserVisibleSiteCount,
@@ -561,6 +562,11 @@ export function transferDomainToAnyUser( context, next ) {
 	// background via .is-section-checkout-thank-you
 	context.section.name = 'checkout-thank-you';
 	context.primary = <DomainTransferToAnyUser domain={ context.params.domain } />;
+	next( context );
+}
+
+export async function refreshUserSession( context, next ) {
+	await context.store.dispatch( fetchCurrentUser() );
 	next( context );
 }
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -29,6 +29,7 @@ import {
 	hundredYearCheckoutThankYou,
 	transferDomainToAnyUser,
 	checkoutFailedPurchases,
+	refreshUserSession,
 } from './controller';
 
 export default function () {
@@ -171,6 +172,7 @@ export default function () {
 
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
+		refreshUserSession, // Load user session into state in userless checkout
 		redirectLoggedOut,
 		checkoutPending,
 		makeLayout,
@@ -181,6 +183,7 @@ export default function () {
 	// not include the `siteSelection` middleware.
 	page(
 		'/checkout/thank-you/no-site/:receiptId?',
+		refreshUserSession, // Load user session into state in userless checkout
 		redirectLoggedOut,
 		noSite,
 		checkoutThankYou,


### PR DESCRIPTION
## Proposed Changes

We currently display /log-in screen in userless checkout even though we create an account for user and automatically log them in. The reason for this is that we don't update the store state with current user data before checking if a user is logged in (and redirecting to the auth screen).

![image](https://github.com/Automattic/wp-calypso/assets/8419292/ee4d4fd1-7bb8-4a2e-870c-e7bd85027e37)

This PR fixes that by adding a step of re-fetching user details and loads user state to store properly.

## Testing Instructions

* If you don't want to pay (and refund), you can enable store sandbox on your sandbox, and point `public-api.wordpress.com` to it
* Open Calypso Live in the incognito card
* Go to checkout site of any product e.g. `/checkout/jetpack/jetpack_social_advanced_yearly`
* Put email that you haven't used before (aliases (`+something`) to your current email work well)
* Pay, and make sure you're not being redirected to the auth page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?