### PR TITLE
Automattic for Agencies: Implement list licenses API

### DIFF
--- a/client/a8c-for-agencies/data/purchases/lib/format-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/lib/format-licenses.ts
@@ -1,0 +1,39 @@
+import { License } from 'calypso/state/partner-portal/types';
+
+interface APILicense {
+	license_id: number;
+	license_key: string;
+	product_id: number;
+	product: string;
+	user_id: number | null;
+	username: string | null;
+	blog_id: number | null;
+	siteurl: string | null;
+	has_downloads: boolean;
+	issued_at: string;
+	attached_at: string | null;
+	revoked_at: string | null;
+	owner_type: string | null;
+	quantity: number | null;
+	parent_license_id: number | null;
+}
+
+export default function formatLicenses( items: APILicense[] ): License[] {
+	return items.map( ( item ) => ( {
+		licenseId: item.license_id,
+		licenseKey: item.license_key,
+		product: item.product,
+		productId: item.product_id,
+		userId: item.user_id,
+		username: item.username,
+		blogId: item.blog_id,
+		siteUrl: item.siteurl,
+		hasDownloads: item.has_downloads,
+		issuedAt: item.issued_at,
+		attachedAt: item.attached_at,
+		revokedAt: item.revoked_at,
+		ownerType: item.owner_type,
+		quantity: item.quantity,
+		parentLicenseId: item.parent_license_id,
+	} ) );
+}

--- a/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts
@@ -1,34 +1,24 @@
-import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 export default function useFetchLicenseCounts() {
-	const showDummyData = config.isEnabled( 'a4a/mock-api-data' );
-
-	const getLicenseCounts = () => {
-		if ( showDummyData ) {
-			return {
-				attached: 1,
-				detached: 1,
-				revoked: 0,
-				not_revoked: 2,
-				standard: 0,
-				all: 2,
-				products: {},
-			};
-		}
-		return {
-			attached: 0,
-			detached: 0,
-			revoked: 0,
-			not_revoked: 0,
-			standard: 0,
-			all: 0,
-			products: {},
-		}; // FIXME: This is a placeholder for the actual API call.
-	};
+	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: [ 'a4a-license-counts' ],
-		queryFn: () => getLicenseCounts(),
+		queryKey: [ 'a4a-license-counts', agencyId ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: '/jetpack-licensing/licenses/counts',
+				},
+				{
+					...( agencyId && { agency_id: agencyId } ),
+				}
+			),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
 	} );
 }

--- a/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { LICENSES_PER_PAGE } from 'calypso/a8c-for-agencies/sections/purchases/lib/constants';
 import {
@@ -6,6 +5,10 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import formatLicenses from './lib/format-licenses';
 
 export default function useFetchLicenses(
 	filter: LicenseFilter,
@@ -14,72 +17,33 @@ export default function useFetchLicenses(
 	sortDirection: LicenseSortDirection,
 	page: number
 ) {
-	const showDummyData = config.isEnabled( 'a4a/mock-api-data' );
-
-	const getLicenses = () => {
-		if ( showDummyData ) {
-			const items = [
-				{
-					licenseId: 1,
-					licenseKey: 'license-key',
-					product: 'dummy-product',
-					blogId: 1,
-					siteUrl: 'dummy-url',
-					hasDownloads: true,
-					issuedAt: '2021-01-01',
-					attachedAt: '2021-01-01',
-					quantity: 5,
-					revokedAt: null,
-					ownerType: 'jetpack_partner_key',
-					parentLicenseId: undefined,
-				},
-				{
-					licenseId: 2,
-					licenseKey: 'license-key-2',
-					product: 'dummy-product-2',
-					blogId: 1,
-					siteUrl: null,
-					hasDownloads: true,
-					issuedAt: '2021-01-01',
-					attachedAt: null,
-					quantity: undefined,
-					revokedAt: null,
-					ownerType: 'jetpack_partner_key',
-					parentLicenseId: undefined,
-				},
-			];
-
-			const result = search
-				? items.filter( ( item ) => {
-						return item.licenseKey.includes( search ) || item.product.includes( search );
-				  } )
-				: items;
-
-			return {
-				items: result,
-				total_pages: Math.ceil( result.length / LICENSES_PER_PAGE ),
-				total_items: result.length,
-				items_per_page: LICENSES_PER_PAGE,
-			};
-		}
-		return {
-			items: [],
-			total_pages: 0,
-			total_items: 0,
-			items_per_page: LICENSES_PER_PAGE,
-		}; // FIXME: This is a placeholder for the actual API call.
-	};
+	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: [ 'a4a-licenses', filter, search, sortField, sortDirection, page ],
-		queryFn: () => getLicenses(),
+		queryKey: [ 'a4a-licenses', filter, search, sortField, sortDirection, page, agencyId ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: '/jetpack-licensing/licenses',
+				},
+				{
+					...( agencyId && { agency_id: agencyId } ),
+					...( search ? { search: search } : { filter: filter, page: page } ),
+					sort_field: sortField,
+					sort_direction: sortDirection,
+					per_page: LICENSES_PER_PAGE,
+				}
+			),
 		select: ( data ) => {
 			return {
-				items: data.items,
+				items: formatLicenses( data.items ),
 				total: data.total_items,
 				perPage: data.items_per_page,
 				totalPages: data.total_pages,
 			};
 		},
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
 	} );
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/300

## Proposed Changes

This PR implements API for:

- Fetch Licenses count
- Fetch Licenses 
- Fetch Bundle Licenses

NOTE:

- API implementation for all the license actions will be implemented on another PR
- Please ignore if there is any difference in the API data.

## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Click the Marketplace menu item -> Issue a few licenses including a bundle(Volume pricing)
- Go to Purchases > Licenses. Verify the API call to licenses count and licenses is being made and you can see the count and licenses on the UI 

<img width="1150" alt="Screenshot 2024-03-21 at 12 04 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/bd91eb32-6ba1-44cc-8773-92ac3c12e514">

- Expand any bundle > Verify that the child licenses are fetched and shown in the UI:

<img width="1043" alt="Screenshot 2024-03-21 at 12 04 46 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6e3c4dc4-587c-4bb2-929a-dcd80e0e9993">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?