### PR TITLE
Plugins update manager: Add selected plugins number and frequency params to record events

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -22,6 +22,7 @@ import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleForm } from './schedule-form';
+import type { SyncSuccessParams } from './types';
 
 interface Props {
 	onNavBack?: () => void;
@@ -61,9 +62,11 @@ export const ScheduleCreate = ( props: Props ) => {
 		}
 	}, [ siteHasEligiblePlugins, siteHasEligiblePluginsLoading ] );
 
-	const onSyncSuccess = () => {
+	const onSyncSuccess = ( params: SyncSuccessParams ) => {
 		recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {
 			site_slug: siteSlug,
+			frequency: params.frequency,
+			plugins_number: params.plugins.length,
 		} );
 
 		createMonitor();

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -67,6 +67,7 @@ export const ScheduleCreate = ( props: Props ) => {
 			site_slug: siteSlug,
 			frequency: params.frequency,
 			plugins_number: params.plugins.length,
+			hours: params.hours,
 		} );
 
 		createMonitor();

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -57,6 +57,7 @@ export const ScheduleEdit = ( props: Props ) => {
 			site_slug: siteSlug,
 			frequency: params.frequency,
 			plugins_number: params.plugins.length,
+			hours: params.hours,
 		} );
 
 		setSyncError( '' );

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -17,6 +17,7 @@ import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleForm } from './schedule-form';
+import type { SyncSuccessParams } from './types';
 
 interface Props {
 	scheduleId?: string;
@@ -51,9 +52,11 @@ export const ScheduleEdit = ( props: Props ) => {
 		return null;
 	}
 
-	const onSyncSuccess = () => {
+	const onSyncSuccess = ( params: SyncSuccessParams ) => {
 		recordTracksEvent( 'calypso_scheduled_updates_edit_schedule', {
 			site_slug: siteSlug,
+			frequency: params.frequency,
+			plugins_number: params.plugins.length,
 		} );
 
 		setSyncError( '' );

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -13,12 +13,13 @@ import {
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { validatePlugins, validateTimeSlot } from './schedule-form.helper';
+import type { SyncSuccessParams } from './types';
 
 import './schedule-form.scss';
 
 interface Props {
 	scheduleForEdit?: ScheduleUpdates;
-	onSyncSuccess?: () => void;
+	onSyncSuccess?: ( params: SyncSuccessParams ) => void;
 	onSyncError?: ( error: string ) => void;
 }
 export const ScheduleForm = ( props: Props ) => {
@@ -26,15 +27,8 @@ export const ScheduleForm = ( props: Props ) => {
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
 
-	const serverSyncCallbacks = {
-		onSuccess: () => onSyncSuccess && onSyncSuccess(),
-		onError: ( e: Error ) => onSyncError && onSyncError( e.message ),
-	};
-
 	const { data: schedulesData = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const schedules = schedulesData.filter( ( s ) => s.id !== scheduleForEdit?.id ) ?? [];
-	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, serverSyncCallbacks );
-	const { editUpdateSchedule } = useEditUpdateScheduleMutation( siteSlug, serverSyncCallbacks );
 
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >(
 		scheduleForEdit?.args || []
@@ -55,6 +49,18 @@ export const ScheduleForm = ( props: Props ) => {
 		timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
 	} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
+
+	const serverSyncCallbacks = {
+		onSuccess: () =>
+			onSyncSuccess &&
+			onSyncSuccess( {
+				plugins: selectedPlugins,
+				frequency,
+			} ),
+		onError: ( e: Error ) => onSyncError && onSyncError( e.message ),
+	};
+	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, serverSyncCallbacks );
+	const { editUpdateSchedule } = useEditUpdateScheduleMutation( siteSlug, serverSyncCallbacks );
 
 	const onFormSubmit = () => {
 		const formValid = ! Object.values( validationErrors ).filter( ( e ) => !! e ).length;

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -56,6 +56,7 @@ export const ScheduleForm = ( props: Props ) => {
 			onSyncSuccess( {
 				plugins: selectedPlugins,
 				frequency,
+				hours: new Date( timestamp * 1000 ).getHours(),
 			} ),
 		onError: ( e: Error ) => onSyncError && onSyncError( e.message ),
 	};

--- a/client/blocks/plugins-update-manager/types.ts
+++ b/client/blocks/plugins-update-manager/types.ts
@@ -1,0 +1,4 @@
+export type SyncSuccessParams = {
+	plugins: string[];
+	frequency: 'daily' | 'weekly';
+};

--- a/client/blocks/plugins-update-manager/types.ts
+++ b/client/blocks/plugins-update-manager/types.ts
@@ -1,4 +1,5 @@
 export type SyncSuccessParams = {
 	plugins: string[];
 	frequency: 'daily' | 'weekly';
+	hours: number;
 };


### PR DESCRIPTION
## Proposed Changes

* Adds additional params to record events for schedule `create` and `edit` events
  * `plugins_number` and 
  * `frequency`

## Testing Instructions

* Go to `/plugins/scheduled-updates/{SITE}`
* Create or edit an existing schedule
* Check if there are additional params for recordTracksEvent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?