### PR TITLE
Disable storage add on dropdown when plan not interactive

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/plan-storage-options.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-storage-options.tsx
@@ -25,51 +25,57 @@ const PlanStorageOptions = ( {
 }: PlanStorageOptionsProps ) => {
 	const translate = useTranslate();
 
-	return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
-		if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
-			return null;
+	return renderedGridPlans.map(
+		( { availableForPurchase, planSlug, features: { storageOptions } } ) => {
+			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
+				return null;
+			}
+
+			const shouldRenderStorageTitle =
+				storageOptions.length > 0 &&
+				( storageOptions.length === 1 ||
+					intervalType !== 'yearly' ||
+					! showUpgradeableStorage ||
+					! availableForPurchase );
+			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
+				intervalType,
+				showUpgradeableStorage,
+				storageOptions,
+			} );
+			const storageJSX =
+				canUpgradeStorageForPlan && availableForPurchase ? (
+					<StorageAddOnDropdown
+						label={ translate( 'Storage' ) }
+						planSlug={ planSlug }
+						onStorageAddOnClick={ onStorageAddOnClick }
+						storageOptions={ storageOptions }
+					/>
+				) : (
+					storageOptions.map( ( storageOption ) => {
+						if ( ! storageOption?.isAddOn ) {
+							return (
+								<div className="plan-features-2023-grid__storage-buttons" key={ planSlug }>
+									{ getStorageStringFromFeature( storageOption?.slug ) }
+								</div>
+							);
+						}
+					} )
+				);
+
+			return (
+				<PlanDivOrTdContainer
+					key={ planSlug }
+					className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
+					isTableCell={ options?.isTableCell }
+				>
+					{ shouldRenderStorageTitle ? (
+						<div className="plan-features-2023-grid__storage-title">{ translate( 'Storage' ) }</div>
+					) : null }
+					{ storageJSX }
+				</PlanDivOrTdContainer>
+			);
 		}
-
-		const shouldRenderStorageTitle =
-			storageOptions.length > 0 &&
-			( storageOptions.length === 1 || intervalType !== 'yearly' || ! showUpgradeableStorage );
-		const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
-			intervalType,
-			showUpgradeableStorage,
-			storageOptions,
-		} );
-		const storageJSX = canUpgradeStorageForPlan ? (
-			<StorageAddOnDropdown
-				label={ translate( 'Storage' ) }
-				planSlug={ planSlug }
-				onStorageAddOnClick={ onStorageAddOnClick }
-				storageOptions={ storageOptions }
-			/>
-		) : (
-			storageOptions.map( ( storageOption ) => {
-				if ( ! storageOption?.isAddOn ) {
-					return (
-						<div className="plan-features-2023-grid__storage-buttons" key={ planSlug }>
-							{ getStorageStringFromFeature( storageOption?.slug ) }
-						</div>
-					);
-				}
-			} )
-		);
-
-		return (
-			<PlanDivOrTdContainer
-				key={ planSlug }
-				className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
-				isTableCell={ options?.isTableCell }
-			>
-				{ shouldRenderStorageTitle ? (
-					<div className="plan-features-2023-grid__storage-title">{ translate( 'Storage' ) }</div>
-				) : null }
-				{ storageJSX }
-			</PlanDivOrTdContainer>
-		);
-	} );
+	);
 };
 
 export default PlanStorageOptions;


### PR DESCRIPTION
Related to # https://github.com/Automattic/wp-calypso/issues/87767

## Proposed Changes

Disable storage add-on selector when plan is not interactive/purchasable

## Testing Instructions

1. Checkout branch 
2. Go to `/plans/[ site not owned ]`
3. Verify storage add-on selector is disabled on plan that is not purchasable  

<img width="1195" alt="image" src="https://github.com/Automattic/wp-calypso/assets/25906001/adcbbbd4-b1ea-42cf-adf9-e8e9408edd7b">


