### PR TITLE
Stats: Update UTM support URL.

### DIFF
--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -2,6 +2,8 @@
 // eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 export const SUPPORT_URL = 'https://wordpress.com/support/stats/understand-your-sites-traffic/';
 // eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+export const JETPACK_SUPPORT_URL = 'https://jetpack.com/support/jetpack-stats/traffic-dashboard/';
+// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 export const SUBSCRIBERS_SUPPORT_URL = 'https://wordpress.com/support/subscribers/';
 export const INSIGHTS_SUPPORT_URL =
 	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,6 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { SUPPORT_URL, INSIGHTS_SUPPORT_URL } from './const';
+import { SUPPORT_URL, INSIGHTS_SUPPORT_URL, JETPACK_SUPPORT_URL } from './const';
 
 export default function () {
 	const statsStrings = {};
@@ -83,7 +83,7 @@ export default function () {
 			{
 				comment: '{{link}} links to support documentation.',
 				components: {
-					link: <a href={ localizeUrl( `${ SUPPORT_URL }#utm` ) } />,
+					link: <a href={ localizeUrl( `${ JETPACK_SUPPORT_URL }#utm-stats` ) } />,
 				},
 				context: 'Stats: Info box label when the UTM module is empty',
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88117

## Proposed Changes

* updating support URL to the correct page and section

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and verify that if the UTM module it empty it shows a link pointing to Jetpack documentation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?