### PR TITLE
Pattern Library: Add 'Get Access' modal tracking

### DIFF
--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -77,7 +77,6 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 													: category.regularPreviewPattern
 											}
 											patternTypeFilter={ patternTypeFilter }
-											view="grid" /* Passing this prop to satisfy TS, using 'grid' as a placeholder */
 											viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
 										/>
 									</div>

--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -69,12 +69,15 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 								>
 									<div className="patterns-category-gallery__item-preview-inner">
 										<PatternPreview
+											category={ category.name }
 											className="pattern-preview--category-gallery"
 											pattern={
 												patternTypeFilter === PatternTypeFilter.PAGES
 													? category.pagePreviewPattern
 													: category.regularPreviewPattern
 											}
+											patternTypeFilter={ patternTypeFilter }
+											view="grid"
 											viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
 										/>
 									</div>

--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -77,7 +77,7 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 													: category.regularPreviewPattern
 											}
 											patternTypeFilter={ patternTypeFilter }
-											view="grid"
+											view="grid" /* Passing this prop to satisfy TS, using 'grid' as a placeholder */
 											viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
 										/>
 									</div>

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -75,7 +75,7 @@ export const PatternsGetAccessModal = ( {
 						<Button
 							transparent
 							href={ loginUrl }
-							onClick={ () => recordLoginClickEvent( 'calypso_pattern_library_get_access_signup' ) }
+							onClick={ () => recordLoginClickEvent( 'calypso_pattern_library_get_access_login' ) }
 						>
 							Log in
 						</Button>

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -1,21 +1,41 @@
 import { Button, Dialog } from '@automattic/components';
 import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getTracksPatternType } from '../../lib/get-tracks-pattern-type';
+import { PatternTypeFilter } from '../../types';
 
 import './style.scss';
 
 type PatternsGetAccessModalProps = {
+	category: string;
 	isOpen: boolean;
 	onClose: () => void;
+	pattern: string;
+	patternTypeFilter: PatternTypeFilter;
 };
 
-export const PatternsGetAccessModal = ( { isOpen, onClose }: PatternsGetAccessModalProps ) => {
+export const PatternsGetAccessModal = ( {
+	category,
+	isOpen,
+	onClose,
+	pattern,
+	patternTypeFilter,
+}: PatternsGetAccessModalProps ) => {
 	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
 
 	const isLoggedIn = false;
 	const startUrl = localizeUrl( '//wordpress.com/start/account/user', locale, isLoggedIn );
 	const loginUrl = localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn );
+
+	const recordSignupClickEvent = ( tracksEventName: string ) => {
+		recordTracksEvent( tracksEventName, {
+			name: pattern,
+			category,
+			type: getTracksPatternType( patternTypeFilter ),
+		} );
+	};
 
 	return (
 		<Dialog
@@ -35,7 +55,13 @@ export const PatternsGetAccessModal = ( { isOpen, onClose }: PatternsGetAccessMo
 						WordPress.com account to get started.
 					</div>
 					<div className="patterns-get-access-modal__upgrade-buttons">
-						<Button primary href={ startUrl }>
+						<Button
+							primary
+							href={ startUrl }
+							onClick={ () =>
+								recordSignupClickEvent( 'calypso_pattern_library_get_access_signup' )
+							}
+						>
 							Create a free account
 						</Button>
 						<Button transparent href={ loginUrl }>

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -1,26 +1,19 @@
 import { Button, Dialog } from '@automattic/components';
 import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getTracksPatternType } from '../../lib/get-tracks-pattern-type';
-import { PatternTypeFilter } from '../../types';
 
 import './style.scss';
 
 type PatternsGetAccessModalProps = {
-	category: string;
 	isOpen: boolean;
 	onClose: () => void;
-	pattern: string;
-	patternTypeFilter: PatternTypeFilter;
+	tracksEventHandler: ( eventName: string ) => void;
 };
 
 export const PatternsGetAccessModal = ( {
-	category,
 	isOpen,
 	onClose,
-	pattern,
-	patternTypeFilter,
+	tracksEventHandler,
 }: PatternsGetAccessModalProps ) => {
 	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
@@ -29,28 +22,15 @@ export const PatternsGetAccessModal = ( {
 	const startUrl = localizeUrl( '//wordpress.com/start/account/user', locale, isLoggedIn );
 	const loginUrl = localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn );
 
-	const recordSignupClickEvent = ( tracksEventName: string ) => {
-		recordTracksEvent( tracksEventName, {
-			name: pattern,
-			category,
-			type: getTracksPatternType( patternTypeFilter ),
-		} );
-	};
-
-	const recordLoginClickEvent = ( tracksEventName: string ) => {
-		recordTracksEvent( tracksEventName, {
-			name: pattern,
-			category,
-			type: getTracksPatternType( patternTypeFilter ),
-		} );
-	};
-
 	return (
 		<Dialog
 			isVisible={ isOpen }
 			additionalClassNames="patterns-get-access-modal"
 			additionalOverlayClassNames="patterns-get-access-modal__backdrop"
-			onClose={ onClose }
+			onClose={ () => {
+				onClose();
+				tracksEventHandler( 'calypso_pattern_library_get_access_dismiss' );
+			} }
 		>
 			<div className="patterns-get-access-modal__content">
 				<button className="patterns-get-access-modal__close" onClick={ onClose }>
@@ -66,16 +46,14 @@ export const PatternsGetAccessModal = ( {
 						<Button
 							primary
 							href={ startUrl }
-							onClick={ () =>
-								recordSignupClickEvent( 'calypso_pattern_library_get_access_signup' )
-							}
+							onClick={ () => tracksEventHandler( 'calypso_pattern_library_get_access_signup' ) }
 						>
 							Create a free account
 						</Button>
 						<Button
 							transparent
 							href={ loginUrl }
-							onClick={ () => recordLoginClickEvent( 'calypso_pattern_library_get_access_login' ) }
+							onClick={ () => tracksEventHandler( 'calypso_pattern_library_get_access_login' ) }
 						>
 							Log in
 						</Button>

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -37,6 +37,14 @@ export const PatternsGetAccessModal = ( {
 		} );
 	};
 
+	const recordLoginClickEvent = ( tracksEventName: string ) => {
+		recordTracksEvent( tracksEventName, {
+			name: pattern,
+			category,
+			type: getTracksPatternType( patternTypeFilter ),
+		} );
+	};
+
 	return (
 		<Dialog
 			isVisible={ isOpen }
@@ -64,7 +72,11 @@ export const PatternsGetAccessModal = ( {
 						>
 							Create a free account
 						</Button>
-						<Button transparent href={ loginUrl }>
+						<Button
+							transparent
+							href={ loginUrl }
+							onClick={ () => recordLoginClickEvent( 'calypso_pattern_library_get_access_signup' ) }
+						>
 							Log in
 						</Button>
 					</div>

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -33,7 +33,13 @@ export const PatternsGetAccessModal = ( {
 			} }
 		>
 			<div className="patterns-get-access-modal__content">
-				<button className="patterns-get-access-modal__close" onClick={ onClose }>
+				<button
+					className="patterns-get-access-modal__close"
+					onClick={ () => {
+						onClose();
+						tracksEventHandler( 'calypso_pattern_library_get_access_dismiss' );
+					} }
+				>
 					<Icon icon={ iconClose } size={ 24 } />
 				</button>
 				<div className="patterns-get-access-modal__inner">

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -92,7 +92,13 @@ function MasonryGallery( { children, className, enableMasonry }: MasonryGalleryP
 const LOGGED_OUT_USERS_CAN_COPY_COUNT = 3;
 
 export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
-	const { getPatternPermalink, isGridView = false, patterns = [], patternTypeFilter } = props;
+	const {
+		category,
+		getPatternPermalink,
+		isGridView = false,
+		patterns = [],
+		patternTypeFilter,
+	} = props;
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const patternIdsByCategory = {
@@ -120,6 +126,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 					{ patterns.map( ( pattern, i ) => (
 						<PatternPreview
 							canCopy={ isLoggedIn || i < LOGGED_OUT_USERS_CAN_COPY_COUNT }
+							category={ category }
 							className={ classNames( {
 								'pattern-preview--grid': isGridView,
 								'pattern-preview--list': ! isGridView,
@@ -128,6 +135,8 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 							isResizable={ ! isGridView }
 							key={ pattern.ID }
 							pattern={ pattern }
+							patternTypeFilter={ patternTypeFilter }
+							view={ isGridView ? 'grid' : 'list' }
 							viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }
 						/>
 					) ) }

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -136,7 +136,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 							key={ pattern.ID }
 							pattern={ pattern }
 							patternTypeFilter={ patternTypeFilter }
-							view={ isGridView ? 'grid' : 'list' }
+							isGridView={ isGridView }
 							viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }
 						/>
 					) ) }

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -295,6 +295,7 @@ export const PatternLibrary = ( {
 						</div>
 
 						<PatternGallery
+							category={ category }
 							getPatternPermalink={ ( pattern ) =>
 								getPatternPermalink( pattern, category, patternTypeFilter, categories )
 							}

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -101,20 +101,16 @@ function PatternPreviewFragment( {
 		return null;
 	}
 
-	const recordOpenModalEvent = ( tracksEventName: string ) => {
+	// This handler will be used to fire each of the different 'Get Access'
+	// events for logged out users: opening the modal, closing the modal,
+	// signing up, and logging in. The handler will be passed the name of the
+	// event to fire, and the event props will be the same for each.
+	const recordGetAccessEvent = ( tracksEventName: string ) => {
 		recordTracksEvent( tracksEventName, {
-			name: pattern?.name,
+			name: pattern.name,
 			category,
 			type: getTracksPatternType( patternTypeFilter ),
 			view,
-		} );
-	};
-
-	const recordCloseModalEvent = ( tracksEventName: string ) => {
-		recordTracksEvent( tracksEventName, {
-			name: pattern?.name,
-			category,
-			type: getTracksPatternType( patternTypeFilter ),
 		} );
 	};
 
@@ -172,7 +168,7 @@ function PatternPreviewFragment( {
 						className="pattern-preview__get-access"
 						onClick={ () => {
 							setIsAuthModalOpen( true );
-							recordOpenModalEvent( 'calypso_pattern_library_get_access' );
+							recordGetAccessEvent( 'calypso_pattern_library_get_access' );
 						} }
 						transparent
 					>
@@ -182,14 +178,9 @@ function PatternPreviewFragment( {
 			</div>
 
 			<PatternsGetAccessModal
-				category={ category }
 				isOpen={ isAuthModalOpen }
-				onClose={ () => {
-					setIsAuthModalOpen( false );
-					recordCloseModalEvent( 'calypso_pattern_library_get_access_dismiss' );
-				} }
-				pattern={ pattern.name }
-				patternTypeFilter={ patternTypeFilter }
+				onClose={ () => setIsAuthModalOpen( false ) }
+				tracksEventHandler={ recordGetAccessEvent }
 			/>
 		</div>
 	);

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -16,7 +16,6 @@ import type {
 	Pattern,
 	PatternGalleryProps,
 	PatternTypeFilter,
-	PatternView,
 } from 'calypso/my-sites/patterns/types';
 import type { Dispatch, SetStateAction } from 'react';
 
@@ -54,7 +53,7 @@ type PatternPreviewProps = {
 	isResizable?: boolean;
 	pattern: Pattern | null;
 	patternTypeFilter: PatternTypeFilter;
-	view: PatternView;
+	isGridView?: boolean;
 	viewportWidth?: number;
 };
 
@@ -65,7 +64,7 @@ function PatternPreviewFragment( {
 	getPatternPermalink = () => '',
 	pattern,
 	patternTypeFilter,
-	view,
+	isGridView,
 	viewportWidth,
 }: PatternPreviewProps ) {
 	const ref = useRef< HTMLDivElement >( null );
@@ -110,7 +109,7 @@ function PatternPreviewFragment( {
 			name: pattern.name,
 			category,
 			type: getTracksPatternType( patternTypeFilter ),
-			view,
+			view: isGridView ? 'grid' : 'list',
 		} );
 	};
 

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -110,6 +110,14 @@ function PatternPreviewFragment( {
 		} );
 	};
 
+	const recordCloseModalEvent = ( tracksEventName: string ) => {
+		recordTracksEvent( tracksEventName, {
+			name: pattern?.name,
+			category,
+			type: getTracksPatternType( patternTypeFilter ),
+		} );
+	};
+
 	return (
 		<div
 			className={ classNames( 'pattern-preview', className, {
@@ -175,7 +183,10 @@ function PatternPreviewFragment( {
 
 			<PatternsGetAccessModal
 				isOpen={ isAuthModalOpen }
-				onClose={ () => setIsAuthModalOpen( false ) }
+				onClose={ () => {
+					setIsAuthModalOpen( false );
+					recordCloseModalEvent( 'calypso_pattern_library_get_access_dismiss' );
+				} }
 			/>
 		</div>
 	);

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -182,11 +182,14 @@ function PatternPreviewFragment( {
 			</div>
 
 			<PatternsGetAccessModal
+				category={ category }
 				isOpen={ isAuthModalOpen }
 				onClose={ () => {
 					setIsAuthModalOpen( false );
 					recordCloseModalEvent( 'calypso_pattern_library_get_access_dismiss' );
 				} }
+				pattern={ pattern.name }
+				patternTypeFilter={ patternTypeFilter }
 			/>
 		</div>
 	);

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -48,6 +48,7 @@ type CategoryGalleryProps = {
 export type CategoryGalleryFC = React.FC< CategoryGalleryProps >;
 
 export type PatternGalleryProps = {
+	category: string;
 	getPatternPermalink?( pattern: Pattern ): string;
 	isGridView?: boolean;
 	patterns?: Pattern[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6134-gh-Automattic/dotcom-forge

## Proposed Changes

- Add tracking to the free trial modal open, dismiss, and CTA buttons

## Testing Instructions

- With this branch checked out, visit `/patterns`, and make sure you're logged out of wpcom
- Select a category, then scroll down to the fourth (or later) pattern and hit the **Get Access** button
 - Confirm that the modal opens and the `calypso_pattern_library_get_access` Tracks event fires with the following props:
   - `name`: carrying the name of the pattern you chose to copy
   - `category`: carrying the name of the currently displayed category
   - `type`: carrying either `pattern` or `page-layout`, depending on what kind of content you copied
   - `view`: carrying either `grid` or `list`, based on which view you're currently using
 - Repeat, experimenting with different categories, patterns, types, and views
- Open the modal again. This time click on the **Create a free account** button
- Confirm that the sign up flow is launched, and that the `calypso_pattern_library_get_access_signup` Tracks event fires with the following props:
   - `name`: carrying the name of the pattern you chose to copy
   - `category`: carrying the name of the currently displayed category
   - `type`: carrying either `pattern` or `page-layout`, depending on what kind of content you copied
- Test different combinations, checking each prop for accuracy
- Open the modal once more, and this time dismiss it with the close button, <kbd>Esc</kbd> key, or clicking outside the modal
- Confirm that the modal closes and the `calypso_pattern_library_get_access_dismiss` Tracks event fires with the following props:
   - `name`: carrying the name of the pattern you chose to copy
   - `category`: carrying the name of the currently displayed category
   - `type`: carrying either `pattern` or `page-layout`, depending on what kind of content you copied
- Open the modal and this time click the **Login** button. Confirm that the `calypso_pattern_library_get_access_login` Tracks event fires with the following props:
   - `name`: carrying the name of the pattern you chose to copy
   - `category`: carrying the name of the currently displayed category
   - `type`: carrying either `pattern` or `page-layout`, depending on what kind of content you copied
-  One last time, test different combos for accuracy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?