### PR TITLE
Social login: Catch inaccessible `sessionStorage` errors

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -7,6 +7,7 @@ import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { isWpccFlow } from 'calypso/signup/is-flow';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -108,8 +109,12 @@ class SocialSignupForm extends Component {
 	trackLoginAndRememberRedirect = ( service ) => {
 		this.trackSocialSignup( service );
 
-		if ( this.props.redirectToAfterLoginUrl && typeof window !== 'undefined' ) {
-			window.sessionStorage.setItem( 'signup_redirect_to', this.props.redirectToAfterLoginUrl );
+		try {
+			if ( this.props.redirectToAfterLoginUrl && typeof window !== 'undefined' ) {
+				window.sessionStorage.setItem( 'signup_redirect_to', this.props.redirectToAfterLoginUrl );
+			}
+		} catch ( error ) {
+			this.props.showErrorNotice( this.props.translate( 'Error accessing sessionStorage.' ) );
 		}
 	};
 
@@ -147,5 +152,5 @@ export default connect(
 				isWooCommerceCoreProfilerFlow( state ),
 		};
 	},
-	{ recordTracksEvent }
+	{ recordTracksEvent, showErrorNotice: errorNotice }
 )( localize( SocialSignupForm ) );

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -114,7 +115,22 @@ class SocialSignupForm extends Component {
 				window.sessionStorage.setItem( 'signup_redirect_to', this.props.redirectToAfterLoginUrl );
 			}
 		} catch ( error ) {
-			this.props.showErrorNotice( this.props.translate( 'Error accessing sessionStorage.' ) );
+			this.props.showErrorNotice(
+				this.props.translate(
+					'Error accessing sessionStorage. {{a}}Please check your browser settings{{/a}}.',
+					{
+						components: {
+							a: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/support/browser-issues/' ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				)
+			);
 		}
 	};
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/88792.

## Proposed Changes

* add error handling for cases where `sessionStorage` is not accessible

![Markup on 2024-03-22 at 10:41:20](https://github.com/Automattic/wp-calypso/assets/25105483/96617f5e-fe17-48d7-ba0e-059dd8e3a84b)

ℹ️ Since this error is quite infrequent, this PR doesn't wait for the translations to be finished.

## Testing Instructions

1. Check out and build the proposed changes.
2. Navigate to http://calypso.localhost:3000/start/user-social.
3. Open browser console and delete `sessionStorage` by entering  `delete window.sessionStorage;`.
4. Click on the _Continue with Google_ button.
5. The error notice should display (as can be seen in the screenshot above).

## Pre-merge Checklist`

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?