### PR TITLE
Update notification panel slide out direction

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -1,7 +1,7 @@
 $no-sidebar-min-page-width: 800px;
 $with-sidebar-min-page-width: 1114px;
 
-@mixin setToggleNoteBehaviour {
+@mixin setToggleNoteBehaviourRTL {
 	.wpnc__list-view.wpnc__current {
 		display: block;
 
@@ -23,6 +23,51 @@ $with-sidebar-min-page-width: 1114px;
 	.wpnc__single-view {
 		right: 410px;
 		left: 10px;
+		top: 0;
+		bottom: 0;
+		z-index: -1;
+
+		header {
+			nav {
+				display: none;
+			}
+		}
+
+		.wpnc__note {
+			margin-top: 0;
+		}
+
+		-webkit-transform: translate3d(0, 0, 0); // fix for getting scrollbar in right z-index
+		animation-name: wpnc__slideIn;
+		animation-timing-function: ease-out;
+		animation-fill-mode: forwards;
+		animation-duration: 0.2s;
+		animation-iteration-count: 1;
+	}
+}
+
+@mixin setToggleNoteBehaviourLTR {
+	.wpnc__list-view.wpnc__current {
+		display: block;
+
+		.wpnc__selected-note {
+			animation-name: wpnc__selectIn;
+			animation-timing-function: ease-in;
+			animation-duration: 0.4s;
+			animation-iteration-count: 1;
+		}
+
+		box-shadow: none;
+	}
+
+	.wpnc__note-list {
+		right: auto;
+		width: 410px;
+	}
+
+	.wpnc__single-view {
+		left: 410px;
+		right: 10px;
 		top: 0;
 		bottom: 0;
 		z-index: -1;
@@ -946,14 +991,14 @@ $with-sidebar-min-page-width: 1114px;
 	// Check if global-sidebar-visible not present
 	&:not(.global-sidebar-visible) {
 		@media only screen and ( min-width: $no-sidebar-min-page-width ) {
-			@include setToggleNoteBehaviour;
+			@include setToggleNoteBehaviourRTL;
 		}
 	}
 
 	// Override the CSS variable value if .global-sidebar-visible is present
 	&.global-sidebar-visible {
 		@media only screen and ( min-width: $with-sidebar-min-page-width ) {
-			@include setToggleNoteBehaviour;
+			@include setToggleNoteBehaviourLTR;
 		}
 	}
 

--- a/client/layout/global-sidebar/menu-items/notifications/style.scss
+++ b/client/layout/global-sidebar/menu-items/notifications/style.scss
@@ -1,3 +1,8 @@
 .sidebar-notifications__panel {
 	position: absolute;
+
+	#wpnc-panel.wpnt-open {
+		right: auto;
+		left: var(--sidebar-width-max);
+	}
 }


### PR DESCRIPTION
This PR is related to the issue https://github.com/Automattic/wp-calypso/issues/88302

When we are working with the global sidebar and click the notification icon, the panel still slides out from the right.

This PR is a test to see what would be involved to make it possible to slide from the left to right. We can then test this to see if its a better UX.