### PR TITLE
Improve Jetpack error banner network state update

### DIFF
--- a/client/state/jetpack-connection-health/actions.js
+++ b/client/state/jetpack-connection-health/actions.js
@@ -80,11 +80,11 @@ export const requestJetpackConnectionHealthStatus = ( siteId ) => ( dispatch, ge
 			apiNamespace: 'wpcom/v2',
 		} )
 		.then( ( response ) => {
-			const { isHealthy, error } = response;
-			if ( isHealthy && reduxIsUnhealthy ) {
+			const { is_healthy, error } = response;
+			if ( is_healthy && reduxIsUnhealthy ) {
 				dispatch( setJetpackConnectionHealthy( siteId ) );
 			}
-			if ( ! isHealthy && ! reduxIsUnhealthy ) {
+			if ( ! is_healthy && ! reduxIsUnhealthy ) {
 				dispatch( setJetpackConnectionUnhealthy( siteId, error ) );
 			}
 		} )

--- a/client/state/jetpack-connection-health/selectors/should-request-jetpack-connection-health-status.js
+++ b/client/state/jetpack-connection-health/selectors/should-request-jetpack-connection-health-status.js
@@ -1,8 +1,10 @@
 import 'calypso/state/jetpack-connection-health/init';
 import getJetpackConnectionHealthLastRequestTime from 'calypso/state/jetpack-connection-health/selectors/get-jetpack-connection-health-last-request-time';
+import getJetpackConnectionHealth from './get-jetpack-connection-health';
 import isJetpackConnectionProblem from './is-jetpack-connection-problem';
 
 export const STALE_CONNECTION_HEALTH_THRESHOLD = 1000 * 60 * 5; // 5 minutes
+export const STALE_CONNECTION_HEALTH_THRESHOLD_SHORT = 1000 * 60 * 2; // 2 minutes
 
 /**
  * Returns true if the current site Jetpack site connection health status should be requested
@@ -16,8 +18,12 @@ export const STALE_CONNECTION_HEALTH_THRESHOLD = 1000 * 60 * 5; // 5 minutes
  */
 export const shouldRequestJetpackConnectionHealthStatus = ( state, siteId ) => {
 	const lastRequestTime = getJetpackConnectionHealthLastRequestTime( state, siteId );
+	const connectionHealth = getJetpackConnectionHealth( state, siteId );
+	const threshold = connectionHealth?.error
+		? STALE_CONNECTION_HEALTH_THRESHOLD_SHORT
+		: STALE_CONNECTION_HEALTH_THRESHOLD;
 	return (
-		( ! lastRequestTime || Date.now() - lastRequestTime > STALE_CONNECTION_HEALTH_THRESHOLD ) &&
+		( ! lastRequestTime || Date.now() - lastRequestTime > threshold ) &&
 		isJetpackConnectionProblem( state, siteId )
 	);
 };

--- a/client/state/jetpack-connection-health/test/actions.js
+++ b/client/state/jetpack-connection-health/test/actions.js
@@ -79,7 +79,7 @@ describe( 'action', () => {
 				},
 			} );
 			mockFetchHealthStatus( siteId ).reply( 200, {
-				isHealthy: true,
+				is_healthy: true,
 			} );
 			await requestJetpackConnectionHealthStatus( siteId )( dispatchSpy, stateSpy );
 			expect( dispatchSpy ).toHaveBeenNthCalledWith( 1, {
@@ -106,7 +106,7 @@ describe( 'action', () => {
 				},
 			} );
 			mockFetchHealthStatus( siteId ).reply( 200, {
-				isHealthy: false,
+				is_healthy: false,
 				error: 'foo_bar',
 			} );
 			await requestJetpackConnectionHealthStatus( siteId )( dispatchSpy, stateSpy );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/jetpack/issues/36171

## Proposed Changes

* Fix bug reading data from `/jetpack-connection-health` endpoint.
* Reduce delay time to 2 mins when the Jetpack connection is broken.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an atomic site edit `wp-config.php` and introduce a typo to break the php code. For example `a` at the end of the file.
* Access Calypso live or this branch locally on `/home/${siteId}`
* Observe a request to `https://public-api.wordpress.com/wpcom/v2/sites/${siteId}/jetpack-connection-health`
* The response should be an error.
```
{
    "body": {
        "is_healthy": false,
        "error": "fatal_error"
    },
    "status": 200,
    "headers": {
        "Allow": "GET"
    }
}
```
* Observe the error banner appears with the following text: `Jetpack can’t communicate with your site due to a critical error on the site.`
* Optional: Explore the redux state in your console: ```state.jetpackConnectionHealth[`${siteId}`]```
* Fix the typo introduced on `wp-config.php`
* Wait 5 minutes or update [this line to wait less time](https://github.com/Automattic/wp-calypso/blob/c511441329b3f3170b7fed912fad900bbfb6a4b0/client/state/jetpack-connection-health/selectors/should-request-jetpack-connection-health-status.js#L5).
* In your open tab `/home/${siteId}`, click on home in the sidebar, or refresh the page.
* Observe a request to `https://public-api.wordpress.com/wpcom/v2/sites/${siteId}/jetpack-connection-health`
* The response should be a success:
```
{"body":{"is_healthy":true,"error":null},"status":200,"headers":{"Allow":"GET"}}
```
* Observe the banner has disappeared.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?