### PR TITLE
A4A: Add next steps component to the overview section

### DIFF
--- a/client/a8c-for-agencies/components/guided-tour-step/index.tsx
+++ b/client/a8c-for-agencies/components/guided-tour-step/index.tsx
@@ -1,0 +1,89 @@
+import { Button, Popover } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { LegacyRef, useContext, useEffect } from 'react';
+import { GuidedTourContext } from 'calypso/a8c-for-agencies/data/guided-tours/guided-tour-context';
+
+type Props = {
+	id: string;
+	context: LegacyRef< HTMLSpanElement | null >;
+	className?: string;
+	hideSteps?: boolean;
+};
+
+/**
+ * Renders a single step in a guided tour.
+ */
+export function GuidedTourStep( { id, context, hideSteps, className }: Props ) {
+	const translate = useTranslate();
+
+	const {
+		currentStep,
+		currentStepCount,
+		stepsCount,
+		nextStep,
+		endTour,
+		registerRenderedStep,
+		unregisterRenderedStep,
+		tourDismissed,
+	} = useContext( GuidedTourContext );
+
+	const lastTourLabel = stepsCount === 1 ? translate( 'Got it' ) : translate( 'Done' );
+
+	// Keep track of which tour steps are currently rendered/mounted.
+	useEffect( () => {
+		// Register on mount.
+		registerRenderedStep( id );
+		// Unregister on unmount.
+		return () => unregisterRenderedStep( id );
+	}, [ id, registerRenderedStep, unregisterRenderedStep ] );
+
+	// Do not render unless this is the current step in the active tour.
+	if ( ! currentStep || id !== currentStep.id || tourDismissed ) {
+		return null;
+	}
+
+	return (
+		<Popover
+			isVisible={ true }
+			className={ classNames( className, 'guided-tour__popover' ) }
+			context={ context }
+			position={ currentStep.popoverPosition }
+		>
+			<h2 className="guided-tour__popover-heading">{ currentStep.title }</h2>
+			<p className="guided-tour__popover-description">{ currentStep.description }</p>
+			<div className="guided-tour__popover-footer">
+				<div>
+					{
+						// Show the step count if there are multiple steps and we're not on the last step, unless we explicitly choose to hide them
+						stepsCount > 1 && ! hideSteps && (
+							<span className="guided-tour__popover-step-count">
+								{ translate( 'Step %(currentStep)d of %(totalSteps)d', {
+									args: { currentStep: currentStepCount, totalSteps: stepsCount },
+								} ) }
+							</span>
+						)
+					}
+				</div>
+				<div className="guided-tour__popover-footer-right-content">
+					<>
+						{ ( ( ! currentStep.nextStepOnTargetClick &&
+							stepsCount > 1 &&
+							currentStepCount < stepsCount ) ||
+							currentStep.forceShowSkipButton ) && (
+							// Show the skip button if there are multiple steps and we're not on the last step, unless we explicitly choose to add them
+							<Button borderless onClick={ endTour }>
+								{ translate( 'Skip' ) }
+							</Button>
+						) }
+						{ ! currentStep.nextStepOnTargetClick && (
+							<Button onClick={ nextStep }>
+								{ currentStepCount === stepsCount ? lastTourLabel : translate( 'Next' ) }
+							</Button>
+						) }
+					</>
+				</div>
+			</div>
+		</Popover>
+	);
+}

--- a/client/a8c-for-agencies/components/guided-tour/index.tsx
+++ b/client/a8c-for-agencies/components/guided-tour/index.tsx
@@ -1,0 +1,200 @@
+import page from '@automattic/calypso-router';
+import { Popover, Button } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect, useCallback } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getJetpackDashboardPreference as getPreference } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { preferencesLastFetchedTimestamp } from 'calypso/state/preferences/selectors';
+
+import './style.scss';
+
+export interface Tour {
+	id: string;
+	target: string;
+	title: string;
+	description: string | JSX.Element;
+	popoverPosition?:
+		| 'top'
+		| 'top right'
+		| 'right'
+		| 'bottom right'
+		| 'bottom'
+		| 'bottom left'
+		| 'left'
+		| 'top left';
+	nextStepOnTargetClick?: string;
+	forceShowSkipButton?: boolean;
+}
+
+interface Props {
+	className?: string;
+	tours: Tour[];
+	preferenceName: string;
+	redirectAfterTourEnds?: string;
+	hideSteps?: boolean;
+}
+
+// This hook will return the async element matching the target selector.
+// After timeout has passed, it will return null.
+//
+// @param target - The selector to match the element against
+// @param timeoutDuration - The maximum duration (in milliseconds) to wait for the element
+//
+// @returns The element matching the target selector, or null if the timeout has passed
+const useAsyncElement = ( target: string, timeoutDuration: number ): HTMLElement | null => {
+	const [ asyncElement, setAsyncElement ] = useState< HTMLElement | null >( null );
+
+	useEffect( () => {
+		// Set timeout to ensure we don't wait too long for the element
+		const endTime = Date.now() + timeoutDuration;
+
+		const getAsyncElement = ( endTime: number ) => {
+			const element = document.querySelector( target ) as HTMLElement | null;
+			if ( element ) {
+				setAsyncElement( element );
+			} else if ( Date.now() < endTime ) {
+				requestAnimationFrame( () => getAsyncElement( endTime ) );
+			} else {
+				setAsyncElement( null );
+			}
+		};
+
+		getAsyncElement( endTime );
+	}, [ target, timeoutDuration ] );
+
+	return asyncElement;
+};
+
+const GuidedTour = ( {
+	className,
+	tours,
+	preferenceName,
+	redirectAfterTourEnds,
+	hideSteps = false,
+}: Props ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ currentStep, setCurrentStep ] = useState( 0 );
+	const [ isVisible, setIsVisible ] = useState( false );
+
+	const preference = useSelector( ( state ) => getPreference( state, preferenceName ) );
+	const hasFetched = !! useSelector( preferencesLastFetchedTimestamp );
+
+	const isDismissed = preference?.dismiss;
+
+	const {
+		title,
+		description,
+		target,
+		popoverPosition,
+		nextStepOnTargetClick,
+		forceShowSkipButton = false,
+	} = tours[ currentStep ];
+
+	const targetElement = useAsyncElement( target, 3000 );
+
+	useEffect( () => {
+		if ( targetElement && ! isDismissed && hasFetched ) {
+			setIsVisible( true );
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_cloud_start_tour', {
+					tour: preferenceName,
+				} )
+			);
+		}
+	}, [ dispatch, isDismissed, preferenceName, targetElement, hasFetched ] );
+
+	const endTour = useCallback( () => {
+		dispatch( savePreference( preferenceName, { ...preference, dismiss: true } ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_cloud_end_tour', {
+				tour: preferenceName,
+			} )
+		);
+		if ( redirectAfterTourEnds ) {
+			page.redirect( redirectAfterTourEnds );
+		}
+	}, [ dispatch, preferenceName, preference, redirectAfterTourEnds ] );
+
+	const nextStep = useCallback( () => {
+		if ( currentStep < tours.length - 1 ) {
+			setCurrentStep( currentStep + 1 );
+		} else {
+			endTour();
+		}
+	}, [ currentStep, tours.length, endTour ] );
+
+	useEffect( () => {
+		let nextStepClickTargetElement: Element | null = null;
+		// We should wait for targetElement before attaching any events to advance to the next step
+		if ( nextStepOnTargetClick && targetElement && ! isDismissed && hasFetched ) {
+			// Find the target element using the nextStepOnTargetClick selector
+			nextStepClickTargetElement = document.querySelector( nextStepOnTargetClick );
+			if ( nextStepClickTargetElement ) {
+				// Attach the event listener to the nextStepClickTargetElement
+				nextStepClickTargetElement.addEventListener( 'click', nextStep );
+			}
+		}
+
+		// Cleanup function to remove the event listener
+		return () => {
+			if ( nextStepClickTargetElement ) {
+				nextStepClickTargetElement.removeEventListener( 'click', nextStep );
+			}
+		};
+	}, [ nextStepOnTargetClick, nextStep, targetElement, isDismissed, hasFetched ] );
+
+	if ( isDismissed || ! targetElement ) {
+		return null;
+	}
+
+	const lastTourLabel = tours.length === 1 ? translate( 'Got it' ) : translate( 'Done' );
+
+	return (
+		<Popover
+			isVisible={ isVisible }
+			className={ classNames( className, 'guided-tour__popover' ) }
+			context={ targetElement }
+			position={ popoverPosition }
+		>
+			<h2 className="guided-tour__popover-heading">{ title }</h2>
+			<p className="guided-tour__popover-description">{ description }</p>
+			<div className="guided-tour__popover-footer">
+				<div>
+					{
+						// Show the step count if there are multiple steps and we're not on the last step, unless we explicitly choose to hide them
+						tours.length > 1 && ! hideSteps && (
+							<span className="guided-tour__popover-step-count">
+								{ translate( 'Step %(currentStep)d of %(totalSteps)d', {
+									args: { currentStep: currentStep + 1, totalSteps: tours.length },
+								} ) }
+							</span>
+						)
+					}
+				</div>
+				<div className="guided-tour__popover-footer-right-content">
+					<>
+						{ ( ( ! nextStepOnTargetClick && tours.length > 1 && currentStep < tours.length - 1 ) ||
+							forceShowSkipButton ) && (
+							// Show the skip button if there are multiple steps and we're not on the last step, unless we explicitly choose to add them
+							<Button borderless onClick={ endTour }>
+								{ translate( 'Skip' ) }
+							</Button>
+						) }
+						{ ! nextStepOnTargetClick && (
+							<Button onClick={ nextStep }>
+								{ currentStep === tours.length - 1 ? lastTourLabel : translate( 'Next' ) }
+							</Button>
+						) }
+					</>
+				</div>
+			</div>
+		</Popover>
+	);
+};
+
+export default GuidedTour;

