### PR TITLE
Add wpcom account creation disclaimer for userless checkout (Jetpack/Akismet)

### DIFF
--- a/client/my-sites/checkout/src/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/src/components/contact-details-container.tsx
@@ -4,11 +4,14 @@ import {
 	isDomainMapping,
 	getDomain,
 } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { Field, styled } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import {
@@ -29,6 +32,12 @@ const ContactDetailsFormDescription = styled.p`
 	font-size: 14px;
 	color: ${ ( props ) => props.theme.colors.textColor };
 	margin: 0 0 16px;
+`;
+
+const NewAccountCreationDisclaimer = styled.p`
+	font-size: 12px;
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+	margin: 16px 0 0;
 `;
 
 export default function ContactDetailsContainer( {
@@ -139,6 +148,35 @@ export default function ContactDetailsContainer( {
 						isDisabled={ isDisabled }
 						allowVat
 					/>
+					{ /* For Jetpack and Akismet - we want to inform users that by continuing checkout process they create WordPress.com account */ }
+					{ ( isJetpackCheckout() || isAkismetCheckout() ) && isLoggedOutCart && (
+						<NewAccountCreationDisclaimer>
+							{ translate(
+								'%(serviceName)s is powered by WordPress.com. If you don’t already have a WordPress.com account, checking out below will create one for you with this email address. Accounts are subject to the {{tosLink}}Terms of Service{{/tosLink}} and {{ppLink}}Privacy Policy{{/ppLink}}.',
+								{
+									components: {
+										tosLink: (
+											<a
+												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+												target="_blank"
+												rel="noreferrer"
+											/>
+										),
+										ppLink: (
+											<a
+												href={ localizeUrl( 'https://automattic.com/privacy' ) }
+												target="_blank"
+												rel="noreferrer"
+											/>
+										),
+									},
+									args: {
+										serviceName: isJetpackCheckout() ? 'Jetpack' : 'Akismet',
+									},
+								}
+							) }
+						</NewAccountCreationDisclaimer>
+					) }
 				</Fragment>
 			);
 	}


### PR DESCRIPTION
## Proposed Changes

For Jetpack/Akismet userless checkouts, we want to add a disclaimer that continuing the process means creating WordPress.com account - to avoid misunderstandings.

![CleanShot 2024-03-20 at 15 24 55@2x](https://github.com/Automattic/wp-calypso/assets/8419292/c3d3fc9b-2f1c-4c39-bcf0-763cceb0401a)

## Testing Instructions

* Run Calypso Live and checkout any Jetpack (`/checkout/jetpack/jetpack_social_advanced_yearly`) and Akismet (`/checkout/akismet/ak_bus5k_yearly`) product
* Make sure you're running userless checkout (e.g. in incognito mode)
* Notice that the disclaimer shows up correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?