### PR TITLE
Stats: Release UTM metrics module

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -39,10 +39,7 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getJetpackStatsAdminVersion, isJetpackSite } from 'calypso/state/sites/selectors';
-import {
-	getEnvStatsFeatureSupportChecks,
-	useIsJetpackSite,
-} from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { requestModuleSettings } from 'calypso/state/stats/module-settings/actions';
 import { getModuleSettings } from 'calypso/state/stats/module-settings/selectors';
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
@@ -744,8 +741,7 @@ export default connect(
 
 		const { supportsPlanUsage, supportsEmailStats, supportsUTMStats } =
 			getEnvStatsFeatureSupportChecks( state, siteId );
-		const isUTMModuleEnabled =
-			config.isEnabled( 'stats/utm-module' ) && supportsUTMStats && useIsJetpackSite( siteId );
+		const isUTMModuleEnabled = config.isEnabled( 'stats/utm-module' ) && supportsUTMStats;
 
 		return {
 			canUserViewStats,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -39,7 +39,10 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getJetpackStatsAdminVersion, isJetpackSite } from 'calypso/state/sites/selectors';
-import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import {
+	getEnvStatsFeatureSupportChecks,
+	useIsJetpackSite,
+} from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { requestModuleSettings } from 'calypso/state/stats/module-settings/actions';
 import { getModuleSettings } from 'calypso/state/stats/module-settings/selectors';
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
@@ -741,7 +744,8 @@ export default connect(
 
 		const { supportsPlanUsage, supportsEmailStats, supportsUTMStats } =
 			getEnvStatsFeatureSupportChecks( state, siteId );
-		const isUTMModuleEnabled = config.isEnabled( 'stats/utm-module' ) && supportsUTMStats;
+		const isUTMModuleEnabled =
+			config.isEnabled( 'stats/utm-module' ) && supportsUTMStats && useIsJetpackSite( siteId );
 
 		return {
 			canUserViewStats,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -209,6 +209,7 @@ class StatsSite extends Component {
 			moduleSettings,
 			supportsPlanUsage,
 			supportsEmailStats,
+			isUTMModuleEnabled,
 		} = this.props;
 
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -427,7 +428,7 @@ class StatsSite extends Component {
 							className={ classNames( 'stats__flexible-grid-item--full' ) }
 						/>
 
-						{ config.isEnabled( 'stats/utm-module' ) && (
+						{ isUTMModuleEnabled && (
 							<>
 								<StatsModuleUTM
 									siteId={ siteId }
@@ -478,16 +479,13 @@ class StatsSite extends Component {
 								statType="statsTopAuthors"
 								className={ classNames(
 									{
-										'stats__author-views': ! config.isEnabled( 'stats/utm-module' ),
-										'stats__flexible-grid-item--one-third--two-spaces':
-											! config.isEnabled( 'stats/utm-module' ),
-										'stats__flexible-grid-item--half--large':
-											! config.isEnabled( 'stats/utm-module' ),
+										'stats__author-views': ! isUTMModuleEnabled,
+										'stats__flexible-grid-item--one-third--two-spaces': ! isUTMModuleEnabled,
+										'stats__flexible-grid-item--half--large': ! isUTMModuleEnabled,
 									},
 									{
-										'stats__flexible-grid-item--half': config.isEnabled( 'stats/utm-module' ),
-										'stats__flexible-grid-item--half--large':
-											config.isEnabled( 'stats/utm-module' ),
+										'stats__flexible-grid-item--half': isUTMModuleEnabled,
+										'stats__flexible-grid-item--half--large': isUTMModuleEnabled,
 									},
 									'stats__flexible-grid-item--full--medium'
 								) }
@@ -505,22 +503,21 @@ class StatsSite extends Component {
 							className={ classNames(
 								{
 									'stats__flexible-grid-item--one-third--two-spaces':
-										! this.isModuleHidden( 'authors' ) && ! config.isEnabled( 'stats/utm-module' ),
+										! this.isModuleHidden( 'authors' ) && ! isUTMModuleEnabled,
 									'stats__flexible-grid-item--half--large':
-										! this.isModuleHidden( 'authors' ) && ! config.isEnabled( 'stats/utm-module' ),
+										! this.isModuleHidden( 'authors' ) && ! isUTMModuleEnabled,
 									'stats__flexible-grid-item--half':
-										this.isModuleHidden( 'authors' ) && ! config.isEnabled( 'stats/utm-module' ),
+										this.isModuleHidden( 'authors' ) && ! isUTMModuleEnabled,
 								},
 								{
-									'stats__flexible-grid-item--one-third--two-spaces':
-										config.isEnabled( 'stats/utm-module' ),
-									'stats__flexible-grid-item--half--large': config.isEnabled( 'stats/utm-module' ),
+									'stats__flexible-grid-item--one-third--two-spaces': isUTMModuleEnabled,
+									'stats__flexible-grid-item--half--large': isUTMModuleEnabled,
 								},
 								'stats__flexible-grid-item--full--medium'
 							) }
 						/>
 
-						{ ! config.isEnabled( 'stats/utm-module' ) && (
+						{ ! isUTMModuleEnabled && (
 							<StatsModule
 								path="clicks"
 								moduleStrings={ moduleStrings.clicks }
@@ -549,19 +546,17 @@ class StatsSite extends Component {
 								showSummaryLink
 								className={ classNames(
 									{
-										'stats__flexible-grid-item--half': ! config.isEnabled( 'stats/utm-module' ),
+										'stats__flexible-grid-item--half': ! isUTMModuleEnabled,
 									},
 									{
-										'stats__flexible-grid-item--one-third--two-spaces':
-											config.isEnabled( 'stats/utm-module' ),
-										'stats__flexible-grid-item--half--large':
-											config.isEnabled( 'stats/utm-module' ),
+										'stats__flexible-grid-item--one-third--two-spaces': isUTMModuleEnabled,
+										'stats__flexible-grid-item--half--large': isUTMModuleEnabled,
 									},
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>
 						) }
-						{ supportsEmailStats && ! config.isEnabled( 'stats/utm-module' ) && (
+						{ supportsEmailStats && ! isUTMModuleEnabled && (
 							<StatsModuleEmails
 								period={ this.props.period }
 								query={ query }
@@ -590,15 +585,12 @@ class StatsSite extends Component {
 									useShortLabel={ true }
 									className={ classNames(
 										{
-											'stats__flexible-grid-item--half': ! config.isEnabled( 'stats/utm-module' ),
-											'stats__flexible-grid-item--full--large':
-												! config.isEnabled( 'stats/utm-module' ),
+											'stats__flexible-grid-item--half': ! isUTMModuleEnabled,
+											'stats__flexible-grid-item--full--large': ! isUTMModuleEnabled,
 										},
 										{
-											'stats__flexible-grid-item--one-third--two-spaces':
-												config.isEnabled( 'stats/utm-module' ),
-											'stats__flexible-grid-item--half--large':
-												config.isEnabled( 'stats/utm-module' ),
+											'stats__flexible-grid-item--one-third--two-spaces': isUTMModuleEnabled,
+											'stats__flexible-grid-item--half--large': isUTMModuleEnabled,
 										},
 										'stats__flexible-grid-item--full--medium'
 									) }
@@ -746,10 +738,10 @@ export default connect(
 		const slug = getSelectedSiteSlug( state );
 		const upsellModalView =
 			config.isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId );
-		const { supportsPlanUsage, supportsEmailStats } = getEnvStatsFeatureSupportChecks(
-			state,
-			siteId
-		);
+
+		const { supportsPlanUsage, supportsEmailStats, supportsUTMStats } =
+			getEnvStatsFeatureSupportChecks( state, siteId );
+		const isUTMModuleEnabled = config.isEnabled( 'stats/utm-module' ) && supportsUTMStats;
 
 		return {
 			canUserViewStats,
@@ -767,6 +759,7 @@ export default connect(
 			statsAdminVersion,
 			supportsEmailStats,
 			supportsPlanUsage,
+			isUTMModuleEnabled,
 		};
 	},
 	{

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -209,7 +209,7 @@ class StatsSite extends Component {
 			moduleSettings,
 			supportsPlanUsage,
 			supportsEmailStats,
-			isUTMModuleEnabled,
+			supportsUTMStats,
 		} = this.props;
 
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -428,7 +428,7 @@ class StatsSite extends Component {
 							className={ classNames( 'stats__flexible-grid-item--full' ) }
 						/>
 
-						{ isUTMModuleEnabled && (
+						{ supportsUTMStats && (
 							<>
 								<StatsModuleUTM
 									siteId={ siteId }
@@ -479,13 +479,13 @@ class StatsSite extends Component {
 								statType="statsTopAuthors"
 								className={ classNames(
 									{
-										'stats__author-views': ! isUTMModuleEnabled,
-										'stats__flexible-grid-item--one-third--two-spaces': ! isUTMModuleEnabled,
-										'stats__flexible-grid-item--half--large': ! isUTMModuleEnabled,
+										'stats__author-views': ! supportsUTMStats,
+										'stats__flexible-grid-item--one-third--two-spaces': ! supportsUTMStats,
+										'stats__flexible-grid-item--half--large': ! supportsUTMStats,
 									},
 									{
-										'stats__flexible-grid-item--half': isUTMModuleEnabled,
-										'stats__flexible-grid-item--half--large': isUTMModuleEnabled,
+										'stats__flexible-grid-item--half': supportsUTMStats,
+										'stats__flexible-grid-item--half--large': supportsUTMStats,
 									},
 									'stats__flexible-grid-item--full--medium'
 								) }
@@ -503,21 +503,21 @@ class StatsSite extends Component {
 							className={ classNames(
 								{
 									'stats__flexible-grid-item--one-third--two-spaces':
-										! this.isModuleHidden( 'authors' ) && ! isUTMModuleEnabled,
+										! this.isModuleHidden( 'authors' ) && ! supportsUTMStats,
 									'stats__flexible-grid-item--half--large':
-										! this.isModuleHidden( 'authors' ) && ! isUTMModuleEnabled,
+										! this.isModuleHidden( 'authors' ) && ! supportsUTMStats,
 									'stats__flexible-grid-item--half':
-										this.isModuleHidden( 'authors' ) && ! isUTMModuleEnabled,
+										this.isModuleHidden( 'authors' ) && ! supportsUTMStats,
 								},
 								{
-									'stats__flexible-grid-item--one-third--two-spaces': isUTMModuleEnabled,
-									'stats__flexible-grid-item--half--large': isUTMModuleEnabled,
+									'stats__flexible-grid-item--one-third--two-spaces': supportsUTMStats,
+									'stats__flexible-grid-item--half--large': supportsUTMStats,
 								},
 								'stats__flexible-grid-item--full--medium'
 							) }
 						/>
 
-						{ ! isUTMModuleEnabled && (
+						{ ! supportsUTMStats && (
 							<StatsModule
 								path="clicks"
 								moduleStrings={ moduleStrings.clicks }
@@ -546,17 +546,17 @@ class StatsSite extends Component {
 								showSummaryLink
 								className={ classNames(
 									{
-										'stats__flexible-grid-item--half': ! isUTMModuleEnabled,
+										'stats__flexible-grid-item--half': ! supportsUTMStats,
 									},
 									{
-										'stats__flexible-grid-item--one-third--two-spaces': isUTMModuleEnabled,
-										'stats__flexible-grid-item--half--large': isUTMModuleEnabled,
+										'stats__flexible-grid-item--one-third--two-spaces': supportsUTMStats,
+										'stats__flexible-grid-item--half--large': supportsUTMStats,
 									},
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>
 						) }
-						{ supportsEmailStats && ! isUTMModuleEnabled && (
+						{ supportsEmailStats && ! supportsUTMStats && (
 							<StatsModuleEmails
 								period={ this.props.period }
 								query={ query }
@@ -585,12 +585,12 @@ class StatsSite extends Component {
 									useShortLabel={ true }
 									className={ classNames(
 										{
-											'stats__flexible-grid-item--half': ! isUTMModuleEnabled,
-											'stats__flexible-grid-item--full--large': ! isUTMModuleEnabled,
+											'stats__flexible-grid-item--half': ! supportsUTMStats,
+											'stats__flexible-grid-item--full--large': ! supportsUTMStats,
 										},
 										{
-											'stats__flexible-grid-item--one-third--two-spaces': isUTMModuleEnabled,
-											'stats__flexible-grid-item--half--large': isUTMModuleEnabled,
+											'stats__flexible-grid-item--one-third--two-spaces': supportsUTMStats,
+											'stats__flexible-grid-item--half--large': supportsUTMStats,
 										},
 										'stats__flexible-grid-item--full--medium'
 									) }
@@ -741,7 +741,6 @@ export default connect(
 
 		const { supportsPlanUsage, supportsEmailStats, supportsUTMStats } =
 			getEnvStatsFeatureSupportChecks( state, siteId );
-		const isUTMModuleEnabled = config.isEnabled( 'stats/utm-module' ) && supportsUTMStats;
 
 		return {
 			canUserViewStats,
@@ -759,7 +758,7 @@ export default connect(
 			statsAdminVersion,
 			supportsEmailStats,
 			supportsPlanUsage,
-			isUTMModuleEnabled,
+			supportsUTMStats,
 		};
 	},
 	{

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -18,6 +18,7 @@ import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getSitePost, getPostPreviewUrl } from 'calypso/state/posts/selectors';
 import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'calypso/state/sites/selectors';
+import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostDetailHighlightsSection from '../post-detail-highlights-section';
@@ -152,6 +153,7 @@ class StatsPostDetail extends Component {
 			siteSlug,
 			showViewLink,
 			previewUrl,
+			isUTMModuleEnabled,
 		} = this.props;
 
 		const isLoading = isRequestingStats && ! countViews;
@@ -214,7 +216,7 @@ class StatsPostDetail extends Component {
 						</>
 					) }
 
-					{ config.isEnabled( 'stats/utm-module' ) && (
+					{ isUTMModuleEnabled && (
 						<div className="stats-module-utm__post-detail">
 							<StatsModuleUTM siteId={ siteId } postId={ postId } query={ { num: -1, max: 0 } } />
 						</div>
@@ -243,6 +245,9 @@ const connectComponent = connect( ( state, { postId } ) => {
 	const isPreviewable = isSitePreviewable( state, siteId );
 	const isPostHomepage = postId === 0;
 
+	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
+	const isUTMModuleEnabled = config.isEnabled( 'stats/utm-module' ) && supportsUTMStats;
+
 	return {
 		post: getSitePost( state, siteId, postId ),
 		// NOTE: Post object from the stats response does not conform to the data structure returned by getSitePost!
@@ -254,6 +259,7 @@ const connectComponent = connect( ( state, { postId } ) => {
 		showViewLink: ! isJetpack && ! isPostHomepage && isPreviewable,
 		previewUrl: getPostPreviewUrl( state, siteId, postId ),
 		siteId,
+		isUTMModuleEnabled,
 	};
 } );
 

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -18,7 +18,10 @@ import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getSitePost, getPostPreviewUrl } from 'calypso/state/posts/selectors';
 import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'calypso/state/sites/selectors';
-import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import {
+	getEnvStatsFeatureSupportChecks,
+	useIsJetpackSite,
+} from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostDetailHighlightsSection from '../post-detail-highlights-section';
@@ -246,7 +249,8 @@ const connectComponent = connect( ( state, { postId } ) => {
 	const isPostHomepage = postId === 0;
 
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
-	const isUTMModuleEnabled = config.isEnabled( 'stats/utm-module' ) && supportsUTMStats;
+	const isUTMModuleEnabled =
+		config.isEnabled( 'stats/utm-module' ) && supportsUTMStats && useIsJetpackSite( siteId );
 
 	return {
 		post: getSitePost( state, siteId, postId ),

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
@@ -153,7 +152,7 @@ class StatsPostDetail extends Component {
 			siteSlug,
 			showViewLink,
 			previewUrl,
-			isUTMModuleEnabled,
+			supportsUTMStats,
 		} = this.props;
 
 		const isLoading = isRequestingStats && ! countViews;
@@ -216,7 +215,7 @@ class StatsPostDetail extends Component {
 						</>
 					) }
 
-					{ isUTMModuleEnabled && (
+					{ supportsUTMStats && (
 						<div className="stats-module-utm__post-detail">
 							<StatsModuleUTM siteId={ siteId } postId={ postId } query={ { num: -1, max: 0 } } />
 						</div>
@@ -246,7 +245,6 @@ const connectComponent = connect( ( state, { postId } ) => {
 	const isPostHomepage = postId === 0;
 
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
-	const isUTMModuleEnabled = config.isEnabled( 'stats/utm-module' ) && supportsUTMStats;
 
 	return {
 		post: getSitePost( state, siteId, postId ),
@@ -259,7 +257,7 @@ const connectComponent = connect( ( state, { postId } ) => {
 		showViewLink: ! isJetpack && ! isPostHomepage && isPreviewable,
 		previewUrl: getPostPreviewUrl( state, siteId, postId ),
 		siteId,
-		isUTMModuleEnabled,
+		supportsUTMStats,
 	};
 } );
 

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -18,10 +18,7 @@ import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getSitePost, getPostPreviewUrl } from 'calypso/state/posts/selectors';
 import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'calypso/state/sites/selectors';
-import {
-	getEnvStatsFeatureSupportChecks,
-	useIsJetpackSite,
-} from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostDetailHighlightsSection from '../post-detail-highlights-section';
@@ -249,8 +246,7 @@ const connectComponent = connect( ( state, { postId } ) => {
 	const isPostHomepage = postId === 0;
 
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
-	const isUTMModuleEnabled =
-		config.isEnabled( 'stats/utm-module' ) && supportsUTMStats && useIsJetpackSite( siteId );
+	const isUTMModuleEnabled = config.isEnabled( 'stats/utm-module' ) && supportsUTMStats;
 
 	return {
 		post: getSitePost( state, siteId, postId ),

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -12,6 +12,7 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
+import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Countries from '../stats-countries';
@@ -56,7 +57,7 @@ class StatsSummary extends Component {
 	}
 
 	render() {
-		const { translate, statsQueryOptions, siteId } = this.props;
+		const { translate, statsQueryOptions, siteId, isUTMModuleEnabled } = this.props;
 		const summaryViews = [];
 		let title;
 		let summaryView;
@@ -332,7 +333,7 @@ class StatsSummary extends Component {
 				backLink = `/stats/traffic/`;
 				path = 'utm';
 				statType = 'statsUTM';
-				summaryView = isEnabled( 'stats/utm-module' ) ? (
+				summaryView = isUTMModuleEnabled ? (
 					<>
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
 						<StatsModuleUTM
@@ -380,10 +381,15 @@ class StatsSummary extends Component {
 export default connect( ( state, { context, postId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const upsellModalView = isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId );
+
+	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
+	const isUTMModuleEnabled = isEnabled( 'stats/utm-module' ) && supportsUTMStats;
+
 	return {
 		siteId: getSelectedSiteId( state ),
 		siteSlug: getSelectedSiteSlug( state, siteId ),
 		media: context.params.module === 'videodetails' ? getMediaItem( state, siteId, postId ) : false,
 		upsellModalView,
+		isUTMModuleEnabled,
 	};
 } )( localize( StatsSummary ) );

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -12,10 +12,7 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
-import {
-	getEnvStatsFeatureSupportChecks,
-	useIsJetpackSite,
-} from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Countries from '../stats-countries';
@@ -386,8 +383,7 @@ export default connect( ( state, { context, postId } ) => {
 	const upsellModalView = isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId );
 
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
-	const isUTMModuleEnabled =
-		isEnabled( 'stats/utm-module' ) && supportsUTMStats && useIsJetpackSite( siteId );
+	const isUTMModuleEnabled = isEnabled( 'stats/utm-module' ) && supportsUTMStats;
 
 	return {
 		siteId: getSelectedSiteId( state ),

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -12,7 +12,10 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
-import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import {
+	getEnvStatsFeatureSupportChecks,
+	useIsJetpackSite,
+} from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Countries from '../stats-countries';
@@ -383,7 +386,8 @@ export default connect( ( state, { context, postId } ) => {
 	const upsellModalView = isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId );
 
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
-	const isUTMModuleEnabled = isEnabled( 'stats/utm-module' ) && supportsUTMStats;
+	const isUTMModuleEnabled =
+		isEnabled( 'stats/utm-module' ) && supportsUTMStats && useIsJetpackSite( siteId );
 
 	return {
 		siteId: getSelectedSiteId( state ),

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -57,7 +57,7 @@ class StatsSummary extends Component {
 	}
 
 	render() {
-		const { translate, statsQueryOptions, siteId, isUTMModuleEnabled } = this.props;
+		const { translate, statsQueryOptions, siteId, supportsUTMStats } = this.props;
 		const summaryViews = [];
 		let title;
 		let summaryView;
@@ -333,7 +333,7 @@ class StatsSummary extends Component {
 				backLink = `/stats/traffic/`;
 				path = 'utm';
 				statType = 'statsUTM';
-				summaryView = isUTMModuleEnabled ? (
+				summaryView = supportsUTMStats ? (
 					<>
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
 						<StatsModuleUTM
@@ -383,13 +383,12 @@ export default connect( ( state, { context, postId } ) => {
 	const upsellModalView = isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId );
 
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
-	const isUTMModuleEnabled = isEnabled( 'stats/utm-module' ) && supportsUTMStats;
 
 	return {
 		siteId: getSelectedSiteId( state ),
 		siteSlug: getSelectedSiteSlug( state, siteId ),
 		media: context.params.module === 'videodetails' ? getMediaItem( state, siteId, postId ) : false,
 		upsellModalView,
-		isUTMModuleEnabled,
+		supportsUTMStats,
 	};
 } )( localize( StatsSummary ) );

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -40,5 +40,10 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 			'0.16.0-alpha',
 			isOdysseyStats
 		),
+		supportsUTMStats: version_greater_than_or_equal(
+			statsAdminVersion,
+			'0.17.0-alpha',
+			isOdysseyStats
+		),
 	};
 }

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -1,5 +1,7 @@
 import config from '@automattic/calypso-config';
 import version_compare from 'calypso/lib/version-compare';
+import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 
 const version_greater_than_or_equal = (
@@ -10,7 +12,11 @@ const version_greater_than_or_equal = (
 	return !! ( ! isOdysseyStats || ( version && version_compare( version, compareVersion, '>=' ) ) );
 };
 
-export default function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
+const useIsJetpackSite = ( siteId: number | null ) => {
+	return useSelector( ( state ) => isJetpackSite( state, siteId ) );
+};
+
+function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
 
@@ -47,3 +53,9 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 		),
 	};
 }
+
+export {
+	getEnvStatsFeatureSupportChecks as default,
+	getEnvStatsFeatureSupportChecks,
+	useIsJetpackSite,
+};

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -43,6 +43,8 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 			isOdysseyStats
 		),
 		supportsUTMStats:
+			// TODO: Remove the flag check once UTM stats are released.
+			config.isEnabled( 'stats/utm-module' ) &&
 			// TODO: Make UTM stats available for internal Simple sites.
 			// UTM stats are only available for Jetpack and Atomic sites for now.
 			isSiteJetpack &&

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import version_compare from 'calypso/lib/version-compare';
-import { useSelector } from 'calypso/state';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 
@@ -12,13 +11,10 @@ const version_greater_than_or_equal = (
 	return !! ( ! isOdysseyStats || ( version && version_compare( version, compareVersion, '>=' ) ) );
 };
 
-const useIsJetpackSite = ( siteId: number | null ) => {
-	return useSelector( ( state ) => isJetpackSite( state, siteId ) );
-};
-
-function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
+export default function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
+	const isSiteJetpack = isJetpackSite( state, siteId );
 
 	return {
 		supportsHighlightsSettings: version_greater_than_or_equal(
@@ -46,16 +42,10 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.16.0-alpha',
 			isOdysseyStats
 		),
-		supportsUTMStats: version_greater_than_or_equal(
-			statsAdminVersion,
-			'0.17.0-alpha',
-			isOdysseyStats
-		),
+		supportsUTMStats:
+			// TODO: Make UTM stats available for internal Simple sites.
+			// UTM stats are only available for Jetpack and Atomic sites for now.
+			isSiteJetpack &&
+			version_greater_than_or_equal( statsAdminVersion, '0.17.0-alpha', isOdysseyStats ),
 	};
 }
-
-export {
-	getEnvStatsFeatureSupportChecks as default,
-	getEnvStatsFeatureSupportChecks,
-	useIsJetpackSite,
-};

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -136,7 +136,7 @@
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
-		"stats/utm-module": false,
+		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
 		"onboarding/new-migration-flow": false,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -179,7 +179,7 @@
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
-		"stats/utm-module": false,
+		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
 		"onboarding/new-migration-flow": false,
 		"storage-addon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -172,7 +172,7 @@
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
-		"stats/utm-module": false,
+		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
 		"onboarding/new-migration-flow": false,
 		"storage-addon": true,

--- a/config/test.json
+++ b/config/test.json
@@ -122,7 +122,7 @@
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
-		"stats/utm-module": false,
+		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
 		"onboarding/new-migration-flow": false,
 		"storage-addon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -170,7 +170,7 @@
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
-		"stats/utm-module": false,
+		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
 		"onboarding/new-migration-flow": false,
 		"storage-addon": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88599 

## Proposed Changes

* Release the feature flag `stats/utm-module`.
* Introduce `supportsUTMStats` to check UTM Stats support.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Ensure the UTM module on the **Traffic**, **Post details**, and **UTM module summary** pages work in line with the design for **_Jetpack and Atomic sites_**.
* Spin this change up for Odyssey Stats: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/path-to-jetpack/projects/packages/stats-admin yarn dev`.
* Ensure the UTM module on the **Traffic**, **Post details**, and **UTM module summary** pages on Odyssey Stats work according to the design.
* Ensure the UTM module is not displayed when the Jetpack `stats-admin` package version is behind `0.17.0-alpha`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?