### PR TITLE
Plans Next: Storybook setup for the plans-grids-next package

### DIFF
--- a/packages/plans-grid-next/.storybook/main.js
+++ b/packages/plans-grid-next/.storybook/main.js
@@ -1,1 +1,3 @@
-module.exports = require( '@automattic/calypso-storybook' )();
+const path = require( 'path' );
+const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
+module.exports = storybookDefaultConfig();

--- a/packages/plans-grid-next/.storybook/preview.js
+++ b/packages/plans-grid-next/.storybook/preview.js
@@ -1,0 +1,5 @@
+import '@automattic/calypso-color-schemes';
+import '@wordpress/components/build-style/style.css';
+import './styles.scss';
+
+window.__i18n_text_domain__ = 'default';

--- a/packages/plans-grid-next/.storybook/styles.scss
+++ b/packages/plans-grid-next/.storybook/styles.scss
@@ -1,0 +1,6 @@
+@import "@wordpress/base-styles/variables";
+
+html {
+	font-family: $default-font;
+	margin: 2rem;
+}

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -31,7 +31,8 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
-		"watch": "tsc --build ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch",
+		"storybook": "sb dev"
 	},
 	"dependencies": {
 		"@automattic/calypso-products": "workspace:^",
@@ -64,6 +65,7 @@
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/addon-actions": "^7.6.17",
+		"@storybook/cli": "^7.6.17",
 		"@storybook/react": "^7.6.17",
 		"@testing-library/dom": "^9.3.4",
 		"@testing-library/jest-dom": "^6.4.2",

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -1,0 +1,462 @@
+import { Meta } from '@storybook/react';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { FeaturesGrid } from '../..';
+
+const queryClient = new QueryClient();
+
+const wpcomFeatures = [
+	{
+		getSlug: () => {},
+		getTitle: () => 'Dotcom Feature 1',
+		availableForCurrentPlan: true,
+	},
+	{
+		getSlug: () => {},
+		getTitle: () => 'Dotcom Feature 2',
+		availableForCurrentPlan: true,
+	},
+	{
+		getSlug: () => {},
+		getTitle: () => 'Dotcom Feature 3',
+		availableForCurrentPlan: true,
+	},
+];
+
+const jetpackFeatures = [
+	{
+		getSlug: () => {},
+		getTitle: () => 'Jetpack Feature 1',
+		availableForCurrentPlan: true,
+	},
+	{
+		getSlug: () => {},
+		getTitle: () => 'Jetpack Feature 2',
+		availableForCurrentPlan: true,
+	},
+	{
+		getSlug: () => {},
+		getTitle: () => 'Jetpack Feature 3',
+		availableForCurrentPlan: true,
+	},
+];
+
+export default {
+	title: 'plans-grid-next',
+	component: FeaturesGrid,
+	decorators: [
+		( Story ) => (
+			<QueryClientProvider client={ queryClient }>
+				<Story />
+			</QueryClientProvider>
+		),
+	],
+	parameters: {
+		viewport: {
+			defaultViewport: 'LARGE',
+		},
+	},
+} as Meta;
+
+const defaultArgs = {
+	gridPlans: [
+		{
+			planSlug: 'free_plan',
+			isVisible: true,
+			tagline: 'Get a taste of the world’s most popular CMS & blogging software.',
+			availableForPurchase: false,
+			productNameShort: 'Free',
+			planTitle: 'Free',
+			billingTimeframe: 'No expiration date',
+			current: false,
+			isMonthlyPlan: true,
+			cartItemForPlan: null,
+			highlightLabel: null,
+			pricing: {
+				originalPrice: {
+					monthly: 0,
+					full: 0,
+				},
+				discountedPrice: {
+					monthly: null,
+					full: null,
+				},
+				billingPeriod: -1,
+				currencyCode: 'AUD',
+				introOffer: null,
+			},
+			storageAddOnsForPlan: null,
+			features: {
+				wpcomFeatures,
+				jetpackFeatures,
+				storageOptions: [
+					{
+						slug: '1gb-storage',
+						isAddOn: false,
+					},
+				],
+			},
+		},
+		{
+			planSlug: 'personal-bundle',
+			isVisible: true,
+			tagline: 'Create your home on the web with a custom domain name.',
+			availableForPurchase: false,
+			productNameShort: 'Starter',
+			planTitle: 'Starter',
+			billingTimeframe: 'per month, billed annually',
+			current: false,
+			isMonthlyPlan: false,
+			cartItemForPlan: {
+				product_slug: 'personal-bundle',
+			},
+			highlightLabel: null,
+			pricing: {
+				originalPrice: {
+					monthly: 600,
+					full: 7200,
+				},
+				discountedPrice: {
+					monthly: null,
+					full: null,
+				},
+				billingPeriod: 365,
+				currencyCode: 'AUD',
+				introOffer: null,
+			},
+			storageAddOnsForPlan: null,
+			features: {
+				wpcomFeatures,
+				jetpackFeatures,
+				storageOptions: [
+					{
+						slug: '6gb-storage',
+						isAddOn: false,
+					},
+				],
+			},
+		},
+		{
+			planSlug: 'value_bundle',
+			isVisible: true,
+			tagline: 'Build a unique website with powerful design tools.',
+			availableForPurchase: false,
+			productNameShort: 'Explorer',
+			planTitle: 'Explorer',
+			billingTimeframe: 'per month, billed annually',
+			current: false,
+			isMonthlyPlan: false,
+			cartItemForPlan: {
+				product_slug: 'value_bundle',
+			},
+			highlightLabel: null,
+			pricing: {
+				originalPrice: {
+					monthly: 1200,
+					full: 14400,
+				},
+				discountedPrice: {
+					monthly: null,
+					full: null,
+				},
+				billingPeriod: 365,
+				currencyCode: 'AUD',
+				introOffer: null,
+			},
+			storageAddOnsForPlan: null,
+			features: {
+				wpcomFeatures,
+				jetpackFeatures,
+				storageOptions: [
+					{
+						slug: '13gb-storage',
+						isAddOn: false,
+					},
+				],
+			},
+		},
+		{
+			planSlug: 'business-bundle',
+			isVisible: true,
+			tagline: 'Unlock the power of WordPress with plugins and cloud tools.',
+			availableForPurchase: false,
+			productNameShort: 'Creator',
+			planTitle: 'Creator',
+			billingTimeframe: 'per month, billed annually',
+			current: true,
+			isMonthlyPlan: false,
+			cartItemForPlan: {
+				product_slug: 'business-bundle',
+			},
+			highlightLabel: 'Your plan',
+			pricing: {
+				originalPrice: {
+					monthly: 3800,
+					full: 45600,
+				},
+				discountedPrice: {
+					monthly: null,
+					full: null,
+				},
+				billingPeriod: 365,
+				currencyCode: 'AUD',
+				expiry: '2025-01-17T00:00:00+00:00',
+				introOffer: null,
+			},
+			storageAddOnsForPlan: [
+				{
+					productSlug: 'wordpress_com_1gb_space_addon_yearly',
+					featureSlugs: [ '50gb-storage-add-on' ],
+					icon: null,
+					quantity: 50,
+					name: '50 GB Storage',
+					displayCost: 'A$74.58/month, billed yearly',
+					prices: {
+						monthlyPrice: 7458.333333333333,
+						yearlyPrice: 89500,
+						formattedMonthlyPrice: 'A$74.58',
+						formattedYearlyPrice: 'A$895',
+					},
+					description: 'Make more space for high-quality photos, videos, and other media. ',
+					featured: false,
+					purchased: false,
+					checkoutLink: '/checkout/wordpress_com_1gb_space_addon_yearly',
+					exceedsSiteStorageLimits: true,
+				},
+				{
+					productSlug: 'wordpress_com_1gb_space_addon_yearly',
+					featureSlugs: [ '100gb-storage-add-on' ],
+					quantity: 100,
+					name: '100 GB Storage',
+					displayCost: 'A$124.25/month, billed yearly',
+					prices: {
+						monthlyPrice: 12425,
+						yearlyPrice: 149100,
+						formattedMonthlyPrice: 'A$124.25',
+						formattedYearlyPrice: 'A$1,491',
+					},
+					description:
+						'Take your site to the next level. Store all your media in one place without worrying about running out of space.',
+					featured: false,
+					purchased: false,
+					checkoutLink: '/checkout/wordpress_com_1gb_space_addon_yearly',
+					exceedsSiteStorageLimits: true,
+				},
+			],
+			features: {
+				wpcomFeatures,
+				jetpackFeatures,
+				storageOptions: [
+					{
+						slug: '50gb-storage',
+						isAddOn: false,
+					},
+					{
+						slug: '50gb-storage-add-on',
+						isAddOn: true,
+					},
+					{
+						slug: '100gb-storage-add-on',
+						isAddOn: true,
+					},
+				],
+			},
+		},
+		{
+			planSlug: 'ecommerce-bundle',
+			isVisible: true,
+			tagline: 'Create a powerful online store with built-in premium extensions.',
+			availableForPurchase: true,
+			productNameShort: 'Entrepreneur',
+			planTitle: 'Entrepreneur',
+			billingTimeframe: 'per month, billed annually',
+			current: false,
+			isMonthlyPlan: false,
+			cartItemForPlan: {
+				product_slug: 'ecommerce-bundle',
+			},
+			highlightLabel: null,
+			pricing: {
+				originalPrice: {
+					monthly: 6800,
+					full: 81600,
+				},
+				discountedPrice: {
+					monthly: 3316.67,
+					full: 39800,
+				},
+				billingPeriod: 365,
+				currencyCode: 'AUD',
+				introOffer: null,
+			},
+			features: {
+				wpcomFeatures,
+				jetpackFeatures,
+				storageOptions: [
+					{
+						slug: '50gb-storage',
+						isAddOn: false,
+					},
+					{
+						slug: '50gb-storage-add-on',
+						isAddOn: true,
+					},
+					{
+						slug: '100gb-storage-add-on',
+						isAddOn: true,
+					},
+				],
+			},
+		},
+		{
+			planSlug: 'plan-enterprise-grid-wpcom',
+			isVisible: true,
+			tagline:
+				'Deliver an unmatched performance with the highest security standards on our enterprise content platform.',
+			availableForPurchase: false,
+			productNameShort: 'enterprise',
+			planTitle: 'Enterprise',
+			billingTimeframe: '',
+			current: false,
+			isMonthlyPlan: true,
+			cartItemForPlan: null,
+			highlightLabel: null,
+			pricing: {
+				originalPrice: {
+					monthly: null,
+					full: null,
+				},
+				discountedPrice: {
+					monthly: null,
+					full: null,
+				},
+			},
+			storageAddOnsForPlan: null,
+			features: {
+				wpcomFeatures: [],
+				jetpackFeatures: [],
+				storageOptions: [],
+			},
+		},
+	],
+	gridPlanForSpotlight: {
+		planSlug: 'business-bundle',
+		isVisible: true,
+		tagline: 'Unlock the power of WordPress with plugins and cloud tools.',
+		availableForPurchase: false,
+		productNameShort: 'Creator',
+		planTitle: 'Creator',
+		billingTimeframe: 'per month, billed annually',
+		current: true,
+		isMonthlyPlan: false,
+		cartItemForPlan: {
+			product_slug: 'business-bundle',
+		},
+		highlightLabel: 'Your plan',
+		pricing: {
+			originalPrice: {
+				monthly: 3800,
+				full: 45600,
+			},
+			discountedPrice: {
+				monthly: null,
+				full: null,
+			},
+			billingPeriod: 365,
+			currencyCode: 'AUD',
+			expiry: '2025-01-17T00:00:00+00:00',
+			introOffer: null,
+		},
+		storageAddOnsForPlan: [
+			{
+				productSlug: 'wordpress_com_1gb_space_addon_yearly',
+				featureSlugs: [ '50gb-storage-add-on' ],
+				icon: null,
+				quantity: 50,
+				name: '50 GB Storage',
+				displayCost: 'A$74.58/month, billed yearly',
+				prices: {
+					monthlyPrice: 7458.333333333333,
+					yearlyPrice: 89500,
+					formattedMonthlyPrice: 'A$74.58',
+					formattedYearlyPrice: 'A$895',
+				},
+				description: 'Make more space for high-quality photos, videos, and other media. ',
+				featured: false,
+				purchased: false,
+				checkoutLink: '/checkout/wordpress_com_1gb_space_addon_yearly',
+				exceedsSiteStorageLimits: true,
+			},
+			{
+				productSlug: 'wordpress_com_1gb_space_addon_yearly',
+				featureSlugs: [ '100gb-storage-add-on' ],
+				quantity: 100,
+				name: '100 GB Storage',
+				displayCost: 'A$124.25/month, billed yearly',
+				prices: {
+					monthlyPrice: 12425,
+					yearlyPrice: 149100,
+					formattedMonthlyPrice: 'A$124.25',
+					formattedYearlyPrice: 'A$1,491',
+				},
+				description:
+					'Take your site to the next level. Store all your media in one place without worrying about running out of space.',
+				featured: false,
+				purchased: false,
+				checkoutLink: '/checkout/wordpress_com_1gb_space_addon_yearly',
+				exceedsSiteStorageLimits: true,
+			},
+		],
+		features: {
+			wpcomFeatures,
+			jetpackFeatures,
+			storageOptions: [
+				{
+					slug: '50gb-storage',
+					isAddOn: false,
+				},
+				{
+					slug: '50gb-storage-add-on',
+					isAddOn: true,
+				},
+				{
+					slug: '100gb-storage-add-on',
+					isAddOn: true,
+				},
+			],
+		},
+	},
+	generatedWPComSubdomain: {
+		isLoading: false,
+		result: {},
+	},
+	isCustomDomainAllowedOnFreePlan: false,
+	isInSignup: false,
+	isInAdmin: true,
+	isLaunchPage: false,
+	onUpgradeClick: () => {},
+	selectedSiteId: 182283121,
+	intervalType: 'yearly',
+	hideUnavailableFeatures: false,
+	currentSitePlanSlug: 'business-bundle',
+	planActionOverrides: {
+		currentPlan: {},
+	},
+	intent: 'plans-default-wpcom',
+	showLegacyStorageFeature: false,
+	showUpgradeableStorage: true,
+	stickyRowOffset: 32,
+	useCheckPlanAvailabilityForPurchase: () => ( { value_bundle: true } ),
+	allFeaturesList: {},
+	onStorageAddOnClick: () => {},
+	showRefundPeriod: false,
+	recordTracksEvent: () => {},
+	planUpgradeCreditsApplicable: 418,
+};
+
+const storyDefaults = {
+	args: defaultArgs,
+};
+
+export const FeaturesGridTest = {
+	...storyDefaults,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,6 +1547,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@storybook/addon-actions": "npm:^7.6.17"
+    "@storybook/cli": "npm:^7.6.17"
     "@storybook/react": "npm:^7.6.17"
     "@testing-library/dom": "npm:^9.3.4"
     "@testing-library/jest-dom": "npm:^6.4.2"


### PR DESCRIPTION
Related to #86640

## Proposed Changes

Configures [Storybook](https://storybook.js.org/) for the `plans-grid-next` package and adds a very simple `FeaturesGrid` story as a minimal example. Going forward, the plan is to implement stories that closely reflect real world instances of the features/comparison grids.

![CleanShot 2024-03-20 at 16 38 48@2x](https://github.com/Automattic/wp-calypso/assets/69198925/7a7a83d1-7891-4fd7-bcc9-d4c04f6d3fe8)

## Testing Instructions

1. Run `yarn workspace @automattic/plans-grid-next storybook`
2. A browser window should open to `http://localhost:49955`
3. Expand the 'plan-grid-next' item in the sidebar and select the story 'Features Grid Test'
4. Verify that the features grid is displayed
6. Save a code change for the features grid
7. Verify that the change is reflected in the story


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?