### PR TITLE
hide jp app promo when whats new modal is shown

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -204,10 +204,10 @@ export class AppBanner extends Component {
 			</div>
 		);
 	};
-
 	render() {
 		if (
 			! this.props.shouldDisplayAppBanner ||
+			this.props.shouldShowWhatsNew ||
 			this.state.isDraftPostModalShown ||
 			this.state.isLaunchpadEnabled
 		) {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -204,6 +204,7 @@ export class AppBanner extends Component {
 			</div>
 		);
 	};
+
 	render() {
 		if (
 			! this.props.shouldDisplayAppBanner ||

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -208,7 +208,6 @@ export class AppBanner extends Component {
 	render() {
 		if (
 			! this.props.shouldDisplayAppBanner ||
-			this.props.shouldShowWhatsNew ||
 			this.state.isDraftPostModalShown ||
 			this.state.isLaunchpadEnabled
 		) {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -3,8 +3,8 @@ import { HelpCenter } from '@automattic/data-stores';
 import { shouldLoadInlineHelp } from '@automattic/help-center';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import WhatsNewGuide, { useWhatsNewAnnouncementsQuery } from '@automattic/whats-new';
-import { useDispatch, useSelect } from '@wordpress/data';
+import WhatsNewGuide, { useShouldShowCriticalAnnouncementsQuery } from '@automattic/whats-new';
+import { useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { Component, useCallback, useEffect, useState } from 'react';
@@ -100,38 +100,15 @@ function SidebarScrollSynchronizer() {
 }
 
 function WhatsNewLoader( { loadWhatsNew, siteId } ) {
-	const { fetchSeenWhatsNewAnnouncements } = useDispatch( HELP_CENTER_STORE );
+	const { data: shouldShowCriticalAnnouncements, isLoading } =
+		useShouldShowCriticalAnnouncementsQuery( siteId );
 	const [ showWhatsNew, setShowWhatsNew ] = useState( false );
 
-	const { data, isLoading } = useWhatsNewAnnouncementsQuery( siteId );
-
 	useEffect( () => {
-		fetchSeenWhatsNewAnnouncements();
-	}, [ fetchSeenWhatsNewAnnouncements ] );
-
-	const { seenWhatsNewAnnouncements } = useSelect( ( select ) => {
-		const helpCenterSelect = select( HELP_CENTER_STORE );
-		return {
-			seenWhatsNewAnnouncements: helpCenterSelect.getSeenWhatsNewAnnouncements(),
-		};
-	}, [] );
-
-	useEffect( () => {
-		if (
-			data &&
-			data.length > 0 &&
-			! isLoading &&
-			seenWhatsNewAnnouncements &&
-			typeof seenWhatsNewAnnouncements.indexOf === 'function'
-		) {
-			data.forEach( ( item ) => {
-				if ( item.critical && -1 === seenWhatsNewAnnouncements.indexOf( item.announcementId ) ) {
-					setShowWhatsNew( true );
-					return;
-				}
-			} );
+		if ( ! isLoading && shouldShowCriticalAnnouncements ) {
+			setShowWhatsNew( true );
 		}
-	}, [ data, isLoading, seenWhatsNewAnnouncements, setShowWhatsNew ] );
+	}, [ shouldShowCriticalAnnouncements, isLoading ] );
 
 	const handleClose = useCallback( () => {
 		setShowWhatsNew( false );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -173,6 +173,26 @@ function SidebarOverflowDelay( { layoutFocus } ) {
 	return null;
 }
 
+function AppBannerLoader( siteId ) {
+	const { data: shouldShowCriticalAnnouncements, isLoading } =
+		useShouldShowCriticalAnnouncementsQuery( siteId );
+	const [ showWhatsNew, setShowWhatsNew ] = useState( false );
+
+	useEffect( () => {
+		if ( ! isLoading && shouldShowCriticalAnnouncements ) {
+			setShowWhatsNew( true );
+		}
+	}, [ shouldShowCriticalAnnouncements, isLoading ] );
+
+	return (
+		<AsyncLoad
+			require="calypso/blocks/app-banner"
+			placeholder={ null }
+			shouldShowWhatsNew={ showWhatsNew }
+		/>
+	);
+}
+
 class Layout extends Component {
 	static propTypes = {
 		primary: PropTypes.element,
@@ -396,9 +416,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/support-article-dialog' ) && (
 					<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'layout/app-banner' ) && (
-					<AsyncLoad require="calypso/blocks/app-banner" placeholder={ null } />
-				) }
+				{ config.isEnabled( 'layout/app-banner' ) && <AppBannerLoader /> }
 				{ config.isEnabled( 'cookie-banner' ) && (
 					<AsyncLoad require="calypso/blocks/cookie-banner" placeholder={ null } />
 				) }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -173,7 +173,7 @@ function SidebarOverflowDelay( { layoutFocus } ) {
 	return null;
 }
 
-function AppBannerLoader( siteId ) {
+function AppBannerLoader( { siteId } ) {
 	const { data: shouldShowCriticalAnnouncements, isLoading } =
 		useShouldShowCriticalAnnouncementsQuery( siteId );
 	const [ showWhatsNew, setShowWhatsNew ] = useState( false );
@@ -413,7 +413,9 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/support-article-dialog' ) && (
 					<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'layout/app-banner' ) && <AppBannerLoader /> }
+				{ config.isEnabled( 'layout/app-banner' ) && (
+					<AppBannerLoader siteId={ this.props.siteId } />
+				) }
 				{ config.isEnabled( 'cookie-banner' ) && (
 					<AsyncLoad require="calypso/blocks/cookie-banner" placeholder={ null } />
 				) }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -185,11 +185,8 @@ function AppBannerLoader( siteId ) {
 	}, [ shouldShowCriticalAnnouncements, isLoading ] );
 
 	return (
-		<AsyncLoad
-			require="calypso/blocks/app-banner"
-			placeholder={ null }
-			shouldShowWhatsNew={ showWhatsNew }
-		/>
+		! isLoading &&
+		! showWhatsNew && <AsyncLoad require="calypso/blocks/app-banner" placeholder={ null } />
 	);
 }
 

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -11,31 +11,6 @@ export const receiveHasSeenWhatsNewModal = ( value: boolean | undefined ) =>
 		value,
 	} ) as const;
 
-export const receiveSeenWhatsNewAnnouncements = ( value: string[] | undefined ) =>
-	( {
-		type: 'HELP_CENTER_SET_SEEN_WHATS_NEW_ANNOUNCEMENTS',
-		value,
-	} ) as const;
-
-export function* fetchSeenWhatsNewAnnouncements() {
-	let response: {
-		seen_announcement_ids: string[];
-	};
-	if ( canAccessWpcomApis() ) {
-		response = yield wpcomRequest( {
-			path: `/whats-new/seen-announcement-ids`,
-			apiNamespace: 'wpcom/v2',
-		} );
-	} else {
-		response = yield apiFetch( {
-			global: true,
-			path: `/wpcom/v2/whats-new/seen-announcement-ids`,
-		} as APIFetchOptions );
-	}
-
-	return receiveSeenWhatsNewAnnouncements( response.seen_announcement_ids );
-}
-
 export function* setHasSeenWhatsNewModal( value: boolean ) {
 	let response: {
 		has_seen_whats_new_modal: boolean;
@@ -59,31 +34,6 @@ export function* setHasSeenWhatsNewModal( value: boolean ) {
 	}
 
 	return receiveHasSeenWhatsNewModal( response.has_seen_whats_new_modal );
-}
-
-export function* setSeenWhatsNewAnnouncements( ids: string[] ) {
-	let response: {
-		seen_announcement_ids: string[];
-	};
-	if ( canAccessWpcomApis() ) {
-		response = yield wpcomRequest( {
-			path: `/whats-new/seen-announcement-ids`,
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			body: {
-				seen_announcement_ids: ids,
-			},
-		} );
-	} else {
-		response = yield apiFetch( {
-			global: true,
-			path: `/wpcom/v2/whats-new/seen-announcement-ids`,
-			method: 'POST',
-			data: { seen_announcement_ids: ids },
-		} as APIFetchOptions );
-	}
-
-	return receiveSeenWhatsNewAnnouncements( response.seen_announcement_ids );
 }
 
 export const setSite = ( site: HelpCenterSite | undefined ) =>
@@ -198,7 +148,6 @@ export type HelpCenterAction =
 			| typeof setSubject
 			| typeof resetStore
 			| typeof receiveHasSeenWhatsNewModal
-			| typeof receiveSeenWhatsNewAnnouncements
 			| typeof setMessage
 			| typeof setUserDeclaredSite
 			| typeof setUserDeclaredSiteUrl
@@ -206,9 +155,4 @@ export type HelpCenterAction =
 			| typeof setIsMinimized
 			| typeof setInitialRoute
 	  >
-	| GeneratorReturnType<
-			| typeof setShowHelpCenter
-			| typeof setHasSeenWhatsNewModal
-			| typeof setSeenWhatsNewAnnouncements
-			| typeof fetchSeenWhatsNewAnnouncements
-	  >;
+	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -42,17 +42,6 @@ const hasSeenWhatsNewModal: Reducer< boolean | undefined, HelpCenterAction > = (
 	return state;
 };
 
-const seenWhatsNewAnnouncements: Reducer< string[] | undefined, HelpCenterAction > = (
-	state,
-	action
-) => {
-	switch ( action.type ) {
-		case 'HELP_CENTER_SET_SEEN_WHATS_NEW_ANNOUNCEMENTS':
-			return action.value;
-	}
-	return state;
-};
-
 const isMinimized: Reducer< boolean, HelpCenterAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'HELP_CENTER_SET_MINIMIZED':
@@ -135,7 +124,6 @@ const reducer = combineReducers( {
 	userDeclaredSite,
 	userDeclaredSiteUrl,
 	hasSeenWhatsNewModal,
-	seenWhatsNewAnnouncements,
 	isMinimized,
 	unreadCount,
 	initialRoute,

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -11,5 +11,4 @@ export const getUserDeclaredSite = ( state: State ) => state.userDeclaredSite;
 export const getUnreadCount = ( state: State ) => state.unreadCount;
 export const getIsMinimized = ( state: State ) => state.isMinimized;
 export const getHasSeenWhatsNewModal = ( state: State ) => state.hasSeenWhatsNewModal;
-export const getSeenWhatsNewAnnouncements = ( state: State ) => state.seenWhatsNewAnnouncements;
 export const getInitialRoute = ( state: State ) => state.initialRoute;

--- a/packages/whats-new/src/hooks/use-seen-whats-new-announcements-mutation.ts
+++ b/packages/whats-new/src/hooks/use-seen-whats-new-announcements-mutation.ts
@@ -20,7 +20,7 @@ export const useSeenWhatsNewAnnouncementsMutation = () => {
 		mutationFn: async ( seenAnnouncenmentIds: string[] ) => {
 			return canAccessWpcomApis()
 				? await wpcomRequest( {
-						path: `/whats-new/seen-announcement-ids-1`,
+						path: `/whats-new/seen-announcement-ids`,
 						apiNamespace: 'wpcom/v2',
 						method: 'POST',
 						body: {
@@ -29,7 +29,7 @@ export const useSeenWhatsNewAnnouncementsMutation = () => {
 				  } )
 				: await apiFetch( {
 						global: true,
-						path: `/wpcom/v2/whats-new/seen-announcement-ids-1`,
+						path: `/wpcom/v2/whats-new/seen-announcement-ids`,
 						method: 'POST',
 						data: { seen_announcement_ids: seenAnnouncenmentIds },
 				  } as APIFetchOptions );

--- a/packages/whats-new/src/hooks/use-seen-whats-new-announcements-mutation.ts
+++ b/packages/whats-new/src/hooks/use-seen-whats-new-announcements-mutation.ts
@@ -1,0 +1,55 @@
+/* eslint-disable no-restricted-imports */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { SEEN_WHATS_NEW_ANNOUCNEMENT_IDS } from './use-seen-whats-new-announcements-query';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+/**
+ * Saves the list of "Whats New" announcements that the user has seen
+ * @returns A react-query mutation to save to the "whats-new/seen-announcement-ids" endpoint
+ */
+export const useSeenWhatsNewAnnouncementsMutation = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: async ( seenAnnouncenmentIds: string[] ) => {
+			return canAccessWpcomApis()
+				? await wpcomRequest( {
+						path: `/whats-new/seen-announcement-ids-1`,
+						apiNamespace: 'wpcom/v2',
+						method: 'POST',
+						body: {
+							seen_announcement_ids: seenAnnouncenmentIds,
+						},
+				  } )
+				: await apiFetch( {
+						global: true,
+						path: `/wpcom/v2/whats-new/seen-announcement-ids-1`,
+						method: 'POST',
+						data: { seen_announcement_ids: seenAnnouncenmentIds },
+				  } as APIFetchOptions );
+		},
+		onMutate: async ( seenAnnouncenmentIds: string[] ) => {
+			await queryClient.cancelQueries( { queryKey: [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ] } );
+
+			queryClient.setQueryData( [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ], seenAnnouncenmentIds );
+
+			const previousData = queryClient.getQueryData< string[] >( [
+				SEEN_WHATS_NEW_ANNOUCNEMENT_IDS,
+			] );
+
+			return { previousData };
+		},
+		onError: ( error, variables, context ) => {
+			queryClient.setQueryData( [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ], context?.previousData );
+		},
+		onSettled: async () => {
+			await queryClient.invalidateQueries( { queryKey: [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ] } );
+		},
+	} );
+};

--- a/packages/whats-new/src/hooks/use-seen-whats-new-announcements-query.ts
+++ b/packages/whats-new/src/hooks/use-seen-whats-new-announcements-query.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-restricted-imports */
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+interface SeenAnnouncementIDsResponse {
+	seen_announcement_ids: string[];
+}
+
+export const SEEN_WHATS_NEW_ANNOUCNEMENT_IDS = 'SEEN_WHATS_NEW_ANNOUCNEMENT_IDS';
+
+/**
+ * Get a list of the "Whats New" announcements that the user has seen
+ * @returns Returns the result of querying the "whats-new/seen-announcement-ids" endpoint
+ */
+export const useSeenWhatsNewAnnouncementsQuery = () => {
+	return useQuery< SeenAnnouncementIDsResponse, Error, string[] >( {
+		queryKey: [ SEEN_WHATS_NEW_ANNOUCNEMENT_IDS ],
+		queryFn: async () =>
+			canAccessWpcomApis()
+				? await wpcomRequest( {
+						path: `/whats-new/seen-announcement-ids`,
+						apiNamespace: 'wpcom/v2',
+				  } )
+				: await apiFetch( {
+						global: true,
+						path: `/wpcom/v2/whats-new/seen-announcement-ids`,
+				  } as APIFetchOptions ),
+		refetchOnWindowFocus: false,
+		select: ( data ) => data.seen_announcement_ids,
+	} );
+};

--- a/packages/whats-new/src/hooks/use-should-show-critical-announcements-query.ts
+++ b/packages/whats-new/src/hooks/use-should-show-critical-announcements-query.ts
@@ -1,12 +1,14 @@
+import { QueryObserverResult } from '@tanstack/react-query';
 import { useSeenWhatsNewAnnouncementsQuery } from './use-seen-whats-new-announcements-query';
 import { useWhatsNewAnnouncementsQuery } from './use-whats-new-announcements-query';
-
 /**
  * Queries the "whats new" announcements and the seen announcements to determine if there are any critical announcements that should be shown
  * @param siteId Id of the site to query
  * @returns Whether the critical announcements should be shown
  */
-export const useShouldShowCriticalAnnouncementsQuery = ( siteId: string ) => {
+export const useShouldShowCriticalAnnouncementsQuery = (
+	siteId: string
+): QueryObserverResult< boolean, Error > => {
 	const { data: whatsNewList, isLoading: isLoadingList } = useWhatsNewAnnouncementsQuery( siteId );
 	const { data: seenWhatsNewAnnouncements, isLoading: isLoadingSeen } =
 		useSeenWhatsNewAnnouncementsQuery();
@@ -14,7 +16,7 @@ export const useShouldShowCriticalAnnouncementsQuery = ( siteId: string ) => {
 	if ( isLoadingList || isLoadingSeen ) {
 		return {
 			isLoading: true,
-		};
+		} as QueryObserverResult< boolean, Error >;
 	}
 
 	if (
@@ -31,12 +33,12 @@ export const useShouldShowCriticalAnnouncementsQuery = ( siteId: string ) => {
 				return {
 					isLoading: false,
 					data: true,
-				};
+				} as QueryObserverResult< boolean, Error >;
 			}
 		}
 	}
 	return {
 		isLoading: false,
 		data: false,
-	};
+	} as QueryObserverResult< boolean, Error >;
 };

--- a/packages/whats-new/src/hooks/use-should-show-critical-announcements-query.ts
+++ b/packages/whats-new/src/hooks/use-should-show-critical-announcements-query.ts
@@ -1,0 +1,42 @@
+import { useSeenWhatsNewAnnouncementsQuery } from './use-seen-whats-new-announcements-query';
+import { useWhatsNewAnnouncementsQuery } from './use-whats-new-announcements-query';
+
+/**
+ * Queries the "whats new" announcements and the seen announcements to determine if there are any critical announcements that should be shown
+ * @param siteId Id of the site to query
+ * @returns Whether the critical announcements should be shown
+ */
+export const useShouldShowCriticalAnnouncementsQuery = ( siteId: string ) => {
+	const { data: whatsNewList, isLoading: isLoadingList } = useWhatsNewAnnouncementsQuery( siteId );
+	const { data: seenWhatsNewAnnouncements, isLoading: isLoadingSeen } =
+		useSeenWhatsNewAnnouncementsQuery();
+
+	if ( isLoadingList || isLoadingSeen ) {
+		return {
+			isLoading: true,
+		};
+	}
+
+	if (
+		whatsNewList &&
+		whatsNewList.length > 0 &&
+		seenWhatsNewAnnouncements &&
+		typeof seenWhatsNewAnnouncements.indexOf === 'function'
+	) {
+		for ( let i = 0; i < whatsNewList.length; i++ ) {
+			if (
+				whatsNewList[ i ].critical &&
+				-1 === seenWhatsNewAnnouncements.indexOf( whatsNewList[ i ].announcementId )
+			) {
+				return {
+					isLoading: false,
+					data: true,
+				};
+			}
+		}
+	}
+	return {
+		isLoading: false,
+		data: false,
+	};
+};

--- a/packages/whats-new/src/hooks/use-should-show-critical-announcements-query.ts
+++ b/packages/whats-new/src/hooks/use-should-show-critical-announcements-query.ts
@@ -23,7 +23,7 @@ export const useShouldShowCriticalAnnouncementsQuery = (
 		whatsNewList &&
 		whatsNewList.length > 0 &&
 		seenWhatsNewAnnouncements &&
-		typeof seenWhatsNewAnnouncements.indexOf === 'function'
+		Array.isArray( seenWhatsNewAnnouncements )
 	) {
 		for ( let i = 0; i < whatsNewList.length; i++ ) {
 			if (

--- a/packages/whats-new/src/index.tsx
+++ b/packages/whats-new/src/index.tsx
@@ -21,8 +21,8 @@ interface Props {
 
 const WhatsNewGuide: React.FC< Props > = ( { onClose, siteId } ) => {
 	const { data, isLoading } = useWhatsNewAnnouncementsQuery( siteId );
-
 	const { mutate } = useSeenWhatsNewAnnouncementsMutation();
+
 	useEffect( () => {
 		// check for whether the announcement has been seen already.
 		if ( data && data.length ) {

--- a/packages/whats-new/src/index.tsx
+++ b/packages/whats-new/src/index.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-imports */
 import { HelpCenter } from '@automattic/data-stores';
-import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import Guide from './components/guide';
+import { useSeenWhatsNewAnnouncementsMutation } from './hooks/use-seen-whats-new-announcements-mutation';
 import { useWhatsNewAnnouncementsQuery } from './hooks/use-whats-new-announcements-query';
 import WhatsNewPage from './whats-new-page';
 import './style.scss';
@@ -12,6 +12,7 @@ export {
 	useWhatsNewAnnouncementsQuery,
 	type WhatsNewAnnouncement,
 } from './hooks/use-whats-new-announcements-query';
+export { useShouldShowCriticalAnnouncementsQuery } from './hooks/use-should-show-critical-announcements-query';
 
 interface Props {
 	onClose: () => void;
@@ -19,16 +20,16 @@ interface Props {
 }
 
 const WhatsNewGuide: React.FC< Props > = ( { onClose, siteId } ) => {
-	const { setSeenWhatsNewAnnouncements } = useDispatch( HELP_CENTER_STORE );
 	const { data, isLoading } = useWhatsNewAnnouncementsQuery( siteId );
 
+	const { mutate } = useSeenWhatsNewAnnouncementsMutation();
 	useEffect( () => {
 		// check for whether the announcement has been seen already.
 		if ( data && data.length ) {
 			const announcementIds = data.map( ( item ) => item.announcementId );
-			setSeenWhatsNewAnnouncements( announcementIds );
+			mutate( announcementIds );
 		}
-	}, [ data, setSeenWhatsNewAnnouncements ] );
+	}, [ data, mutate ] );
 
 	if ( ! data || isLoading ) {
 		return null;


### PR DESCRIPTION
fixes 6113-gh-Automattic/dotcom-forge

Unfortunately the way I'd originally implemented the whats-new modal was a mix of the older style react store and the newer style hooks. This made it very hard to pick out the logic for showing the whats-new modal and reuse it for the jetpack app banner.

This PR refactors the whats-new modal to be all in the modern react hook style which allows me to reuse the logic for showing the jetpack app promo.

The jetpack app banner should not be shown if whats-new modal will also be shown.

#### Testing instructions

To make the app banner show, I modified code in `client/state/selectors/should-display-app-banner.ts` so that it would always `return true`.
To ensure that the whats new banner is shown I cleared the flags on my sandbox:
`wp user meta delete 182004064 seen_whats_new_announcement_ids`

Now when loading on mobile:
* the whats-new modal should be shown. (the app banner should be hidden)
* A call should be made to `/whats-new/seen-announcement-ids` which records that the user has seen the announcements
* after reloading the page, the whats-new banner should NOT be shown, the app banner SHOULD be shown.