### PR TITLE
A4A: Change Volume pricing 'Discount' label to 'Save up to'.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
@@ -41,7 +41,7 @@ export default function VolumePriceSelector( {
 	return (
 		<A4ASlider
 			label={ translate( 'Volume pricing' ) }
-			sub={ translate( 'Discount' ) }
+			sub={ translate( 'Save up to' ) }
 			className="product-listing__volume-price-selector"
 			value={ options.findIndex( ( { value } ) => selectedBundleSize === value ) }
 			options={ options }


### PR DESCRIPTION
This was missed previously. The correct text to display in the Volume pricing should be **'Save up to'** instead of **'Discount'**.

**Before**
<img width="325" alt="Screenshot 2024-03-25 at 8 21 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/83af4e50-a2c2-4a54-968d-3e5b58442a54">
**After**
<img width="285" alt="Screenshot 2024-03-25 at 8 21 08 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f6949d54-da68-4f95-8b29-d2363fedc4bb">

pfunGA-Jv-p2#comment-1091

## Proposed Changes

* Change Volume pricing sub text to **'Save up to'**.

## Testing Instructions
* Use the live link and go to `/marketplace/products`
* Confirm that the volume pricing selector now displays the correct text.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?