### PR TITLE
Remove the Theme Showcase Survey

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -26,7 +26,7 @@ import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcase-theme-collection';
 import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme-collection-view-header';
-import ThemeShowcaseSurvey, { SurveyType } from 'calypso/my-sites/themes/survey';
+import ThemeShowcaseSurvey from 'calypso/my-sites/themes/survey';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getLastNonEditorRoute from 'calypso/state/selectors/get-last-non-editor-route';
@@ -668,10 +668,7 @@ class ThemeShowcase extends Component {
 				/>
 				{ this.renderSiteAssemblerSelectorModal() }
 				{ isLoggedIn && (
-					<ThemeShowcaseSurvey
-						survey={ SurveyType.MARCH_2024 }
-						condition={ () => lastNonEditorRoute.includes( 'theme/' ) }
-					/>
+					<ThemeShowcaseSurvey condition={ () => lastNonEditorRoute.includes( 'theme/' ) } />
 				) }
 				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6185

## Proposed Changes

As noted in pdKhl6-3lg-p2#comment-5831 the theme showcase survey isn't being effective at attracting the user types we're currently most interested in interviewing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use the calypso live link
 2. Go to /themes/:siteSlug
 3. Pick a theme
 4. Go back to the the theme grid
 5. You should not see an invitation to complete a survey

Before | After
-------|------
<img width="1444" alt="Screenshot 2024-03-21 at 18 25 52" src="https://github.com/Automattic/wp-calypso/assets/93301/bba7f6ef-4f9c-42f1-891a-c194be465f22"> | <img width="1444" alt="Screenshot 2024-03-21 at 18 26 04" src="https://github.com/Automattic/wp-calypso/assets/93301/ebd533a8-697a-446d-b3c4-ed52fcb36d83">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?