### PR TITLE
A4A: Add intro cards to the overview page

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/index.tsx
@@ -1,12 +1,12 @@
 import OverviewBodyHosting from './hosting';
+import OverviewBodyIntroCards from './intro-cards';
 import OverviewBodyNextSteps from './next-steps';
 import OverviewBodyProducts from './products';
-import OverviewBodyTips from './tips';
 
 const OverviewBody = () => {
 	return (
 		<div className="overview-body">
-			<OverviewBodyTips />
+			<OverviewBodyIntroCards />
 			<OverviewBodyNextSteps />
 			<OverviewBodyProducts />
 			<OverviewBodyHosting />

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
@@ -1,0 +1,101 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import DotPager from 'calypso/components/dot-pager';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.scss';
+
+const Card1 = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<h1>{ translate( 'Welcome to the Automattic for Agencies beta' ) }</h1>
+			<p>
+				{ translate(
+					'Automattic for Agencies is a new agency program that brings together all of Automattic’s brands under one roof, enabling you to get the best deals on our products and services. We’ll also provide you with tooling to help you be more efficient in your work and grow your business.'
+				) }
+			</p>
+			<p>
+				{ translate(
+					'This is only just the beginning. Soon, we’ll add referral commissions, partner directory listings across our brands, bonus incentives, and much more.'
+				) }
+			</p>
+		</>
+	);
+};
+
+const Card2 = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<h1>{ translate( 'Get big discounts when purchasing in bulk' ) }</h1>
+			<p>
+				{ translate(
+					'You can save up to 80% on Woo, Jetpack, WordPress.com, and Pressable plans when purchasing in bulk. We also charge on a monthly basis, so you don’t have to pay for a year upfront to get the best prices.'
+				) }
+			</p>
+		</>
+	);
+};
+
+const Card3 = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<h1>{ translate( 'Manage all of your sites in a single place, regardless of host' ) }</h1>
+			<p>
+				{ translate(
+					'With our sites dashboard, you can get a birds-eye view of the security and performance across all your sites, regardless of host. You’ll be notified immediately if critical issues need your attention, ensuring your clients remain happy.'
+				) }
+			</p>
+		</>
+	);
+};
+
+const Card4 = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<h1>{ translate( 'And more to come' ) }</h1>
+			<p>
+				{ translate(
+					// to do: change the x@automattic.com email address
+					'We’re only just getting started. Our mission is to create an agency program that helps your business to grow with us. If you have any feedback or suggestions for us, we’d love to hear from you at X@automattic.com.'
+				) }
+			</p>
+		</>
+	);
+};
+
+export default function OverviewBodyIntroCards( { onFinish = () => {} } ) {
+	const dispatch = useDispatch();
+
+	const tracksFn = ( tracksEventName?: string, tracksEventProps?: object ) => {
+		if ( ! tracksEventName ) {
+			return;
+		}
+		dispatch( recordTracksEvent( tracksEventName, tracksEventProps ) );
+	};
+
+	return (
+		<Card>
+			<div>
+				<DotPager
+					className="intro-cards"
+					navArrowSize={ 24 }
+					tracksPrefix="calypso_a4a_overview_intro_cards"
+					tracksFn={ tracksFn }
+					includeNextButton
+					includeFinishButton
+					onFinish={ onFinish }
+				>
+					<Card1 />
+					<Card2 />
+					<Card3 />
+					<Card4 />
+				</DotPager>
+			</div>
+		</Card>
+	);
+}

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
@@ -87,7 +87,6 @@ export default function OverviewBodyIntroCards( { onFinish = () => {} } ) {
 					tracksPrefix="calypso_a4a_overview_intro_cards"
 					tracksFn={ tracksFn }
 					includeNextButton
-					includeFinishButton
 					onFinish={ onFinish }
 				>
 					<Card1 />

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
@@ -1,0 +1,24 @@
+.intro-cards {
+	.dot-pager__page {
+		p,
+		li {
+			font-size: rem(16px);
+			font-weight: 400;
+			line-height: 24px;
+			color: var(--studio-gray-80);
+		}
+
+		h1 {
+			font-size: rem(32px);
+			font-weight: 700;
+			line-height: 48px;
+			color: var(--studio-black);
+			margin-bottom: 16px;
+		}
+
+		ul {
+			margin: 0 0 0 1rem;
+			margin-left: 1rem;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
@@ -5,14 +5,12 @@
 			font-size: rem(16px);
 			font-weight: 400;
 			line-height: 24px;
-			color: var(--studio-gray-80);
 		}
 
 		h1 {
 			font-size: rem(32px);
 			font-weight: 700;
 			line-height: 48px;
-			color: var(--studio-black);
 			margin-bottom: 16px;
 		}
 

--- a/client/a8c-for-agencies/sections/overview/body/tips/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/tips/index.tsx
@@ -1,5 +1,0 @@
-const OverviewBodyTips = () => {
-	return <div>Tips</div>;
-};
-
-export default OverviewBodyTips;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/291

## Proposed Changes

* Changes `tips` naming to `intro-cards` to match Jetpack Manage verbiage.
* Add the intro cards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the intro cards via the `/overview` page on desktop and mobile.
* Validate the card content against the P2: p2-pfunGA-AR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="811" alt="Screenshot 2024-03-19 at 3 40 36 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/fce86206-64ec-43f1-ab64-ab7d26628a1f">

