### PR TITLE
Patterns: adjut gallery items, appearance of patern type switcher and paddings

### DIFF
--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -61,9 +61,9 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 							>
 								<div
 									className={ classNames( 'patterns-category-gallery__item-preview', {
-										'patterns-category-gallery__item-preview_page-layouts':
+										'patterns-category-gallery__item-preview--page-layout':
 											patternTypeFilter === PatternTypeFilter.PAGES,
-										'patterns-category-gallery__item-preview_mirrored': category.name === 'footer',
+										'patterns-category-gallery__item-preview--mirrored': category.name === 'footer',
 									} ) }
 								>
 									<div className="patterns-category-gallery__item-preview-inner">

--- a/client/my-sites/patterns/components/category-gallery/server.tsx
+++ b/client/my-sites/patterns/components/category-gallery/server.tsx
@@ -30,9 +30,9 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 						<div className="patterns-category-gallery__item-preview">
 							<div
 								className={ classNames( 'patterns-category-gallery__item-preview', {
-									'patterns-category-gallery__item-preview_page-layouts':
+									'patterns-category-gallery__item-preview--page-layout':
 										patternTypeFilter === PatternTypeFilter.PAGES,
-									'patterns-category-gallery__item-preview_mirrored': category.name === 'footer',
+									'patterns-category-gallery__item-preview--mirrored': category.name === 'footer',
 								} ) }
 							>
 								<div className="patterns-category-gallery__item-preview-inner">

--- a/client/my-sites/patterns/components/category-gallery/style.scss
+++ b/client/my-sites/patterns/components/category-gallery/style.scss
@@ -24,50 +24,42 @@
 	}
 
 	.patterns-category-gallery__item-preview {
-		aspect-ratio: 7 / 3.9;
-		align-content: end;
+		aspect-ratio: 29 / 16;
 		background: #f6f7f7;
 		border-radius: 4px;
 		margin-bottom: 14px;
 		overflow: hidden;
 	}
 
