### PR TITLE
AI Logo Generator: Check media library and use thumbnail

### DIFF
--- a/packages/jetpack-ai-calypso/src/constants.ts
+++ b/packages/jetpack-ai-calypso/src/constants.ts
@@ -18,5 +18,5 @@ export const EVENT_PLACEMENT_FREE_USER_SCREEN = 'free_user_screen';
 export const EVENT_PLACEMENT_UPGRADE_PROMPT = 'upgrade_prompt';
 
 // Feature constants
-export const MINIMUM_PROMPT_LENGTH = 10;
+export const MINIMUM_PROMPT_LENGTH = 3;
 export const DEFAULT_LOGO_COST = 10;

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../constants';
 import useLogoGenerator from '../hooks/use-logo-generator';
 import useRequestErrors from '../hooks/use-request-errors';
-import { isLogoHistoryEmpty } from '../lib/logo-storage';
+import { isLogoHistoryEmpty, clearDeletedMedia } from '../lib/logo-storage';
 import { STORE_NAME } from '../store';
 import { FeatureFetchFailureScreen } from './feature-fetch-failure-screen';
 import { FirstLoadScreen } from './first-load-screen';
@@ -127,6 +127,10 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 				return;
 			}
 
+			// Load the logo history and clear any deleted media.
+			await clearDeletedMedia( String( siteId ) );
+			loadLogoHistory( siteId );
+
 			// If there is any logo, we do not need to generate a first logo again.
 			if ( ! isLogoHistoryEmpty( String( siteId ) ) ) {
 				setLoadingState( null );
@@ -139,15 +143,14 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			debug( 'Error fetching feature', error );
 			setLoadingState( null );
 		}
