### PR TITLE
Pattern Library: Pass `useLocale` value to block-renderer API endpoint

### DIFF
--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useLocale } from '@automattic/i18n-utils';
 import { useQueries } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { RenderedPattern, RenderedPatterns, SiteInfo } from '../types';
@@ -7,6 +8,7 @@ const CACHE_TIME = isEnabled( 'pattern-assembler/v2' ) ? 0 : 1000 * 60 * 5; // 5
 
 const fetchRenderedPatterns = (
 	siteId: number | string,
+	locale: string,
 	stylesheet: string,
 	category: string,
 	patternIds: string[],
@@ -17,7 +19,7 @@ const fetchRenderedPatterns = (
 		stylesheet,
 		category,
 		pattern_ids: patternIds.join( ',' ),
-		_locale: 'user',
+		_locale: locale,
 	} );
 
 	if ( title ) {
@@ -41,9 +43,12 @@ const useRenderedPatterns = (
 	patternIdsByCategory: Record< string, string[] >,
 	siteInfo: SiteInfo = {}
 ) => {
+	const locale = useLocale();
+
 	const queries = Object.entries( patternIdsByCategory ).map( ( [ category, patternIds ] ) => ( {
-		queryKey: [ 'rendered-patterns', siteId, stylesheet, category, patternIds, siteInfo ],
-		queryFn: () => fetchRenderedPatterns( siteId, stylesheet, category, patternIds, siteInfo ),
+		queryKey: [ 'rendered-patterns', siteId, locale, stylesheet, category, patternIds, siteInfo ],
+		queryFn: () =>
+			fetchRenderedPatterns( siteId, locale, stylesheet, category, patternIds, siteInfo ),
 		staleTime: CACHE_TIME,
 		refetchOnWindowFocus: false,
 	} ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6162

## Proposed Changes

We've noticed that the pattern previews on `/patterns` aren't translated, even if the markup returned from the `/ptk/patterns` endpoint is translated. This produces a weird scenario where the content that is copied when clicking `Copy pattern` is translated, but the preview is not.

Similarly to #88705, this PR fixes this problem by passing the return value from `useLocale` to the `/block-renderer/patterns/render` API endpoint. `useLocale` is apparently "more aware" of the different ways the locale can be specified when compared to `_locale: user` on the API side. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open an incognito window
2. Navigate to `/fr/patterns/about`
3. Ensure that (most) pattern previews contain text translated into French
4. Go back to a logged-in window
5. Change your interface language to something other than English (https://wordpress.com/me/account)
6. Navigate to `/setup/assembler-first`, select `Existing website`, pick any website
7. On the next page, ensure that the pattern previews in the left sidebar are translated
