### PR TITLE
Fix woo passwordless form label spacing

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1317,15 +1317,6 @@ $breakpoint-mobile: 660px;
 					max-width: $max-width;
 					margin: 0;
 				}
-
-				.login__form-userdata .form-label {
-					color: var(--color-gray-100);
-					font-size: 1rem;
-					font-style: normal;
-					font-weight: 600;
-					line-height: 24px;
-					margin-bottom: 16px;
-				}
 			}
 
 			.auth-form__separator {
@@ -1333,6 +1324,15 @@ $breakpoint-mobile: 660px;
 					margin-block: 0;
 				}
 			}
+		}
+
+		label.form-label {
+			color: var(--color-gray-100);
+			font-size: 1rem;
+			font-style: normal;
+			font-weight: 600;
+			line-height: 24px;
+			margin-bottom: 10px;
 		}
 
 		.wp-login__main-footer {
@@ -1596,15 +1596,6 @@ $breakpoint-mobile: 660px;
 						max-width: $max-width;
 					}
 				}
-
-				label.form-label {
-					color: var(--studio-gray-100);
-					font-size: 1rem;
-					font-style: normal;
-					font-weight: 600;
-					line-height: 24px;
-					margin-bottom: 16px;
-				}
 			}
 
 			.magic-login__form p.magic-login__form-sub-header,
@@ -1670,15 +1661,6 @@ $breakpoint-mobile: 660px;
 		.logged-out-form {
 			padding: 0;
 			margin: 0;
-
-			label.form-label {
-				color: var(--color-gray-100);
-				font-size: 1rem;
-				font-style: normal;
-				font-weight: 600;
-				line-height: 24px;
-				margin-bottom: 16px;
-			}
 		}
 
 		.login__lostpassword-form {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1326,7 +1326,9 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		label.form-label {
+		label.form-label,
+		.logged-out-form label.form-label,
+		.magic-login__form label.form-label {
 			color: var(--color-gray-100);
 			font-size: 1rem;
 			font-style: normal;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->



## Proposed Changes

* Change `margin-bottom` from `16px` to `10px`. The Figma designs have a 16px margin-bottom, but the line height of the text isn't the same, so we need to use 10px.  (4ixWMlzrxllx93tSFsCW6k-fi-10009_10023#743041125)
* Refactor form label styles in woo.scss

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up woo-start-env
* Use incognito mode
* Go to https://wordpress.com/start/wpcc/oauth2-user?oauth2_client_id=50916&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dd231ae6d23275825558cbb5358896fe5267017301525c112c155237379382776%26redirect_uri%3Dhttps%253A%252F%252Fwoo.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&woo-passwordless=yes
* Observe that the label margin-bottom is `10px`
* Go to Log in screen
* Observe that the label margin-bottom is `10px`
* Click on `Email me a login link` button
* Observe that the label margin-bottom is `10px`

<img width="600" alt="Screenshot 2024-03-25 at 17 40 51" src="https://github.com/Automattic/wp-calypso/assets/4344253/5fcfd2c5-2502-4131-a784-718d1f3cc17d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?