### PR TITLE
Pattern Library: Adjust position of `ResizableBox` resize handle

### DIFF
--- a/client/components/category-pill-navigation/style.scss
+++ b/client/components/category-pill-navigation/style.scss
@@ -24,7 +24,13 @@
 		display: flex;
 		gap: 16px;
 		align-items: center;
+		// Chrome, Edge, Firefox
 		scrollbar-width: none;
+
+		// Safari
+		&::-webkit-scrollbar {
+			display: none;
+		}
 	}
 
 	.category-pill-navigation__arrow {

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -1,6 +1,7 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import { Button } from '@automattic/components';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { ResizableBox, Tooltip } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { Icon, lock } from '@wordpress/icons';
@@ -139,12 +140,13 @@ function PatternPreviewFragment( {
 
 export function PatternPreview( props: PatternPreviewProps ) {
 	const { isResizable, pattern } = props;
+	const isDesktop = useDesktopBreakpoint();
 
 	if ( ! pattern ) {
 		return null;
 	}
 
-	if ( ! isResizable ) {
+	if ( ! isResizable || ! isDesktop ) {
 		return <PatternPreviewFragment { ...props } />;
 	}
 

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -1,7 +1,7 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import { Button } from '@automattic/components';
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { ResizableBox, Tooltip } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { Icon, lock } from '@wordpress/icons';
@@ -140,13 +140,13 @@ function PatternPreviewFragment( {
 
 export function PatternPreview( props: PatternPreviewProps ) {
 	const { isResizable, pattern } = props;
-	const isDesktop = useDesktopBreakpoint();
+	const isMobile = useMobileBreakpoint();
 
 	if ( ! pattern ) {
 		return null;
 	}
 
-	if ( ! isResizable || ! isDesktop ) {
+	if ( ! isResizable || isMobile ) {
 		return <PatternPreviewFragment { ...props } />;
 	}
 

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -146,20 +146,23 @@
 }
 
 .pattern-preview__resizer .components-resizable-box__handle-right {
+	bottom: 3rem;
+	height: auto;
+	left: 100%;
+	right: initial;
+
 	&::after {
 		background-color: #a7aaad;
 		border-radius: 3px;
 		box-shadow: none;
 		height: 50px;
-		margin-right: -10px;
-		right: calc(50% - 5px);
-		top: calc(50% - 8px - 3rem);
+		right: calc(50% - 3px);
+		top: calc(50% - 8px);
 		width: 6px;
 	}
 
-	&:active::before,
-	&:hover::before {
-		animation: none;
+	&::before {
+		content: none;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6183
Follow-up to #88563

## Proposed Changes

The pattern preview resize handle would previously overlap the `Copy pattern` button, which it shouldn't. This PR fixes that.

I've also taken this opportunity to disable the resize behavior on mobile viewports.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/about`
2. Ensure that the resize handle doesn't overlap the `Copy pattern` button
3. Activate a mobile-sized viewport
4. Ensure that you no longer see the resize handles