--- a/client/a8c-for-agencies/components/guided-tour/style.scss
+++ b/client/a8c-for-agencies/components/guided-tour/style.scss
@@ -1,0 +1,49 @@
+.guided-tour__popover {
+	.popover__inner {
+		display: flex;
+		gap: 16px;
+		padding: 16px;
+		flex-direction: column;
+		align-items: flex-start;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 8px;
+	}
+}
+
+.guided-tour__popover-heading {
+	color: var(--studio-gray-100);
+	font-size: rem(14px);
+	line-height: 1.5;
+	font-weight: 500;
+}
+
+.guided-tour__popover-description {
+	color: var(--studio-gray-80);
+	font-size: rem(12px);
+	line-height: 1.5;
+	max-width: 220px;
+	text-align: left;
+	margin-block-end: 0;
+}
+
+.guided-tour__popover-footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+
+	.guided-tour__popover-step-count {
+		color: var(--studio-gray-60);
+		font-size: rem(12px);
+	}
+
+	.guided-tour__popover-footer-right-content {
+		display: flex;
+		gap: 8px;
+
+		button {
+			padding: 4px 8px;
+			font-size: rem(12px);
+		}
+	}
+}

--- a/client/a8c-for-agencies/data/guided-tours/guided-tour-context.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/guided-tour-context.tsx
@@ -1,0 +1,111 @@
+import { ReactNode, createContext, useCallback, useMemo, useState } from 'react';
+import { Tour } from 'calypso/a8c-for-agencies/components/guided-tour';
+
+type GuidedTourContextType = {
+	currentStep: Tour | null;
+	currentStepCount: number;
+	stepsCount: number;
+	nextStep: () => void;
+	endTour: () => void;
+	registerRenderedStep: ( stepId: string ) => void;
+	unregisterRenderedStep: ( stepId: string ) => void;
+	tourDismissed: boolean;
+};
+
+const defaultGuidedTourContextValue = {
+	currentStep: null,
+	currentStepCount: 0,
+	stepsCount: 0,
+	nextStep: () => {},
+	endTour: () => {},
+	registerRenderedStep: () => {},
+	unregisterRenderedStep: () => {},
+	tourDismissed: false,
+};
+
+export const GuidedTourContext = createContext< GuidedTourContextType >(
+	defaultGuidedTourContextValue
+);
+
+/**
+ * Guided Tour Context Provider
+ * Provides access to interact with the contextually relevant guided tour.
+ */
+export const GuidedTourContextProvider = ( {
+	children,
+	steps = [],
+}: {
+	children?: ReactNode;
+	steps?: Tour[];
+} ) => {
+	const [ renderedSteps, setRenderedSteps ] = useState< string[] >( [] );
+	const [ completedSteps, setCompletedSteps ] = useState< string[] >( [] );
+	const [ tourDismissed, setTourDismissed ] = useState< boolean >( false );
+
+	/**
+	 * Derive current tour state from the available vs completed steps.
+	 */
+	const { currentStep, currentStepCount, stepsCount } = useMemo( () => {
+		return steps.reduce(
+			( carry, step ) => {
+				if ( renderedSteps.includes( step.id ) ) {
+					carry.stepsCount++;
+					if ( ! carry.currentStep && ! completedSteps.includes( step.id ) ) {
+						carry.currentStep = step;
+						carry.currentStepCount = carry.stepsCount;
+					}
+				}
+				return carry;
+			},
+			{
+				currentStep: null,
+				currentStepCount: 0,
+				stepsCount: 0,
+			}
+		);
+	}, [ steps, renderedSteps, completedSteps ] );
+
+	/**
+	 * Proceed to the next available step in the tour.
+	 */
+	const nextStep = useCallback( () => {
+		if ( currentStep ) {
+			setCompletedSteps( ( currentSteps ) => [ ...currentSteps, currentStep.id ] );
+		}
+	}, [ currentStep ] );
+
+	/**
+	 * Dismiss all steps in the tour.
+	 */
+	const endTour = () => setTourDismissed( true );
+
+	const registerRenderedStep = useCallback( ( stepId: string ) => {
+		setRenderedSteps( ( currentSteps ) => {
+			if ( ! currentSteps.includes( stepId ) ) {
+				return [ ...currentSteps, stepId ];
+			}
+			return currentSteps;
+		} );
+	}, [] );
+
+	const unregisterRenderedStep = useCallback( ( stepId: string ) => {
+		setRenderedSteps( ( currentSteps ) => currentSteps.filter( ( step ) => step !== stepId ) );
+	}, [] );
+
+	return (
+		<GuidedTourContext.Provider
+			value={ {
+				stepsCount,
+				currentStep,
+				currentStepCount,
+				nextStep,
+				endTour,
+				registerRenderedStep,
+				unregisterRenderedStep,
+				tourDismissed,
+			} }
+		>
+			{ children }
+		</GuidedTourContext.Provider>
+	);
+};

