### PR TITLE
Magic link: Better notice on error

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -74,6 +74,7 @@
 	&.is-transparent-info {
 		background: unset;
 		color: var(--color-error-40);
+		margin-bottom: 0;
 
 		&.is-compact {
 			.notice__icon-wrapper-drop {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -95,8 +95,8 @@
 
 		.notice__icon-wrapper {
 			background: transparent;
-			align-items: flex-start;
-			padding-top: 13px;
+			align-items: center;
+			padding: 0;
 		}
 		.notice__icon-wrapper-drop {
 			background: var(--color-error);

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -218,16 +218,6 @@ class RequestLoginEmailForm extends Component {
 				<h1 className="magic-login__form-header">
 					{ headerText || translate( 'Email me a login link' ) }
 				</h1>
-				{ requestError && (
-					<Notice
-						// duration={ 10000 }
-						text={ errorText }
-						className="magic-login__request-login-email-form-notice"
-						showDismiss={ false }
-						onDismissClick={ this.onNoticeDismiss }
-						status="is-transparent-info"
-					/>
-				) }
 				{ currentUser && currentUser.username && (
 					<p>
 						{ translate( 'NOTE: You are already logged in as user: %(user)s', {
@@ -254,6 +244,16 @@ class RequestLoginEmailForm extends Component {
 							placeholder={ inputPlaceholder }
 						/>
 						{ tosComponent }
+						{ requestError && (
+							<Notice
+								duration={ 10000 }
+								text={ errorText }
+								className="magic-login__request-login-email-form-notice"
+								showDismiss={ false }
+								onDismissClick={ this.onNoticeDismiss }
+								status="is-transparent-info"
+							/>
+						) }
 						<div className="magic-login__form-action">
 							<FormButton primary disabled={ ! submitEnabled }>
 								{ submitButtonLabel || buttonLabel }

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -220,12 +220,12 @@ class RequestLoginEmailForm extends Component {
 				</h1>
 				{ requestError && (
 					<Notice
-						duration={ 10000 }
+						// duration={ 10000 }
 						text={ errorText }
 						className="magic-login__request-login-email-form-notice"
-						showDismiss={ true }
+						showDismiss={ false }
 						onDismissClick={ this.onNoticeDismiss }
-						status="is-error"
+						status="is-transparent-info"
 					/>
 				) }
 				{ currentUser && currentUser.username && (


### PR DESCRIPTION
## Before

<img width="1136" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/638f54f6-357a-4c1d-9416-62b5948a2e57">

## After

<img width="928" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/011ca2b5-2433-4a25-a33a-737352562ecc">

## Testing

1. Visit `/log-in/link` and use your A8C email
2. Check the notice