### PR TITLE
A4A: Add missing CSS Styles - Fix the feature column styles 

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -488,4 +488,474 @@
 			display: none;
 		}
 	}
+
+	.sites-overview__add-site-issue-license-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		> a,
+		> button {
+			font-size: 1rem;
+			box-sizing: border-box;
+			max-height: 40px;
+		}
+
+		@include break-large {
+			flex-direction: row;
+		}
+	}
+
+
+	.sites-overview__add-site-issue-license-buttons.is-with-split-button {
+		flex-direction: row;
+
+		> a {
+			flex-grow: 1;
+		}
+
+		.split-button {
+			display: flex;
+		}
+
+		.split-button__main {
+			flex-grow: 1;
+		}
+
+		@include break-small {
+			> a {
+				flex-grow: 0;
+			}
+		}
+	}
+
+	.sites-overview__add-new-site {
+		white-space: nowrap;
+	}
+
+	.sites-overview__column-action-button {
+		max-width: 100%;
+		display: inline-flex;
+		flex-direction: row;
+		justify-content: center;
+		align-items: center;
+		width: fit-content;
+		height: 22px;
+		background: var(--studio-white);
+		box-sizing: border-box;
+		border-radius: 12px; /* stylelint-disable-line scales/radii */
+		font-weight: 500;
+		font-size: 0.75rem;
+		vertical-align: middle;
+		color: var(--studio-gray-80);
+		border: 1px solid var(--studio-gray-5);
+		padding: 2px 11px;
+		cursor: pointer;
+		white-space: nowrap;
+
+		span {
+			margin: 0 0.2em;
+		}
+		svg {
+			margin-inline-start: -0.4em;
+		}
+		&:hover:not(.is-link) {
+			background: var(--studio-gray-80);
+			color: var(--studio-white);
+		}
+
+		&:visited:not(:hover) {
+			color: var(--studio-gray-80);
+		}
+
+		&.is-selected {
+			background: var(--studio-jetpack-green-50);
+			color: var(--studio-white);
+			border: none;
+		}
+
+		&.is-link {
+			border: none;
+			background: none;
+			text-decoration: underline;
+			outline: none;
+			margin: 0;
+			padding: 0;
+
+			&:hover {
+				color: var(--studio-gray-80);
+			}
+		}
+	}
+
+	.sites-overview__grey-icon {
+		vertical-align: middle;
+		color: var(--studio-gray-40);
+	}
+	.sites-overview__icon-active {
+		vertical-align: middle;
+		color: var(--studio-gray-5);
+	}
+	.sites-overview__stats-trend__up,
+	.sites-overview__stats-trend__down {
+		vertical-align: middle;
+		display: inline-flex;
+		margin-inline-start: -5px;
+	}
+	.sites-overview__stats-trend__up {
+		fill: var(--studio-jetpack-green-40);
+	}
+	.sites-overview__stats-trend__down {
+		fill: var(--studio-red-50);
+	}
+	.sites-overview__stats-trend__same .empty-icon {
+		vertical-align: middle;
+		height: 8px;
+		width: 8px;
+		border-radius: 50%;
+		background: var(--studio-gray-5);
+		display: inline-flex;
+		margin-inline-end: 5px;
+		@media screen and (max-width: $break-xlarge) {
+			margin-block-start: 8px;
+		}
+	}
+	.sites-overview__stats .shortened-number,
+	.sites-overview__stats-trend .shortened-number {
+		vertical-align: middle;
+		color: var(--studio-gray-80);
+		font-size: 0.75rem;
+	}
+	.sites-overview__stats-trend svg {
+		position: relative;
+		inset-block-start: 0.3rem;
+		@media screen and (max-width: $break-xlarge) {
+			inset-block-start: 0.27rem;
+		}
+	}
+	.sites-overview__disabled {
+		color: var(--studio-gray-5);
+		cursor: not-allowed;
+		opacity: 0.5;
+		button {
+			pointer-events: none;
+		}
+	}
+	.sites-overview__row-text {
+		display: inline-block;
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: clip;
+		vertical-align: middle;
+		color: var(--studio-gray-100);
+		align-items: center;
+		@include break-zoomed-in {
+			width: calc(100% - 120px);
+			margin-inline-start: 8px;
+			margin-inline-end: 5px;
+			font-size: 1rem !important;
+		}
+	}
+
+	.site-host-info {
+		display: inline-block;
+		margin-inline-end: 10px;
+		min-width: 40px;
+		text-align: center;
+
+		.wordpress-logo {
+			display: inline-block;
+			fill: var(--studio-blue-50);
+			visibility: hidden;
+			margin: auto 0;
+
+			&.is-visible {
+				visibility: visible;
+			}
+		}
+	}
+
+	.sites-overview__error-container {
+		background: #414141;
+		margin: 0 -6px;
+		display: flex;
+		align-items: center;
+		height: 40px;
+		position: relative;
+	}
+	.sites-overview__error-icon {
+		background: #d94f4f;
+		padding: 11px;
+		color: var(--studio-white);
+		width: 5%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	.sites-overview__error-message {
+		font-size: 0.75rem;
+		color: var(--studio-white);
+		padding: 0.5em;
+		margin: auto 0;
+	}
+	.sites-overview__error-message-large-screen {
+		display: none;
+		@include break-wide {
+			display: inline-block;
+		}
+	}
+	.sites-overview__error-message-small-screen {
+		display: inline-block;
+		@include break-wide {
+			display: none;
+		}
+	}
+	.sites-overview__error-message-link {
+		font-size: 0.75rem;
+		color: var(--studio-white) !important;
+		padding: 6px;
+		position: absolute;
+		inset-inline-end: 16px;
+		text-decoration: underline;
+		font-weight: 500;
+	}
+	.sites-overview__badge {
+		font-size: 0.75rem !important;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		vertical-align: middle;
+		@include break-wide {
+			max-width: 70px;
+		}
+		@include break-wide() {
+			max-width: fit-content;
+		}
+	}
+
+	.sites-overview__stats {
+		color: var(--studio-black);
+		display: inline-block;
+		line-height: 17px;
+		height: 18px;
+		padding: 2px 1px;
+	}
+	.sites-overview__tooltip {
+		.popover__arrow {
+			&::before {
+				border-bottom-color: var(--studio-gray-60) !important;
+				inset-block-start: 1px !important;
+			}
+		}
+		.popover__inner {
+			background: var(--studio-gray-60);
+			color: var(--studio-white);
+			padding: 10px 12px;
+			border: none;
+		}
+	}
+	.sites-overview__status-critical {
+		color: var(--studio-red-50);
+		position: absolute;
+		inset-inline-end: 42px;
+		inset-block-start: 50%;
+		transform: translateY(-50%);
+		display: inline-flex;
+	}
+	.sites-overview__status-count {
+		position: absolute;
+		inset-inline-end: 42px;
+		inset-block-start: 50%;
+		transform: translateY(-50%);
+		border-radius: 50%;
+		border-width: 2px;
+		border-style: solid;
+		width: 24px;
+		height: 24px;
+		text-align: center;
+		font-size: 0.75rem;
+		line-height: 20px;
+		box-sizing: border-box;
+	}
+	.sites-overview__status-failed {
+		background-color: var(--studio-red-50);
+		border-color: var(--studio-red-50);
+		color: var(--color-text-inverted);
+	}
+	.sites-overview__status-warning {
+		background-color: var(--studio-yellow-20);
+		border-color: var(--studio-yellow-20);
+		color: var(--color-warning-80);
+	}
+	@keyframes highlight-tab-animation {
+		0% {
+			background: var(--color-neutral-70);
+		}
+		100% {
+			background: unset;
+		}
+	}
+	@keyframes highlight-tab-animation-count {
+		0% {
+			color: var(--color-text-inverted);
+		}
+		100% {
+			color: unset;
+		}
+	}
+	@keyframes highlight-tab-animation-icon {
+		0% {
+			fill: var(--color-text-inverted);
+		}
+		100% {
+			fill: unset;
+		}
+	}
+	.sites-overview__highlight-tab.section-nav {
+		animation: highlight-tab-animation 0.4s linear;
+		.section-nav__mobile-header-text {
+			animation: highlight-tab-animation-count 0.4s linear;
+		}
+		.section-nav__mobile-header .gridicon {
+			animation: highlight-tab-animation-icon 0.4s linear;
+		}
+	}
+	.sites-overview__no-sites {
+		text-align: center;
+		font-size: 1.5rem;
+		margin-top: 16px;
+	}
+
+	.sites-overview__issue-licenses-button-small-screen {
+		position: fixed;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		padding: 1rem;
+		background: var(--studio-white);
+		box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.12);
+		z-index: 20;
+
+		.sites-overview__licenses-buttons-issue-license {
+			width: 70%;
+			max-width: 275px;
+		}
+
+		@include break-mobile {
+			text-align: right;
+		}
+
+		@include breakpoint-deprecated( ">660px" ) {
+			left: var(--sidebar-width-min);
+			padding: 0.5rem;
+		}
+	}
+
+	.sites-overview__column-content {
+		font-size: 0.75rem !important;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		vertical-align: middle;
+	}
+
+	.sites-overview__warning {
+		@extend .sites-overview__column-content;
+		color: var(--color-warning-50);
+	}
+
+	.sites-overview__failed {
+		@extend .sites-overview__column-content;
+		color: var(--studio-red-50);
+	}
+
+	.sites-overview__critical {
+		@extend .sites-overview__column-content;
+		padding: 15px;
+		color: var(--studio-red-50);
+	}
+
+	@mixin boost-score-style($color, $background-color) {
+		@extend .sites-overview__column-content;
+		color: $color;
+		background-color: $background-color;
+
+		&:hover,
+		&:active,
+		&:focus {
+			color: $color;
+			background-color: $background-color;
+		}
+	}
+
+	a.sites-overview__boost-score {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 50%;
+		width: 24px;
+		height: 24px;
+		font-weight: 500;
+		user-select: none;
+
+		&.boost-score-good {
+			@include boost-score-style(var(--studio-green-50), var(--studio-green-0));
+		}
+
+		&.boost-score-okay {
+			@include boost-score-style(var(--studio-yellow-50), var(--studio-yellow-0));
+		}
+
+		&.boost-score-bad {
+			@include boost-score-style(var(--studio-red-50), var(--studio-red-0));
+		}
+	}
+
+	.width-fit-content {
+		width: fit-content !important;
+	}
+
+	.site-content__small-screen-view {
+		.sites-overview__icon-active {
+			position: relative;
+			left: 4px;
+		}
+	}
+
+	.fixed-site-column {
+		max-width: 140px !important;
+		min-width: 140px !important;
+	}
+
+	.cursor-pointer {
+		cursor: pointer;
+	}
+
+	.is-loading {
+		opacity: 0.5;
+	}
+
+	.margin-top-16 {
+		margin-top: 16px;
+	}
+
+	.sites-dataviews__favorite-btn-wrapper {
+		position: relative;
+
+		.site-set-favorite__favorite-icon {
+			visibility: hidden;
+			color: var(--color-primary);
+		}
+
+		button.site-set-favorite__favorite-icon {
+			position: unset;
+		}
+
+		&:hover {
+			.site-set-favorite__favorite-icon {
+				visibility: visible;
+			}
+		}
+	}
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -342,6 +342,10 @@
 			width: 86%;
 			margin-right: 6px;
 		}
+
+		.site-preview__open {
+			display: none;
+		}
 	}
 
 	&.sites-dashboard__layout:not(.preview-hidden) .a4a-layout__navigation-wrapper {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/105
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/93

## Proposed Changes

* This PR adds missing CSS Styles that were not ported from Jetpack Manage. The most notable differences are the missing styles in the feature columns, and the caret button being visible while the preview pane is open.

## Testing Instructions

* Go to the A4A sites dashboard ( `agencies.localhost:3000/sites` )
* Check if the feature column styles match our previous design from Jetpack Manage
* Check if the caret button is hidden when the preview pane is open

Before:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/690ed925-e09e-4549-a2c5-4d0a2c3dbef3)

![image](https://github.com/Automattic/wp-calypso/assets/37049295/89e0d5fc-fe52-4ffb-85ef-a1c430bd0cfe)


After:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/43e0b063-4bb9-4a80-bb04-7b54f6096b68)

![image](https://github.com/Automattic/wp-calypso/assets/37049295/00a6048a-20ef-4ba1-8e73-a7fdaf642622)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?