### PR TITLE
Newsletter Settings: Remove deprecated settings notices.

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
@@ -77,24 +77,6 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 						</FormSettingExplanation>
 					</>
 				) }
-
-				<FormLabel htmlFor="comment_follow_email_message">
-					{ translate( 'Comment follow email message' ) }
-				</FormLabel>
-				<FormSettingExplanation>
-					{ translate(
-						'The ability to customize the comment follow email message had to be disabled to prevent abuse. It will revert to the default message for all new subscribers.'
-					) }
-				</FormSettingExplanation>
-
-				<FormLabel htmlFor="confirmation_email_message">
-					{ translate( 'Confirmation email message' ) }
-				</FormLabel>
-				<FormSettingExplanation>
-					{ translate(
-						'The ability to customize the confirmation email message had to be disabled to prevent abuse. It will revert to the default message for all new subscribers.'
-					) }
-				</FormSettingExplanation>
 			</FormFieldset>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1711200243417759/1696507364.013669-slack-C02TCEHP3HA

## Proposed Changes

| Before | After |
|:---:|:---:|
| <img src="https://github.com/Automattic/wp-calypso/assets/2019970/0c8592f3-aef1-4b09-8e81-e088c4404091" width="400" style="max-height:200px;"> | <img src="https://github.com/Automattic/wp-calypso/assets/2019970/8c9ae49c-82fb-4d97-835c-afa589e089d3" width="400" style="max-height:200px;"> |


* Remove the notice messages. It has been almost 6 months since the changes were made. It is the time to drop the messages now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [calypso.localhost:3000/settings/newsletter](http://calypso.localhost:3000/settings/newsletter) and select your test site.
* Ensure the notice messages are not displayed anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?