### PR TITLE
AI Logo Generator: Add logo acceptance message

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/assets/images/jetpack-logo.svg
+++ b/packages/jetpack-ai-calypso/src/logo-generator/assets/images/jetpack-logo.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="33" viewBox="0 0 32 33" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M16 32.5C24.8366 32.5 32 25.3366 32 16.5C32 7.66344 24.8366 0.5 16 0.5C7.16344 0.5 0 7.66344 0 16.5C0 25.3366 7.16344 32.5 16 32.5Z" fill="#069E08"/>
+	<path fill-rule="evenodd" clip-rule="evenodd" d="M15.3295 3.67557V19.1565H7.36005L15.3295 3.67557ZM16.9478 29.3244V13.813H24.9478L16.9478 29.3244Z" fill="white"/>
+</svg>

--- a/packages/jetpack-ai-calypso/src/logo-generator/assets/index.d.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/assets/index.d.ts
@@ -1,2 +1,3 @@
 declare module '*.gif';
 declare module '*.png';
+declare module '*.svg';

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.scss
@@ -76,3 +76,15 @@
 	justify-content: flex-end;
 	gap: 12px;
 }
+
+.jetpack-ai-logo-generator__accept {
+	display: flex;
+	flex-direction: column;
+	gap: 64px;
+}
+
+.jetpack-ai-logo-generator__accept-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 22px;
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/logo-presenter.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/logo-presenter.scss
@@ -100,3 +100,15 @@
 		margin-right: 8px;
 	}
 }
+
+.jetpack-ai-logo-generator-modal-presenter__success-wrapper {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 16px;
+	width: 100%;
+
+	@media (max-width: 700px) {
+		padding-bottom: 16px;
+	}
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/visit-site-banner.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/visit-site-banner.scss
@@ -1,0 +1,27 @@
+.jetpack-ai-logo-generator-modal-visit-site-banner {
+	border-radius: 4px;
+	background: var(--studio-gray-0, #f6f7f7);
+	padding: 16px 20px;
+	display: flex;
+	gap: 16px;
+
+	@media (max-width: 700px) {
+		flex-direction: column;
+	}
+}
+
+.jetpack-ai-logo-generator-modal-visit-site-banner__jetpack-logo {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
+.jetpack-ai-logo-generator-modal-visit-site-banner__content {
+	font-size: var($font-body-small, 14px);
+	display: flex;
+	flex-direction: column;
+
+	@media (max-width: 700px) {
+		gap: 8px;
+	}
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/visit-site-banner.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/visit-site-banner.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { Button, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import jetpackLogo from '../assets/images/jetpack-logo.svg';
+import './visit-site-banner.scss';
+/**
+ * Types
+ */
+import type React from 'react';
+
+export const VisitSiteBanner: React.FC< {
+	className?: string;
+	siteURL?: string;
+	onVisitBlankTarget: () => void;
+} > = ( { className = null, siteURL = '#', onVisitBlankTarget } ) => {
+	return (
+		<div className={ classnames( 'jetpack-ai-logo-generator-modal-visit-site-banner', className ) }>
+			<div className="jetpack-ai-logo-generator-modal-visit-site-banner__jetpack-logo">
+				<img src={ jetpackLogo } alt="Jetpack" />
+			</div>
+			<div className="jetpack-ai-logo-generator-modal-visit-site-banner__content">
+				<strong>
+					{ __(
+						'Do you want to know all the amazing things you can do with Jetpack AI?',
+						'jetpack'
+					) }
+				</strong>
+				<span>
+					{ __(
+						'Generate and tweak content, create forms, get feedback and much more.',
+						'jetpack'
+					) }
+				</span>
+				<div>
+					<Button variant="link" href={ siteURL } target="_blank" onClick={ onVisitBlankTarget }>
+						{ __( 'Visit website', 'jetpack' ) }
+						<Icon icon={ external } size={ 20 } />
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/packages/jetpack-ai-calypso/src/types.ts
+++ b/packages/jetpack-ai-calypso/src/types.ts
@@ -15,6 +15,7 @@ export interface LogoPresenterProps {
 	logo?: Logo;
 	loading?: boolean;
 	onApplyLogo: () => void;
+	logoAccepted?: boolean;
 }
 
 export type SaveToMediaLibraryProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86873

## Proposed Changes

* Updates the UI to add  a success message after updating the logo, according to kJj8rPzRgHXAMHzhsmrfpy-fi-4449_73

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the AI logo generator
* Click on "Use on site" on any generated logo
* Check that there is a success message
* Check that it matches the behavior and UI of the figma file

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?