### PR TITLE
Address woo passwordless UI feedback

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1158,6 +1158,16 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
+		// Remove browser autofill styles.
+		input:-webkit-autofill,
+		input:-webkit-autofill:hover,
+		input:-webkit-autofill:focus,
+		input:-webkit-autofill:active {
+			-webkit-background-clip: text;
+			-webkit-box-shadow: 0 0 0 1000px #fff inset;
+			transition: background-color 5000s ease-in-out 0s;
+		}
+
 		.button.is-primary,
 		.login .button.is-primary,
 		.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
@@ -1634,8 +1644,6 @@ $breakpoint-mobile: 660px;
 				p {
 					color: var(--studio-gray-60);
 					text-align: center;
-
-					font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 					font-size: rem(14px);
 					font-style: normal;
 					font-weight: 400;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1468,7 +1468,7 @@ $breakpoint-mobile: 660px;
 				align-items: center;
 				align-self: stretch;
 				border-radius: 8px; // stylelint-disable-line scales/radii
-				border: 2px solid #dcdcde;
+				border: 1px solid #dcdcde;
 				height: 221px;
 				box-sizing: border-box;
 				padding: 32px 24px 16px 24px;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1349,6 +1349,10 @@ $breakpoint-mobile: 660px;
 
 			.auth-form__social-buttons-tos {
 				margin: 0;
+
+				@media ( max-width: $break-medium ) {
+					max-width: $max-width;
+				}
 			}
 
 			.login__lost-password-link {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1158,11 +1158,12 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		// Remove browser autofill styles.
+		// Remove autofill styles.
 		input:-webkit-autofill,
 		input:-webkit-autofill:hover,
 		input:-webkit-autofill:focus,
-		input:-webkit-autofill:active {
+		input:-webkit-autofill:active,
+		input[data-com-onepassword-filled="light"] {
 			-webkit-background-clip: text;
 			-webkit-box-shadow: 0 0 0 1000px #fff inset;
 			transition: background-color 5000s ease-in-out 0s;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1,3 +1,4 @@
+@import url( https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap );
 @import "@wordpress/base-styles/colors";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88747 

Figma: 4ixWMlzrxllx93tSFsCW6k-fi-10009%3A10044

This PR addressed woo passwordless QA UI feedback

## Proposed Changes

* Decrease the "Continue as User" box border from 2px to 1px.
* Remove default autofill (blue) styles

Before:
![Screenshot 2024-03-21 at 16 22 43](https://github.com/Automattic/wp-calypso/assets/4344253/c8b21462-0ce1-416c-a2a3-8ff58aade69c)

After:

![Screenshot 2024-03-21 at 16 22 30](https://github.com/Automattic/wp-calypso/assets/4344253/97985954-5023-4951-8846-b0920f6c2fb7)

* Remove SF Pro font from footer text. We're using Inter font now.
* Redirect to log out if user is already logged in when they click on 'Signup'


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in WordPress.com but log out of woo.com
* Go to woo.com
* Click on "Log in"
* Observe that you're on the Continue as User page
* Confirm that the border is 1px.
![Screenshot 2024-03-21 at 15 35 26](https://github.com/Automattic/wp-calypso/assets/4344253/af8bb84b-aa4c-43c7-a584-93193eec77bc)

* Click on `Sign in as a different user`
* Auto-fill the `Your email or username` field
* Confirm the input background is white
* Click on "Sign up"
* Observe that you're redirected to Woo Signup screen.
* Go to Log in screen
* Log in with a passwordless account
* Confirm `Didn't get the email? You might want to double check if the email address is associated with your account` text font is `Inter`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?