### PR TITLE
Help Centre: Check Default Locale against English Variants

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -5,7 +5,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice } from '@automattic/components';
-import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
+import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
 import { comment, Icon } from '@wordpress/icons';
@@ -72,6 +72,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 } ) => {
 	const { __ } = useI18n();
 	const locale = useLocale();
+	const isEnglishLocale = useIsEnglishLocale();
 	const renderEmail = useShouldRenderEmailOption();
 	const {
 		hasActiveChats,
@@ -104,7 +105,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	}, [ isLoading, renderChat.state, renderEmail.render ] );
 
 	const liveChatHeaderText = useMemo( () => {
-		if ( isDefaultLocale( locale ) || ! hasTranslation( 'Live chat (English)' ) ) {
+		if ( isEnglishLocale || ! hasTranslation( 'Live chat (English)' ) ) {
 			return __( 'Live chat', __i18n_text_domain__ );
 		}
 
@@ -112,7 +113,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	}, [ __, locale ] );
 
 	const emailHeaderText = useMemo( () => {
-		if ( isDefaultLocale( locale ) ) {
+		if ( isEnglishLocale ) {
 			return __( 'Email', __i18n_text_domain__ );
 		}
 
@@ -139,7 +140,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	}, [ __, locale ] );
 
 	const forumHeaderText = useMemo( () => {
-		if ( isDefaultLocale( locale ) ) {
+		if ( isEnglishLocale ) {
 			return __( 'Community forums', __i18n_text_domain__ );
 		}
 		return __( 'Community forums (English)', __i18n_text_domain__ );

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -24,12 +24,12 @@ export function getPathParts( path: string ) {
 }
 
 /**
- * Checks if provided locale is a default one - eg. en; en-GB; en-AU.
+ * Checks if provided locale is a default one.
  * @param {string} locale - locale slug (eg: 'fr')
  * @returns {boolean} true when the default locale is provided
  */
 export function isDefaultLocale( locale: string | null ) {
-	return locale?.startsWith( config( 'i18n_default_locale_slug' ) );
+	return locale === config( 'i18n_default_locale_slug' );
 }
 
 /**

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -24,12 +24,12 @@ export function getPathParts( path: string ) {
 }
 
 /**
- * Checks if provided locale is a default one.
+ * Checks if provided locale is a default one - eg. en; en-GB; en-AU.
  * @param {string} locale - locale slug (eg: 'fr')
  * @returns {boolean} true when the default locale is provided
  */
 export function isDefaultLocale( locale: string | null ) {
-	return locale === config( 'i18n_default_locale_slug' );
+	return locale?.startsWith( config( 'i18n_default_locale_slug' ) );
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

At the moment, `isDefaultLocale` only checks against `en`. This is a bit inconsistent with what similar functions do in Calypso in checking against English variants. 

https://github.com/Automattic/wp-calypso/blob/1540ea658d9fa9dce9d38d3d39ef649433cd2f11/client/components/translator-invite/utils.js#L17-L19

## Testing Instructions

Select British English and open the Help Centre, which is an example of something that uses this `isDefaultLocale` function (could test anywhere though). Confirm that your locale is now treated as default.

**Before:**
<img width="395" alt="Screenshot 2024-03-23 at 13 02 09" src="https://github.com/Automattic/wp-calypso/assets/43215253/d0c18bb2-cbd0-47f6-9759-0b1d228c0e77">

**After:**
<img width="404" alt="Screenshot 2024-03-23 at 13 01 57" src="https://github.com/Automattic/wp-calypso/assets/43215253/f794287d-d65f-46e9-bcb6-2e3f069794a6">

cc @alshakero 