### PR TITLE
Deprecate showing upgrade-credit-applied price in the full-term price

### DIFF
--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -97,7 +97,6 @@ describe( 'usePricingMetaForGridPlans', () => {
 
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
-			withoutPlanUpgradeCredits: false,
 			storageAddOns: null,
 			selectedSiteId: 100,
 			coupon: undefined,
@@ -138,7 +137,6 @@ describe( 'usePricingMetaForGridPlans', () => {
 
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
-			withoutPlanUpgradeCredits: false,
 			storageAddOns: null,
 			selectedSiteId: 100,
 			coupon: undefined,
@@ -165,49 +163,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 		expect( pricingMeta ).toEqual( expectedPricingMeta );
 	} );
 
-	it( 'should return the original price and discounted price (prorated) when withoutPlanUpgradeCredits is false', () => {
-		Plans.useCurrentPlan.mockImplementation( () => ( {
-			productSlug: PLAN_PERSONAL,
-			planSlug: PLAN_PERSONAL,
-		} ) );
-
-		const useCheckPlanAvailabilityForPurchase = () => {
-			return {
-				[ PLAN_PERSONAL ]: true,
-				[ PLAN_PREMIUM ]: true,
-			};
-		};
-
-		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
-			withoutPlanUpgradeCredits: false,
-			storageAddOns: null,
-			selectedSiteId: 100,
-			coupon: undefined,
-			useCheckPlanAvailabilityForPurchase,
-		} );
-
-		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
-				originalPrice: {
-					full: 500,
-					monthly: 500,
-				},
-				discountedPrice: {
-					full: 250,
-					monthly: 250,
-				},
-				billingPeriod: 365,
-				currencyCode: 'USD',
-				expiry: null,
-				introOffer: null,
-			},
-		};
-
-		expect( pricingMeta ).toEqual( expectedPricingMeta );
-	} );
-
-	it( 'should return the original price and discounted price (not prorated) when withoutPlanUpgradeCredits is true', () => {
+	it( 'should return the original price and discounted price', () => {
 		Plans.useCurrentPlan.mockImplementation( () => ( {
 			productSlug: PLAN_PERSONAL,
 			planSlug: PLAN_PERSONAL,
@@ -222,7 +178,6 @@ describe( 'usePricingMetaForGridPlans', () => {
 
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
-			withoutPlanUpgradeCredits: true,
 			storageAddOns: null,
 			selectedSiteId: 100,
 			coupon: undefined,

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -40,7 +40,6 @@ interface Props {
 	 * `storageAddOmns` TODO: should become a required prop.
 	 */
 	storageAddOns: ( AddOnMeta | null )[] | null;
-	withoutPlanUpgradeCredits?: boolean;
 }
 
 function getTotalPrice( planPrice: number | null | undefined, addOnPrice = 0 ): number | null {
@@ -62,7 +61,6 @@ const usePricingMetaForGridPlans = ( {
 	selectedSiteId,
 	coupon,
 	useCheckPlanAvailabilityForPurchase,
-	withoutPlanUpgradeCredits = false,
 	storageAddOns,
 }: Props ): { [ planSlug: string ]: Plans.PricingMetaForGridPlan } | null => {
 	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( { planSlugs } );
@@ -177,7 +175,6 @@ const usePricingMetaForGridPlans = ( {
 
 				/**
 				 * 2. Original and Discounted prices for plan available for purchase.
-				 * - If prorated credits are needed, then pick the discounted price from sitePlan (site context) if one exists.
 				 */
 				if ( availableForPurchase ) {
 					const originalPrice = {
@@ -185,17 +182,11 @@ const usePricingMetaForGridPlans = ( {
 						full: getTotalPrice( plan.pricing.originalPrice.full, storageAddOnPriceYearly ),
 					};
 					const discountedPrice = {
-						monthly:
-							sitePlan?.pricing && ! withoutPlanUpgradeCredits
-								? getTotalPrice(
-										sitePlan.pricing.discountedPrice.monthly,
-										storageAddOnPriceMonthly
-								  )
-								: getTotalPrice( plan.pricing.discountedPrice.monthly, storageAddOnPriceMonthly ),
-						full:
-							sitePlan?.pricing && ! withoutPlanUpgradeCredits
-								? getTotalPrice( sitePlan.pricing.discountedPrice.full, storageAddOnPriceYearly )
-								: getTotalPrice( plan.pricing.discountedPrice.full, storageAddOnPriceYearly ),
+						monthly: getTotalPrice(
+							plan.pricing.discountedPrice.monthly,
+							storageAddOnPriceMonthly
+						),
+						full: getTotalPrice( plan.pricing.discountedPrice.full, storageAddOnPriceYearly ),
 					};
 
 					return [

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -37,7 +37,6 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	);
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
 		planSlugs: currentSitePlanSlug ? [ currentSitePlanSlug ] : [],
-		withoutPlanUpgradeCredits: true,
 		coupon,
 		selectedSiteId,
 		useCheckPlanAvailabilityForPurchase,

--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discount.ts
@@ -20,7 +20,6 @@ export default function useMaxDiscount(
 		.filter( Boolean ) as PlanSlug[];
 	const monthlyPlansPricing = Plans.usePricingMetaForGridPlans( {
 		planSlugs: wpcomMonthlyPlans,
-		withoutPlanUpgradeCredits: true,
 		selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,
@@ -28,7 +27,6 @@ export default function useMaxDiscount(
 	} );
 	const yearlyPlansPricing = Plans.usePricingMetaForGridPlans( {
 		planSlugs: yearlyVariantPlanSlugs,
-		withoutPlanUpgradeCredits: true,
 		selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,

--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
@@ -49,7 +49,6 @@ export default function useMaxDiscountsForPlanTerms(
 
 	const plansPricing = Plans.usePricingMetaForGridPlans( {
 		planSlugs: allRelatedPlanSlugs,
-		withoutPlanUpgradeCredits: true,
 		selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -27,14 +27,10 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 		storageAddOnsForPlan,
 	} = gridPlansIndex[ planSlug ];
 
-	// We want the yearly-variant plan's price to be the raw price the user
-	// would pay if they choose an annual plan instead of the monthly one. So pro-rated
-	// (or other) credits should not apply.
 	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
 
 	const yearlyVariantPricing = Plans.usePricingMetaForGridPlans( {
 		planSlugs: yearlyVariantPlanSlug ? [ yearlyVariantPlanSlug ] : [],
-		withoutPlanUpgradeCredits: true,
 		storageAddOns: storageAddOnsForPlan,
 		coupon,
 		selectedSiteId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1927

## Proposed Changes

This PR is a follow-up fix of https://github.com/Automattic/wp-calypso/pull/86860 for fixing the remaining part of Automattic/martech#1927. 

As a follow-up report demonstrated by @tanjoymor in https://github.com/Automattic/martech/issues/1927#issuecomment-1925064772, it's confusing that we show the credit-applied term price(e.g. annual price, bienniel price, etc.) rather than the expected full price. This PR fully deprecates the concept of computing the upgrade-credit-applied price as a discount from the data store level up to the UI level.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that the updated unit tests make sense and pass.
* On a site with a paid plan, `/plans`, `/plans/2yearly/` and `/plans/3yearly` should all show the full price, instead of a first-term discounted price like `per month, {price} for the first X years, excl. taxes`. Checking a site on a monthly paid plan would be a good idea since it'd allow you to check all the cases.
* Correct prices should be shown on the signup flows, e.g. /start
* On a site without a paid plan, `/plans` should work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
