### PR TITLE
Patterns: sticky pattern nav and adjusted home button

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -304,20 +304,20 @@ export const PatternLibrary = ( {
 						/>
 					</PatternLibraryBody>
 				) }
+
+				{ isHomePage && <PatternsCopyPasteInfo /> }
+
+				{ isHomePage && (
+					<CategoryGallery
+						title={ translate_not_yet( 'Beautifully curated page layouts' ) }
+						description={ translate_not_yet(
+							'Start even faster with ready-to-use pages and preassembled patterns. Then tweak the design until it’s just right.'
+						) }
+						categories={ categories?.filter( ( c ) => c.pagePatternCount ) }
+						patternTypeFilter={ PatternTypeFilter.PAGES }
+					/>
+				) }
 			</div>
-
-			{ isHomePage && <PatternsCopyPasteInfo /> }
-
-			{ isHomePage && (
-				<CategoryGallery
-					title={ translate_not_yet( 'Beautifully curated page layouts' ) }
-					description={ translate_not_yet(
-						'Start even faster with ready-to-use pages and preassembled patterns. Then tweak the design until it’s just right.'
-					) }
-					categories={ categories?.filter( ( c ) => c.pagePatternCount ) }
-					patternTypeFilter={ PatternTypeFilter.PAGES }
-				/>
-			) }
 
 			<PatternsGetStarted />
 		</>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -5,12 +5,7 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
