### PR TITLE
Update/stats utm exports 2

### DIFF
--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -2,6 +2,8 @@ import { StatsCard } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import useUTMMetricTopPostsQuery from '../hooks/use-utm-metric-top-posts-query';
@@ -25,6 +27,7 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	const moduleStrings = statsStrings();
 	const translate = useTranslate();
 	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SOURCE_MEDIUM );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	// Check if blog is internal.
 	const { isFetching: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
@@ -93,6 +96,9 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	};
 
 	const showFooterWithDownloads = summary === true;
+	const fileNameForExport = showFooterWithDownloads
+		? generateFileNameForDownload( siteSlug, period )
+		: '';
 
 	return (
 		<>
@@ -131,7 +137,7 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 					/>
 					{ showFooterWithDownloads && (
 						<div className="stats-module__footer-actions stats-module__footer-actions--summary">
-							<UTMExportButton data={ data } />
+							<UTMExportButton data={ data } fileName={ fileNameForExport } />
 						</div>
 					) }
 				</>
@@ -139,5 +145,26 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 		</>
 	);
 };
+
+function generateFileNameForDownload( siteSlug, period ) {
+	// Build a filename for the CSV export button.
+	// The "format('L')" method can return strings that are not safe for the file system.
+	// While the "saveAs" function handles this, we do it here for correctness.
+	// We prefer '-' for word boundries, and '_' within words/dates.
+	// This allows text editing shortcuts to work properly.
+	//
+	// example output: jetpack.com-utm-day-03_20_2024-03_20_2024.csv
+	//
+	const newFileName =
+		[
+			siteSlug,
+			'utm',
+			period.period,
+			period.startOf.format( 'L' ),
+			period.endOf.format( 'L' ),
+		].join( '-' ) + '.csv';
+
+	return newFileName.replace( /\//g, '_' );
+}
 
 export { StatsModuleUTM as default, StatsModuleUTM, OPTION_KEYS };

--- a/client/my-sites/stats/stats-module-utm/utm-export-button.jsx
+++ b/client/my-sites/stats/stats-module-utm/utm-export-button.jsx
@@ -8,21 +8,16 @@ function UTMExportButton( { data } ) {
 	const buttonLabel = translate( 'Download data as CSV' );
 	const shouldDisableExport = data && data.length !== 0 ? false : true;
 
-	// Turns the working data into a flattened array of objects.
-	// Preserves the original data but updates the label for export.
+	// Flatten the data into a shallow array.
+	// Children gain a "context" property to indicate their parent label.
 	const flattenDataForExport = ( originalData ) => {
 		const newData = [];
-		// Map the array of objects.
 		originalData.forEach( ( row ) => {
-			// Wrap label in quotes and push values.
-			let newLabel = `"${ row.label }"`;
-			newData.push( { label: newLabel, value: row.value } );
-			// Flatten children if present.
+			newData.push( row );
 			const children = row?.children;
 			if ( children ) {
 				const newChildren = children.map( ( child ) => {
-					newLabel = `"${ row.label } > ${ child.label }"`;
-					return { ...child, label: newLabel };
+					return { ...child, context: row.label };
 				} );
 				newData.push( ...newChildren );
 			}
@@ -31,10 +26,16 @@ function UTMExportButton( { data } ) {
 	};
 
 	// Turns the flat array into a CSV string.
+	// Processes the label before export.
 	const prepareDataForDownload = ( flatData ) => {
 		const csvData = flatData
 			.map( ( row ) => {
-				return `${ row.label },${ row.value }`;
+				// Label should include parent context if present.
+				// ie: "parent label > child label" -- including surrounding quotes.
+				let label = row?.context ? `${ row.context } > ${ row.label }` : row.label;
+				label = label.replace( /"/g, '""' );
+				// Return the label and value.
+				return `"${ label }",${ row.value }`;
 			} )
 			.join( '\n' );
 

--- a/client/my-sites/stats/stats-module-utm/utm-export-button.jsx
+++ b/client/my-sites/stats/stats-module-utm/utm-export-button.jsx
@@ -2,7 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { saveAs } from 'browser-filesaver';
 import { useTranslate } from 'i18n-calypso';
 
-function UTMExportButton( { data } ) {
+function UTMExportButton( { data, fileName } ) {
 	// Button set up.
 	const translate = useTranslate();
 	const buttonLabel = translate( 'Download data as CSV' );
@@ -45,8 +45,6 @@ function UTMExportButton( { data } ) {
 	const initiateDownload = ( event ) => {
 		event.preventDefault();
 
-		// TODO: Provide a better default file name.
-		const fileName = 'my-data.csv';
 		const flattenedData = flattenDataForExport( data );
 		const csvData = prepareDataForDownload( flattenedData );
 		const blob = new Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87687.

## Proposed Changes

* Reworks export logic to better separate concerns. Flatten array, then process items.
* Adds guard for double quotes in the middle of a label.
* Generates useful file names when exporting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Live site.
* Visit the Traffic page on a site with UTM data.
* Enable the `stats/utm-module` flag.
* Scroll down to the UTM section and click "View all" or "View details".
* Or go directly to Summary page at: `/stats/day/utm/SITE_SLUG`
* Confirm the download button is enabled and works if there is UTM data to show.
* Click the download button and confirm the CSV data looks correct.
* Confirm the filename is in the format of: `SITE_URL-utm-PERIOD-DATE_START-DATE_END.csv`

An example of  the above format would be: `jetpack.com-utm-day-03_20_2024-03_20_2024.csv`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?