### PR TITLE
Tighten padding on the /sites table

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -3,8 +3,8 @@ import { HelpCenter } from '@automattic/data-stores';
 import { shouldLoadInlineHelp } from '@automattic/help-center';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import WhatsNewGuide, { useWhatsNewAnnouncementsQuery } from '@automattic/whats-new';
-import { useDispatch, useSelect } from '@wordpress/data';
+import WhatsNewGuide, { useShouldShowCriticalAnnouncementsQuery } from '@automattic/whats-new';
+import { useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { Component, useCallback, useEffect, useState } from 'react';
@@ -100,40 +100,15 @@ function SidebarScrollSynchronizer() {
 }
 
 function WhatsNewLoader( { loadWhatsNew, siteId } ) {
-	const { fetchSeenWhatsNewAnnouncements } = useDispatch( HELP_CENTER_STORE );
+	const { data: shouldShowCriticalAnnouncements, isLoading } =
+		useShouldShowCriticalAnnouncementsQuery( siteId );
 	const [ showWhatsNew, setShowWhatsNew ] = useState( false );
 
-	const { data, isLoading } = useWhatsNewAnnouncementsQuery( siteId );
-
 	useEffect( () => {
-		fetchSeenWhatsNewAnnouncements();
-	}, [ fetchSeenWhatsNewAnnouncements ] );
-
-	const { seenWhatsNewAnnouncements } = useSelect( ( select ) => {
-		const helpCenterSelect = select( HELP_CENTER_STORE );
-		return {
-			seenWhatsNewAnnouncements: helpCenterSelect.getSeenWhatsNewAnnouncements(),
-		};
-	}, [] );
-
-	useEffect( () => {
-		if (
-			data &&
-			data.length > 0 &&
-			! isLoading &&
-			seenWhatsNewAnnouncements &&
-			typeof seenWhatsNewAnnouncements.indexOf === 'function'
-		) {
-			if ( config.isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-				data.forEach( ( item ) => {
-					if ( item.critical && -1 === seenWhatsNewAnnouncements.indexOf( item.announcementId ) ) {
-						setShowWhatsNew( true );
-						return;
-					}
-				} );
-			}
+		if ( ! isLoading && shouldShowCriticalAnnouncements ) {
+			setShowWhatsNew( true );
 		}
-	}, [ data, isLoading, seenWhatsNewAnnouncements, setShowWhatsNew ] );
+	}, [ shouldShowCriticalAnnouncements, isLoading ] );
 
 	const handleClose = useCallback( () => {
 		setShowWhatsNew( false );

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -47,7 +47,7 @@ const Row = styled.tr`
 const Column = styled.td< { tabletHidden?: boolean } >`
 	padding-block-start: 12px;
 	padding-block-end: 12px;
-	padding-inline-end: 24px;
+	padding-inline-end: 12px;
 	vertical-align: middle;
 	font-size: 14px;
 	line-height: 20px;

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -63,7 +63,7 @@ const SiteTh = styled.th( {
 } );
 
 const StatusTh = styled.th( {
-	width: '124px',
+	width: '140px',
 } );
 
 const StatsTh = styled.th( {

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -62,10 +62,8 @@ const SiteTh = styled.th( {
 	},
 } );
 
-const PlanTh = styled.th( {
-	[ MEDIA_QUERIES.wide ]: {
-		width: '15%',
-	},
+const StatusTh = styled.th( {
+	width: '124px',
 } );
 
 const StatsTh = styled.th( {
@@ -148,8 +146,8 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 			>
 				<Row>
 					<SiteTh>{ __( 'Site' ) }</SiteTh>
-					<PlanTh>{ __( 'Plan' ) }</PlanTh>
-					<th>{ __( 'Status' ) }</th>
+					<th>{ __( 'Plan' ) }</th>
+					<StatusTh>{ __( 'Status' ) }</StatusTh>
 					<th>{ __( 'Last Publish' ) }</th>
 					<StatsTh>
 						<StatsThInner>

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -11,31 +11,6 @@ export const receiveHasSeenWhatsNewModal = ( value: boolean | undefined ) =>
 		value,
 	} ) as const;
 
-export const receiveSeenWhatsNewAnnouncements = ( value: string[] | undefined ) =>
-	( {
-		type: 'HELP_CENTER_SET_SEEN_WHATS_NEW_ANNOUNCEMENTS',
-		value,
-	} ) as const;
-
-export function* fetchSeenWhatsNewAnnouncements() {
-	let response: {
-		seen_announcement_ids: string[];
-	};
-	if ( canAccessWpcomApis() ) {
-		response = yield wpcomRequest( {
-			path: `/whats-new/seen-announcement-ids`,
-			apiNamespace: 'wpcom/v2',
-		} );
-	} else {
-		response = yield apiFetch( {
-			global: true,
-			path: `/wpcom/v2/whats-new/seen-announcement-ids`,
-		} as APIFetchOptions );
-	}
-
-	return receiveSeenWhatsNewAnnouncements( response.seen_announcement_ids );
-}
-
 export function* setHasSeenWhatsNewModal( value: boolean ) {
 	let response: {
 		has_seen_whats_new_modal: boolean;
@@ -59,31 +34,6 @@ export function* setHasSeenWhatsNewModal( value: boolean ) {
 	}
 
 	return receiveHasSeenWhatsNewModal( response.has_seen_whats_new_modal );
-}
-
-export function* setSeenWhatsNewAnnouncements( ids: string[] ) {
-	let response: {
-		seen_announcement_ids: string[];
-	};
-	if ( canAccessWpcomApis() ) {
-		response = yield wpcomRequest( {
-			path: `/whats-new/seen-announcement-ids`,
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			body: {
-				seen_announcement_ids: ids,
-			},
-		} );
-	} else {
-		response = yield apiFetch( {
-			global: true,
-			path: `/wpcom/v2/whats-new/seen-announcement-ids`,
-			method: 'POST',
-			data: { seen_announcement_ids: ids },
-		} as APIFetchOptions );
-	}
-
-	return receiveSeenWhatsNewAnnouncements( response.seen_announcement_ids );
 }
 
 export const setSite = ( site: HelpCenterSite | undefined ) =>
@@ -198,7 +148,6 @@ export type HelpCenterAction =
 			| typeof setSubject
 			| typeof resetStore
 			| typeof receiveHasSeenWhatsNewModal
-			| typeof receiveSeenWhatsNewAnnouncements
 			| typeof setMessage
 			| typeof setUserDeclaredSite
 			| typeof setUserDeclaredSiteUrl
@@ -206,9 +155,4 @@ export type HelpCenterAction =
 			| typeof setIsMinimized
 			| typeof setInitialRoute
 	  >
-	| GeneratorReturnType<
-			| typeof setShowHelpCenter
-			| typeof setHasSeenWhatsNewModal
-			| typeof setSeenWhatsNewAnnouncements
-			| typeof fetchSeenWhatsNewAnnouncements
-	  >;
+	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -42,17 +42,6 @@ const hasSeenWhatsNewModal: Reducer< boolean | undefined, HelpCenterAction > = (
 	return state;
 };
 
-const seenWhatsNewAnnouncements: Reducer< string[] | undefined, HelpCenterAction > = (
-	state,
-	action
-) => {
-	switch ( action.type ) {
-		case 'HELP_CENTER_SET_SEEN_WHATS_NEW_ANNOUNCEMENTS':
-			return action.value;
-	}
-	return state;
-};
-
 const isMinimized: Reducer< boolean, HelpCenterAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'HELP_CENTER_SET_MINIMIZED':
@@ -135,7 +124,6 @@ const reducer = combineReducers( {
 	userDeclaredSite,
 	userDeclaredSiteUrl,
 	hasSeenWhatsNewModal,
-	seenWhatsNewAnnouncements,
 	isMinimized,
 	unreadCount,
 	initialRoute,

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -11,5 +11,4 @@ export const getUserDeclaredSite = ( state: State ) => state.userDeclaredSite;
 export const getUnreadCount = ( state: State ) => state.unreadCount;
 export const getIsMinimized = ( state: State ) => state.isMinimized;
 export const getHasSeenWhatsNewModal = ( state: State ) => state.hasSeenWhatsNewModal;
-export const getSeenWhatsNewAnnouncements = ( state: State ) => state.seenWhatsNewAnnouncements;
 export const getInitialRoute = ( state: State ) => state.initialRoute;

--- a/packages/whats-new/src/hooks/use-seen-whats-new-announcements-mutation.ts
+++ b/packages/whats-new/src/hooks/use-seen-whats-new-announcements-mutation.ts
@@ -1,0 +1,55 @@
+/* eslint-disable no-restricted-imports */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { SEEN_WHATS_NEW_ANNOUCNEMENT_IDS } from './use-seen-whats-new-announcements-query';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+/**
+ * Saves the list of "Whats New" announcements that the user has seen
+ * @returns A react-query mutation to save to the "whats-new/seen-announcement-ids" endpoint
+ */
+export const useSeenWhatsNewAnnouncementsMutation = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: async ( seenAnnouncenmentIds: string[] ) => {
+			return canAccessWpcomApis()
+				? await wpcomRequest( {
+						path: `/whats-new/seen-announcement-ids-1`,
+						apiNamespace: 'wpcom/v2',
+						method: 'POST',
+						body: {
+							seen_announcement_ids: seenAnnouncenmentIds,
+						},
+				  } )
+				: await apiFetch( {
+						global: true,
+						path: `/wpcom/v2/whats-new/seen-announcement-ids-1`,
+						method: 'POST',
+						data: { seen_announcement_ids: seenAnnouncenmentIds },
+				  } as APIFetchOptions );
+		},
+		onMutate: async ( seenAnnouncenmentIds: string[] ) => {
+			await queryClient.cancelQueries( { queryKey: [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ] } );
+
+			queryClient.setQueryData( [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ], seenAnnouncenmentIds );
+
+			const previousData = queryClient.getQueryData< string[] >( [
+				SEEN_WHATS_NEW_ANNOUCNEMENT_IDS,
+			] );
+
+			return { previousData };
+		},
+		onError: ( error, variables, context ) => {
+			queryClient.setQueryData( [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ], context?.previousData );
+		},
+		onSettled: async () => {
+			await queryClient.invalidateQueries( { queryKey: [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ] } );
+		},
+	} );
+};

--- a/packages/whats-new/src/hooks/use-seen-whats-new-announcements-query.ts
+++ b/packages/whats-new/src/hooks/use-seen-whats-new-announcements-query.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-restricted-imports */
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+interface SeenAnnouncementIDsResponse {
+	seen_announcement_ids: string[];
+}
+
+export const SEEN_WHATS_NEW_ANNOUCNEMENT_IDS = 'SEEN_WHATS_NEW_ANNOUCNEMENT_IDS';
+
+/**
+ * Get a list of the "Whats New" announcements that the user has seen
+ * @returns Returns the result of querying the "whats-new/seen-announcement-ids" endpoint
+ */
+export const useSeenWhatsNewAnnouncementsQuery = () => {
+	return useQuery< SeenAnnouncementIDsResponse, Error, string[] >( {
+		queryKey: [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ],
+		queryFn: async () =>
+			canAccessWpcomApis()
+				? await wpcomRequest( {
+						path: `/whats-new/seen-announcement-ids`,
+						apiNamespace: 'wpcom/v2',
+				  } )
+				: await apiFetch( {
+						global: true,
+						path: `/wpcom/v2/whats-new/seen-announcement-ids`,
+				  } as APIFetchOptions ),
+		refetchOnWindowFocus: false,
+		select: ( data ) => data.seen_announcement_ids,
+	} );
+};

--- a/packages/whats-new/src/hooks/use-should-show-critical-announcements-query.ts
+++ b/packages/whats-new/src/hooks/use-should-show-critical-announcements-query.ts
@@ -1,0 +1,42 @@
+import { useSeenWhatsNewAnnouncementsQuery } from './use-seen-whats-new-announcements-query';
+import { useWhatsNewAnnouncementsQuery } from './use-whats-new-announcements-query';
+
+/**
+ * Queries the "whats new" announcements and the seen announcements to determine if there are any critical announcements that should be shown
+ * @param siteId Id of the site to query
+ * @returns Whether the critical announcements should be shown
+ */
+export const useShouldShowCriticalAnnouncementsQuery = ( siteId: string ) => {
+	const { data: whatsNewList, isLoading: isLoadingList } = useWhatsNewAnnouncementsQuery( siteId );
+	const { data: seenWhatsNewAnnouncements, isLoading: isLoadingSeen } =
+		useSeenWhatsNewAnnouncementsQuery();
+
+	if ( isLoadingList || isLoadingSeen ) {
+		return {
+			isLoading: true,
+		};
+	}
+
+	if (
+		whatsNewList &&
+		whatsNewList.length > 0 &&
+		seenWhatsNewAnnouncements &&
+		typeof seenWhatsNewAnnouncements.indexOf === 'function'
+	) {
+		for ( let i = 0; i < whatsNewList.length; i++ ) {
+			if (
+				whatsNewList[ i ].critical &&
+				-1 === seenWhatsNewAnnouncements.indexOf( whatsNewList[ i ].announcementId )
+			) {
+				return {
+					isLoading: false,
+					data: true,
+				};
+			}
+		}
+	}
+	return {
+		isLoading: false,
+		data: false,
+	};
+};

--- a/packages/whats-new/src/index.tsx
+++ b/packages/whats-new/src/index.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-imports */
 import { HelpCenter } from '@automattic/data-stores';
-import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import Guide from './components/guide';
+import { useSeenWhatsNewAnnouncementsMutation } from './hooks/use-seen-whats-new-announcements-mutation';
 import { useWhatsNewAnnouncementsQuery } from './hooks/use-whats-new-announcements-query';
 import WhatsNewPage from './whats-new-page';
 import './style.scss';
@@ -12,6 +12,7 @@ export {
 	useWhatsNewAnnouncementsQuery,
 	type WhatsNewAnnouncement,
 } from './hooks/use-whats-new-announcements-query';
+export { useShouldShowCriticalAnnouncementsQuery } from './hooks/use-should-show-critical-announcements-query';
 
 interface Props {
 	onClose: () => void;
@@ -19,16 +20,16 @@ interface Props {
 }
 
 const WhatsNewGuide: React.FC< Props > = ( { onClose, siteId } ) => {
-	const { setSeenWhatsNewAnnouncements } = useDispatch( HELP_CENTER_STORE );
 	const { data, isLoading } = useWhatsNewAnnouncementsQuery( siteId );
 
+	const { mutate } = useSeenWhatsNewAnnouncementsMutation();
 	useEffect( () => {
 		// check for whether the announcement has been seen already.
 		if ( data && data.length ) {
 			const announcementIds = data.map( ( item ) => item.announcementId );
-			setSeenWhatsNewAnnouncements( announcementIds );
+			mutate( announcementIds );
 		}
-	}, [ data, setSeenWhatsNewAnnouncements ] );
+	}, [ data, mutate ] );
 
 	if ( ! data || isLoading ) {
 		return null;


### PR DESCRIPTION
Reaction to this suggestion, also improves the table in general https://github.com/Automattic/wp-calypso/pull/88503#issuecomment-2007273432

**before**:
<img width="983" alt="Screenshot 2024-03-20 at 1 27 57 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/4210a75f-fd2e-42a3-9520-36a7eb2b6e10">

**after**:
<img width="988" alt="Screenshot 2024-03-20 at 1 28 42 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/71ff9084-646c-4477-bb8c-e1dae8b427f3">

### Testing instructions

/sites page on medium width screens. As far as I can tell, a macbook air 14' is 1280px wide for example.

