### PR TITLE
Marketplace: Add context to "Save" to mean save money.

### DIFF
--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -54,7 +54,7 @@ const BillingIntervalSwitcher: FunctionComponent< Props > = ( props: Props ) => 
 	const translate = useTranslate();
 	const monthlyLabel = translate( 'Monthly' );
 	const annualLabel = translate( 'Annually' );
-	const saveLabel = translate( 'Save' );
+	const saveLabel = translate( 'Save', { context: 'save money' } );
 
 	const searchParams = new URLSearchParams( document.location.search );
 	const billingIntervalParam = searchParams.get( 'interval' );


### PR DESCRIPTION
## Proposed Changes

* In the plugin checkout section, "Save" in the string "Annually (Save 9,00 US$)" means to save money, but it's being translated in many language as save modifications.

![image](https://github.com/Automattic/wp-calypso/assets/23708351/390c103c-ea73-42cb-b645-2e9d2326b47a)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso link below and switch your interface to a Mag-16 language.
* Navigate to Plugins and select a paid plugin (e.g. Sensei Pro)
* Confirm that the Save text shows untranslated, as context has been added:
![image](https://github.com/Automattic/wp-calypso/assets/23708351/d689e7e4-e2a0-455a-95be-97d2209b92c0)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
