### PR TITLE
A4A: Add support for "a8c-for-agencies" source parameter in Jetpack connection

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -68,6 +68,7 @@ import {
 	XMLRPC_ERROR,
 } from './connection-notice-types';
 import {
+	JPC_A4A_PATH,
 	JPC_JETPACK_MANAGE_PATH,
 	JPC_PATH_PLANS,
 	JPC_PATH_PLANS_COMPLETE,
@@ -273,6 +274,9 @@ export class JetpackAuthorize extends Component {
 				{ site_connected: urlToSlug( homeUrl ) },
 				JPC_JETPACK_MANAGE_PATH
 			);
+			navigate( urlRedirect );
+		} else if ( source === 'a8c-for-agencies' ) {
+			const urlRedirect = addQueryArgs( { site_connected: urlToSlug( homeUrl ) }, JPC_A4A_PATH );
 			navigate( urlRedirect );
 		}
 

--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -27,3 +27,4 @@ export const JETPACK_COUPON_PRESET_MAPPING = {
 	HMOA: 'jetpack_backup_daily',
 };
 export const JPC_JETPACK_MANAGE_PATH = 'https://cloud.jetpack.com/dashboard';
+export const JPC_A4A_PATH = 'https://agencies.automattic.com/sites';

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -103,7 +103,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 			if ( status === ALREADY_CONNECTED && ! this.state.redirecting ) {
 				const currentPlan = retrievePlan();
 				clearPlan();
-				if ( source === 'jetpack-manage' ) {
+				if ( source === 'jetpack-manage' || source === 'a8c-for-agencies' ) {
 					this.setState( { status: ALREADY_CONNECTED } );
 				} else if ( currentPlan ) {
 					if ( currentPlan === PLAN_JETPACK_FREE ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-genesis/issues/290

Depends on https://github.com/Automattic/jetpack/pull/36491

## Proposed Changes

* Copies some of the Jetpack Manage logic related to the `?source=jetpack-manage` query parameter handling in `/jetpack/connect`, in order to also support a `?source=a8c-for-agencies` value.
  * When the source is `a8c-for-agencies`, the post-connection redirect should be the A4A `/sites` page.
  * Similar to the Jetpack Manage query value, if the site is already connected a notice will be displayed. See the screenshot for reference.
  * The PR that initially introduced this logic for Jetpack Manage can be found here:
   https://github.com/Automattic/wp-calypso/pull/83963

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the live Calypso preview link from this PR, visit the `/jetpack/connect` page and add the `?source=a8c-for-agencies` parameter. Validate the following:
  * You are redirected back to A4A following a successful connection.
  * A notice is displayed immediately if you attempt to connect an already-connected site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="462" alt="Screenshot 2024-03-20 at 3 31 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/c0da2eed-3458-47e0-9f93-b056ab4a6ee6">