### PR TITLE
Fix `CategoryPillNavigation` scrollbar styling in non-Webkit browsers

### DIFF
--- a/client/components/category-pill-navigation/style.scss
+++ b/client/components/category-pill-navigation/style.scss
@@ -24,10 +24,7 @@
 		display: flex;
 		gap: 16px;
 		align-items: center;
-
-		&::-webkit-scrollbar {
-			display: none; /* for browsers that support this */
-		}
+		scrollbar-width: none;
 	}
 
 	.category-pill-navigation__arrow {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

`scrollbar-width: none` is essentially a standardized version of `::-webkit-scrollbar { display: none }`. 

The screenshots below are from Firefox:

| Before | After |
| - | - |
| ![before](https://github.com/Automattic/wp-calypso/assets/1101677/a8f7f581-f755-4fc8-a730-5cc81b97d7ff) | ![after](https://github.com/Automattic/wp-calypso/assets/1101677/b50ec57a-3947-4252-b9ea-030e842b8b63) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On Mac, open System Settings > Appearance and set **Show scroll bars** to **Always**
2. Navigate to `/patterns` in Firefox
3. Ensure that you don't see a scrollbar
