### PR TITLE
Subscribers: All WPCOM sites uses WPCOM docs/help

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -57,6 +57,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 	const isFreeSite = site?.plan?.is_free ?? false;
 	const isBusinessTrial = site ? isBusinessTrialSite( site ) : false;
 	const hasSubscriberLimit = isFreeSite || isBusinessTrial;
+	const isWPCOMSite = ! site?.jetpack || site?.is_wpcom_atomic;
 
 	return (
 		<Modal
@@ -99,6 +100,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 				showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
 				recordTracksEvent={ recordTracksEvent }
 				hidden={ isUploading }
+				isWPCOMSite={ isWPCOMSite }
 			/>
 		</Modal>
 	);

--- a/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
@@ -4,7 +4,10 @@ import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, chevronRight, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { useSelector } from 'react-redux';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
 import './style.scss';
 
 type EmptyListCTALinkProps = {
@@ -46,11 +49,15 @@ const EmptyListView = () => {
 		recordTracksEvent( 'calypso_subscribers_empty_view_displayed' );
 	}, [] );
 
-	const subscribeBlockUrl = isJetpackCloud()
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = selectedSite?.ID || null;
+	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
+
+	const subscribeBlockUrl = ! isWPCOMSite
 		? 'https://jetpack.com/support/jetpack-blocks/subscription-form-block/'
 		: 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/';
 
-	const importSubscribersUrl = isJetpackCloud()
+	const importSubscribersUrl = ! isWPCOMSite
 		? 'https://jetpack.com/support/newsletter/import-subscribers/'
 		: 'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';
 