--- a/client/a8c-for-agencies/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
+++ b/client/a8c-for-agencies/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
@@ -1,0 +1,40 @@
+import { useTranslate } from 'i18n-calypso';
+import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
+import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from '../constants';
+
+import '../style.scss';
+
+export default function AddNewSiteTourStep1() {
+	const translate = useTranslate();
+	const urlParams = new URLSearchParams( window.location.search );
+	const shouldRenderAddSiteTourStep1 = urlParams.get( 'tour' ) === 'add-new-site';
+
+	return (
+		shouldRenderAddSiteTourStep1 && (
+			<GuidedTour
+				className="onboarding-tours__guided-tour"
+				preferenceName={ A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'addSiteStep1' ] }
+				tours={ [
+					{
+						target: '#sites-overview-add-sites-button .split-button__toggle',
+						popoverPosition: 'bottom left',
+						title: translate( 'Click the arrow button' ),
+						description: (
+							<>
+								{ translate( 'Click the arrow button and select "Connect a site to Jetpack".' ) }
+								<br />
+								<br />
+								{ translate(
+									'Sites with Jetpack installed will automatically appear in the site management view.'
+								) }
+							</>
+						),
+
+						nextStepOnTargetClick: '#sites-overview-add-sites-button .split-button__toggle',
+						forceShowSkipButton: true,
+					},
+				] }
+			/>
+		)
+	);
+}

--- a/client/a8c-for-agencies/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
+++ b/client/a8c-for-agencies/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
@@ -1,0 +1,57 @@
+import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
+import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
+import { SiteData } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { useSelector } from 'calypso/state';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import SitesDashboardContext from '../../sites/sites-dashboard-context';
+import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from '../constants';
+
+import '../style.scss';
+
+interface Props {
+	siteItems: Array< SiteData >;
+}
+
+export default function AddNewSiteTourStep2( { siteItems }: Props ) {
+	const translate = useTranslate();
+	const { mostRecentConnectedSite } = useContext( SitesDashboardContext );
+	const hasFinishedStep1 = useSelector( ( state ) =>
+		getPreference( state, A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'addSiteStep1' ] )
+	);
+	// We should only render the second step if the first one has finished (hasFinishedStep1) and we have a new connected site (mostRecentConnectedSite).
+	// to do: implement mostRecentConnectedSite
+	const shouldRenderAddSiteTourStep2 = hasFinishedStep1 && mostRecentConnectedSite;
+
+	const tourHTMLTarget =
+		siteItems.length < 20
+			? 'tr.is-most-recent-jetpack-connected-site td:first-of-type'
+			: '.site-table__table th:first-of-type';
+
+	return (
+		shouldRenderAddSiteTourStep2 && (
+			<GuidedTour
+				className="onboarding-tours__guided-tour"
+				preferenceName={ A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'addSiteStep2' ] }
+				redirectAfterTourEnds="/overview"
+				tours={ [
+					{
+						target: tourHTMLTarget,
+						popoverPosition: 'bottom right',
+						title: translate( '🎉 Your new site is here' ),
+						description: (
+							<>
+								{ translate( 'Check out your new site here. That was straightforward, right?' ) }
+								<br />
+								<br />
+								{ translate(
+									'Sites with Jetpack installed will automatically appear in the site management view.'
+								) }
+							</>
+						),
+					},
+				] }
+			/>
+		)
+	);
+}

--- a/client/a8c-for-agencies/sections/onboarding-tours/constants.tsx
+++ b/client/a8c-for-agencies/sections/onboarding-tours/constants.tsx
@@ -1,16 +1,14 @@
 /**
  * Constant holding all preference names for our onboarding tours.
  */
-export const JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
-	addSiteStep1: 'jetpack-manage-site-dashboard-add-new-site-tour-step-1',
-	addSiteStep2: 'jetpack-manage-site-dashboard-add-new-site-tour-step-2',
-	enableMonitorStep1: 'jetpack-manage-site-dashboard-enable-monitor-tour-step-1',
-	enableMonitorStep2: 'jetpack-manage-site-dashboard-enable-monitor-tour-step-2',
-	dashboardWalkthrough: 'jetpack-manage-sites-overview-dashboard-walkthrough-tour',
-	pluginOverview: 'jetpack-manage-plugin-management-v2-plugin-overview-tour',
+export const A4A_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
+	addSiteStep1: 'a4a-sites-add-new-site-tour-step-1',
+	addSiteStep2: 'a4a-sites-add-new-site-tour-step-2',
+	sitesWalkthrough: 'a4a-sites-tour',
+	exploreMarketplace: 'a4a-marketplace-tour',
 };
 
