### PR TITLE
Backup: fix retention setting confirmation modal

### DIFF
--- a/client/state/rewind/reducer.js
+++ b/client/state/rewind/reducer.js
@@ -5,6 +5,7 @@ import browser from './browser/reducer';
 import capabilities from './capabilities/reducer';
 import policies from './policies/reducer';
 import preflight from './preflight/reducer';
+import retention from './retention/reducer';
 import size from './size/reducer';
 import staging from './staging/reducer';
 import state from './state/reducer';
@@ -20,6 +21,7 @@ const rewind = combineReducers( {
 	storage,
 	staging,
 	preflight,
+	retention,
 } );
 
 const reducer = keyedReducer( 'siteId', rewind );

--- a/client/state/rewind/retention/reducer.ts
+++ b/client/state/rewind/retention/reducer.ts
@@ -8,22 +8,32 @@ import { BACKUP_RETENTION_UPDATE_REQUEST } from './constants';
 import type { AppState } from 'calypso/types';
 import type { AnyAction } from 'redux';
 
-export const updateBackupRetentionRequestStatus = (
-	state: AppState = BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED,
-	{ type }: AnyAction
-) => {
+const initialState: AppState = {
+	requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED,
+};
+
+export const updateBackupRetentionRequestStatus = ( state = initialState, { type }: AnyAction ) => {
 	switch ( type ) {
 		case JETPACK_BACKUP_RETENTION_UPDATE:
-			return BACKUP_RETENTION_UPDATE_REQUEST.PENDING;
+			return {
+				...state,
+				requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.PENDING,
+			};
 
 		case JETPACK_BACKUP_RETENTION_UPDATE_SUCCESS:
-			return BACKUP_RETENTION_UPDATE_REQUEST.SUCCESS;
+			return {
+				...state,
+				requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.SUCCESS,
+			};
 
 		case JETPACK_BACKUP_RETENTION_UPDATE_ERROR:
-			return BACKUP_RETENTION_UPDATE_REQUEST.FAILED;
+			return {
+				...state,
+				requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.FAILED,
+			};
 
 		case JETPACK_BACKUP_RETENTION_UPDATE_RESET:
-			return BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED;
+			return initialState;
 	}
 	return state;
 };

--- a/client/state/rewind/retention/test/reducer.js
+++ b/client/state/rewind/retention/test/reducer.js
@@ -49,7 +49,7 @@ describe( 'updateBackupRetentionRequestStatus', () => {
 		).toEqual( { requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.PENDING } );
 	} );
 
