### PR TITLE
Chore: Adds watch mode to package assets

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -105,6 +105,23 @@ If your package requires compilation, the `package.json` `build` script should c
 - If it contains ES6+ code that needs to be transpiled, use `transpile` (from `@automattic/calypso-build`) which will automatically compile code in `src/` to `dist/cjs` (CommonJS) and `dist/esm` (ECMAScript Modules) by running `babel` over any source files it finds. Also, make sure to add `@automattic/calypso-build` in `devDependencies`.
 - If it contains [assets](https://github.com/Automattic/wp-calypso/blob/d709f0e79ba29f2feb35690d275087179b18f632/packages/calypso-build/bin/copy-assets.js#L17-L25) (eg `.scss`) then after `transpile` append `&& copy-assets` ie `"build": "transpile && copy-assets"`.
 
+
+#### Watching asset changes
+If you also need to watch asset changes in your package you can add the following lines, make sure to add `npm-run-all` to your devDependencies
+```	
+		"watch:tsc": "tsc --build ./tsconfig.json --watch",
+		"watch:assets": "copy-assets --watch",
+		"watch": "npm-run-all --parallel watch:tsc watch:assets"
+```
+This will concurrently watch for tsc changes as well as [assets](https://github.com/Automattic/wp-calypso/blob/d709f0e79ba29f2feb35690d275087179b18f632/packages/calypso-build/bin/copy-assets.js#L17-L25) changes.
+ Next running the following command should watch your changes
+`yarn workspace @automattic/plans-grid-next watch` 
+
+If not you can simply do 
+`yarn workspace @automattic/plans-grid-next copy-assets --watch` 
+
+
+
 `package.json` is linted using ESLint. Run `yarn eslint packages/*/package.json apps/*/package.json` to validate them.
 
 If you need exceptions to linting rules, add a `./eslintrc.js` file to your app/package and disable the relevant rules.

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -105,9 +105,12 @@ If your package requires compilation, the `package.json` `build` script should c
 - If it contains ES6+ code that needs to be transpiled, use `transpile` (from `@automattic/calypso-build`) which will automatically compile code in `src/` to `dist/cjs` (CommonJS) and `dist/esm` (ECMAScript Modules) by running `babel` over any source files it finds. Also, make sure to add `@automattic/calypso-build` in `devDependencies`.
 - If it contains [assets](https://github.com/Automattic/wp-calypso/blob/d709f0e79ba29f2feb35690d275087179b18f632/packages/calypso-build/bin/copy-assets.js#L17-L25) (eg `.scss`) then after `transpile` append `&& copy-assets` ie `"build": "transpile && copy-assets"`.
 
+`package.json` is linted using ESLint. Run `yarn eslint packages/*/package.json apps/*/package.json` to validate them.
+
+If you need exceptions to linting rules, add a `./eslintrc.js` file to your app/package and disable the relevant rules.
 
 #### Watching asset changes
-If you also need to watch asset changes in your package you can add the following lines, make sure to add `npm-run-all` to your devDependencies
+If you also need to watch asset changes in your packages (like scss files) you can add the following lines, make sure to add `npm-run-all` to your devDependencies
 ```	
 		"watch:tsc": "tsc --build ./tsconfig.json --watch",
 		"watch:assets": "copy-assets --watch",
@@ -120,11 +123,6 @@ This will concurrently watch for tsc changes as well as [assets](https://github.
 If not you can simply do 
 `yarn workspace @automattic/plans-grid-next copy-assets --watch` 
 
-
-
-`package.json` is linted using ESLint. Run `yarn eslint packages/*/package.json apps/*/package.json` to validate them.
-
-If you need exceptions to linting rules, add a `./eslintrc.js` file to your app/package and disable the relevant rules.
 
 ## Running Tests
 

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
 		"bunyan": "^1.8.15",
 		"chalk": "^4.1.2",
 		"check-node-version": "^4.0.2",
+		"chokidar": "^3.6.0",
 		"chroma-js": "^2.1.2",
 		"css-loader": "^6.10.0",
 		"doctrine": "^3.0.0",

--- a/packages/calypso-build/bin/copy-assets.js
+++ b/packages/calypso-build/bin/copy-assets.js
@@ -52,6 +52,13 @@ const copyAssets = ( args ) => () => {
 	}
 };
 
+const resolveShortPath = ( filePath ) => {
+	if ( filePath.includes( 'wp-calypso' ) ) {
+		return filePath.split( 'wp-calypso/' )[ 1 ];
+	}
+	return filePath;
+};
+
 const isWatched = process.argv.some( ( arg ) => arg.includes( '--watch' ) );
 const copyAssetsFn = copyAssets( process.argv );
 let debounceTimeout;
@@ -64,14 +71,18 @@ if ( ! isWatched ) {
 		ignored: [ `${ dir }/**/test/**`, outputDirESM, outputDirCJS ],
 		persistent: true,
 	} );
-	console.log( `Copy assets is watching for change in ${ dir }` );
-	console.log( 'Watching for changes in the following files:' );
-	watchedFiles.forEach( ( file ) => console.log( `${ file }` ) );
+	console.log(
+		`Copy assets is watching for changes in package ${ resolveShortPath(
+			dir
+		) } for the following file paths \n`
+	);
+	watchedFiles.forEach( ( file ) => console.log( `👀 ==> ${ resolveShortPath( file ) }` ) );
 	watcher.on( 'change', ( changedPath ) => {
 		clearTimeout( debounceTimeout );
 		debounceTimeout = setTimeout( () => {
-			const [ , shortPath ] = changedPath.split( 'wp-calypso/' );
-			console.log( `File ${ shortPath } has been changed, triggering copy assets` );
+			console.log(
+				`File ${ resolveShortPath( changedPath ) } has been changed, triggering copy assets`
+			);
 			copyAssetsFn();
 		}, 500 );
 	} );

--- a/packages/calypso-build/bin/copy-assets.js
+++ b/packages/calypso-build/bin/copy-assets.js
@@ -2,6 +2,8 @@
 
 // find all the packages
 const path = require( 'path' );
+// eslint-disable-next-line import/no-extraneous-dependencies
+const chokidar = require( 'chokidar' );
 const rcopy = require( 'recursive-copy' );
 
 const dir = process.cwd();
@@ -28,22 +30,49 @@ let copyAll = true;
 let copyESM = false;
 let copyCJS = false;
 
-for ( const arg of process.argv.slice( 2 ) ) {
-	if ( arg === '--esm' ) {
-		copyAll = false;
-		copyESM = true;
+const copyAssets = ( args ) => () => {
+	for ( const arg of args.slice( 2 ) ) {
+		if ( arg === '--esm' ) {
+			copyAll = false;
+			copyESM = true;
+		}
+
+		if ( arg === '--cjs' ) {
+			copyAll = false;
+			copyCJS = true;
+		}
 	}
 
-	if ( arg === '--cjs' ) {
-		copyAll = false;
-		copyCJS = true;
+	if ( copyAll || copyESM ) {
+		rcopy( inputDir, outputDirESM, copyOptions );
 	}
-}
 
-if ( copyAll || copyESM ) {
-	rcopy( inputDir, outputDirESM, copyOptions );
-}
+	if ( copyAll || copyCJS ) {
+		rcopy( inputDir, outputDirCJS, copyOptions );
+	}
+};
 
-if ( copyAll || copyCJS ) {
-	rcopy( inputDir, outputDirCJS, copyOptions );
+const isWatched = process.argv.some( ( arg ) => arg.includes( '--watch' ) );
+const copyAssetsFn = copyAssets( process.argv );
+let debounceTimeout;
+
+if ( ! isWatched ) {
+	copyAssetsFn();
+} else {
+	const watchedFiles = copyOptions.filter.slice( 0, 6 ).map( ( o ) => `${ dir }/${ o }` );
+	const watcher = chokidar.watch( watchedFiles, {
+		ignored: [ `${ dir }/**/test/**`, outputDirESM, outputDirCJS ],
+		persistent: true,
+	} );
+	console.log( `Copy assets is watching for change in ${ dir }` );
+	console.log( 'Watching for changes in the following files:' );
+	watchedFiles.forEach( ( file ) => console.log( `${ file }` ) );
+	watcher.on( 'change', ( changedPath ) => {
+		clearTimeout( debounceTimeout );
+		debounceTimeout = setTimeout( () => {
+			const [ , shortPath ] = changedPath.split( 'wp-calypso/' );
+			console.log( `File ${ shortPath } has been changed, triggering copy assets` );
+			copyAssetsFn();
+		}, 500 );
+	} );
 }

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -31,8 +31,10 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
-		"watch": "tsc --build ./tsconfig.json --watch",
-		"storybook": "sb dev"
+		"storybook": "sb dev",
+		"watch:tsc": "tsc --build ./tsconfig.json --watch",
+		"watch:assets": "copy-assets --watch",
+		"watch": "npm-run-all --parallel watch:tsc watch:assets"
 	},
 	"dependencies": {
 		"@automattic/calypso-products": "workspace:^",
@@ -71,6 +73,7 @@
 		"@testing-library/jest-dom": "^6.4.2",
 		"@testing-library/react": "^14.2.1",
 		"@testing-library/user-event": "^14.5.2",
+		"npm-run-all": "^4.1.5",
 		"resize-observer-polyfill": "^1.5.1",
 		"typescript": "^5.3.3",
 		"webpack": "^5.90.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,6 +1559,7 @@ __metadata:
     "@wordpress/warning": "npm:^2.54.0"
     classnames: "npm:^2.3.2"
     i18n-calypso: "workspace:^"
+    npm-run-all: "npm:^4.1.5"
     react-intersection-observer: "npm:^9.4.3"
     react-transition-group: "npm:^4.3.0"
     resize-observer-polyfill: "npm:^1.5.1"
@@ -12752,7 +12753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:>=3.0.0 <4.0.0, chokidar@npm:^3.3.0, chokidar@npm:^3.3.1, chokidar@npm:^3.4.0, chokidar@npm:^3.4.2, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
+"chokidar@npm:>=3.0.0 <4.0.0, chokidar@npm:^3.3.0, chokidar@npm:^3.3.1, chokidar@npm:^3.4.0, chokidar@npm:^3.4.2, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -32614,6 +32615,7 @@ __metadata:
     calypso-codemods: "workspace:^"
     chalk: "npm:^4.1.2"
     check-node-version: "npm:^4.0.2"
+    chokidar: "npm:^3.6.0"
     chroma-js: "npm:^2.1.2"
     cmdk: "npm:^0.2.0"
     config: "npm:^3.3.6"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds a watch mode option to the copy-assets script. Currently added only to the plans-grid-next package. The following text might not appear sometimes since typescript watchmode seems to hijack the entire terminal.
<img width="794" alt="Screenshot 2024-03-25 at 5 19 22 AM" src="https://github.com/Automattic/wp-calypso/assets/3422709/40a2cb8e-1466-4950-97a8-2891a57a3bcf">


## Testing Instructions

- Run a package watch command `yarn workspace @automattic/plans-grid-next watch`
- Run yarn start
- Make sure scss changes in package update the build

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?