### PR TITLE
Plugins Update Manager: Sidebar menu, mark "Scheduled Updates" item selected

### DIFF
--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -8,7 +8,7 @@ const fragmentIsEqual = ( path, currentPath, position ) =>
 	currentPath.split( /[/,?]/ )?.[ position ] === path.split( /[/,?]/ )?.[ position ];
 
 const isManageAllSitesPluginsPath = ( path ) =>
-	path.match( /^\/plugins\/(?:manage|active|inactive|updates)/ ) !== null;
+	path.match( /^\/plugins\/(?:manage|active|inactive|updates|scheduled-updates)/ ) !== null;
 
 /**
  * Checks if `currentPath` starts with the first fragment of `path`


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Sidebar menu: mark "Plugins -> Scheduled Updates" menu item selected in case when the route is "/plugins/scheduled-updates"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/home/{SITE}`
* From the left sidebar menu, select **Plugins -> Scheduled Updates**
* Check if the menu item becomes selected/highlighted

<img width="339" alt="Screenshot 2024-03-21 at 16 47 12" src="https://github.com/Automattic/wp-calypso/assets/1241413/fb8cb956-95a3-4309-acd5-12dd385e45f2">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?