### PR TITLE
A4A: Sites Dashboard - Add the Backup page to the preview pane

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -461,4 +461,13 @@
 			}
 		}
 	}
+
+	.backup__page {
+		.daily-backup-status__restore-button,
+		.status-card__no-backup-last-backup,
+		.activity-card__toolbar--reverse,
+		.backup-date-picker {
+			display: none;
+		}
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
@@ -1,6 +1,5 @@
 import BackupsPage from 'calypso/my-sites/backup/main';
 import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
-import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
 
 export function JetpackBackupPreview() {
 	return (
@@ -8,7 +7,6 @@ export function JetpackBackupPreview() {
 			<SitePreviewPaneContent>
 				<BackupsPage queryDate={ undefined } />
 			</SitePreviewPaneContent>
-			<SitePreviewPaneFooter />
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
@@ -1,19 +1,12 @@
-import BackupStorage from '../site-expanded-content/backup-storage';
+import BackupsPage from 'calypso/my-sites/backup/main';
 import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
-import { Site } from '../types';
 
-type Props = {
-	site: Site;
-	trackEvent: ( eventName: string ) => void;
-	hasError?: boolean;
-};
-
-export function JetpackBackupPreview( { site, trackEvent, hasError = false }: Props ) {
+export function JetpackBackupPreview() {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<BackupStorage site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+				<BackupsPage queryDate={ undefined } />
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -56,7 +56,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedFeatureId,
 				setSelectedFeatureId,
-				<JetpackBackupPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+				<JetpackBackupPreview />
 			),
 			createFeaturePreview(
 				'jetpack_scan',


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/96

## Proposed Changes

* This PR adds the Backup page to the preview pane. All actions, except for `Back up now`, are hidden because they depend on using Jetpack Manage's URL as the base URL.

## Testing Instructions

* Go to the site dashboard (http://agencies.localhost:3000/sites).
* Select any of the sites.
* Open the Backup feature.
* Make sure it displays the correct page and no errors arise.

*IMPORTANT NOTE:* The scrollbar for this page will not be visible. Please ensure that the window is big enough to for the entire Backup page. The issue with the scrollbar will be resolved in a separate PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?