### PR TITLE
Remove Subscribers from Global Site Nav menu

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -92,12 +92,6 @@ export default function globalSiteSidebarMenu( {
 			url: `/earn/${ siteDomain }`,
 		},
 		{
-			slug: 'subscribers',
-			title: translate( 'Subscribers' ),
-			type: 'menu-item',
-			url: `/subscribers/${ siteDomain }`,
-		},
-		{
 			slug: 'connections',
 			title: translate( 'Connections' ),
 			type: 'menu-item',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6176

> [!NOTE]  
> Do not merge until Subscribers has launched to production in Jetpack Green peKye1-Lz-p2

## Proposed Changes

* Removes "Subscribers" from the "Global site nav" menu.
* This menu item is being removed because we've added it underneath the Jetpack menu here: https://github.com/Automattic/jetpack/pull/36510

<img width="1346" alt="Screenshot 2024-03-21 at 5 30 19 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/824f71c4-1af9-4b8e-a52b-814380072b02">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* On a site with Classic and early release enabled, view the "Global site nav" and see that the "Subscribers" link is gone.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?