### PR TITLE
DIFM: fix responsiveness issue on the content form

### DIFF
--- a/client/signup/accordion-form/accordion-form-section.tsx
+++ b/client/signup/accordion-form/accordion-form-section.tsx
@@ -25,7 +25,7 @@ interface SectionHeaderProps {
 const Section = styled.div`
 	border-bottom: 1px solid var( --studio-gray-5 );
 	padding: 0 20px;
-	@media ( min-width: 600px ) {
+	@media ( min-width: 1280px ) {
 		width: 775px;
 	}
 `;
@@ -47,7 +47,7 @@ const SectionContent = styled.div`
 	display: flex;
 	flex-direction: column;
 	padding: 0 0 36px 0;
-	@media ( min-width: 600px ) {
+	@media ( min-width: 1280px ) {
 		padding-right: 96px;
 		min-width: 675px;
 	}

--- a/client/signup/steps/website-content/style.scss
+++ b/client/signup/steps/website-content/style.scss
@@ -3,12 +3,6 @@
 
 .signup__step.is-website-content {
 	.step-wrapper {
-		@include break-small {
-			&.is-horizontal-layout {
-				margin-top: 17vh;
-			}
-		}
-
 		body.is-section-signup .layout:not(.dops) & {
 			max-width: 1440px;
 			@include break-small {
@@ -19,6 +13,17 @@
 		.step-wrapper__content {
 			flex-basis: 55%;
 			margin-bottom: 64px;
+		}
+
+		&.is-horizontal-layout {
+			@include break-small {
+				display: block;
+				margin-top: initial;
+			}
+			@include break-wide {
+				display: flex;
+				margin-top: 17vh;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/1564

## Proposed Changes

* This PR modifies the media queries on the website content form so that the form wraps at 1280px instead of 600px.

#### Screenshots
<img width="1512" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/386c1188-335b-48ab-8517-87720aaf9938">

<img width="1234" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/9b5d7370-c91a-4a39-93cb-a487f4e96e7a">

<img width="637" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/c3858f0b-6762-4b7e-bb6a-737505acd7df">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`, go through the flow steps and purchase the product.
* On the website content step, check that the form works in different screen resolutions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?