### PR TITLE
i18n: Fix build-languages script translations ref key

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -148,7 +148,9 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 				modulePath = getModuleReference( modulePath );
 				const key = /\.\w+/.test( modulePath )
 					? modulePath
-					: Object.keys( translationsByRef ).find( ( ref ) => ref.indexOf( modulePath ) === 0 );
+					: Object.keys( translationsByRef ).find(
+							( ref ) => ref.indexOf( modulePath + '.' ) === 0
+					  );
 
 				if ( ! key ) {
 					return;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 762-gh-Automattic/i18n-issues

## Proposed Changes

As a result of removing the file extension for modules within packages by the `getModuleReference()` function and the fact the the script is using `.indexOf( modulePath )` to find the translations reference key, there's a chance that the incorrect key gets picked. For example, `/packages/path/to/module` could pick the translations for `/packages/path/to/module/submodule.jsx`.

One specific component that got affected by this error and ended up not having the expected translations associated with its translation chunk is the help center popup:

![zacYLmHKwHlf9Bb1](https://github.com/Automattic/wp-calypso/assets/2722412/072b6763-efbf-4f49-8d1b-87505622fb4a)

* Add a `.` to the `modulePath` when comparing with the reference pathname to ensure only the expected path gets matched and not other references which pathnames may begin with the `modulePath`.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Test the Help center component and confirm that the Search placeholder gets translated correctly with the fix.
* Optional: Build the translation chunks with and without the fix and compare the two sets of files. Check whether the chunks that got affected by this change include the expected set of translation entries.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
