### PR TITLE
A4A overview page reusable component for products and hosting

### DIFF
--- a/client/a8c-for-agencies/components/offering/index.tsx
+++ b/client/a8c-for-agencies/components/offering/index.tsx
@@ -1,0 +1,15 @@
+import OfferingItem from './offering-item';
+import { OfferingCardProps } from './types';
+import './style.scss';
+
+const Offering: React.FC< OfferingCardProps > = ( { title, description, items } ) => {
+	return (
+		<div className="a4a-offering-card__wrapper">
+			<h2 className="a4a-offering-card__title">{ title }</h2>
+			<p className="a4a-offering-card__description">{ description }</p>
+			{ items?.map( ( item ) => <OfferingItem key={ item.title } { ...item } /> ) }
+		</div>
+	);
+};
+
+export default Offering;

--- a/client/a8c-for-agencies/components/offering/offering-item.tsx
+++ b/client/a8c-for-agencies/components/offering/offering-item.tsx
@@ -7,6 +7,7 @@ const OfferingItem: React.FC< OfferingItemProps > = ( {
 	description,
 	highlights,
 	buttonTitle,
+	expanded,
 	actionHandler,
 } ) => {
 	const header = (
@@ -19,7 +20,7 @@ const OfferingItem: React.FC< OfferingItemProps > = ( {
 	);
 
 	return (
-		<FoldableCard className="a4a-offering-item__card" header={ header } expanded>
+		<FoldableCard className="a4a-offering-item__card" header={ header } expanded={ expanded }>
 			<p className="a4a-offering-item__description">{ description }</p>
 			<ul className="a4a-offering-item__card-list">
 				{ highlights.map( ( highlightItemText ) => (

--- a/client/a8c-for-agencies/components/offering/offering-item.tsx
+++ b/client/a8c-for-agencies/components/offering/offering-item.tsx
@@ -1,0 +1,41 @@
+import { Gridicon, Button, FoldableCard } from '@automattic/components';
+import { OfferingItemProps } from './types';
+
+const OfferingItem: React.FC< OfferingItemProps > = ( {
+	title,
+	titleIcon,
+	description,
+	highlights,
+	buttonTitle,
+	actionHandler,
+} ) => {
+	const header = (
+		<div>
+			<div className="a4a-offering-item__title-container">
+				{ titleIcon }
+				<h3 className="a4a-offering-item__title">{ title }</h3>
+			</div>
+		</div>
+	);
+
+	return (
+		<FoldableCard className="a4a-offering-item__card" header={ header } expanded>
+			<p className="a4a-offering-item__description">{ description }</p>
+			<ul className="a4a-offering-item__card-list">
+				{ highlights.map( ( highlightItemText ) => (
+					<li className="a4a-offering-item__card-list-item" key={ highlightItemText }>
+						<div className="a4a-offering-item__icon-container">
+							<Gridicon className="a4a-offering-item__gridicon" icon="checkmark" size={ 24 } />
+						</div>
+						<span className="a4a-offering-item__text">{ highlightItemText }</span>
+					</li>
+				) ) }
+			</ul>
+			<Button className="a4a-offering-item__button" onClick={ actionHandler }>
+				{ buttonTitle }
+			</Button>
+		</FoldableCard>
+	);
+};
+
+export default OfferingItem;

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -1,0 +1,92 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+
+.a4a-offering-card__wrapper {
+	padding-top: 16px;
+
+	.a4a-offering-card__title {
+		font-weight: 500;
+		font-size: 1rem;
+		line-height: 24px;
+		color: var(--studio-gray-100);
+	}
+
+	.a4a-offering-card__description {
+		font-weight: 400;
+		font-size: 0.875rem;
+		line-height: 20px;
+		color: var(--studio-gray-60);
+		margin-bottom: 16px;
+	}
+
+	.a4a-offering-item__card {
+		border-radius: 4px;
+
+		.a4a-offering-item__title-container {
+			display: flex;
+			align-items: center;
+
+			.a4a-offering-item__title {
+				color: var(--studio-gray-100);
+				font-weight: 500;
+				font-size: 1rem;
+				margin-left: 10px;
+			}
+		}
+
+		.a4a-offering-item__description {
+			color: var(--studio-gray-60);
+			font-weight: 400;
+			font-size: 0.875rem;
+		}
+
+		.foldable-card__content {
+			border: none;
+			padding-top: 0;
+		}
+	}
+
+	.a4a-offering-item__card-list {
+		display: grid;
+		gap: 16px;
+
+		margin: 8px 0 16px 0;
+		padding: 0;
+
+		list-style-type: none;
+
+		@include break-large {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	.a4a-offering-item__card-list-item {
+		color: var(--studio-gray-80);
+		display: flex;
+		align-items: center;
+		font-size: 0.875rem;
+		line-height: 20px;
+	}
+
+	.a4a-offering-item__icon-container {
+		margin-right: 10px;
+
+		.a4a-offering-item__gridicon {
+			fill: var(--color-primary-20);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+	}
+
+	.a4a-offering-item__button {
+		background-color: #0088bf;
+		fill: var(--color-primary-60);
+		border-radius: 4px;
+		color: var(--studio-white);
+		font-weight: 500;
+		font-size: 0.875rem;
+	}
+}
+

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -9,14 +9,14 @@
 		font-weight: 500;
 		font-size: 1rem;
 		line-height: 24px;
-		color: var(--studio-gray-100);
+		color: var(--color-neutral-100);
 	}
 
 	.a4a-offering-card__description {
 		font-weight: 400;
 		font-size: 0.875rem;
 		line-height: 20px;
-		color: var(--studio-gray-60);
+		color: var(--color-neutral-60);
 		margin-block-end: 16px;
 	}
 
@@ -28,7 +28,7 @@
 			align-items: center;
 
 			.a4a-offering-item__title {
-				color: var(--studio-gray-100);
+				color: var(--color-neutral-100);
 				font-weight: 500;
 				font-size: 1rem;
 				margin-inline-start: 10px;
@@ -36,7 +36,7 @@
 		}
 
 		.a4a-offering-item__description {
-			color: var(--studio-gray-60);
+			color: var(--color-neutral-60);
 			font-weight: 400;
 			font-size: 0.875rem;
 		}
@@ -62,7 +62,7 @@
 	}
 
 	.a4a-offering-item__card-list-item {
-		color: var(--studio-gray-80);
+		color: var(--color-neutral-80);
 		display: flex;
 		align-items: center;
 		font-size: 0.875rem;

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -3,7 +3,7 @@
 
 
 .a4a-offering-card__wrapper {
-	padding-top: 16px;
+	padding-block-start: 16px;
 
 	.a4a-offering-card__title {
 		font-weight: 500;
@@ -17,7 +17,7 @@
 		font-size: 0.875rem;
 		line-height: 20px;
 		color: var(--studio-gray-60);
-		margin-bottom: 16px;
+		margin-block-end: 16px;
 	}
 
 	.a4a-offering-item__card {
@@ -31,7 +31,7 @@
 				color: var(--studio-gray-100);
 				font-weight: 500;
 				font-size: 1rem;
-				margin-left: 10px;
+				margin-inline-start: 10px;
 			}
 		}
 
@@ -43,7 +43,7 @@
 
 		.foldable-card__content {
 			border: none;
-			padding-top: 0;
+			padding-block-start: 0;
 		}
 	}
 
@@ -70,7 +70,7 @@
 	}
 
 	.a4a-offering-item__icon-container {
-		margin-right: 10px;
+		margin-inline-end: 10px;
 
 		.a4a-offering-item__gridicon {
 			fill: var(--color-primary-20);

--- a/client/a8c-for-agencies/components/offering/types.ts
+++ b/client/a8c-for-agencies/components/offering/types.ts
@@ -9,6 +9,7 @@ export type OfferingItemProps = {
 	titleIcon: JSX.Element;
 	description: string;
 	highlights: string[];
+	expanded: boolean;
 	buttonTitle: string;
 	actionHandler: () => void;
 };

--- a/client/a8c-for-agencies/components/offering/types.ts
+++ b/client/a8c-for-agencies/components/offering/types.ts
@@ -1,0 +1,14 @@
+export type OfferingCardProps = {
+	title: string;
+	description: string;
+	items?: OfferingItemProps[];
+};
+
+export type OfferingItemProps = {
+	title: string;
+	titleIcon: JSX.Element;
+	description: string;
+	highlights: string[];
+	buttonTitle: string;
+	actionHandler: () => void;
+};

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -1,5 +1,32 @@
+import Offering from 'calypso/a8c-for-agencies/components/offering';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+
 const OverviewBodyProducts = () => {
-	return <div>Products</div>;
+	//TODO: replace with proper products
+	return (
+		<Offering
+			title="Products"
+			description="Add services to secure, improve performance, and sell goods on your clients’ sites."
+			items={ [
+				{
+					title: 'Jetpack',
+					titleIcon: <JetpackLogo size={ 26 } />,
+					description:
+						'Jetpack offers a flexible suite of security, performance, and growth tools. Pick and choose exactly what you need, à la carte, or explore product bundles for world-class savings.',
+					highlights: [
+						'Optimize your site speed in a few clicks.',
+						'Back up your site in real-time as you edit.',
+						'Create better content with AI.',
+						'Automatically block comment & form spam.',
+						'Stay safe with malware firewall & one-click fixes.',
+						'Get advanced site stats and traffic insights.',
+					],
+					buttonTitle: 'View all Jetpack products',
+					actionHandler: () => {},
+				},
+			] }
+		/>
+	);
 };
 
 export default OverviewBodyProducts;

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -22,6 +22,7 @@ const OverviewBodyProducts = () => {
 						'Get advanced site stats and traffic insights.',
 					],
 					buttonTitle: 'View all Jetpack products',
+					expanded: true,
 					actionHandler: () => {},
 				},
 			] }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/301

## Proposed Changes

Creates a reusable component for the overview page for **Products** and **Hosting** sections. The component called `Offering`. Feel free to suggest a better name, as it's the best I could come up with.

**Open**

<img width="731" alt="Screenshot 2024-03-20 at 12 28 43 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/af883f04-1d35-4909-a80a-8a2ce02cb92a">

**Closed**

<img width="725" alt="Screenshot 2024-03-20 at 12 28 50 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/3bb95ef0-4dbd-43d1-be73-6142ab3d70ed">


## Testing Instructions

- Spin up the branch locally
- Navigate to http://agencies.localhost:3000/overview
- Check that new section is visible and behaves normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?