### PR TITLE
Checkout: Hide site preview if DIFM in cart

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -9,7 +9,7 @@ import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
-import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
+import { hasDIFMProduct, hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -180,19 +180,24 @@ export default function WPCheckoutOrderReview( {
 		( state ) =>
 			getCurrentUser( state ) && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 	);
+	const isDIFMInCart = hasDIFMProduct( responseCart );
 
 	return (
 		<>
 			{ /*
 			 * Only show the site preview for WPCOM domains that have a site connected to the site id
 			 * */ }
-			{ shouldUseCheckoutV2 && selectedSiteData && wpcomDomain && ! isSignupCheckout && (
-				<div className="checkout-site-preview">
-					<SitePreviewWrapper>
-						<SitePreview showEditSite={ false } showSiteDetails={ false } />
-					</SitePreviewWrapper>
-				</div>
-			) }
+			{ shouldUseCheckoutV2 &&
+				selectedSiteData &&
+				wpcomDomain &&
+				! isSignupCheckout &&
+				! isDIFMInCart && (
+					<div className="checkout-site-preview">
+						<SitePreviewWrapper>
+							<SitePreview showEditSite={ false } showSiteDetails={ false } />
+						</SitePreviewWrapper>
+					</div>
+				) }
 			<div
 				className={ joinClasses( [
 					className,


### PR DESCRIPTION
Initially, we tried to hide the site preview for any cart that is either:

- for a 3rd party hosted site
- in signup flow
- a site with no site data found
- and DIFM sites

The last item is because DIFM sites are bought with the intent for us to discuss a site build with the customer, so showing a generic site preview is not ideal.

Related to p7DVsv-kcK-p2#comment-49576

## Proposed Changes

While the initial attempt to fix this was to hide the preview in the new site/signup flow, this didn't account for purchased DIFM sites where the customer accesses the cart from another flow outside of signup.

This check specifically hides the preview if the cart contains a DIFM product.

## Testing Instructions

* Start here [here](https://wordpress.com/start/do-it-for-me/new-or-existing-site)
* Follow the prompts and get to the checkout screen, see if preview shows (it should not)
* Remove ?signup=1 query parameter, ensure preview doesn't show
* Go to your WordPress.com home page, search for your DIFM test site, access the cart and ensure no preview is seen