-	}, [ siteId, getFeature, siteDetails?.domain, generateFirstLogo ] );
+	}, [ getFeature, siteId, loadLogoHistory, generateFirstLogo, siteDetails?.domain ] );
 
 	const handleModalOpen = useCallback( async () => {
 		setContext( context );
 		recordTracksEvent( EVENT_MODAL_OPEN, { context, placement: EVENT_PLACEMENT_QUICK_LINKS } );
-		loadLogoHistory( siteId );
 
 		initializeModal();
-	}, [ setContext, context, loadLogoHistory, siteId, initializeModal ] );
+	}, [ setContext, context, initializeModal ] );
 
 	const closeModal = () => {
 		onClose();

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -228,6 +228,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 					logo={ selectedLogo }
 					onApplyLogo={ handleApplyLogo }
 					logoAccepted={ logoAccepted }
+					siteId={ String( siteId ) }
 				/>
 				{ logoAccepted ? (
 					<div className="jetpack-ai-logo-generator__accept">

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/history-carousel.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/history-carousel.tsx
@@ -27,6 +27,16 @@ export const HistoryCarousel: React.FC = () => {
 		setSelectedLogoIndex( index );
 	};
 
+	const thumbnailFrom = ( url: string ): string => {
+		const thumbnailURL = new URL( url );
+
+		if ( ! thumbnailURL.searchParams.has( 'resize' ) ) {
+			thumbnailURL.searchParams.append( 'resize', '48,48' );
+		}
+
+		return thumbnailURL.toString();
+	};
+
 	return (
 		<div className="jetpack-ai-logo-generator__carousel">
 			{ logos.map( ( logo, index ) => (
@@ -37,7 +47,7 @@ export const HistoryCarousel: React.FC = () => {
 					} ) }
 					onClick={ () => handleClick( index ) }
 				>
-					<img src={ logo.url } alt={ logo.description } />
+					<img src={ thumbnailFrom( logo.url ) } alt={ logo.description } />
 				</Button>
 			) ) }
 		</div>

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/logo-storage.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/logo-storage.ts
@@ -1,8 +1,11 @@
 /**
  * Types
  */
-import { SaveToStorageProps } from '../../types';
+import { RemoveFromStorageProps, SaveToStorageProps } from '../../types';
 import { Logo } from '../store/types';
+import { mediaExists } from './media-exists';
+
+const MAX_LOGOS = 10;
 
 export function stashLogo( { siteId, url, description, mediaId }: SaveToStorageProps ) {
 	const storedString = localStorage.getItem( `logo-history-${ siteId }` );
@@ -16,13 +19,41 @@ export function stashLogo( { siteId, url, description, mediaId }: SaveToStorageP
 
 	storedContent.push( logo );
 
-	localStorage.setItem( `logo-history-${ siteId }`, JSON.stringify( storedContent.slice( -10 ) ) );
+	localStorage.setItem(
+		`logo-history-${ siteId }`,
+		JSON.stringify( storedContent.slice( -MAX_LOGOS ) )
+	);
 	return logo;
 }
 
 export function getSiteLogoHistory( siteId: string ) {
 	const storedString = localStorage.getItem( `logo-history-${ siteId }` );
-	const storedContent = storedString ? JSON.parse( storedString ) : [];
+	let storedContent: Logo[] = storedString ? JSON.parse( storedString ) : [];
+
+	// Ensure that the stored content is an array
+	if ( ! Array.isArray( storedContent ) ) {
+		storedContent = [];
+	}
+
+	// Ensure a maximum of 10 logos are stored
+	storedContent = storedContent.slice( -MAX_LOGOS );
+
+	// Ensure that the stored content is an array of Logo objects
+	storedContent = storedContent
+		.filter( ( logo ) => {
+			return (
+				typeof logo === 'object' &&
+				typeof logo.url === 'string' &&
+				typeof logo.description === 'string' &&
+				logo.mediaId !== undefined &&
+				typeof logo.mediaId === 'number'
+			);
+		} )
+		.map( ( logo ) => ( {
+			url: logo.url,
+			description: logo.description,
+			mediaId: logo.mediaId,
+		} ) );
 
 	return storedContent;
 }
@@ -31,4 +62,42 @@ export function isLogoHistoryEmpty( siteId: string ) {
 	const storedContent = getSiteLogoHistory( siteId );
 
 	return storedContent.length === 0;
+}
+
+export function removeLogo( { siteId, mediaId }: RemoveFromStorageProps ) {
+	const storedContent = getSiteLogoHistory( siteId );
+	const index = storedContent.findIndex( ( logo ) => logo.mediaId === mediaId );
+
+	if ( index === -1 ) {
+		return;
+	}
+
+	storedContent.splice( index, 1 );
+	localStorage.setItem( `logo-history-${ siteId }`, JSON.stringify( storedContent ) );
+}
+
+export async function clearDeletedMedia( siteId: string ) {
+	const storedContent = getSiteLogoHistory( siteId );
+
+	const checks = storedContent
+		.filter( ( { mediaId } ) => mediaId !== undefined )
+		.map(
+			( { mediaId } ) =>
+				new Promise( ( resolve, reject ) => {
+					mediaExists( { siteId, mediaId } )
+						.then( ( exists ) => resolve( { mediaId, exists } ) )
+						.catch( ( error ) => reject( error ) );
+				} )
+		);
+
+	try {
+		const responses = ( await Promise.all( checks ) ) as {
+			mediaId: Logo[ 'mediaId' ];
+			exists: boolean;
+		}[];
+
+		responses
+			.filter( ( { exists } ) => ! exists )
+			.forEach( ( { mediaId } ) => removeLogo( { siteId, mediaId } ) );
+	} catch ( error ) {} // Assume that the media exists if there was a network error and do nothing to avoid data loss.
 }

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/logo-storage.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/logo-storage.ts
@@ -1,15 +1,14 @@
 /**
  * Types
  */
-import { RemoveFromStorageProps, SaveToStorageProps } from '../../types';
+import { RemoveFromStorageProps, SaveToStorageProps, UpdateInStorageProps } from '../../types';
 import { Logo } from '../store/types';
 import { mediaExists } from './media-exists';
 
 const MAX_LOGOS = 10;
 
 export function stashLogo( { siteId, url, description, mediaId }: SaveToStorageProps ) {
-	const storedString = localStorage.getItem( `logo-history-${ siteId }` );
-	const storedContent = storedString ? JSON.parse( storedString ) : [];
+	const storedContent = getSiteLogoHistory( siteId );
 
 	const logo: Logo = {
 		url,
@@ -23,7 +22,26 @@ export function stashLogo( { siteId, url, description, mediaId }: SaveToStorageP
 		`logo-history-${ siteId }`,
 		JSON.stringify( storedContent.slice( -MAX_LOGOS ) )
 	);
+
 	return logo;
+}
+
+export function updateLogo( { siteId, url, newUrl, mediaId }: UpdateInStorageProps ) {
+	const storedContent = getSiteLogoHistory( siteId );
+
+	const index = storedContent.findIndex( ( logo ) => logo.url === url );
+
+	if ( index > -1 ) {
+		storedContent[ index ].url = newUrl;
+		storedContent[ index ].mediaId = mediaId;
+	}
+
+	localStorage.setItem(
+		`logo-history-${ siteId }`,
+		JSON.stringify( storedContent.slice( -MAX_LOGOS ) )
+	);
+
+	return storedContent[ index ];
 }
 
 export function getSiteLogoHistory( siteId: string ) {
@@ -44,9 +62,7 @@ export function getSiteLogoHistory( siteId: string ) {
 			return (
 				typeof logo === 'object' &&
 				typeof logo.url === 'string' &&
-				typeof logo.description === 'string' &&
-				logo.mediaId !== undefined &&
-				typeof logo.mediaId === 'number'
+				typeof logo.description === 'string'
 			);
 		} )
 		.map( ( logo ) => ( {

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/media-exists.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/media-exists.ts
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import wpcomProxyRequest from 'wpcom-proxy-request';
+/**
+ * Types
+ */
+import type { CheckMediaProps } from '../../types';
+
+export async function mediaExists( { siteId, mediaId }: CheckMediaProps ): Promise< boolean > {
+	const id = Number( mediaId );
+
+	if ( Number.isNaN( id ) ) {
+		return false;
+	}
+
+	try {
+		// Using wpcomProxyRequest directly here because we don't want to limit the number of concurrent media checks
+		// We store at most 10 logos in the local storage, so the number of concurrent requests should be limited
+		await wpcomProxyRequest( {
+			path: `/sites/${ String( siteId ) }/media/${ Number( mediaId ) }`,
+			apiVersion: '1.1',
+			method: 'GET',
+		} );
+
+		return true;
+	} catch ( error ) {
+		const status = ( error as { status?: number } )?.status;
+
+		if ( status === 404 ) {
+			return false;
+		}
+
+		throw error;
+	}
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/actions.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/actions.ts
@@ -191,6 +191,7 @@ const actions = {
 
 	loadLogoHistory( siteId: string ) {
 		const history = getSiteLogoHistory( siteId );
+
 		return {
 			type: ACTION_SET_SITE_HISTORY,
 			history,

--- a/packages/jetpack-ai-calypso/src/types.ts
+++ b/packages/jetpack-ai-calypso/src/types.ts
@@ -39,6 +39,11 @@ export type SaveToMediaLibraryResponseProps = {
 	];
 };
 
+export type CheckMediaProps = {
+	siteId: string | number;
+	mediaId: Logo[ 'mediaId' ];
+};
+
 export type SetSiteLogoProps = {
 	siteId: string | number;
 	imageId: string | number;
@@ -68,5 +73,10 @@ export type TokenDataEndpointResponseProps = {
 };
 
 export type SaveToStorageProps = Logo & {
+	siteId: string;
+};
+
+export type RemoveFromStorageProps = {
+	mediaId: Logo[ 'mediaId' ];
 	siteId: string;
 };

--- a/packages/jetpack-ai-calypso/src/types.ts
+++ b/packages/jetpack-ai-calypso/src/types.ts
@@ -16,6 +16,7 @@ export interface LogoPresenterProps {
 	loading?: boolean;
 	onApplyLogo: () => void;
 	logoAccepted?: boolean;
+	siteId: string | number;
 }
 
 export type SaveToMediaLibraryProps = {
@@ -74,6 +75,13 @@ export type TokenDataEndpointResponseProps = {
 
 export type SaveToStorageProps = Logo & {
 	siteId: string;
+};
+
+export type UpdateInStorageProps = {
+	siteId: string;
+	url: Logo[ 'url' ];
+	newUrl: Logo[ 'url' ];
+	mediaId: Logo[ 'mediaId' ];
 };
 
 export type RemoveFromStorageProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #86868
Fixes #88866
Fixes #87020

## Proposed Changes

* Checks the existence of the logo media files on modal open, removing unsaved logos and logos deleted from the media library
* Fix an issue with manually saved logos not updated on localStorage
* Uses the image's thumbnail in the history carousel
* Reduces the minimum prompt to 3 characters

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Generate a couple of logos
* Go to the media library and delete one of them
* Open the generator modal again
* Check that the deleted logo is not listed
* Check that a prompt can be sent with 3 characters or more
* Check that the history carousel image sources are thumbnails (right click the image, open in another tab, the image should be small)
* Check that there are no regressions on normal usage

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?