### PR TITLE
Pattern Library: Add pattern preview resize tracking

### DIFF
--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -125,14 +125,14 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 				>
 					{ patterns.map( ( pattern, i ) => (
 						<PatternPreview
-							canCopy={ isLoggedIn || i < LOGGED_OUT_USERS_CAN_COPY_COUNT }
 							category={ category }
+							canCopy={ isLoggedIn || i < LOGGED_OUT_USERS_CAN_COPY_COUNT }
 							className={ classNames( {
 								'pattern-preview--grid': isGridView,
 								'pattern-preview--list': ! isGridView,
 							} ) }
-							getPatternPermalink={ getPatternPermalink }
 							isResizable={ ! isGridView }
+							getPatternPermalink={ getPatternPermalink }
 							key={ pattern.ID }
 							pattern={ pattern }
 							patternTypeFilter={ patternTypeFilter }

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -125,18 +125,18 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 				>
 					{ patterns.map( ( pattern, i ) => (
 						<PatternPreview
-							category={ category }
 							canCopy={ isLoggedIn || i < LOGGED_OUT_USERS_CAN_COPY_COUNT }
+							category={ category }
 							className={ classNames( {
 								'pattern-preview--grid': isGridView,
 								'pattern-preview--list': ! isGridView,
 							} ) }
-							isResizable={ ! isGridView }
 							getPatternPermalink={ getPatternPermalink }
+							isGridView={ isGridView }
+							isResizable={ ! isGridView }
 							key={ pattern.ID }
 							pattern={ pattern }
 							patternTypeFilter={ patternTypeFilter }
-							isGridView={ isGridView }
 							viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }
 						/>
 					) ) }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -225,7 +225,7 @@ export function PatternPreview( props: PatternPreviewProps ) {
 			minWidth={ 375 }
 			maxWidth="100%"
 			onResizeStop={ () => {
-				recordResizeEvent( 'calypso_pattern_library_viewport_resize' );
+				recordResizeEvent( 'calypso_pattern_library_resize' );
 			} }
 		>
 			<PatternPreviewFragment { ...props } />

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -11,12 +11,11 @@ import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { PatternsGetAccessModal } from 'calypso/my-sites/patterns/components/get-access-modal';
-import { PatternTypeFilter } from 'calypso/my-sites/patterns/types';
+import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
+import { PatternTypeFilter, Pattern, PatternGalleryProps } from 'calypso/my-sites/patterns/types';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import { getTracksPatternType } from '../../lib/get-tracks-pattern-type';
-import type { Pattern, PatternGalleryProps } from 'calypso/my-sites/patterns/types';
 import type { Dispatch, SetStateAction } from 'react';
 
 import './style.scss';

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -100,10 +100,6 @@ function PatternPreviewFragment( {
 		return null;
 	}
 
-	// This handler will be used to fire each of the different 'Get Access'
-	// events for logged out users: opening the modal, closing the modal,
-	// signing up, and logging in. The handler will be passed the name of the
-	// event to fire, and the event props will be the same for each.
 	const recordGetAccessEvent = ( tracksEventName: string ) => {
 		recordTracksEvent( tracksEventName, {
 			name: pattern.name,

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -204,7 +204,7 @@ export function PatternPreview( props: PatternPreviewProps ) {
 			name: pattern?.name,
 			category,
 			type: getTracksPatternType( patternTypeFilter ),
-			is_logged_in: isLoggedIn ? '1' : '0',
+			is_logged_in: isLoggedIn,
 			user_is_dev_account: isDevAccount ? '1' : '0',
 		} );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6134-gh-Automattic/dotcom-forge

## Proposed Changes

- Add tracking to the resizing handle on pattern previews


## Testing Instructions

- With this branch checked out, visit `/patterns`, and make sure you're logged in to wpcom
- Select a category, then use the resize handle on any of the displayed patterns
- Confirm that the `calypso_pattern_library_resize` Tracks event fires with the following props:
   - `name`: carrying the name of the pattern you chose to copy
   - `category`: carrying the name of the currently displayed category
   - `type`: carrying either `pattern` or `page-layout`, depending on what kind of content you copied
   - `is_logged_in`: carrying either `true` or `false`
   - `user_is_dev_account`: carrying either `0` or `1` depending on whether or not the user in question chose to check the "I'm a developer" box.
- Repeat the above test, swapping out only the variables you can (e.g. try a different category, check out page layouts instead of patterns.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?