### PR TITLE
Pattern Library: add tracking for 'Copy Pattern' button

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -47,12 +47,12 @@ function useTimeoutToResetBoolean(
 
 type PatternPreviewProps = {
 	canCopy?: boolean;
-	category: string;
+	category?: string;
 	className?: string;
 	getPatternPermalink?: PatternGalleryProps[ 'getPatternPermalink' ];
 	isResizable?: boolean;
 	pattern: Pattern | null;
-	patternTypeFilter: PatternTypeFilter;
+	patternTypeFilter?: PatternTypeFilter;
 	isGridView?: boolean;
 	viewportWidth?: number;
 };
@@ -116,11 +116,15 @@ function PatternPreviewFragment( {
 	}
 
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+	const patternType =
+		typeof patternTypeFilter !== 'undefined'
+			? getTracksPatternType( patternTypeFilter )
+			: patternTypeFilter;
 	const recordCopyEvent = ( tracksEventName: string ) => {
 		recordTracksEvent( tracksEventName, {
 			name: pattern?.name,
 			category,
-			type: getTracksPatternType( patternTypeFilter ),
+			type: patternType,
 			user_is_dev_account: isDevAccount ? '1' : '0',
 			view: isGridView ? 'grid' : 'list',
 		} );
@@ -141,7 +145,7 @@ function PatternPreviewFragment( {
 		recordTracksEvent( tracksEventName, {
 			name: pattern.name,
 			category,
-			type: getTracksPatternType( patternTypeFilter ),
+			type: patternType,
 			view: isGridView ? 'grid' : 'list',
 		} );
 	};

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -115,6 +115,17 @@ function PatternPreviewFragment( {
 			  } );
 	}
 
+	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+	const recordCopyEvent = ( tracksEventName: string ) => {
+		recordTracksEvent( tracksEventName, {
+			name: pattern?.name,
+			category,
+			type: getTracksPatternType( patternTypeFilter ),
+			user_is_dev_account: isDevAccount ? '1' : '0',
+			view: isGridView ? 'grid' : 'list',
+		} );
+	};
+
 	useTimeoutToResetBoolean( isPermalinkCopied, setIsPermalinkCopied );
 	useTimeoutToResetBoolean( isPatternCopied, setIsPatternCopied );
 
@@ -175,6 +186,7 @@ function PatternPreviewFragment( {
 					<ClipboardButton
 						className="pattern-preview__copy"
 						onCopy={ () => {
+							recordCopyEvent( 'calypso_pattern_library_copy' );
 							setIsPatternCopied( true );
 						} }
 						text={ pattern?.html ?? '' }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -116,15 +116,11 @@ function PatternPreviewFragment( {
 	}
 
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
-	const patternType =
-		typeof patternTypeFilter !== 'undefined'
-			? getTracksPatternType( patternTypeFilter )
-			: patternTypeFilter;
 	const recordCopyEvent = ( tracksEventName: string ) => {
 		recordTracksEvent( tracksEventName, {
 			name: pattern?.name,
 			category,
-			type: patternType,
+			type: getTracksPatternType( patternTypeFilter ),
 			user_is_dev_account: isDevAccount ? '1' : '0',
 			view: isGridView ? 'grid' : 'list',
 		} );

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -141,7 +141,7 @@ function PatternPreviewFragment( {
 		recordTracksEvent( tracksEventName, {
 			name: pattern.name,
 			category,
-			type: patternType,
+			type: getTracksPatternType( patternTypeFilter ),
 			view: isGridView ? 'grid' : 'list',
 		} );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6134-gh-Automattic/dotcom-forge

## Proposed Changes

- Add tracking to the **Copy Pattern** button


## Testing Instructions

- With this branch checked out, visit `/patterns`, and make sure you're logged in to wpcom
- Select a category, then hit the **Copy Pattern button on any pattern**
 - Confirm that the `calypso_pattern_library_copy` Tracks event fires with the following props:
   - `name`: carrying the name of the pattern you chose to copy
   - `category`: carrying the name of the currently displayed category
   - `type`: carrying either `pattern` or `page-layout`, depending on what kind of content you copied
   - `view`: carrying either `grid` or `list`, based on which view you're currently using
   - `user_is_dev_account`: carrying either `0` or `1` depending on whether or not the user in question chose to check the "I'm a developer" box.
- Repeat the above test, swapping out only the variables you can (e.g. try a different category, use the grid view instead of list, and check out page layouts instead of patterns.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?