### PR TITLE
Global sidebar mobile - update masterbar color to black, show sidebar border shadow

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -959,28 +959,29 @@ a.masterbar__quick-language-switcher {
 }
 
 .masterbar__global-nav {
-	background: var(--color-sidebar-background);
-	border-bottom: 1 px solid var(--color-sidebar-background);
+	background: var(--color-global-masterbar-background);
+	border-bottom: 1 px solid var(--color-global-masterbar-background);
 
 	.masterbar__section--left {
 		flex: 10;
 	}
 	.masterbar__item.is-active {
-		background-color: var(--color-sidebar-background);
+		background-color: var(--color-global-masterbar-background);
 	}
 
 	.masterbar__item .gridicon {
-		fill: var(--color-sidebar-gridicon-fill);
+		fill: var(--color-global-masterbar-gridicon-fill);
 	}
 
 	.masterbar__item,
 	.site {
+		color: var(--color-global-masterbar-text);
 		&:hover {
-			background-color: var(--color-sidebar-menu-hover-background);
+			background-color: var(--color-global-masterbar-hover-background);
 		}
 		.site__info .site__domain-and-badges .site__badge {
 			&::before {
-				color: var(--color-sidebar-text);
+				color: var(--color-global-masterbar-text);
 			}
 		}
 	}
@@ -991,7 +992,7 @@ a.masterbar__quick-language-switcher {
 		}
 		.site__title,
 		.site__domain {
-			color: var(--color-sidebar-text);
+			color: var(--color-global-masterbar-text);
 		}
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -57,6 +57,14 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-tooltip-text: var(--color-sidebar-menu-hover-text);
 		--color-masterbar-text: var(--color-sidebar-gridicon-fill);
 	}
+
+	.layout__secondary {
+		overflow: initial;
+
+		.global-sidebar {
+			overflow: hidden;
+		}
+	}
 }
 
 // Local Vars

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -49,13 +49,16 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-menu-hover-background: #eee;
 		--color-sidebar-submenu-background: var(--studio-gray-5);
 		--color-sidebar-border: var(--studio-gray-10);
+		--color-global-masterbar-background: var(--studio-black);
 		--color-sidebar-submenu-text: var(--color-sidebar-text);
 		--color-sidebar-submenu-selected-text: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-submenu-hover-text: var(--color-sidebar-text);
 		--color-sidebar-gridicon-fill: var(--color-sidebar-text);
 		--color-sidebar-tooltip-background: var(--color-sidebar-menu-hover-background);
 		--color-sidebar-tooltip-text: var(--color-sidebar-menu-hover-text);
-		--color-masterbar-text: var(--color-sidebar-gridicon-fill);
+		--color-global-masterbar-text: var(--studio-white);
+		--color-global-masterbar-gridicon-fill: var(--color-masterbar-text);
+		--color-global-masterbar-hover-background: var(--studio-gray-80);
 	}
 
 	.layout__secondary {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updates the global sidebar's masterbar that is shown on mobile to be black.
* Moves an overflow hidden mechanism from the layout__secondary to the global sidebar so we are able to see the box shadow.

BEFORE
<img width="377" alt="Screenshot 2024-03-22 at 4 27 52 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/1eb2112b-70cc-4e11-9cbc-ccc4e342c816">


AFTER
<img width="373" alt="Screenshot 2024-03-22 at 4 50 47 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/dc2bacfe-ccbf-453e-9755-d8aa28592ca8">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso.
* visit /sites
* test mobile and tablet viewports
* verify things look as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
