### PR TITLE
Pattern Library: Fix `LocalizedLink` SSR bug

### DIFF
--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -1,10 +1,13 @@
-import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import { addLocaleToPathLocaleInFront, useLocale } from '@automattic/i18n-utils';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export function LocalizedLink( { children, href = '', ...props }: JSX.IntrinsicElements[ 'a' ] ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const localizedHref = ! isLoggedIn ? addLocaleToPathLocaleInFront( href ) : href;
+	// `addLocaleToPathLocaleInFront` retrieves the active locale differently from `useLocale`.
+	// Crucially, it doesn't work with SSR unless we pass the `useLocale` value explicitly
+	const locale = useLocale();
+	const localizedHref = ! isLoggedIn ? addLocaleToPathLocaleInFront( href, locale ) : href;
 
 	return (
 		<a { ...props } href={ localizedHref }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

As reported by @stephanethomas here p1710770045591549-slack-C06ELHR6L9J, the SSR logic on `/patterns` doesn't generate localized URLs in links like it's supposed to.

I looked into this and concluded that the issue lies in the `LocalizedLink` component. Specifically, `addLocaleToPathLocaleInFront` doesn't pick up the active locale on the server unless we explicitly pass the correct locale. Thankfully, `useLocale` works as expected with SSR, so my changes here are quite simple.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open an incognito window in Firefox
2. Open the dev tools and disable Javascript
3. Navigate to `/fr/patterns`
4. Ensure that the category links start with `/fr`