### PR TITLE
SSO: Add check on render invite button

### DIFF
--- a/client/my-sites/people/people-list-item/index.tsx
+++ b/client/my-sites/people/people-list-item/index.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { get } from 'lodash';
 import React from 'react';
 import { getRole } from 'calypso/blocks/importer/wordpress/import-everything/import-users/utils';
+import { userCan } from 'calypso/lib/site/utils';
 import PeopleProfile from 'calypso/my-sites/people/people-profile';
 import { useDispatch } from 'calypso/state';
 import { recordGoogleEvent, composeAnalytics } from 'calypso/state/analytics/actions';
@@ -127,7 +128,9 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 			handleInviteError( siteId, error );
 		}
 	};
-
+	const canUserInviteUsers = () => {
+		return site && userCan( 'promote_users', site );
+	};
 	const renderInviteButton = () => {
 		return (
 			<div className="people-list-item__invite-status">
@@ -179,7 +182,7 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 	} );
 
 	const tagName = canLinkToProfile() ? 'a' : 'span';
-	const inviteButton = renderInviteButton();
+	const inviteButton = canUserInviteUsers() ? renderInviteButton() : false;
 
 	return (
 		<CompactCard

--- a/client/my-sites/people/people-list-item/index.tsx
+++ b/client/my-sites/people/people-list-item/index.tsx
@@ -128,8 +128,10 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 			handleInviteError( siteId, error );
 		}
 	};
-	const canUserInviteUsers = () => {
-		return site && userCan( 'promote_users', site );
+
+	const shouldShowInviteButton = ( isInvite: boolean | undefined ) => {
+		const canSendInvite = site && userCan( 'promote_users', site );
+		return canReceiveInvite() && ! isInvite && canSendInvite;
 	};
 	const renderInviteButton = () => {
 		return (
@@ -182,7 +184,6 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 	} );
 
 	const tagName = canLinkToProfile() ? 'a' : 'span';
-	const inviteButton = canUserInviteUsers() ? renderInviteButton() : false;
 
 	return (
 		<CompactCard
@@ -201,7 +202,7 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 					showRole={ !! maybeGetCardLink() }
 				/>
 			</div>
-			{ canReceiveInvite() && ! isInvite && inviteButton }
+			{ shouldShowInviteButton( isInvite ) && renderInviteButton() }
 			{ onRemove && (
 				<div className="people-list-item__actions">
 					<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* We are getting some logs regarding users trying to invite users, but they are failing because these users are not authorized to invite others. This PR adds a check to only render the invite button if the user is allowed to do that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and navigate to {LIVE_LINK/people/team/{ATOMIC_SITE_SLUG}
* Make sure your user is not an admin or fake it by returning false https://github.com/Automattic/wp-calypso/pull/88760/files#diff-6e6e54ba6ea32a7c6bd49e9de7f9873ab461eebf15cb8b61903c573651971c92R132
* The invite button should **not** be visible.

<img width="738" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/931d8fd7-da64-4da0-bbb1-cd10cf9eeae8">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?