### PR TITLE
Stats: Tracks events for the UTM module

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -1,12 +1,12 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import React, { ReactNode } from 'react';
+import React from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
@@ -14,11 +14,10 @@ import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
 interface Props {
 	className: string;
 	siteSlug: string;
-	buttonComponent?: ReactNode;
+	tracksEvent?: string;
 }
 
-// TODO: avoid making UTM call and show a ghost element instead
-const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteSlug } ) => {
+const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteSlug, tracksEvent } ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const copyText = translate(
@@ -45,7 +44,7 @@ const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteSlug } ) =>
 
 		// publish an event
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_utm_upgrade_clicked` );
+		recordTracksEvent( `${ event_from }_${ tracksEvent }` );
 
 		// redirect to the Purchase page
 		setTimeout(

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -38,6 +38,7 @@ const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteSlug, track
 		const queryParams = new URLSearchParams();
 
 		queryParams.set( 'productType', 'commercial' );
+		queryParams.set( 'from', `${ tracksEvent }` );
 		if ( currentParams.has( 'irclickid' ) ) {
 			queryParams.set( 'irclickid', currentParams.get( 'irclickid' ) || '' );
 		}

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-dropdown.tsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-dropdown.tsx
@@ -1,10 +1,10 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Popover } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown, chevronUp, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useState, useRef } from 'react';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { OPTION_KEYS as SELECTED_OPTION_KEYS } from './';
 
 import './stats-module-utm-dropdown.scss';
@@ -41,6 +41,18 @@ const UTMDropdown: React.FC< UTMDropdownProps > = ( {
 		togglePopoverOpened( ! popoverOpened );
 	};
 
+	const handleOptionSelection = ( key: string ) => {
+		onSelect( key );
+
+		// publish an event
+		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+		recordTracksEvent( `${ event_from }_stats_utm_dropdown_option_selected`, {
+			option: key,
+		} );
+
+		togglePopoverOpened( false );
+	};
+
 	return (
 		<div className={ classNames( className, BASE_CLASS_NAME ) }>
 			<Button onClick={ togglePopoverVisibility } ref={ infoReferenceElement }>
@@ -57,6 +69,7 @@ const UTMDropdown: React.FC< UTMDropdownProps > = ( {
 				isVisible={ popoverOpened }
 				className={ `${ BASE_CLASS_NAME }__popover-wrapper` }
 				onClose={ () => togglePopoverOpened( false ) }
+				hideArrow
 			>
 				<ul className={ `${ BASE_CLASS_NAME }__popover-list` }>
 					{ Object.entries( selectOptions ).map( ( [ key, option ], index ) => {
@@ -71,13 +84,7 @@ const UTMDropdown: React.FC< UTMDropdownProps > = ( {
 									[ 'is-not-grouped' ]: ! option.isGrouped,
 								} ) }
 							>
-								<Button
-									key={ index }
-									onClick={ () => {
-										onSelect( key );
-										togglePopoverOpened( false );
-									} }
-								>
+								<Button key={ index } onClick={ () => handleOptionSelection( key ) }>
 									<span>{ option.selectLabel }</span>
 									{ isSelected && <Icon icon={ check } /> }
 								</Button>

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
@@ -58,7 +58,13 @@ const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( { siteId
 			showMore={ {
 				label: 'View all',
 			} }
-			overlay={ <StatsCardUpsellJetpack className="stats-module__upsell" siteSlug={ siteSlug } /> }
+			overlay={
+				<StatsCardUpsellJetpack
+					className="stats-module__upsell"
+					siteSlug={ siteSlug }
+					tracksEvent="stats_utm_upgrade_clicked"
+				/>
+			}
 		></StatsListCard>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87570

## Proposed Changes

* Updating Tracks events and introducing a new event for dropdown selection
* Removing dropdown tip to match the designs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch and navigate to a blog with the UTM module
* click on the dropdown in the header and change the selected option
* verify that a new pixel event was triggered
* verify that the pixel it triggered after clicking on the upgrade button (e.g. for a JN site)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?