### PR TITLE
Stats: allow some a8c blogs as showcases

### DIFF
--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { isA8CSpecialBlog } from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import useUTMMetricTopPostsQuery from '../hooks/use-utm-metric-top-posts-query';
@@ -42,7 +43,8 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	// Fetch top posts for all UTM metric items.
 	const { topPosts } = useUTMMetricTopPostsQuery( siteId, selectedOption, metrics );
 
-	const isSiteInternal = ! isFetchingUsage && usageData?.is_internal;
+	const isSiteInternal =
+		isA8CSpecialBlog( siteId ) || ( ! isFetchingUsage && usageData?.is_internal );
 	const isFetching = isFetchingUsage || isLoadingFeatureCheck || isFetchingUTM;
 	const isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse;
 

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -3,6 +3,17 @@ import version_compare from 'calypso/lib/version-compare';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 
+/**
+ * TODO: look at why it is not working for is_internal option, and remove the check here.
+ */
+const A8C_SPECIAL_BLOG_IDS = [
+	9619154, //en.support.wordpress.com
+	20115252, //jetpack.com
+];
+
+export const isA8CSpecialBlog = ( siteId: number | null ) =>
+	A8C_SPECIAL_BLOG_IDS.includes( siteId ?? 0 );
+
 const version_greater_than_or_equal = (
 	version: string | null,
 	compareVersion: string,
@@ -43,11 +54,12 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 			isOdysseyStats
 		),
 		supportsUTMStats:
+			isA8CSpecialBlog( siteId ) ||
 			// TODO: Remove the flag check once UTM stats are released.
-			config.isEnabled( 'stats/utm-module' ) &&
-			// TODO: Make UTM stats available for internal Simple sites.
-			// UTM stats are only available for Jetpack and Atomic sites for now.
-			isSiteJetpack &&
-			version_greater_than_or_equal( statsAdminVersion, '0.17.0-alpha', isOdysseyStats ),
+			( config.isEnabled( 'stats/utm-module' ) &&
+				// TODO: Make UTM stats available for internal Simple sites.
+				// UTM stats are only available for Jetpack and Atomic sites for now.
+				isSiteJetpack &&
+				version_greater_than_or_equal( statsAdminVersion, '0.17.0-alpha', isOdysseyStats ) ),
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This is a temporary approach to enable some a8c sites from accessing the utm module as showcases, while we investigate https://github.com/Automattic/wp-calypso/issues/88688.

## Testing Instructions

* Add yourself to jetpack.com via network admin
* Ensure you see module UTM when accessing: `/stats/day/jetpack.com`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?