### PR TITLE
Adjust Odyssey Stats to allow Simple Classic to load properly

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -1,7 +1,6 @@
 /**
  * This is a Odyssey implementation of 'calypso/components/data/query-site-purchases'.
  */
-import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { isError } from 'lodash';
 import { useEffect } from 'react';
@@ -13,6 +12,7 @@ import {
 	PURCHASES_SITE_FETCH_COMPLETED,
 	PURCHASES_SITE_FETCH_FAILED,
 } from 'calypso/state/action-types';
+import { getApiNamespace, getApiPath } from '../lib/get-api';
 
 async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
 	if ( ! siteId ) {
@@ -21,10 +21,8 @@ async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
 
 	return wpcom.req
 		.get( {
-			path: config.isEnabled( 'is_running_in_jetpack_site' )
-				? '/site/purchases'
-				: `/sites/${ siteId }/purchases`,
-			apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1',
+			path: getApiPath( '/site/purchases', { siteId } ),
+			apiNamespace: getApiNamespace(),
 		} )
 		.then( ( res: { data: string } ) => JSON.parse( res.data ) )
 		.catch( ( error: Error ) => error );

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -1,6 +1,7 @@
 /**
  * This is a Odyssey implementation of 'calypso/components/data/query-site-purchases'.
  */
+import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { isError } from 'lodash';
 import { useEffect } from 'react';
@@ -19,7 +20,12 @@ async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
 	}
 
 	return wpcom.req
-		.get( { path: '/site/purchases', apiNamespace: 'jetpack/v4' } )
+		.get( {
+			path: config.isEnabled( 'is_running_in_jetpack_site' )
+				? '/site/purchases'
+				: `/sites/${ siteId }/purchases`,
+			apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1',
+		} )
 		.then( ( res: { data: string } ) => JSON.parse( res.data ) )
 		.catch( ( error: Error ) => error );
 }

