### PR TITLE
Pattern Library: Don't rely on `useDebounce`

### DIFF
--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from 'react';
-import { useDebounce } from 'use-debounce';
+import { useEffect, useState } from 'react';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
@@ -14,9 +13,19 @@ type PatternsPageViewTrackerProps = {
 export function PatternsPageViewTracker( { category, searchTerm }: PatternsPageViewTrackerProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+	const [ debouncedSeachTerm, setDebouncedSearchTerm ] = useState( searchTerm );
+
 	// We debounce the search term because search happens instantaneously, without the user
 	// submitting the search form
-	const [ debouncedSeachTerm ] = useDebounce( searchTerm, 1500 );
+	useEffect( () => {
+		const timeoutId = window.setTimeout( () => {
+			setDebouncedSearchTerm( searchTerm );
+		}, 1500 );
+
+		return () => {
+			window.clearTimeout( timeoutId );
+		};
+	}, [ searchTerm ] );
 
 	useEffect( () => {
 		if ( category ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to #88614

## Proposed Changes

Apparently, `useDebounce` generated the following exception server-side:

```
TypeError: Cannot read properties of null (reading 'useState')
```

This PR removes the `useDebounce` code in favor of an equivalent `useEffect` callback.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Fire up Calypso locally (restart it after pulling this branch if you already had it running)
2. Navigate to `/patterns`
3. Ensure that no exception is logged in the terminal
