### PR TITLE
Automattic for Agencies: API implementation for license actions

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts
@@ -3,11 +3,15 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
+export const getFetchLicenseCountsQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-license-counts', agencyId ];
+};
+
 export default function useFetchLicenseCounts() {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: [ 'a4a-license-counts', agencyId ],
+		queryKey: getFetchLicenseCountsQueryKey( agencyId ),
 		queryFn: () =>
 			wpcom.req.get(
 				{

--- a/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
@@ -10,6 +10,17 @@ import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import formatLicenses from './lib/format-licenses';
 
+export const getFetchLicensesQueryKey = (
+	filter: LicenseFilter,
+	search: string,
+	sortField: LicenseSortField,
+	sortDirection: LicenseSortDirection,
+	page: number,
+	agencyId?: number
+) => {
+	return [ 'a4a-licenses', filter, search, sortField, sortDirection, page, agencyId ];
+};
+
 export default function useFetchLicenses(
 	filter: LicenseFilter,
 	search: string,
@@ -20,7 +31,7 @@ export default function useFetchLicenses(
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: [ 'a4a-licenses', filter, search, sortField, sortDirection, page, agencyId ],
+		queryKey: getFetchLicensesQueryKey( filter, search, sortField, sortDirection, page, agencyId ),
 		queryFn: () =>
 			wpcom.req.get(
 				{

--- a/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-refetch-licenses.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-refetch-licenses.ts
@@ -1,0 +1,34 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { Context, useContext } from 'react';
+import { getFetchLicenseCountsQueryKey } from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
+import { getFetchLicensesQueryKey } from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { LicenseListContext } from 'calypso/state/partner-portal/types';
+
+export default function useRefetchLicenses( context: Context< LicenseListContext > ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const queryClient = useQueryClient();
+
+	const { filter, search, sortField, sortDirection, currentPage } = useContext( context );
+
+	const refetchLicenses = () => {
+		// Invalidate the queries for the license counts and the licenses to refetch the data
+		queryClient.invalidateQueries( {
+			queryKey: getFetchLicenseCountsQueryKey( agencyId ),
+		} );
+		queryClient.invalidateQueries( {
+			queryKey: getFetchLicensesQueryKey(
+				filter,
+				search,
+				sortField,
+				sortDirection,
+				currentPage,
+				agencyId
+			),
+		} );
+	};
+
+	return refetchLicenses;
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import {
 	LicenseRole,
 	LicenseState,
@@ -37,7 +37,7 @@ export default function LicenseDetailsActions( {
 
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 
-	const debugUrl = ''; // FIXME: Fix the debugUrl
+	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
 
 	const openRevokeDialog = useCallback( () => {
@@ -50,17 +50,20 @@ export default function LicenseDetailsActions( {
 		dispatch( recordTracksEvent( 'calypso_a4a_license_details_revoke_dialog_close' ) );
 	}, [ dispatch ] );
 
+	const { mutate, status, error, data } = downloadUrl;
+
+	useEffect( () => {
+		if ( status === 'success' ) {
+			window.location.replace( data.download_url );
+		} else if ( status === 'error' ) {
+			dispatch( errorNotice( error.message ) );
+		}
+	}, [ status, error, dispatch, data ] );
+
 	const download = useCallback( () => {
-		downloadUrl.mutate( null, {
-			onSuccess: ( data ) => {
-				window.location.replace( data.download_url );
-			},
-			onError: ( error: Error ) => {
-				dispatch( errorNotice( error.message ) );
-			},
-		} );
+		mutate( null );
 		dispatch( recordTracksEvent( 'calypso_a4a_license_details_download' ) );
-	}, [ dispatch, downloadUrl ] );
+	}, [ dispatch, mutate ] );
 
 	return (
 		<div className="license-details__actions">

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/hooks/use-license-download-url-mutation.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/hooks/use-license-download-url-mutation.ts
@@ -1,11 +1,11 @@
 import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 interface APILicenseDownload {
 	download_url: string;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const noop = ( _key: string ) => Promise.resolve( { download_url: 'test' } as APILicenseDownload );
 
 /**
  * This is technically not a mutation but is used imperatively and is therefore more useful as a mutation than a query.
@@ -13,7 +13,18 @@ const noop = ( _key: string ) => Promise.resolve( { download_url: 'test' } as AP
 export default function useLicenseDownloadUrlMutation< TVariables = null, TContext = unknown >(
 	licenseKey: string
 ): UseMutationResult< APILicenseDownload, Error, TVariables, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
 	return useMutation< APILicenseDownload, Error, TVariables, TContext >( {
-		mutationFn: () => noop( licenseKey ), // Implement actual API call
+		mutationFn: () =>
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: `/jetpack-licensing/license/${ licenseKey }/download`,
+				},
+				{
+					agency_id: agencyId,
+				}
+			) as Promise< APILicenseDownload >,
 	} );
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/hooks/use-revoke-license-mutation.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/hooks/use-revoke-license-mutation.ts
@@ -1,24 +1,36 @@
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
-import { APILicense } from 'calypso/state/partner-portal/types';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { APILicense } from 'calypso/state/partner-portal/types';
 
 interface MutationRevokeLicenseVariables {
 	licenseKey: string;
+	agencyId?: number;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const noop = ( _key: string ) => Promise.resolve( {} as APILicense );
 
 function mutationRevokeLicense( {
 	licenseKey,
+	agencyId,
 }: MutationRevokeLicenseVariables ): Promise< APILicense > {
-	return noop( licenseKey ); // Implement actual API call
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to assign a license' );
+	}
+	return wpcom.req.post( {
+		method: 'DELETE',
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-licensing/license',
+		body: { license_key: licenseKey, agency_id: agencyId },
+	} );
 }
 
 export default function useRevokeLicenseMutation< TContext = unknown >(
 	options?: UseMutationOptions< APILicense, Error, MutationRevokeLicenseVariables, TContext >
 ): UseMutationResult< APILicense, Error, MutationRevokeLicenseVariables, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
 	return useMutation< APILicense, Error, MutationRevokeLicenseVariables, TContext >( {
 		...options,
-		mutationFn: mutationRevokeLicense,
+		mutationFn: ( args ) => mutationRevokeLicense( { ...args, agencyId } ),
 	} );
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/302

## Proposed Changes

This PR implements API for:

- Download license
- Revoke License

Includes:

- `useRefetchLicenses` to invalidate the license count and license list query to refetch the data

NOTE:

- UI for `/download-products` will be implemented in another PR.

## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Click the Marketplace menu item -> Issue a few licenses, including a bundle(Volume pricing) and WooCommerce Extensions: Booking to test the download part. 
- Go to Purchases > Licenses. Assign the `WooCommerce Booking` license to a site >When you are redirected to `/download-products`, please visit `/purchases/licenses`. This will be implemented later. Expand it after coming back > Click on `Download` and verify the plugin gets downloaded.

<img width="1227" alt="Screenshot 2024-03-22 at 10 57 33 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d8e8530b-5afb-4763-8ce0-9a3fd0a1368d">

- Click View Site and Debug Site, and verify you are taken to the site URL and Pc9OEs-v-p2, respectively.
- Now click the Revoke button and perform the action > Verify that the license is revoked.
- Do the same on a bundle and verify it works as expected.

<img width="267" alt="Screenshot 2024-03-22 at 10 58 09 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/34ac1307-f2a8-4991-a6b6-75692a5004cb">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?