### PR TITLE
Checkout: Fix Akismet license dropdown in v2 checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -551,6 +551,7 @@ export default function CheckoutMainContent( {
 								{ shouldUseCheckoutV2 && (
 									<WPCheckoutOrderReview
 										removeProductFromCart={ removeProductFromCart }
+										replaceProductInCart={ replaceProductInCart }
 										couponFieldStateProps={ couponFieldStateProps }
 										removeCouponAndClearField={ removeCouponAndClearField }
 										isCouponFieldVisible={ isCouponFieldVisible }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -123,7 +123,7 @@ export default function WPCheckoutOrderReview( {
 }: {
 	className?: string;
 	removeProductFromCart?: RemoveProductFromCart;
-	replaceProductInCart?: ReplaceProductInCart;
+	replaceProductInCart: ReplaceProductInCart;
 	couponFieldStateProps: CouponFieldStateProps;
 	onChangeSelection?: OnChangeItemVariant;
 	removeCouponAndClearField: RemoveCouponAndClearField;

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -82,7 +82,7 @@ export function WPOrderReviewLineItems( {
 	className?: string;
 	isSummary?: boolean;
 	removeProductFromCart?: RemoveProductFromCart;
-	replaceProductInCart?: ReplaceProductInCart;
+	replaceProductInCart: ReplaceProductInCart;
 	removeCoupon: RemoveCouponFromCart;
 	onChangeSelection?: OnChangeItemVariant;
 	createUserAndSiteBeforeTransaction?: boolean;
@@ -158,14 +158,13 @@ export function WPOrderReviewLineItems( {
 					new_quantity: newQuantity,
 				} )
 			);
-			replaceProductInCart &&
-				replaceProductInCart( uuid, {
-					product_slug: productSlug,
-					product_id: productId,
-					quantity: newQuantity,
-				} ).catch( () => {
-					// Nothing needs to be done here. CartMessages will display the error to the user.
-				} );
+			replaceProductInCart( uuid, {
+				product_slug: productSlug,
+				product_id: productId,
+				quantity: newQuantity,
+			} ).catch( () => {
+				// Nothing needs to be done here. CartMessages will display the error to the user.
+			} );
 		},
 		[ replaceProductInCart, reduxDispatch ]
 	);


### PR DESCRIPTION
## Proposed Changes

The sidebar in Checkout v2 was missing a prop to allow changing licenses for Akismet products. This PR adds that prop and makes it required to prevent future regressions.

<img width="472" alt="Screenshot 2024-03-19 at 6 49 42 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/1feb9b2a-2dc3-45ca-aaff-4ba5f35b449f">

The bug (for v2 checkout) was added in https://github.com/Automattic/wp-calypso/pull/84393 since it only added the prop to v1 checkout.

Fixes https://github.com/Automattic/wp-calypso/issues/88455

## Testing Instructions

- Go to https://akismet.com/pricing/ and click 'Get Pro'
- Edit the URL of checkout to add `checkoutVersion=2` to the query params.
- In the checkout, select any option in the dropdown under 'Number of licenses'.
- Verify that the cart is updated with the new license count.