### PR TITLE
Themes: Fix Features Link

### DIFF
--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -24,7 +24,7 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 				<ul className="theme__sheet-features-list">
 					{ features.map( ( { name, slug, term } ) => {
 						const filterPath = localizeThemesPath(
-							`/themes/filter/${ term }/${ siteSlug || '' }`,
+							`/themes/all/filter/${ term }/${ siteSlug || '' }`,
 							locale,
 							! isLoggedIn
 						);


### PR DESCRIPTION
## Proposed Changes

* Quick fix for the features link on individual themes

## Testing Instructions

* Head to an individual theme - eg. https://wordpress.com/theme/button-2
* Scroll to the bottom
* Click a feature - eg. "Custom Header"
* Confirm that the link now works, whereas it didn't before 

<img width="763" alt="Screenshot 2024-03-24 at 12 18 20" src="https://github.com/Automattic/wp-calypso/assets/43215253/b5a06214-165e-4b0e-adcf-2a1e4a6c1ca3">

cc @Copons, @xavier-lc, @rcrdortiz 