-export const JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE = [
+export const A4A_ONBOARDING_TOURS_EXAMPLE_SITE = [
 	{
 		site: {
 			value: {

--- a/client/a8c-for-agencies/sections/onboarding-tours/sites-walkthrough-tour/index.tsx
+++ b/client/a8c-for-agencies/sections/onboarding-tours/sites-walkthrough-tour/index.tsx
@@ -1,0 +1,230 @@
+import { useTranslate, translate } from 'i18n-calypso';
+import GuidedTour, { Tour } from 'calypso/a8c-for-agencies/components/guided-tour';
+import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
+
+import '../style.scss';
+
+export const sitesWalkthroughTour: Tour[] = [
+	{
+		id: 'sites-walkthrough-intro',
+		target: '.sites-dataview__site-header',
+		popoverPosition: 'bottom right',
+		title: translate( 'Manage all your sites' ),
+		description: translate( 'Here you can find your sites and detailed overview about each.' ),
+	},
+	{
+		id: 'sites-walkthrough-stats',
+		target: '.sites-dataview__stats-header',
+		popoverPosition: 'bottom right',
+		title: translate( '📊 Stats' ),
+		description: translate(
+			'Here you can see page view metrics and how they evolved over the last 7 days.'
+		),
+	},
+	{
+		id: 'sites-walkthrough-boost',
+		target: '.sites-dataview__boost-header',
+		popoverPosition: 'bottom right',
+		title: translate( '🚀 Boost score rating' ),
+		description: translate(
+			"Here's a score reflecting your website's load speed. Click 'Get Score' to know your site's speed rating – it's free!"
+		),
+	},
+	{
+		id: 'sites-walkthrough-backup',
+		target: '.sites-dataview__backup-header',
+		popoverPosition: 'bottom right',
+		title: translate( '🛡️ Backups' ),
+		description: translate(
+			'We automatically back up your site and safeguard your data. Restoring is as simple as a single click.'
+		),
+	},
+	{
+		id: 'sites-walkthrough-monitor',
+		target: '.sites-dataview__monitor-header',
+		popoverPosition: 'bottom left',
+		title: translate( '⏲️ Uptime Monitor' ),
+		description: (
+			<>
+				{ translate(
+					"We keep tabs on your site's uptime. Simply toggle this on, and we'll alert you if your site goes down."
+				) }
+				<br />
+				<br />
+				{ translate(
+					'🟢 With the premium plan, you can tweak notification settings to alert multiple recipients simultaneously.'
+				) }
+			</>
+		),
+	},
+	{
+		id: 'sites-walkthrough-scan',
+		target: '.sites-dataview__scan-header',
+		popoverPosition: 'bottom right',
+		title: translate( '🔍 Scan' ),
+		description: translate(
+			'We scan your site and flag any detected issues using a traffic light warning system – 🔴 for severe or 🟡 for a warning.'
+		),
+	},
+	{
+		id: 'sites-walkthrough-plugins',
+		target: '.sites-dataview__plugins-header',
+		popoverPosition: 'bottom right',
+		title: translate( '🔌 Plugin updates' ),
+		description: (
+			<>
+				{ translate(
+					"We keep an eye on the status of your plugins for every site. If any plugins require updates, we'll let you know."
+				) }
+				<br />
+				<br />
+				{ translate(
+					"From here, you can update individually, enable auto-updates, or update all plugins simultaneously. Oh, and it's all free."
+				) }
+			</>
+		),
+	},
+	{
+		id: 'sites-walkthrough-site-preview',
+		target: '.site-preview__open',
+		nextStepOnTargetClick: '.site-preview__open',
+		popoverPosition: 'bottom right',
+		title: translate( '🔍 Detailed views' ),
+		description: translate(
+			'Click the arrow for detailed insights on stats, site speed performance, recent backups, and monitoring activity trends. Handy, right?'
+		),
+	},
+	{
+		id: 'sites-walkthrough-site-preview-tabs',
+		target: '.site-preview__tabs',
+		popoverPosition: 'bottom right',
+		title: translate( '🔍 Detailed site view' ),
+		description: (
+			<>
+				{ translate( "Great! You're now viewing detailed insights." ) }
+				<br />
+				<br />
+				{ translate(
+					'Use the tabs to navigate between site speed, backups, uptime monitor, activity trends, and plugins.'
+				) }
+			</>
+		),
+	},
+];
+
+export default function SitesWalkthroughTour() {
+	const translate = useTranslate();
+
+	const urlParams = new URLSearchParams( window.location.search );
+	const shouldRenderSitesTour = true || urlParams.get( 'tour' ) === 'sites-walkthrough';
+
+	const tourSteps: Tour[] = [
+		{
+			target: '.sites-dataview__site-header',
+			popoverPosition: 'bottom right',
+			title: translate( 'Manage all your sites' ),
+			description: translate( 'Here you can find your sites and detailed overview about each.' ),
+		},
+		{
+			target: '.sites-dataview__stats-header',
+			popoverPosition: 'bottom right',
+			title: translate( '📊 Stats' ),
+			description: translate(
+				'Here you can see page view metrics and how they evolved over the last 7 days.'
+			),
+		},
+		{
+			target: '.sites-dataview__boost-header',
+			popoverPosition: 'bottom right',
+			title: translate( '🚀 Boost score rating' ),
+			description: translate(
+				"Here's a score reflecting your website's load speed. Click 'Get Score' to know your site's speed rating – it's free!"
+			),
+		},
+		{
+			target: '.sites-dataview__backup-header',
+			popoverPosition: 'bottom right',
+			title: translate( '🛡️ Backups' ),
+			description: translate(
+				'We automatically back up your site and safeguard your data. Restoring is as simple as a single click.'
+			),
+		},
+		{
+			target: '.sites-dataview__monitor-header',
+			popoverPosition: 'bottom left',
+			title: translate( '⏲️ Uptime Monitor' ),
+			description: (
+				<>
+					{ translate(
+						"We keep tabs on your site's uptime. Simply toggle this on, and we'll alert you if your site goes down."
+					) }
+					<br />
+					<br />
+					{ translate(
+						'🟢 With the premium plan, you can tweak notification settings to alert multiple recipients simultaneously.'
+					) }
+				</>
+			),
+		},
+		{
+			target: '.sites-dataview__scan-header',
+			popoverPosition: 'bottom right',
+			title: translate( '🔍 Scan' ),
+			description: translate(
+				'We scan your site and flag any detected issues using a traffic light warning system – 🔴 for severe or 🟡 for a warning.'
+			),
+		},
+		{
+			target: '.sites-dataview__plugins-header',
+			popoverPosition: 'bottom right',
+			title: translate( '🔌 Plugin updates' ),
+			description: (
+				<>
+					{ translate(
+						"We keep an eye on the status of your plugins for every site. If any plugins require updates, we'll let you know."
+					) }
+					<br />
+					<br />
+					{ translate(
+						"From here, you can update individually, enable auto-updates, or update all plugins simultaneously. Oh, and it's all free."
+					) }
+				</>
+			),
+		},
+		{
+			target: '.site-preview__open',
+			nextStepOnTargetClick: '.site-preview__open',
+			popoverPosition: 'bottom right',
+			title: translate( '🔍 Detailed views' ),
+			description: translate(
+				'Click the arrow for detailed insights on stats, site speed performance, recent backups, and monitoring activity trends. Handy, right?'
+			),
+		},
+		{
+			target: '.site-preview__tabs',
+			popoverPosition: 'bottom right',
+			title: translate( '🔍 Detailed site view' ),
+			description: (
+				<>
+					{ translate( "Great! You're now viewing detailed insights." ) }
+					<br />
+					<br />
+					{ translate(
+						'Use the tabs to navigate between site speed, backups, uptime monitor, activity trends, and plugins.'
+					) }
+				</>
+			),
+		},
+	];
+
+	return (
+		shouldRenderSitesTour && (
+			<GuidedTour
+				className="onboarding-tours__guided-tour"
+				preferenceName={ A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'sitesWalkthrough' ] }
+				redirectAfterTourEnds="/overview"
+				tours={ tourSteps }
+			/>
+		)
+	);
+}

--- a/client/a8c-for-agencies/sections/onboarding-tours/style.scss
+++ b/client/a8c-for-agencies/sections/onboarding-tours/style.scss
@@ -1,0 +1,21 @@
+.onboarding-tours__guided-tour {
+	.guided-tour__popover-heading {
+		font-size: rem(16px);
+	}
+
+	.guided-tour__popover-description {
+		font-size: rem(14px);
+	}
+
+	.guided-tour__popover-step-count,
+	.guided-tour__popover-footer-right-content .button {
+		font-size: rem(13px);
+	}
+
+	.button:not(.is-borderless) {
+		padding: 5px 16px;
+		background-color: var(--studio-jetpack-green-50);
+		border-color: var(--studio-jetpack-green-50);
+		color: var(--color-text-inverted);
+	}
+}

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/constants.ts
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/constants.ts
@@ -1,0 +1,125 @@
+/**
+ * Constant holding all preference names for our onboarding tours.
+ */
+export const JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
+	addSiteStep1: 'jetpack-manage-site-dashboard-add-new-site-tour-step-1',
+	addSiteStep2: 'jetpack-manage-site-dashboard-add-new-site-tour-step-2',
+	enableMonitorStep1: 'jetpack-manage-site-dashboard-enable-monitor-tour-step-1',
+	enableMonitorStep2: 'jetpack-manage-site-dashboard-enable-monitor-tour-step-2',
+	dashboardWalkthrough: 'jetpack-manage-sites-overview-dashboard-walkthrough-tour',
+	pluginOverview: 'jetpack-manage-plugin-management-v2-plugin-overview-tour',
+};
+
+export const JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE = [
+	{
+		site: {
+			value: {
+				url: 'example.jetpack.com',
+				url_with_scheme: 'https://example.jetpack.com',
+				blogname: 'Example WordPress Site',
+				monitor_settings: {
+					monitor_deferment_time: 5,
+					check_interval: null,
+					last_down_time: null,
+					monitor_active: false,
+					monitor_site_status: null,
+					monitor_site_status_raw: null,
+					monitor_notify_users_emails: [],
+					monitor_user_emails: [],
+					monitor_user_email_notifications: true,
+					monitor_user_wp_note_notifications: true,
+					monitor_user_sms_notifications: false,
+					monitor_notify_additional_user_emails: [],
+					monitor_notify_additional_user_sms: [],
+					sms_sent_count: 0,
+					sms_remaining_count: 0,
+					sms_monthly_limit: 20,
+					is_over_limit: null,
+				},
+				site_stats: {
+					visitors: {
+						total: 0,
+						trend: 'same',
+						trend_change: 0,
+					},
+					views: {
+						total: 0,
+						trend: 'same',
+						trend_change: 0,
+					},
+				},
+			},
+			error: false,
+			status: 'active',
+			type: 'site',
+		},
+		stats: {
+			status: 'active',
+			type: 'stats',
+			value: {
+				visitors: {
+					total: 0,
+					trend: 'same',
+					trend_change: 0,
+				},
+				views: {
+					total: 0,
+					trend: 'same',
+					trend_change: 0,
+				},
+			},
+		},
+		boost: {
+			status: 'active',
+			type: 'boost',
+			value: {
+				desktop: null,
+				mobile: null,
+				overall: null,
+			},
+		},
+		backup: {
+			value: '',
+			status: 'inactive',
+			type: 'backup',
+		},
+		scan: {
+			value: '',
+			status: 'inactive',
+			type: 'scan',
+			threats: 0,
+		},
+		monitor: {
+			value: '',
+			status: 'disabled',
+			type: 'monitor',
+			error: false,
+			settings: {
+				monitor_deferment_time: 5,
+				check_interval: null,
+				last_down_time: null,
+				monitor_active: false,
+				monitor_site_status: null,
+				monitor_site_status_raw: null,
+				monitor_notify_users_emails: [ 'example@example.jetpack.com' ],
+				monitor_user_emails: [ 'diego.rodrigues@automattic.com' ],
+				monitor_user_email_notifications: true,
+				monitor_user_wp_note_notifications: true,
+				monitor_user_sms_notifications: false,
+				monitor_notify_additional_user_emails: [],
+				monitor_notify_additional_user_sms: [],
+				sms_sent_count: 0,
+				sms_remaining_count: 0,
+				sms_monthly_limit: 20,
+				is_over_limit: null,
+			},
+		},
+		plugin: {
+			value: '0 Available',
+			status: 'success',
+			type: 'plugin',
+			updates: 0,
+		},
+		isFavorite: false,
+	},
+];

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
@@ -1,5 +1,118 @@
-const OverviewBodyNextSteps = () => {
-	return <div>Next Steps</div>;
-};
+import { isEnabled } from '@automattic/calypso-config';
+import { CircularProgressBar } from '@automattic/components';
+import { Checklist, ChecklistItem, type Task } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
+import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from './constants';
 
-export default OverviewBodyNextSteps;
+// import './style.scss';
+
+export default function OverviewBodyNextSteps( { onDismiss = () => {} } ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const preferences = useSelector( getAllRemotePreferences );
+
+	const checkTourCompletion = ( prefSlug: string ): boolean => {
+		if ( preferences && JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] ) {
+			return JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] in preferences;
+		}
+		return false;
+	};
+
+	const resetTour = ( prefSlugs: string[] ): void => {
+		prefSlugs.forEach( ( slug ) => {
+			if ( JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ] ) {
+				dispatch( savePreference( JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ], null ) );
+			}
+		} );
+	};
+
+	const tasks: Task[] = [
+		{
+			calypso_path: '/dashboard?tour=dashboard-walkthrough',
+			completed: checkTourCompletion( 'dashboardWalkthrough' ),
+			disabled: false,
+			actionDispatch: () => {
+				dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_get_familiar_click' ) );
+				resetTour( [ 'dashboardWalkthrough' ] );
+			},
+			id: 'get_familiar',
+			title: translate( 'Get familiar with the sites management dashboard' ),
+			useCalypsoPath: true,
+		},
+		{
+			calypso_path: isEnabled( 'jetpack/manage-sites-v2-menu' )
+				? '/sites?tour=add-new-site'
+				: '/dashboard?tour=add-new-site',
+			completed: checkTourCompletion( 'addSiteStep1' ),
+			disabled: false,
+			actionDispatch: () => {
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_overview_next_steps_explore_marketplace_click' )
+				);
+				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
+			},
+			id: 'explore_marketplace',
+			title: translate( 'Explore the marketplace' ),
+			useCalypsoPath: true,
+		},
+		{
+			calypso_path: '/dashboard?tour=enable-monitor',
+			completed: checkTourCompletion( 'enableMonitorStep2' ),
+			disabled: false,
+			actionDispatch: () => {
+				dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_add_sites_click' ) );
+				resetTour( [ 'enableMonitorStep1', 'enableMonitorStep2' ] );
+			},
+			id: 'add_sites',
+			title: translate( 'Learn how to add new sites' ),
+			useCalypsoPath: true,
+		},
+	];
+
+	const numberOfTasks = tasks.length;
+	const completedTasks = tasks.filter( ( task ) => task.completed ).length;
+
+	const isCompleted = completedTasks === numberOfTasks;
+
+	return (
+		<div className="next-steps">
+			<div className="next-steps__header">
+				<h2>{ isCompleted ? translate( '🎉 Congratulations!' ) : translate( 'Next Steps' ) }</h2>
+				<CircularProgressBar
+					size={ 32 }
+					enableDesktopScaling
+					numberOfSteps={ numberOfTasks }
+					currentStep={ completedTasks }
+				/>
+			</div>
+			{ isCompleted && (
+				<p>
+					{ translate(
+						"Right now there's nothing left for you to do. We'll let you know when anything needs your attention."
+					) }{ ' ' }
+					<button
+						className="dismiss"
+						onClick={ () => {
+							dispatch(
+								recordTracksEvent( 'calypso_jetpack_manage_overview_next_steps_dismiss_click' )
+							);
+							onDismiss();
+						} }
+					>
+						{ translate( 'Hide' ) }
+					</button>
+				</p>
+			) }
+			<Checklist>
+				{ tasks.map( ( task ) => (
+					<ChecklistItem task={ task } key={ task.id } />
+				) ) }
+			</Checklist>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
@@ -1,14 +1,13 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { CircularProgressBar } from '@automattic/components';
+import { Card, CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, type Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
+import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
-import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from './constants';
 
-// import './style.scss';
+import './style.scss';
 
 export default function OverviewBodyNextSteps( { onDismiss = () => {} } ) {
 	const dispatch = useDispatch();
@@ -17,56 +16,54 @@ export default function OverviewBodyNextSteps( { onDismiss = () => {} } ) {
 	const preferences = useSelector( getAllRemotePreferences );
 
 	const checkTourCompletion = ( prefSlug: string ): boolean => {
-		if ( preferences && JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] ) {
-			return JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] in preferences;
+		if ( preferences && A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] ) {
+			return A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] in preferences;
 		}
 		return false;
 	};
 
 	const resetTour = ( prefSlugs: string[] ): void => {
 		prefSlugs.forEach( ( slug ) => {
-			if ( JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ] ) {
-				dispatch( savePreference( JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ], null ) );
+			if ( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ] ) {
+				dispatch( savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ], null ) );
 			}
 		} );
 	};
 
 	const tasks: Task[] = [
 		{
-			calypso_path: '/dashboard?tour=dashboard-walkthrough',
-			completed: checkTourCompletion( 'dashboardWalkthrough' ),
+			calypso_path: '/sites?tour=sites-walkthrough',
+			completed: checkTourCompletion( 'sitesWalkthrough' ),
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_get_familiar_click' ) );
-				resetTour( [ 'dashboardWalkthrough' ] );
+				resetTour( [ 'sitesWalkthrough' ] );
 			},
 			id: 'get_familiar',
 			title: translate( 'Get familiar with the sites management dashboard' ),
 			useCalypsoPath: true,
 		},
 		{
-			calypso_path: isEnabled( 'jetpack/manage-sites-v2-menu' )
-				? '/sites?tour=add-new-site'
-				: '/dashboard?tour=add-new-site',
-			completed: checkTourCompletion( 'addSiteStep1' ),
+			calypso_path: '/marketplace',
+			completed: checkTourCompletion( 'exploreMarketplace' ),
 			disabled: false,
 			actionDispatch: () => {
 				dispatch(
 					recordTracksEvent( 'calypso_a4a_overview_next_steps_explore_marketplace_click' )
 				);
-				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
+				resetTour( [ 'exploreMarketplace' ] );
 			},
 			id: 'explore_marketplace',
 			title: translate( 'Explore the marketplace' ),
 			useCalypsoPath: true,
 		},
 		{
-			calypso_path: '/dashboard?tour=enable-monitor',
-			completed: checkTourCompletion( 'enableMonitorStep2' ),
+			calypso_path: '/sites?tour=add-new-site',
+			completed: checkTourCompletion( 'addSiteStep1' ),
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_add_sites_click' ) );
-				resetTour( [ 'enableMonitorStep1', 'enableMonitorStep2' ] );
+				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
 			},
 			id: 'add_sites',
 			title: translate( 'Learn how to add new sites' ),
