### PR TITLE
Continue with GitHub: Remove `login/github` feature flag

### DIFF
--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -130,16 +130,14 @@ const SocialAuthenticationForm = ( {
 							}
 						/>
 
-						{ config.isEnabled( 'login/github' ) ? (
-							<GithubSocialButton
-								socialServiceResponse={ socialService === 'github' ? socialServiceResponse : null }
-								redirectUri={ getRedirectUri( 'github' ) }
-								responseHandler={ handleGitHubResponse }
-								onClick={ () => {
-									trackLoginAndRememberRedirect( 'github' );
-								} }
-							/>
-						) : null }
+						<GithubSocialButton
+							socialServiceResponse={ socialService === 'github' ? socialServiceResponse : null }
+							redirectUri={ getRedirectUri( 'github' ) }
+							responseHandler={ handleGitHubResponse }
+							onClick={ () => {
+								trackLoginAndRememberRedirect( 'github' );
+							} }
+						/>
 
 						{ children }
 					</div>

--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -38,18 +37,9 @@ function SocialAuthToS( props ) {
 		);
 	}
 
-	if ( config.isEnabled( 'login/github' ) ) {
-		return getToSComponent(
-			props.translate(
-				'If you continue with Google, Apple or GitHub, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-				toSLinks
-			)
-		);
-	}
-
 	return getToSComponent(
 		props.translate(
-			'If you continue with Google and Apple, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			'If you continue with Google, Apple or GitHub, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			toSLinks
 		)
 	);

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -43,7 +43,7 @@ const GitHubLoginButton = ( {
 }: GithubLoginButtonProps ) => {
 	const translate = useTranslate();
 
-	const { code, service } = useSelector( ( state: AppState ) => state.route?.query?.initial );
+	const { code, service } = useSelector( ( state: AppState ) => state.route?.query?.initial ) ?? {};
 	const authError = useSelector( ( state: AppState ) => {
 		const path = state?.route?.path?.current;
 		const { initial, current } = state?.route?.query ?? {};

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -159,12 +159,6 @@ const GitHubLoginButton = ( {
 		customButton = cloneElement( children as ReactElement, childProps );
 	}
 
-	// This feature is already gated inside client/blocks/authentication/social/index.tsx
-	// Adding an extra check here to prevent accidental inclusions in other parts of the app
-	if ( ! config.isEnabled( 'login/github' ) ) {
-		return;
-	}
-
 	return (
 		<>
 			{ customButton ? (

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -238,11 +238,12 @@ exports[`JetpackSignup should render 1`] = `
             >
               GoogleSocialButton
               AppleLoginButton
+              GitHubLoginButton
             </div>
             <p
               class="auth-form__social-buttons-tos"
             >
-              If you continue with Google and Apple, you agree to our 
+              If you continue with Google, Apple or GitHub, you agree to our 
               <a
                 href="https://wordpress.com/tos/"
                 rel="noopener noreferrer"
@@ -536,11 +537,12 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
             >
               GoogleSocialButton
               AppleLoginButton
+              GitHubLoginButton
             </div>
             <p
               class="auth-form__social-buttons-tos"
             >
-              If you continue with Google and Apple, you agree to our 
+              If you continue with Google, Apple or GitHub, you agree to our 
               <a
                 href="https://wordpress.com/tos/"
                 rel="noopener noreferrer"

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -12,6 +12,7 @@ import { JetpackSignup } from '../signup.js';
 jest.mock( 'calypso/components/data/document-head', () => () => 'DocumentHead' );
 jest.mock( 'calypso/components/social-buttons/google', () => () => 'GoogleSocialButton' );
 jest.mock( 'calypso/components/social-buttons/apple', () => () => 'AppleLoginButton' );
+jest.mock( 'calypso/components/social-buttons/github', () => () => 'GitHubLoginButton' );
 
 const render = ( el, options ) =>
 	renderWithProvider( el, {

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -65,16 +65,14 @@ class SocialLogin extends Component {
 					/>
 				) }
 
-				{ config.isEnabled( 'login/github' ) && (
-					<SocialLoginService
-						service="github"
-						icon={ <GitHubIcon /> }
-						redirectUri={ redirectUri }
-						socialServiceResponse={
-							this.props.socialService === 'github' ? this.props.socialServiceResponse : null
-						}
-					/>
-				) }
+				<SocialLoginService
+					service="github"
+					icon={ <GitHubIcon /> }
+					redirectUri={ redirectUri }
+					socialServiceResponse={
+						this.props.socialService === 'github' ? this.props.socialServiceResponse : null
+					}
+				/>
 			</div>
 		);
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -125,7 +125,6 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,
-		"login/github": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,6 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
-		"login/github": true,
 		"login/social-first": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,

--- a/config/production.json
+++ b/config/production.json
@@ -101,7 +101,6 @@
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
-		"login/github": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -95,7 +95,6 @@
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
-		"login/github": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,7 +93,6 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
-		"login/github": true,
 		"login/magic-login": true,
 		"login/social-first": true,
 		"logmein": true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/88569.

## Proposed Changes

* remove the `login/github` feature flag - the new button is launched, so there's no need to keep the feature flag cluttering the codebase
* update related snapshot test

## Testing Instructions

1. Check out and build the proposed changes.
2. Try to connect / disconnect your test WordPress.com account with GitHub account.
3. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?