### PR TITLE
A4A: Fix the NavSection in the Preview Pane (random issue)

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -218,7 +218,7 @@ export default function SitesDashboard() {
 			</LayoutColumn>
 
 			{ sitesViewState.selectedSite && (
-				<LayoutColumn wide>
+				<LayoutColumn className="site-preview-pane" wide>
 					<JetpackPreviewPane
 						site={ sitesViewState.selectedSite }
 						closeSitePreviewPane={ closeSitePreviewPane }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -9,6 +9,10 @@
 	background: inherit;
 	padding-block-start: 0;
 
+	.site-preview-pane .a4a-layout-column__container {
+		display: flex;
+	}
+
 	.dataviews-view-table-wrapper {
 		height: calc(100vh - 265px); /* It subtracts the header height to allow scrolling in this block */
 		overflow-y: auto;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -59,16 +59,18 @@ export default function SitePreviewPane( {
 		visible: feature.tab.visible,
 	} ) );
 
+	const navItems = featureTabs.map( ( featureTab ) => (
+		<NavItem { ...featureTab }>{ featureTab.label }</NavItem>
+	) );
+
 	return (
 		<div className={ classNames( 'site-preview__pane', className ) }>
 			<SitePreviewPaneHeader site={ site } closeSitePreviewPane={ closeSitePreviewPane } />
-			<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
-				<NavTabs selectedText={ selectedFeature.tab.label }>
-					{ featureTabs.map( ( featureTab ) => (
-						<NavItem { ...featureTab }>{ featureTab.label }</NavItem>
-					) ) }
-				</NavTabs>
-			</SectionNav>
+			{ navItems && navItems.length > 0 ? (
+				<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
+					<NavTabs selectedText={ selectedFeature.tab.label }>{ navItems }</NavTabs>
+				</SectionNav>
+			) : null }
 			{ selectedFeature.preview }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -43,7 +43,7 @@ export default function SitePreviewPane( {
 	useEffect( () => {
 		setTimeout( () => {
 			setCanDisplayNavTabs( true );
-		}, 100 );
+		}, 150 );
 	}, [] );
 
 	// Ensure we have features

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -36,6 +36,10 @@ export default function SitePreviewPane( {
 	className,
 }: SitePreviewPaneProps ) {
 	const [ canDisplayNavTabs, setCanDisplayNavTabs ] = useState( false );
+
+	// For future iterations lets consider something other than SectionNav due to the
+	// manipulation we need to make so that the navigation shows correctly on some smaller
+	// screens within the PreviewPane (hence the timeout).
 	useEffect( () => {
 		setTimeout( () => {
 			setCanDisplayNavTabs( true );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -35,6 +35,13 @@ export default function SitePreviewPane( {
 	closeSitePreviewPane,
 	className,
 }: SitePreviewPaneProps ) {
+	const [ canDisplayNavTabs, setCanDisplayNavTabs ] = useState( false );
+	useEffect( () => {
+		setTimeout( () => {
+			setCanDisplayNavTabs( true );
+		}, 100 );
+	}, [] );
+
 	// Ensure we have features
 	if ( ! features || ! features.length ) {
 		return null;
@@ -71,11 +78,11 @@ export default function SitePreviewPane( {
 	return (
 		<div className={ classNames( 'site-preview__pane', className ) }>
 			<SitePreviewPaneHeader site={ site } closeSitePreviewPane={ closeSitePreviewPane } />
-			{ navItems && navItems.length > 0 ? (
-				<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
-					<NavTabs selectedText={ selectedFeature.tab.label }>{ navItems }</NavTabs>
-				</SectionNav>
-			) : null }
+			<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
+				{ navItems && navItems.length > 0 && canDisplayNavTabs ? (
+					<NavTabs>{ navItems }</NavTabs>
+				) : null }
+			</SectionNav>
 			{ selectedFeature.preview }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -53,15 +53,20 @@ export default function SitePreviewPane( {
 		key: feature.id,
 		label: feature.tab.label,
 		selected: feature.tab.selected,
-		path: null,
 		onClick: feature.tab.onTabClick,
-		children: [],
 		visible: feature.tab.visible,
 	} ) );
 
-	const navItems = featureTabs.map( ( featureTab ) => (
-		<NavItem { ...featureTab }>{ featureTab.label }</NavItem>
-	) );
+	const navItems = featureTabs.map( ( featureTab ) => {
+		if ( ! featureTab.visible ) {
+			return null;
+		}
+		return (
+			<NavItem selected={ featureTab.selected } onClick={ featureTab.onClick }>
+				{ featureTab.label }
+			</NavItem>
+		);
+	} );
 
 	return (
 		<div className={ classNames( 'site-preview__pane', className ) }>


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/118

## Proposed Changes

This PR fixes the issue introduced in this PR: https://github.com/Automattic/wp-calypso/pull/88682 with the SectionNav (Calypso component). It was a random issue; sometimes, it renders the tabs bar as a dropdown menu and sometimes as a normal tabs bar. The issue was because SectionNav tries to calculate the width size of the NavItems, and depending on how fast we render del NavItem, it gets different results because we are adding NavItem dynamically.

The trick is to first load all the NavItem and then render the SectionNav.

![image](https://github.com/Automattic/wp-calypso/assets/9832440/3e409b36-c22a-4a7a-a282-b269c468c508)

VS

![image](https://github.com/Automattic/wp-calypso/assets/9832440/fe38d90b-eef2-4c62-a028-680dc12f381f)


## Testing Instructions

- Check the code
- Select a site to open the Preview Pane
   - In trunk, the tabs bar will be displayed as a dropdown menu (Sometimes it renders the normal tabs bar)
   - In this branch, the tabs bar will be rendered as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
