### PR TITLE
Checkout: Update checkout masterbar styles

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -81,6 +81,7 @@ body.is-mobile-app-view {
 		color: var(--color-checkout-masterbar-text);
 		height: var(--masterbar-height);
 		position: absolute;
+		padding: 0 1em;
 
 		@include break-mobile {
 			height: var(--masterbar-checkout-height);
@@ -88,6 +89,7 @@ body.is-mobile-app-view {
 
 		@include breakpoint-deprecated( ">960px" ) {
 			background-color: var(--color-checkout-masterbar-background);
+			padding: 0 2em;
 		}
 	}
 
@@ -234,7 +236,6 @@ body.is-mobile-app-view {
 	font-size: $masterbar-font-size;
 	height: var(--masterbar-height);
 	line-height: var(--masterbar-height);
-	padding: 0 8px;
 	text-decoration: none;
 	cursor: default;
 	transition: all 0.2s ease-in-out;
@@ -381,7 +382,6 @@ body.is-mobile-app-view {
 		display: block;
 		width: 150px;
 		height: 25px;
-		margin: 0 5px;
 	}
 
 	@include breakpoint-deprecated( "<480px" ) {
@@ -393,7 +393,6 @@ body.is-mobile-app-view {
 			display: block;
 			height: 24px;
 			width: 24px;
-			margin-left: 5px;
 			fill: var(--color-text-inverted);
 		}
 
@@ -888,47 +887,48 @@ a.masterbar__quick-language-switcher {
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
-	margin-left: 24px;
+
+	.masterbar--is-akismet &,
+	.masterbar--is-jetpack & {
+		column-gap: 1em;
+	}
 
 	.masterbar__wpcom-wordmark {
 		color: var(--color-checkout-masterbar-text);
 		fill: var(--color-checkout-masterbar-text);
-		margin-right: 5px;
 	}
 
 	.masterbar__jetpack-wordmark {
 		height: 25px;
-		margin: 0 5px;
+
 	}
 
-	.masterbar__akismet-wordmark {
-		margin: 0 5px;
-	}
+	/* empty for now, saved for future use if needed
+		.masterbar__akismet-wordmark {
+		}
+	*/
 
 	.masterbar__close-button {
 		flex: initial;
 		width: initial;
-		margin-right: 10px;
-
-		@include break-mobile {
-			margin-right: 0;
-		}
 	}
 
 	.masterbar__secure-checkout-text {
 		color: var(--color-checkout-masterbar-text);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1.2em;
 		font-size: 0.75rem;
-		margin-left: 5px;
 		position: relative;
 		top: -0.5px;
+
+		/* Hide the secure checkout text on very small devices */
+		@media screen and ( max-width: 300px ) {
+			display: none;
+		}
 
 		@include breakpoint-deprecated( ">480px" ) {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 100%;
-			margin-left: 0;
 		}
+
 
 		.masterbar--is-jetpack & {
 			transform: translateY(0.5px);

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -81,7 +81,12 @@ body.is-mobile-app-view {
 		color: var(--color-checkout-masterbar-text);
 		height: var(--masterbar-height);
 		position: absolute;
-		padding: 0 1em;
+		padding-inline-end: 1.5em;
+
+		&.masterbar--is-akismet,
+		&.masterbar--is-jetpack {
+			padding-inline-start: 1.5em;
+		}
 
 		@include break-mobile {
 			height: var(--masterbar-checkout-height);
@@ -89,7 +94,6 @@ body.is-mobile-app-view {
 
 		@include breakpoint-deprecated( ">960px" ) {
 			background-color: var(--color-checkout-masterbar-background);
-			padding: 0 2em;
 		}
 	}
 
@@ -236,6 +240,7 @@ body.is-mobile-app-view {
 	font-size: $masterbar-font-size;
 	height: var(--masterbar-height);
 	line-height: var(--masterbar-height);
+	padding: 0 8px;
 	text-decoration: none;
 	cursor: default;
 	transition: all 0.2s ease-in-out;
@@ -244,6 +249,7 @@ body.is-mobile-app-view {
 	.masterbar--is-checkout & {
 		height: var(--masterbar-height);
 		line-height: var(--masterbar-height);
+		padding: 0;
 		@include break-mobile {
 			height: var(--masterbar-checkout-height);
 			line-height: var(--masterbar-checkout-height);
@@ -382,6 +388,11 @@ body.is-mobile-app-view {
 		display: block;
 		width: 150px;
 		height: 25px;
+		margin: 0 5px;
+
+		.masterbar--is-checkout & {
+			margin: 0;
+		}
 	}
 
 	@include breakpoint-deprecated( "<480px" ) {
@@ -393,7 +404,12 @@ body.is-mobile-app-view {
 			display: block;
 			height: 24px;
 			width: 24px;
+			margin-left: 5px;
 			fill: var(--color-text-inverted);
+
+			.masterbar--is-checkout & {
+				margin-left: 0;
+			}
 		}
 
 		.masterbar__wpcom-wordmark {
@@ -911,6 +927,11 @@ a.masterbar__quick-language-switcher {
 	.masterbar__close-button {
 		flex: initial;
 		width: initial;
+		padding: 1em;
+
+		@include breakpoint-deprecated( ">480px" ) {
+			padding: 1.5em;
+		}
 	}
 
 	.masterbar__secure-checkout-text {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -16,8 +16,6 @@ const ContactContainer = styled.div`
 	display: flex;
 	align-items: center;
 	column-gap: 8px;
-	padding-right: 24px;
-	padding-left: 24px;
 	font-size: 14px;
 	line-height: 20px;
 	font-weight: 500;
@@ -37,6 +35,7 @@ const ContactContainer = styled.div`
 	span {
 		display: none;
 	}
+
 	@media ( min-width: 600px ) {
 		.gridicon {
 			display: none;


### PR DESCRIPTION
The checkout masterbar has had this issue where elements on the page will distort the background width so that a gray bar begins to form on the right hand side:

![image](https://github.com/Automattic/wp-calypso/assets/16580129/b2a7c535-c229-4bc1-b97a-325873a36036)

At first, this was due to the masterbar expanding beyond its allotted space because it is fixed to one row by default. This is handled in this PR by a) adjusting the existing margin and padding and b) hiding the "Secure checkout" text on device widths below 300px. 

While this does prevent the gray bar from appearing at 300px, it seems another element somewhere in checkout breaks the layout again but this time at around 240px. This seems acceptable for now as Calypso in general seems to not support devices of that size for a number of sections and functionality.

## Testing Instructions

* Go to dotcom checkout
* Check that masterbar looks great and as expected, i.e. even spacing between left and right margin
* Reduce window size slowly and look for any breakage of the layout such as incorrect wrapping or border overflow (especially on the right border)
* Ensure logo and secure checkout text do not overlap and stay spaced
* Under 300px width the secure checkout text should disappear
* Do the same for Jetpack and Akismet and also RTL language layouts
