### PR TITLE
Automattic for Agencies: Update the sign-up flow to redirect to /sites if an agency exists.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/controller.tsx
+++ b/client/a8c-for-agencies/sections/signup/controller.tsx
@@ -1,21 +1,5 @@
-import { Context, type Callback } from '@automattic/calypso-router';
-import page from '@automattic/calypso-router';
-import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { type Callback } from '@automattic/calypso-router';
 import AgencySignUp from './primary/agency-signup';
-
-export function requireNoPartnerRecordContext( context: Context, next: () => void ): void {
-	const state = context.store.getState();
-	const partner = getActiveAgency( state );
-
-	// Users who already have a partner record should be redirected away from the signup form.
-	if ( partner ) {
-		page.redirect( A4A_SITES_LINK );
-		return;
-	}
-
-	next();
-}
 
 export const signUpContext: Callback = ( context, next ) => {
 	context.primary = <AgencySignUp />;

--- a/client/a8c-for-agencies/sections/signup/index.ts
+++ b/client/a8c-for-agencies/sections/signup/index.ts
@@ -3,11 +3,5 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
 export default function () {
-	page(
-		'/signup',
-		controller.requireNoPartnerRecordContext,
-		controller.signUpContext,
-		makeLayout,
-		clientRender
-	);
+	page( '/signup', controller.signUpContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx
@@ -1,11 +1,36 @@
+import page from '@automattic/calypso-router';
+import { useEffect } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useSelector } from 'calypso/state';
+import {
+	getActiveAgency,
+	hasFetchedAgency,
+	isFetchingAgency,
+} from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 export default function AgencySignup() {
+	const agency = useSelector( getActiveAgency );
+	const hasFetched = useSelector( hasFetchedAgency );
+	const isFetching = useSelector( isFetchingAgency );
+
+	useEffect( () => {
+		if ( agency ) {
+			// Redirect to the sites page if the user already has an agency record.
+			page.redirect( A4A_SITES_LINK );
+		}
+	}, [ agency ] );
+
+	// Show nothing if we haven't fetched the agency record yet, or if we're in the process of fetching it.
+	if ( ! hasFetched || isFetching || agency ) {
+		return null;
+	}
+
 	return (
 		<Layout title="Sign Up" wide>
 			<LayoutTop>


### PR DESCRIPTION
## Proposed Changes

This PR updated the sign-up flow to redirect to /sites if there is an existing agency.

## Testing Instructions

- Switch to the current branch by running `git checkout update/a4a/signup-flow`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Visit the /signup page when logged in and verify that you can see the signup page.
- Follow the steps here to create the agency ID: D139529-code and visit the /signup page again > Verify that you are redirected to the /sites page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?