### PR TITLE
E2E: Set the `gutenbergCoreE2eBuildType` bash scripts to run on the new base image

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -52,7 +52,7 @@ object WPComTests : Project({
 	// Gutenberg Atomic Nightly
 	buildType(gutenbergPlaywrightBuildType("desktop", "a3f58555-56bb-42c6-8543-ab27213d3085" , atomic=true, nightly=true));
 	buildType(gutenbergPlaywrightBuildType("mobile", "8191e677-0682-4709-9201-66a7788980f0", atomic=true, nightly=true));
-	// Gutenberg Core 
+	// Gutenberg Core
 	buildType(gutenbergCoreE2eBuildType());
 
 	// E2E Tests for Jetpack Simple Deployment
@@ -113,10 +113,11 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 
 					# Install deps
 					npm ci
-					
+
 					# Build packages
 					npm run build:packages
 				""".trimIndent()
+				dockerImage = "%docker_image_ci_e2e_gb_core_on_dotcom%"
 			}
 
 			bashNodeScript {
@@ -135,6 +136,7 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 					# Run suite.
 					npm run test:e2e:playwright
 				""".trimIndent()
+				dockerImage = "%docker_image_ci_e2e_gb_core_on_dotcom%"
 			}
 		}
 	})
@@ -250,7 +252,7 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		uuid = buildUuid
 		name = "Jetpack Simple Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating the deployment of Jetpack on Simple sites on $targetDevice viewport"
-		
+
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
@@ -306,13 +308,13 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 
 fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String ): BuildType {
 	val atomicVariations = listOf("default", "php-old", "php-new", "wp-beta", "wp-previous", "private", "ecomm-plan")
-	
+
 	return BuildType({
 		id("WPComTests_jetpack_atomic_deployment_e2e_$targetDevice")
 		uuid = buildUuid
 		name = "Jetpack Atomic Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating a Jetpack release candidate for full WPCOM Atomic deployment. Runs all tests on all Atomic environment variations."
-		
+
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
@@ -384,7 +386,7 @@ fun jetpackAtomicBuildSmokeE2eBuildType( targetDevice: String, buildUuid: String
 		uuid = buildUuid
 		name = "Jetpack Atomic Build Smoke E2E Tests ($targetDevice)"
 		description = "Runs E2E tests to smoke test the most recent Jetpack build on Atomic staging sites. It uses a randomized mix of Atomic environment variations."
-		
+
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -66,6 +66,7 @@ project {
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)
 		text("docker_image", "registry.a8c.com/calypso/base:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)
 		text("docker_image_e2e", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker e2e image", description = "Docker image used to run e2e tests", allowEmpty = true)
+		text("docker_image_ci_e2e_gb_core_on_dotcom", "registry.a8c.com/calypso/ci-e2e-gb-core-on-dotcom:latest", label = "Docker GB core on dotcom image", description = "Docker image used to run GB core E2E tests on dotcom", allowEmpty = true)
 		text("env.DOCKER_BUILDKIT", "1", label = "Enable Docker BuildKit", description = "Enables BuildKit (faster image generation). Values 0 or 1", allowEmpty = true)
 		password("mc_post_root", "credentialsJSON:2f764583-d399-4d5f-8ee1-06f68ef2e2a6", display = ParameterDisplay.HIDDEN )
 		password("mc_auth_secret", "credentialsJSON:5b1903f9-4b03-43ff-bba8-4a7509d07088", display = ParameterDisplay.HIDDEN)


### PR DESCRIPTION
Related/follow-up to: https://github.com/Automattic/wp-calypso/pull/88104.

## Proposed Changes

After creating and pushing the image to the registry from https://github.com/Automattic/wp-calypso/pull/88104, using the `test/build-tag-push-ci-e2e-gb-core-on-dotcom-base-image.sh` script, it should now be accessible form the A8C registry. The next step is to make the new build use it. 

**Why was this done?** To fix a node/version mismatch in the build. Check the https://github.com/Automattic/wp-calypso/pull/88104 for more info.

I'll leave the related PR open until I'm sure this works well, as there's the possibility I might need to adjust the base image.


## Testing Instructions

* All checks should pass;
* Merge, cross fingers and verify the `Gutenberg Core E2E Tests` is working and the node/npm version mismatch is not happening anymore.