### PR TITLE
Pattern Library: Remove unnecessary `display: block`

### DIFF
--- a/client/my-sites/patterns/components/pattern-gallery/style.scss
+++ b/client/my-sites/patterns/components/pattern-gallery/style.scss
@@ -19,8 +19,6 @@
 }
 
 .pattern-gallery--grid.pattern-gallery--pages {
-	display: block;
-
 	@include break-medium {
 		column-count: 2;
 	}


### PR DESCRIPTION
## Proposed Changes

This removes a seemingly unnecessary `display: block` from the pattern library.

May fix the problems reported in https://github.com/Automattic/dotcom-forge/issues/6247  and https://github.com/Automattic/dotcom-forge/issues/6249

Alternative to #88842. See #88842 for more details.

## Testing Instructions

Refer to #88842 for testing instructions