### PR TITLE
Github Deployments: Show a contextual permissions notice based on repository selection

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/repository-list.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list.tsx
@@ -64,20 +64,23 @@ export const GitHubBrowseRepositoriesList = ( {
 	}
 
 	const getRepositoryPermissionsNotice = () => {
-		const noticeText =
-			installation.repository_selection === 'all'
-				? __( 'Need to adjust permissions?' )
-				: __( 'Missing GitHub repositories?' );
-
-		const linkText =
-			installation.repository_selection === 'all'
-				? __( 'Update them on GitHub' )
-				: __( 'Adjust permissions on GitHub' );
+		if ( installation.repository_selection === 'all' ) {
+			return (
+				<p className="github-repositories-list-permissions-notice">
+					{ __( 'Need to adjust permissions?' ) }{ ' ' }
+					<ExternalLink href={ installation.management_url }>
+						{ __( 'Update them on GitHub' ) }
+					</ExternalLink>
+				</p>
+			);
+		}
 
 		return (
 			<p className="github-repositories-list-permissions-notice">
-				{ noticeText }{ ' ' }
-				<ExternalLink href={ installation.management_url }>{ linkText }</ExternalLink>
+				{ __( 'Missing GitHub repositories?' ) }{ ' ' }
+				<ExternalLink href={ installation.management_url }>
+					{ __( 'Adjust permissions on GitHub' ) }
+				</ExternalLink>
 			</p>
 		);
 	};

--- a/client/my-sites/github-deployments/components/repositories/repository-list.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list.tsx
@@ -63,6 +63,25 @@ export const GitHubBrowseRepositoriesList = ( {
 		return <NoResults manageInstallationUrl={ installation.management_url } />;
 	}
 
+	const getRepositoryPermissionsNotice = () => {
+		const noticeText =
+			installation.repository_selection === 'all'
+				? __( 'Need to adjust permissions?' )
+				: __( 'Missing GitHub repositories?' );
+
+		const linkText =
+			installation.repository_selection === 'all'
+				? __( 'Update them on GitHub' )
+				: __( 'Adjust permissions on GitHub' );
+
+		return (
+			<p className="github-repositories-list-permissions-notice">
+				{ noticeText }{ ' ' }
+				<ExternalLink href={ installation.management_url }>{ linkText }</ExternalLink>
+			</p>
+		);
+	};
+
 	return (
 		<div className="github-repositories-list">
 			<GitHubRepositoryListTable
@@ -72,12 +91,7 @@ export const GitHubBrowseRepositoriesList = ( {
 				sortDirection={ direction }
 				onSortChange={ handleSortChange }
 			/>
-			<p className="github-repositories-list-permissions-notice">
-				{ __( 'Missing GitHub repositories?' ) }{ ' ' }
-				<ExternalLink href={ installation.management_url }>
-					{ __( 'Adjust permissions on GitHub' ) }
-				</ExternalLink>
-			</p>
+			{ getRepositoryPermissionsNotice() }
 			<Pagination
 				page={ page }
 				perPage={ pageSize }

--- a/client/my-sites/github-deployments/use-github-installations-query.ts
+++ b/client/my-sites/github-deployments/use-github-installations-query.ts
@@ -17,7 +17,7 @@ export interface GitHubInstallationData {
 	external_id: number;
 	account_name: string;
 	management_url: string;
-	repository_selection: string;
+	repository_selection: 'all' | 'selected';
 }
 
 export const useGithubInstallationsQuery = (

--- a/client/my-sites/github-deployments/use-github-installations-query.ts
+++ b/client/my-sites/github-deployments/use-github-installations-query.ts
@@ -17,6 +17,7 @@ export interface GitHubInstallationData {
 	external_id: number;
 	account_name: string;
 	management_url: string;
+	repository_selection: string;
 }
 
 export const useGithubInstallationsQuery = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/5908

## Proposed Changes

This PR shows a different copy based on whether the installation has access to all or selected repository

* Show contextual permissions copy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply patch D142989-code

* go to `/github-deployments/siteSlug`
* go to connect repository modal
* Adjust permission to to have access to all repository and verify the notice is now "Need to adjust permissions? Update them on GitHub"
* Adjust permissions to only selected repository and verify notice is now "Missing Github repositories? Adjust permissions on GitHub"


![image](https://github.com/Automattic/wp-calypso/assets/47489215/d10acb7d-42a1-4a9c-8e22-970bae9737de)
![image](https://github.com/Automattic/wp-calypso/assets/47489215/3e714536-2172-4576-b298-9ba13bd979a3)


Note you will have to close and reopen the dialog for the notice to update since the installation is not refetched when repository changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?