### PR TITLE
Login: Fix post log-in link redirect flow

### DIFF
--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -1,3 +1,4 @@
+import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export default function redirectLoggedIn( context, next ) {
@@ -6,7 +7,11 @@ export default function redirectLoggedIn( context, next ) {
 	if ( userLoggedIn ) {
 		// force full page reload to avoid SSR hydration issues.
 		// Redirect parameters should have higher priority.
-		window.location = context?.query?.redirect_to ?? '/';
+		let url = safeProtocolUrl( context?.query?.redirect_to );
+		if ( ! url || url === 'http:' ) {
+			url = '/';
+		}
+		window.location = url;
 		return;
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR improves the way we handle the post-login redirect URL by additionally verifying the protocol.

## Testing Instructions

* Verify logging in by link still works.
* Verify that redirection for already logged-in users still works well. 
