### PR TITLE
A4A: Signup form additional fields

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -10,6 +10,8 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 		body: {
 			agency_name: details.agencyName,
 			agency_url: details.agencyUrl,
+			number_sites: details.managedSites,
+			services_offered: details.servicesOffered,
 			address_line1: details.line1,
 			address_line2: details.line2,
 			address_city: details.city,

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -18,6 +18,7 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			address_country: details.country,
 			address_state: details.state,
 			address_postal_code: details.postalCode,
+			referral_status: details.referer,
 		},
 	} );
 }

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -6,8 +6,7 @@ import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholde
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
-import type { ChangeList } from 'calypso/components/forms/multi-checkbox';
+import MultiCheckbox, { ChangeList } from 'calypso/components/forms/multi-checkbox';
 import { Option as CountryOption, useCountriesAndStates } from './hooks/use-countries-and-states';
 import { AgencyDetailsPayload } from './types';
 import type { FormEventHandler } from 'react';
@@ -32,6 +31,7 @@ interface Props {
 	includeTermsOfService?: boolean;
 	isLoading: boolean;
 	onSubmit: ( payload: AgencyDetailsPayload ) => void;
+	referer?: string | null;
 	initialValues?: {
 		agencyName?: string;
 		agencyUrl?: string;
@@ -52,6 +52,7 @@ export default function AgencyDetailsForm( {
 	isLoading,
 	initialValues = {},
 	onSubmit,
+	referer,
 	submitLabel,
 }: Props ) {
 	const translate = useTranslate();
@@ -66,7 +67,7 @@ export default function AgencyDetailsForm( {
 	const [ addressState, setAddressState ] = useState( initialValues.state ?? '' );
 	const [ agencyName, setAgencyName ] = useState( initialValues.agencyName ?? '' );
 	const [ agencyUrl, setAgencyUrl ] = useState( initialValues.agencyUrl ?? '' );
-	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '1-5' );
+	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '1-20' );
 	const [ servicesOffered, setServicesOffered ] = useState( initialValues.servicesOffered ?? [] );
 
 	const country = getCountry( countryValue, countryOptions );
@@ -89,6 +90,7 @@ export default function AgencyDetailsForm( {
 			country,
 			postalCode,
 			state: addressState,
+			referer,
 			...( includeTermsOfService ? { tos: 'consented' } : {} ),
 		} ),
 		[
@@ -102,6 +104,7 @@ export default function AgencyDetailsForm( {
 			country,
 			postalCode,
 			addressState,
+			referer,
 			includeTermsOfService,
 		]
 	);
@@ -137,8 +140,7 @@ export default function AgencyDetailsForm( {
 		setManagedSites( value );
 	};
 
-	// TODO: Fix the TS type for "services" here.
-	const handleSetServicesOffered = ( services: any ) => {
+	const handleSetServicesOffered = ( services: ChangeList< string > ) => {
 		setServicesOffered( services.value );
 	};
 
@@ -179,12 +181,9 @@ export default function AgencyDetailsForm( {
 						value={ managedSites }
 						onChange={ handleSetManagedSites }
 					>
-						<option value="1-5">{ translate( '1–5' ) }</option>
-						<option value="6-20">{ translate( '6–20' ) }</option>
-						<option value="21-50">{ translate( '21–50' ) }</option>
-						<option value="51-100">{ translate( '51–100' ) }</option>
-						<option value="101-500">{ translate( '101–500' ) }</option>
-						<option value="500+">{ translate( '500+' ) }</option>
+						<option value="1-20">{ translate( '1-20' ) }</option>
+						<option value="21-100">{ translate( '21–100' ) }</option>
+						<option value="101+">{ translate( '101+' ) }</option>
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>
@@ -199,7 +198,9 @@ export default function AgencyDetailsForm( {
 						name="services_offered"
 						checked={ servicesOffered }
 						options={ getServicesOfferedOptions() }
-						onChange={ handleSetServicesOffered }
+						// // Using 'as any' to bypass TypeScript type checks due to a known and intentional type mismatch between
+						// the expected custom event type for `onChange` and the standard event types.
+						onChange={ handleSetServicesOffered as any }
 					/>
 				</FormFieldset>
 				<FormFieldset>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -4,9 +4,13 @@ import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
 import SearchableDropdown from 'calypso/a8c-for-agencies/components/searchable-dropdown';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
+import type { ChangeList } from 'calypso/components/forms/multi-checkbox';
 import { Option as CountryOption, useCountriesAndStates } from './hooks/use-countries-and-states';
 import { AgencyDetailsPayload } from './types';
+import type { FormEventHandler } from 'react';
 
 import './style.scss';
 
@@ -31,6 +35,8 @@ interface Props {
 	initialValues?: {
 		agencyName?: string;
 		agencyUrl?: string;
+		managedSites?: string;
+		servicesOffered?: string[];
 		city?: string;
 		line1?: string;
 		line2?: string;
@@ -60,6 +66,8 @@ export default function AgencyDetailsForm( {
 	const [ addressState, setAddressState ] = useState( initialValues.state ?? '' );
 	const [ agencyName, setAgencyName ] = useState( initialValues.agencyName ?? '' );
 	const [ agencyUrl, setAgencyUrl ] = useState( initialValues.agencyUrl ?? '' );
+	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '1-5' );
+	const [ servicesOffered, setServicesOffered ] = useState( initialValues.servicesOffered ?? [] );
 
 	const country = getCountry( countryValue, countryOptions );
 	const stateOptions = stateOptionsMap[ country ];
@@ -73,6 +81,8 @@ export default function AgencyDetailsForm( {
 		() => ( {
 			agencyName,
 			agencyUrl,
+			managedSites,
+			servicesOffered,
 			city,
 			line1,
 			line2,
@@ -84,6 +94,8 @@ export default function AgencyDetailsForm( {
 		[
 			agencyName,
 			agencyUrl,
+			managedSites,
+			servicesOffered,
 			city,
 			line1,
 			line2,
@@ -106,6 +118,29 @@ export default function AgencyDetailsForm( {
 		},
 		[ showCountryFields, isLoading, onSubmit, payload ]
 	);
+
+	const getServicesOfferedOptions = () => {
+		return [
+			{ value: 'strategy_consulting', label: translate( 'Strategy consulting' ) },
+			{ value: 'website_design_development', label: translate( 'Website design & development' ) },
+			{ value: 'performance_optimization', label: translate( 'Performance optimization' ) },
+			{ value: 'digital_strategy_marketing', label: translate( 'Digital strategy & marketing' ) },
+			{ value: 'maintenance_support_plans', label: translate( 'Maintenance & support plans' ) },
+		];
+	};
+
+	// <FormSelect> complains if we "just" pass "setManagedSites" because it expects
+	// React.FormEventHandler, so this wrapper function is made to satisfy everything
+	// in an easily readable way.
+	const handleSetManagedSites: FormEventHandler = ( { target } ) => {
+		const value: string = ( target as HTMLSelectElement ).value;
+		setManagedSites( value );
+	};
+
+	// TODO: Fix the TS type for "services" here.
+	const handleSetServicesOffered = ( services: any ) => {
+		setServicesOffered( services.value );
+	};
 
 	return (
 		<div className="agency-details-form">
@@ -132,6 +167,39 @@ export default function AgencyDetailsForm( {
 							setAgencyUrl( event.target.value )
 						}
 						disabled={ isLoading }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="managed_sites">
+						{ translate( 'How many sites do you manage?' ) }
+					</FormLabel>
+					<FormSelect
+						name="managed_sites"
+						id="managed_sites"
+						value={ managedSites }
+						onChange={ handleSetManagedSites }
+					>
+						<option value="1-5">{ translate( '1–5' ) }</option>
+						<option value="6-20">{ translate( '6–20' ) }</option>
+						<option value="21-50">{ translate( '21–50' ) }</option>
+						<option value="51-100">{ translate( '51–100' ) }</option>
+						<option value="101-500">{ translate( '101–500' ) }</option>
+						<option value="500+">{ translate( '500+' ) }</option>
+					</FormSelect>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="services_offered">
+						{ translate( 'What services do you offer?', {
+							comment:
+								'Possible values are: "Strategy consulting", "Website design & development", "Performance optimization", "Digital strategy & marketing", "Maintenance & support plans".',
+						} ) }
+					</FormLabel>
+					<MultiCheckbox
+						id="services_offered"
+						name="services_offered"
+						checked={ servicesOffered }
+						options={ getServicesOfferedOptions() }
+						onChange={ handleSetServicesOffered }
 					/>
 				</FormFieldset>
 				<FormFieldset>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -1,6 +1,8 @@
 export interface AgencyDetailsPayload {
 	agencyName: string;
 	agencyUrl: string;
+	managedSites?: string;
+	servicesOffered: string[];
 	city: string;
 	line1: string;
 	line2: string;

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -9,5 +9,6 @@ export interface AgencyDetailsPayload {
 	country: string;
 	postalCode: string;
 	state: string;
+	referer?: string | null;
 	tos?: 'consented';
 }

--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -19,6 +19,9 @@ export default function SignupForm() {
 	const dispatch = useDispatch();
 	const notificationId = 'a4a-agency-signup-form';
 
+	const queryParams = new URLSearchParams( window.location.search );
+	const referer = queryParams.get( 'ref' );
+
 	const createAgency = useCreateAgencyMutation( {
 		onSuccess: () => {
 			dispatch( fetchAgencies() );
@@ -46,6 +49,7 @@ export default function SignupForm() {
 					country: payload.country,
 					postal_code: payload.postalCode,
 					state: payload.state,
+					referer: payload.referer,
 				} )
 			);
 		},
@@ -69,6 +73,7 @@ export default function SignupForm() {
 				isLoading={ createAgency.isPending }
 				onSubmit={ onSubmit }
 				submitLabel={ translate( 'Continue' ) }
+				referer={ referer }
 			/>
 		</Card>
 	);

--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -42,7 +42,7 @@ export default function SignupForm() {
 					name: payload.agencyName,
 					business_url: payload.agencyUrl,
 					managed_sites: payload.managedSites,
-					services_offered: payload.servicesOffered,
+					services_offered: ( payload.servicesOffered || [] ).join( ',' ),
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,

--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -38,6 +38,8 @@ export default function SignupForm() {
 				recordTracksEvent( 'calypso_a4a_create_agency_submit', {
 					name: payload.agencyName,
 					business_url: payload.agencyUrl,
+					managed_sites: payload.managedSites,
+					services_offered: payload.servicesOffered,
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,

--- a/client/components/forms/multi-checkbox/index.tsx
+++ b/client/components/forms/multi-checkbox/index.tsx
@@ -15,7 +15,7 @@ interface Option< T = OptionValue > {
 	label: string;
 }
 
-interface ChangeList< T = OptionValue > {
+export interface ChangeList< T = OptionValue > {
 	value: T[];
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR adds a few additional fields to the agency signup form:
- Number of managed sites
- Services offered
- Referral (coming from the `?ref=` GET parameter)

## Testing Instructions

In case you already have an agency account, it would be easier to start with a new WordPress.com account.

- Checkout this branch locally and run the A4A environment
- Visit http://agencies.localhost:3000/signup
- Verify that the signup form work as expected and the new fields are stored correctly on the backend. Testing instruction here D142696-code might help.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?