### PR TITLE
A4A: Small refactor copying some components from Manage to A4A and to create features folders

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/features.ts
+++ b/client/a8c-for-agencies/sections/sites/features/features.ts
@@ -1,0 +1,8 @@
+// Jetpack features IDs
+export const JETPACK_BOOST_ID = 'jetpack_boost';
+export const JETPACK_BACKUP_ID = 'jetpack_backup';
+export const JETPACK_SCAN_ID = 'jetpack_scan';
+export const JETPACK_MONITOR_ID = 'jetpack_monitor';
+export const JETPACK_STATS_ID = 'jetpack_stats';
+export const JETPACK_PLUGINS_ID = 'jetpack_plugins';
+export const JETPACK_ACTIVITY_ID = 'jetpack_activity';

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/activity/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/activity/index.tsx
@@ -1,0 +1,13 @@
+import ActivityLogV2 from 'calypso/my-sites/activity/activity-log-v2';
+import SitePreviewPaneContent from '../../../site-preview-pane/site-preview-pane-content';
+
+import 'calypso/my-sites/activity/activity-log-v2/style.scss';
+import './style.scss';
+
+export function JetpackActivityPreview() {
+	return (
+		<SitePreviewPaneContent>
+			<ActivityLogV2 />
+		</SitePreviewPaneContent>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/activity/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/activity/style.scss
@@ -1,0 +1,3 @@
+.activity-log-v2 {
+	text-align: left;
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-backup.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-backup.tsx
@@ -1,0 +1,12 @@
+import BackupsPage from 'calypso/my-sites/backup/main';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+
+export function JetpackBackupPreview() {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<BackupsPage queryDate={ undefined } />
+			</SitePreviewPaneContent>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-boost.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-boost.tsx
@@ -1,0 +1,21 @@
+import BoostSitePerformance from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../../types';
+
+type Props = {
+	site: Site;
+	trackEvent: ( eventName: string ) => void;
+	hasError?: boolean;
+};
+
+export function JetpackBoostPreview( { site, trackEvent, hasError = false }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<BoostSitePerformance site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -1,0 +1,26 @@
+import MonitorActivity from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../../types';
+
+type Props = {
+	site: Site;
+	trackEvent: ( eventName: string ) => void;
+	hasError?: boolean;
+};
+
+export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<MonitorActivity
+					hasMonitor={ site.monitor_settings.monitor_active }
+					site={ site }
+					trackEvent={ trackEvent }
+					hasError={ hasError }
+				/>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@automattic/components';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
+
+type Props = {
+	featureText: string | React.ReactNode;
+	link: string;
+	linkLabel: string;
+};
+
+export function JetpackPluginsPreview( { featureText, link, linkLabel }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<h3>{ featureText }</h3>
+				<div style={ { marginTop: '40px' } }>
+					<Button href={ link } primary>
+						{ linkLabel }
+					</Button>
+				</div>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -56,7 +56,7 @@ export function JetpackPreviewPane( {
 				JETPACK_BOOST_ID,
 				'Boost',
 				true,
-				selectedSiteFeature ?? JETPACK_BOOST_ID,
+				selectedSiteFeature,
 				setSelectedSiteFeature,
 				<JetpackBoostPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -1,0 +1,129 @@
+import { useTranslate } from 'i18n-calypso';
+import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import {
+	JETPACK_ACTIVITY_ID,
+	JETPACK_BACKUP_ID,
+	JETPACK_BOOST_ID,
+	JETPACK_MONITOR_ID,
+	JETPACK_PLUGINS_ID,
+	JETPACK_SCAN_ID,
+	JETPACK_STATS_ID,
+} from 'calypso/a8c-for-agencies/sections/sites/features/features';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import { useJetpackAgencyDashboardRecordTrackEvent } from 'calypso/jetpack-cloud/sections/agency-dashboard/hooks';
+import SitePreviewPane, { createFeaturePreview } from '../../site-preview-pane';
+import { PreviewPaneProps } from '../../site-preview-pane/types';
+import { JetpackActivityPreview } from './activity';
+import { JetpackBackupPreview } from './jetpack-backup';
+import { JetpackBoostPreview } from './jetpack-boost';
+import { JetpackMonitorPreview } from './jetpack-monitor';
+import { JetpackPluginsPreview } from './jetpack-plugins';
+import { JetpackScanPreview } from './jetpack-scan';
+import { JetpackStatsPreview } from './jetpack-stats';
+
+export function JetpackPreviewPane( {
+	site,
+	closeSitePreviewPane,
+	className,
+	isSmallScreen = false,
+	hasError = false,
+}: PreviewPaneProps ) {
+	const translate = useTranslate();
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
+
+	const trackEvent = useCallback(
+		( eventName: string ) => {
+			recordEvent( eventName );
+		},
+		[ recordEvent ]
+	);
+
+	const { selectedSiteFeature, setSelectedSiteFeature } = useContext( SitesDashboardContext );
+
+	useEffect( () => {
+		if ( selectedSiteFeature === undefined ) {
+			setSelectedSiteFeature( JETPACK_BOOST_ID );
+		}
+		return () => {
+			setSelectedSiteFeature( undefined );
+		};
+	}, [] );
+
+	// Jetpack features: Boost, Backup, Monitor, Stats
+	const features = useMemo(
+		() => [
+			createFeaturePreview(
+				JETPACK_BOOST_ID,
+				'Boost',
+				true,
+				selectedSiteFeature ?? JETPACK_BOOST_ID,
+				setSelectedSiteFeature,
+				<JetpackBoostPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+			),
+			createFeaturePreview(
+				JETPACK_BACKUP_ID,
+				'Backup',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackBackupPreview />
+			),
+			createFeaturePreview(
+				JETPACK_SCAN_ID,
+				'Scan',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackScanPreview sideId={ site.blog_id } />
+			),
+			createFeaturePreview(
+				JETPACK_MONITOR_ID,
+				'Monitor',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackMonitorPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+			),
+			createFeaturePreview(
+				JETPACK_PLUGINS_ID,
+				translate( 'Plugins' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackPluginsPreview
+					link={ '/plugins/manage/' + site.url }
+					linkLabel={ translate( 'Manage Plugins' ) }
+					featureText={ translate( 'Manage all plugins installed on %(siteUrl)s', {
+						args: { siteUrl: site.url },
+					} ) }
+				/>
+			),
+			createFeaturePreview(
+				JETPACK_STATS_ID,
+				'Stats',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackStatsPreview site={ site } trackEvent={ trackEvent } />
+			),
+			createFeaturePreview(
+				JETPACK_ACTIVITY_ID,
+				translate( 'Activity' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackActivityPreview />
+			),
+		],
+		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ]
+	);
+
+	return (
+		<SitePreviewPane
+			site={ site }
+			closeSitePreviewPane={ closeSitePreviewPane }
+			features={ features }
+			className={ className }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-scan.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-scan.tsx
@@ -1,0 +1,53 @@
+import SitePreviewPaneContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content';
+import {
+	showJetpackIsDisconnected,
+	showNotAuthorizedForNonAdmins,
+	showUpsellIfNoScan,
+	showUnavailableForVaultPressSites,
+	scan,
+} from 'calypso/my-sites/scan/controller';
+
+import 'calypso/my-sites/scan/style.scss';
+
+type Props = {
+	sideId: number;
+};
+type ContextHandler = ( context: object, next: () => void ) => void;
+
+// Hack: to simulate the contexts chain
+function processContextsChain( contextsChain: ContextHandler[], context: object ) {
+	const next = ( index: number ) => {
+		if ( index < contextsChain.length ) {
+			contextsChain[ index ]( context, () => next( index + 1 ) );
+		}
+	};
+	next( 0 );
+}
+
+export function JetpackScanPreview( { sideId }: Props ) {
+	const contextsChain: ContextHandler[] = [
+		showNotAuthorizedForNonAdmins,
+		showJetpackIsDisconnected,
+		showUnavailableForVaultPressSites,
+		showUpsellIfNoScan,
+		//wrapInSiteOffsetProvider,
+		scan,
+	];
+
+	const context = {
+		primary: null,
+		params: {
+			site: sideId,
+		},
+	};
+
+	processContextsChain( contextsChain, context );
+
+	return (
+		<>
+			<SitePreviewPaneContent>
+				{ sideId ? context.primary : <div>Loading Scan page...</div> }
+			</SitePreviewPaneContent>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-stats.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-stats.tsx
@@ -1,0 +1,24 @@
+import InsightsStats from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../../types';
+
+type Props = {
+	site: Site;
+	trackEvent: ( eventName: string ) => void;
+};
+
+export function JetpackStatsPreview( { site, trackEvent }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<InsightsStats
+					stats={ site.site_stats }
+					siteUrlWithScheme={ site.url_with_scheme }
+					trackEvent={ trackEvent }
+				/>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/overview/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/overview/index.tsx
@@ -1,0 +1,6 @@
+import { PreviewPaneProps } from 'calypso/a8c-for-agencies/sections/sites/site-preview-pane/types';
+import { JetpackPreviewPane } from '../jetpack/jetpack-preview-pane';
+
+export function OverviewFamily( props: PreviewPaneProps ) {
+	return <JetpackPreviewPane { ...props } />;
+}

--- a/client/a8c-for-agencies/sections/sites/site-favicon/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-favicon/index.tsx
@@ -1,0 +1,30 @@
+import { WordPressLogo } from '@automattic/components';
+import classNames from 'classnames';
+import SiteIcon from 'calypso/blocks/site-icon';
+import { Site } from '../types';
+
+import './style.scss';
+
+interface SiteFaviconProps {
+	site: Site;
+	size?: number;
+	className?: string;
+}
+
+const SiteFavicon = ( { site, size = 40, className = '' }: SiteFaviconProps ) => {
+	const siteColor = site.site_color ?? 'linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4)';
+
+	const defaultFavicon = site.is_atomic ? (
+		<WordPressLogo className="wpcom-favicon" size={ size * 0.8 } />
+	) : (
+		<div className="no-favicon" style={ { background: siteColor } } />
+	);
+
+	return (
+		<div className={ classNames( 'site-favicon', className ) }>
+			<SiteIcon siteId={ site.blog_id } size={ size } defaultIcon={ defaultFavicon } />
+		</div>
+	);
+};
+
+export default SiteFavicon;

--- a/client/a8c-for-agencies/sections/sites/site-favicon/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-favicon/style.scss
@@ -1,0 +1,19 @@
+.site-favicon {
+	margin-right: 16px;
+
+	.site-icon {
+		border-radius: 10px; /* stylelint-disable-line scales/radii */
+		&.is-blank {
+			background: transparent;
+			.wpcom-favicon {
+				fill: var(--studio-blue-50);
+			}
+
+			.no-favicon {
+				width: 100%;
+				height: 100%;
+				background: linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4);
+			}
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/index.tsx
@@ -1,0 +1,97 @@
+import classNames from 'classnames';
+import React, { useEffect, useState } from 'react';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import SitePreviewPaneHeader from './site-preview-pane-header';
+import { FeaturePreviewInterface, PreviewPaneProps } from './types';
+
+import './style.scss';
+
+export const createFeaturePreview = (
+	id: string,
+	label: string,
+	enabled: boolean,
+	selectedFeatureId: string | undefined,
+	setSelectedFeatureId: ( id: string ) => void,
+	preview: React.ReactNode
+): FeaturePreviewInterface => {
+	return {
+		id,
+		tab: {
+			label,
+			visible: enabled,
+			selected: enabled && selectedFeatureId === id,
+			onTabClick: () => enabled && setSelectedFeatureId( id ),
+		},
+		enabled,
+		preview: enabled ? preview : null,
+	};
+};
+
+export default function SitePreviewPane( {
+	site,
+	features,
+	closeSitePreviewPane,
+	className,
+}: PreviewPaneProps ) {
+	const [ canDisplayNavTabs, setCanDisplayNavTabs ] = useState( false );
+
+	// For future iterations lets consider something other than SectionNav due to the
+	// manipulation we need to make so that the navigation shows correctly on some smaller
+	// screens within the PreviewPane (hence the timeout).
+	useEffect( () => {
+		setTimeout( () => {
+			setCanDisplayNavTabs( true );
+		}, 150 );
+	}, [] );
+
+	// Ensure we have features
+	if ( ! features || ! features.length ) {
+		return null;
+	}
+
+	// Find the selected feature or default to the first feature
+	const selectedFeature = features.find( ( feature ) => feature.tab.selected ) || features[ 0 ];
+
+	// Ensure we have a valid feature
+	if ( ! selectedFeature ) {
+		return null;
+	}
+
+	// Extract the tabs from the features
+	const featureTabs = features.map( ( feature ) => ( {
+		key: feature.id,
+		label: feature.tab.label,
+		selected: feature.tab.selected,
+		onClick: feature.tab.onTabClick,
+		visible: feature.tab.visible,
+	} ) );
+
+	const navItems = featureTabs.map( ( featureTab ) => {
+		if ( ! featureTab.visible ) {
+			return null;
+		}
+		return (
+			<NavItem
+				key={ featureTab.key }
+				selected={ featureTab.selected }
+				onClick={ featureTab.onClick }
+			>
+				{ featureTab.label }
+			</NavItem>
+		);
+	} );
+
+	return (
+		<div className={ classNames( 'site-preview__pane', className ) }>
+			<SitePreviewPaneHeader site={ site } closeSitePreviewPane={ closeSitePreviewPane } />
+			<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
+				{ navItems && navItems.length > 0 && canDisplayNavTabs ? (
+					<NavTabs>{ navItems }</NavTabs>
+				) : null }
+			</SectionNav>
+			{ selectedFeature.preview }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/index.tsx
@@ -1,0 +1,13 @@
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+type Props = {
+	children?: ReactNode;
+	className?: string;
+};
+
+export default function SitePreviewPaneContent( { children, className }: Props ) {
+	return <div className={ classNames( 'site-preview__content', className ) }>{ children }</div>;
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -1,0 +1,16 @@
+.site-preview__content {
+	flex-grow: 1;
+	background-color: var(--studio-white);
+	padding: 48px;
+	text-align: center;
+	overflow-y: auto;
+
+	.expanded-card {
+		max-width: 320px;
+		width: auto;
+
+		.site-expanded-content__card-footer {
+			justify-content: center;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-footer/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-footer/index.tsx
@@ -1,0 +1,17 @@
+import classNames from 'classnames';
+import './style.scss';
+
+type Props = {
+	children?: React.ReactNode;
+	className?: string;
+};
+
+export default function SitePreviewPaneFooter( { children, className }: Props ) {
+	return (
+		children && (
+			<>
+				<div className={ classNames( 'site-preview__footer', className ) }>{ children }</div>
+			</>
+		)
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-footer/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-footer/style.scss
@@ -1,0 +1,6 @@
+.site-preview__footer {
+	height: 48px;
+	background-color: var(--studio-white);
+	padding: 32px 48px;
+	border-top: 1px solid var(--studio-gray-0);
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-header/index.tsx
@@ -1,0 +1,51 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { useMediaQuery } from '@wordpress/compose';
+import { Icon, external } from '@wordpress/icons';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import SiteFavicon from '../../site-favicon';
+import { Site } from '../../types';
+
+import './style.scss';
+
+const ICON_SIZE = 24;
+
+interface Props {
+	site: Site;
+	closeSitePreviewPane?: () => void;
+	className?: string;
+}
+
+export default function SitePreviewPaneHeader( { site, closeSitePreviewPane, className }: Props ) {
+	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
+	const size = isLargerThan960px ? 64 : 50;
+	return (
+		<div className={ classNames( 'site-preview__header', className ) }>
+			<div className="site-preview__header-content">
+				<SiteFavicon site={ site } className="site-preview__header-favicon" size={ size } />
+				<div className="site-preview__header-title-summary">
+					<div className="site-preview__header-title">{ site.blogname }</div>
+					<div className="site-preview__header-summary">
+						<Button
+							variant="link"
+							className="site-preview__header-summary-link"
+							href={ site.url_with_scheme }
+							target="_blank"
+						>
+							<span>{ site.url }</span>
+							<Icon className="sidebar-v2__external-icon" icon={ external } size={ ICON_SIZE } />
+						</Button>
+					</div>
+				</div>
+				<Button
+					onClick={ closeSitePreviewPane }
+					className="site-preview__close-preview"
+					aria-label={ translate( 'Close Preview' ) }
+				>
+					<Gridicon icon="cross" size={ ICON_SIZE } />
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-header/style.scss
@@ -1,0 +1,99 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.site-preview__header {
+
+	@media ( min-width: $break-large ) {
+		.site-preview__header-favicon {
+			margin-right: 24px;
+			position: relative;
+		}
+
+		.site-preview__header-content {
+			padding: 48px 48px 24px 48px;
+			display: flex;
+			align-items: center;
+
+			.site-preview__header-title-summary {
+				flex-grow: 1;
+				display: flex;
+				flex-direction: column;
+
+				.site-preview__header-title {
+					font-style: normal;
+					font-weight: 500;
+					font-size: rem(32px);
+					line-height: 32px;
+					color: var(--studio-black);
+					margin-bottom: 4px;
+				}
+
+				.site-preview__header-summary {
+
+					.site-preview__header-summary-link {
+						display: flex;
+						align-items: center;
+						font-size: rem(18px);
+						font-weight: 400;
+						color: var(--studio-gray-70);
+						line-height: 26px;
+						width: fit-content;
+
+						&:focus {
+							box-shadow: none;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@media ( max-width: $break-large ) {
+		display: flex;
+		padding: 24px 24px 8px;
+
+		.sites-dataviews__site-favicon {
+			border-radius: 2px;
+		}
+
+		.site-preview__header-content {
+			flex-grow: 1;
+			display: flex;
+			justify-content: space-between;
+			.site-preview__header-title-summary {
+				word-wrap: anywhere;
+				flex-grow: 1;
+				display: flex;
+				flex-direction: column;
+
+				.site-preview__header-title {
+					font-style: normal;
+					font-weight: 500;
+					font-size: rem(16px);
+					line-height: 16px;
+					color: var(--studio-black);
+					margin-bottom: 4px;
+				}
+
+				.site-preview__header-summary {
+
+					.site-preview__header-summary-link {
+						display: flex;
+						align-items: center;
+						font-size: rem(13px);
+						font-weight: 400;
+						color: var(--studio-gray-70);
+						line-height: 13px;
+						width: fit-content;
+						text-decoration: none;
+
+						&:focus {
+							box-shadow: none;
+						}
+					}
+				}
+
+			}
+		}
+	}
+
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
@@ -1,0 +1,118 @@
+.site-preview__pane {
+	display: flex;
+	flex-direction: column;
+
+	.preview-pane__navigation {
+		clip-path: inset(0 -1px -1px -1px);
+		box-shadow: 0 0 0 1px var(--studio-gray-0), 0 1px 2px var(--color-neutral-0);
+		margin: 0;
+
+		.section-nav-tab__link {
+			color: #000;
+		}
+
+		.section-nav-tab__link:hover {
+			color: #000;
+			background-color: inherit;
+		}
+
+		.section-nav-tabs__list {
+			padding: 0 32px;
+		}
+
+		.section-nav-tab__text {
+			font-weight: 500;
+		}
+
+		.section-nav-tab:not(.is-selected):hover {
+			border-bottom: none;
+		}
+
+		.section-nav-tab {
+			&.is-selected {
+				border-bottom-color: var(--color-neutral-70);
+			}
+		}
+
+		.section-nav-tabs__dropdown .select-dropdown__container {
+			max-width: revert;
+		}
+
+		.section-nav__panel:has(.is-dropdown) {
+			padding: 16px;
+		}
+
+		.select-dropdown.is-open {
+			height: revert;
+		}
+
+		@media (min-width: 481px) {
+			.section-nav-group {
+				.is-dropdown {
+					width: 100%;
+				}
+			}
+		}
+
+		@media (max-width: 480px) {
+			.section-nav-group {
+				margin-top: 0;
+			}
+			.section-nav-tabs__list {
+				margin: 0 24px;
+				padding: 0 !important;
+				border: 1px solid var(--color-neutral-10) !important;
+			}
+
+			.section-nav__mobile-header {
+				margin: 16px 24px 0 24px;
+				width: 88%;
+				border: 1px solid var(--color-neutral-10) !important;
+				border-radius: 2px;
+				justify-content: space-between;
+			}
+
+			.section-nav-tab__link {
+				color: var(--color-neutral-70);
+				font-weight: 400;
+			}
+
+			.section-nav-tab {
+				.section-nav-tab__link {
+					&:hover {
+						color: var(--color-accent);
+						background-color: var(--color-neutral-5);
+					}
+				}
+
+				&.is-selected {
+					.section-nav-tab__link {
+						color: #fff;
+
+						&:hover {
+							color: #fff;
+							background-color: var(--studio-automattic-60);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@media (max-width: 480px) {
+	.section-nav {
+		box-shadow: 0 0 0 1px #fff !important;
+	}
+
+	.section-nav.is-open {
+		.section-nav__panel {
+			border-top: none !important;//px solid white;
+			background: none !important;
+		}
+
+		.section-nav__mobile-header {
+			background-color: var(--color-neutral-0);
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
@@ -107,7 +107,7 @@
 
 	.section-nav.is-open {
 		.section-nav__panel {
-			border-top: none !important;//px solid white;
+			border-top: none !important;
 			background: none !important;
 		}
 

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/types.ts
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/types.ts
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Site } from '../types';
+
+export interface FeaturePreviewInterface {
+	id: string;
+	tab: FeatureTabInterface;
+	preview?: React.ReactNode;
+	enabled?: boolean;
+}
+
+export interface FeatureTabInterface {
+	label: string;
+	countValue?: number;
+	countColor?: string;
+	selected?: boolean;
+	visible?: boolean;
+	onTabClick?: () => void;
+}
+
+export interface PreviewPaneProps {
+	site: Site;
+	closeSitePreviewPane?: () => void;
+	selectedFeatureId?: string;
+	features?: FeaturePreviewInterface[];
+	className?: string;
+	isSmallScreen?: boolean;
+	hasError?: boolean;
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -14,12 +14,12 @@ import LayoutNavigation, {
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features/overview';
 import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import SitesOverviewContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/context';
 import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
-import { JetpackPreviewPane } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane';
 import SiteTopHeaderButtons from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons';
 import SitesDataViews from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews';
 import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
@@ -244,7 +244,7 @@ export default function SitesDashboard() {
 
 			{ sitesViewState.selectedSite && (
 				<LayoutColumn className="site-preview-pane" wide>
-					<JetpackPreviewPane
+					<OverviewFamily
 						site={ sitesViewState.selectedSite }
 						closeSitePreviewPane={ closeSitePreviewPane }
 						isSmallScreen={ ! isLargeScreen }

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -4,6 +4,8 @@ import {
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
+export * from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
 export interface SitesDashboardContextInterface {
 	selectedCategory?: string;
 	setSelectedCategory: ( category: string ) => void;


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/136

## Proposed Changes

( this PR is based on the [`update/a4a/sites-dashboard-routes-improvements` branch](https://github.com/Automattic/wp-calypso/pull/88800) )

This PR aims to start copying components from Manage to A4A and create the first feature folder structure where any A8c product family could add their components to the Sites Dashboard habitat.

- Created the feature IDs list
- Copied the JetpackPreviewPane (folder) with all the Jetpack features preview panes to A4A
- Created the OverviewFamily component as the initial one for the A4A v1. For the A4A v1, the OverviewFamily component will display the JetpackPreviewPane.
- Copied the SitePreviewPane (folder) to A8A
- Copied other Sites Dashboard components or files dependencies from Manage
   - SiteFavicon
   - types.ts. Instead of copying it, we export from agency-dashboard: `export * from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';`
- All the references from these imported components were updated to the A4A context/folder.

## Testing Instructions

- Check the code and the core changes 
- Check that everything is working as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
