### PR TITLE
Add domain name in set primary button

### DIFF
--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -133,7 +133,14 @@ const SetAsPrimary = ( { domain, selectedSite }: SetAsPrimaryProps ) => {
 					busy={ isSettingPrimaryDomain }
 					disabled={ shouldDisableSetAsPrimaryButton }
 				>
-					{ translate( 'Set this domain as primary' ) }
+					{ translate( 'Set {{strong}}%(domainName)s{{/strong}} as primary', {
+						args: {
+							domainName: domain.name,
+						},
+						components: {
+							strong: <strong />,
+						},
+					} ) }
 				</Button>
 			</Accordion>
 		</div>


### PR DESCRIPTION
## Proposed Changes

We want to improve the set primary domain flow in domain management page, adding the domain name in the set primary button.

## Testing Instructions

Apply the patch or visit the calypso link and visit the setting page of a custom domain name that isn't set as primary. Verify that the button in the Set as Primary card display the domain name.

![primary-before](https://github.com/Automattic/wp-calypso/assets/2797601/237772f2-66fb-4f27-a132-e4941eedd4b3)

![primary-after](https://github.com/Automattic/wp-calypso/assets/2797601/d24ae8f6-c1cc-43ce-ab45-f0d57da5f2cb)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?