### PR TITLE
Reduce size of images in theme picker

### DIFF
--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -4,24 +4,26 @@ import type { MShotsOptions } from '@automattic/onboarding';
 
 type MShotInputOptions = {
 	scrollable?: boolean;
+	highRes?: boolean;
 	isMobile?: boolean;
 };
 
 // Used for both prefetching and loading design screenshots
 export const getMShotOptions = ( {
 	scrollable,
+	highRes,
 	isMobile,
 }: MShotInputOptions = {} ): MShotsOptions => {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
 
-	// These settings are arbitrary. Switching from the previous settings (1199x3600) to these settings reduces page weight from 70 MB to 16 MB,
+	// These settings are arbitrary. Switching from the previous settings (1199x3600) to these settings reduces page weight from 70 MB to ~5 MB,
 	// These settings are intended to, at best, be temporary. A long-term solution for this should probably have values determined by A/B tests,
 	// end up serving WEBPs instead of JPEGs, spend fewer bits on parts of images that are not displayed, and possibly display fewer images.
 	return {
 		vpw: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 		vph: scrollable ? 1600 : 1040,
-		w: 500,
-		screen_height: 1000,
+		w: highRes ? 600 : 600,
+		screen_height: 1100,
 	};
 };
 

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -4,25 +4,24 @@ import type { MShotsOptions } from '@automattic/onboarding';
 
 type MShotInputOptions = {
 	scrollable?: boolean;
-	highRes?: boolean;
 	isMobile?: boolean;
 };
 
 // Used for both prefetching and loading design screenshots
 export const getMShotOptions = ( {
 	scrollable,
-	highRes,
 	isMobile,
 }: MShotInputOptions = {} ): MShotsOptions => {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
+
+	// These settings are arbitrary. Switching from the previous settings (1199x3600) to these settings reduces page weight from 70 MB to 16 MB,
+	// These settings are intended to, at best, be temporary. A long-term solution for this should probably have values determined by A/B tests,
+	// end up serving WEBPs instead of JPEGs, spend fewer bits on parts of images that are not displayed, and possibly display fewer images.
 	return {
 		vpw: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
-		// 1040 renders well with all the current designs, more details in the links below.
-		// See: #77052
 		vph: scrollable ? 1600 : 1040,
-		// When `w` was 1200 it created a visual glitch on one thumbnail. #57261
-		w: highRes ? 1199 : 600,
-		screen_height: 3600,
+		w: 500,
+		screen_height: 1000,
 	};
 };
 

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -19,10 +19,12 @@ export const getMShotOptions = ( {
 	// These settings are arbitrary. Switching from the previous settings (1199x3600) to these settings reduces page weight from 70 MB to ~5 MB,
 	// These settings are intended to, at best, be temporary. A long-term solution for this should probably have values determined by A/B tests,
 	// end up serving WEBPs instead of JPEGs, spend fewer bits on parts of images that are not displayed, and possibly display fewer images.
+	//
+	// See #88786 for more info.
 	return {
 		vpw: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 		vph: scrollable ? 1600 : 1040,
-		w: highRes ? 600 : 600,
+		w: highRes ? 500 : 500, // Stubbed out. See #88786 for more info.
 		screen_height: 1100,
 	};
 };


### PR DESCRIPTION
I'm new to Calypso and Wordpress and am basically a contractor or intern who doesn't know anything, so apologies if I'm missing a step somewhere in the process here. This is a follow-up to @niranjan-uma-shankar finding that the design picker has a 70 MB payload. Looking at the funnel data, we can see that a lot of users drop out at this step, including new users. When segmenting users, we can see that users are relatively more likely to drop out if they have a slow connection or a slow device, which makes sense considering the payload size. From looking at the history here, it looks like there was a change made in 2017 by @fditrapani that reduced the number of themes shown in a category from 9 to 3 (compared to 84 now in the default category), which reduced the number of users dropping out of this flow, especially on mobile. That seems related, in that page weight and complexity tend to cause more attrition on mobile since users are more likely to be on devices or connections that can't handle a heavy or complex plage.

There are a number of ways we could try to address this, including A/B testing various changes, but @bazza suggested that it would be ok to just try deploying a simple change that reduces image sizes and then looking at our funnels to see the impact. This commit reduces the payload size to 16 MB, which is still too large a payload for many users, but will allow more users to be able to pick a theme and create a site.

Without going back to static images, another solution would be to modify mShots to allow webp output or to use photon to get a smaller webp, but just doing that is probably not sufficient to get image sizes down to a level where almost every user will be able to use the theme selector, just like this change alone isn't large enough to do that. Perhaps both of those combined or one of those combined with having fewer themes shown by default could work.

## Proposed Changes

This change reduces the size of each thumbail that's downloaded from `1199x3600` to `500x1000`. The `1000` seems wasteful in that, with most window sizes a user might have, the thumbnail will be displayed at a much lower resolution (for example, fullscreened, on a `3440x1440` display, the actual size of each thumbnail is `460x300`. If I drag my window to try a bunch of possible sizes, I can get a bigger thumbnail, up to something like `600x400`, but `400` is still much smaller than `1000`. But, due to the way the images are handled, without tweaking other settings, much less of the page is shown if a height of less `1000` is picked and I don't think I understand the setup here enough to pick a much better size. With jpeg images, the total size of the image at a fixed quality for an image like this seems like it should be super-linear in the number of pixels, so most data the user downloads is effectively being thrown away even with the smaller version here.

Someone on a retina display can probably observe slightly lower image quality, but if the tradeoff for better image quality on a retina display is that many users are unable to load this page and pick a theme, I'm not sure that's worth it.

Below are screenshots of the original and the changed version on a `3440x1440` display:

![designsetup-a](https://github.com/Automattic/wp-calypso/assets/157136/546be572-7fa8-4470-9232-f68a8860167d)

![designsetup-b](https://github.com/Automattic/wp-calypso/assets/157136/8f4d142d-0e41-48e5-95e4-6fdf5acdcc02)

If we zoom in on both versions, looking at a few different parts, we can see that almost all of the loss in image quality comes from scaling artifacts and that throwing more pixels at the user has little to no effect on image quality (in some areas, the `1199x3600` image looks slightly better, and in some cases, the `500x1000` image looks slightly better. Which parts look better has more to do with how the small displayed size causes aliasing with respect to the "raw" sisze than the number of pixels in the raw large image.

![zoom-1-a](https://github.com/Automattic/wp-calypso/assets/157136/04dc40f4-c682-4d6e-a68b-9bbb09dc56fd)

![zoom-1-b](https://github.com/Automattic/wp-calypso/assets/157136/764fb15a-93b4-4678-b4b3-3e33327783ce)

![zoom-2-a](https://github.com/Automattic/wp-calypso/assets/157136/02eff1b7-a30f-4b32-ac0d-39f8f9cf16eb)

![zoom-2-b](https://github.com/Automattic/wp-calypso/assets/157136/8a8fc18b-0d05-4517-a95e-b370516423bf)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This change is observable by setting up a new site and navigating to `http://calypso.localhost:3000/setup/update-design/designSetup?siteSlug={yoursitehere}` during the process.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
