### PR TITLE
Stats: Remove redundant top posts query

### DIFF
--- a/client/my-sites/stats/hooks/use-utm-metric-top-posts-query.ts
+++ b/client/my-sites/stats/hooks/use-utm-metric-top-posts-query.ts
@@ -13,6 +13,9 @@ export default function useUTMMetricTopPostsQuery(
 	const dispatch = useDispatch();
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 
+	// TODO: Remove this hook.
+	// Logic here no longer works as the metrics object
+	// contains all the necessary children.
 	const metricsKey = JSON.stringify( metrics );
 	useEffect( () => {
 		if ( JSON.parse( metricsKey ).length > 0 ) {

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -7,7 +7,6 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { isA8CSpecialBlog } from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
 import useStatsPurchases from '../hooks/use-stats-purchases';
-import useUTMMetricTopPostsQuery from '../hooks/use-utm-metric-top-posts-query';
 import useUTMMetricsQuery from '../hooks/use-utm-metrics-query';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleDataQuery from '../stats-module/stats-module-data-query';
@@ -34,14 +33,12 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	const { isFetching: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
 	const { isLoading: isLoadingFeatureCheck, supportCommercialUse } = useStatsPurchases( siteId );
 	// Fetch UTM metrics with switched UTM parameters.
-	const { isFetching: isFetchingUTM, metrics } = useUTMMetricsQuery(
+	const { isFetching: isFetchingUTM, metrics: data } = useUTMMetricsQuery(
 		siteId,
 		selectedOption,
 		query,
 		postId
 	);
-	// Fetch top posts for all UTM metric items.
-	const { topPosts } = useUTMMetricTopPostsQuery( siteId, selectedOption, metrics );
 
 	const isSiteInternal =
 		isA8CSpecialBlog( siteId ) || ( ! isFetchingUsage && usageData?.is_internal );
@@ -49,21 +46,6 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	const isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse;
 
 	// TODO: trigger useUTMMetricsQuery manually once isAdvancedFeatureEnabled === true
-
-	// Combine metrics with top posts.
-	const data = metrics.map( ( metric ) => {
-		const paramValues = metric.paramValues;
-		const children = topPosts[ paramValues ] || [];
-
-		if ( ! children.length ) {
-			return metric;
-		}
-
-		return {
-			...metric,
-			children,
-		};
-	} );
 
 	// Hide the module if the specific post is the Home page.
 	if ( postId === 0 ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87567.

## Proposed Changes

Removes call to `useUTMMetricTopPostsQuery` now that `useUTMMetricsQuery` returns all the necessary data. The hook was still being called but the logic failed in such a way as to not trigger any network requests or disrupt things.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Traffic page and confirm the UTM module still displays data from the API.
* Visit the summary page and confirm it works there too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?