### PR TITLE
SSO: Handle and log errors when sending SSO invites

### DIFF
--- a/client/my-sites/people/people-list-item/index.tsx
+++ b/client/my-sites/people/people-list-item/index.tsx
@@ -94,16 +94,18 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 		};
 	};
 
-	const handleInviteSuccess = ( site_id: number ) => {
-		dispatch( requestSiteInvites( site_id ) );
+	const handleInviteSuccess = ( siteId: number ) => {
+		dispatch( requestSiteInvites( siteId ) );
 		displayNotice( translate( 'Invitation sent successfully' ) );
-		dispatch( recordTracksEvent( 'calypso_sso_user_invite_success', { site_id } ) );
+		dispatch( recordTracksEvent( 'calypso_sso_user_invite_success', { site_id: siteId } ) );
 	};
 
-	const handleInviteError = ( site_id: number, error: unknown ) => {
+	const handleInviteError = ( siteId: number, error: unknown ) => {
 		displayNotice( translate( 'The invitation sending has failed.' ), 'is-error' );
 		const error_message = error instanceof Error ? error.message : 'error sending invite';
-		dispatch( recordTracksEvent( 'calypso_sso_user_invite_error', { site_id, error_message } ) );
+		dispatch(
+			recordTracksEvent( 'calypso_sso_user_invite_error', { site_id: siteId, error_message } )
+		);
 	};
 
 	const onSendInvite = async ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* This PR aims to improve logs and handling failures when inviting not connected users to join a site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and navigate to {live_link}/people/team/{YOUR_SITE_SLUG}
* There you should be able to invite not connected users to join your site
* Using tracks vigilante PCYsg-T9m-p2, make sure you see success invites `calypso_sso_user_invite_success` being logged when inviting users
* You will need to fake your API response to fake API errors. Maybe it's easier to pull and apply this branch locally
* Update this line fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Svaivgrf%2Svaivgrf.cuc%3Se%3Q8r65q5n7%26zb%3Q5282%26sv%3Q185%23186-og to be able to return any random error
```
return new WP_Error(
			'fake error',
			'Forced fake error ',
			500
		);
```
* Try to invite a new user, you should see an error and if you check track vigilante, it should log the error there too




Success example
<img width="774" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/a0917400-cff5-40ba-a452-28d594c2838b">


Failure example
<img width="781" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/d753b8d3-13f3-4f61-8d0d-63ed6d56ed6c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?