### PR TITLE
Plugins update manager: Add weekday to track events

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -68,6 +68,7 @@ export const ScheduleCreate = ( props: Props ) => {
 			frequency: params.frequency,
 			plugins_number: params.plugins.length,
 			hours: params.hours,
+			weekday: params.weekday,
 		} );
 
 		createMonitor();

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -58,6 +58,7 @@ export const ScheduleEdit = ( props: Props ) => {
 			frequency: params.frequency,
 			plugins_number: params.plugins.length,
 			hours: params.hours,
+			weekday: params.weekday,
 		} );
 
 		setSyncError( '' );

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -51,13 +51,15 @@ export const ScheduleForm = ( props: Props ) => {
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
 
 	const serverSyncCallbacks = {
-		onSuccess: () =>
-			onSyncSuccess &&
-			onSyncSuccess( {
+		onSuccess: () => {
+			const date = new Date( timestamp * 1000 );
+			onSyncSuccess?.( {
 				plugins: selectedPlugins,
 				frequency,
-				hours: new Date( timestamp * 1000 ).getHours(),
-			} ),
+				hours: date.getHours(),
+				weekday: frequency === 'weekly' ? date.getDay() : undefined,
+			} );
+		},
 		onError: ( e: Error ) => onSyncError && onSyncError( e.message ),
 	};
 	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, serverSyncCallbacks );

--- a/client/blocks/plugins-update-manager/types.ts
+++ b/client/blocks/plugins-update-manager/types.ts
@@ -2,4 +2,5 @@ export type SyncSuccessParams = {
 	plugins: string[];
 	frequency: 'daily' | 'weekly';
 	hours: number;
+	weekday?: number;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds weekday to track events

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create or edit scheduled updates and check the console to see if there is a weekday param inside the "calypso:analytics" event

<img width="843" alt="Screenshot 2024-03-25 at 10 58 17" src="https://github.com/Automattic/wp-calypso/assets/1241413/43be3239-560b-4894-868b-188cafe2e6d3">
<img width="818" alt="Screenshot 2024-03-25 at 10 57 57" src="https://github.com/Automattic/wp-calypso/assets/1241413/5b6c9247-5880-4be1-8d6f-957c6f0f2b4d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?