### PR TITLE
Stats: Fix for unexpected elements in referrers export.

### DIFF
--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -26,6 +26,23 @@ class StatsDownloadCsv extends Component {
 		borderless: PropTypes.bool,
 	};
 
+	processExportData = ( data ) => {
+		const { statType } = this.props;
+		if ( statType !== 'statsReferrers' ) {
+			return data;
+		}
+		// Work-around for a bug in the referrers data.
+		// Can include unexpected elements in the data array.
+		// Results in "[object Object]" in the CSV output.
+		// To avoid this, we only include the first two elements of each row.
+		return data.map( ( row ) => {
+			if ( Array.isArray( row ) ) {
+				return row.slice( 0, 2 );
+			}
+			return row;
+		} );
+	};
+
 	downloadCsv = ( event ) => {
 		event.preventDefault();
 		const { siteSlug, path, period, data } = this.props;
@@ -41,7 +58,7 @@ class StatsDownloadCsv extends Component {
 
 		this.props.recordGoogleEvent( 'Stats', 'CSV Download ' + titlecase( path ) );
 
-		const csvData = data
+		const csvData = this.processExportData( data )
 			.map( ( row ) => {
 				if ( Array.isArray( row ) ) {
 					return row.join( ',' );


### PR DESCRIPTION
The rows we get back from the `getSiteStatsCSVData()` call can contain unexpected data. For now we just trim the rows before export to avoid dumping those elements into the CSV output.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88804.

## Proposed Changes

Trim extra data from the set before converting into a CSV string. We just want the label and the value. I'm not seeing this behaviour with any of the other summary pages so this workaround is specific to `statsReferrers`. It should be fine until we can move this over to a simplified Tanstack query.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Referrers summary page.
* Click the "Download data as CSV" link.
* Confirm the CSV output looks correct. (example below)
* Confirm there aren't any "[object Object]" strings in the output.

```
"Search Engines",2584
"Search Engines > Google Search",2453
"Search Engines > Google Search > google.com",2382
"Search Engines > Google Search > google.co.in",12
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?