### PR TITLE
Untangle: Redirect /marketing/{connections -> traffic}/:domain#analytics when site is not nav redesign enabled

### DIFF
--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -8,7 +8,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import { setExpandedService } from 'calypso/state/sharing/actions';
 import { requestSite } from 'calypso/state/sites/actions';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MarketingBusinessTools from './business-tools';
 import SharingButtons from './buttons/buttons';
@@ -82,6 +82,19 @@ export const connections = ( context, next ) => {
 		dispatch(
 			errorNotice( translate( 'You are not authorized to manage sharing settings for this site.' ) )
 		);
+	}
+
+	// Google Analytics settings
+	if ( context.hashstring === 'analytics' ) {
+		// This route is only available when the site is included in the early release of nav redesign.
+		// TODO: remove this block when the early release check is dropped.
+		// See: https://github.com/Automattic/wp-calypso/pull/88742
+		if ( ! isGlobalSiteViewEnabled( state, siteId ) ) {
+			// Redirect to the original location of the Google Analytics settings.
+			return page.redirect(
+				`/marketing/traffic/${ context.params.domain }#${ context.hashstring }`
+			);
+		}
 	}
 
 	const siteSlug = getSiteSlug( state, siteId );


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6105

## Proposed Changes

This is an attempt to have the `Configure your GA settings` link to go to the new location (Global Site View -> Connections), when the nav redesign is enabled:

|<img width="844" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/e7248e69-eefb-4c7e-9962-129761eeae17">|<img width="873" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/af16f967-2a6f-49f8-ad2c-8c36e78c06b2">|
|-|-|


### Approaches

I tried updating the link directly from the Jetpack side. However, it requires the React app in Jetpack to "know" if the current site has the nav redesign enabled (is included in the early release). This means there will be another "source of truth" that we need to update when we decide to drop the early release check, which is not ideal. Also, we cannot really control the timing because Jetpack release to Atomic is weekly.

This PR offers an alternative approach, where Jetpack always points to `/marketing/connections/:site#analytics` when the admin interface is set to Classic. Then, in Calypso, we redirect it to the original `/marketing/traffic/:site#analytics` when the site is not included in the early release check. Later, when we release nav redesign to all classic view users (dropping the early release check), we can just remove the redirection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Prepare an Atomic site with a Jetpack Beta Tester pointing to the branch from https://github.com/Automattic/jetpack/pull/36493.
2. Set the Settings -> Hosting Configuration -> Admin interface style to Classic.
3. Unset the early release option (_cli -> `wp option delete wpcom_classic_early_release`)
    - Go to `/wp-admin/admin.php?page=jetpack#/traffic`.
    - Click the Configure your GA settings link.
    - Then, replace the `https://wordpress.com` with the Calyspo Live URL from this PR.
    - Verify that you (are redirected and then) see the Google Analytics setting in Tools -> Marketing -> Traffic.
4. Set the early release option (_cli -> `wp option update wpcom_classic_early_release 1`)
    - Go to `/wp-admin/admin.php?page=jetpack#/traffic`.
    - Click the Configure your GA settings link.
    - Then, replace the `https://wordpress.com` with the Calyspo Live URL from this PR.
    - Verify that you see the Google Analytics setting in Global Site View -> Connections.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?