### PR TITLE
Pattern Library: Use Masonry layout for page layout patterns in grid view

### DIFF
--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -6,19 +6,16 @@ import {
 	PatternPreview,
 } from 'calypso/my-sites/patterns/components/pattern-preview';
 import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/controller';
+import { PatternTypeFilter, type PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import type { PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
 const LOGGED_OUT_USERS_CAN_COPY_COUNT = 3;
 
-export const PatternGalleryClient: PatternGalleryFC = ( {
-	getPatternPermalink,
-	isGridView,
-	patterns = [],
-} ) => {
+export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
+	const { getPatternPermalink, isGridView, patterns = [], patternTypeFilter } = props;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const patternIdsByCategory = {
 		first: patterns.map( ( { ID } ) => `${ ID }` ) ?? [],
@@ -27,7 +24,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( {
 	return (
 		<BlockRendererProvider
 			siteId={ RENDERER_SITE_ID }
-			placeholder={ <PatternGalleryServer isGridView={ isGridView } patterns={ patterns } /> }
+			placeholder={ <PatternGalleryServer { ...props } /> }
 		>
 			<PatternsRendererProvider
 				patternIdsByCategory={ patternIdsByCategory }
@@ -37,6 +34,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( {
 				<div
 					className={ classNames( 'pattern-gallery', {
 						'pattern-gallery--grid': isGridView,
+						'pattern-gallery--pages': patternTypeFilter === PatternTypeFilter.PAGES,
 					} ) }
 				>
 					{ patterns.map( ( pattern, i ) => (
@@ -46,6 +44,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( {
 							className={ classNames( {
 								'pattern-preview--grid': isGridView,
 								'pattern-preview--list': ! isGridView,
+								'pattern-preview--page': patternTypeFilter === PatternTypeFilter.PAGES,
 							} ) }
 							getPatternPermalink={ getPatternPermalink }
 							key={ pattern.ID }

--- a/client/my-sites/patterns/components/pattern-gallery/style.scss
+++ b/client/my-sites/patterns/components/pattern-gallery/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .pattern-gallery {
 	display: grid;
@@ -6,9 +7,23 @@
 }
 .pattern-gallery--grid {
 	gap: 16px 24px;
-	grid-template-columns: repeat(3, 1fr);
 
-	@media ( max-width: $break-medium ) {
-		grid-template-columns: 1fr;
+	@include break-medium {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@include break-huge {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+.pattern-gallery--grid.pattern-gallery--pages {
+	display: block;
+
+	@include break-medium {
+		column-count: 2;
+	}
+
+	@include break-huge {
+		column-count: 3;
 	}
 }

--- a/client/my-sites/patterns/components/pattern-gallery/style.scss
+++ b/client/my-sites/patterns/components/pattern-gallery/style.scss
@@ -5,6 +5,7 @@
 	display: grid;
 	gap: 48px;
 }
+
 .pattern-gallery--grid {
 	gap: 16px 24px;
 
@@ -16,6 +17,7 @@
 		grid-template-columns: repeat(3, 1fr);
 	}
 }
+
 .pattern-gallery--grid.pattern-gallery--pages {
 	display: block;
 

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -249,6 +249,7 @@ export const PatternLibrary = ( {
 						}
 						isGridView={ isGridView }
 						patterns={ patterns }
+						patternTypeFilter={ patternTypeFilter }
 					/>
 				</PatternLibraryBody>
 			) }

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -129,6 +129,11 @@
 	}
 }
 
+.pattern-preview--page {
+	break-inside: avoid;
+	margin-bottom: 16px;
+}
+
 .pattern-preview--category-gallery {
 	.pattern-preview__renderer {
 		border-radius: 0;

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -51,6 +51,7 @@ export type PatternGalleryProps = {
 	getPatternPermalink?( pattern: Pattern ): string;
 	isGridView?: boolean;
 	patterns?: Pattern[];
+	patternTypeFilter: PatternTypeFilter;
 };
 
 export type PatternGalleryFC = React.FC< PatternGalleryProps >;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6153

## Proposed Changes

Per the Figma mockups BnTfb6hzKcRTb2LBtuPwKe-fi-246%3A43250, page layouts are supposed to render in a Masonry-like layout in grid view.

This PR implements this by using CSS columns. With CSS columns, the patterns are laid out in columns instead of rows, meaning the order differs from what we get with CSS grid. This could be considered a small drawback, but I don't think it's really a big deal. Especially when we consider that getting around this would require a lot more JS, potentially even pulling in the entire [Masonry library](https://masonry.desandro.com/), then I think this approach is fine.

![page layouts masonry](https://github.com/Automattic/wp-calypso/assets/1101677/51254e23-c10e-48f0-9c59-855aec360569)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/layouts/about`
2. Click the grid view button
3. Ensure that the pattern previews don't align on grid rows