### PR TITLE
Automattic for Agencies: Add box-shadow to the search box on the Licenses page

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/style.scss
@@ -1,3 +1,8 @@
+
+.licenses-overview .search {
+	box-shadow: 0 0 0 1px var(--color-neutral-5);
+}
+
 .licenses-overview__empty-message {
 	margin: 32px auto;
 	text-align: center;


### PR DESCRIPTION
## Proposed Changes

This PR adds box-shadow to the search box on the Licenses page.

## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Go to Purchases > Licenses. Verify that you can now see a border for the search box as shown below:

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1254" alt="Screenshot 2024-03-25 at 2 07 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6a102fda-baa3-4e7c-91b9-4c37bf5ea3d6">
</td>
<td>
<img width="1254" alt="Screenshot 2024-03-25 at 2 07 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/763b4fde-376c-4dab-b7ab-41768b89f4a2">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?