### PR TITLE
Subscriber Importer Improvements

### DIFF
--- a/client/components/staging-gate/index.tsx
+++ b/client/components/staging-gate/index.tsx
@@ -1,0 +1,42 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC, ReactNode } from 'react';
+import Notice from 'calypso/components/notice';
+import { useSelector } from 'calypso/state';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import type { SiteId } from 'calypso/types';
+
+import './style.scss';
+
+interface Props {
+	children: ReactNode;
+	siteId: SiteId | null;
+}
+
+const StagingGate: FC< Props > = ( { children, siteId } ) => {
+	const translate = useTranslate();
+	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
+
+	const getNoticeBanner = () => {
+		return (
+			<Notice
+				className="scheduled-updates__activating-notice"
+				status="is-warning"
+				showDismiss={ false }
+				text={ translate( 'This feature is currently disabled on the staging site.' ) }
+				icon="notice"
+			></Notice>
+		);
+	};
+
+	if ( ! isStagingSite ) {
+		return (
+			<div tabIndex={ -1 } className="staging-gate">
+				{ getNoticeBanner() }
+				<div className="staging-gate__content">{ children }</div>
+			</div>
+		);
+	}
+	return <div>{ children }</div>;
+};
+
+export default StagingGate;

--- a/client/components/staging-gate/index.tsx
+++ b/client/components/staging-gate/index.tsx
@@ -28,7 +28,7 @@ const StagingGate: FC< Props > = ( { children, siteId } ) => {
 		);
 	};
 
