### PR TITLE
Fix scroll in CategoryPillNavigation after click

### DIFF
--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -55,8 +55,20 @@ export const CategoryPillNavigation = ( {
 	};
 
 	useEffect( () => {
+		if ( ! listRef.current ) {
+			return;
+		}
+
 		checkScrollArrows();
-	}, [] );
+
+		const target = listRef.current.querySelector( '.is-active' );
+
+		target?.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'nearest',
+			inline: 'center',
+		} );
+	}, [ selectedCategory ] );
 
 	return (
 		<div className="category-pill-navigation">

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -4,14 +4,14 @@ import './style.scss';
 
 type PatternsHeaderProps = {
 	description: string;
-	initialSearchTerm?: string;
+	searchTerm?: string;
 	onSearch?( searchTerm: string ): void;
 	title: string;
 };
 
 export const PatternsHeader = ( {
 	description,
-	initialSearchTerm = '',
+	searchTerm = '',
 	onSearch = () => {},
 	title,
 }: PatternsHeaderProps ) => {
@@ -23,7 +23,7 @@ export const PatternsHeader = ( {
 				<Search
 					additionalClasses="patterns-header__search-input"
 					delaySearch
-					initialValue={ initialSearchTerm }
+					value={ searchTerm }
 					onSearch={ onSearch }
 					placeholder="Search patterns..."
 				/>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -12,7 +12,7 @@ import {
 	menu as iconMenu,
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -92,11 +92,6 @@ export const PatternLibrary = ( {
 	const locale = useLocale();
 	const translate_not_yet = useTranslate();
 
-	// Helps prevent resetting the search input if a search term was provided through the URL
-	const isInitialRender = useRef( true );
-	// Helps reset the search input when navigating between categories
-	const [ searchFormKey, setSearchFormKey ] = useState( category );
-
 	const [ searchTerm, setSearchTerm ] = usePatternSearchTerm( urlQuerySearchTerm );
 	const { data: categories = [] } = usePatternCategories( locale );
 	const { data: patterns = [] } = usePatterns( locale, category, {
@@ -108,25 +103,6 @@ export const PatternLibrary = ( {
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
-
-	// Resets the search term when navigating from `/patterns?s=lorem` to `/patterns`
-	useEffect( () => {
-		if ( ! urlQuerySearchTerm ) {
-			setSearchTerm( '' );
-			setSearchFormKey( Math.random().toString() );
-		}
-	}, [ urlQuerySearchTerm ] );
-
-	// Resets the search term whenever the category changes
-	useEffect( () => {
-		if ( isInitialRender.current ) {
-			isInitialRender.current = false;
-			return;
-		}
-
-		setSearchTerm( '' );
-		setSearchFormKey( category );
-	}, [ category ] );
 
 	const handleViewChange = ( view: 'grid' | 'list' ) => {
 		const currentView = isGridView ? 'grid' : 'list';
@@ -153,6 +129,10 @@ export const PatternLibrary = ( {
 		// Removing the origin ensures that a full refresh is not attempted
 		page( url.href.replace( url.origin, '' ) );
 	};
+
+	useEffect( () => {
+		setSearchTerm( urlQuerySearchTerm );
+	}, [ urlQuerySearchTerm, setSearchTerm ] );
 
 	const categoryObject = categories?.find( ( { name } ) => name === category );
 
@@ -188,8 +168,7 @@ export const PatternLibrary = ( {
 				description={ translate_not_yet(
 					'Dive into hundreds of expertly designed, fully responsive layouts, and bring any kind of site to life, faster.'
 				) }
-				initialSearchTerm={ searchTerm }
-				key={ `${ searchFormKey }-search` }
+				searchTerm={ searchTerm }
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -24,7 +24,7 @@ export function usePatternSearchTerm(
 		}
 
 		if ( url.href !== location.href ) {
-			page.redirect( url.href );
+			page( url.href.replace( url.origin, '' ) );
 		}
 	}, [ searchTerm ] );
 

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -27,7 +27,6 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 					category={ context.params.category }
 					categoryGallery={ CategoryGalleryClient }
 					isGridView={ !! context.query.grid }
-					key={ context.params.category }
 					patternGallery={ PatternGalleryClient }
 					patternTypeFilter={
 						context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
