### PR TITLE
Related Posts: Remove temporary "Related posts" section from Traffic settings

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useEffect } from 'react';
@@ -16,7 +15,6 @@ import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mod
 import JetpackSiteStats from 'calypso/my-sites/site-settings/jetpack-site-stats';
 import SeoSettingsHelpCard from 'calypso/my-sites/site-settings/seo-settings/help';
 import SiteVerification from 'calypso/my-sites/site-settings/seo-settings/site-verification';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import Shortlinks from 'calypso/my-sites/site-settings/shortlinks';
 import Sitemaps from 'calypso/my-sites/site-settings/sitemaps';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
@@ -82,26 +80,6 @@ const SiteSettingsTraffic = ( {
 					require="calypso/my-sites/site-settings/seo-settings/form"
 					placeholder={ null }
 				/>
-			) }
-			{ isAdmin && (
-				<>
-					<SettingsSectionHeader
-						id="related-posts-settings"
-						title={ translate( 'Related posts' ) }
-					/>
-					<Card className="site-settings__card">
-						<em>
-							{ translate(
-								'Related posts configuration has moved to the {{a}}Settings > Reading{{/a}}.',
-								{
-									components: {
-										a: <a href={ `/settings/reading/${ siteSlug }#related-posts-settings` } />,
-									},
-								}
-							) }
-						</em>
-					</Card>
-				</>
 			) }
 			{ ! isJetpack && isAdmin && config.isEnabled( 'cloudflare' ) && (
 				<CloudflareAnalyticsSettings />


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/86897.

## Proposed Changes

* remove temporary "Related posts" section from Traffic settings; this section was originally introduced in https://github.com/Automattic/wp-calypso/pull/86851

![Markup on 2024-03-22 at 12:07:55](https://github.com/Automattic/wp-calypso/assets/25105483/49854bd5-9ed5-415a-af84-0f7975e94c98)

## Testing Instructions

1. Navigate to http://calypso.localhost:3000/marketing/traffic/.
2. There should be no "Related posts" section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?