### PR TITLE
A4A: Add partnerships email address to the overview page intro cards

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
@@ -60,8 +60,12 @@ const Card4 = () => {
 			<h1>{ translate( 'And more to come' ) }</h1>
 			<p>
 				{ translate(
-					// to do: change the x@automattic.com email address
-					'We’re only just getting started. Our mission is to create an agency program that helps your business to grow with us. If you have any feedback or suggestions for us, we’d love to hear from you at X@automattic.com.'
+					'We’re only just getting started. Our mission is to create an agency program that helps your business to grow with us. If you have any feedback or suggestions for us, we’d love to hear from you at {{mailto}}partnerships@automattic.com{{/mailto}}.',
+					{
+						components: {
+							mailto: <a href="mailto:partnerships@automattic.com" />,
+						},
+					}
 				) }
 			</p>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Replaces the placeholder "x" email address with the official partnerships address.
* Wraps address with a `mailto` link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the last intro card on the A4A `/overview` page, validate the email address is updated and clicking it opens your email client.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="741" alt="Screenshot 2024-03-25 at 12 10 07 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/37fb916c-750d-46ab-89f6-529f74f63670">

