### PR TITLE
Fix/sites table padding v2

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -47,7 +47,7 @@ const Row = styled.tr`
 const Column = styled.td< { tabletHidden?: boolean } >`
 	padding-block-start: 12px;
 	padding-block-end: 12px;
-	padding-inline-end: 24px;
+	padding-inline-end: 12px;
 	vertical-align: middle;
 	font-size: 14px;
 	line-height: 20px;

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -63,7 +63,7 @@ const SiteTh = styled.th( {
 } );
 
 const StatusTh = styled.th( {
-	width: '124px',
+	width: '140px',
 } );
 
 const StatsTh = styled.th( {

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -62,10 +62,8 @@ const SiteTh = styled.th( {
 	},
 } );
 
-const PlanTh = styled.th( {
-	[ MEDIA_QUERIES.wide ]: {
-		width: '15%',
-	},
+const StatusTh = styled.th( {
+	width: '124px',
 } );
 
 const StatsTh = styled.th( {
@@ -148,8 +146,8 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 			>
 				<Row>
 					<SiteTh>{ __( 'Site' ) }</SiteTh>
-					<PlanTh>{ __( 'Plan' ) }</PlanTh>
-					<th>{ __( 'Status' ) }</th>
+					<th>{ __( 'Plan' ) }</th>
+					<StatusTh>{ __( 'Status' ) }</StatusTh>
 					<th>{ __( 'Last Publish' ) }</th>
 					<StatsTh>
 						<StatsThInner>


### PR DESCRIPTION
replay of https://github.com/Automattic/wp-calypso/pull/88699 I'd accidentally messed up the rebase of that, this just includes the commits that were supposed to go out 