### PR TITLE
A4A Fill overview products section

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -1,31 +1,91 @@
+import page from '@automattic/calypso-router';
+import { useDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import Offering from 'calypso/a8c-for-agencies/components/offering';
+import { OfferingItemProps } from 'calypso/a8c-for-agencies/components/offering/types';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import WooCommerceLogo from 'calypso/components/woocommerce-logo';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import './style.scss';
+
+const A4A_PRODUCTS_MARKETPLACE_LINK = '/marketplace/products';
 
 const OverviewBodyProducts = () => {
-	//TODO: replace with proper products
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const actionHandlerCallback = useCallback(
+		( section: string, product: string ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_overview_click_open_marketplace', {
+					section,
+					product,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
+
+	const jetpack: OfferingItemProps = {
+		//translators: Title for the action card
+		title: translate( 'Jetpack' ),
+		titleIcon: <JetpackLogo size={ 26 } />,
+		description: translate(
+			'Jetpack offers best-in-class security, performance, and growth tools for WordPress. Install only the products you need, or purchase bundles for a complete site at greater savings.'
+		),
+		highlights: [
+			translate( 'Optimize your site speed in a few clicks.' ),
+			translate( 'Back up your site in real-time as you edit.' ),
+			translate( 'Create better content with AI.' ),
+			translate( 'Automatically block comment & form spam.' ),
+			translate( 'Stay safe with malware firewall & one-click fixes.' ),
+			translate( 'Get advanced site stats and traffic insights.' ),
+		],
+		// translators: Button navigating to A4A Marketplace
+		buttonTitle: translate( 'View all Jetpack products' ),
+		expanded: true,
+		actionHandler: () => {
+			actionHandlerCallback( 'products', 'jetpack' );
+			page( A4A_PRODUCTS_MARKETPLACE_LINK );
+		},
+	};
+
+	const woo: OfferingItemProps = {
+		//translators: Title for the action card
+		title: translate( 'WooCommerce' ),
+		titleIcon: <WooCommerceLogo className="a4a-overview-products__woocommerce-logo" size={ 40 } />,
+		description: translate(
+			'WooCommerce is the platform that offers unlimited potential to build the perfect ecommerce experiences for your clients. No matter what success looks like, you can do it with WooCommerce. Purchase Woo extensions in bulk to save big.'
+		),
+		highlights: [
+			translate( 'AutomateWoo: Grow sales with less effort using powerful marketing automation.' ),
+			translate( 'Bookings: Offer appointment bookings, reservations, or equipment rentals.' ),
+			translate(
+				'Min/Max Quantities: Set min and max rules for products, orders, and categories.'
+			),
+			translate( 'Product Add-Ons: Offer add-ons like gift wrapping, special messages, and more.' ),
+			translate(
+				'Product Bundles: Offer personalized bundles, bulk discounts, and assembled products.'
+			),
+			translate( 'Subscriptions: Enable weekly, monthly, or annual subscriptions.' ),
+		],
+		// translators: Button navigating to A4A Marketplace
+		buttonTitle: translate( 'View all WooCommerce products' ),
+		expanded: false,
+		actionHandler: () => {
+			actionHandlerCallback( 'products', 'woocommerce' );
+			page( A4A_PRODUCTS_MARKETPLACE_LINK );
+		},
+	};
+
 	return (
 		<Offering
-			title="Products"
-			description="Add services to secure, improve performance, and sell goods on your clients’ sites."
-			items={ [
-				{
-					title: 'Jetpack',
-					titleIcon: <JetpackLogo size={ 26 } />,
-					description:
-						'Jetpack offers a flexible suite of security, performance, and growth tools. Pick and choose exactly what you need, à la carte, or explore product bundles for world-class savings.',
-					highlights: [
-						'Optimize your site speed in a few clicks.',
-						'Back up your site in real-time as you edit.',
-						'Create better content with AI.',
-						'Automatically block comment & form spam.',
-						'Stay safe with malware firewall & one-click fixes.',
-						'Get advanced site stats and traffic insights.',
-					],
-					buttonTitle: 'View all Jetpack products',
-					expanded: true,
-					actionHandler: () => {},
-				},
-			] }
+			title={ translate( 'Products' ) }
+			description={ translate(
+				'Add services to create sites, increase security and performance, and provide excellent shopping experiences for your clients’ sites.'
+			) }
+			items={ [ jetpack, woo ] }
 		/>
 	);
 };

--- a/client/a8c-for-agencies/sections/overview/body/products/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/products/style.scss
@@ -1,0 +1,4 @@
+.a4a-overview-products__woocommerce-logo {
+	fill: var(--studio-woocommerce-purple-60);
+	margin: 0;
+}

--- a/client/a8c-for-agencies/sections/overview/body/products/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/products/style.scss
@@ -1,4 +1,4 @@
 .a4a-overview-products__woocommerce-logo {
-	fill: var(--studio-woocommerce-purple-60);
+	fill: var(--color-woocommerce);
 	margin: 0;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label tos
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/293

## Proposed Changes

Filling information about Products options in the Overview page for A4A. We are keeping these in client for now: pfunGA-Hp-p2#comment-1111

<img width="885" alt="Screenshot 2024-03-22 at 11 05 03 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/c5d971fb-54a1-4f71-a13d-49300fec53f3">



## Testing Instructions

- Spin up the branch locally
- Navigate to http://agencies.localhost:3000/overview
- Check that new section is visible and behaves normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?