### PR TITLE
Help Center: Add checkout context

### DIFF
--- a/packages/help-center/src/route-to-query-mapping.json
+++ b/packages/help-center/src/route-to-query-mapping.json
@@ -4,6 +4,7 @@
 	"/add-ons/": "add-ons",
 	"/mailboxes": "mail",
 	"/comments/": "comments",
+	"/checkout/": "checkout",
 	"/backup/": "backup",
 	"/themes/": "themes",
 	"/plugins/manage": "manage plugins",


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/88555

This PR adds more helpful results in the Help Center when in checkout.

## Testing

1. Live link
2. Reach checkout
3. Open the Help Center and you should see

![image](https://github.com/Automattic/wp-calypso/assets/52076348/d74739cf-fbcd-4258-ae6e-9301143fa879)