@@ -80,39 +77,41 @@ export default function OverviewBodyNextSteps( { onDismiss = () => {} } ) {
 	const isCompleted = completedTasks === numberOfTasks;
 
 	return (
-		<div className="next-steps">
-			<div className="next-steps__header">
-				<h2>{ isCompleted ? translate( '🎉 Congratulations!' ) : translate( 'Next Steps' ) }</h2>
-				<CircularProgressBar
-					size={ 32 }
-					enableDesktopScaling
-					numberOfSteps={ numberOfTasks }
-					currentStep={ completedTasks }
-				/>
+		<Card>
+			<div className="next-steps">
+				<div className="next-steps__header">
+					<h2>{ isCompleted ? translate( '🎉 Congratulations!' ) : translate( 'Next Steps' ) }</h2>
+					<CircularProgressBar
+						size={ 32 }
+						enableDesktopScaling
+						numberOfSteps={ numberOfTasks }
+						currentStep={ completedTasks }
+					/>
+				</div>
+				{ isCompleted && (
+					<p>
+						{ translate(
+							"Right now there's nothing left for you to do. We'll let you know when anything needs your attention."
+						) }{ ' ' }
+						<button
+							className="dismiss"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_jetpack_manage_overview_next_steps_dismiss_click' )
+								);
+								onDismiss();
+							} }
+						>
+							{ translate( 'Hide' ) }
+						</button>
+					</p>
+				) }
+				<Checklist>
+					{ tasks.map( ( task ) => (
+						<ChecklistItem task={ task } key={ task.id } />
+					) ) }
+				</Checklist>
 			</div>
