### PR TITLE
Stats: Update UTM status for Atomic sites.

### DIFF
--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -56,11 +56,11 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 			isOdysseyStats
 		),
 		supportsUTMStats:
+			// TODO: Make UTM stats available for internal Simple sites.
 			isA8CSpecialBlog( siteId ) ||
 			// TODO: Remove the flag check once UTM stats are released.
 			( config.isEnabled( 'stats/utm-module' ) &&
-				// TODO: Make UTM stats available for internal Simple sites.
-				// UTM stats are only available for Jetpack and Atomic sites for now.
+				// UTM stats are only available for Jetpack sites for now.
 				isSiteJetpackNotAtomic &&
 				version_greater_than_or_equal( statsAdminVersion, '0.17.0-alpha', isOdysseyStats ) ),
 	};

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -25,7 +25,9 @@ const version_greater_than_or_equal = (
 export default function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
-	const isSiteJetpack = isJetpackSite( state, siteId );
+	const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {
+		treatAtomicAsJetpackSite: false,
+	} );
 
 	return {
 		supportsHighlightsSettings: version_greater_than_or_equal(
@@ -59,7 +61,7 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 			( config.isEnabled( 'stats/utm-module' ) &&
 				// TODO: Make UTM stats available for internal Simple sites.
 				// UTM stats are only available for Jetpack and Atomic sites for now.
-				isSiteJetpack &&
+				isSiteJetpackNotAtomic &&
 				version_greater_than_or_equal( statsAdminVersion, '0.17.0-alpha', isOdysseyStats ) ),
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Limit Jetpack UTM module to Jetpack sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch
* go to an atomic site and verify that UTM module is not visible
* got to a Jetpack site and verify that UTM module is visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?