### PR TITLE
Plans Next: Fix content overflow in comparison grid

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -858,6 +858,7 @@ const PlansFeaturesMain = ( {
 									recordTracksEvent={ recordTracksEvent }
 									coupon={ coupon }
 									planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
+									className="plans-features-main__features-grid"
 								/>
 								{ showEscapeHatch && hidePlansFeatureComparison && (
 									<div className="plans-features-main__escape-hatch">
@@ -923,6 +924,7 @@ const PlansFeaturesMain = ( {
 												coupon={ coupon }
 												recordTracksEvent={ recordTracksEvent }
 												planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
+												className="plans-features-main__comparison-grid"
 											/>
 											<ComparisonGridToggle
 												onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -24,11 +24,9 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
-.plans-features-main {
-	.plans-grid-next__features-grid,
-	.plans-grid-next__comparison-grid {
-		margin-top: 50px;
-	}
+.plans-features-main__features-grid,
+.plans-features-main__comparison-grid {
+	margin-top: 50px;
 }
 
 .is-2023-pricing-grid {

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
@@ -25,27 +25,8 @@
 }
 
 .wooexpress-plans__grid.is-2023-pricing-grid {
-	.plans-grid__header-title {
-		font-family: $sans;
-	}
-
-	.plans-grid__content .plans-grid__table-item .plan-price,
-	.plans-grid__plan-comparison-grid-container .plan-comparison-grid .plan-price {
-		font-family: $sans;
-	}
-
 	.plan-price .plan-price__currency-symbol {
 		font-size: $woo-font-title-medium;
-	}
-
-	.plans-grid__plan-comparison-grid-container .plan-comparison-grid .wp-brand-font {
-		display: none;
-	}
-
-	.plans-grid__table.has-2-cols {
-		margin-left: auto;
-		margin-right: auto;
-		max-width: 800px;
 	}
 }
 

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1113,7 +1113,7 @@ const ComparisonGrid = ( {
 	 * Some padding is applied in the stylesheet to cover the badges/labels.
 	 */
 	const hasHighlightedPlan = gridPlans.some( ( { highlightLabel } ) => !! highlightLabel );
-	const classes = classNames( 'plan-comparison-grid', {
+	const classes = classNames( 'plans-grid-next-comparison-grid', {
 		'has-highlighted-plan': hasHighlightedPlan,
 	} );
 

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -275,7 +275,7 @@ const FeaturesGrid = ( {
 	};
 
 	return (
-		<>
+		<div className="plans-grid-next-features-grid">
 			{ 'small' !== gridSize && <SpotlightPlan { ...spotlightPlanProps } /> }
 			<div className="plan-features">
 				<div className="plan-features-2023-grid__content">
@@ -298,7 +298,7 @@ const FeaturesGrid = ( {
 					</div>
 				</div>
 			</div>
-		</>
+		</div>
 	);
 };
 

--- a/packages/plans-grid-next/src/components/header-price.tsx
+++ b/packages/plans-grid-next/src/components/header-price.tsx
@@ -47,7 +47,7 @@ const HeaderPriceContainer = styled.div`
 	padding: 0 20px;
 	margin: 0 0 4px 0;
 
-	.plan-comparison-grid & {
+	.plans-grid-next-comparison-grid & {
 		padding: 0;
 		display: flex;
 		flex-direction: column;

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -32,6 +32,7 @@ const WrappedComparisonGrid = ( {
 	onStorageAddOnClick,
 	stickyRowOffset,
 	coupon,
+	className,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
@@ -46,7 +47,7 @@ const WrappedComparisonGrid = ( {
 		] ),
 	} );
 
-	const classNames = classnames( 'plans-grid-next', 'plans-grid-next__comparison-grid', {
+	const classNames = classnames( 'plans-grid-next', className, {
 		'is-small': 'small' === gridSize,
 		'is-smedium': 'smedium' === gridSize,
 		'is-medium': 'medium' === gridSize,
@@ -95,6 +96,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		allFeaturesList,
 		coupon,
 		isInAdmin,
+		className,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
@@ -107,11 +109,10 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		] ),
 	} );
 
-	const classNames = classnames( 'plans-grid-next', 'plans-grid-next__features-grid', {
+	const classNames = classnames( 'plans-grid-next', className, {
 		'is-small': 'small' === gridSize,
 		'is-medium': 'medium' === gridSize,
 		'is-large': 'large' === gridSize,
-		'is-visible': true,
 	} );
 
 	return (

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -5,14 +5,6 @@
 $table-cell-max-width: 344px;
 $mobile-card-max-width: 440px;
 
-.plans-grid-next__features-grid {
-	display: none;
-
-	&.is-visible {
-		display: block;
-	}
-}
-
 .plan-features-2023-grid__header {
 	display: flex;
 	position: relative;
@@ -721,7 +713,10 @@ $mobile-card-max-width: 440px;
 	}
 }
 
-.plan-comparison-grid {
+.plans-grid-next-comparison-grid {
+	// fixes mobile view cards in features grid not containing content properly
+	min-width: fit-content;
+
 	&.has-highlighted-plan {
 		@include plans-grid-medium-large {
 			padding-top: 43px; // enough to cover `plans-grid__popular-badge` repositioning (top: -43px)

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -151,6 +151,7 @@ export type GridContextProps = {
 
 export type ComparisonGridExternalProps = Omit< GridContextProps, 'children' > &
 	Omit< ComparisonGridProps, 'onUpgradeClick' | 'gridContainerRef' | 'gridSize' > & {
+		className?: string;
 		onUpgradeClick?: (
 			cartItems?: MinimalRequestCartProduct[] | null,
 			clickedPlanSlug?: PlanSlug
@@ -162,6 +163,7 @@ export type FeaturesGridExternalProps = Omit< GridContextProps, 'children' > &
 		FeaturesGridProps,
 		'onUpgradeClick' | 'isLargeCurrency' | 'translate' | 'gridContainerRef' | 'gridSize'
 	> & {
+		className?: string;
 		onUpgradeClick?: (
 			cartItems?: MinimalRequestCartProduct[] | null,
 			clickedPlanSlug?: PlanSlug


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/80941

## Proposed Changes

- Fixes the width of the comparison grid not consistently covering the content. Overflow happens when the "one-time discount" label is shown for some currencies (e.g. INR).
- Some cleanup to the CSS class names while at it. Also architecturally, we now have `plans-grid-next` at the top level, then `plans-grid-next-comparison-grid` immediately following, etc. From there on, component classes can the attached underscored e.g. `plans-grid-next-comparison-grid__header-price`. 

### Media

| Before | After |
|--------|--------|
| <img width="300" alt="Screenshot 2024-03-21 at 1 01 23 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/0fd2bf95-6b93-4afa-b967-78b10fc9b649"> |  <img width="300" alt="Screenshot 2024-03-21 at 1 01 35 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/620398e6-1fcb-427e-b78f-265614faf52c"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to INR currency and ensure `One-time discount` shows above the plan prices
* Go to `/start/plans` and resize window to mobile view
* Ensure the overflow visible in the issue above is no longer there (other issues still exist with the mobile view, with two cards being too many for small viewports (not intended to be fixes here)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?