### PR TITLE
Site Migration: Update migration instructions screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -88,7 +88,7 @@ const SiteMigrationInstructions: Step = function () {
 								},
 							}
 						) }
-						<ShowHideInput value={ migrationKey } />
+						<ShowHideInput value={ migrationKey } className="site-migration-instructions__key" />
 					</li>
 				) }
 				{ isError && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,184 +1,128 @@
-import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
-import { ClipboardButton } from '@wordpress/components';
-import { addQueryArgs } from '@wordpress/url';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migraiton-key';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import wpcom from 'calypso/lib/wp';
+import { ShowHideInput } from './show-hide-input';
 import type { Step } from '../../types';
 import './style.scss';
+
+const removeDuplicatedSlashes = ( url: string ) => url.replace( /(https?:\/\/)|(\/)+/g, '$1$2' );
+
+const getInstallationURL = ( fromUrl: string ) => {
+	return removeDuplicatedSlashes(
+		`${ fromUrl }/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term`
+	);
+};
+
+const getMigrateGuruPageURL = ( siteURL: string ) =>
+	removeDuplicatedSlashes( `${ siteURL }/wp-admin/admin.php?page=migrateguru` );
+
+const Loading = () => {
+	return (
+		<div className="loading">
+			<div className="loading__content">
+				<LoadingEllipsis />
+			</div>
+		</div>
+	);
+};
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
 	const site = useSite();
 	const siteId = site?.ID;
 	const fromUrl = useQuery().get( 'from' ) || '';
-	const sourceSiteUrl = fromUrl
-		? addQueryArgs( fromUrl + '/wp-admin/admin.php', { page: 'migrateguru' } )
-		: '';
-	const destSiteUrl = fromUrl
-		? addQueryArgs( site?.URL + '/wp-admin/admin.php', { page: 'migrateguru' } )
-		: '';
-	const [ buttonTextCopy, setButtonTextCopy ] = useState( false );
-	const onCopy = () => {
-		recordTracksEvent( 'calypso_migration_instructions_key_copy' );
-		setButtonTextCopy( true );
-		setTimeout( () => {
-			setButtonTextCopy( false );
-		}, 2000 );
-	};
-	const [ siteMigrationKey, setSiteMigrationKey ] = useState< string | null >( null );
-	const [ siteMigrationKeyError, setSiteMigrationKeyError ] = useState< string | null >( null );
-	const [ hideSiteMigrationKey, setHideSiteMigrationKey ] = useState( true );
 
-	const getMigrationKey = async () => {
-		try {
-			const response = await wpcom.req.get(
-				`/sites/${ siteId }/atomic-migration-status/migrate-guru-key?http_envelope=1`,
-				{
-					apiNamespace: 'wpcom/v2',
-				}
-			);
-
-			setSiteMigrationKey( response?.migration_key );
-			recordTracksEvent( 'calypso_migration_instructions_key_retrieved' );
-		} catch ( error ) {
-			setSiteMigrationKeyError( error as string );
-			recordTracksEvent( 'calypso_migration_instructions_key_error' );
-		}
-	};
+	const {
+		data: { migrationKey } = {},
+		isSuccess,
+		isError,
+		isFetching,
+		isFetched,
+	} = useSiteMigrationKey( siteId );
 
 	const stepContent = (
-		<div>
+		<div className="site-migration-instructions__content">
 			<ol className="site-migration-instructions__list">
 				<li>
-					{ translate( 'Install the {{a}}Migrate Guru plugin{{/a}} on your existing site.', {
-						components: {
-							a: (
-								<a
-									href="https://wordpress.org/plugins/migrate-guru/"
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-						},
-					} ) }
-				</li>
-				<li>
-					<div
-						className={ classNames( 'site-migration-instructions__list-migration-key-item', {
-							expanded: siteMigrationKey,
-							error: siteMigrationKeyError,
-						} ) }
-					>
-						{ ! siteMigrationKey && (
-							<>
-								{ ! siteMigrationKeyError && (
-									<Button
-										primary
-										compact
-										className="site-migration-instructions__get-key-button component-button"
-										onClick={ getMigrationKey }
-									>
-										{ translate( 'Get migration key', {
-											components: {
-												strong: <strong />,
-											},
-										} ) }
-									</Button>
-								) }
-								{ siteMigrationKeyError && (
-									<>
-										{ translate(
-											'We were unable to retrieve your migration key. To get the key manually, go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}}.',
-											{
-												components: {
-													a: <a href={ destSiteUrl } target="_blank" rel="noreferrer" />,
-												},
-											}
-										) }
-									</>
-								) }
-							</>
-						) }
-						{ siteMigrationKey && ! siteMigrationKeyError && (
-							<>
-								{ translate(
-									'Click {{strong}}Copy key{{/strong}} below to copy your migration key - you will need that in a few minutes to start the migration. This key is unique to your site and will only be available once.',
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-								<div className="site-migration-instructions__migration-key">
-									<code className="site-migration-instructions__key">
-										{ hideSiteMigrationKey
-											? '*'.repeat( siteMigrationKey.length - 5 )
-											: siteMigrationKey }
-									</code>
-									<Button
-										onClick={ () => {
-											setHideSiteMigrationKey( ! hideSiteMigrationKey );
-										} }
-										className="site-migration-instructions__show-key-button components-button"
-									>
-										{ hideSiteMigrationKey ? translate( 'Show key' ) : translate( 'Hide key' ) }
-									</Button>
-									<ClipboardButton
-										text={ siteMigrationKey }
-										className="site-migration-instructions__copy-key-button is-secondary"
-										onCopy={ onCopy }
-									>
-										{ buttonTextCopy ? translate( 'Copied!' ) : translate( 'Copy key' ) }
-									</ClipboardButton>
-								</div>
-							</>
-						) }
-					</div>
+					{ translate(
+						'Install and active the {{a}}Migrate Guru plugin{{/a}} on your existing site.',
+						{
+							components: {
+								a: <a href={ getInstallationURL( fromUrl ) } target="_blank" rel="noreferrer" />,
+							},
+						}
+					) }
 				</li>
 				<li>
 					{ translate(
 						'Go to the {{a}}Migrate Guru page on the source site{{/a}}, enter your email address, and click {{strong}}Migrate{{/strong}}.',
 						{
 							components: {
-								a: <a href={ sourceSiteUrl } target="_blank" rel="noreferrer" />,
+								a: <a href={ getMigrateGuruPageURL( fromUrl ) } target="_blank" rel="noreferrer" />,
 								strong: <strong />,
 							},
 						}
 					) }
 				</li>
 				<li>
-					{ translate(
-						'You will see a screen showing multiple hosting providers. Select {{em}}Automattic{{/em}} as the destination host.',
-						{
-							components: {
-								em: <em />,
-							},
-						}
-					) }
+					{ translate( 'When asked to select a destination host, pick {{em}}“Automattic”{{/em}}.', {
+						components: {
+							em: <em />,
+						},
+					} ) }
 				</li>
-				<li>
-					{ translate(
-						'Find the {{em}}Migrate Guru Migration Key{{/em}} field, and paste the key you copied in step 2. Then click {{strong}}Migrate{{/strong}} to start your migration.',
-						{
-							components: {
-								em: <em />,
-								strong: <strong />,
-							},
-						}
-					) }
-				</li>
-				<li>{ translate( 'Migrate Guru will send you an email when the migration finishes.' ) }</li>
+				{ isSuccess && migrationKey && (
+					<li>
+						{ translate(
+							'Copy and paste the migration key below in the {{em}}“Migrate Guru Migration Key”{{/em}} field and click {{strong}}Migrate{{/strong}}.',
+							{
+								components: {
+									em: <em />,
+									strong: <strong />,
+								},
+							}
+						) }
+						<ShowHideInput value={ migrationKey } />
+					</li>
+				) }
+				{ isError && (
+					<li>
+						{ translate(
+							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{em}}"Migrate Guru Migration Key"{{/em}} field of your existing site and click {{strong}}"Migrate"{{/strong}}.',
+							{
+								components: {
+									em: <em />,
+									a: (
+										<a
+											href={ getMigrateGuruPageURL( site!.URL ) }
+											target="_blank"
+											rel="noreferrer"
+										/>
+									),
+									strong: <strong />,
+								},
+							}
+						) }
+					</li>
+				) }
 			</ol>
+			<p>
+				{ translate(
+					'And you are done! When the migration finishes, Migrate Guru will send you an email.'
+				) }
+			</p>
 		</div>
 	);
+
+	if ( isFetching || ! isFetched ) {
+		return <Loading />;
+	}
 
 	return (
 		<>
@@ -190,14 +134,13 @@ const SiteMigrationInstructions: Step = function () {
 				hideSkip={ true }
 				hideBack={ true }
 				formattedHeader={
-					<>
-						<FormattedHeader
-							id="site-migration-instructions-header"
-							headerText={ translate( 'Ready to migrate your site?' ) }
-							align="center"
-						/>
-						<p>{ translate( 'Follow these steps to get started.' ) }</p>
-					</>
+					<FormattedHeader
+						id="site-migration-instructions-header"
+						headerText={ translate( 'Ready to migrate your site?' ) }
+						align="center"
+						subHeaderText={ translate( 'Follow these steps to get started.' ) }
+						subHeaderAlign="center"
+					/>
 				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,6 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, type FC } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -33,7 +33,10 @@ const Loading = () => {
 		</div>
 	);
 };
-const DoNotTranslateIt = ( { value, as: As = 'span' } ) => <As>{ value }</As>;
+
+const DoNotTranslateIt: FC< { value: string; as: string } > = ( { value, as: As = 'span' } ) => (
+	<As>{ value }</As>
+);
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -76,11 +76,12 @@ const SiteMigrationInstructions: Step = function () {
 				</li>
 				<li>
 					{ translate(
-						'Go to the {{a}}Migrate Guru page on your source site{{/a}}, enter your email address, and click {{migrateButton /}}.',
+						'Go to the {{a}}Migrate Guru page on your source site{{/a}}, enter your email address, and click {{strong}}{{migrateButton /}}{{/strong}}.',
 						{
 							components: {
 								a: <a href={ getMigrateGuruPageURL( fromUrl ) } target="_blank" rel="noreferrer" />,
-								migrateButton: <DoNotTranslateIt value="Migrate" as="strong" />,
+								migrateButton: <DoNotTranslateIt value="Migrate" />,
+								strong: <strong />,
 							},
 						}
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -34,10 +34,7 @@ const Loading = () => {
 	);
 };
 
-const DoNotTranslateIt: FC< { value: string; as: keyof JSX.IntrinsicElements } > = ( {
-	value,
-	as: As = 'span',
-} ) => <As>{ value }</As>;
+const DoNotTranslateIt: FC< { value: string } > = ( { value } ) => <>{ value }</>;
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
@@ -101,13 +98,13 @@ const SiteMigrationInstructions: Step = function () {
 				{ isSuccess && migrationKey && (
 					<li>
 						{ translate(
-							'Copy and paste the migration key below in the {{ migrationKeyField /}} field and click {{migrateButton /}}.',
+							'Copy and paste the migration key below in the {{em}}{{ migrationKeyField /}}{{/em}} field and click {{strong}}{{migrateButton /}}{{/strong}}.',
 							{
 								components: {
-									migrationKeyField: (
-										<DoNotTranslateIt value="Migrate Guru Migration key" as="em" />
-									),
-									migrateButton: <DoNotTranslateIt value="Migrate" as="strong" />,
+									migrationKeyField: <DoNotTranslateIt value="Migrate Guru Migration key" />,
+									migrateButton: <DoNotTranslateIt value="Migrate" />,
+									em: <em />,
+									strong: <strong />,
 								},
 							}
 						) }
@@ -117,7 +114,7 @@ const SiteMigrationInstructions: Step = function () {
 				{ isError && (
 					<li>
 						{ translate(
-							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{migrationKeyField /}} field of your existing site and click {{migrateButton /}}.',
+							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{em}}{{migrationKeyField /}}{{/em}} field of your existing site and click {{strong}}{{migrateButton /}}{{/strong}}.',
 							{
 								components: {
 									a: (
@@ -127,11 +124,10 @@ const SiteMigrationInstructions: Step = function () {
 											rel="noreferrer"
 										/>
 									),
-									migrationKeyField: (
-										<DoNotTranslateIt value="Migrate Guru Migration key" as="em" />
-									),
-
-									migrateButton: <DoNotTranslateIt value="Migrate" as="strong" />,
+									em: <em />,
+									strong: <strong />,
+									migrationKeyField: <DoNotTranslateIt value="Migrate Guru Migration key" />,
+									migrateButton: <DoNotTranslateIt value="Migrate" />,
 								},
 							}
 						) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -71,11 +71,14 @@ const SiteMigrationInstructions: Step = function () {
 					) }
 				</li>
 				<li>
-					{ translate( 'When asked to select a destination host, pick {{em}}“Automattic”{{/em}}.', {
-						components: {
-							em: <em />,
-						},
-					} ) }
+					{ translate(
+						'When asked to select a destination host, pick {{em}}WordPress.com{{/em}}.',
+						{
+							components: {
+								em: <em />,
+							},
+						}
+					) }
 				</li>
 				{ isSuccess && migrationKey && (
 					<li>
@@ -94,7 +97,7 @@ const SiteMigrationInstructions: Step = function () {
 				{ isError && (
 					<li>
 						{ translate(
-							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{em}}"Migrate Guru Migration Key"{{/em}} field of your existing site and click {{strong}}"Migrate"{{/strong}}.',
+							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{em}}Migrate Guru Migration Key"{{/em}} field of your existing site and click {{strong}}"Migrate"{{/strong}}.',
 							{
 								components: {
 									em: <em />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -83,7 +83,7 @@ const SiteMigrationInstructions: Step = function () {
 				{ isSuccess && migrationKey && (
 					<li>
 						{ translate(
-							'Copy and paste the migration key below in the {{em}}“Migrate Guru Migration Key”{{/em}} field and click {{strong}}Migrate{{/strong}}.',
+							'Copy and paste the migration key below in the {{em}}Migrate Guru Migration Key{{/em}} field and click {{strong}}Migrate{{/strong}}.',
 							{
 								components: {
 									em: <em />,
@@ -97,7 +97,7 @@ const SiteMigrationInstructions: Step = function () {
 				{ isError && (
 					<li>
 						{ translate(
-							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{em}}Migrate Guru Migration Key"{{/em}} field of your existing site and click {{strong}}"Migrate"{{/strong}}.',
+							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{em}}Migrate Guru Migration Key{{/em}} field of your existing site and click {{strong}}Migrate{{/strong}}.',
 							{
 								components: {
 									em: <em />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -64,7 +64,7 @@ const SiteMigrationInstructions: Step = function () {
 			<ol className="site-migration-instructions__list">
 				<li>
 					{ translate(
-						'Install and active the {{a}}Migrate Guru plugin{{/a}} on your existing site.',
+						'Install and activate the {{a}}Migrate Guru plugin{{/a}} on your existing site.',
 						{
 							components: {
 								a: <a href={ getInstallationURL( fromUrl ) } target="_blank" rel="noreferrer" />,
@@ -74,7 +74,7 @@ const SiteMigrationInstructions: Step = function () {
 				</li>
 				<li>
 					{ translate(
-						'Go to the {{a}}Migrate Guru page on the source site{{/a}}, enter your email address, and click {{strong}}Migrate{{/strong}}.',
+						'Go to the {{a}}Migrate Guru page on your source site{{/a}}, enter your email address, and click {{strong}}Migrate{{/strong}}.',
 						{
 							components: {
 								a: <a href={ getMigrateGuruPageURL( fromUrl ) } target="_blank" rel="noreferrer" />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -34,9 +34,10 @@ const Loading = () => {
 	);
 };
 
-const DoNotTranslateIt: FC< { value: string; as: string } > = ( { value, as: As = 'span' } ) => (
-	<As>{ value }</As>
-);
+const DoNotTranslateIt: FC< { value: string; as: keyof JSX.IntrinsicElements } > = ( {
+	value,
+	as: As = 'span',
+} ) => <As>{ value }</As>;
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -33,6 +33,7 @@ const Loading = () => {
 		</div>
 	);
 };
+const DoNotTranslateIt = ( { value, as: As = 'span' } ) => <As>{ value }</As>;
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
@@ -74,11 +75,11 @@ const SiteMigrationInstructions: Step = function () {
 				</li>
 				<li>
 					{ translate(
-						'Go to the {{a}}Migrate Guru page on your source site{{/a}}, enter your email address, and click {{strong}}Migrate{{/strong}}.',
+						'Go to the {{a}}Migrate Guru page on your source site{{/a}}, enter your email address, and click {{migrateButton /}}.',
 						{
 							components: {
 								a: <a href={ getMigrateGuruPageURL( fromUrl ) } target="_blank" rel="noreferrer" />,
-								strong: <strong />,
+								migrateButton: <DoNotTranslateIt value="Migrate" as="strong" />,
 							},
 						}
 					) }
@@ -96,11 +97,13 @@ const SiteMigrationInstructions: Step = function () {
 				{ isSuccess && migrationKey && (
 					<li>
 						{ translate(
-							'Copy and paste the migration key below in the {{em}}Migrate Guru Migration Key{{/em}} field and click {{strong}}Migrate{{/strong}}.',
+							'Copy and paste the migration key below in the {{ migrationKeyField /}} field and click {{migrateButton /}}.',
 							{
 								components: {
-									em: <em />,
-									strong: <strong />,
+									migrationKeyField: (
+										<DoNotTranslateIt value="Migrate Guru Migration key" as="em" />
+									),
+									migrateButton: <DoNotTranslateIt value="Migrate" as="strong" />,
 								},
 							}
 						) }
@@ -110,10 +113,9 @@ const SiteMigrationInstructions: Step = function () {
 				{ isError && (
 					<li>
 						{ translate(
-							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{em}}Migrate Guru Migration Key{{/em}} field of your existing site and click {{strong}}Migrate{{/strong}}.',
+							'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{migrationKeyField /}} field of your existing site and click {{migrateButton /}}.',
 							{
 								components: {
-									em: <em />,
 									a: (
 										<a
 											href={ getMigrateGuruPageURL( site!.URL ) }
@@ -121,7 +123,11 @@ const SiteMigrationInstructions: Step = function () {
 											rel="noreferrer"
 										/>
 									),
-									strong: <strong />,
+									migrationKeyField: (
+										<DoNotTranslateIt value="Migrate Guru Migration key" as="em" />
+									),
+
+									migrateButton: <DoNotTranslateIt value="Migrate" as="strong" />,
 								},
 							}
 						) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,5 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -9,6 +10,7 @@ import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migr
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ShowHideInput } from './show-hide-input';
 import type { Step } from '../../types';
+
 import './style.scss';
 
 const removeDuplicatedSlashes = ( url: string ) => url.replace( /(https?:\/\/)|(\/)+/g, '$1$2' );
@@ -45,6 +47,17 @@ const SiteMigrationInstructions: Step = function () {
 		isFetching,
 		isFetched,
 	} = useSiteMigrationKey( siteId );
+
+	useEffect( () => {
+		if ( isError && fromUrl ) {
+			recordTracksEvent(
+				'calypso_onboarding_site_migration_instructions_unable_to_get_migration_key',
+				{
+					from: fromUrl,
+				}
+			);
+		}
+	}, [ fromUrl, isError ] );
 
 	const stepContent = (
 		<div className="site-migration-instructions__content">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/index.tsx
@@ -9,8 +9,9 @@ import './style.scss';
 
 interface Props {
 	value: string;
+	className?: string;
 }
-export const ShowHideInput: FC< Props > = ( { value } ) => {
+export const ShowHideInput: FC< Props > = ( { value, className } ) => {
 	const [ hide, setHide ] = useState( true );
 	const [ copied, setCopied ] = useState( false );
 	const inputRef = useRef< HTMLInputElement >( null );
@@ -46,7 +47,7 @@ export const ShowHideInput: FC< Props > = ( { value } ) => {
 
 	return (
 		<div
-			className={ classNames( 'show-hide-input', {
+			className={ classNames( 'show-hide-input', className, {
 				'show-hide-input--hidden': hide,
 			} ) }
 		>
@@ -54,6 +55,7 @@ export const ShowHideInput: FC< Props > = ( { value } ) => {
 				type="text"
 				className="show-hide-input__value"
 				readOnly
+				disabled={ hide }
 				value={ hide ? hiddenValue : value }
 				ref={ inputRef }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/index.tsx
@@ -1,0 +1,81 @@
+import { Button } from '@automattic/components';
+import { ClipboardButton } from '@wordpress/components';
+import { Icon, seen, unseen } from '@wordpress/icons';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { FC, useState, useMemo, useRef, useEffect } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import './style.scss';
+
+interface Props {
+	value: string;
+}
+export const ShowHideInput: FC< Props > = ( { value } ) => {
+	const [ hide, setHide ] = useState( true );
+	const [ copied, setCopied ] = useState( false );
+	const inputRef = useRef< HTMLInputElement >( null );
+	const translate = useTranslate();
+	const hiddenValue = useMemo( () => String.fromCharCode( 183 ).repeat( value.length ), [ value ] );
+
+	const onCopy = () => {
+		recordTracksEvent( 'calypso_migration_instructions_key_copy' );
+		setCopied( true );
+	};
+
+	const toggleShowHide = () => {
+		setHide( ( state ) => ! state );
+	};
+
+	useEffect( () => {
+		if ( ! hide ) {
+			inputRef.current?.select();
+		}
+	}, [ hide ] );
+
+	useEffect( () => {
+		if ( ! copied ) {
+			return;
+		}
+
+		const timerId = setTimeout( () => {
+			setCopied( () => false );
+		}, 2000 );
+
+		return () => clearTimeout( timerId );
+	}, [ copied ] );
+
+	return (
+		<div
+			className={ classNames( 'show-hide-input', {
+				'show-hide-input--hidden': hide,
+			} ) }
+		>
+			<input
+				type="text"
+				className="show-hide-input__value"
+				readOnly
+				value={ hide ? hiddenValue : value }
+				ref={ inputRef }
+			/>
+			<div className="show-hide-input__actions">
+				<Button
+					transparent
+					borderless
+					compact
+					onClick={ toggleShowHide }
+					className="show-hide-input__visibility-button"
+					title={ hide ? translate( 'Show key' ) : translate( 'Hide key' ) }
+				>
+					<Icon icon={ hide ? unseen : seen } size={ 20 } />
+				</Button>
+				<ClipboardButton
+					text={ value }
+					className="show-hide-input__copy-button is-secondary"
+					onCopy={ onCopy }
+				>
+					{ copied ? translate( 'copied!' ) : translate( 'copy' ) }
+				</ClipboardButton>
+			</div>
+		</div>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/style.scss
@@ -9,6 +9,7 @@
 	height: 24px;
 	max-width: 456px;
 	margin-top: 8px;
+	transition: all 0.2s;
 
 	&--hidden {
 		overflow-x: hidden;
@@ -23,7 +24,8 @@
 		width: 100%;
 	}
 
-	&:has(:focus) {
+	&:has(:focus),
+	&:hover {
 		outline-color: var(--color-primary);
 		box-shadow: 0 0 0 2px var(--color-primary-10);
 	}
@@ -39,6 +41,11 @@
 
 	&__visibility-button {
 		width: 20px;
+		fill: #a7aaad;
+		transition: all 0.2s;
+		&:hover {
+			fill: #787c82;
+		}
 	}
 
 	&__copy-button {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/style.scss
@@ -3,17 +3,20 @@
 	justify-content: space-between;
 	align-items: center;
 	outline: solid 1px var(--studio-gray-10);
-	padding: 12px 8px;
+	padding: 8px;
 	border-radius: 4px;
 	gap: 10px;
-	height: 24px;
+	height: 28px;
 	max-width: 456px;
-	margin-top: 8px;
 	transition: all 0.2s;
 
 	&--hidden {
 		overflow-x: hidden;
 		user-select: none;
+
+		input {
+			background-color: transparent;
+		}
 	}
 
 	&__value {
@@ -36,7 +39,6 @@
 		justify-content: space-between;
 		align-items: center;
 		gap: 10px;
-		height: 24px;
 	}
 
 	&__visibility-button {
@@ -49,7 +51,8 @@
 	}
 
 	&__copy-button {
-		padding: 12px 8px;
+		padding: 0 8px;
+		height: 28px;
 		border-radius: 4px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/style.scss
@@ -11,7 +11,7 @@
 	transition: all 0.2s;
 
 	&--hidden {
-		overflow-x: hidden;
+		overflow: hidden;
 		user-select: none;
 
 		input {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/show-hide-input/style.scss
@@ -1,0 +1,48 @@
+.show-hide-input {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	outline: solid 1px var(--studio-gray-10);
+	padding: 12px 8px;
+	border-radius: 4px;
+	gap: 10px;
+	height: 24px;
+	max-width: 456px;
+	margin-top: 8px;
+
+	&--hidden {
+		overflow-x: hidden;
+		user-select: none;
+	}
+
+	&__value {
+		overflow-x: scroll;
+		font-size: 0.875rem;
+		border: none;
+		outline: none;
+		width: 100%;
+	}
+
+	&:has(:focus) {
+		outline-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+	}
+
+	&__actions {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+		gap: 10px;
+		height: 24px;
+	}
+
+	&__visibility-button {
+		width: 20px;
+	}
+
+	&__copy-button {
+		padding: 12px 8px;
+		border-radius: 4px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -1,57 +1,59 @@
 @import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .site-migration-instructions {
 	.step-container {
-		padding: 0 1.5rem;
+		padding: 0 1.5rem 1.5rem 1rem;
 		max-width: 654px;
+		min-height: calc(100svh - 2 * #{$header-height});
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+
+	}
+
+	.step-container__content {
+		height: auto;
+		min-height: auto;
+	}
+	.step-container__header {
+		margin-top: 0;
+		margin-bottom: 2rem;
 	}
 
 	.site-migration-instructions__list {
+		margin-left: 18px;
+		margin-bottom: 12px;
+
 		li {
 			margin-bottom: 0.5rem;
 		}
+	}
+	.site-migration-instructions__content {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
 	}
 
 	.step-container__header p {
 		margin-top: 1.5rem;
 	}
-
-	.site-migration-instructions__list-migration-key-item {
-		height: 30px;
-		overflow: hidden;
-		transition: height 0.75s ease;
-
-		&.expanded {
-			height: auto;
-		}
-
-		&.error {
-			height: 55px;
-			color: $alert-red;
-		}
-	}
-
-	.site-migration-instructions__show-key-button,
-	.site-migration-instructions__copy-key-button {
-		display: inline-block;
-		width: 100px;
-		margin-right: 0.5rem;
-		padding: 6px 12px;
-	}
-
-	.site-migration-instructions__migration-key {
+	.loading {
+		tab-size: 4;
+		min-height: calc(100vh - 2 * #{$header-height});
+		width: 100%;
 		display: flex;
-		justify-content: space-between;
+		justify-content: center;
+		flex-direction: column;
 		align-items: center;
-		margin: 0.5rem 0.75rem 0 0;
-		max-width: 100%;
-		background: var(--color-neutral-0);
-		padding: 0.75rem;
-	}
 
-	.site-migration-instructions__migration-key .site-migration-instructions__key {
-		width: 340px;
-		margin-right: 0.5rem;
-		overflow-x: scroll;
+		.loading__content {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 1rem;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -37,6 +37,10 @@
 		gap: 16px;
 	}
 
+	.site-migration-instructions__key {
+		margin-top: 8px;
+	}
+
 	.step-container__header p {
 		margin-top: 1.5rem;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -33,7 +33,7 @@ describe( 'SiteMigrationInstructions', () => {
 		render();
 
 		const link = await screen.findByRole( 'link', {
-			name: /Migrate Guru page on the source site/,
+			name: /Migrate Guru page on your source site/,
 		} );
 
 		expect( link ).toHaveAttribute( 'href', `${ FROM_URL }/wp-admin/admin.php?page=migrateguru` );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import React from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import SiteMigrationInstructions from '..';
+import { StepProps } from '../../../types';
+import { mockStepProps, renderStep } from '../../test/helpers';
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site' );
+
+( useSite as jest.Mock ).mockReturnValue( {
+	ID: 'some-site-id',
+} );
+
+describe( 'SiteMigrationInstructions', () => {
+	const FROM_URL = 'some-source-site-url.example.com';
+	const render = ( props?: Partial< StepProps > ) => {
+		const combinedProps = { ...mockStepProps( props ) };
+		return renderStep( <SiteMigrationInstructions { ...combinedProps } />, {
+			initialEntry: `/some-path?from=${ FROM_URL }`,
+		} );
+	};
+
+	beforeAll( () => {
+		nock.disableNetConnect();
+	} );
+
+	it( 'renders a link to migrate guru source site', async () => {
+		render();
+
+		const link = await screen.findByRole( 'link', {
+			name: /Migrate Guru page on the source site/,
+		} );
+
+		expect( link ).toHaveAttribute( 'href', `${ FROM_URL }/wp-admin/admin.php?page=migrateguru` );
+	} );
+
+	it( 'copies the migration key', async () => {
+		document.execCommand = jest.fn();
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/sites/some-site-id/atomic-migration-status/migrate-guru-key' )
+			.query( { http_envelope: 1 } )
+			.reply( 200, { migration_key: 'some-migration-key' } );
+
+		render();
+		await userEvent.click( await screen.findByRole( 'button', { name: 'copy' } ) );
+
+		expect( screen.getByText( 'copied!' ) ).toBeVisible();
+		expect( document.execCommand ).toHaveBeenCalledWith( 'copy' );
+	} );
+
+	it( 'renders the migration key', async () => {
+		document.execCommand = jest.fn();
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/sites/some-site-id/atomic-migration-status/migrate-guru-key' )
+			.query( { http_envelope: 1 } )
+			.reply( 200, { migration_key: 'some-migration-key' } );
+
+		render();
+
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Show key' } ) );
+
+		expect( screen.getByDisplayValue( 'some-migration-key' ) ).toBeVisible();
+	} );
+
+	it( 'renders the fallback text', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/sites/some-site-id/atomic-migration-status/migrate-guru-key' )
+			.query( { http_envelope: 1 } )
+			.reply( 500, new Error( 'Internal Server Error' ) );
+
+		render();
+
+		expect( await screen.findByText( /Migrate Guru page on the new WordPress.com/ ) ).toBeVisible();
+	} );
+} );

--- a/client/landing/stepper/hooks/test/use-site-migration-key.tsx
+++ b/client/landing/stepper/hooks/test/use-site-migration-key.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { useSiteMigrationKey } from '../use-site-migraiton-key';
+
+describe( 'useSiteMigrationKey', () => {
+	it( 'returns the site migration key', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/sites/some-site-id/atomic-migration-status/migrate-guru-key' )
+			.query( { http_envelope: 1 } )
+			.once()
+			.reply( 200, { migration_key: 'some-migration-key' } );
+
+		const { result } = renderHook( () => useSiteMigrationKey( 'some-site-id' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.data?.migrationKey ).toEqual( 'some-migration-key' );
+	} );
+
+	it( 'skip the request when the siteId is not available', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+
+		const { result } = renderHook( () => useSiteMigrationKey( undefined ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+	} );
+} );

--- a/client/landing/stepper/hooks/use-site-migraiton-key.ts
+++ b/client/landing/stepper/hooks/use-site-migraiton-key.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface ApiResponse {
+	migration_key: string;
+}
+
+const getMigrationKey = async ( siteId: number ): Promise< ApiResponse > =>
+	wpcom.req.get( `/sites/${ siteId }/atomic-migration-status/migrate-guru-key?http_envelope=1`, {
+		apiNamespace: 'wpcom/v2',
+	} );
+
+export const useSiteMigrationKey = ( siteId?: number ) => {
+	return useQuery( {
+		queryKey: [ 'site-migration-key', siteId ],
+		queryFn: () => getMigrationKey( siteId! ),
+		retry: false,
+		enabled: !! siteId,
+		select: ( data ) => ( { migrationKey: data?.migration_key } ),
+		refetchOnWindowFocus: false,
+	} );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



Related to #88588

## Proposed Changes
* Update the site migration instructions page to reflect the figma layout  5yhaC6umexdQLlLpCrCyEe-fi-2095_9011
* Update the instructions
* Automatically load the migration key without any user interaction
* Show a different message when we can’t get the migration link
* Add links directly to the related pages

More context: p1711029899474269-slack-C0Q664T29




## Testing Instructions
**SHORT VERSION:**
1. Enable the feature toggle
2. Access `/setup/site-migration/site-migration-instructions?from=[JN site]&siteSlug=[YOUR_WORDPRESS.COM site created by previous migrations]`
3. Jump to the steps 10, 11 and 12.


**LONG VERSION:**
1. Go to the `/start` URL using the calypso.live instructions
2. Follow the flow until see the "Goals" page
4. Open the browser Web developer tools and copy and paste the following code `sessionStorage.setItem('flags', "onboarding/new-migration-flow")`
5. Type Enter
6. Reload the goals page
7. Select "Import or migrate content"
8. "Where will you import from?" set `https://test-vanilla-wp.godaddy.test-wpcom-migrations.net/`
9. Select "Everything (requires a Creator Plan)" on "What do you want to migrate?"
10. When you arrive at the "Ready to migrate your site?" follow the instructions using the page links and copying the migration key. **Screenshot 1(a,b)**
11. After following the instructions, refresh the page to see a screen variation. **Screenshot 2(a,b)**
12. Check again the instructions for the new version, using the links.

NOTE: The screen variation with the migration key is only shown the first time the user sees the screen, after a reload only the second variation is shown. 

NOTE 2: If you want to reset the site state to see screen 1 again,  you just need to open the URL([TARGET_SITE]/_cli) and run the command `wp option delete wpcom_site_migration_migrate_guru_key_read` to delete the site option we are using to not show again the migration key.


### Screenshots
**1a. Desktop - Migration key available**
<img width="1022" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/1d91384d-5c53-4793-877f-f6400b529691">

**1.b Mobile - Migration key available**
<img width="408" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/b1d00d5f-600e-4bd0-9fcc-261fcdd4e0dd">

**2a. Desktop - Migration key not available**
<img width="1028" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/018d2588-718d-4565-8988-ea082f3ea7b8">

**2b. Mobile - Migration key not available**
<img width="380" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/0c700d1f-888c-4589-8a41-7e0f2c749387">


Interactions:

https://github.com/Automattic/wp-calypso/assets/38718/6082efbb-1069-4526-811b-aaba9e30b60c

