### PR TITLE
A4A: Add site notices component and display success message when user returns from connecting a Jetpack site

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -37,6 +37,7 @@ import {
 	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
 } from '../constants';
 import SitesDashboardContext from '../sites-dashboard-context';
+import SiteNotifications from '../sites-notifications';
 
 import './style.scss';
 
@@ -224,6 +225,8 @@ export default function SitesDashboard() {
 						<NavigationTabs { ...selectedItemProps } items={ navItems } />
 					</LayoutNavigation>
 				</LayoutTop>
+
+				<SiteNotifications />
 
 				<DashboardDataContext.Provider
 					value={ {

--- a/client/a8c-for-agencies/sections/sites/sites-notifications/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-notifications/index.tsx
@@ -1,0 +1,5 @@
+import JetpackSiteConnected from './jetpack-site-connected';
+
+export default function SiteNotifications() {
+	return <JetpackSiteConnected />;
+}

--- a/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
@@ -19,7 +19,7 @@ export default function JetpackSiteConnected() {
 	useEffect( () => {
 		if ( jetpackConnectedSite ) {
 			setSuccessNotification( () =>
-				translate( '{{em}}%(jetpackConnectedSite)s{{/em}} was successfully connected', {
+				translate( '{{em}}%(jetpackConnectedSite)s{{/em}} was successfully connected to Jetpack', {
 					args: {
 						jetpackConnectedSite,
 					},
@@ -30,7 +30,7 @@ export default function JetpackSiteConnected() {
 				} )
 			);
 			setMostRecentConnectedSite( jetpackConnectedSite );
-			page.redirect(
+			page(
 				removeQueryArgs( window.location.pathname + window.location.search, 'site_connected' )
 			);
 		}
@@ -42,7 +42,7 @@ export default function JetpackSiteConnected() {
 			dispatch( successNotice( successNotification ) );
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_sites_jetpack_connected_notice_shown', {
-					site_url: jetpackConnectedSite,
+					siteUrl: jetpackConnectedSite,
 				} )
 			);
 		}

--- a/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
@@ -1,0 +1,52 @@
+import page from '@automattic/calypso-router';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useContext, useEffect, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import SitesDashboardContext from '../sites-dashboard-context';
+
+export default function JetpackSiteConnected() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const jetpackConnectedSite = ( getQueryArg( window.location.href, 'site_connected' ) ??
+		'' ) as string;
+	const [ successNotification, setSuccessNotification ] = useState< React.ReactNode >( null );
+	const { setMostRecentConnectedSite } = useContext( SitesDashboardContext );
+	// Set the success notification when the site is connected and remove the query arg from the URL
+	useEffect( () => {
+		if ( jetpackConnectedSite ) {
+			setSuccessNotification( () =>
+				translate( '{{em}}%(jetpackConnectedSite)s{{/em}} was successfully connected', {
+					args: {
+						jetpackConnectedSite,
+					},
+					comment: '%(jetpackConnectedSite) is the site URL that was connected to Jetpack',
+					components: {
+						em: <em />,
+					},
+				} )
+			);
+			setMostRecentConnectedSite( jetpackConnectedSite );
+			page.redirect(
+				removeQueryArgs( window.location.pathname + window.location.search, 'site_connected' )
+			);
+		}
+	}, [ jetpackConnectedSite, translate, setSuccessNotification, setMostRecentConnectedSite ] );
+
+	// Show the success notification when the site is connected and record the event
+	useEffect( () => {
+		if ( successNotification ) {
+			dispatch( successNotice( successNotification ) );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_sites_jetpack_connected_notice_shown', {
+					siteUrl: jetpackConnectedSite,
+				} )
+			);
+		}
+	}, [ dispatch, jetpackConnectedSite, successNotification ] );
+
+	return null;
+}

--- a/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
@@ -19,7 +19,7 @@ export default function JetpackSiteConnected() {
 	useEffect( () => {
 		if ( jetpackConnectedSite ) {
 			setSuccessNotification( () =>
-				translate( '{{em}}%(jetpackConnectedSite)s{{/em}} was successfully connected to Jetpack', {
+				translate( '{{em}}%(jetpackConnectedSite)s{{/em}} was successfully connected', {
 					args: {
 						jetpackConnectedSite,
 					},

--- a/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
@@ -42,7 +42,7 @@ export default function JetpackSiteConnected() {
 			dispatch( successNotice( successNotification ) );
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_sites_jetpack_connected_notice_shown', {
-					siteUrl: jetpackConnectedSite,
+					site_url: jetpackConnectedSite,
 				} )
 			);
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-genesis/issues/290

## Proposed Changes

* Copies over the `SitesNotifications` and `JetpackSiteConnected` components, in order to display a success message when the user visits the `sites` page with a `site_connected` query parameter.
* Removed the "to Jetpack" from the end of the success message, so it just reads "[site] was successfully connected".
* Based on code from Jetpack Manage: https://github.com/Automattic/wp-calypso/pull/83963

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load `/sites?site_connected=example.com` and validate:
  * The success notice is rendered at the top right of the screen.
  * The query parameter is removed automatically from the URL.
  * The notice can be dismissed.
* Load `/sites` and validate there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1179" alt="Screenshot 2024-03-20 at 3 57 13 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/f8480449-7aa6-41a7-aa2c-ba52b8b0306e">

