### PR TITLE
Try: poc getting blaze running on simple classic

### DIFF
--- a/client/data/promote-post/use-promote-post-posts-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-posts-query-paged.ts
@@ -5,6 +5,7 @@ import {
 	useInfiniteQuery,
 	useQuery,
 } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
 import wpcom from 'calypso/lib/wp';
 import { SearchOptions } from 'calypso/my-sites/promote-post-i2/components/search-bar';
 import { PostQueryResult } from './types';
@@ -36,12 +37,17 @@ export const getSearchOptionsQueryParams = ( searchOptions: SearchOptions ) => {
 };
 
 async function queryPosts( siteId: number, queryparams: string ) {
-	return await wpcom.req.get( {
+	return await wpcomRequest< Response >( {
 		path: `/sites/${ siteId }/blaze/posts?${ queryparams }`,
-		apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' )
-			? 'jetpack/v4/blaze-app'
-			: 'wpcom/v2',
+		apiNamespace: 'wpcom/v2',
 	} );
+
+	// return await wpcom.req.get( {
+	// 	path: `/sites/${ siteId }/blaze/posts?${ queryparams }`,
+	// 	apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' )
+	// 		? 'jetpack/v4/blaze-app'
+	// 		: 'wpcom/v2',
+	// } );
 }
 
 export const usePostsQueryStats = ( siteId: number, queryOptions = {} ) => {

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -268,9 +268,10 @@ export const requestDSP = async < T >(
 	const params = {
 		path,
 		method,
-		apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' )
-			? 'jetpack/v4/blaze-app'
-			: 'wpcom/v2',
+		apiNamespace: 'wpcom/v2',
+		// config.isEnabled( 'is_running_in_jetpack_site' )
+		// 	? 'jetpack/v4/blaze-app'
+		// 	: 'wpcom/v2',
 		body,
 	};
 

--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -3,7 +3,7 @@ import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
 import { clearStore } from 'calypso/lib/user/store';
 
 // For Calypso in Jetpack, these API namespaces are accessed from the site, not from wp.com.
-const DIRECT_API_NAMESPACES = [ 'jetpack/v4', 'my-jetpack/v1', 'jetpack/v4/blaze-app' ];
+const DIRECT_API_NAMESPACES = [ 'jetpack/v4', 'my-jetpack/v1', 'jetpack/v4/blaze-app', 'wpcom/v2' ];
 
 export default async function ( params, callback ) {
 	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )


### PR DESCRIPTION
Related to pfsHM7-ne-p2

## Proposed Changes

* Enables loading blaze via wp-admin on simple sites


## Testing Instructions

* See slack p1711075554263769-slack-C0351BKR0M6

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?