### PR TITLE
Nav Redesign: Add the wp-admin link to the site of the all sites list

### DIFF
--- a/client/sites-dashboard/components/sites-site-admin-link.tsx
+++ b/client/sites-dashboard/components/sites-site-admin-link.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import { ExternalLink } from '@wordpress/components';
+
+export const SiteAdminLink = styled( ExternalLink )`
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	font-size: 14px;
+	color: var( --studio-gray-60 ) !important;
+	&:hover {
+		text-decoration: underline;
+	}
+	svg {
+		flex-shrink: 0;
+	}
+`;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -24,6 +24,7 @@ import {
 } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import SitesP2Badge from './sites-p2-badge';
+import { SiteAdminLink } from './sites-site-admin-link';
 import { SiteItemThumbnail } from './sites-site-item-thumbnail';
 import { SiteLaunchNag } from './sites-site-launch-nag';
 import { SiteName } from './sites-site-name';
@@ -90,6 +91,10 @@ const ListTileTitle = styled.div`
 const ListTileSubtitle = styled.div`
 	display: flex;
 	align-items: center;
+
+	&:not( :last-child ) {
+		margin-block-end: 2px;
+	}
 `;
 
 const StatsOffIndicatorStyled = styled.div`
@@ -205,11 +210,18 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 						</ListTileTitle>
 					}
 					subtitle={
-						<ListTileSubtitle>
-							<SiteUrl href={ siteUrl } title={ siteUrl }>
-								<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
-							</SiteUrl>
-						</ListTileSubtitle>
+						<>
+							<ListTileSubtitle>
+								<SiteUrl href={ siteUrl } title={ siteUrl }>
+									<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
+								</SiteUrl>
+							</ListTileSubtitle>
+							<ListTileSubtitle>
+								<SiteAdminLink href={ dashboardUrl } title={ __( 'Visit Dashboard' ) }>
+									{ __( 'WP Admin' ) }
+								</SiteAdminLink>
+							</ListTileSubtitle>
+						</>
 					}
 				/>
 			</Column>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -217,7 +217,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 								</SiteUrl>
 							</ListTileSubtitle>
 							<ListTileSubtitle>
-								<SiteAdminLink href={ dashboardUrl } title={ __( 'Visit Dashboard' ) }>
+								<SiteAdminLink href={ getSiteWpAdminUrl( site ) } title={ __( 'Visit WP Admin' ) }>
 									{ __( 'WP Admin' ) }
 								</SiteAdminLink>
 							</ListTileSubtitle>

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -103,7 +103,7 @@ export const generateSiteInterfaceLink = (
 };
 
 export const getSiteWpAdminUrl = ( site: SiteExcerptNetworkData ) => {
-	return site?.options?.admin_url;
+	return site?.options?.admin_url ?? '';
 };
 
 export const SMALL_MEDIA_QUERY = 'screen and ( max-width: 600px )';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6253

## Proposed Changes

* Add the wp-admin link to the site of the all sites list and it will open the WP Admin on the new tab

| Before | After |
| - | - |
|  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ca5dae62-7c30-4628-a58f-69a0cedb2ea6)  | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/d17efb3d-1f35-4276-a391-a6b06e24ebc7) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Make sure there is a `WP Admin` link on each site
* Click on the link
* Make sure it opens the WP Admin on the new tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?