### PR TITLE
DIFM Page Picker: remove cart

### DIFF
--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -52,7 +52,7 @@ import { buildDIFMCartExtrasObject } from 'calypso/state/difm/assemblers';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { getSitePlan } from 'calypso/state/sites/selectors';
+import { getSiteId, getSitePlan } from 'calypso/state/sites/selectors';
 import { SiteSlug } from 'calypso/types';
 import ShoppingCartForDIFM from './shopping-cart-for-difm';
 import useCartForDIFM from './use-cart-for-difm';
@@ -428,7 +428,7 @@ function DIFMPagePicker( props: StepProps ) {
 	const {
 		stepName,
 		goToNextStep,
-		signupDependencies: { siteId, siteSlug, newOrExistingSiteChoice },
+		signupDependencies: { siteId: siteIdFromDependencies, siteSlug, newOrExistingSiteChoice },
 		flowName,
 	} = props;
 	const translate = useTranslate();
@@ -442,6 +442,7 @@ function DIFMPagePicker( props: StepProps ) {
 			: [ HOME_PAGE, ABOUT_PAGE, CONTACT_PAGE, PHOTO_GALLERY_PAGE, SERVICES_PAGE ]
 	);
 
+	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) ) || siteIdFromDependencies;
 	const currentPlan = useSelector( ( state ) => ( siteId ? getSitePlan( state, siteId ) : null ) );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) || '';
 

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -445,14 +445,7 @@ function DIFMPagePicker( props: StepProps ) {
 	const isExistingSite = newOrExistingSiteChoice === 'existing-site' || siteSlug;
 
 	const { replaceProductsInCart } = useShoppingCart( cartKey ?? undefined );
-	const {
-		isCartLoading,
-		isCartPendingUpdate,
-		isCartUpdateStarted,
-		isProductsLoading,
-		isFormattedCurrencyLoading,
-		effectiveCurrencyCode,
-	} = useCartForDIFM( selectedPages, isStoreFlow, isExistingSite );
+	const { isProductsLoading, effectiveCurrencyCode } = useCartForDIFM( selectedPages, isStoreFlow );
 
 	const difmLiteProduct = useSelector( ( state ) => getProductBySlug( state, WPCOM_DIFM_LITE ) );
 	let difmTieredPriceDetails = null;
@@ -496,12 +489,7 @@ function DIFMPagePicker( props: StepProps ) {
 	};
 
 	const isCheckoutButtonBusy =
-		( isExistingSite &&
-			( isProductsLoading ||
-				isCartPendingUpdate ||
-				isCartLoading ||
-				isCartUpdateStarted ||
-				isLoadingIsEligibleForOneClickCheckout ) ) ||
+		( isExistingSite && ( isProductsLoading || isLoadingIsEligibleForOneClickCheckout ) ) ||
 		isCheckoutPressed;
 
 	const isBusyForWhile = useLongFetchingDetection( 'difm-page-picker', isCheckoutButtonBusy, 5000 );
@@ -513,9 +501,6 @@ function DIFMPagePicker( props: StepProps ) {
 			const message =
 				'Page Picker Infinite Loading state:' +
 				` isProductsLoading: ${ isProductsLoading }` +
-				` isCartPendingUpdate: ${ isCartPendingUpdate }` +
-				` isCartLoading: ${ isCartLoading }` +
-				` isCartUpdateStarted: ${ isCartUpdateStarted }` +
 				` isLoadingIsEligibleForOneClickCheckout: ${ isLoadingIsEligibleForOneClickCheckout }`;
 			logToLogstash( {
 				feature: 'calypso_client',
@@ -523,14 +508,7 @@ function DIFMPagePicker( props: StepProps ) {
 				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 			} );
 		}
-	}, [
-		isBusyForWhile,
-		isCartLoading,
-		isCartPendingUpdate,
-		isCartUpdateStarted,
-		isLoadingIsEligibleForOneClickCheckout,
-		isProductsLoading,
-	] );
+	}, [ isBusyForWhile, isLoadingIsEligibleForOneClickCheckout, isProductsLoading ] );
 
 	const headerText = translate( 'Add pages to your {{wbr}}{{/wbr}}website', {
 		components: { wbr: <wbr /> },
@@ -543,12 +521,7 @@ function DIFMPagePicker( props: StepProps ) {
 				{
 					components: {
 						br: <br />,
-						PriceWrapper:
-							difmTieredPriceDetails?.perExtraPagePrice && ! isFormattedCurrencyLoading ? (
-								<span />
-							) : (
-								<Placeholder />
-							),
+						PriceWrapper: difmTieredPriceDetails?.perExtraPagePrice ? <span /> : <Placeholder />,
 					},
 					args: {
 						freePageCount: difmTieredPriceDetails?.numberOfIncludedPages as number,
@@ -568,12 +541,7 @@ function DIFMPagePicker( props: StepProps ) {
 				{
 					components: {
 						br: <br />,
-						PriceWrapper:
-							difmTieredPriceDetails?.perExtraPagePrice && ! isFormattedCurrencyLoading ? (
-								<span />
-							) : (
-								<Placeholder />
-							),
+						PriceWrapper: difmTieredPriceDetails?.perExtraPagePrice ? <span /> : <Placeholder />,
 					},
 					args: {
 						freePageCount: difmTieredPriceDetails?.numberOfIncludedPages as number,
@@ -619,7 +587,7 @@ function DIFMPagePicker( props: StepProps ) {
 			isWideLayout={ false }
 			headerButton={
 				<StyledButton
-					disabled={ isFormattedCurrencyLoading }
+					disabled={ isProductsLoading }
 					busy={ isCheckoutButtonBusy }
 					primary
 					onClick={ submitPickedPages }
@@ -628,11 +596,7 @@ function DIFMPagePicker( props: StepProps ) {
 				</StyledButton>
 			}
 			headerContent={
-				<ShoppingCartForDIFM
-					selectedPages={ selectedPages }
-					isStoreFlow={ isStoreFlow }
-					isExistingSite={ isExistingSite }
-				/>
+				<ShoppingCartForDIFM selectedPages={ selectedPages } isStoreFlow={ isStoreFlow } />
 			}
 			{ ...props }
 		/>

--- a/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
@@ -162,19 +162,13 @@ function DummyLineItem( {
 export default function ShoppingCartForDIFM( {
 	selectedPages,
 	isStoreFlow,
-	isExistingSite,
 }: {
 	selectedPages: string[];
 	isStoreFlow: boolean;
-	isExistingSite: boolean;
 } ) {
 	const translate = useTranslate();
-	const { items, total, effectiveCurrencyCode, isFormattedCurrencyLoading } = useCartForDIFM(
-		selectedPages,
-		isStoreFlow,
-		isExistingSite
-	);
-	return isFormattedCurrencyLoading || effectiveCurrencyCode === null ? (
+	const { items, total, effectiveCurrencyCode } = useCartForDIFM( selectedPages, isStoreFlow );
+	return effectiveCurrencyCode === null ? (
 		<LoadingContainer>
 			<LoadingLine key="plan-placeholder" />
 			<LoadingLine key="difm-placeholder" />

--- a/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import LoadingLine from './loading-content';
 import useCartForDIFM, { CartItem } from './use-cart-for-difm';
 
@@ -162,13 +164,21 @@ function DummyLineItem( {
 export default function ShoppingCartForDIFM( {
 	selectedPages,
 	isStoreFlow,
+	currentPlanSlug,
 }: {
 	selectedPages: string[];
 	isStoreFlow: boolean;
+	currentPlanSlug?: string | null;
 } ) {
 	const translate = useTranslate();
-	const { items, total, effectiveCurrencyCode } = useCartForDIFM( selectedPages, isStoreFlow );
-	return effectiveCurrencyCode === null ? (
+	const { items, total, isProductsLoading } = useCartForDIFM( {
+		selectedPages,
+		isStoreFlow,
+		currentPlanSlug,
+	} );
+	const currencyCode = useSelector( getCurrentUserCurrencyCode ) || '';
+
+	return isProductsLoading ? (
 		<LoadingContainer>
 			<LoadingLine key="plan-placeholder" />
 			<LoadingLine key="difm-placeholder" />
@@ -179,11 +189,7 @@ export default function ShoppingCartForDIFM( {
 			<Cart>
 				<LineItemsWrapper>
 					{ items.map( ( item ) => (
-						<DummyLineItem
-							key={ item.productSlug }
-							{ ...item }
-							currencyCode={ effectiveCurrencyCode }
-						/>
+						<DummyLineItem key={ item.productSlug } { ...item } currencyCode={ currencyCode } />
 					) ) }
 
 					<Total>

--- a/client/signup/steps/page-picker/use-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/use-cart-for-difm.tsx
@@ -149,10 +149,11 @@ function getDummyCartProducts( {
 				productSlug: activePlanScheme.product_slug,
 				productOriginalName: activePlanScheme.product_name,
 				itemSubTotal: activePlanScheme.cost_smallest_unit,
-				productDisplayCost: formatCurrency( activePlanScheme.cost_smallest_unit, currencyCode, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ),
+				productDisplayCost:
+					formatCurrency( activePlanScheme.cost_smallest_unit, currencyCode, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ) + '*',
 				subLabel: translate( 'Plan Subscription: %(planPrice)s per year', {
 					args: {
 						planPrice: formatCurrency( activePlanScheme.cost_smallest_unit, currencyCode, {

--- a/client/signup/steps/page-picker/use-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/use-cart-for-difm.tsx
@@ -5,23 +5,14 @@ import {
 	PLAN_BUSINESS,
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
-import { MinimalRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
-import debugFactory from 'debug';
 import { LocalizeProps, useTranslate, TranslateResult } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import getCartKey from 'calypso/my-sites/checkout/get-cart-key';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { buildDIFMCartExtrasObject } from 'calypso/state/difm/assemblers';
 import { requestProductsList } from 'calypso/state/products-list/actions';
 import { getProductBySlug, isProductsListFetching } from 'calypso/state/products-list/selectors';
-import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
-import { getSite } from 'calypso/state/sites/selectors';
-import { debounce } from 'calypso/utils';
-import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
-const debug = debugFactory( 'calypso:difm:page-picker' );
 export type CartItem = {
 	nameOverride?: TranslateResult;
 	productSlug: string;
@@ -152,148 +143,23 @@ function getDummyCartProducts( {
 	return displayedCartItems;
 }
 
-function getSiteCartProducts( {
-	responseCart,
-	translate,
-	difmLiteProduct,
-}: {
-	responseCart: ResponseCart;
-	translate: LocalizeProps[ 'translate' ];
-	difmLiteProduct: ProductListItem;
-} ): Array< CartItem > {
-	const cartItems: Array< CartItem | null > = responseCart.products.map( ( product ) => {
-		switch ( product.product_slug ) {
-			case PLAN_PREMIUM:
-			case PLAN_BUSINESS:
-				return {
-					productSlug: product.product_slug,
-					productOriginalName: product.product_name,
-					itemSubTotal: product.item_subtotal_integer,
-					productDisplayCost: formatCurrency(
-						product.item_subtotal_integer,
-						responseCart.currency,
-						{
-							isSmallestUnit: true,
-							stripZeros: true,
-						}
-					),
-					subLabel: translate( 'Plan Subscription: %(planPrice)s per year', {
-						args: {
-							planPrice: formatCurrency( product.item_subtotal_integer, responseCart.currency, {
-								isSmallestUnit: true,
-								stripZeros: true,
-							} ),
-						},
-					} ),
-				};
-			case WPCOM_DIFM_LITE: {
-				return {
-					productSlug: product.product_slug,
-					nameOverride: translate( 'Website Design Service' ),
-					productOriginalName: product.product_name,
-					itemSubTotal: product.item_subtotal_integer,
-					productDisplayCost: formatCurrency(
-						product.item_subtotal_integer,
-						responseCart.currency,
-						{
-							isSmallestUnit: true,
-							stripZeros: true,
-						}
-					),
-					...getDIFMPriceBreakdownSubLabel( {
-						product: difmLiteProduct,
-						noOfPages: product.quantity,
-						currencyCode: responseCart.currency,
-						translate,
-					} ),
-				};
-			}
-			default:
-				debug(
-					'We show only products relevent to the DIFM flow and the following product was hidden',
-					product
-				);
-				return null;
-		}
-	} );
-
-	// Enforce order of display, so that the DIFM product is visible first
-	const difmRelatedCartItems = cartItems.filter( ( e ) => e !== null );
-	const difmProduct = difmRelatedCartItems.find( ( e ) => e?.productSlug === WPCOM_DIFM_LITE );
-	const planProduct = difmRelatedCartItems.find( ( e ) =>
-		[ PLAN_PREMIUM, PLAN_BUSINESS ].includes( e?.productSlug || '' )
-	);
-
-	//Enforce order
-	const finalCartItems: CartItem[] = [];
-	if ( difmProduct ) {
-		finalCartItems.push( difmProduct );
-	}
-	if ( planProduct ) {
-		finalCartItems.push( planProduct );
-	}
-
-	return finalCartItems;
-}
-
 export function useCartForDIFM(
 	selectedPages: string[],
-	isStoreFlow: boolean,
-	isExistingSite: boolean
+	isStoreFlow: boolean
 ): {
 	items: CartItem[];
 	total: string | null;
-	isCartLoading: boolean;
-	isCartPendingUpdate: boolean;
-	isCartUpdateStarted: boolean;
 	isProductsLoading: boolean;
 	effectiveCurrencyCode: string | null;
-	isFormattedCurrencyLoading: boolean;
 } {
-	//This state is used by loader states to provide immediate feedback when a deebounced change happens to a cart
-	const [ isCartUpdateStarted, setIsCartUpdateStarted ] = useState( false );
-
-	const signupDependencies = useSelector( getSignupDependencyStore );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const activePlanScheme = useSelector( ( state ) =>
 		getProductBySlug( state, isStoreFlow ? PLAN_BUSINESS : PLAN_PREMIUM )
 	);
-	const { siteId, siteSlug } = signupDependencies;
 	const isProductsLoading = useSelector( isProductsListFetching );
 	const difmLiteProduct = useSelector( ( state ) => getProductBySlug( state, WPCOM_DIFM_LITE ) );
 	const userCurrencyCode = useSelector( getCurrentUserCurrencyCode );
-	const site = useSelector( ( state ) => getSite( state, siteSlug ?? siteId ) );
-	const cartKey = site ? getCartKey( { selectedSite: site } ) : undefined;
-	const { replaceProductsInCart, responseCart, isLoading, isPendingUpdate } =
-		useShoppingCart( cartKey );
-
-	const getEffectiveCurrencyCode = useCallback( () => {
-		if ( isExistingSite ) {
-			return responseCart.currency ?? userCurrencyCode;
-		}
-		return userCurrencyCode;
-	}, [ isExistingSite, responseCart.currency, userCurrencyCode ] );
-
-	// [Callback] Encapsulates difm lite cart product creation
-	const getDifmLiteCartProduct = useCallback( () => {
-		if ( difmLiteProduct ) {
-			return {
-				...difmLiteProduct,
-				extra: buildDIFMCartExtrasObject(
-					{
-						...signupDependencies,
-						selectedPageTitles: selectedPages,
-						isStoreFlow,
-					},
-					siteSlug,
-					'use-cart-for-difm'
-				),
-				quantity: selectedPages.length,
-			};
-		}
-		return null;
-	}, [ difmLiteProduct, signupDependencies, selectedPages, isStoreFlow, siteSlug ] );
 
 	// [Effect] Loads required initial data
 	useEffect( () => {
@@ -302,52 +168,17 @@ export function useCartForDIFM(
 		}
 	}, [ dispatch, difmLiteProduct, userCurrencyCode ] );
 
-	// [Effect] Updates flag to show loading feedback to the user on page selection change
-	useEffect( () => {
-		if ( isExistingSite ) {
-			setIsCartUpdateStarted( true );
-		}
-	}, [ isExistingSite, setIsCartUpdateStarted, selectedPages ] );
-
-	const debouncedReplaceProductsInCart = useMemo(
-		() =>
-			debounce( async ( products: MinimalRequestCartProduct[] ) => {
-				await replaceProductsInCart( products );
-				// Switch off loading feedback once basket is properly updated
-				setIsCartUpdateStarted( false );
-			}, 800 ),
-		[ replaceProductsInCart ]
-	);
-
-	// [Effect] that controls cart manipulations
-	useEffect( () => {
-		if ( isExistingSite ) {
-			const difmLiteProduct = getDifmLiteCartProduct();
-			if ( difmLiteProduct && difmLiteProduct.product_slug ) {
-				debouncedReplaceProductsInCart( [ difmLiteProduct ] );
-			}
-		}
-	}, [ isExistingSite, getDifmLiteCartProduct, debouncedReplaceProductsInCart ] );
-
-	const effectiveCurrencyCode = getEffectiveCurrencyCode();
+	const effectiveCurrencyCode = userCurrencyCode;
 	let displayedCartItems: CartItem[] = [];
 	let totalCostFormatted = null;
 	if ( difmLiteProduct && activePlanScheme && effectiveCurrencyCode ) {
-		if ( isExistingSite ) {
-			displayedCartItems = getSiteCartProducts( {
-				responseCart,
-				translate,
-				difmLiteProduct,
-			} );
-		} else {
-			displayedCartItems = getDummyCartProducts( {
-				selectedPages,
-				currencyCode: effectiveCurrencyCode,
-				translate,
-				activePlanScheme: activePlanScheme,
-				difmLiteProduct,
-			} );
-		}
+		displayedCartItems = getDummyCartProducts( {
+			selectedPages,
+			currencyCode: effectiveCurrencyCode,
+			translate,
+			activePlanScheme: activePlanScheme,
+			difmLiteProduct,
+		} );
 
 		const totalCost = displayedCartItems.reduce(
 			( total, currentProduct ) => currentProduct.itemSubTotal + total,
@@ -358,21 +189,11 @@ export function useCartForDIFM(
 			isSmallestUnit: true,
 		} );
 	}
-	const isInitialBasketLoaded = displayedCartItems.length > 0;
 	return {
 		items: displayedCartItems,
 		total: totalCostFormatted,
-		isCartLoading: isLoading,
-		isCartPendingUpdate: isPendingUpdate,
 		isProductsLoading,
-		isCartUpdateStarted,
 		effectiveCurrencyCode,
-		// Proper formatted currency is visible only when the following conditions are met
-		isFormattedCurrencyLoading:
-			( isExistingSite && isLoading ) ||
-			! isInitialBasketLoaded ||
-			! effectiveCurrencyCode ||
-			isProductsLoading,
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR removes cart actions from the page picker step. Now, for both new and existing sites, the cart shown on the front end will have statically calculated values. This removes the need for a network request and eliminates the chances of a cart error on this step. If there are any errors in the cart, those will now show up on the checkout page, where they are handled better.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**DIFM flow, new site**
* Go to `/start/do-it-for-me`.
* Choose "new site" and go through the flow steps till you reach the page picker step.
* Confirm that the values in the cart are shown correctly.

**DIFM flow, existing site, free plan**
* Go to `/start/do-it-for-me`.
* Choose "existing site" and select a site on the free plan. Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is present** and the values in the cart are shown correctly.

**DIFM flow, existing site, Starter(Personal) plan**
* Go to `/start/do-it-for-me`.
* Choose "existing site" and select a site on the Starter plan. Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is present** and the values in the cart are shown correctly.

**DIFM flow, existing site, Explorer or higher plans**
* Go to `/start/do-it-for-me`.
* Choose "existing site" and select a site on an Explorer or higher plan. Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is not present** and the values in the cart are shown correctly.

**DIFM store flow, existing site, free plan**
* Go to `/start/do-it-for-me-store`.
* Choose "existing site" and select a site on a free plan. Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is present** and the values in the cart are shown correctly.

**DIFM store flow, existing site, Starter/Explorer plan**
* Go to `/start/do-it-for-me-store`.
* Choose "existing site" and select a site on a Starter/Explorer plan. Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is present** and the values in the cart are shown correctly.

**DIFM store flow, existing site, Creator or higher plans**
* Go to `/start/do-it-for-me-store`.
* Choose "existing site" and select a site on a Creator or higher plan. Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is not present** and the values in the cart are shown correctly.

**Post-onboarding flow, free plan**
* Go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>` for a site on the free plan.
* Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is present** and the values in the cart are shown correctly.

**Post-onboarding flow, Starter plan**
* Go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>` for a site on the Starter plan.
* Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is present** and the values in the cart are shown correctly.

**Post-onboarding flow, Starter plan**
* Go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>` for a site on an Explorer or higher plan. Follow the flow steps until you reach the page picker step.
* Confirm that the plan **is not present** and the values in the cart are shown correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?