### PR TITLE
Checkout: update text color & copy for coupon field

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -959,7 +959,7 @@ const CheckoutTermsAndCheckboxesWrapper = styled.div`
 	padding: 32px 20px 0 24px;
 	width: 100%;
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		padding: 32px 20px 0 40px;
+		padding: 12px 20px 0 40px;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -59,7 +59,7 @@ const CouponAreaWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
 		padding-inline-start: ${ ( props ) => ( props.shouldUseCheckoutV2 ? 'initial' : '40px' ) };
 		padding-inline-end: ${ ( props ) => ( props.shouldUseCheckoutV2 ? 'initial' : '0' ) };
 	}
-	padding-top: ${ ( props ) => ( props.shouldUseCheckoutV2 ? 'initial' : '48px' ) };
+	padding-top: ${ ( props ) => ( props.shouldUseCheckoutV2 ? 'initial' : '28px' ) };
 	align-self: stretch;
 `;
 
@@ -68,7 +68,7 @@ const CouponField = styled( Coupon )``;
 const CouponEnableButton = styled.button< { shouldUseCheckoutV2: boolean } >`
 	cursor: pointer;
 	text-decoration: underline;
-	color: ${ ( props ) => props.theme.colors.highlight };
+	color: ${ ( props ) => props.theme.colors.textColorLight };
 
 	&.wp-checkout-order-review__show-coupon-field-button {
 		${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 12px` : `font-size: 14px;` ) }
@@ -287,13 +287,12 @@ export function CouponFieldArea( {
 	return (
 		<CouponAreaWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 			<CouponLinkWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
-				{ translate( 'Have a coupon? ' ) }{ ' ' }
 				<CouponEnableButton
 					className="wp-checkout-order-review__show-coupon-field-button"
 					onClick={ () => setCouponFieldVisible( true ) }
 					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 				>
-					{ translate( 'Add a coupon code' ) }
+					{ translate( 'Have a coupon?' ) }
 				</CouponEnableButton>
 			</CouponLinkWrapper>
 		</CouponAreaWrapper>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -68,7 +68,8 @@ const CouponField = styled( Coupon )``;
 const CouponEnableButton = styled.button< { shouldUseCheckoutV2: boolean } >`
 	cursor: pointer;
 	text-decoration: underline;
-	color: ${ ( props ) => props.theme.colors.textColorLight };
+	color: ${ ( props ) =>
+		props.shouldUseCheckoutV2 ? props.theme.colors.highlight : props.theme.colors.textColorLight };
 
 	&.wp-checkout-order-review__show-coupon-field-button {
 		${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 12px` : `font-size: 14px;` ) }

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -57,7 +57,7 @@ const selectors = {
 	cardCVVInput: 'input[data-elements-stable-field-name="cardCvc"]',
 
 	// Checkout elements
-	couponCodeInputButton: `button:text("Add a coupon code"):visible`,
+	couponCodeInputButton: `button:text("Have a coupon?"):visible`,
 	couponCodeInput: `input[id="order-review-coupon"]`,
 	couponCodeApplyButton: `button:text("Apply")`,
 	disabledButton: 'button[disabled]:has-text("Processing")',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This is a follow-up to https://github.com/Automattic/wp-calypso/pull/88450. It adds a few cosmetic changes which were missed in the original PR. Screenshot:
v1:
<img width="766" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b367e538-b2d1-41ec-b6b6-3deedc28b906">

v2:
<img width="423" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/1a2f4770-aa1b-4523-96ec-1f0c3744a557">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add any product to the cart and go to checkout.
* Confirm that the coupon field matches the screenshot.
* Test in a variety of screen sizes and confirm that the field displays correctly.
* Append `?checkoutVersion=2` to the URL to switch to checkout v2. Re-check the above scenarios.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?