### PR TITLE
Pattern Library: Fix scroll in `CategoryPillNavigation` after click

### DIFF
--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -55,8 +55,20 @@ export const CategoryPillNavigation = ( {
 	};
 
 	useEffect( () => {
+		if ( ! listRef.current ) {
+			return;
+		}
+
 		checkScrollArrows();
-	}, [] );
+
+		const target = listRef.current.querySelector( '.is-active' );
+
+		target?.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'nearest',
+			inline: 'center',
+		} );
+	}, [ selectedCategory ] );
 
 	return (
 		<div className="category-pill-navigation">

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -24,7 +24,7 @@ export function usePatternSearchTerm(
 		}
 
 		if ( url.href !== location.href ) {
-			page.redirect( url.href );
+			page( url.href.replace( url.origin, '' ) );
 		}
 	}, [ searchTerm ] );
 

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -27,7 +27,6 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 					category={ context.params.category }
 					categoryGallery={ CategoryGalleryClient }
 					isGridView={ !! context.query.grid }
-					key={ context.params.category }
 					patternGallery={ PatternGalleryClient }
 					patternTypeFilter={
 						context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6186

## Proposed Changes

| Before | After |
| - | - |
| <video src="https://github.com/Automattic/wp-calypso/assets/1101677/ba889769-569b-425d-b680-6192f6ee62bc"></video> | <video src="https://github.com/Automattic/wp-calypso/assets/1101677/dd70222b-7678-4ed8-bbb9-384a84e41092"></video> |

This started happening because of https://github.com/Automattic/wp-calypso/pull/88614/files#diff-2b2580afdcec7241b49335b0f2f485c74ba21f3cd521c361d35318fb809e1534R30, where we pass a `key` prop to the `PatternLibrary` component. That prop changes whenever the user navigates to a new category, which makes React reset and re-render the entire `PatternLibrary` component. This is exactly what we want for the search form and `PatternsPageViewTracker` to work correctly, but it broke the scroll in `CategoryPillNavigation`.

In this PR, I've reverted the `key` prop change from #88614. The search form was already working before that PR, so it still works. For `PageViewTracker,` we now pass `urlQuerySearchTerm` instead of `searchTerm`. A satisfyingly small change that achieves the effect we want. 

For the scroll in `CategoryPillNavigation`, I've added some `useEffect` logic that calls `Element.scrollIntoView`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns`
2. Ensure a `calypso_page_view` event is submitted with the path `/patterns`
3. Search for something 
4. Ensure a `calypso_page_view` event is submitted with the path `/patterns/:search`
5. Click the Intro category in the `CategoryPillNavigation`
6. Ensure that the `CategoryPillNavigation` automatically scrolls to the right
7. Ensure a `calypso_page_view` event is submitted with the path `/patterns/intro` (and no additional page view event with the path `/patterns/intro/:search` was submitted)
8. Search for something 
9. Ensure a `calypso_page_view` event is submitted with the path `/patterns/intro/:search`