### PR TITLE
Pattern Library: Track view change

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -11,7 +11,7 @@ import {
 	category as iconCategory,
 	menu as iconMenu,
 } from '@wordpress/icons';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -11,7 +11,6 @@ import {
 	category as iconCategory,
 	menu as iconMenu,
 } from '@wordpress/icons';
-import { useCallback } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -105,7 +104,6 @@ export const PatternLibrary = ( {
 	const handleViewChange = ( view: 'grid' | 'list' ) => {
 		const currentView = isGridView ? 'grid' : 'list';
 
-		// Let's only handle this if the view changes
 		if ( currentView === view ) {
 			return;
 		}

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '@wordpress/icons';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { PatternsCopyPasteInfo } from 'calypso/my-sites/patterns/components/copy-paste-info';
 import { PatternsGetStarted } from 'calypso/my-sites/patterns/components/get-started';
 import { PatternsHeader } from 'calypso/my-sites/patterns/components/header';
@@ -31,6 +32,9 @@ import {
 	type Pattern,
 	type PatternGalleryFC,
 } from 'calypso/my-sites/patterns/types';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
 
 import './style.scss';
 
@@ -47,7 +51,7 @@ function filterPatternsByType( patterns: Pattern[], type: PatternTypeFilter ) {
 	} );
 }
 
-function handleSettingView( value: 'grid' | 'list' ) {
+const handleSettingView = ( value: 'grid' | 'list' ) => {
 	const searchParams = new URLSearchParams( location.search );
 
 	if ( value === 'grid' ) {
@@ -58,7 +62,7 @@ function handleSettingView( value: 'grid' | 'list' ) {
 
 	const paramsString = searchParams.toString().length ? `?${ searchParams.toString() }` : '';
 	page( location.pathname + paramsString );
-}
+};
 
 // We intentionally disregard grid view when copying the pattern permalink. Our assumption is that
 // it will be more confusing for users to land in grid view when they have a single-pattern permalink
@@ -106,6 +110,30 @@ export const PatternLibrary = ( {
 			return filterPatternsByTerm( patternsByType, searchTerm );
 		},
 	} );
+
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+
+	const recordViewChange = ( view: 'grid' | 'list' ) => {
+		recordTracksEvent( 'calypso_pattern_library_view_switch', {
+			category,
+			is_logged_in: isLoggedIn,
+			type: patternTypeFilter === PatternTypeFilter.REGULAR ? 'pattern' : 'page-layout',
+			user_is_dev_account: isDevAccount ? '1' : '0',
+			view,
+		} );
+	};
+
+	const handleAndRecordViewChange = ( view: 'grid' | 'list' ) => {
+		const searchParams = new URLSearchParams( location.search );
+		const previousView = searchParams.get( 'grid' ) === '1' ? 'grid' : 'list';
+
+		if ( previousView !== view ) {
+			recordViewChange( view );
+		}
+
+		handleSettingView( view );
+	};
 
 	const categoryObject = categories?.find( ( { name } ) => name === category );
 
@@ -212,13 +240,13 @@ export const PatternLibrary = ( {
 								className="pattern-library__toggle-option--list-view"
 								label={ ( <Icon icon={ iconMenu } size={ 20 } /> ) as unknown as string }
 								value="list"
-								onClick={ () => handleSettingView( 'list' ) }
+								onClick={ () => handleAndRecordViewChange( 'list' ) }
 							/>
 							<ToggleGroupControlOption
 								className="pattern-library__toggle-option--grid-view"
 								label={ ( <Icon icon={ iconCategory } size={ 20 } /> ) as unknown as string }
 								value="grid"
-								onClick={ () => handleSettingView( 'grid' ) }
+								onClick={ () => handleAndRecordViewChange( 'grid' ) }
 							/>
 						</ToggleGroupControl>
 					</div>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -115,6 +115,14 @@ export const PatternLibrary = ( {
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
 	const recordViewChange = ( view: 'grid' | 'list' ) => {
+		const searchParams = new URLSearchParams( location.search );
+		const previousView = searchParams.get( 'grid' ) === '1' ? 'grid' : 'list';
+
+		// Let's only track the change if the view changes
+		if ( previousView === view ) {
+			return;
+		}
+
 		recordTracksEvent( 'calypso_pattern_library_view_switch', {
 			category,
 			is_logged_in: isLoggedIn,
@@ -124,13 +132,8 @@ export const PatternLibrary = ( {
 		} );
 	};
 
-	const handleAndRecordViewChange = ( view: 'grid' | 'list' ) => {
-		const searchParams = new URLSearchParams( location.search );
-		const previousView = searchParams.get( 'grid' ) === '1' ? 'grid' : 'list';
-
-		if ( previousView !== view ) {
-			recordViewChange( view );
-		}
+	const trackAndHandleViewChange = ( view: 'grid' | 'list' ) => {
+		recordViewChange( view );
 
 		handleSettingView( view );
 	};
@@ -240,13 +243,13 @@ export const PatternLibrary = ( {
 								className="pattern-library__toggle-option--list-view"
 								label={ ( <Icon icon={ iconMenu } size={ 20 } /> ) as unknown as string }
 								value="list"
-								onClick={ () => handleAndRecordViewChange( 'list' ) }
+								onClick={ () => trackAndHandleViewChange( 'list' ) }
 							/>
 							<ToggleGroupControlOption
 								className="pattern-library__toggle-option--grid-view"
 								label={ ( <Icon icon={ iconCategory } size={ 20 } /> ) as unknown as string }
 								value="grid"
-								onClick={ () => handleAndRecordViewChange( 'grid' ) }
+								onClick={ () => trackAndHandleViewChange( 'grid' ) }
 							/>
 						</ToggleGroupControl>
 					</div>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -102,34 +102,32 @@ export const PatternLibrary = ( {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
-	const handleViewChange = useCallback(
-		( view: 'grid' | 'list' ) => {
-			const searchParams = new URLSearchParams( location.search );
-			const currentView = searchParams.get( 'grid' ) === '1' ? 'grid' : 'list';
+	const handleViewChange = ( view: 'grid' | 'list' ) => {
+		const currentView = isGridView ? 'grid' : 'list';
 
-			// Let's only handle this if the view changes
-			if ( currentView === view ) {
-				return;
-			}
+		// Let's only handle this if the view changes
+		if ( currentView === view ) {
+			return;
+		}
 
-			recordTracksEvent( 'calypso_pattern_library_view_switch', {
-				category,
-				is_logged_in: isLoggedIn,
-				type: patternTypeFilter === PatternTypeFilter.REGULAR ? 'pattern' : 'page-layout',
-				user_is_dev_account: isDevAccount ? '1' : '0',
-				view,
-			} );
+		recordTracksEvent( 'calypso_pattern_library_view_switch', {
+			category,
+			is_logged_in: isLoggedIn,
+			type: patternTypeFilter === PatternTypeFilter.REGULAR ? 'pattern' : 'page-layout',
+			user_is_dev_account: isDevAccount ? '1' : '0',
+			view,
+		} );
 
-			searchParams.delete( 'grid' );
-			if ( view === 'grid' ) {
-				searchParams.set( 'grid', '1' );
-			}
+		const url = new URL( window.location.href );
+		url.searchParams.delete( 'grid' );
 
-			const paramsString = searchParams.toString().length ? `?${ searchParams.toString() }` : '';
-			page( location.pathname + paramsString );
-		},
-		[ category, isDevAccount, isLoggedIn, patternTypeFilter ]
-	);
+		if ( view === 'grid' ) {
+			url.searchParams.set( 'grid', '1' );
+		}
+
+		// Removing the origin ensures that a full refresh is not attempted
+		page( url.href.replace( url.origin, '' ) );
+	};
 
 	const categoryObject = categories?.find( ( { name } ) => name === category );
 


### PR DESCRIPTION
As part of the larger task for implementing event tracking for the pattern library: https://github.com/Automattic/dotcom-forge/issues/6134, this PR sets up tracking for events that are triggered when the pattern view changes from the `list` to `grid` view.


### Testing

 - Navigate to `/patterns/<category>` or `/patterns/layouts/<category>` . 
 - Alternate the pattern view i.e. switch to a grid, then a list etc
 - Confirm that the `calypso_pattern_library_view_switch` event is triggered.