### PR TITLE
GitHub Deployments: Make it beautiful on smaller screens

### DIFF
--- a/client/my-sites/github-deployments/deployments/deployment-commit-details.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-commit-details.tsx
@@ -82,7 +82,10 @@ export const DeploymentCommitDetails = ( { deployment, run }: DeploymentCommitDe
 									fill="#50575E"
 								/>
 							</svg>
-							<span css={ { paddingLeft: '2px' } } title={ deployment.target_dir }>
+							<span
+								css={ { paddingLeft: '2px', whiteSpace: 'nowrap' } }
+								title={ deployment.target_dir }
+							>
 								{ path }
 							</span>
 						</span>

--- a/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
@@ -44,7 +44,7 @@ export const DeploymentStarterMessage = ( { deployment }: DeploymentStarterMessa
 
 	return (
 		<td colSpan={ 4 }>
-			<i css={ { color: 'var(--Gray-Gray-40, #50575E)' } }>
+			<i className="github-deployments-list__starter-message">
 				{ deployment.is_automated
 					? sprintf(
 							// Translators: %(branch)s is the branch name of the repository, %(repo)s is the repository name

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -49,10 +49,6 @@
 			white-space: nowrap;
 		}
 
-		.github-deployments-list__repository-details {
-			white-space: normal;
-		}
-
 		&:last-child {
 			padding-left: 32px;
 			padding-right: 0;
@@ -123,6 +119,11 @@
 			text-decoration: underline;
 			color: var(--studio-gray-60);
 		}
+	}
+
+	&__starter-message {
+		color: var(--gray-gray-40, #50575e);
+		white-space: normal !important;
 	}
 
 	&__menu-item-danger {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