-	.patterns-category-gallery__item-preview_page-layouts {
-		aspect-ratio: 4 / 4.5;
+	.patterns-category-gallery__item-preview--page-layout {
+		aspect-ratio: 39 / 44;
 	}
 
 	.patterns-category-gallery__item-preview-inner {
 		background: var(--color-surface);
-		// stylelint-disable-next-line scales/radii
-		border-radius: 5px 5px 0 0;
+		border-radius: 4px 4px 0 0;
 		box-shadow: 0 0 8px hsla(0, 0%, 0%, 0.08);
 		overflow: hidden;
 		transition: transform 0.35s ease;
-		margin: 30px 30px 0;
+		margin: 20px 30px 0;
+		transform: translateY(10px);
 		height: calc(100% - 20px);
+	}
+
+	.patterns-category-gallery__item-preview--mirrored {
+		.patterns-category-gallery__item-preview-inner {
+			align-items: end;
+			border-radius: 0 0 4px 4px;
+			display: grid;
+			margin: 0 30px 20px;
+			transform-origin: center top;
+			transform: translateY(-10px);
+		}
 	}
 
 	@media ( hover ) {
 		.patterns-category-gallery__item:hover .patterns-category-gallery__item-preview-inner {
-			transform: translateY(-10px);
-		}
-	}
-
-	.patterns-category-gallery__item-preview_mirrored {
-		.patterns-category-gallery__item-preview-inner {
-			// stylelint-disable-next-line scales/radii
-			border-radius: 0 0 5px 5px;
-			transform: translateY(-10px);
-			transform-origin: center top;
-			margin: 0 30px 30px;
-			display: grid;
-			align-items: end;
-		}
-
-		@media ( hover ) {
-			&:hover .patterns-category-gallery__item-preview-inner {
-				transform: translateY(0);
-			}
+			transform: translateY(0);
 		}
 	}
 

--- a/client/my-sites/patterns/components/category-gallery/style.scss
+++ b/client/my-sites/patterns/components/category-gallery/style.scss
@@ -24,48 +24,50 @@
 	}
 
 	.patterns-category-gallery__item-preview {
-		aspect-ratio: 7 / 4;
+		aspect-ratio: 7 / 3.9;
 		align-content: end;
 		background: #f6f7f7;
 		border-radius: 4px;
-		display: grid;
-		grid-template-columns: 100%;
-		grid-template-rows: minmax(50%, max-content);
 		margin-bottom: 14px;
 		overflow: hidden;
 	}
 
 	.patterns-category-gallery__item-preview_page-layouts {
-		aspect-ratio: 4 / 5;
-	}
-
-	.patterns-category-gallery__item-preview_mirrored {
-		align-content: start;
-
-		.patterns-category-gallery__item-preview-inner {
-			// stylelint-disable-next-line scales/radii
-			border-radius: 0 0 5px 5px;
-			transform: scale(var(--scale)) translateY(-10px);
-			transform-origin: center top;
-		}
+		aspect-ratio: 4 / 4.5;
 	}
 
 	.patterns-category-gallery__item-preview-inner {
-		--scale: 0.85;
-
 		background: var(--color-surface);
 		// stylelint-disable-next-line scales/radii
 		border-radius: 5px 5px 0 0;
 		box-shadow: 0 0 8px hsla(0, 0%, 0%, 0.08);
 		overflow: hidden;
-		transform: scale(var(--scale)) translateY(10px);
-		transform-origin: center bottom;
 		transition: transform 0.35s ease;
+		margin: 30px 30px 0;
+		height: calc(100% - 20px);
 	}
 
 	@media ( hover ) {
 		.patterns-category-gallery__item:hover .patterns-category-gallery__item-preview-inner {
-			transform: scale(var(--scale)) translateY(0);
+			transform: translateY(-10px);
+		}
+	}
+
+	.patterns-category-gallery__item-preview_mirrored {
+		.patterns-category-gallery__item-preview-inner {
+			// stylelint-disable-next-line scales/radii
+			border-radius: 0 0 5px 5px;
+			transform: translateY(-10px);
+			transform-origin: center top;
+			margin: 0 30px 30px;
+			display: grid;
+			align-items: end;
+		}
+
+		@media ( hover ) {
+			&:hover .patterns-category-gallery__item-preview-inner {
+				transform: translateY(0);
+			}
 		}
 	}
 

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -251,7 +251,7 @@ export const PatternLibrary = ( {
 								: translate_not_yet( 'Patterns' ) }
 						</h1>
 
-						{ category && (
+						{ category && !! categoryObject?.pagePatternCount && (
 							<ToggleGroupControl
 								className="pattern-library__toggle--pattern-type"
 								isBlock
@@ -276,7 +276,6 @@ export const PatternLibrary = ( {
 								/>
 								<ToggleGroupControlOption
 									className="pattern-library__toggle-option"
-									disabled={ categoryObject?.pagePatternCount === 0 }
 									label={ translate_not_yet( 'Page layouts' ) }
 									value={ PatternTypeFilter.PAGES }
 								/>

--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -21,6 +21,10 @@
 	}
 }
 
+.pattern-library__pill-navigation + .patterns-section {
+	padding-top: 48px;
+}
+
 .pattern-library {
 	@include patterns-page-width;
 	padding-bottom: 96px;


### PR DESCRIPTION
Related to:
1) https://github.com/Automattic/dotcom-forge/issues/6207
2) https://github.com/Automattic/dotcom-forge/issues/6208
3) https://github.com/Automattic/dotcom-forge/issues/6210

## Proposed Changes
With this PR we a fixing UI issues requested by Matt West. Details in "Testing instruction".

## Testing Instructions
1.1) Open `http://calypso.localhost:3000/patterns`
1.2) Assert that padding between CategoryPillNavigation and `Ship faster, ship more` is 80px
2.1) Click on categories in `CategoryPillNavigation`
2.2) Assert that "Patterns/Page layout" switched is hidden when category doesn't have `Page layout` patterns
3.1) Open `http://calypso.localhost:3000/patterns`
3.2) Assert that on wide-screen the pattern previews on category tiles have 130px height and page layout categories have 410px by default.
3.3) Assert that adaptive markup also always looks good and has minimum heights according to the previous point.
