### PR TITLE
Patterns: Add localization support

### DIFF
--- a/client/my-sites/patterns/.eslintrc
+++ b/client/my-sites/patterns/.eslintrc
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"wpcalypso/i18n-translate-identifier": "off"
+	}
+}

--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -4,10 +4,11 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export function LocalizedLink( { children, href = '', ...props }: JSX.IntrinsicElements[ 'a' ] ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
+
 	// `addLocaleToPathLocaleInFront` retrieves the active locale differently from `useLocale`.
 	// Crucially, it doesn't work with SSR unless we pass the `useLocale` value explicitly
 	const locale = useLocale();
-	const localizedHref = ! isLoggedIn ? addLocaleToPathLocaleInFront( href, locale ) : href;
+	const localizedHref = isLoggedIn ? href : addLocaleToPathLocaleInFront( href, locale );
 
 	return (
 		<a { ...props } href={ localizedHref }>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -11,6 +11,7 @@ import {
 	category as iconCategory,
 	menu as iconMenu,
 } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -88,6 +89,7 @@ export const PatternLibrary = ( {
 	searchTerm: urlQuerySearchTerm,
 }: PatternLibraryProps ) => {
 	const locale = useLocale();
+	const translate_not_yet = useTranslate();
 
 	const [ searchTerm, setSearchTerm ] = usePatternSearchTerm( urlQuerySearchTerm ?? '' );
 	const { data: categories = [] } = usePatternCategories( locale );
@@ -148,15 +150,17 @@ export const PatternLibrary = ( {
 		<>
 			<PatternsPageViewTracker category={ category } searchTerm={ searchTerm } />
 
-			<DocumentHead title="WordPress Patterns - Category" />
+			<DocumentHead title={ translate_not_yet( 'WordPress Patterns - Category' ) } />
 
 			<PatternsHeader
-				description="Dive into hundreds of expertly designed, fully responsive layouts, and bring any kind of site to life, faster."
+				description={ translate_not_yet(
+					'Dive into hundreds of expertly designed, fully responsive layouts, and bring any kind of site to life, faster.'
+				) }
 				initialSearchTerm={ searchTerm }
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }
-				title="It’s Easier With Patterns"
+				title={ translate_not_yet( 'It’s Easier With Patterns' ) }
 			/>
 
 			<div className="pattern-library__pill-navigation">
@@ -165,13 +169,13 @@ export const PatternLibrary = ( {
 					buttons={ [
 						{
 							icon: <Icon icon={ iconStar } size={ 30 } />,
-							label: 'Discover',
+							label: translate_not_yet( 'Discover' ),
 							link: addLocaleToPathLocaleInFront( '/patterns' ),
 							isActive: isHomePage,
 						},
 						{
 							icon: <Icon icon={ iconCategory } size={ 26 } />,
-							label: 'All Categories',
+							label: translate_not_yet( 'All Categories' ),
 							link: '/222',
 						},
 					] }
@@ -181,8 +185,10 @@ export const PatternLibrary = ( {
 
 			{ isHomePage && (
 				<CategoryGallery
-					title="Ship faster, ship more"
-					description="Choose from a library of beautiful, functional design patterns to build exactly the page you—or your client—need, in no time."
+					title={ translate_not_yet( 'Ship faster, ship more' ) }
+					description={ translate_not_yet(
+						'Choose from a library of beautiful, functional design patterns to build exactly the page you—or your client—need, in no time.'
+					) }
 					categories={ categories }
 					patternTypeFilter={ PatternTypeFilter.REGULAR }
 				/>
@@ -192,7 +198,12 @@ export const PatternLibrary = ( {
 				<PatternLibraryBody className="pattern-library">
 					<div className="pattern-library__header">
 						<h1 className="pattern-library__title">
-							{ searchTerm ? `${ patterns.length } patterns` : 'Patterns' }
+							{ searchTerm
+								? translate_not_yet( '%(count)d pattern', '%(count)d patterns', {
+										count: patterns.length,
+										args: { count: patterns.length },
+								  } )
+								: translate_not_yet( 'Patterns' ) }
 						</h1>
 
 						{ category && (
@@ -210,13 +221,13 @@ export const PatternLibrary = ( {
 							>
 								<ToggleGroupControlOption
 									className="pattern-library__toggle-option"
-									label="Patterns"
+									label={ translate_not_yet( 'Patterns' ) }
 									value={ PatternTypeFilter.REGULAR }
 								/>
 								<ToggleGroupControlOption
 									className="pattern-library__toggle-option"
 									disabled={ categoryObject?.pagePatternCount === 0 }
-									label="Page layouts"
+									label={ translate_not_yet( 'Page layouts' ) }
 									value={ PatternTypeFilter.PAGES }
 								/>
 							</ToggleGroupControl>
@@ -257,8 +268,10 @@ export const PatternLibrary = ( {
 
 			{ isHomePage && (
 				<CategoryGallery
-					title="Beautifully curated page layouts"
-					description="Start even faster with ready-to-use pages and preassembled patterns. Then tweak the design until it’s just right."
+					title={ translate_not_yet( 'Beautifully curated page layouts' ) }
+					description={ translate_not_yet(
+						'Start even faster with ready-to-use pages and preassembled patterns. Then tweak the design until it’s just right.'
+					) }
 					categories={ categories?.filter( ( c ) => c.pagePatternCount ) }
 					patternTypeFilter={ PatternTypeFilter.PAGES }
 				/>


### PR DESCRIPTION
This pull request introduces a way to localize strings that prevent them from being extracted for translations. This approach was discussed in Slack in p1710952296615669-C02AED43D with @Automattic/i18n. This will allow us to mark strings that need to be localized even if we're not ready to send them for translation yet. Once that's the case, we will have to remove the ESLint rule, and rename all `translate_not_yet` occurrences. This pull request only localizes the `PatternLibrary` component.

#### Testing instructions

1. Run `git checkout add/translate-to-patterns-pages` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/88753#issuecomment-2011878027)
2. Open the [`Patterns` page](http://calypso.localhost:3000/patterns)
3. Assert that all the strings are displayed as before
4. Click the `About` category button
5. Assert that `Patterns` is displayed below the list of categories
6. Type `about` in the search form
7. Assert that `20 patterns` is now displayed instead of `Patterns`
8. Assert that the rest of the strings are displayed as before