-	if ( ! isStagingSite ) {
+	if ( isStagingSite ) {
 		return (
 			<div tabIndex={ -1 } className="staging-gate">
 				{ getNoticeBanner() }

--- a/client/components/staging-gate/style.scss
+++ b/client/components/staging-gate/style.scss
@@ -1,0 +1,5 @@
+.staging-gate__content {
+	position: relative;
+	pointer-events: none;
+	opacity: 0.33;
+}

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -5,7 +5,7 @@ import { useIsEnglishLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -13,6 +13,7 @@ import QueryMembershipsSettings from 'calypso/components/data/query-memberships-
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import StagingGate from 'calypso/components/staging-gate';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import GiftSubscriptionModal from 'calypso/my-sites/subscribers/components/gift-modal/gift-modal';
 import { SubscriberListContainer } from 'calypso/my-sites/subscribers/components/subscriber-list-container';
@@ -21,6 +22,7 @@ import {
 	useSubscribersPage,
 } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AddSubscribersModal } from './components/add-subscribers-modal';
 import { MigrateSubscribersModal } from './components/migrate-subscribers-modal';
@@ -143,6 +145,7 @@ const SubscribersPage = ( {
 	const [ giftUsername, setGiftUsername ] = useState( '' );
 
 	const siteId = selectedSite?.ID || null;
+	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
 	const pageArgs = {
 		currentPage: pageNumber,
@@ -177,6 +180,23 @@ const SubscribersPage = ( {
 		setGiftUsername( display_name );
 	};
 
+	const Gate = ( props: { children: ReactNode } ) => {
+		const { children } = props;
+
+		return isStagingSite ? (
+			<StagingGate siteId={ siteId }>{ children }</StagingGate>
+		) : (
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-expect-error
+			<EmailVerificationGate
+				noticeText={ translate( 'You must verify your email to add subscribers.' ) }
+				noticeStatus="is-warning"
+			>
+				{ children }
+			</EmailVerificationGate>
+		);
+	};
+
 	return (
 		<SubscribersPageProvider
 			siteId={ siteId }
@@ -195,12 +215,7 @@ const SubscribersPage = ( {
 				<DocumentHead title={ translate( 'Subscribers' ) } />
 
 				<SubscribersHeader selectedSiteId={ selectedSite?.ID } isUnverified={ isUnverified } />
-				{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
-				{ /* @ts-ignore */ }
-				<EmailVerificationGate
-					noticeText={ translate( 'You must verify your email to add subscribers.' ) }
-					noticeStatus="is-warning"
-				>
+				<Gate>
 					<SubscriberListContainer
 						siteId={ siteId }
 						onClickView={ onClickView }
@@ -228,7 +243,7 @@ const SubscribersPage = ( {
 					) }
 					{ selectedSite && <AddSubscribersModal site={ selectedSite } /> }
 					{ selectedSite && <MigrateSubscribersModal /> }
-				</EmailVerificationGate>
+				</Gate>
 			</Main>
 		</SubscribersPageProvider>
 	);

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -36,12 +36,12 @@ import './style.scss';
 
 type SubscribersHeaderProps = {
 	selectedSiteId: number | undefined;
-	isUnverified: boolean;
+	disableCta: boolean;
 };
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const SubscribersHeader = ( { selectedSiteId, isUnverified }: SubscribersHeaderProps ) => {
+const SubscribersHeader = ( { selectedSiteId, disableCta }: SubscribersHeaderProps ) => {
 	const { setShowAddSubscribersModal } = useSubscribersPage();
 	const localizeUrl = useLocalizeUrl();
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
@@ -103,7 +103,7 @@ const SubscribersHeader = ( { selectedSiteId, isUnverified }: SubscribersHeaderP
 			<Button
 				className="add-subscribers-button"
 				primary
-				disabled={ isUnverified }
+				disabled={ disableCta }
 				onClick={ () => setShowAddSubscribersModal( true ) }
 			>
 				<Gridicon icon="plus" size={ 24 } />
@@ -145,7 +145,6 @@ const SubscribersPage = ( {
 	const [ giftUsername, setGiftUsername ] = useState( '' );
 
 	const siteId = selectedSite?.ID || null;
-	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
 	const pageArgs = {
 		currentPage: pageNumber,
@@ -160,6 +159,7 @@ const SubscribersPage = ( {
 	);
 
 	const isUnverified = importSelector?.error?.code === 'unverified_email';
+	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
 	const { getSubscribersImports } = useDataStoreDispatch( SubscriberDataStore.store );
 
@@ -214,7 +214,10 @@ const SubscribersPage = ( {
 			<Main wideLayout className="subscribers">
 				<DocumentHead title={ translate( 'Subscribers' ) } />
 
-				<SubscribersHeader selectedSiteId={ selectedSite?.ID } isUnverified={ isUnverified } />
+				<SubscribersHeader
+					selectedSiteId={ selectedSite?.ID }
+					disableCta={ isUnverified || isStagingSite }
+				/>
 				<Gate>
 					<SubscriberListContainer
 						siteId={ siteId }

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -129,6 +129,7 @@
 	}
 
 	.components-text-control__input {
+		min-height: 2.75rem;
 		border-color: var(--studio-gray-10);
 		border-radius: 4px;
 		box-sizing: border-box;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/88847

cc @simison 

## Proposed Changes

* Fixes input height
* Creates a generic StagingGate component with the message "This feature is currently disabled on the staging site."
* Integrates StagingGate with priority over the EmailVerificationGate

## Testing Instructions

* Login as a verified user
* Go to `/subscribers/{SITE}`
* Check if the input form controls have the right height
---
* Go to `/subscribers/{STAGING_SITE}`
* Check if the StagingGate blocks the UI
---
* Login as an unverified user
* Check if the EmailVerificationGate works as before the changes

<img width="1123" alt="Screenshot 2024-03-26 at 15 19 10" src="https://github.com/Automattic/wp-calypso/assets/1241413/308afdfc-0411-4703-b901-f528c6c24d47">

| Before | After |
|--------|--------|
| <img width="727" alt="Screenshot 2024-03-25 at 16 51 01" src="https://github.com/Automattic/wp-calypso/assets/1241413/89e9db99-bac9-4ecd-a96d-d11353b36596"> | <img width="757" alt="Screenshot 2024-03-25 at 16 50 52" src="https://github.com/Automattic/wp-calypso/assets/1241413/249d6108-2a0b-4655-a8fd-29c97401faa6"> | 
| <img width="650" alt="Screenshot 2024-03-25 at 16 54 36" src="https://github.com/Automattic/wp-calypso/assets/1241413/f23225c3-ca47-4bfd-9e07-79fcd29d1327"> | <img width="632" alt="Screenshot 2024-03-25 at 16 54 42" src="https://github.com/Automattic/wp-calypso/assets/1241413/9a2d48b4-98e3-49a9-8efa-3fea294c8f69"> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?