### PR TITLE
Automattic for Agencies: Implement "Download Products" for the Marketplace

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -16,4 +16,4 @@ export const A4A_BILLING_LINK = `${ A4A_PURCHASES_LINK }/billing`;
 export const A4A_INVOICES_LINK = `${ A4A_PURCHASES_LINK }/invoices`;
 export const A4A_PAYMENT_METHODS_LINK = `${ A4A_PURCHASES_LINK }/payment-methods`;
 export const A4A_PAYMENT_METHODS_ADD_LINK = `${ A4A_PURCHASES_LINK }/payment-methods/add`;
-export const A4A_DOWNLOAD_PRODUCTS_LINK = `${ A4A_PURCHASES_LINK }/download-products`;
+export const A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK = `${ A4A_MARKETPLACE_LINK }/download-products`;

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -14,7 +14,7 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import {
-	A4A_DOWNLOAD_PRODUCTS_LINK,
+	A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK,
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -144,7 +144,7 @@ export default function AssignLicense( { sites, currentPage, search }: Props ) {
 			return page.redirect(
 				addQueryArgs(
 					{ products: licenseKeysArray.join( ',' ), attachedSiteId: selectedSite?.ID },
-					A4A_DOWNLOAD_PRODUCTS_LINK
+					A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK
 				)
 			);
 		}

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -6,6 +6,7 @@ import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
 import HostingOverview from './hosting-overview';
+import DownloadProducts from './primary/download-products';
 import ProductsOverview from './products-overview';
 
 export const marketplaceContext: Callback = () => {
@@ -41,5 +42,11 @@ export const assignLicenseContext: Callback = ( context, next ) => {
 	context.primary = (
 		<AssignLicense sites={ sites } currentPage={ currentPage } search={ search || '' } />
 	);
+	next();
+};
+
+export const downloadProductsContext: Callback = ( context, next ) => {
+	context.secondary = <MarketplaceSidebar path={ context.path } />;
+	context.primary = <DownloadProducts />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
@@ -1,0 +1,119 @@
+import page from '@automattic/calypso-router';
+import { Button } from '@automattic/components';
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect } from 'react';
+import {
+	A4A_LICENSES_LINK,
+	A4A_SITES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import {
+	getProductSlugFromLicenseKey,
+	isWooCommerceProduct,
+} from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import { useSelector } from 'calypso/state';
+import getSites from 'calypso/state/selectors/get-sites';
+import WooProductDownload from './woo-product-download';
+
+import './style.scss';
+
+export default function DownloadProductsForm() {
+	const translate = useTranslate();
+	const sites = useSelector( getSites );
+	const { data: allProducts } = useProductsQuery();
+
+	const attachedSiteId = getQueryArg( window.location.href, 'attachedSiteId' ) as string;
+	const licenseKeys = getQueryArg( window.location.href, 'products' ) as string;
+	const source = getQueryArg( window.location.href, 'source' ) as string;
+
+	const site = sites.find( ( site ) => site?.ID === parseInt( attachedSiteId, 10 ) );
+	const siteDomain = site ? site.domain : null;
+
+	const wooKeys =
+		licenseKeys && licenseKeys.split( ',' ).filter( ( key ) => isWooCommerceProduct( key ) );
+
+	const jetpackKeys =
+		licenseKeys && licenseKeys.split( ',' ).filter( ( key ) => ! isWooCommerceProduct( key ) );
+
+	const jetpackProducts =
+		jetpackKeys &&
+		jetpackKeys.map( ( licenseKey: string ) => {
+			const productSlug = getProductSlugFromLicenseKey( licenseKey );
+			const product =
+				allProducts && allProducts.find( ( product ) => product.slug === productSlug );
+
+			return (
+				<li key={ licenseKey }>
+					<h5>{ product && product.name }</h5>
+					<pre>{ licenseKey }</pre>
+				</li>
+			);
+		} );
+
+	const wooProducts =
+		wooKeys &&
+		wooKeys.map( ( licenseKey: string ) => (
+			<WooProductDownload
+				key={ licenseKey }
+				licenseKey={ licenseKey }
+				allProducts={ allProducts }
+			/>
+		) );
+
+	const onNavigate = useCallback( () => {
+		return page.redirect( 'dashboard' === source ? A4A_SITES_LINK : A4A_LICENSES_LINK );
+	}, [ source ] );
+
+	// redirect if licenseKeys does not contain a valid product
+	useEffect( () => {
+		if ( ! licenseKeys || ! allProducts || ! site ) {
+			return;
+		}
+
+		const invalidKeys = licenseKeys.split( ',' ).filter( ( key ) => {
+			const productSlug = getProductSlugFromLicenseKey( key );
+			return ! allProducts.find( ( product ) => product.slug === productSlug );
+		} );
+
+		if ( invalidKeys.length ) {
+			onNavigate();
+		}
+	}, [ licenseKeys, allProducts, site, onNavigate ] );
+
+	return (
+		<div className="download-products-form">
+			<div className="download-products-form__top">
+				<p className="download-products-form__description">
+					{ siteDomain &&
+						translate(
+							'Your license has been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
+							'Your licenses have been applied to {{strong}}%(siteUrl)s{{/strong}}, but more action is required.',
+							{
+								components: { strong: <strong /> },
+								args: { siteUrl: siteDomain || '' },
+								count: licenseKeys.split( ',' ).length,
+							}
+						) }
+				</p>
+				<div className="download-products-form__controls">
+					<Button primary className="download-products-form__navigate" onClick={ onNavigate }>
+						{ translate( 'Done' ) }
+					</Button>
+				</div>
+			</div>
+			<div className="download-products-form__bottom">
+				{ !! jetpackProducts.length && (
+					<div className="download-products-form__action-items">
+						<h4>{ translate( 'No more action is required for these products:' ) }</h4>
+						<ul>{ jetpackProducts }</ul>
+					</div>
+				) }
+				<div className="download-products-form__action-items">
+					<h4>{ translate( 'These extensions need to be downloaded and installed:' ) }</h4>
+					<ul>{ wooProducts }</ul>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/style.scss
@@ -1,0 +1,110 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "../mixins.scss";
+
+.download-products-form {
+	p {
+		font-size: 1rem;
+	}
+
+	.select-dropdown__container {
+		width: 100%;
+	}
+}
+
+.download-products-form__placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	height: 43px;
+}
+
+.download-products-form__actions {
+	display: flex;
+	justify-content: flex-end;
+	margin: 42px -10px 0;
+
+	> * {
+		margin: 0 10px;
+	}
+}
+
+
+.download-products-form__pagination {
+	margin: 64px 0;
+}
+
+.download-products-form__action-items h4 {
+	font-size: 1.25rem;
+}
+
+.download-products-form__action-items h5 {
+	font-size: 1rem;
+}
+
+.download-products-form__action-items pre {
+	font-size: 0.875rem;
+	padding: 0;
+	margin-bottom: 0.6rem;
+}
+
+.download-products-form__action-items ul {
+	list-style-type: none;
+	margin: 1rem 0;
+}
+
+.download-products-form__top {
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: space-between;
+	align-items: center;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		flex-wrap: wrap;
+	}
+}
+
+.download-products-form__controls {
+	@include licensing-portal-bottom-action-bar;
+
+	display: flex;
+	flex-direction: column-reverse;
+	justify-content: stretch;
+	align-items: center;
+	flex-wrap: wrap;
+	flex-grow: 1;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		flex-direction: row;
+		flex-grow: 1;
+		justify-content: flex-end;
+		margin-block-end: 1rem;
+
+		.button {
+			flex-grow: 1;
+		}
+	}
+
+	@include break-medium {
+		.button {
+			flex-grow: 0;
+		}
+	}
+
+	@include break-xlarge {
+		flex-direction: row;
+		flex-grow: 0;
+	}
+}
+
+p.download-products-form__description {
+	flex: 1 0 100%;
+	align-self: flex-end;
+	margin: 0 0 1rem;
+	font-size: 0.875rem;
+	color: #333;
+
+	@include break-medium {
+		flex: 1 1 auto;
+		margin-inline-end: 1rem;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/style.scss
@@ -44,7 +44,7 @@
 .download-products-form__action-items pre {
 	font-size: 0.875rem;
 	padding: 0;
-	margin-bottom: 0.6rem;
+	margin-block-end: 0.6rem;
 }
 
 .download-products-form__action-items ul {
@@ -101,7 +101,7 @@ p.download-products-form__description {
 	align-self: flex-end;
 	margin: 0 0 1rem;
 	font-size: 0.875rem;
-	color: #333;
+	color: var(--color-text-gray);
 
 	@include break-medium {
 		flex: 1 1 auto;

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/woo-product-download.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/woo-product-download.tsx
@@ -1,0 +1,69 @@
+import { Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect } from 'react';
+import ActionCard from 'calypso/components/action-card';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import useLicenseDownloadUrlMutation from '../../purchases/licenses/revoke-license-dialog/hooks/use-license-download-url-mutation';
+
+interface WooProductDownloadProps {
+	licenseKey: string;
+	allProducts: APIProductFamilyProduct[] | undefined;
+}
+
+export default function WooProductDownload( { licenseKey, allProducts }: WooProductDownloadProps ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const productSlug = licenseKey.split( '_' )[ 0 ];
+	const product = allProducts && allProducts.find( ( product ) => product.slug === productSlug );
+	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
+
+	const { mutate, status, error, data } = downloadUrl;
+
+	useEffect( () => {
+		if ( status === 'success' ) {
+			window.location.replace( data.download_url );
+		} else if ( status === 'error' ) {
+			dispatch( errorNotice( error.message ) );
+		}
+	}, [ status, error, dispatch, data ] );
+
+	const download = useCallback( () => {
+		mutate( null );
+		dispatch( recordTracksEvent( 'calypso_marketplace_a4a_download_from_assign' ) );
+	}, [ dispatch, mutate ] );
+
+	const onCopyLicense = useCallback( () => {
+		dispatch( infoNotice( translate( 'License copied!' ), { duration: 2000 } ) );
+		dispatch( recordTracksEvent( 'calypso_marketplace_a4a_download_copy_license_key' ) );
+	}, [ dispatch, translate ] );
+
+	return (
+		<div className="download-products-list">
+			<ActionCard
+				headerText={ product?.name ?? '' }
+				mainText={
+					<div className="license-key">
+						<code className="license-details__license-key">{ licenseKey }</code>
+
+						<ClipboardButton
+							text={ licenseKey }
+							className="license-details__clipboard-button"
+							borderless
+							compact
+							onCopy={ onCopyLicense }
+						>
+							<Gridicon icon="clipboard" />
+						</ClipboardButton>
+					</div>
+				}
+				buttonText={ translate( 'Download' ) }
+				buttonOnClick={ download }
+				buttonDisabled={ status === 'pending' }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -5,6 +5,7 @@ import {
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
 	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
@@ -13,12 +14,15 @@ import {
 	marketplaceContext,
 	marketplaceHostingContext,
 	marketplaceProductsContext,
+	downloadProductsContext,
 } from './controller';
 
 export default function () {
+	// FIXME: check access, TOS consent, valid payment method, all sites context and partner key selection if needed
 	page( A4A_MARKETPLACE_LINK, marketplaceContext, makeLayout, clientRender );
 	page( A4A_MARKETPLACE_PRODUCTS_LINK, marketplaceProductsContext, makeLayout, clientRender );
 	page( A4A_MARKETPLACE_HOSTING_LINK, marketplaceHostingContext, makeLayout, clientRender );
 	page( A4A_MARKETPLACE_CHECKOUT_LINK, checkoutContext, makeLayout, clientRender );
 	page( A4A_MARKETPLACE_ASSIGN_LICENSE_LINK, assignLicenseContext, makeLayout, clientRender );
+	page( A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK, downloadProductsContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/marketplace/primary/download-products/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/primary/download-products/index.tsx
@@ -1,0 +1,42 @@
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import AssignLicenseStepProgress from '../../assign-license-step-progress';
+import DownloadProductsForm from '../../download-products-form';
+
+export default function DownloadProducts() {
+	const translate = useTranslate();
+	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
+	const products = getQueryArg( window.location.href, 'products' ) as string;
+	const licenseKeysArray = products !== undefined ? products.split( ',' ) : [ licenseKey ];
+
+	const title = translate(
+		'Download and install your product',
+		'Download and install your products',
+		{
+			count: licenseKeysArray.length,
+		}
+	);
+
+	return (
+		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<AssignLicenseStepProgress currentStep="downloadProducts" showDownloadStep />
+
+				<LayoutHeader>
+					<Title>{ title } </Title>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<DownloadProductsForm />
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -72,7 +72,7 @@ export default function LicenseDetailsActions( {
 				licenseType === LicenseType.Partner && (
 					<Button
 						compact
-						{ ...( downloadUrl.isPending ? { busy: true } : {} ) }
+						{ ...( status === 'pending' ? { busy: true } : {} ) }
 						onClick={ download }
 					>
 						{ translate( 'Download' ) }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -29,6 +29,7 @@
 	--color-sidebar-text: #fff;
 	--color-sidebar-text-alternative: #bbe0fa;
 	--color-sidebar-gridicon-fill: #bbe0fa;
+	--color-text-gray: "#333";
 
 	--color-scary-0: var(--studio-red-0);
 	--color-scary-5: var(--studio-red-5);

--- a/client/sections.js
+++ b/client/sections.js
@@ -735,7 +735,7 @@ const sections = [
 			'/marketplace/hosting',
 			'/marketplace/checkout',
 			'/marketplace/assign-license',
-			'marketplace/download-products',
+			'/marketplace/download-products',
 		],
 		module: 'calypso/a8c-for-agencies/sections/marketplace',
 		group: 'a8c-for-agencies',

--- a/client/sections.js
+++ b/client/sections.js
@@ -735,6 +735,7 @@ const sections = [
 			'/marketplace/hosting',
 			'/marketplace/checkout',
 			'/marketplace/assign-license',
+			'marketplace/download-products',
 		],
 		module: 'calypso/a8c-for-agencies/sections/marketplace',
 		group: 'a8c-for-agencies',


### PR DESCRIPTION

Resolves https://github.com/Automattic/jetpack-genesis/issues/303

## Proposed Changes

This PR implements the "Download Products" page for the A4A Marketplace.

NOTE: Please ignore the top steps, as we will fix it later

## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Click the Marketplace menu item > Issue WooCommerce Extensions: Booking to test the download part. 
- Assign this license to a site > Verify you are redirected to the "Download Products" page, and it looks as shown below. Also try downloading the plugin and verify it gets downloaded.

<img width="1561" alt="Screenshot 2024-03-22 at 12 20 16 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e0dca1a0-007a-4b98-afd0-56ddd8614037">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?