### PR TITLE
Plans Next: Fix show-all-features button from moving when clicked

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -84,7 +84,7 @@ const MobileView = ( {
 		}, [] as GridPlan[] )
 		.map( ( gridPlan, index ) => {
 			const planCardClasses = classNames(
-				'plan-features-2023-grid__mobile-plan-card',
+				'plans-grid-next-features-grid__mobile-plan-card',
 				getPlanClass( gridPlan.planSlug )
 			);
 
@@ -122,6 +122,7 @@ const MobileView = ( {
 						header={ translate( 'Show all features' ) }
 						planSlug={ gridPlan.planSlug }
 						key={ `${ gridPlan.planSlug }-${ index }` }
+						className="plans-grid-next-features-grid__mobile-plan-card-foldable-container"
 						expanded={
 							selectedFeature &&
 							gridPlan.features.wpcomFeatures.some(

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -64,7 +64,7 @@ $mobile-card-max-width: 440px;
 	margin: 0 auto;
 	max-width: $mobile-card-max-width;
 
-	.plan-features-2023-grid__mobile-plan-card {
+	.plans-grid-next-features-grid__mobile-plan-card {
 		background-color: var(--studio-white);
 		border: 1px solid #e0e0e0;
 		/* stylelint-disable-next-line */
@@ -130,7 +130,7 @@ $mobile-card-max-width: 440px;
 			}
 		}
 
-		&.plan-features-2023-grid__mobile-plan-card {
+		&.plans-grid-next-features-grid__mobile-plan-card {
 			.plan-features-2023-grid__table-item {
 				&.plan-features-2023-grid__storage {
 					padding-top: 0;
@@ -148,26 +148,28 @@ $mobile-card-max-width: 440px;
 		}
 	}
 
-	.foldable-card {
-		box-shadow: unset;
-		margin-top: 24px;
+	.plans-grid-next-features-grid__mobile-plan-card-foldable-container {
+		&.foldable-card {
+			box-shadow: unset;
+			margin-top: 24px;
 
-		.foldable-card__main {
-			color: var(--studio-blue-60);
-			font-family: Inter, $sans;
-			font-weight: 500;
-			font-size: $font-body-small;
-			letter-spacing: -0.24px;
-			line-height: 20px;
-		}
+			.foldable-card__main {
+				color: var(--studio-blue-60);
+				font-family: Inter, $sans;
+				font-weight: 500;
+				font-size: $font-body-small;
+				letter-spacing: -0.24px;
+				line-height: 20px;
+			}
 
-		&.is-compact .foldable-card__header {
-			padding: 0 20px;
-		}
+			&.is-compact .foldable-card__header {
+				padding: 0 20px;
+			}
 
-		&.is-expanded .foldable-card__content {
-			border-top: none;
-			padding: 24px 0 0;
+			&.is-expanded .foldable-card__content {
+				border-top: none;
+				padding: 24px 0 0;
+			}
 		}
 	}
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -83,7 +83,7 @@ $mobile-card-max-width: 440px;
 
 			.foldable-card__content {
 				border-top: none;
-				padding: 24px 0 0;
+				padding: 0;
 			}
 		}
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -83,7 +83,7 @@ $mobile-card-max-width: 440px;
 
 			.foldable-card__content {
 				border-top: none;
-				padding: 0;
+				padding: 12px 0 0;
 			}
 		}
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -56,6 +56,89 @@ $mobile-card-max-width: 440px;
 	margin-top: 10px;
 }
 
+.plans-grid-next-features-grid__mobile-plan-card-foldable-container {
+	&.foldable-card.card {
+		box-shadow: unset;
+		margin-top: 24px;
+
+		.foldable-card__main {
+			color: var(--studio-blue-60);
+			font-family: Inter, $sans;
+			font-weight: 500;
+			font-size: $font-body-small;
+			letter-spacing: -0.24px;
+			line-height: 20px;
+
+			.foldable-card__expand .gridicon {
+				width: 14px;
+			}
+		}
+
+		&.is-compact .foldable-card__header {
+			padding: 0 20px;
+		}
+
+		&.is-expanded {
+			margin-top: 24px;
+
+			.foldable-card__content {
+				border-top: none;
+				padding: 24px 0 0;
+			}
+		}
+
+		.plans-grid-next-features-grid__mobile-plan-card.is-free-plan & {
+			.foldable-card__main {
+				color: var(--studio-blue-50);
+
+				.foldable-card__expand .gridicon {
+					fill: var(--studio-blue-50);
+				}
+			}
+		}
+
+		.plans-grid-next-features-grid__mobile-plan-card.is-personal-plan & {
+			.foldable-card__main {
+				color: var(--studio-blue-60);
+
+				.foldable-card__expand .gridicon {
+					fill: var(--studio-blue-60);
+				}
+			}
+		}
+
+		.plans-grid-next-features-grid__mobile-plan-card.is-premium-plan & {
+			.foldable-card__main {
+				color: #004687;
+
+				.foldable-card__expand .gridicon {
+					fill: #004687;
+				}
+			}
+		}
+
+		.plans-grid-next-features-grid__mobile-plan-card.is-business-plan & {
+			.foldable-card__main {
+				color: #7f54b3;
+
+				.foldable-card__expand .gridicon {
+					fill: #7f54b3;
+				}
+			}
+		}
+
+		.plans-grid-next-features-grid__mobile-plan-card.is-ecommerce-plan & {
+			.foldable-card__main {
+				color: #55347d;
+
+				.foldable-card__expand .gridicon {
+					fill: #55347d;
+				}
+			}
+		}
+	}
+}
+
 .plan-features-2023-grid__mobile-view {
 	display: flex;
 	flex-direction: column;
@@ -86,55 +169,9 @@ $mobile-card-max-width: 440px;
 			margin-top: 0;
 		}
 
-		.foldable-card__main .foldable-card__expand .gridicon {
-			width: 14px;
-		}
-
-		&.is-free-plan .foldable-card__main {
-			color: var(--studio-blue-50);
-
-			.foldable-card__expand .gridicon {
-				fill: var(--studio-blue-50);
-			}
-		}
-
-		&.is-personal-plan .foldable-card__main {
-			color: var(--studio-blue-60);
-
-			.foldable-card__expand .gridicon {
-				fill: var(--studio-blue-60);
-			}
-		}
-
-		&.is-premium-plan .foldable-card__main {
-			color: #004687;
-
-			.foldable-card__expand .gridicon {
-				fill: #004687;
-			}
-		}
-
-		&.is-business-plan .foldable-card__main {
-			color: #7f54b3;
-
-			.foldable-card__expand .gridicon {
-				fill: #7f54b3;
-			}
-		}
-
-		&.is-ecommerce-plan .foldable-card__main {
-			color: #55347d;
-
-			.foldable-card__expand .gridicon {
-				fill: #55347d;
-			}
-		}
-
-		&.plans-grid-next-features-grid__mobile-plan-card {
-			.plan-features-2023-grid__table-item {
-				&.plan-features-2023-grid__storage {
-					padding-top: 0;
-				}
+		.plan-features-2023-grid__table-item {
+			&.plan-features-2023-grid__storage {
+				padding-top: 0;
 			}
 		}
 
@@ -144,31 +181,6 @@ $mobile-card-max-width: 440px;
 			}
 			.components-custom-select-control__button {
 				height: 40px;
-			}
-		}
-	}
-
-	.plans-grid-next-features-grid__mobile-plan-card-foldable-container {
-		&.foldable-card {
-			box-shadow: unset;
-			margin-top: 24px;
-
-			.foldable-card__main {
-				color: var(--studio-blue-60);
-				font-family: Inter, $sans;
-				font-weight: 500;
-				font-size: $font-body-small;
-				letter-spacing: -0.24px;
-				line-height: 20px;
-			}
-
-			&.is-compact .foldable-card__header {
-				padding: 0 20px;
-			}
-
-			&.is-expanded .foldable-card__content {
-				border-top: none;
-				padding: 24px 0 0;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2078

## Proposed Changes

Fixes the margin on the foldable card by binding the card to a CSS class.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` or `/plans/[ site ]`
* Go to mobile view. 
* Click on "show all features" to expand. Click again to close. Ensure it doesn't move up/down.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?