### PR TITLE
Hosting Configuration: Update Learn More Links

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -96,7 +96,7 @@ const contextLinks = {
 		post_id: 98905,
 	},
 	'hosting-sftp': {
-		link: 'https://developer.wordpress.com/docs/developer-tools/sftp-ssh/',
+		link: 'https://developer.wordpress.com/docs/developer-tools/sftp/',
 		post_id: 99380,
 		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
 	},
@@ -106,11 +106,11 @@ const contextLinks = {
 		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
 	},
 	'hosting-clear-cache': {
-		link: 'https://wordpress.com/support/clear-your-sites-cache/',
+		link: 'https://developer.wordpress.com/docs/site-performance/global-edge-cache/#1-clear-your-site-s-cache',
 		post_id: 164969,
 	},
 	'hosting-connect-to-ssh': {
-		link: 'https://wordpress.com/support/connect-to-ssh-on-wordpress-com/',
+		link: 'https://developer.wordpress.com/docs/developer-tools/ssh/',
 		post_id: 213309,
 	},
 	'hosting-mysql': {

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -107,12 +107,12 @@ const contextLinks = {
 	},
 	'hosting-clear-cache': {
 		link: 'https://developer.wordpress.com/docs/site-performance/global-edge-cache/#1-clear-your-site-s-cache',
-		post_id: 164969,
+		post_id: 99415,
 		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
 	},
 	'hosting-connect-to-ssh': {
 		link: 'https://developer.wordpress.com/docs/developer-tools/ssh/',
-		post_id: 213309,
+		post_id: 100385,
 		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
 	},
 	'hosting-mysql': {

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -108,10 +108,12 @@ const contextLinks = {
 	'hosting-clear-cache': {
 		link: 'https://developer.wordpress.com/docs/site-performance/global-edge-cache/#1-clear-your-site-s-cache',
 		post_id: 164969,
+		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
 	},
 	'hosting-connect-to-ssh': {
 		link: 'https://developer.wordpress.com/docs/developer-tools/ssh/',
 		post_id: 213309,
+		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
 	},
 	'hosting-mysql': {
 		link: 'https://developer.wordpress.com/docs/developer-tools/database-access/',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1710864734866069-slack-C0347E545HR

## Proposed Changes

This PR changes the `Learn more` links on `Hosting Configuration` page from:

* `Learn more about SFTP on WordPress.com`: from https://developer.wordpress.com/docs/developer-tools/sftp-ssh/ to https://developer.wordpress.com/docs/developer-tools/sftp/
* `Learn more` by the `Enable SSH access for this site` on Hosting Configuration card: from https://wordpress.com/support/connect-to-ssh-on-wordpress-com/ to https://developer.wordpress.com/docs/developer-tools/ssh/
* `Learn more` by `Manage your site’s server-side caching`: from https://wordpress.com/support/clear-your-sites-cache/ to https://developer.wordpress.com/docs/site-performance/global-edge-cache/#1-clear-your-site-s-cache

## Testing Instructions

* Navigate to Calypso live link generated by this branch
* Make sure you have an Atomic site
* Navigate to `Settings > Hosting Configuration`: /hosting-config/{yourAtomicSite}
* Look for `Learn more about SFTP on WordPress.com` on the top of the SFTP/SSH credentials card
* Confirm that clicking the link opens the inline help article from https://developer.wordpress.com/docs/developer-tools/sftp/
* Navigate through an arrow from inline help and confirm you are brought to the right page:

<img width="922" alt="Screenshot 2024-03-21 at 4 14 48 PM" src="https://github.com/Automattic/wp-calypso/assets/25575134/6166258a-eaea-4889-a86e-9cbee4c82463">

* Look for the `Learn more` link to the `Enable SSH access for this site` toggle
* Confirm that clicking the link opens the inline help article from https://developer.wordpress.com/docs/developer-tools/ssh/
* Navigate through an arrow from inline help and confirm you are brought to the right page:

<img width="918" alt="Screenshot 2024-03-21 at 4 16 19 PM" src="https://github.com/Automattic/wp-calypso/assets/25575134/456e2b94-9aa9-4967-bd26-6041833eea8a">

* `Learn more` by `Manage your site’s server-side caching`
* Confirm that clicking the link opens the inline help article from https://developer.wordpress.com/docs/site-performance/global-edge-cache/#1-clear-your-site-s-cache
* Navigate through an arrow from inline help and confirm you are brought to the right page:

<img width="887" alt="Screenshot 2024-03-21 at 4 17 32 PM" src="https://github.com/Automattic/wp-calypso/assets/25575134/bf7a5d88-6948-40a5-95bd-91eb175aa576">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?