### PR TITLE
Help Center: Fix usage of wp_localize_script

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -103,7 +103,9 @@ class Help_Center {
 		wp_localize_script(
 			'help-center-script',
 			'helpCenterLocale',
-			\A8C\FSE\Common\get_iso_639_locale( determine_locale() )
+			array(
+				'locale' => \A8C\FSE\Common\get_iso_639_locale( determine_locale() ),
+			)
 		);
 
 		// Adds feature flags for development.

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/CalypsoStateProvider.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/CalypsoStateProvider.js
@@ -41,7 +41,7 @@ const currentSite = window.helpCenterData.currentSite;
 currentSite && store.dispatch( setSelectedSiteId( currentSite.ID ) );
 store.dispatch( setSection( { name: section } ) );
 
-i18n.configure( { defaultLocaleSlug: window.helpCenterLocale } );
+i18n.configure( { defaultLocaleSlug: window.helpCenterLocale?.locale } );
 
 rawCurrentUserFetch()
 	.then( filterUserObject )

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -91,7 +91,7 @@ registerPlugin( 'etk-help-center', {
 		return (
 			<QueryClientProvider client={ whatsNewQueryClient }>
 				<CalypsoStateProvider>
-					<LocaleProvider localeSlug={ window.helpCenterLocale }>
+					<LocaleProvider localeSlug={ window.helpCenterLocale?.locale }>
 						<HelpCenterContent />
 					</LocaleProvider>
 				</CalypsoStateProvider>


### PR DESCRIPTION
Context: p1711093043892119-slack-C03N25JPCE4

In the help center, `wp_localize_script` was used passing a string to it, not an array.
This PR fixes this.

## Testing

1. Sync to ETK
2. Visit Editor of a sandboxed site
3. Check that translations still work