### PR TITLE
Sites Dashboard: Fix the scan component in the preview pane

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -46,6 +46,54 @@ export default function SitePreviewPane( {
 		}, 150 );
 	}, [] );
 
+	const currentURL = window.location.href;
+
+	useEffect( () => {
+		const handleClick = ( event: MouseEvent ) => {
+			const target = event.target as HTMLElement;
+			if ( ! target ) {
+				return;
+			}
+
+			if ( currentURL.includes( 'jetpack-scan' ) ) {
+				const newScanURL = currentURL.split( 'jetpack-scan' )[ 0 ] + 'jetpack-scan';
+
+				const scanLinks = [
+					...document.querySelectorAll(
+						'a.section-nav-tab__link[href*="/scan/"]:not([href*="/scan/history"])'
+					),
+					...document.querySelectorAll( 'a.section-nav-tab__link[href*="/scan/history"]' ),
+					...document.querySelectorAll( 'a.section-nav-tab__link[href*="/scan/history/fixed"]' ),
+					...document.querySelectorAll( 'a.section-nav-tab__link[href*="/scan/history/ignored"]' ),
+				];
+
+				scanLinks.forEach( ( link ) => {
+					let newerScanURL = newScanURL;
+					if ( ( link as HTMLAnchorElement ).href.includes( '/scan/history' ) ) {
+						newerScanURL += '/history';
+					} else if ( ( link as HTMLAnchorElement ).href.includes( '/scan/history/fixed' ) ) {
+						newerScanURL += '/history/fixed';
+					} else if ( ( link as HTMLAnchorElement ).href.includes( '/scan/history/ignored' ) ) {
+						newerScanURL += '/history/ignored';
+					}
+
+					( link as HTMLAnchorElement ).setAttribute( 'href', newerScanURL );
+				} );
+			}
+		};
+
+		document.addEventListener( 'click', handleClick );
+
+		return () => {
+			document.removeEventListener( 'click', handleClick );
+		};
+	}, [ currentURL ] );
+
+	// Ensure we have features
+	if ( ! features || ! features.length ) {
+		return null;
+	}
+
 	// Ensure we have features
 	if ( ! features || ! features.length ) {
 		return null;


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/103

## Still in progress

## Proposed Changes


Note - the suggested code in this PR is unlikely to be what we use as manipulating context would be better, so this is more like a plan B. 

* This PR currently makes sure links within any tabs in the Preview Pane scan component are changed to be links that are usable within the A4A context, keeping the user within the Preview Pane scan component
  * This change was made within `SitePreviewPane` instead of the actual Scan components (used by My Sites, Jetpack Cloud) so as not to clutter those components. 
* It doesn't yet consider routes / how navigation between tabs in the My Sites / Jetpack Cloud scan page opens different components.

Still to do:
* If we continue this route with the URL changes, then move the functionality into a separate component perhaps to clean up the SitePreviewPane component.
  * The link changes for /ignored and /fixed need to be removed as those tabs are not traditional links. They can be set by  adding a filter param to context within 'JetpackScanPreview'
* Show the upsell view if the site doesn't have scan
* Make sure the history tab correctly shows the history component, and that other tabs correctly show their components

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* This is tricky to properly test without the path PR - https://github.com/Automattic/wp-calypso/pull/88644 - being merged, but you can test parts of it by visiting links such as as `http://agencies.localhost:3000/sites/overview/my-website.com/jetpack_scan` once you've opened up the Preview Pane and clicked on the Scan tab.
* What you'd be testing for when doing this, is that hovering over the 'Scanner' tab you see the URL showing at the bottom of the browser that reflects what the new path would be (in this case the same as what you were on). Hovering over 'History' you should see '/history' appended to the URL. 
* If you add '/history' to the end of your URL and refresh the page, the link in the 'Scanner' tab should be the same minus history. 
* So we're not testing all the links here as the history tab isn't yet configured to show the history component.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?