-			{ isCompleted && (
-				<p>
-					{ translate(
-						"Right now there's nothing left for you to do. We'll let you know when anything needs your attention."
-					) }{ ' ' }
-					<button
-						className="dismiss"
-						onClick={ () => {
-							dispatch(
-								recordTracksEvent( 'calypso_jetpack_manage_overview_next_steps_dismiss_click' )
-							);
-							onDismiss();
-						} }
-					>
-						{ translate( 'Hide' ) }
-					</button>
-				</p>
-			) }
-			<Checklist>
-				{ tasks.map( ( task ) => (
-					<ChecklistItem task={ task } key={ task.id } />
-				) ) }
-			</Checklist>
-		</div>
+		</Card>
 	);
 }

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -1,0 +1,77 @@
+.next-steps {
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 16px;
+
+		h2 {
+			font-size: rem(16px);
+			font-weight: 500;
+			color: var(--studio-gray-100);
+		}
+		.circular__progress-bar {
+			margin-right: 8px;
+
+			.circular__progress-bar-text {
+				font-size: rem(10px);
+				font-weight: 500;
+				line-height: 20px;
+				color: var(--studio-gray-100);
+			}
+
+			.circular__progress-bar-fill-circle {
+				stroke: var(--studio-jetpack-green-50);
+			}
+		}
+	}
+
+	p,
+	button {
+		font-size: rem(14px);
+		font-weight: 400;
+		color: var(--studio-gray-80);
+	}
+
+	button.dismiss {
+		cursor: pointer;
+		text-decoration: underline;
+
+		&:hover {
+			color: var(--studio-jetpack-green-50);
+		}
+	}
+
+	.checklist-item__task {
+
+		.checklist-item__text {
+			font-size: rem(14px);
+			font-weight: 400;
+			color: var(--studio-gray-80);
+		}
+
+		&.completed .checklist-item__text {
+			text-decoration: line-through;
+		}
+
+		&.completed.enabled:hover,
+		&.pending:hover,
+		&.completed.enabled > a:focus,
+		&.pending > a:focus {
+			.checklist-item__text {
+				color: var(--studio-jetpack-green-50);
+			}
+
+			.checklist-item__chevron,
+			.checklist-item__checkmark {
+				fill: var(--studio-jetpack-green-50);
+			}
+		}
+	}
+
+}
+
+.card:has(.next-steps) {
+	padding: 16px 24px;
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/index.tsx
@@ -86,7 +86,10 @@ export default function SitePreviewPane( {
 	return (
 		<div className={ classNames( 'site-preview__pane', className ) }>
 			<SitePreviewPaneHeader site={ site } closeSitePreviewPane={ closeSitePreviewPane } />
-			<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
+			<SectionNav
+				className="preview-pane__navigation site-preview__tabs"
+				selectedText={ selectedFeature.tab.label }
+			>
 				{ navItems && navItems.length > 0 && canDisplayNavTabs ? (
 					<NavTabs>{ navItems }</NavTabs>
 				) : null }

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
@@ -2,19 +2,22 @@ import { Button, Gridicon, Spinner } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { LegacyRef, useCallback, useContext, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
+import SiteSetFavorite from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite';
+import SiteSort from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import SiteDataField from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/site-data-field';
+import {
+	AllowedTypes,
+	Site,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-import SiteSetFavorite from '../site-set-favorite';
-import SiteSort from '../site-sort';
-import { AllowedTypes, Site } from '../types';
 import { SitesDataViewsProps, SiteInfo } from './interfaces';
 
 import './style.scss';
@@ -36,7 +39,9 @@ const SitesDataViews = ( {
 	const sites = useFormattedSites( data?.sites ?? [] );
 
 	const [ sitesWalkthroughTourIntroStepAnchor, setSitesWalkthroughTourIntroStepAnchor ] =
-		useState( null );
+		useState< LegacyRef< HTMLSpanElement | null > >( null );
+	const [ sitesWalkthroughTourStatsStepAnchor, setSitesWalkthroughTourStatsStepAnchor ] =
+		useState< LegacyRef< HTMLSpanElement | null > >( null );
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
@@ -102,7 +107,7 @@ const SitesDataViews = ( {
 						<SiteSort isSortable={ true } columnKey="site">
 							<span
 								className="sites-dataview__site-header"
-								ref={ ( ref ) => setSitesWalkthroughTourIntroStepAnchor( ref ) }
+								ref={ setSitesWalkthroughTourIntroStepAnchor }
 							>
 								{ translate( 'Site' ).toUpperCase() }
 							</span>
@@ -132,7 +137,20 @@ const SitesDataViews = ( {
 			},
 			{
 				id: 'stats',
-				header: <span className="sites-dataview__stats-header">STATS</span>,
+				header: (
+					<>
+						<span
+							className="sites-dataview__stats-header"
+							ref={ setSitesWalkthroughTourStatsStepAnchor }
+						>
+							STATS
+						</span>
+						<GuidedTourStep
+							id="sites-walkthrough-stats"
+							context={ sitesWalkthroughTourStatsStepAnchor }
+						/>
+					</>
+				),
 				getValue: () => '-',
 				render: ( { item }: { item: SiteInfo } ) => renderField( 'stats', item ),
 				enableHiding: false,

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
@@ -1,0 +1,45 @@
+import { Site, SiteData } from '../types';
+
+export interface SitesDataResponse {
+	sites: Array< Site >;
+	total: number;
+	perPage: number;
+	totalFavorites: number;
+}
+
+export interface SitesDataViewsProps {
+	className?: string;
+	data: SitesDataResponse | undefined;
+	forceTourExampleSite?: boolean;
+	isLargeScreen: boolean;
+	isLoading: boolean;
+	onSitesViewChange: ( view: SitesViewState ) => void;
+	sitesViewState: SitesViewState;
+}
+
+export interface Sort {
+	field: string;
+	direction: 'asc' | 'desc';
+}
+
+export interface Filter {
+	field: string;
+	operator: string;
+	value: number;
+}
+
+export interface SitesViewState {
+	type: 'table' | 'list' | 'grid';
+	perPage: number;
+	page: number;
+	sort: Sort;
+	search: string;
+	filters: Filter[];
+	hiddenFields: string[];
+	layout: object;
+	selectedSite?: Site | undefined;
+}
+
+export interface SiteInfo extends SiteData {
+	id: number;
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -1,0 +1,215 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.sites-overview__content {
+
+	.components-checkbox-control__input[type="checkbox"]:focus {
+		box-shadow: 0 0 0 var(--studio-jetpack-green-50) #fff, 0 0 0 calc(2* var(--studio-jetpack-green-50)) var(--studio-jetpack-green-50);
+		outline: 2px solid transparent;
+		outline-offset: 2px;
+	}
+	.components-checkbox-control__input[type="checkbox"]:checked,
+	.components-checkbox-control__input[type="checkbox"]:indeterminate {
+		background: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
+		border-color: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
+	}
+
+	.dataviews-bulk-edit-button.components-button.is-tertiary:active:not(:disabled),
+	.dataviews-bulk-edit-button.components-button.is-tertiary:hover:not(:disabled) {
+		box-shadow: none;
+		background-color: transparent;
+		color: var(--studio-jetpack-green-50);
+	}
+
+	.dataviews-view-table__actions-column {
+		display: none;
+	}
+
+	thead {
+		th.sites-dataviews__site {
+			background: var(--studio-white);
+			td {
+				padding: 16px 0;
+				border-bottom: 1px solid var(--studio-gray-5);
+			}
+		}
+	}
+
+	tr.dataviews-view-table__row {
+		background: var(--studio-white);
+
+		.components-checkbox-control__input {
+			opacity: 0;
+		}
+		.components-checkbox-control__input:checked,
+		.components-checkbox-control__input:indeterminate, {
+			opacity: 1;
+		}
+
+		.dataviews-view-table-selection-checkbox {
+			padding-left: 12px;
+			&.is-selected {
+				.components-checkbox-control__input {
+					opacity: 1;
+				}
+			}
+		}
+
+		&:hover {
+			background: var(--studio-gray-0);
+
+			.site-set-favorite__favorite-icon,
+			.components-checkbox-control__input {
+				opacity: 1;
+			}
+		}
+
+		th {
+			padding: 16px 4px;
+			border-bottom: 1px solid var(--studio-gray-5);
+			font-size: rem(13px);
+			font-weight: 400;
+		}
+
+		td {
+			padding: 16px 4px;
+			border-bottom: 1px solid var(--studio-gray-5);
+			vertical-align: middle;
+		}
+
+		td:has(.sites-dataviews__site) {
+			padding: 8px 16px 8px 4px;
+			width: 20%;
+		}
+
+		.site-sort__clickable {
+			cursor: pointer;
+			padding-left: 1rem;
+
+		}
+
+		.dataviews-view-table__checkbox-column,
+		.components-checkbox-control__input {
+			label.components-checkbox-control__label {
+				display: none;
+			}
+			&[type="checkbox"] {
+				border-color: var(--studio-gray-5);
+			}
+		}
+	}
+
+	ul.dataviews-view-list {
+		li:hover {
+			background: var(--studio-gray-0);
+		}
+		.is-selected {
+			background-color: var(--studio-jetpack-green-0);
+		}
+	}
+}
+
+.components-search-control input[type="search"].components-search-control__input {
+	background: var(--studio-white);
+	border: 1px solid var(--studio-gray-5);
+}
+
+.dataviews-filters__view-actions {
+	margin-bottom: 8px;
+}
+
+.sites-dataviews__site {
+	display: flex;
+	flex-direction: row;
+
+	.button {
+		padding: 0;
+	}
+}
+
+.sites-dataviews__site-name {
+	display: inline-block;
+	text-align: left;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	width: 180px;
+	font-weight: 500;
+	font-size: rem(14px);
+}
+
+.sites-dataviews__site-url {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	font-size: rem(12px);
+	color: var(--studio-gray-60);
+	font-weight: 400;
+}
+
+.preview-hidden {
+	@media (min-width: 2040px) {
+		.sites-dataviews__site-name {
+			width: 250px;
+		}
+	}
+}
+
+.sites-dataviews__actions {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	flex-wrap: nowrap;
+
+	@media (min-width: 1080px) {
+		.site-actions__actions-large-screen {
+			float: none;
+			margin-inline-end: 20px;
+		}
+	}
+
+	.site-preview__open {
+		.gridicon.gridicons-chevron-right {
+			width: 18px;
+			height: 18px;
+		}
+	}
+}
+
+.dataviews-pagination {
+	margin-bottom: 2rem;
+}
+
+
+.dataviews-wrapper {
+	.dataviews-no-results,
+	.dataviews-loading {
+		padding-top: 1rem;
+		text-align: center;
+	}
+
+	.spinner-wrapper {
+		display: none;
+	}
+
+}
+
+.dataviews-wrapper:has(.dataviews-loading) {
+	.spinner-wrapper {
+		display: block;
+	}
+	.dataviews-loading p {
+		display: none;
+	}
+
+	.dataviews-view-table-wrapper {
+		height: 0 !important;
+	}
+}
+
+.dataviews-wrapper:has(.dataviews-no-results) {
+	.spinner-wrapper {
+		display: none;
+	}
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/types.d.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/types.d.ts
@@ -1,0 +1,1 @@
+declare module '@wordpress/dataviews';

--- a/client/a8c-for-agencies/sections/sites/sites-top-header-buttons/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-top-header-buttons/index.tsx
@@ -1,0 +1,94 @@
+import { Button } from '@automattic/components';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+// import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
+// import WPCOMHostingPopover from './wpcom-hosting-popover';
+
+import './style.scss';
+
+/** @todo Do we need the WPCOM Hosting Popover? */
+/** @todo Do we need to implement the partnerCanIssueLicense check? */
+export default function SiteTopHeaderButtons() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const isMobile = useMobileBreakpoint();
+	// const partner = useSelector( getCurrentPartner );
+
+	const buttonRef = useRef< HTMLElement | null >( null );
+	const [ toggleIsOpen, setToggleIsOpen ] = useState( false );
+
+	// const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
+
+	// const onIssueNewLicenseClick = () => {
+	// 	dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click' ) );
+	// };
+
+	return (
+		<div className="sites-overview__top-header-buttons">
+			{ /* <Button
+				href={ partnerCanIssueLicense ? '/partner-portal/issue-license' : undefined }
+				className="sites-overview__issue-license-button"
+				disabled={ ! partnerCanIssueLicense }
+				onClick={ onIssueNewLicenseClick }
+			>
+				{ translate( 'Issue License', { context: 'button label' } ) }
+			</Button> */ }
+
+			<span id="sites-overview-add-sites-button">
+				<AddNewSiteButton
+					showMainButtonLabel={ ! isMobile }
+					// popoverContext={ buttonRef }
+					// onToggleMenu={ ( isOpen: boolean ) => setToggleIsOpen( isOpen ) }
+					onClickAddNewSite={ () =>
+						dispatch(
+							recordTracksEvent(
+								'calypso_jetpack_agency_dashboard_sites_overview_add_new_site_click'
+							)
+						)
+					}
+					onClickWpcomMenuItem={ () =>
+						dispatch(
+							recordTracksEvent(
+								'calypso_jetpack_agency_dashboard_sites_overview_create_wpcom_site_click'
+							)
+						)
+					}
+					onClickJetpackMenuItem={ () =>
+						dispatch(
+							recordTracksEvent(
+								'calypso_jetpack_agency_dashboard_sites_overview_connect_jetpack_site_click'
+							)
+						)
+					}
+					onClickUrlMenuItem={ () =>
+						dispatch(
+							recordTracksEvent(
+								'calypso_jetpack_agency_dashboard_sites_overview_connect_url_site_click'
+							)
+						)
+					}
+				/>
+
+				{ /* <WPCOMHostingPopover
+                    context={ buttonRef.current }
+                    // Show the popover only when the split button is closed
+                    isVisible={ ! toggleIsOpen }
+                /> */ }
+			</span>
+			<Button
+				primary
+				href={ A4A_MARKETPLACE_PRODUCTS_LINK }
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_a4a_sites_add_products_click' ) );
+				} }
+			>
+				{ translate( 'Add products' ) }
+			</Button>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/sites-top-header-buttons/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-top-header-buttons/style.scss
@@ -1,0 +1,5 @@
+.sites-overview__top-header-buttons {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/292

## Proposed Changes

* Adds the "Next Steps" card to the A4A overview page.
* Adds the related walkthroughs necessary to complete each step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click through each step. You will be navigated to the relevant section, with walkthrough cards displayed touring you through the screen. Follow the tutorial to completion, and you will be redirected back to the overview page, with the step marked as completed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="793" alt="Screenshot 2024-03-26 at 11 41 01 AM" src="https://github.com/Automattic/wp-calypso/assets/10933065/c38aa8fd-b4a6-44df-b836-79dbaafffa38">

<img width="447" alt="Screenshot 2024-03-26 at 10 58 38 AM" src="https://github.com/Automattic/wp-calypso/assets/10933065/7c5dc8ec-ca5c-49b3-a6e3-8118be056718">