@@ -74,7 +81,7 @@ const EmptyListView = () => {
 				url={ localizeUrl( importSubscribersUrl ) }
 				eventName="calypso_subscribers_empty_view_import_subscribers_clicked"
 			/>
-			{ ! isJetpackCloud() && (
+			{ ! isWPCOMSite && (
 				<EmptyListCTALink
 					icon={ trendingUp }
 					text={ translate( 'Grow your audience' ) }

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -5,9 +5,9 @@ import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { SectionContainer } from 'calypso/components/section';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import { getSiteOption } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
@@ -65,6 +65,13 @@ const GrowYourAudience = () => {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
+	const isAdminInterfaceWPAdmin = useSelector(
+		( state ) => getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin'
+	);
+	const isClassicEarlyRelease = !! useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'wpcom_classic_early_release' )
+	);
+	const globalSiteEnabled = isAdminInterfaceWPAdmin && isClassicEarlyRelease;
 
 	const statsCardTranslated =
 		englishLocales.includes( locale ) ||
@@ -74,11 +81,12 @@ const GrowYourAudience = () => {
 			) &&
 			hasTranslation( 'Check stats' ) );
 
-	const statsUrl = isJetpackCloud()
-		? `${ siteAdminUrl }admin.php?page=stats#!/stats/subscribers/${ selectedSiteSlug }`
-		: `/stats/subscribers/${ selectedSiteSlug }`;
+	const statsUrl =
+		! isWPCOMSite || globalSiteEnabled
+			? `${ siteAdminUrl }admin.php?page=stats#!/stats/subscribers/${ selectedSiteSlug }`
+			: `https://wordpress.com/stats/subscribers/${ selectedSiteSlug }`;
 
-	const subscribeBlockUrl = isJetpackCloud()
+	const subscribeBlockUrl = ! isWPCOMSite
 		? 'https://jetpack.com/support/jetpack-blocks/subscription-form-block/'
 		: 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/';
 
@@ -112,29 +120,29 @@ const GrowYourAudience = () => {
 					/>
 				) }
 				{ isWPCOMSite && (
-					<GrowYourAudienceCard
-						icon={ trendingUp }
-						text={ translate(
-							'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
-						) }
-						title={ translate( 'Start earning' ) }
-						tracksEventCta="earn"
-						ctaLabel={ translate( 'Learn more' ) }
-						url={ `https://wordpress.com/earn/${ selectedSiteSlug ?? '' }` }
-					/>
-				) }
-				{ ! isJetpackCloud() && (
-					<GrowYourAudienceCard
-						icon={ people }
-						text={ translate(
-							'Create fresh content, publish regularly, and understand your audience with site stats.'
-						) }
-						title={ translate( 'Keep your readers engaged' ) }
-						tracksEventCta="go-content-strategy"
-						ctaLabel={ translate( 'Learn more' ) }
-						externalUrl
-						url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
-					/>
+					<>
+						<GrowYourAudienceCard
+							icon={ trendingUp }
+							text={ translate(
+								'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
+							) }
+							title={ translate( 'Start earning' ) }
+							tracksEventCta="earn"
+							ctaLabel={ translate( 'Learn more' ) }
+							url={ `https://wordpress.com/earn/${ selectedSiteSlug ?? '' }` }
+						/>
+						<GrowYourAudienceCard
+							icon={ people }
+							text={ translate(
+								'Create fresh content, publish regularly, and understand your audience with site stats.'
+							) }
+							title={ translate( 'Keep your readers engaged' ) }
+							tracksEventCta="go-content-strategy"
+							ctaLabel={ translate( 'Learn more' ) }
+							externalUrl
+							url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
+						/>
+					</>
 				) }
 			</div>
 		</SectionContainer>

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -6,11 +6,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -56,6 +56,8 @@ const MigrateSubscribersModal = () => {
 	const selectedSourceSite = useSelector( ( state ) => getSite( state, selectedSourceSiteId ) );
 	const selectedSourceSiteName = selectedSourceSite?.name || selectedSourceSite?.URL || '';
 
+	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, targetSiteId ) );
+
 	useEffect( () => {
 		if ( showMigrateSubscribersModal ) {
 			recordTracksEvent( 'calypso_subscribers_migrate_subscribers_selection' );
@@ -66,7 +68,7 @@ const MigrateSubscribersModal = () => {
 		return null;
 	}
 
-	const migrateSubscribersUrl = isJetpackCloud()
+	const migrateSubscribersUrl = ! isWPCOMSite
 		? 'https://jetpack.com/support/newsletter/import-subscribers/#migrate-subscribers-from-a-word-press-com-site'
 		: 'https://wordpress.com/support/migrate-subscribers-from-another-site/';
 

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -20,6 +20,7 @@ import {
 	SubscribersPageProvider,
 	useSubscribersPage,
 } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AddSubscribersModal } from './components/add-subscribers-modal';
 import { MigrateSubscribersModal } from './components/migrate-subscribers-modal';
@@ -44,13 +45,16 @@ const SubscribersHeader = ( { selectedSiteId, isUnverified }: SubscribersHeaderP
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const { hasTranslation } = useI18n();
 	const isEnglishLocale = useIsEnglishLocale();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = selectedSite?.ID || null;
+	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 
 	const openHelpCenter = () => {
 		setShowHelpCenter( true );
 		setShowSupportDoc( localizeUrl( 'https://wordpress.com/support/paid-newsletters/' ), 168381 );
 	};
 
-	const paidNewsletterUrl = isJetpackCloud()
+	const paidNewsletterUrl = ! isWPCOMSite
 		? 'https://jetpack.com/support/newsletter/paid-newsletters/'
 		: 'https://wordpress.com/support/paid-newsletters/';
 

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -19,12 +19,11 @@ import {
 	useRef,
 	useCallback,
 } from 'react';
-// eslint-disable-next-line no-restricted-imports
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useActiveJobRecognition } from '../../hooks/use-active-job-recognition';
 import { useInProgressState } from '../../hooks/use-in-progress-state';
 import { RecordTrackEvents, useRecordAddFormEvents } from '../../hooks/use-record-add-form-events';
 import { tip } from './icon';
+
 import './style.scss';
 
 interface Props {
@@ -48,6 +47,7 @@ interface Props {
 	subtitleText?: string;
 	showSkipLink?: boolean;
 	hidden?: boolean;
+	isWPCOMSite?: boolean;
 }
 
 export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
@@ -77,6 +77,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		subtitleText,
 		showSkipLink,
 		hidden = false,
+		isWPCOMSite = false,
 	} = props;
 
 	const {
@@ -358,7 +359,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	}
 
 	function renderImportCsvDisclaimerMsg() {
-		const importSubscribersUrl = isJetpackCloud()
+		const importSubscribersUrl = ! isWPCOMSite
 			? 'https://jetpack.com/support/newsletter/import-subscribers/'
 			: 'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';
 
@@ -393,7 +394,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			? translate( 'Or upload a CSV file of up to 100 emails from your existing list. Learn more.' )
 			: translate( 'Or upload a CSV file of emails from your existing list. Learn more.' );
 
-		const importSubscribersUrl = isJetpackCloud()
+		const importSubscribersUrl = ! isWPCOMSite
 			? 'https://jetpack.com/support/newsletter/import-subscribers/'
 			: 'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';
 


### PR DESCRIPTION
P2: peKye1-Lz-p2#comment-625

## Proposed Changes

All WPcom sites' support/help links should link to WPcom support docs. When in Jetpack Cloud, it was linking to Jetpack docs.

## Testing Instructions

* Run `yarn start-jetpack-cloud `
* Go to `http://jetpack.cloud.localhost:3000/subscribers/:your-site`
* With an Atomic sites, check support/help links should link to WPcom support pages
* With a Self-hosted site should link to Jetpack docs.
* You can run `yarn start` and check the same on `http://calypso.localhost:3000/subscribers/:your-site`
