### PR TITLE
Developer cards: Amend GitHub Deployments copies

### DIFF
--- a/client/me/developer/features/github-deployment-card.tsx
+++ b/client/me/developer/features/github-deployment-card.tsx
@@ -13,11 +13,11 @@ export const GitHubDeploymentCard = () => {
 		<Card className="developer-features-list__item developer-features-list__item--full">
 			<div className="developer-features-list__item-tag">{ translate( 'New' ) }</div>
 			<div className="developer-features-list__item-title">
-				{ translate( 'GitHub Deployment' ) }
+				{ translate( 'GitHub Deployments' ) }
 			</div>
 			<div className="developer-features-list__item-description">
 				{ translate(
-					'Speed up your development workflow and take version control further by connecting your WordPress.com sites and GitHub repos. Choose from fully automatic or on-demand deployment.'
+					'Speed up your development workflow and take version control further by connecting your WordPress.com sites and GitHub repos. Choose from fully automatic or on-demand deployments.'
 				) }
 			</div>
 			<div className="developer-features-list__item-learn-more">


### PR DESCRIPTION
## Proposed changes

Let's use "GitHub Deployments," with an "s" at the end. The feature is named like that because the user can configure multiple repositories to a single site.

![image](https://github.com/Automattic/wp-calypso/assets/26530524/25bda574-c6cc-4975-b4d2-a755b99015d4)
