### PR TITLE
Pattern Library: Add tracking for calypso_pattern_library_type_switch

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -111,6 +111,20 @@ export const PatternLibrary = ( {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
 
+	const recordClickEvent = (
+		tracksEventName: string,
+		view: PatternView,
+		typeFilter: PatternTypeFilter
+	) => {
+		recordTracksEvent( tracksEventName, {
+			category,
+			is_logged_in: isLoggedIn,
+			type: getTracksPatternType( typeFilter ),
+			user_is_dev_account: isDevAccount ? '1' : '0',
+			view,
+		} );
+	};
+
 	const currentView = isGridView ? 'grid' : 'list';
 
 	const handleViewChange = ( view: PatternView ) => {
@@ -118,13 +132,7 @@ export const PatternLibrary = ( {
 			return;
 		}
 
-		recordTracksEvent( 'calypso_pattern_library_view_switch', {
-			category,
-			is_logged_in: isLoggedIn,
-			type: getTracksPatternType( patternTypeFilter ),
-			user_is_dev_account: isDevAccount ? '1' : '0',
-			view,
-		} );
+		recordClickEvent( 'calypso_pattern_library_view_switch', view, patternTypeFilter );
 
 		const url = new URL( window.location.href );
 		url.searchParams.delete( 'grid' );
@@ -252,6 +260,11 @@ export const PatternLibrary = ( {
 									const href =
 										getCategoryUrlPath( category, value as PatternTypeFilter ) +
 										( isGridView ? '?grid=1' : '' );
+									recordClickEvent(
+										'calypso_pattern_library_type_switch',
+										currentView,
+										value as PatternTypeFilter
+									);
 									page( href );
 								} }
 								value={ patternTypeFilter }


### PR DESCRIPTION
See: pcYYuD-1hV-p2 

`calypso_pattern_library_type_switch` is the event fired when users switches between `pattern` and `page layout`.

### Testing

 - Navigate to any pattern category i.e. `/patterns/<category>` . 
 - Alternate switching between  the pattern types: patterns and page layouts.

 
<img width="285" alt="Screenshot 2024-03-22 at 18 00 12" src="https://github.com/Automattic/wp-calypso/assets/277661/b9c9c9c6-7931-46a1-b666-98b31b8e7726">


 - Confirm that the `calypso_pattern_library_type_switch` event is triggered.