### PR TITLE
Add `wccom_from` and `oauth2_client_id` to Signup getRecordProps() 

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -58,6 +58,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
@@ -329,7 +330,7 @@ class Signup extends Component {
 	};
 
 	getRecordProps() {
-		const { signupDependencies, hostingFlow, queryObject } = this.props;
+		const { signupDependencies, hostingFlow, queryObject, wccomFrom, oauth2Client } = this.props;
 		const mainFlow = queryObject?.main_flow;
 
 		let theme = get( signupDependencies, 'selectedDesign.theme' );
@@ -346,6 +347,8 @@ class Signup extends Component {
 			intent: get( signupDependencies, 'intent' ),
 			starting_point: get( signupDependencies, 'startingPoint' ),
 			is_in_hosting_flow: hostingFlow,
+			wccom_from: wccomFrom,
+			oauth2_client_id: oauth2Client?.id,
 			...( mainFlow ? { flow: mainFlow } : {} ),
 		};
 	}
@@ -965,6 +968,7 @@ export default connect(
 			localeSlug: getCurrentLocaleSlug( state ),
 			oauth2Client,
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
+			wccomFrom: getWccomFrom( state ),
 			hostingFlow,
 		};
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

I found that there are no properties in the `calypso_signup_step_start` event that can filter for Woo or Woo Express only.

This PR adds `wccom_from` and `oauth2_client_id` props so that we can analyze Woo Express signup metrics more accurately and use them to expose event properties.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up woo start env
* Go to wordpress.com
* Open dev tool > enable logging via `window.localStorage.setItem( 'debug', 'calypso:analytics')`  
* https://woo.com/start/#/installation
* Click on `Try Woo Express for free`
* Observe that  event "calypso_signup_start" called with props 

```json
{
    "flow": "wpcc",
    "ref": "oauth2",
    "is_in_hosting_flow": false,
    "wccom_from": "nux",
    "oauth2_client_id": 50916
}
```

<img width="715" alt="Screenshot 2024-03-22 at 17 17 20" src="https://github.com/Automattic/wp-calypso/assets/4344253/c27f3c7c-4b43-43e5-ad65-8f1a54b4f9d8">

* Go to https://wordpress.com/start
* Observe that event "calypso_signup_start" called with `wccom_from = null` and `oauth2_client_id = null`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?