### PR TITLE
Checkout: Adjust mobile footer to accommodate help icon

### DIFF
--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.jsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.jsx
@@ -3,22 +3,26 @@ import styled from '@emotion/styled';
 import { CheckoutSummaryRefundWindows } from './wp-checkout-order-summary';
 
 const CheckoutMoneyBackGuaranteeWrapper = styled.div`
-	display: flex;
+	display: grid;
+	grid-template-columns: 20px 1fr 70px;
+	column-gap: 1em;
 	align-items: center;
-	margin: 1em 0;
-	align-self: flex-start;
-	margin: 1em 0 0;
-	justify-content: center;
+	margin: 1.5em 0 0;
 
 	& li {
 		list-style: none;
-		padding-left: 0;
 		font-size: 14px;
-		margin: 0;
-
+		margin-bottom: 0;
+		padding: 0;
 		svg {
 			display: none;
 		}
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		grid-template-columns: 20px minmax( 150px, max-content );
+		justify-content: center;
+		margin: 1.5em 0 0;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.jsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.jsx
@@ -19,10 +19,22 @@ const CheckoutMoneyBackGuaranteeWrapper = styled.div`
 		}
 	}
 
+	.rtl & {
+		grid-template-columns: 20px 1fr;
+		padding: 10px 80px 10px 20px;
+
+		& li {
+			padding: 0;
+		}
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
+		grid-template-columns: 20px minmax( min-content, 300px ) 70px;
+	}
+
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		grid-template-columns: 20px minmax( 150px, max-content );
 		justify-content: center;
-		margin: 1.5em 0 0;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1097,8 +1097,11 @@ const JetpackCheckoutSealsWrapper = styled.div< React.HTMLAttributes< HTMLDivEle
 	flex-direction: column;
 	align-items: center;
 	gap: 0.5rem;
+	padding: 1.5rem 4rem 0 1.5rem;
 
-	padding: 1.5rem 1.5rem 0;
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding: 1.5rem 1.5rem 0;
+	}
 
 	img {
 		margin-right: 0.75rem;

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -577,7 +577,7 @@ export const SubmitButtonWrapper = styled.div`
 
 // Set right padding so that text doesn't overlap with inline help floating button.
 export const SubmitFooterWrapper = styled.div`
-	padding-right: 42px;
+	padding-right: 0;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		padding-right: 0;


### PR DESCRIPTION
There is a long and storied history to fixing the help icon in dotcom checkout. The original approach was to add a custom zendesk icon to the masterbar, but the functionality of the zendesk plugin is complicated and prone to error. Also, the original approach relied too heavily on the shopping cart provider which made the change not very portable and led to issues in the past.

That being said, the original issue was that the help icon was overlapping the footer payment button. Jetpack had handled this by increasing space beneath the payment button which worked well enough because they already used that space below the payment button for their money back guarantees. Now that Dotcom also has a money back guarantee we can do something similar.

At this point, I am inclined to abandon the masterbar chat icon work in favor of creating a more flexible checkout mobile footer that accommodates the existing help icon.

Related to https://github.com/Automattic/wp-calypso/issues/79018

## Proposed Changes

* Update`CheckoutMoneyBackGuaranteeWrapper` to CSS grid
* On mobile, provide a 70px wide column to accommodate the help icon

<img width="380" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/a3ce60b5-9235-4e2e-8a95-dadff43d54dd">


## Testing Instructions

Note: to skip the presalesChat availability check you can go to `client/lib/presales-chat/index.ts` and set the default prop `skipAvailabilityCheck` to `true`. Additionally, to show the icon for RTL languages, you can remove the condition `isEnglishLocale`. At this time presales chat is only shown to `en` locales, but I added RTL styles to future proof in case this changes.

* Go to Checkout, wait for help icon to appear
* Ensure that the chat icon doesn't overlap other elements and is properly spaced
* Go to Jetpack checkout and ensure spacing is still appropriate for their use case
* Go to your account settings and change language to an RTL language like Hebrew
* Go back to dotcom checkout and ensure the RTL styling is clear and well spaced
