### PR TITLE
Site Migration: Fix continue button over the mobile navigation bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .import-or-migrate {
 	max-width: 602px;
 	padding: 0 12px;
@@ -11,8 +14,14 @@
 	.import-or-migrate__content {
 		display: flex;
 		flex-direction: column;
-		gap: 80px;
+		gap: 50px;
+		padding-bottom: 108px;
 		align-items: center;
+
+		@include break-mobile {
+			gap: 80px;
+			padding-bottom: revert;
+		}
 	}
 
 	.import-or-migrate__list {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, to avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/88817

## Proposed Changes
* Reduce the gap between elements when the user is using a small screen
* Add extra padding only on mobile devices to ensure scrolling on smaller screens. 


## Testing Instructions
* Access `/setup/site-migration/site-migration-import-or-migrate?from=[JN SITE] &siteSlug=[YOUR WPCOM SITE]&flags=onboarding/new-migration-flow`
* Open the dev tools
* Use the mobile emulation tools 
<img width="840" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/02be1d88-b43f-443e-a29f-2e943d225aad">

* Select iPhone SE

* Check if the continue button is visible

<img width="729" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/3b707965-0659-4bba-b847-ed64fa759278">



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?