--- a/apps/odyssey-stats/src/hooks/use-module-data-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-module-data-query.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
@@ -15,7 +16,7 @@ function queryModuleData( module: Module ): Promise< ModuleData > {
 		.get( {
 			method: 'GET',
 			// Ensure you add the apiNamespace to be able to access Jetpack's `jetpack/v4` endpoints, otherwise it's all defaulted to `jetpack/v4/stats-app`.
-			apiNamespace: 'jetpack/v4',
+			apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1',
 			path: `/module/${ module }/data`,
 		} )
 		.catch( ( error: Error & ErrorResponse ) => {

--- a/apps/odyssey-stats/src/hooks/use-module-data-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-module-data-query.ts
@@ -1,7 +1,7 @@
-import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
+import { getApiNamespace } from '../lib/get-api';
 
 type Module = 'akismet' | 'protect' | 'vaultpress' | 'monitor' | 'stats' | 'verification-tools';
 type ModuleData = number | string | boolean;
@@ -16,7 +16,7 @@ function queryModuleData( module: Module ): Promise< ModuleData > {
 		.get( {
 			method: 'GET',
 			// Ensure you add the apiNamespace to be able to access Jetpack's `jetpack/v4` endpoints, otherwise it's all defaulted to `jetpack/v4/stats-app`.
-			apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1',
+			apiNamespace: getApiNamespace(),
 			path: `/module/${ module }/data`,
 		} )
 		.catch( ( error: Error & ErrorResponse ) => {

--- a/apps/odyssey-stats/src/lib/get-api.ts
+++ b/apps/odyssey-stats/src/lib/get-api.ts
@@ -5,7 +5,7 @@ import config from '@automattic/calypso-config';
  * This is needed as WP.com Simple Classic is loading Odyssey Stats, which we will use the public-api.wordpress.com APIs.
  * @returns {string} The API namespace to use.
  */
-export const getApiNamespace = () => {
+export const getApiNamespace = (): string => {
 	return config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1';
 };
 

--- a/apps/odyssey-stats/src/lib/get-api.ts
+++ b/apps/odyssey-stats/src/lib/get-api.ts
@@ -1,0 +1,25 @@
+import config from '@automattic/calypso-config';
+
+/**
+ * Set the API namespace based on whether the app is running in a Jetpack site or not.
+ * This is needed as WP.com Simple Classic is loading Odyssey Stats, which we will use the public-api.wordpress.com APIs.
+ * @returns {string} The API namespace to use.
+ */
+export const getApiNamespace = () => {
+	return config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1';
+};
+
+/**
+ * Get the API path based on the config is_running_in_jetpack_site.
+ * @param jetpackPath The path to the Jetpack API endpoint.
+ */
+export const getApiPath = ( jetpackPath: string, params: Record< string, string | number > ) => {
+	switch ( jetpackPath ) {
+		case '/site/purchases':
+			return `/sites/${ params.siteId }/purchases`;
+		case '/site':
+			return `/sites/${ params.siteId }`;
+		default:
+			return jetpackPath;
+	}
+};

--- a/apps/odyssey-stats/src/lib/get-api.ts
+++ b/apps/odyssey-stats/src/lib/get-api.ts
@@ -15,6 +15,9 @@ export const getApiNamespace = (): string => {
  * @param params Contains 'siteId' and optional additional parameters.
  */
 export const getApiPath = ( jetpackPath: string, params: Record< string, string | number > ) => {
+	if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+		return jetpackPath;
+	}
 	switch ( jetpackPath ) {
 		case '/site/purchases':
 			return `/sites/${ params.siteId }/purchases`;

--- a/apps/odyssey-stats/src/lib/get-api.ts
+++ b/apps/odyssey-stats/src/lib/get-api.ts
@@ -12,6 +12,7 @@ export const getApiNamespace = (): string => {
 /**
  * Get the API path based on the config is_running_in_jetpack_site.
  * @param jetpackPath The path to the Jetpack API endpoint.
+ * @param params Contains 'siteId' and optional additional parameters.
  */
 export const getApiPath = ( jetpackPath: string, params: Record< string, string | number > ) => {
 	switch ( jetpackPath ) {

--- a/apps/odyssey-stats/src/lib/test/get-api.test.js
+++ b/apps/odyssey-stats/src/lib/test/get-api.test.js
@@ -1,0 +1,49 @@
+import { getApiPath } from '../get-api';
+
+const config = {
+	isEnabled: jest.fn(),
+};
+
+describe( 'getApiPath for jetpack/atomic sites', () => {
+	beforeAll( () => {
+		config.isEnabled.mockReturnValue( true );
+	} );
+	afterAll( () => {
+		jest.clearAllMocks();
+	} );
+	it( 'should return the passed in jetpackPath', () => {
+		config.isEnabled.mockReturnValue( true );
+		const jetpackPath = '/jetpack-api';
+		const params = { siteId: 123 };
+
+		const result = getApiPath( jetpackPath, params );
+
+		expect( result ).toBe( jetpackPath );
+	} );
+} );
+
+describe( 'getApiPath for simple sites', () => {
+	beforeAll( () => {
+		config.isEnabled.mockReturnValue( false );
+	} );
+	afterAll( () => {
+		jest.clearAllMocks();
+	} );
+	it( '/site/purchases', () => {
+		const jetpackPath = '/site/purchases';
+		const params = { siteId: 123 };
+
+		const result = getApiPath( jetpackPath, params );
+
+		expect( result ).toBe( `/sites/${ params.siteId }/purchases` );
+	} );
+
+	it( '/site', () => {
+		const jetpackPath = '/site';
+		const params = { siteId: 123 };
+
+		const result = getApiPath( jetpackPath, params );
+
+		expect( result ).toBe( `/sites/${ params.siteId }` );
+	} );
+} );

--- a/apps/odyssey-stats/src/routes.ts
+++ b/apps/odyssey-stats/src/routes.ts
@@ -46,7 +46,10 @@ const siteSelection = ( context: Context, next: () => void ) => {
 
 	dispatch( { type: SITE_REQUEST, siteId: siteId } );
 	wpcom.req
-		.get( { path: '/site', apiNamespace: 'jetpack/v4' } )
+		.get( {
+			path: config.isEnabled( 'is_running_in_jetpack_site' ) ? '/site' : `/sites/${ siteId }`,
+			apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1',
+		} )
 		.then( ( site: { data: string } ) => JSON.parse( site.data ) )
 		.then( ( site: SiteDetails ) => {
 			dispatch( { type: ODYSSEY_SITE_RECEIVE, site } );

--- a/apps/odyssey-stats/src/routes.ts
+++ b/apps/odyssey-stats/src/routes.ts
@@ -25,6 +25,7 @@ import {
 import { getSite, isRequestingSite } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import config from './lib/config-api';
+import { getApiNamespace, getApiPath } from './lib/get-api';
 import { makeLayout, render as clientRender } from './page-middleware/layout';
 import 'calypso/my-sites/stats/style.scss';
 
@@ -47,8 +48,8 @@ const siteSelection = ( context: Context, next: () => void ) => {
 	dispatch( { type: SITE_REQUEST, siteId: siteId } );
 	wpcom.req
 		.get( {
-			path: config.isEnabled( 'is_running_in_jetpack_site' ) ? '/site' : `/sites/${ siteId }`,
-			apiNamespace: config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1',
+			path: getApiPath( '/site', { siteId } ),
+			apiNamespace: getApiNamespace(),
 		} )
 		.then( ( site: { data: string } ) => JSON.parse( site.data ) )
 		.then( ( site: SiteDetails ) => {

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -91,7 +91,6 @@ class StatsDatePicker extends Component {
 
 	renderQueryDate() {
 		const { query, queryDate, moment, translate } = this.props;
-
 		let content;
 
 		if ( ! queryDate || ! isAutoRefreshAllowedForQuery( query ) ) {

--- a/client/state/sites/selectors/is-jetpack-site-pred.ts
+++ b/client/state/sites/selectors/is-jetpack-site-pred.ts
@@ -37,6 +37,10 @@ export default function isJetpackSitePred( options?: IsJetpackSitePredOptions ) 
 		// Merge default options with options.
 		const mergedOptions = options ? { ...DEFAULT_OPTIONS, ...options } : DEFAULT_OPTIONS;
 
+		if ( ! site.is_wpcom_simple ) {
+			return false;
+		}
+
 		// If the site is an Atomic site, but we should not treat it as Jetpack site, return false.
 		if ( ! mergedOptions.treatAtomicAsJetpackSite && site.options?.is_wpcom_atomic ) {
 			return false;

--- a/client/state/sites/selectors/is-jetpack-site-pred.ts
+++ b/client/state/sites/selectors/is-jetpack-site-pred.ts
@@ -37,7 +37,7 @@ export default function isJetpackSitePred( options?: IsJetpackSitePredOptions ) 
 		// Merge default options with options.
 		const mergedOptions = options ? { ...DEFAULT_OPTIONS, ...options } : DEFAULT_OPTIONS;
 
-		if ( ! site.is_wpcom_simple ) {
+		if ( site.is_wpcom_simple ) {
 			return false;
 		}
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -128,6 +128,7 @@ export interface SiteDetails {
 	is_private?: boolean;
 	is_vip?: boolean;
 	is_wpcom_atomic?: boolean;
+	is_wpcom_simple?: boolean;
 	is_wpcom_staging_site?: boolean;
 	jetpack: boolean;
 	lang?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6213

## Proposed Changes

As Simple Classic will be loading Odyssey Stats, this PR makes sure the correct API endpoints are being called.

We will address color schemes in another PR/Issue, that's fine for now.
For the broken 'en' locale, created another issue to track: https://github.com/Automattic/dotcom-forge/issues/6334

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the PRs: https://github.com/Automattic/jetpack/pull/36628, https://github.com/Automattic/jetpack/pull/36633 by running the following commands in your sandbox

```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/wpcom-simple-odyssey-stats
bin/jetpack-downloader test jetpack update/odyssey-stats-config
```

* Load this PR in your sandbox by running
```
install-plugin.sh odyssey-stats try/odyssey-stats-simple
```

* Sandbox `yoursimplesite.wordpress.com` and `widgets.wp.com`
* On a simple site, go to `yoursimplesite.wordpress.com/wp-admin`
* On the left menu, you should see a Jetpack menu

![image](https://github.com/Automattic/wp-calypso/assets/6586048/477747ad-67c0-41ab-81cc-70391860939f)

* Go to the stats page from the menu
* Check if the stats page are working okay
* Go to wp-admin Dashboard
* Check if the stats widget is working
* Check in the console to see if there are any new errors introduced

![sandbox](https://github.com/Automattic/wp-calypso/assets/6586048/f3f3c5ea-ea7e-4aad-b1da-84863d5e84a8)

![widget](https://github.com/Automattic/wp-calypso/assets/6586048/209a2466-ff1b-4ee3-bb33-f77b79473180)

Test for atomic and self-hosted sites to make sure we're not introducing a regression and breaking things there.
Tip: Use the Jetpack Beta plugin to load the 2 PRs https://github.com/Automattic/jetpack/pull/36628, https://github.com/Automattic/jetpack/pull/36633 into your WoA and Jetpack site when testing.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?