### PR TITLE
Release Subscribers to JPCloud

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -69,6 +69,7 @@
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
+		"subscriber-csv-upload": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": false,
 		"jetpack/pricing-page-cart": true,
@@ -93,6 +94,7 @@
 		"jetpack-cloud-golden-token": false,
 		"jetpack-search": true,
 		"jetpack-social": true,
+		"jetpack-subscribers": true,
 		"scan": true,
 		"site-purchases": true
 	},


### PR DESCRIPTION
Slack: p1711121504486989-slack-C06DN6QQVAQ

## Proposed Changes

Release Subscribers on Jetpack Cloud production.

## Testing Instructions

* We should see the Subscribers menu on Jetpack Cloud while unproxied.
