### PR TITLE
Pattern Library: Prep strings for localization

### DIFF
--- a/client/my-sites/patterns/.eslintrc
+++ b/client/my-sites/patterns/.eslintrc
@@ -1,5 +1,0 @@
-{
-	"rules": {
-		"wpcalypso/i18n-translate-identifier": "off"
-	}
-}

--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -57,43 +57,51 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 							'is-page-patterns': patternTypeFilter === PatternTypeFilter.PAGES,
 						} ) }
 					>
-						{ categories?.map( ( category ) => (
-							<LocalizedLink
-								className="patterns-category-gallery__item"
-								href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
-								key={ category.name }
-							>
-								<div
-									className={ classNames( 'patterns-category-gallery__item-preview', {
-										'patterns-category-gallery__item-preview--page-layout':
-											patternTypeFilter === PatternTypeFilter.PAGES,
-										'patterns-category-gallery__item-preview--mirrored': category.name === 'footer',
-									} ) }
-								>
-									<div className="patterns-category-gallery__item-preview-inner">
-										<PatternPreview
-											category={ category.name }
-											className="pattern-preview--category-gallery"
-											pattern={
-												patternTypeFilter === PatternTypeFilter.PAGES
-													? category.pagePreviewPattern
-													: category.regularPreviewPattern
-											}
-											patternTypeFilter={ patternTypeFilter }
-											viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
-										/>
-									</div>
-								</div>
+						{ categories?.map( ( category ) => {
+							const patternCount =
+								patternTypeFilter === PatternTypeFilter.PAGES
+									? category.pagePatternCount
+									: category.regularPatternCount;
 
-								<div className="patterns-category-gallery__item-name">{ category.label }</div>
-								<div className="patterns-category-gallery__item-count">
-									{ patternTypeFilter === PatternTypeFilter.PAGES
-										? category.pagePatternCount
-										: category.regularPatternCount }{ ' ' }
-									{ translate( 'patterns' ) }
-								</div>
-							</LocalizedLink>
-						) ) }
+							return (
+								<LocalizedLink
+									className="patterns-category-gallery__item"
+									href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
+									key={ category.name }
+								>
+									<div
+										className={ classNames( 'patterns-category-gallery__item-preview', {
+											'patterns-category-gallery__item-preview--page-layout':
+												patternTypeFilter === PatternTypeFilter.PAGES,
+											'patterns-category-gallery__item-preview--mirrored':
+												category.name === 'footer',
+										} ) }
+									>
+										<div className="patterns-category-gallery__item-preview-inner">
+											<PatternPreview
+												category={ category.name }
+												className="pattern-preview--category-gallery"
+												pattern={
+													patternTypeFilter === PatternTypeFilter.PAGES
+														? category.pagePreviewPattern
+														: category.regularPreviewPattern
+												}
+												patternTypeFilter={ patternTypeFilter }
+												viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
+											/>
+										</div>
+									</div>
+
+									<div className="patterns-category-gallery__item-name">{ category.label }</div>
+									<div className="patterns-category-gallery__item-count">
+										{ translate( '%(count)d pattern', '%(count)d patterns', {
+											count: patternCount,
+											args: { count: patternCount },
+										} ) }
+									</div>
+								</LocalizedLink>
+							);
+						} ) }
 					</div>
 				</PatternsSection>
 			</PatternsRendererProvider>

--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -1,5 +1,6 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { CategoryGalleryServer } from 'calypso/my-sites/patterns/components/category-gallery/server';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 import {
@@ -29,6 +30,8 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 				?.filter( ( { regularPreviewPattern } ) => regularPreviewPattern )
 				.map( ( { regularPreviewPattern } ) => `${ regularPreviewPattern?.ID }` ) ?? [],
 	};
+
+	const translate = useTranslate();
 
 	return (
 		<BlockRendererProvider
@@ -87,7 +90,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 									{ patternTypeFilter === PatternTypeFilter.PAGES
 										? category.pagePatternCount
 										: category.regularPatternCount }{ ' ' }
-									patterns
+									{ translate( 'patterns' ) }
 								</div>
 							</LocalizedLink>
 						) ) }

--- a/client/my-sites/patterns/components/category-gallery/server.tsx
+++ b/client/my-sites/patterns/components/category-gallery/server.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview/placeholder';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
@@ -13,6 +14,8 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 	title,
 	patternTypeFilter,
 } ) => {
+	const translate = useTranslate();
+
 	return (
 		<PatternsSection title={ title } description={ description }>
 			<div
@@ -52,7 +55,7 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 							{ patternTypeFilter === PatternTypeFilter.PAGES
 								? category.pagePatternCount
 								: category.regularPatternCount }{ ' ' }
-							patterns
+							{ translate( 'patterns' ) }
 						</div>
 					</LocalizedLink>
 				) ) }

--- a/client/my-sites/patterns/components/category-gallery/server.tsx
+++ b/client/my-sites/patterns/components/category-gallery/server.tsx
@@ -24,41 +24,48 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 					'is-page-patterns': patternTypeFilter === PatternTypeFilter.PAGES,
 				} ) }
 			>
-				{ categories?.map( ( category ) => (
-					<LocalizedLink
-						className="patterns-category-gallery__item"
-						href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
-						key={ category.name }
-					>
-						<div className="patterns-category-gallery__item-preview">
-							<div
-								className={ classNames( 'patterns-category-gallery__item-preview', {
-									'patterns-category-gallery__item-preview--page-layout':
-										patternTypeFilter === PatternTypeFilter.PAGES,
-									'patterns-category-gallery__item-preview--mirrored': category.name === 'footer',
-								} ) }
-							>
-								<div className="patterns-category-gallery__item-preview-inner">
-									<PatternPreviewPlaceholder
-										pattern={
-											patternTypeFilter === PatternTypeFilter.PAGES
-												? category.pagePreviewPattern
-												: category.regularPreviewPattern
-										}
-									/>
+				{ categories?.map( ( category ) => {
+					const patternCount =
+						patternTypeFilter === PatternTypeFilter.PAGES
+							? category.pagePatternCount
+							: category.regularPatternCount;
+
+					return (
+						<LocalizedLink
+							className="patterns-category-gallery__item"
+							href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
+							key={ category.name }
+						>
+							<div className="patterns-category-gallery__item-preview">
+								<div
+									className={ classNames( 'patterns-category-gallery__item-preview', {
+										'patterns-category-gallery__item-preview--page-layout':
+											patternTypeFilter === PatternTypeFilter.PAGES,
+										'patterns-category-gallery__item-preview--mirrored': category.name === 'footer',
+									} ) }
+								>
+									<div className="patterns-category-gallery__item-preview-inner">
+										<PatternPreviewPlaceholder
+											pattern={
+												patternTypeFilter === PatternTypeFilter.PAGES
+													? category.pagePreviewPattern
+													: category.regularPreviewPattern
+											}
+										/>
+									</div>
 								</div>
 							</div>
-						</div>
 
-						<div className="patterns-category-gallery__item-name">{ category.label }</div>
-						<div className="patterns-category-gallery__item-count">
-							{ patternTypeFilter === PatternTypeFilter.PAGES
-								? category.pagePatternCount
-								: category.regularPatternCount }{ ' ' }
-							{ translate( 'patterns' ) }
-						</div>
-					</LocalizedLink>
-				) ) }
+							<div className="patterns-category-gallery__item-name">{ category.label }</div>
+							<div className="patterns-category-gallery__item-count">
+								{ translate( '%(count)d pattern', '%(count)d patterns', {
+									count: patternCount,
+									args: { count: patternCount },
+								} ) }
+							</div>
+						</LocalizedLink>
+					);
+				} ) }
 			</div>
 		</PatternsSection>
 	);

