### PR TITLE
Sites dashboard: modify needs attention icon and search placeholder to match design specs

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { category, chevronLeft, formatListBulletsRTL, starEmpty } from '@wordpress/icons';
+import { category, chevronLeft, starEmpty, warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import Sidebar from '../sidebar';
@@ -22,7 +22,7 @@ export default function ( { path }: Props ) {
 		return [
 			createItem(
 				{
-					icon: formatListBulletsRTL,
+					icon: warning,
 					path: A4A_SITES_LINK,
 					link: A4A_SITES_LINK_NEEDS_ATTENTION,
 					title: translate( 'Needs Attention' ),

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -289,7 +289,7 @@ const SitesDataViews = ( {
 				fields={ fields }
 				view={ sitesViewState }
 				search={ true }
-				searchLabel={ translate( 'Search sites' ) }
+				searchLabel={ translate( 'Search for sites' ) }
 				getItemId={ ( item: SiteInfo ) => {
 					item.id = item.site.value.blog_id; // setting the id because of a issue with the DataViews component
 					return item.id;


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/79
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/57

## Proposed Changes

* This PR modifies the 'Needs Attention' icon in the Sites sidebar to match design specs, as well as changing the sites overview search field placeholder to 'Search for sites'.

## Testing Instructions


For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* To test, when visiting the sites dashboard you should see the above changes - the Needs Attention Icon has changed to the warning icon and the Search placeholder is now saying 'Search for sites'.

Here is how it should look:

<img width="684" alt="Screenshot 2024-03-21 at 14 13 55" src="https://github.com/Automattic/wp-calypso/assets/16754605/55f49c8b-15b7-4a2f-9b4d-7e6d9103cdaf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?