### PR TITLE
Checkout: Update v2 A/B test to only run on dotcom carts

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -1,5 +1,7 @@
 import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { useExperiment } from 'calypso/lib/explat';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { useSelector } from 'calypso/state';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
@@ -16,10 +18,11 @@ let cachedExperimentAssignment: 'treatment' | 'control' | undefined;
 
 export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {
 	const isCheckoutSection = useSelector( getSectionName ) === 'checkout';
+	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout();
 
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
 		'calypso_launch_checkout_v2',
-		{ isEligible: isCheckoutSection && ! hasCheckoutVersion( '2' ) }
+		{ isEligible: isCheckoutSection && isWPcomCheckout && ! hasCheckoutVersion( '2' ) }
 	);
 
 	if ( cachedExperimentAssignment ) {

--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -3,7 +3,9 @@ import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { useSelector } from 'calypso/state';
-import { getSectionName } from 'calypso/state/ui/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 
 // The `isLoadingExperimentAssignment` return value of useExperiment is not
 // stable across multiple calls; each instance runs its own `useEffect` which
@@ -17,12 +19,22 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 let cachedExperimentAssignment: 'treatment' | 'control' | undefined;
 
 export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {
-	const isCheckoutSection = useSelector( getSectionName ) === 'checkout';
-	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const isJetpackNotAtomic = useSelector(
+		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
+	);
+
+	const isWPcomCheckout =
+		useSelector( getSectionName ) === 'checkout' &&
+		! isJetpackCheckout() &&
+		! isAkismetCheckout() &&
+		! isJetpackNotAtomic;
 
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
 		'calypso_launch_checkout_v2',
-		{ isEligible: isCheckoutSection && isWPcomCheckout && ! hasCheckoutVersion( '2' ) }
+		{
+			isEligible: isWPcomCheckout && ! hasCheckoutVersion( '2' ),
+		}
 	);
 
 	if ( cachedExperimentAssignment ) {


### PR DESCRIPTION
The Checkout v2 A/B test will only run for carts with dotcom products, otherwise v1 will be shown for Jetpack and Akismet products.

Experiment 21646-explat-experiment

Related to #87812 

## Proposed Changes

* Load experiment only when the cart has dotcom products

## Testing Instructions

You can assign yourself to the treatment by following these steps: PCYsg-SwK-p2 (scroll down to 'Manually assign with Abacus assignment bookmarklet').

- Go to Checkout for a Dotcom product and ensure the v1 version looks correct - look for any style or functionality bleed
- Assign yourself to the treatment group according to the instructions in the link above
- Go to Checkout again and make sure the v2 styles and functionality match those found under the checkout v2 feature flag
- Test a number of products and use cases to ensure that styling remains the same between the feature flagged v2 and the non-flagged 'treatment' v2
- While still assigned to treatment, do the following:
-- Add a Jetpack product to your cart, ensure that v1 of checkout shows
-- Add an Akismet product to your cart, ensure that v1 of checkout shows
