### PR TITLE
Plugin Details: Show all sites on multi-site view

### DIFF
--- a/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
@@ -2,11 +2,9 @@ import { Dialog, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
-import {
-	getSiteObjectsWithPlugin,
-	getSiteObjectsWithoutPlugin,
-} from 'calypso/state/plugins/installed/selectors';
+import { getSiteObjectsWithPlugin } from 'calypso/state/plugins/installed/selectors';
 import { isFetching as isWporgPluginFetchingSelector } from 'calypso/state/plugins/wporg/selectors';
+import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import './style.scss';
 import PluginAvailableOnSitesList from '../plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list';
@@ -21,8 +19,10 @@ export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, plugin.slug )
 	);
-	const sitesWithoutPlugin = useSelector( ( state ) =>
-		getSiteObjectsWithoutPlugin( state, siteIds, plugin.slug )
+
+	const sites = useSelector( getSelectedOrAllSites );
+	const sitesWithoutPlugin = sites.filter(
+		( site ) => ! sitesWithPlugin.find( ( siteWithPlugin ) => siteWithPlugin.ID === site.ID )
 	);
 
 	const isLoading = useSelector( ( state ) => isWporgPluginFetchingSelector( state, plugin.slug ) );

--- a/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
@@ -21,6 +21,7 @@ export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 	);
 
 	const sites = useSelector( getSelectedOrAllSites );
+	sites.sort( orderByAtomic );
 	const sitesWithoutPlugin = sites.filter(
 		( site ) => ! sitesWithPlugin.find( ( siteWithPlugin ) => siteWithPlugin.ID === site.ID )
 	);
@@ -53,3 +54,18 @@ export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 		</Dialog>
 	);
 };
+
+function orderByAtomic( siteA, siteB ) {
+	const { is_wpcom_atomic: siteAAtomic } = siteA?.options ?? {};
+	const { is_wpcom_atomic: siteBAtomic } = siteB?.options ?? {};
+
+	if ( siteAAtomic === siteBAtomic ) {
+		return 0;
+	}
+
+	if ( siteAAtomic && ! siteBAtomic ) {
+		return -1;
+	}
+
+	return 1;
+}

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { WPCOM_FEATURES_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import React from 'react';
@@ -16,7 +17,10 @@ import { site, plugin, paidPlugin } from './utils/constants';
 
 const initialReduxState = {
 	siteConnection: { items: { [ site.ID ]: true } },
-	sites: { items: { [ site.ID ]: site } },
+	sites: {
+		items: { [ site.ID ]: site },
+		features: { [ site.ID ]: { data: { active: [ WPCOM_FEATURES_INSTALL_PLUGINS ] } } },
+	},
 	currentUser: {
 		capabilities: {},
 	},

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
@@ -43,9 +43,9 @@ const initialReduxState = {
 	},
 };
 
-const render = ( el ) =>
+const render = ( el, partialState ) =>
 	renderWithProvider( el, {
-		initialState: initialReduxState,
+		initialState: { ...initialReduxState, ...partialState },
 		reducers: { ui, plugins, documentHead, productsList, siteConnection, marketplace },
 		store: undefined,
 	} );
@@ -160,7 +160,12 @@ describe( '<PluginRowFormatter>', () => {
 
 	test( 'should render correctly and show install button', () => {
 		props.columnKey = 'install';
-		const { getAllByText } = render( <PluginRowFormatter { ...props } /> );
+		const { getAllByText } = render( <PluginRowFormatter { ...props } />, {
+			sites: {
+				items: { [ site.ID ]: { ...site, options: { ...site.options, is_wpcom_atomic: true } } },
+				features: initialReduxState.sites.features,
+			},
+		} );
 
 		const [ autoManagedSite ] = getAllByText( `Install` );
 		expect( autoManagedSite ).toBeInTheDocument();


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83536
Fixes https://github.com/Automattic/wp-calypso/issues/88730

## Proposed Changes

Show all sites on the Manage Sites option on the multi-site view. Now even non-atomic sites and sites with plan below than Creator will be shown:

* On cases where the user will not be able to install the plugin directly, the CTA will present the `Go to plugin page`  text. After this redirect, the user should be able to install the plugin as a normal single site installation.
* The atomic sites will be displayed before the non-atomic ones.

![CleanShot 2024-04-11 at 14 27 23@2x](https://github.com/Automattic/wp-calypso/assets/5039531/c501f048-7715-4bd2-aebe-0789615c8a70)


## Testing Instructions

**DotOrg Plugins**
* Go to the Plugin Details page for a free plugin without a specified site. Ex: `/plugins/mailpoet`
* Click on `Manage sites`
* Click on `Install` for Business already atomic sites, the installation should be completed.
* Click on `Go to plugin page` and you should be redirected to the plugin page with the site selected, the installation should be completed as well.


**Marketplace Plugins**
* Go to the Plugin Details page for a Marketplace plugin without a specified site. Ex: `/plugins/woocommerce-subscriptions
* Click on `Manage sites`
* Click on `Purchase and activate` and you should be redirected to the cart with the plugin
* Click on `Upgrade and activate` and you should be redirected to the cart with the plugin and the Business Plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?