### PR TITLE
Automattic for Agencies: Implement API for the Invoices page

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/invoices/hooks/use-pay-invoice-mutation.ts
+++ b/client/a8c-for-agencies/sections/purchases/invoices/hooks/use-pay-invoice-mutation.ts
@@ -1,18 +1,74 @@
-import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import {
+	useMutation,
+	UseMutationOptions,
+	UseMutationResult,
+	useQueryClient,
+} from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { getFetchInvoicesQueryKey } from 'calypso/a8c-for-agencies/data/purchases/use-fetch-invoices';
+import wpcom from 'calypso/lib/wp';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import type { APIInvoice } from 'calypso/state/partner-portal/types';
 
 interface PayInvoiceMutationVariables {
 	invoiceId: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const noop = () => Promise.resolve() as unknown as Promise< APIInvoice >;
-
 export default function usePayInvoiceMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIInvoice, Error, PayInvoiceMutationVariables, TContext >
 ): UseMutationResult< APIInvoice, Error, PayInvoiceMutationVariables, TContext > {
-	return useMutation< APIInvoice, Error, PayInvoiceMutationVariables, TContext >( {
-		mutationFn: noop, // Implement actual API call
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const mutation = useMutation< APIInvoice, Error, PayInvoiceMutationVariables, TContext >( {
+		mutationFn: ( { invoiceId } ) =>
+			wpcom.req.post(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: `/jetpack-licensing/partner/invoice/${ invoiceId }/payment`,
+				},
+				{
+					agency_id: agencyId,
+				}
+			),
 		...options,
 	} );
+
+	const { isSuccess, isError, error, data } = mutation;
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			queryClient.invalidateQueries( {
+				queryKey: getFetchInvoicesQueryKey( {
+					starting_after: '',
+					ending_before: '',
+					agencyId: agencyId,
+				} ),
+			} );
+			dispatch(
+				successNotice(
+					translate( 'Invoice %s settled successfully.', {
+						args: [ data.id ],
+					} ),
+					{
+						id: 'a4a-pay-invoice-success',
+					}
+				)
+			);
+		}
+	}, [ isSuccess, dispatch, data, agencyId, queryClient, translate ] );
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch( errorNotice( error.message, { id: 'a4a-pay-invoice-failure' } ) );
+		}
+	}, [ isError, dispatch, error?.message ] );
+
+	return mutation;
 }

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
@@ -1,7 +1,7 @@
 import { Badge, Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import { memo, useCallback } from 'react';
+import { memo } from 'react';
 import FormattedDate from 'calypso/components/formatted-date';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import usePayInvoiceMutation from '../hooks/use-pay-invoice-mutation';
@@ -16,11 +16,6 @@ function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUr
 	const moment = useLocalizedMoment();
 	const dueDateMoment = moment( dueDate );
 	const payInvoice = usePayInvoiceMutation();
-
-	const pay = useCallback(
-		() => payInvoice.mutate( { invoiceId: id } ),
-		[ id, payInvoice.mutate ]
-	);
 
 	let badgeType: BadgeType = 'info';
 	let badgeLabel = translate( 'Draft' );
@@ -69,7 +64,12 @@ function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUr
 
 			<div className="invoices-list-card__actions">
 				{ status === 'open' && (
-					<Button compact primary busy={ payInvoice.isPending } onClick={ pay }>
+					<Button
+						compact
+						primary
+						busy={ payInvoice.isPending }
+						onClick={ () => payInvoice.mutate( { invoiceId: id } ) }
+					>
 						{ translate( 'Pay' ) }
 					</Button>
 				) }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/288

## Proposed Changes

This PR implements API for the A4A Invoices page that includes:

- Fetch Invoices
- Pay Invoice

<img width="1561" alt="Screenshot 2024-03-25 at 10 55 41 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ad04c38a-c14f-40ec-9dda-5f4840538ce2">


## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Follow the steps here to add some invoices manually: 33f09-pb.
- Click the Purchases menu item > Click the Invoices menu item > Verify the invoices are loaded
- Click on "Download Invoice" and verify that the Invoice gets downloaded.
- Verify that the "Pay" button exists for an unpaid invoice. You don't have to test this flow, as I have tested it. If you still want to test it, manually set the status for the paid invoice to unpaid and verify that you get a response that the invoice is already paid.  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?