### PR TITLE
Global Sidebar: Remove Link to `/sites` when on Sites Dashboard

### DIFF
--- a/client/layout/global-sidebar/header.tsx
+++ b/client/layout/global-sidebar/header.tsx
@@ -1,5 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { getSectionName } from 'calypso/state/ui/selectors';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import SkipNavigation from '../sidebar/skip-navigation';
 import { GLOBAL_SIDEBAR_EVENTS } from './events';
 import SidebarNotifications from './menu-items/notifications';
@@ -7,20 +9,25 @@ import { SidebarSearch } from './menu-items/search';
 
 export const GlobalSidebarHeader = () => {
 	const translate = useTranslate();
+	const sectionName = useSelector( getSectionName );
 	return (
 		<div className="sidebar__header">
 			<SkipNavigation
 				skipToElementId="primary"
 				displayText={ translate( 'Skip to main content' ) }
 			/>
-			<a
-				href="/sites"
-				className="link-logo tooltip tooltip-bottom-left"
-				data-tooltip={ translate( 'View all sites' ) }
-				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.ALLSITES_CLICK ) }
-			>
+			{ sectionName === 'sites-dashboard' ? (
 				<span className="dotcom"></span>
-			</a>
+			) : (
+				<a
+					href="/sites"
+					className="link-logo tooltip tooltip-bottom-left"
+					data-tooltip={ translate( 'View all sites' ) }
+					onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.ALLSITES_CLICK ) }
+				>
+					<span className="dotcom"></span>
+				</a>
+			) }
 			<span className="gap"></span>
 			<SidebarSearch
 				tooltip={ translate( 'Jump to…' ) }


### PR DESCRIPTION
## Proposed Changes

I'm not really sure that it makes much sense to link to `/sites` when the user is already on the page. I just spent a few minutes confused about why the link wasn't working, as I was expecting something new to appear, but it never did. 

## Testing Instructions

Navigate to `/sites`, and confirm the following cases. You should no longer see a pop-up for the "View all sites" link when you're already viewing all sites. You should see it when you aren't viewing all sites!

| Current | Proposed | Unchanged |
|--------|--------|--------|
| <img width="296" alt="Screenshot 2024-03-23 at 11 33 54" src="https://github.com/Automattic/wp-calypso/assets/43215253/c71341a7-1e42-4edd-89c0-d17d8e9cb6ac"> | <img width="275" alt="Screenshot 2024-03-23 at 11 34 03" src="https://github.com/Automattic/wp-calypso/assets/43215253/ff95fede-0ad0-4a12-b35e-853391a20dad"> | <img width="287" alt="Screenshot 2024-03-23 at 11 34 08" src="https://github.com/Automattic/wp-calypso/assets/43215253/1d138d77-4302-4791-91ea-fdea0b597a24"> | 

cc @taipeicoder, @Addison-Stavlo