--- a/client/my-sites/patterns/components/category-not-found/index.tsx
+++ b/client/my-sites/patterns/components/category-not-found/index.tsx
@@ -19,20 +19,21 @@ export const PatternsCategoryNotFound = ( {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const translate = useTranslate();
 
-	const emptyContentStrings = {
-		title: translate( "Oops! We can't find this category!", {
-			comment:
-				'Message displayed when an invalid category was specified while searching block patterns',
-		} ),
-		line: translate( "The category you are looking for doesn't exist.", {
-			comment:
-				'Message displayed when an invalid category was specified while searching block patterns',
-		} ),
-		action: translate( 'Browse all patterns', {
-			comment:
-				'Message displayed when an invalid category was specified while searching block patterns',
-		} ),
-	};
+	const title = translate( "Oops! We can't find this category!", {
+		comment:
+			'Heading displayed when an invalid category was specified while searching block patterns',
+	} );
+
+	const line = translate( "The category you are looking for doesn't exist.", {
+		comment:
+			'Message displayed when an invalid category was specified while searching block patterns',
+	} );
+
+	const action = translate( 'Browse all patterns', {
+		comment:
+			'Label of the button displayed when an invalid category was specified while searching block patterns',
+	} );
+
 	return (
 		<>
 			<PatternsPageViewTracker
@@ -42,9 +43,9 @@ export const PatternsCategoryNotFound = ( {
 			/>
 
 			<EmptyContent
-				title={ emptyContentStrings.title }
-				line={ emptyContentStrings.line }
-				action={ emptyContentStrings.action }
+				title={ title }
+				line={ line }
+				action={ action }
 				actionURL={ isLoggedIn ? '/patterns' : addLocaleToPathLocaleInFront( '/patterns' ) }
 				illustration="/calypso/images/illustrations/illustration-404.svg"
 			/>

--- a/client/my-sites/patterns/components/category-not-found/index.tsx
+++ b/client/my-sites/patterns/components/category-not-found/index.tsx
@@ -17,11 +17,22 @@ export const PatternsCategoryNotFound = ( {
 	referrer,
 }: PatternsCategoryNotFoundProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const translate_not_yet = useTranslate();
+	const translate = useTranslate();
 
-	const comment =
-		'Message displayed when an invalid category was specified while searching block patterns';
-
+	const emptyContentStrings = {
+		title: translate( "Oops! We can't find this category!", {
+			comment:
+				'Message displayed when an invalid category was specified while searching block patterns',
+		} ),
+		line: translate( "The category you are looking for doesn't exist.", {
+			comment:
+				'Message displayed when an invalid category was specified while searching block patterns',
+		} ),
+		action: translate( 'Browse all patterns', {
+			comment:
+				'Message displayed when an invalid category was specified while searching block patterns',
+		} ),
+	};
 	return (
 		<>
 			<PatternsPageViewTracker
@@ -31,9 +42,9 @@ export const PatternsCategoryNotFound = ( {
 			/>
 
 			<EmptyContent
-				title={ translate_not_yet( "Oops! We can't find this category!", { comment } ) }
-				line={ translate_not_yet( "The category you are looking for doesn't exist.", { comment } ) }
-				action={ translate_not_yet( 'Browse all patterns', { comment } ) }
+				title={ emptyContentStrings.title }
+				line={ emptyContentStrings.line }
+				action={ emptyContentStrings.action }
 				actionURL={ isLoggedIn ? '/patterns' : addLocaleToPathLocaleInFront( '/patterns' ) }
 				illustration="/calypso/images/illustrations/illustration-404.svg"
 			/>

--- a/client/my-sites/patterns/components/copy-paste-info/index.tsx
+++ b/client/my-sites/patterns/components/copy-paste-info/index.tsx
@@ -12,9 +12,11 @@ export function PatternsCopyPasteInfo() {
 	return (
 		<PatternsSection
 			bodyFullWidth
-			description="Pick out a pattern, copy-paste it into your design, and customize it any way you like. No plugins needed."
+			description={ translate(
+				'Pick out a pattern, copy-paste it into your design, and customize it any way you like. No plugins needed.'
+			) }
 			theme="dark"
-			title="Copy, paste, customize—it’s easy like that"
+			title={ translate( 'Copy, paste, customize—it’s easy like that' ) }
 		>
 			<div className="section-patterns-info">
 				<div className="section-patterns-info__inner">

--- a/client/my-sites/patterns/components/copy-paste-info/index.tsx
+++ b/client/my-sites/patterns/components/copy-paste-info/index.tsx
@@ -8,7 +8,7 @@ import ImgStyle from './images/style.svg';
 import './style.scss';
 
 export function PatternsCopyPasteInfo() {
-	const translate_not_yet = useTranslate();
+	const translate = useTranslate();
 	return (
 		<PatternsSection
 			bodyFullWidth
@@ -24,10 +24,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translate_not_yet( 'Copy-paste your way' ) }
+							{ translate( 'Copy-paste your way' ) }
 						</div>
 						<div className="section-patterns-info__item-description">
-							{ translate_not_yet(
+							{ translate(
 								'Paste patterns directly into the WordPress editor to fully customize them.'
 							) }
 						</div>
@@ -39,10 +39,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translate_not_yet( 'Bring your style with you' ) }
+							{ translate( 'Bring your style with you' ) }
 						</div>
 						<div className="section-patterns-info__item-description">
-							{ translate_not_yet(
+							{ translate(
 								'Patterns replicate the typography and color palette from your site to ensure every page is on-brand.'
 							) }
 						</div>
@@ -54,10 +54,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translate_not_yet( 'Make it yours' ) }
+							{ translate( 'Make it yours' ) }
 						</div>
 						<div className="section-patterns-info__item-description">
-							{ translate_not_yet(
+							{ translate(
 								'Patterns are collections of regular WordPress blocks, so you can edit every detail, however you want.'
 							) }
 						</div>
@@ -69,10 +69,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translate_not_yet( 'Responsive by design' ) }
+							{ translate( 'Responsive by design' ) }
 						</div>
 						<div className="section-patterns-info__item-description">
-							{ translate_not_yet(
+							{ translate(
 								'All patterns are fully responsive to ensure they look fantastic on any device or screen.'
 							) }
 						</div>

--- a/client/my-sites/patterns/components/copy-paste-info/index.tsx
+++ b/client/my-sites/patterns/components/copy-paste-info/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 import ImgCopyPaste from './images/copy-paste.svg';
 import ImgEdit from './images/edit.svg';
@@ -7,6 +8,7 @@ import ImgStyle from './images/style.svg';
 import './style.scss';
 
 export function PatternsCopyPasteInfo() {
+	const translateNotYet = useTranslate();
 	return (
 		<PatternsSection
 			bodyFullWidth
@@ -21,9 +23,13 @@ export function PatternsCopyPasteInfo() {
 							<img src={ ImgCopyPaste } alt="" />
 						</div>
 
-						<div className="section-patterns-info__item-title">Copy-paste your way</div>
+						<div className="section-patterns-info__item-title">
+							{ translateNotYet( 'Copy-paste your way' ) }
+						</div>
 						<div className="section-patterns-info__item-description">
-							Paste patterns directly into the WordPress editor to fully customize them.
+							{ translateNotYet(
+								'Paste patterns directly into the WordPress editor to fully customize them.'
+							) }
 						</div>
 					</div>
 
@@ -32,10 +38,13 @@ export function PatternsCopyPasteInfo() {
 							<img src={ ImgStyle } alt="" />
 						</div>
 
-						<div className="section-patterns-info__item-title">Bring your style with you</div>
+						<div className="section-patterns-info__item-title">
+							{ translateNotYet( 'Bring your style with you' ) }
+						</div>
 						<div className="section-patterns-info__item-description">
-							Patterns replicate the typography and color palette from your site to ensure every
-							page is on-brand.
+							{ translateNotYet(
+								'Patterns replicate the typography and color palette from your site to ensure every page is on-brand.'
+							) }
 						</div>
 					</div>
 
@@ -44,10 +53,13 @@ export function PatternsCopyPasteInfo() {
 							<img src={ ImgEdit } alt="" />
 						</div>
 
-						<div className="section-patterns-info__item-title">Make it yours</div>
+						<div className="section-patterns-info__item-title">
+							{ translateNotYet( 'Make it yours' ) }
+						</div>
 						<div className="section-patterns-info__item-description">
-							Patterns are collections of regular WordPress blocks, so you can edit every detail,
-							however you want.
+							{ translateNotYet(
+								'Patterns are collections of regular WordPress blocks, so you can edit every detail, however you want.'
+							) }
 						</div>
 					</div>
 
@@ -56,10 +68,13 @@ export function PatternsCopyPasteInfo() {
 							<img src={ ImgResponsive } alt="" />
 						</div>
 
-						<div className="section-patterns-info__item-title">Responsive by design</div>
+						<div className="section-patterns-info__item-title">
+							{ translateNotYet( 'Responsive by design' ) }
+						</div>
 						<div className="section-patterns-info__item-description">
-							All patterns are fully responsive to ensure they look fantastic on any device or
-							screen.
+							{ translateNotYet(
+								'All patterns are fully responsive to ensure they look fantastic on any device or screen.'
+							) }
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/patterns/components/copy-paste-info/index.tsx
+++ b/client/my-sites/patterns/components/copy-paste-info/index.tsx
@@ -13,10 +13,18 @@ export function PatternsCopyPasteInfo() {
 		<PatternsSection
 			bodyFullWidth
 			description={ translate(
-				'Pick out a pattern, copy-paste it into your design, and customize it any way you like. No plugins needed.'
+				'Pick out a pattern, copy-paste it into your design, and customize it any way you like. No plugins needed.',
+				{
+					comment: 'Refers to block patterns in the WordPress.com pattern library',
+					textOnly: true,
+				}
 			) }
 			theme="dark"
-			title={ translate( 'Copy, paste, customize—it’s easy like that' ) }
+			title={ translate( 'Copy, paste, customize—it’s easy like that', {
+				comment:
+					'Heading text in a section that contains info about block patterns built by WordPress.com',
+				textOnly: true,
+			} ) }
 		>
 			<div className="section-patterns-info">
 				<div className="section-patterns-info__inner">
@@ -26,7 +34,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translate( 'Copy-paste your way' ) }
+							{ translate( 'Copy-paste your way', {
+								comment:
+									'Refers to block patterns, and the fact that they can easily be copy-pasted',
+							} ) }
 						</div>
 						<div className="section-patterns-info__item-description">
 							{ translate(
@@ -41,7 +52,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translate( 'Bring your style with you' ) }
+							{ translate( 'Bring your style with you', {
+								comment:
+									'Refers to block patterns built by WordPress.com, and the way they adapt to theme style settings',
+							} ) }
 						</div>
 						<div className="section-patterns-info__item-description">
 							{ translate(
@@ -56,7 +70,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translate( 'Make it yours' ) }
+							{ translate( 'Make it yours', {
+								comment:
+									'Refers to block patterns, and their ability to be customized to build a site.',
+							} ) }
 						</div>
 						<div className="section-patterns-info__item-description">
 							{ translate(
@@ -71,11 +88,18 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translate( 'Responsive by design' ) }
+							{ translate( 'Responsive by design', {
+								comment:
+									'Refers to block patterns built by WordPress.com, and their built-in responsiveness.',
+							} ) }
 						</div>
 						<div className="section-patterns-info__item-description">
 							{ translate(
-								'All patterns are fully responsive to ensure they look fantastic on any device or screen.'
+								'All patterns are fully responsive to ensure they look fantastic on any device or screen.',
+								{
+									comment:
+										'Refers to block patterns built by WordPress.com, and their built-in responsiveness.',
+								}
 							) }
 						</div>
 					</div>

--- a/client/my-sites/patterns/components/copy-paste-info/index.tsx
+++ b/client/my-sites/patterns/components/copy-paste-info/index.tsx
@@ -8,7 +8,7 @@ import ImgStyle from './images/style.svg';
 import './style.scss';
 
 export function PatternsCopyPasteInfo() {
-	const translateNotYet = useTranslate();
+	const translate_not_yet = useTranslate();
 	return (
 		<PatternsSection
 			bodyFullWidth
@@ -24,10 +24,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translateNotYet( 'Copy-paste your way' ) }
+							{ translate_not_yet( 'Copy-paste your way' ) }
 						</div>
 						<div className="section-patterns-info__item-description">
-							{ translateNotYet(
+							{ translate_not_yet(
 								'Paste patterns directly into the WordPress editor to fully customize them.'
 							) }
 						</div>
@@ -39,10 +39,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translateNotYet( 'Bring your style with you' ) }
+							{ translate_not_yet( 'Bring your style with you' ) }
 						</div>
 						<div className="section-patterns-info__item-description">
-							{ translateNotYet(
+							{ translate_not_yet(
 								'Patterns replicate the typography and color palette from your site to ensure every page is on-brand.'
 							) }
 						</div>
@@ -54,10 +54,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translateNotYet( 'Make it yours' ) }
+							{ translate_not_yet( 'Make it yours' ) }
 						</div>
 						<div className="section-patterns-info__item-description">
-							{ translateNotYet(
+							{ translate_not_yet(
 								'Patterns are collections of regular WordPress blocks, so you can edit every detail, however you want.'
 							) }
 						</div>
@@ -69,10 +69,10 @@ export function PatternsCopyPasteInfo() {
 						</div>
 
 						<div className="section-patterns-info__item-title">
-							{ translateNotYet( 'Responsive by design' ) }
+							{ translate_not_yet( 'Responsive by design' ) }
 						</div>
 						<div className="section-patterns-info__item-description">
-							{ translateNotYet(
+							{ translate_not_yet(
 								'All patterns are fully responsive to ensure they look fantastic on any device or screen.'
 							) }
 						</div>

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -46,7 +46,10 @@ export const PatternsGetAccessModal = ( {
 				</button>
 				<div className="patterns-get-access-modal__inner">
 					<div className="patterns-get-access-modal__title">
-						{ translate( 'Unlock the full pattern library' ) }
+						{ translate( 'Unlock the full pattern library', {
+							comment:
+								'This string is used as a title for the modal that prompts users to sign up or log in to access the full pattern library.',
+						} ) }
 					</div>
 					<div className="patterns-get-access-modal__description">
 						{ translate(

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Dialog } from '@automattic/components';
 import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
@@ -21,6 +22,7 @@ export const PatternsGetAccessModal = ( {
 	const isLoggedIn = false;
 	const startUrl = localizeUrl( '//wordpress.com/start/account/user', locale, isLoggedIn );
 	const loginUrl = localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn );
+	const translateNotYet = useTranslate();
 
 	return (
 		<Dialog
@@ -43,10 +45,13 @@ export const PatternsGetAccessModal = ( {
 					<Icon icon={ iconClose } size={ 24 } />
 				</button>
 				<div className="patterns-get-access-modal__inner">
-					<div className="patterns-get-access-modal__title">Unlock the full pattern library</div>
+					<div className="patterns-get-access-modal__title">
+						{ translateNotYet( 'Unlock the full pattern library' ) }
+					</div>
 					<div className="patterns-get-access-modal__description">
-						Build sites faster using hundreds of professionally designed layouts. All you need's a
-						WordPress.com account to get started.
+						{ translateNotYet(
+							"Build sites faster using hundreds of professionally designed layouts. All you need's a WordPress.com account to get started."
+						) }
 					</div>
 					<div className="patterns-get-access-modal__upgrade-buttons">
 						<Button
@@ -54,14 +59,14 @@ export const PatternsGetAccessModal = ( {
 							href={ startUrl }
 							onClick={ () => tracksEventHandler( 'calypso_pattern_library_get_access_signup' ) }
 						>
-							Create a free account
+							{ translate_not_yet( 'Create a free account' ) }
 						</Button>
 						<Button
 							transparent
 							href={ loginUrl }
 							onClick={ () => tracksEventHandler( 'calypso_pattern_library_get_access_login' ) }
 						>
-							Log in
+							{ translate_not_yet( 'Log in' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -22,7 +22,7 @@ export const PatternsGetAccessModal = ( {
 	const isLoggedIn = false;
 	const startUrl = localizeUrl( '//wordpress.com/start/account/user', locale, isLoggedIn );
 	const loginUrl = localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn );
-	const translate_not_yet = useTranslate();
+	const translate = useTranslate();
 
 	return (
 		<Dialog
@@ -46,10 +46,10 @@ export const PatternsGetAccessModal = ( {
 				</button>
 				<div className="patterns-get-access-modal__inner">
 					<div className="patterns-get-access-modal__title">
-						{ translate_not_yet( 'Unlock the full pattern library' ) }
+						{ translate( 'Unlock the full pattern library' ) }
 					</div>
 					<div className="patterns-get-access-modal__description">
-						{ translate_not_yet(
+						{ translate(
 							"Build sites faster using hundreds of professionally designed layouts. All you need's a WordPress.com account to get started."
 						) }
 					</div>
@@ -59,14 +59,14 @@ export const PatternsGetAccessModal = ( {
 							href={ startUrl }
 							onClick={ () => tracksEventHandler( 'calypso_pattern_library_get_access_signup' ) }
 						>
-							{ translate_not_yet( 'Create a free account' ) }
+							{ translate( 'Create a free account' ) }
 						</Button>
 						<Button
 							transparent
 							href={ loginUrl }
 							onClick={ () => tracksEventHandler( 'calypso_pattern_library_get_access_login' ) }
 						>
-							{ translate_not_yet( 'Log in' ) }
+							{ translate( 'Log in' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -22,7 +22,7 @@ export const PatternsGetAccessModal = ( {
 	const isLoggedIn = false;
 	const startUrl = localizeUrl( '//wordpress.com/start/account/user', locale, isLoggedIn );
 	const loginUrl = localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn );
-	const translateNotYet = useTranslate();
+	const translate_not_yet = useTranslate();
 
 	return (
 		<Dialog
@@ -46,10 +46,10 @@ export const PatternsGetAccessModal = ( {
 				</button>
 				<div className="patterns-get-access-modal__inner">
 					<div className="patterns-get-access-modal__title">
-						{ translateNotYet( 'Unlock the full pattern library' ) }
+						{ translate_not_yet( 'Unlock the full pattern library' ) }
 					</div>
 					<div className="patterns-get-access-modal__description">
-						{ translateNotYet(
+						{ translate_not_yet(
 							"Build sites faster using hundreds of professionally designed layouts. All you need's a WordPress.com account to get started."
 						) }
 					</div>

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -39,7 +39,9 @@ export function PatternsGetStarted() {
 						/>
 						<div className="patterns-get-started__item-name">{ translate( 'Video tutorial' ) }</div>
 						<div className="patterns-get-started__item-description">
-							{ translate( 'Block Patterns' ) }
+							{ translate( 'Block Patterns', {
+								comment: 'This string is refers to the title of the Block Patterns support page',
+							} ) }
 						</div>
 					</a>
 

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -40,7 +40,8 @@ export function PatternsGetStarted() {
 						<div className="patterns-get-started__item-name">{ translate( 'Video tutorial' ) }</div>
 						<div className="patterns-get-started__item-description">
 							{ translate( 'Block Patterns', {
-								comment: 'This string is refers to the title of the Block Patterns support page',
+								comment:
+									'This string is a copy of the page title from wordpress.com/support/wordpress-editor/block-pattern/',
 							} ) }
 						</div>
 					</a>
@@ -59,7 +60,10 @@ export function PatternsGetStarted() {
 						/>
 						<div className="patterns-get-started__item-name">{ translate( 'Video tutorial' ) }</div>
 						<div className="patterns-get-started__item-description">
-							{ translate( 'Use Pre-Made Page Layouts' ) }
+							{ translate( 'Use Pre-Made Page Layouts', {
+								comment:
+									'This string is a copy of the page title from wordpress.com/support/wordpress-editor/page-layouts/',
+							} ) }
 						</div>
 					</a>
 
@@ -77,7 +81,10 @@ export function PatternsGetStarted() {
 						/>
 						<div className="patterns-get-started__item-name">{ translate( 'Free course' ) }</div>
 						<div className="patterns-get-started__item-description">
-							{ translate( 'Design Your Homepage' ) }
+							{ translate( 'Design Your Homepage', {
+								comment:
+									'This string is a copy of the page title from wordpress.com/learn/webinars/compelling-homepages/',
+							} ) }
 						</div>
 					</a>
 				</div>

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -15,7 +15,10 @@ export function PatternsGetStarted() {
 			bodyFullWidth
 			description={ translate( 'Take a look at our how-to guides to get started with patterns.' ) }
 			theme="dark"
-			title={ translate( 'All about patterns' ) }
+			title={ translate( 'All about patterns', {
+				comment: 'Heading text in a section with informative links about block patterns',
+				textOnly: true,
+			} ) }
 		>
 			<div className="patterns-get-started__buttons">
 				<Button className="patterns-get-started__start-button" href="/start">

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -9,19 +9,17 @@ import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 import './style.scss';
 
 export function PatternsGetStarted() {
-	const translate_not_yet = useTranslate();
+	const translate = useTranslate();
 	return (
 		<PatternsSection
 			bodyFullWidth
-			description={ translate_not_yet(
-				'Take a look at our how-to guides to get started with patterns.'
-			) }
+			description={ translate( 'Take a look at our how-to guides to get started with patterns.' ) }
 			theme="dark"
-			title={ translate_not_yet( 'All about patterns' ) }
+			title={ translate( 'All about patterns' ) }
 		>
 			<div className="patterns-get-started__buttons">
 				<Button className="patterns-get-started__start-button" href="/start">
-					{ translate_not_yet( 'Build a site' ) }
+					{ translate( 'Build a site' ) }
 				</Button>
 			</div>
 
@@ -39,11 +37,9 @@ export function PatternsGetStarted() {
 							height="675"
 							loading="lazy"
 						/>
-						<div className="patterns-get-started__item-name">
-							{ translate_not_yet( 'Video tutorial' ) }
-						</div>
+						<div className="patterns-get-started__item-name">{ translate( 'Video tutorial' ) }</div>
 						<div className="patterns-get-started__item-description">
-							{ translate_not_yet( 'Block Patterns' ) }
+							{ translate( 'Block Patterns' ) }
 						</div>
 					</a>
 
@@ -59,11 +55,9 @@ export function PatternsGetStarted() {
 							height="675"
 							loading="lazy"
 						/>
-						<div className="patterns-get-started__item-name">
-							{ translate_not_yet( 'Video tutorial' ) }
-						</div>
+						<div className="patterns-get-started__item-name">{ translate( 'Video tutorial' ) }</div>
 						<div className="patterns-get-started__item-description">
-							{ translate_not_yet( 'Use Pre-Made Page Layouts' ) }
+							{ translate( 'Use Pre-Made Page Layouts' ) }
 						</div>
 					</a>
 
@@ -79,11 +73,9 @@ export function PatternsGetStarted() {
 							height="639"
 							loading="lazy"
 						/>
-						<div className="patterns-get-started__item-name">
-							{ translate_not_yet( 'Free course' ) }
-						</div>
+						<div className="patterns-get-started__item-name">{ translate( 'Free course' ) }</div>
 						<div className="patterns-get-started__item-description">
-							{ translate_not_yet( 'Design Your Homepage' ) }
+							{ translate( 'Design Your Homepage' ) }
 						</div>
 					</a>
 				</div>

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -9,19 +9,19 @@ import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 import './style.scss';
 
 export function PatternsGetStarted() {
-	const translateNotYet = useTranslate();
+	const translate_not_yet = useTranslate();
 	return (
 		<PatternsSection
 			bodyFullWidth
-			description={ translateNotYet(
+			description={ translate_not_yet(
 				'Take a look at our how-to guides to get started with patterns.'
 			) }
 			theme="dark"
-			title={ translateNotYet( 'All about patterns' ) }
+			title={ translate_not_yet( 'All about patterns' ) }
 		>
 			<div className="patterns-get-started__buttons">
 				<Button className="patterns-get-started__start-button" href="/start">
-					{ translateNotYet( 'Build a site' ) }
+					{ translate_not_yet( 'Build a site' ) }
 				</Button>
 			</div>
 
@@ -40,10 +40,10 @@ export function PatternsGetStarted() {
 							loading="lazy"
 						/>
 						<div className="patterns-get-started__item-name">
-							{ translateNotYet( 'Video tutorial' ) }
+							{ translate_not_yet( 'Video tutorial' ) }
 						</div>
 						<div className="patterns-get-started__item-description">
-							{ translateNotYet( 'Block Patterns' ) }
+							{ translate_not_yet( 'Block Patterns' ) }
 						</div>
 					</a>
 
@@ -60,10 +60,10 @@ export function PatternsGetStarted() {
 							loading="lazy"
 						/>
 						<div className="patterns-get-started__item-name">
-							{ translateNotYet( 'Video tutorial' ) }
+							{ translate_not_yet( 'Video tutorial' ) }
 						</div>
 						<div className="patterns-get-started__item-description">
-							{ translateNotYet( 'Use Pre-Made Page Layouts' ) }
+							{ translate_not_yet( 'Use Pre-Made Page Layouts' ) }
 						</div>
 					</a>
 
@@ -80,10 +80,10 @@ export function PatternsGetStarted() {
 							loading="lazy"
 						/>
 						<div className="patterns-get-started__item-name">
-							{ translateNotYet( 'Free course' ) }
+							{ translate_not_yet( 'Free course' ) }
 						</div>
 						<div className="patterns-get-started__item-description">
-							{ translateNotYet( 'Design Your Homepage' ) }
+							{ translate_not_yet( 'Design Your Homepage' ) }
 						</div>
 					</a>
 				</div>

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -1,5 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import imagePreviewPublish from 'calypso/my-sites/patterns/components/get-started/images/preview-publish.png';
 import imagePageLayouts from 'calypso/my-sites/patterns/components/get-started/images/understand-page-layouts.png';
 import imageBlockPatterns from 'calypso/my-sites/patterns/components/get-started/images/use-block-patterns.png';
@@ -8,16 +9,19 @@ import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 import './style.scss';
 
 export function PatternsGetStarted() {
+	const translateNotYet = useTranslate();
 	return (
 		<PatternsSection
 			bodyFullWidth
-			description="Take a look at our how-to guides to get started with patterns."
+			description={ translateNotYet(
+				'Take a look at our how-to guides to get started with patterns.'
+			) }
 			theme="dark"
-			title="All about patterns"
+			title={ translateNotYet( 'All about patterns' ) }
 		>
 			<div className="patterns-get-started__buttons">
 				<Button className="patterns-get-started__start-button" href="/start">
-					Build a site
+					{ translateNotYet( 'Build a site' ) }
 				</Button>
 			</div>
 
@@ -35,8 +39,12 @@ export function PatternsGetStarted() {
 							height="675"
 							loading="lazy"
 						/>
-						<div className="patterns-get-started__item-name">Video tutorial</div>
-						<div className="patterns-get-started__item-description">Block Patterns</div>
+						<div className="patterns-get-started__item-name">
+							{ translateNotYet( 'Video tutorial' ) }
+						</div>
+						<div className="patterns-get-started__item-description">
+							{ translateNotYet( 'Block Patterns' ) }
+						</div>
 					</a>
 
 					<a
@@ -51,8 +59,12 @@ export function PatternsGetStarted() {
 							height="675"
 							loading="lazy"
 						/>
-						<div className="patterns-get-started__item-name">Video tutorial</div>
-						<div className="patterns-get-started__item-description">Use Pre-Made Page Layouts</div>
+						<div className="patterns-get-started__item-name">
+							{ translateNotYet( 'Video tutorial' ) }
+						</div>
+						<div className="patterns-get-started__item-description">
+							{ translateNotYet( 'Use Pre-Made Page Layouts' ) }
+						</div>
 					</a>
 
 					<a
@@ -67,8 +79,12 @@ export function PatternsGetStarted() {
 							height="639"
 							loading="lazy"
 						/>
-						<div className="patterns-get-started__item-name">Free course</div>
-						<div className="patterns-get-started__item-description">Design Your Homepage</div>
+						<div className="patterns-get-started__item-name">
+							{ translateNotYet( 'Free course' ) }
+						</div>
+						<div className="patterns-get-started__item-description">
+							{ translateNotYet( 'Design Your Homepage' ) }
+						</div>
 					</a>
 				</div>
 			</div>

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -16,7 +16,7 @@ export const PatternsHeader = ( {
 	onSearch = () => {},
 	title,
 }: PatternsHeaderProps ) => {
-	const translate_not_yet = useTranslate();
+	const translate = useTranslate();
 	return (
 		<header className="patterns-header">
 			<div className="patterns-header__inner">
@@ -27,7 +27,7 @@ export const PatternsHeader = ( {
 					delaySearch
 					initialValue={ initialSearchTerm }
 					onSearch={ onSearch }
-					placeholder={ translate_not_yet( 'Search patterns…' ) }
+					placeholder={ translate( 'Search patterns…' ) }
 				/>
 			</div>
 		</header>

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -27,7 +27,7 @@ export const PatternsHeader = ( {
 					delaySearch
 					initialValue={ initialSearchTerm }
 					onSearch={ onSearch }
-					placeholder={ translate_not_yet( 'Search patterns...' ) }
+					placeholder={ translate_not_yet( 'Search patterns…' ) }
 				/>
 			</div>
 		</header>

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import Search from 'calypso/components/search';
 
 import './style.scss';
@@ -15,6 +16,7 @@ export const PatternsHeader = ( {
 	onSearch = () => {},
 	title,
 }: PatternsHeaderProps ) => {
+	const translateNotYet = useTranslate();
 	return (
 		<header className="patterns-header">
 			<div className="patterns-header__inner">
@@ -25,7 +27,7 @@ export const PatternsHeader = ( {
 					delaySearch
 					initialValue={ initialSearchTerm }
 					onSearch={ onSearch }
-					placeholder="Search patterns..."
+					placeholder={ translateNotYet( 'Search patterns...' ) }
 				/>
 			</div>
 		</header>

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -16,7 +16,7 @@ export const PatternsHeader = ( {
 	onSearch = () => {},
 	title,
 }: PatternsHeaderProps ) => {
-	const translateNotYet = useTranslate();
+	const translate_not_yet = useTranslate();
 	return (
 		<header className="patterns-header">
 			<div className="patterns-header__inner">
@@ -27,7 +27,7 @@ export const PatternsHeader = ( {
 					delaySearch
 					initialValue={ initialSearchTerm }
 					onSearch={ onSearch }
-					placeholder={ translateNotYet( 'Search patterns...' ) }
+					placeholder={ translate_not_yet( 'Search patterns...' ) }
 				/>
 			</div>
 		</header>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -227,7 +227,7 @@ export const PatternLibrary = ( {
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }
-				title={ translate_not_yet( 'It’s Easier With Patterns' ) }
+				title={ translate_not_yet( 'Build your site faster with patterns' ) }
 			/>
 
 			<div className="pattern-library__wrapper">

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -8,7 +8,7 @@ import {
 import { Icon, category as iconCategory, menu as iconMenu } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -202,53 +202,92 @@ export const PatternLibrary = ( {
 
 	const isHomePage = ! category && ! searchTerm;
 
-	const PATTERN_SEO_CONTENT: Record< Category[ 'name' ], { title: string } > = useMemo(
-		() => ( {
-			default: {
-				title: translate( 'WordPress Patterns' ),
-			},
-			header: {
-				title: translate( 'WordPress Header Patterns' ),
-			},
-			footer: {
-				title: translate( 'WordPress Footer Patterns' ),
-			},
-			about: {
-				title: translate( 'WordPress About Patterns' ),
-			},
-			posts: {
-				title: translate( 'WordPress Blog Post Patterns' ),
-			},
-			contact: {
-				title: translate( 'WordPress Contact Patterns' ),
-			},
-			events: {
-				title: translate( 'WordPress Events Patterns' ),
-			},
-			gallery: {
-				title: translate( 'WordPress Gallery Patterns' ),
-			},
-			intro: {
-				title: translate( 'WordPress Intro Patterns' ),
-			},
-			menu: {
-				title: translate( 'WordPress Menu Patterns' ),
-			},
-			newsletter: {
-				title: translate( 'WordPress Newsletter Patterns' ),
-			},
-			services: {
-				title: translate( 'WordPress Services Patterns' ),
-			},
-			store: {
-				title: translate( 'WordPress Store Patterns' ),
-			},
-			testimonials: {
-				title: translate( 'WordPress Testimonial Patterns' ),
-			},
-		} ),
-		[ translate ]
-	);
+	const PATTERN_SEO_CONTENT: Record< Category[ 'name' ], { title: string } > = {
+		default: {
+			title: translate( 'WordPress Patterns', {
+				comment: 'Pattern Library home page title',
+				textOnly: true,
+			} ),
+		},
+		header: {
+			title: translate( 'WordPress Header Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		footer: {
+			title: translate( 'WordPress Footer Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		about: {
+			title: translate( 'WordPress About Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		posts: {
+			title: translate( 'WordPress Blog Post Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		contact: {
+			title: translate( 'WordPress Contact Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		events: {
+			title: translate( 'WordPress Events Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		gallery: {
+			title: translate( 'WordPress Gallery Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		intro: {
+			title: translate( 'WordPress Intro Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		menu: {
+			title: translate( 'WordPress Menu Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		newsletter: {
+			title: translate( 'WordPress Newsletter Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		services: {
+			title: translate( 'WordPress Services Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		store: {
+			title: translate( 'WordPress Store Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		testimonials: {
+			title: translate( 'WordPress Testimonial Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+	};
 
 	const seoContent = category ? PATTERN_SEO_CONTENT[ category ] : PATTERN_SEO_CONTENT.default;
 

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -8,7 +8,7 @@ import {
 import { Icon, category as iconCategory, menu as iconMenu } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -90,7 +90,7 @@ export const PatternLibrary = ( {
 	searchTerm: urlQuerySearchTerm = '',
 }: PatternLibraryProps ) => {
 	const locale = useLocale();
-	const translate_not_yet = useTranslate();
+	const translate = useTranslate();
 
 	// Helps prevent resetting the search input if a search term was provided through the URL
 	const isInitialRender = useRef( true );
@@ -269,7 +269,7 @@ export const PatternLibrary = ( {
 			<DocumentHead title={ seoContent.title } />
 
 			<PatternsHeader
-				description={ translate_not_yet(
+				description={ translate(
 					'Dive into hundreds of expertly designed, fully responsive layouts, and bring any kind of site to life, faster.'
 				) }
 				initialSearchTerm={ searchTerm }
@@ -277,7 +277,7 @@ export const PatternLibrary = ( {
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }
-				title={ translate_not_yet( 'Build your site faster with patterns' ) }
+				title={ translate( 'Build your site faster with patterns' ) }
 			/>
 
 			<div className="pattern-library__wrapper">
@@ -292,7 +292,7 @@ export const PatternLibrary = ( {
 						buttons={ [
 							{
 								icon: <Icon icon={ iconCategory } size={ 26 } />,
-								label: translate_not_yet( 'All Categories' ),
+								label: translate( 'All Categories' ),
 								link: addLocaleToPathLocaleInFront( '/patterns' ),
 								isActive: isHomePage,
 							},
@@ -303,8 +303,8 @@ export const PatternLibrary = ( {
 
 				{ isHomePage && (
 					<CategoryGallery
-						title={ translate_not_yet( 'Ship faster, ship more' ) }
-						description={ translate_not_yet(
+						title={ translate( 'Ship faster, ship more' ) }
+						description={ translate(
 							'Choose from a library of beautiful, functional design patterns to build exactly the pages you need—or your client needs—in no time.'
 						) }
 						categories={ categories }
@@ -317,11 +317,11 @@ export const PatternLibrary = ( {
 						<div className="pattern-library__header">
 							<h1 className="pattern-library__title">
 								{ searchTerm
-									? translate_not_yet( '%(count)d pattern', '%(count)d patterns', {
+									? translate( '%(count)d pattern', '%(count)d patterns', {
 											count: patterns.length,
 											args: { count: patterns.length },
 									  } )
-									: translate_not_yet( 'Patterns' ) }
+									: translate( 'Patterns' ) }
 							</h1>
 
 							{ category && !! categoryObject?.pagePatternCount && (
@@ -344,12 +344,12 @@ export const PatternLibrary = ( {
 								>
 									<ToggleGroupControlOption
 										className="pattern-library__toggle-option"
-										label={ translate_not_yet( 'Patterns' ) }
+										label={ translate( 'Patterns' ) }
 										value={ PatternTypeFilter.REGULAR }
 									/>
 									<ToggleGroupControlOption
 										className="pattern-library__toggle-option"
-										label={ translate_not_yet( 'Page layouts' ) }
+										label={ translate( 'Page layouts' ) }
 										value={ PatternTypeFilter.PAGES }
 									/>
 								</ToggleGroupControl>
@@ -392,8 +392,8 @@ export const PatternLibrary = ( {
 
 				{ isHomePage && (
 					<CategoryGallery
-						title={ translate_not_yet( 'Beautifully curated page layouts' ) }
-						description={ translate_not_yet(
+						title={ translate( 'Beautifully curated page layouts' ) }
+						description={ translate(
 							'Start even faster with ready-to-use pages and preassembled patterns. Then tweak the design until it’s just right.'
 						) }
 						categories={ categories?.filter( ( c ) => c.pagePatternCount ) }

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -316,7 +316,7 @@ export const PatternLibrary = ( {
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }
-				title={ translate( 'It's Easier With Patterns' ) }
+				title={ translate( "It's Easier With Patterns" ) }
 			/>
 
 			<div className="pattern-library__wrapper">

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -216,7 +216,7 @@ export const PatternLibrary = ( {
 				referrer={ referrer }
 			/>
 
-			<DocumentHead title={ translate_not_yet( 'WordPress Patterns - Category' ) } />
+			<DocumentHead title={ translate_not_yet( `WordPress ${ category } Patterns ` ) } />
 
 			<PatternsHeader
 				description={ translate_not_yet(

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -342,7 +342,11 @@ export const PatternLibrary = ( {
 
 				{ isHomePage && (
 					<CategoryGallery
-						title={ translate( 'Ship faster, ship more' ) }
+						title={ translate( 'Ship faster, ship more', {
+							comment:
+								'Heading text for a section in the Pattern Library with links to block pattern categories',
+							textOnly: true,
+						} ) }
 						description={ translate(
 							'Choose from a library of beautiful, functional design patterns to build exactly the pages you need—or your client needs—in no time.'
 						) }
@@ -362,10 +366,14 @@ export const PatternLibrary = ( {
 									} ) }
 								{ ! searchTerm &&
 									patternTypeFilter === PatternTypeFilter.PAGES &&
-									translate( 'Page Layouts' ) }
+									translate( 'Page Layouts', {
+										comment: 'Refers to block patterns that contain entire page layouts',
+									} ) }
 								{ ! searchTerm &&
 									patternTypeFilter === PatternTypeFilter.REGULAR &&
-									translate( 'Patterns' ) }
+									translate( 'Patterns', {
+										comment: 'Refers to block patterns',
+									} ) }
 							</h1>
 
 							{ category && !! categoryObject?.pagePatternCount && (
@@ -388,12 +396,18 @@ export const PatternLibrary = ( {
 								>
 									<ToggleGroupControlOption
 										className="pattern-library__toggle-option"
-										label={ translate( 'Patterns' ) }
+										label={ translate( 'Patterns', {
+											comment: 'Refers to block patterns',
+											textOnly: true,
+										} ) }
 										value={ PatternTypeFilter.REGULAR }
 									/>
 									<ToggleGroupControlOption
 										className="pattern-library__toggle-option"
-										label={ translate( 'Page Layouts' ) }
+										label={ translate( 'Page Layouts', {
+											comment: 'Refers to block patterns that contain entire page layouts',
+											textOnly: true,
+										} ) }
 										value={ PatternTypeFilter.PAGES }
 									/>
 								</ToggleGroupControl>
@@ -436,7 +450,11 @@ export const PatternLibrary = ( {
 
 				{ isHomePage && (
 					<CategoryGallery
-						title={ translate( 'Beautifully curated page layouts' ) }
+						title={ translate( 'Beautifully curated page layouts', {
+							comment:
+								'Heading text for a section in the Pattern Library with links to block pattern categories containing page layouts',
+							textOnly: true,
+						} ) }
 						description={ translate(
 							'Start even faster with ready-to-use pages and preassembled patterns. Then tweak the design until it’s just right.'
 						) }

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -316,12 +316,17 @@ export const PatternLibrary = ( {
 					<PatternLibraryBody className="pattern-library">
 						<div className="pattern-library__header">
 							<h1 className="pattern-library__title">
-								{ searchTerm
-									? translate( '%(count)d pattern', '%(count)d patterns', {
-											count: patterns.length,
-											args: { count: patterns.length },
-									  } )
-									: translate( 'Patterns' ) }
+								{ searchTerm &&
+									translate( '%(count)d pattern', '%(count)d patterns', {
+										count: patterns.length,
+										args: { count: patterns.length },
+									} ) }
+								{ ! searchTerm &&
+									patternTypeFilter === PatternTypeFilter.PAGES &&
+									translate( 'Page Layouts' ) }
+								{ ! searchTerm &&
+									patternTypeFilter === PatternTypeFilter.REGULAR &&
+									translate( 'Patterns' ) }
 							</h1>
 
 							{ category && !! categoryObject?.pagePatternCount && (
@@ -349,7 +354,7 @@ export const PatternLibrary = ( {
 									/>
 									<ToggleGroupControlOption
 										className="pattern-library__toggle-option"
-										label={ translate( 'Page layouts' ) }
+										label={ translate( 'Page Layouts' ) }
 										value={ PatternTypeFilter.PAGES }
 									/>
 								</ToggleGroupControl>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -10,12 +10,12 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
-import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { PatternsCopyPasteInfo } from 'calypso/my-sites/patterns/components/copy-paste-info';
 import { PatternsGetStarted } from 'calypso/my-sites/patterns/components/get-started';
 import { PatternsHeader } from 'calypso/my-sites/patterns/components/header';
 import { PatternsPageViewTracker } from 'calypso/my-sites/patterns/components/page-view-tracker';
+import { PatternsDocumentHead } from 'calypso/my-sites/patterns/components/patterns-document-head';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import {
 	usePatternSearchTerm,
@@ -202,95 +202,6 @@ export const PatternLibrary = ( {
 
 	const isHomePage = ! category && ! searchTerm;
 
-	const PATTERN_SEO_CONTENT: Record< Category[ 'name' ], { title: string } > = {
-		default: {
-			title: translate( 'WordPress Patterns', {
-				comment: 'Pattern Library home page title',
-				textOnly: true,
-			} ),
-		},
-		header: {
-			title: translate( 'WordPress Header Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		footer: {
-			title: translate( 'WordPress Footer Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		about: {
-			title: translate( 'WordPress About Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		posts: {
-			title: translate( 'WordPress Blog Post Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		contact: {
-			title: translate( 'WordPress Contact Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		events: {
-			title: translate( 'WordPress Events Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		gallery: {
-			title: translate( 'WordPress Gallery Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		intro: {
-			title: translate( 'WordPress Intro Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		menu: {
-			title: translate( 'WordPress Menu Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		newsletter: {
-			title: translate( 'WordPress Newsletter Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		services: {
-			title: translate( 'WordPress Services Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		store: {
-			title: translate( 'WordPress Store Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		testimonials: {
-			title: translate( 'WordPress Testimonial Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-	};
-
-	const seoContent = category ? PATTERN_SEO_CONTENT[ category ] : PATTERN_SEO_CONTENT.default;
-
 	return (
 		<>
 			<PatternsPageViewTracker
@@ -305,7 +216,7 @@ export const PatternLibrary = ( {
 				referrer={ referrer }
 			/>
 
-			<DocumentHead title={ seoContent.title } />
+			<PatternsDocumentHead category={ category } />
 
 			<PatternsHeader
 				description={ translate(

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -316,7 +316,7 @@ export const PatternLibrary = ( {
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }
-				title={ translate( 'Build your site faster with patterns' ) }
+				title={ translate( 'It's Easier With Patterns' ) }
 			/>
 
 			<div className="pattern-library__wrapper">

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -202,6 +202,56 @@ export const PatternLibrary = ( {
 
 	const isHomePage = ! category && ! searchTerm;
 
+	const PATTERN_SEO_CONTENT: Record< Category[ 'name' ], { title: string } > = useMemo(
+		() => ( {
+			default: {
+				title: translate( 'WordPress Patterns' ),
+			},
+			header: {
+				title: translate( 'WordPress Header Patterns' ),
+			},
+			footer: {
+				title: translate( 'WordPress Footer Patterns' ),
+			},
+			about: {
+				title: translate( 'WordPress About Patterns' ),
+			},
+			posts: {
+				title: translate( 'WordPress Blog Post Patterns' ),
+			},
+			contact: {
+				title: translate( 'WordPress Contact Patterns' ),
+			},
+			events: {
+				title: translate( 'WordPress Events Patterns' ),
+			},
+			gallery: {
+				title: translate( 'WordPress Gallery Patterns' ),
+			},
+			intro: {
+				title: translate( 'WordPress Intro Patterns' ),
+			},
+			menu: {
+				title: translate( 'WordPress Menu Patterns' ),
+			},
+			newsletter: {
+				title: translate( 'WordPress Newsletter Patterns' ),
+			},
+			services: {
+				title: translate( 'WordPress Services Patterns' ),
+			},
+			store: {
+				title: translate( 'WordPress Store Patterns' ),
+			},
+			testimonials: {
+				title: translate( 'WordPress Testimonial Patterns' ),
+			},
+		} ),
+		[ translate ]
+	);
+
+	const seoContent = category ? PATTERN_SEO_CONTENT[ category ] : PATTERN_SEO_CONTENT.default;
+
 	return (
 		<>
 			<PatternsPageViewTracker
@@ -216,7 +266,7 @@ export const PatternLibrary = ( {
 				referrer={ referrer }
 			/>
 
-			<DocumentHead title={ translate_not_yet( `WordPress ${ category } Patterns ` ) } />
+			<DocumentHead title={ seoContent.title } />
 
 			<PatternsHeader
 				description={ translate_not_yet(

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -175,7 +175,7 @@ function PatternPreviewFragment( {
 						} }
 						transparent
 					>
-						<Icon height={ 18 } icon={ lock } width={ 18 } /> Get access
+						<Icon height={ 18 } icon={ lock } width={ 18 } /> { translate_not_yet( 'Get access' ) }
 					</Button>
 				) }
 			</div>

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -81,20 +81,16 @@ function PatternPreviewFragment( {
 
 	const isPreviewLarge = nodeSize?.width ? nodeSize.width > 960 : true;
 
-	const translate_not_yet = useTranslate();
+	const translate = useTranslate();
 
 	const titleTooltipText = isPermalinkCopied
-		? translate_not_yet( 'Copied link to pattern' )
-		: translate_not_yet( 'Copy link to pattern' );
+		? translate( 'Copied link to pattern' )
+		: translate( 'Copy link to pattern' );
 
-	let copyButtonText = isPreviewLarge
-		? translate_not_yet( 'Copy pattern' )
-		: translate_not_yet( 'Copy' );
+	let copyButtonText = isPreviewLarge ? translate( 'Copy pattern' ) : translate( 'Copy' );
 
 	if ( isPatternCopied ) {
-		copyButtonText = isPreviewLarge
-			? translate_not_yet( 'Pattern copied!' )
-			: translate_not_yet( 'Copied' );
+		copyButtonText = isPreviewLarge ? translate( 'Pattern copied!' ) : translate( 'Copied' );
 	}
 
 	useTimeoutToResetBoolean( isPermalinkCopied, setIsPermalinkCopied );
@@ -175,7 +171,7 @@ function PatternPreviewFragment( {
 						} }
 						transparent
 					>
-						<Icon height={ 18 } icon={ lock } width={ 18 } /> { translate_not_yet( 'Get access' ) }
+						<Icon height={ 18 } icon={ lock } width={ 18 } /> { translate( 'Get access' ) }
 					</Button>
 				) }
 			</div>

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -6,6 +6,7 @@ import { ResizableBox, Tooltip } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { Icon, lock } from '@wordpress/icons';
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
@@ -80,12 +81,20 @@ function PatternPreviewFragment( {
 
 	const isPreviewLarge = nodeSize?.width ? nodeSize.width > 960 : true;
 
-	const titleTooltipText = isPermalinkCopied ? 'Copied link to pattern' : 'Copy link to pattern';
+	const translate_not_yet = useTranslate();
 
-	let copyButtonText = isPreviewLarge ? 'Copy pattern' : 'Copy';
+	const titleTooltipText = isPermalinkCopied
+		? translate_not_yet( 'Copied link to pattern' )
+		: translate_not_yet( 'Copy link to pattern' );
+
+	let copyButtonText = isPreviewLarge
+		? translate_not_yet( 'Copy pattern' )
+		: translate_not_yet( 'Copy' );
 
 	if ( isPatternCopied ) {
-		copyButtonText = isPreviewLarge ? 'Pattern copied!' : 'Copied';
+		copyButtonText = isPreviewLarge
+			? translate_not_yet( 'Pattern copied!' )
+			: translate_not_yet( 'Copied' );
 	}
 
 	useTimeoutToResetBoolean( isPermalinkCopied, setIsPermalinkCopied );

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -86,19 +86,33 @@ function PatternPreviewFragment( {
 	const titleTooltipText = isPermalinkCopied
 		? translate( 'Copied link to pattern', {
 				comment: 'Tooltip text in Pattern Library for when the user just clicked a button',
+				textOnly: true,
 		  } )
-		: translate( 'Copy link to pattern', { comment: 'Tooltip text in Pattern Library' } );
+		: translate( 'Copy link to pattern', {
+				comment: 'Tooltip text in Pattern Library',
+				textOnly: true,
+		  } );
 
 	let copyButtonText = isPreviewLarge
-		? translate( 'Copy pattern', { comment: 'Button label for copying a pattern' } )
-		: translate( 'Copy', { comment: 'Button label for copying a pattern' } );
+		? translate( 'Copy pattern', {
+				comment: 'Button label for copying a pattern',
+				textOnly: true,
+		  } )
+		: translate( 'Copy', {
+				comment: 'Button label for copying a pattern',
+				textOnly: true,
+		  } );
 
 	if ( isPatternCopied ) {
 		copyButtonText = isPreviewLarge
 			? translate( 'Pattern copied!', {
 					comment: 'Button label for when a pattern was just copied',
+					textOnly: true,
 			  } )
-			: translate( 'Copied', { comment: 'Button label for when a pattern was just copied' } );
+			: translate( 'Copied', {
+					comment: 'Button label for when a pattern was just copied',
+					textOnly: true,
+			  } );
 	}
 
 	useTimeoutToResetBoolean( isPermalinkCopied, setIsPermalinkCopied );

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -84,13 +84,21 @@ function PatternPreviewFragment( {
 	const translate = useTranslate();
 
 	const titleTooltipText = isPermalinkCopied
-		? translate( 'Copied link to pattern' )
-		: translate( 'Copy link to pattern' );
+		? translate( 'Copied link to pattern', {
+				comment: 'Tooltip text in Pattern Library for when the user just clicked a button',
+		  } )
+		: translate( 'Copy link to pattern', { comment: 'Tooltip text in Pattern Library' } );
 
-	let copyButtonText = isPreviewLarge ? translate( 'Copy pattern' ) : translate( 'Copy' );
+	let copyButtonText = isPreviewLarge
+		? translate( 'Copy pattern', { comment: 'Button label for copying a pattern' } )
+		: translate( 'Copy', { comment: 'Button label for copying a pattern' } );
 
 	if ( isPatternCopied ) {
-		copyButtonText = isPreviewLarge ? translate( 'Pattern copied!' ) : translate( 'Copied' );
+		copyButtonText = isPreviewLarge
+			? translate( 'Pattern copied!', {
+					comment: 'Button label for when a pattern was just copied',
+			  } )
+			: translate( 'Copied', { comment: 'Button label for when a pattern was just copied' } );
 	}
 
 	useTimeoutToResetBoolean( isPermalinkCopied, setIsPermalinkCopied );
@@ -171,7 +179,11 @@ function PatternPreviewFragment( {
 						} }
 						transparent
 					>
-						<Icon height={ 18 } icon={ lock } width={ 18 } /> { translate( 'Get access' ) }
+						<Icon height={ 18 } icon={ lock } width={ 18 } />{ ' ' }
+						{ translate( 'Get access', {
+							comment:
+								'Button label for that shows in Pattern Library instead of "Copy" when logged-out users need to sign up',
+						} ) }
 					</Button>
 				) }
 			</div>

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -196,7 +196,7 @@ function PatternPreviewFragment( {
 						<Icon height={ 18 } icon={ lock } width={ 18 } />{ ' ' }
 						{ translate( 'Get access', {
 							comment:
-								'Button label for that shows in Pattern Library instead of "Copy" when logged-out users need to sign up',
+								'Button label shown when logged-out users need to sign up to be able to use a pattern',
 						} ) }
 					</Button>
 				) }

--- a/client/my-sites/patterns/components/patterns-document-head/index.tsx
+++ b/client/my-sites/patterns/components/patterns-document-head/index.tsx
@@ -1,0 +1,98 @@
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import type { Category } from 'calypso/my-sites/patterns/types';
+
+export const PatternsDocumentHead = ( { category }: { category: Category[ 'name' ] } ) => {
+	const translate = useTranslate();
+
+	const PATTERN_SEO_CONTENT: Record< Category[ 'name' ], { title: string } > = {
+		default: {
+			title: translate( 'WordPress Patterns', {
+				comment: 'Pattern Library home page title',
+				textOnly: true,
+			} ),
+		},
+		header: {
+			title: translate( 'WordPress Header Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		footer: {
+			title: translate( 'WordPress Footer Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		about: {
+			title: translate( 'WordPress About Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		posts: {
+			title: translate( 'WordPress Blog Post Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		contact: {
+			title: translate( 'WordPress Contact Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		events: {
+			title: translate( 'WordPress Events Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		gallery: {
+			title: translate( 'WordPress Gallery Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		intro: {
+			title: translate( 'WordPress Intro Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		menu: {
+			title: translate( 'WordPress Menu Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		newsletter: {
+			title: translate( 'WordPress Newsletter Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		services: {
+			title: translate( 'WordPress Services Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		store: {
+			title: translate( 'WordPress Store Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+		testimonials: {
+			title: translate( 'WordPress Testimonial Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} ),
+		},
+	};
+
+	const seoContent = category ? PATTERN_SEO_CONTENT[ category ] : PATTERN_SEO_CONTENT.default;
+
+	return <DocumentHead title={ seoContent.title } />;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 5701-gh-Automattic/dotcom-forge

## Proposed Changes

- Mark all new strings for translation and removing the relevant `.eslintrc` file
- Specify unique `<title>` tag values for each pattern category
- Also updating the `H1` text to hopefully be more SEO friendly and keyword-relevant.
- Finally, updating the page titles slightly to avoid repetitively displaying "WordPress" or "WordPress.com" in those titles.

## Testing Instructions

- Confirm that each of the updated strings still appears as expected
- Test the `<title>` tags for the individual categories and make sure they are all properly populated
- Confirm that the `H1` and page `<title>` are displaying their new strings
- All checks should pass, specifically `ci/i18n` should report that there is sufficient translation for deployment