-	test( '1should return SUCCESS status when retention update request action gets completed successfully', () => {
+	test( 'should return SUCCESS status when retention update request action gets completed successfully', () => {
 		expect(
 			updateBackupRetentionRequestStatus( mockUpdateRequestInitiated, updateSuccessAction )
 		).toEqual( { requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.SUCCESS } );

--- a/client/state/rewind/retention/test/reducer.js
+++ b/client/state/rewind/retention/test/reducer.js
@@ -10,7 +10,7 @@ import { updateBackupRetentionRequestStatus } from '../reducer';
 
 describe( 'updateBackupRetentionRequestStatus', () => {
 	const mockUpdateRequestInitiated = {
-		updateBackupRetentionRequestStatus: BACKUP_RETENTION_UPDATE_REQUEST.PENDING,
+		requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.PENDING,
 	};
 
 	const updateSuccessAction = { type: JETPACK_BACKUP_RETENTION_UPDATE_SUCCESS };
@@ -18,9 +18,9 @@ describe( 'updateBackupRetentionRequestStatus', () => {
 
 	test( 'should default to UNSUBMITTED when receiving other non-retention update related actions', () => {
 		// lets ensure that state is not modified when passed an unrelated action.
-		expect( updateBackupRetentionRequestStatus( undefined, requestSize ) ).toEqual(
-			BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED
-		);
+		expect( updateBackupRetentionRequestStatus( undefined, requestSize ) ).toEqual( {
+			requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED,
+		} );
 	} );
 
 	test( 'should return UNSUBMITTED when retention update request status is RESET', () => {
@@ -28,7 +28,7 @@ describe( 'updateBackupRetentionRequestStatus', () => {
 			updateBackupRetentionRequestStatus( undefined, {
 				type: JETPACK_BACKUP_RETENTION_UPDATE_RESET,
 			} )
-		).toEqual( BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED );
+		).toEqual( { requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED } );
 	} );
 
 	test( 'should return UNSUBMITTED when current retention update request status is RESET, and previous state was SUCCESS', () => {
@@ -39,25 +39,25 @@ describe( 'updateBackupRetentionRequestStatus', () => {
 					type: JETPACK_BACKUP_RETENTION_UPDATE_RESET,
 				}
 			)
-		).toEqual( BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED );
+		).toEqual( { requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED } );
 	} );
 
 	test( 'should return PENDING status when retention update request action is initiated', () => {
 		// lets update backup retention for siteId:123 to 7 days.
 		expect(
 			updateBackupRetentionRequestStatus( undefined, updateBackupRetention( 123, 7 ) )
-		).toEqual( BACKUP_RETENTION_UPDATE_REQUEST.PENDING );
+		).toEqual( { requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.PENDING } );
 	} );
 
-	test( 'should return SUCCESS status when retention update request action gets completed successfully', () => {
+	test( '1should return SUCCESS status when retention update request action gets completed successfully', () => {
 		expect(
 			updateBackupRetentionRequestStatus( mockUpdateRequestInitiated, updateSuccessAction )
-		).toEqual( BACKUP_RETENTION_UPDATE_REQUEST.SUCCESS );
+		).toEqual( { requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.SUCCESS } );
 	} );
 
 	test( 'should return FAILED status when retention update request action gets failed', () => {
 		expect(
 			updateBackupRetentionRequestStatus( mockUpdateRequestInitiated, updateFailedAction )
-		).toEqual( BACKUP_RETENTION_UPDATE_REQUEST.FAILED );
+		).toEqual( { requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.FAILED } );
 	} );
 } );

--- a/client/state/rewind/selectors/get-backup-retention-update-status.ts
+++ b/client/state/rewind/selectors/get-backup-retention-update-status.ts
@@ -1,4 +1,3 @@
-import { BACKUP_RETENTION_UPDATE_REQUEST } from '../retention/constants';
 import type { AppState } from 'calypso/types';
 import 'calypso/state/rewind/init';
 
@@ -9,7 +8,6 @@ import 'calypso/state/rewind/init';
  * @returns The the status of the request.
  */
 const getBackupRetentionUpdateRequestStatus = ( state: AppState, siteId: number ): string =>
-	state.rewind[ siteId ]?.updateBackupRetentionRequestStatus ??
-	BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED;
+	state.rewind[ siteId ].retention.requestStatus;
 
 export default getBackupRetentionUpdateRequestStatus;

--- a/client/state/rewind/test/selectors.js
+++ b/client/state/rewind/test/selectors.js
@@ -122,19 +122,14 @@ describe( 'getBackupRetentionDays()', () => {
 describe( 'getBackupRetentionUpdateRequestStatus()', () => {
 	const TEST_SITE_ID = 123;
 
-	test( 'should default to UNSUBMITTED when the site under test does not exist in the state at all.', () => {
-		const state = {
-			rewind: {},
-		};
-		expect( getBackupRetentionUpdateRequestStatus( state, TEST_SITE_ID ) ).toEqual(
-			BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED
-		);
-	} );
-
 	test( 'should default to UNSUBMITTED when no backup retention update request is being made yet.', () => {
 		const state = {
 			rewind: {
-				[ TEST_SITE_ID ]: {},
+				[ TEST_SITE_ID ]: {
+					retention: {
+						requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.UNSUBMITTED,
+					},
+				},
 			},
 		};
 		expect( getBackupRetentionUpdateRequestStatus( state, TEST_SITE_ID ) ).toEqual(
@@ -146,7 +141,9 @@ describe( 'getBackupRetentionUpdateRequestStatus()', () => {
 		const state = {
 			rewind: {
 				[ TEST_SITE_ID ]: {
-					updateBackupRetentionRequestStatus: BACKUP_RETENTION_UPDATE_REQUEST.PENDING,
+					retention: {
+						requestStatus: BACKUP_RETENTION_UPDATE_REQUEST.PENDING,
+					},
 				},
 			},
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/88201

Currently, we are not hiding the confirmation dialog when the retention update is completed, because we were always assuming the request status (returned by `getBackupRetentionUpdateRequestStatus` selector) is `unsubmitted`. This PR address to properly return the right value, so now if the retention is successful, we will close the confirmation dialog.

## Proposed Changes

* Register the `updateBackupRetentionRequestStatus` reducer as `state.rewind[].retention.requestStatus`
* Fix the `getBackupRetentionUpdateRequestStatus` selector to return the proper request status
* Update unit tests on reducer and selector to reflect this change
  * Removed a test case that is no longer necessary on `getBackupRetentionUpdateRequestStatus`selector tests

## Testing Instructions

* Spin up a Calypso or Jetpack Cloud Live Branch
* Pick a site with Jetpack VaultPress Backup with a plan that has storage limit. Ensure your site is not marked as angency.
* Navigate to `Settings`
* Try switching your retention period to a lower value, like from 30 days to 7 days.
* Ensure you see the confirmation dialog
* Click on `Confirm change`
* Ensure the dialog closes and it shows a success notice indicating the change is successful

### Unit tests
Ensure unit tests are passing:
* `yarn run test-client client/state/rewind`

## Demo

https://github.com/Automattic/wp-calypso/assets/1488641/967ecdb7-8b6c-4dba-b4f4-96db7f51f6e4



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?