### PR TITLE
Security Key Removal: Show error messages in the UI when the backend returns an error

### DIFF
--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -38,7 +38,7 @@ class Security2faKey extends Component {
 
 	addKeyStart = ( event ) => {
 		event.preventDefault();
-		this.setState( { addingKey: true, errorMessage: false } );
+		this.setState( { addingKey: true, errorMessage: null } );
 	};
 
 	addKeyRegister = () => {

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -17,7 +17,7 @@ class Security2faKey extends Component {
 		isEnabled: false,
 		addingKey: false,
 		isBrowserSupported: isWebAuthnSupported(),
-		errorMessage: false,
+		errorMessage: null,
 		security2faChallenge: {},
 		security2faKeys: [],
 	};
@@ -38,7 +38,7 @@ class Security2faKey extends Component {
 
 	addKeyStart = ( event ) => {
 		event.preventDefault();
-		this.setState( { addingKey: true } );
+		this.setState( { addingKey: true, errorMessage: false } );
 	};
 
 	addKeyRegister = () => {
@@ -46,11 +46,23 @@ class Security2faKey extends Component {
 	};
 
 	deleteKeyRegister = ( keyData ) => {
-		wpcom.req.get(
-			'/me/two-step/security-key/delete',
-			{ credential_id: keyData.id },
-			this.getKeysFromServer
-		);
+		const { translate } = this.props;
+		this.setState( { errorMessage: false } );
+		wpcom.req.get( '/me/two-step/security-key/delete', { credential_id: keyData.id }, ( err ) => {
+			if ( null === err ) {
+				this.getKeysFromServer();
+			} else {
+				let errorMessage = translate( 'The key could not be deleted. Please try again later.' );
+				if ( 'invalid_operation' === err.error ) {
+					errorMessage = translate(
+						`Unable to delete the last WordPress.com security key while enhanced account security is active. Deleting this key may result in losing access to your account. To delete the key, please disable enhanced account security first.`
+					);
+				}
+				this.setState( {
+					errorMessage,
+				} );
+			}
+		} );
 	};
 
 	addKeyCancel = () => {
@@ -81,7 +93,14 @@ class Security2faKey extends Component {
 
 	render() {
 		const { translate } = this.props;
-		const { isEnabled, addingKey, isBrowserSupported, errorMessage, security2faKeys } = this.state;
+		const {
+			isEnabled,
+			addingKey,
+			isBrowserSupported,
+			errorMessage,
+			security2faKeys,
+			security2faChallenge,
+		} = this.state;
 
 		if ( ! isEnabled ) {
 			return null;
@@ -106,15 +125,22 @@ class Security2faKey extends Component {
 					<Security2faKeyAdd
 						onRegister={ this.addKeyRegister }
 						onCancel={ this.addKeyCancel }
-						registerRequests={ this.state.security2faChallenge }
+						registerRequests={ security2faChallenge }
 					/>
 				) }
-				{ errorMessage && <Notice status="is-error" icon="notice" text={ errorMessage } /> }
+				{ errorMessage && (
+					<Notice
+						status="is-error"
+						icon="notice"
+						text={ errorMessage }
+						onDismissClick={ () => this.setState( { errorMessage: null } ) }
+					/>
+				) }
 				{ ! addingKey && ! security2faKeys.length && (
 					<Card>
 						{ isBrowserSupported && (
 							<p>
-								{ this.props.translate(
+								{ translate(
 									'Security keys offer a more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser.'
 								) }{ ' ' }
 								<InlineSupportLink
@@ -127,7 +153,7 @@ class Security2faKey extends Component {
 						) }
 						{ ! isBrowserSupported && (
 							<p>
-								{ this.props.translate(
+								{ translate(
 									"Your browser doesn't support the FIDO2 security key standard yet. To use a second factor security key to sign in please try a supported browser like Chrome, Safari, or Firefox."
 								) }
 							</p>
@@ -136,7 +162,7 @@ class Security2faKey extends Component {
 				) }
 				{ ! addingKey && !! security2faKeys.length && (
 					<Security2faKeyList
-						securityKeys={ this.state.security2faKeys }
+						securityKeys={ security2faKeys }
 						onDelete={ this.deleteKeyRegister }
 					/>
 				) }

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -52,12 +52,12 @@ class Security2faKey extends Component {
 			if ( null === err ) {
 				this.getKeysFromServer();
 			} else {
-				let errorMessage = translate( 'The key could not be deleted. Please try again later.' );
-				if ( 'invalid_operation' === err.error ) {
-					errorMessage = translate(
-						`Unable to delete the last WordPress.com security key while enhanced account security is active. Deleting it may result in losing access to your account. If you still want to remove it, please disable enhanced account security.`
-					);
-				}
+				const errorMessage =
+					'invalid_operation' === err.error
+						? translate(
+								`Unable to delete the last WordPress.com security key while enhanced account security is active. Deleting it may result in losing access to your account. If you still want to remove it, please disable enhanced account security.`
+						  )
+						: translate( 'The key could not be deleted. Please try again later.' );
 				this.setState( {
 					errorMessage,
 				} );

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -55,7 +55,7 @@ class Security2faKey extends Component {
 				let errorMessage = translate( 'The key could not be deleted. Please try again later.' );
 				if ( 'invalid_operation' === err.error ) {
 					errorMessage = translate(
-						`Unable to delete the last WordPress.com security key while enhanced account security is active. Deleting this key may result in losing access to your account. To delete the key, please disable enhanced account security first.`
+						`Unable to delete the last WordPress.com security key while enhanced account security is active. Deleting it may result in losing access to your account. If you still want to remove it, please disable enhanced account security.`
 					);
 				}
 				this.setState( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Show error messages when the backend is unable to remove a key.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add one security key on production (wordpress.com)
* Enable the enhanced account security setting.
* Remove the added key (if there's only one security key, the removal should fail and show an error message)

<img width="883" alt="Screenshot 2024-03-21 at 10 19 20" src="https://github.com/Automattic/wp-calypso/assets/1081870/f10451a3-7407-4b2e-975f-128b858d6265">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
