### PR TITLE
[Odie] Send site_id and scroll to the beggining of the message.

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
-import { getSectionName } from 'calypso/state/ui/selectors';
+import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
@@ -39,6 +39,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 			isMinimized: store.getIsMinimized(),
 		};
 	}, [] );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
@@ -105,6 +106,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 							initialUserMessage={ searchTerm }
 							logger={ trackEvent }
 							loggerEventNamePrefix="calypso_odie"
+							selectedSiteId={ selectedSiteId }
 							extraContactOptions={
 								<HelpCenterContactPage
 									hideHeaders

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -34,6 +34,7 @@ type OdieAssistantContextInterface = {
 	lastNudge: Nudge | null;
 	odieClientId: string;
 	sendNudge: ( nudge: Nudge ) => void;
+	selectedSiteId?: number | null;
 	setChat: ( chat: Chat ) => void;
 	setIsLoadingChat: ( isLoadingChat: boolean ) => void;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
@@ -92,6 +93,7 @@ type OdieAssistantProviderProps = {
 	extraContactOptions?: ReactNode;
 	logger?: ( message: string, properties: Record< string, unknown > ) => void;
 	loggerEventNamePrefix?: string;
+	selectedSiteId?: number | null;
 	version?: string | null;
 	children?: ReactNode;
 } & PropsWithChildren;
@@ -105,6 +107,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	enabled = true,
 	logger,
 	loggerEventNamePrefix,
+	selectedSiteId,
 	version = null,
 	children,
 } ) => {
@@ -227,6 +230,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 				isVisible,
 				lastNudge,
 				odieClientId,
+				selectedSiteId,
 				sendNudge: setLastNudge,
 				setChat,
 				setIsLoadingChat: noop,

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -30,8 +30,8 @@ export const OdieAssistant: React.FC = () => {
 					if ( lastMessageElement?.target ) {
 						lastMessageElement.target.scrollIntoView( {
 							behavior: 'auto',
-							block: 'end',
-							inline: 'end',
+							block: 'start',
+							inline: 'nearest',
 						} );
 					}
 				} );


### PR DESCRIPTION
## Proposed Changes

This set of changes is fixing an issue where wpcom server can't infer the current site the user is navigating into. Another issue we are fixing within this patch is the ability to scroll to the beginning of the block, instead of to the end of the message when we receive a message from Wapuu

## Testing Instructions

In order to test this change correctly you need to sandbox your wpcom public-api with the patch D142563.

1. Open a site with multiple blogs and different plans
2. Open Wapuu via flags (eg, ?flags=wapuu)
3. Add a logger in the wpcom patch, to log the plan the user is using. (eg, line 512 of the wpcom patch, `l($plan);`.)
4. Assert that the plan you are using matches the log
5. Change to a different site with a different plan
6. Assert the plan keeps matching the new site.
7. Assert that the question you receive is visible in the initial part of the message (ie, is not scrolled till the bottom of the message)