-import {
-	Icon,
-	starEmpty as iconStar,
-	category as iconCategory,
-	menu as iconMenu,
-} from '@wordpress/icons';
+import { Icon, category as iconCategory, menu as iconMenu } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
@@ -213,15 +208,10 @@ export const PatternLibrary = ( {
 					selectedCategoryId={ category }
 					buttons={ [
 						{
-							icon: <Icon icon={ iconStar } size={ 30 } />,
-							label: translate_not_yet( 'Discover' ),
-							link: addLocaleToPathLocaleInFront( '/patterns' ),
-							isActive: isHomePage,
-						},
-						{
 							icon: <Icon icon={ iconCategory } size={ 26 } />,
 							label: translate_not_yet( 'All Categories' ),
-							link: '/222',
+							link: addLocaleToPathLocaleInFront( '/patterns' ),
+							isActive: isHomePage,
 						},
 					] }
 					categories={ categoryNavList }

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -203,106 +203,108 @@ export const PatternLibrary = ( {
 				title={ translate_not_yet( 'It’s Easier With Patterns' ) }
 			/>
 
-			<div className="pattern-library__pill-navigation">
-				<CategoryPillNavigation
-					selectedCategoryId={ category }
-					buttons={ [
-						{
-							icon: <Icon icon={ iconCategory } size={ 26 } />,
-							label: translate_not_yet( 'All Categories' ),
-							link: addLocaleToPathLocaleInFront( '/patterns' ),
-							isActive: isHomePage,
-						},
-					] }
-					categories={ categoryNavList }
-				/>
-			</div>
+			<div className="pattern-library__wrapper">
+				<div className="pattern-library__pill-navigation">
+					<CategoryPillNavigation
+						selectedCategoryId={ category }
+						buttons={ [
+							{
+								icon: <Icon icon={ iconCategory } size={ 26 } />,
+								label: translate_not_yet( 'All Categories' ),
+								link: addLocaleToPathLocaleInFront( '/patterns' ),
+								isActive: isHomePage,
+							},
+						] }
+						categories={ categoryNavList }
+					/>
+				</div>
 
-			{ isHomePage && (
-				<CategoryGallery
-					title={ translate_not_yet( 'Ship faster, ship more' ) }
-					description={ translate_not_yet(
-						'Choose from a library of beautiful, functional design patterns to build exactly the page you—or your client—need, in no time.'
-					) }
-					categories={ categories }
-					patternTypeFilter={ PatternTypeFilter.REGULAR }
-				/>
-			) }
+				{ isHomePage && (
+					<CategoryGallery
+						title={ translate_not_yet( 'Ship faster, ship more' ) }
+						description={ translate_not_yet(
+							'Choose from a library of beautiful, functional design patterns to build exactly the page you—or your client—need, in no time.'
+						) }
+						categories={ categories }
+						patternTypeFilter={ PatternTypeFilter.REGULAR }
+					/>
+				) }
 
-			{ ! isHomePage && (
-				<PatternLibraryBody className="pattern-library">
-					<div className="pattern-library__header">
-						<h1 className="pattern-library__title">
-							{ searchTerm
-								? translate_not_yet( '%(count)d pattern', '%(count)d patterns', {
-										count: patterns.length,
-										args: { count: patterns.length },
-								  } )
-								: translate_not_yet( 'Patterns' ) }
-						</h1>
+				{ ! isHomePage && (
+					<PatternLibraryBody className="pattern-library">
+						<div className="pattern-library__header">
+							<h1 className="pattern-library__title">
+								{ searchTerm
+									? translate_not_yet( '%(count)d pattern', '%(count)d patterns', {
+											count: patterns.length,
+											args: { count: patterns.length },
+									  } )
+									: translate_not_yet( 'Patterns' ) }
+							</h1>
 
-						{ category && !! categoryObject?.pagePatternCount && (
+							{ category && !! categoryObject?.pagePatternCount && (
+								<ToggleGroupControl
+									className="pattern-library__toggle--pattern-type"
+									isBlock
+									label=""
+									onChange={ ( value ) => {
+										const href =
+											getCategoryUrlPath( category, value as PatternTypeFilter ) +
+											( isGridView ? '?grid=1' : '' );
+										recordClickEvent(
+											'calypso_pattern_library_type_switch',
+											currentView,
+											value as PatternTypeFilter
+										);
+										page( href );
+									} }
+									value={ patternTypeFilter }
+								>
+									<ToggleGroupControlOption
+										className="pattern-library__toggle-option"
+										label={ translate_not_yet( 'Patterns' ) }
+										value={ PatternTypeFilter.REGULAR }
+									/>
+									<ToggleGroupControlOption
+										className="pattern-library__toggle-option"
+										label={ translate_not_yet( 'Page layouts' ) }
+										value={ PatternTypeFilter.PAGES }
+									/>
+								</ToggleGroupControl>
+							) }
+
 							<ToggleGroupControl
-								className="pattern-library__toggle--pattern-type"
-								isBlock
+								className="pattern-library__toggle--view"
 								label=""
-								onChange={ ( value ) => {
-									const href =
-										getCategoryUrlPath( category, value as PatternTypeFilter ) +
-										( isGridView ? '?grid=1' : '' );
-									recordClickEvent(
-										'calypso_pattern_library_type_switch',
-										currentView,
-										value as PatternTypeFilter
-									);
-									page( href );
-								} }
-								value={ patternTypeFilter }
+								isBlock
+								value={ isGridView ? 'grid' : 'list' }
 							>
 								<ToggleGroupControlOption
-									className="pattern-library__toggle-option"
-									label={ translate_not_yet( 'Patterns' ) }
-									value={ PatternTypeFilter.REGULAR }
+									className="pattern-library__toggle-option--list-view"
+									label={ ( <Icon icon={ iconMenu } size={ 20 } /> ) as unknown as string }
+									value="list"
+									onClick={ () => handleViewChange( 'list' ) }
 								/>
 								<ToggleGroupControlOption
-									className="pattern-library__toggle-option"
-									label={ translate_not_yet( 'Page layouts' ) }
-									value={ PatternTypeFilter.PAGES }
+									className="pattern-library__toggle-option--grid-view"
+									label={ ( <Icon icon={ iconCategory } size={ 20 } /> ) as unknown as string }
+									value="grid"
+									onClick={ () => handleViewChange( 'grid' ) }
 								/>
 							</ToggleGroupControl>
-						) }
+						</div>
 
-						<ToggleGroupControl
-							className="pattern-library__toggle--view"
-							label=""
-							isBlock
-							value={ isGridView ? 'grid' : 'list' }
-						>
-							<ToggleGroupControlOption
-								className="pattern-library__toggle-option--list-view"
-								label={ ( <Icon icon={ iconMenu } size={ 20 } /> ) as unknown as string }
-								value="list"
-								onClick={ () => handleViewChange( 'list' ) }
-							/>
-							<ToggleGroupControlOption
-								className="pattern-library__toggle-option--grid-view"
-								label={ ( <Icon icon={ iconCategory } size={ 20 } /> ) as unknown as string }
-								value="grid"
-								onClick={ () => handleViewChange( 'grid' ) }
-							/>
-						</ToggleGroupControl>
-					</div>
-
-					<PatternGallery
-						getPatternPermalink={ ( pattern ) =>
-							getPatternPermalink( pattern, category, patternTypeFilter, categories )
-						}
-						isGridView={ isGridView }
-						patterns={ patterns }
-						patternTypeFilter={ patternTypeFilter }
-					/>
-				</PatternLibraryBody>
-			) }
+						<PatternGallery
+							getPatternPermalink={ ( pattern ) =>
+								getPatternPermalink( pattern, category, patternTypeFilter, categories )
+							}
+							isGridView={ isGridView }
+							patterns={ patterns }
+							patternTypeFilter={ patternTypeFilter }
+						/>
+					</PatternLibraryBody>
+				) }
+			</div>
 
 			{ isHomePage && <PatternsCopyPasteInfo /> }
 

--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -2,8 +2,15 @@
 @import "@automattic/components/src/styles/typography";
 @import "calypso/my-sites/patterns/mixins";
 
+.pattern-library__wrapper {
+	position: relative;
+}
+
 .pattern-library__pill-navigation {
 	background: var(--studio-white);
+	position: sticky;
+	top: 0;
+	z-index: 3;
 
 	.category-pill-navigation {
 		@include patterns-page-width;
@@ -23,6 +30,12 @@
 
 .pattern-library__pill-navigation + .patterns-section {
 	padding-top: 48px;
+}
+
+.is-logged-in {
+	&.is-section-patterns .pattern-library__pill-navigation {
+		top: var(--masterbar-height);
+	}
 }
 
 .pattern-library {

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -3,6 +3,7 @@
 .is-section-patterns {
 	.layout__content {
 		padding: 0;
+		overflow: visible; // necessary for sticky CategoryPillNavigation
 
 		.masterbar {
 			// Makes sure the navigation bar header appears below the masterbar and notices


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6200 and https://github.com/Automattic/dotcom-forge/issues/6201

## Proposed Changes
1) We are removing `Discover` button from navigation and keep only `All categories` as "Home" button
2) We make navigation as a sticky component

## Testing Instructions
1) Open `/patterns/*`
2) Scroll down and assert that it's sticky
3) Log out and assert that it still sticks well
4) You can try to click on pills in navigation and assert that everything look good. I am thinkinking - should we scroll the page to top after changing category... As initial approach I would go w/o scrolling.

