### PR TITLE
Stats: Allow atomic site to use UTM Stats

### DIFF
--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { isA8CSpecialBlog } from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
@@ -43,7 +44,8 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	const isSiteInternal =
 		isA8CSpecialBlog( siteId ) || ( ! isFetchingUsage && usageData?.is_internal );
 	const isFetching = isFetchingUsage || isLoadingFeatureCheck || isFetchingUTM;
-	const isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse;
+	const isSiteAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse || isSiteAtomic;
 
 	// TODO: trigger useUTMMetricsQuery manually once isAdvancedFeatureEnabled === true
 

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -25,8 +25,8 @@ const version_greater_than_or_equal = (
 export default function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
-	const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {
-		treatAtomicAsJetpackSite: false,
+	const isSiteJetpack = isJetpackSite( state, siteId, {
+		treatAtomicAsJetpackSite: true,
 	} );
 
 	return {
@@ -61,7 +61,7 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 			// TODO: Remove the flag check once UTM stats are released.
 			( config.isEnabled( 'stats/utm-module' ) &&
 				// UTM stats are only available for Jetpack sites for now.
-				isSiteJetpackNotAtomic &&
+				isSiteJetpack &&
 				version_greater_than_or_equal( statsAdminVersion, '0.17.0-alpha', isOdysseyStats ) ),
 	};
 }


### PR DESCRIPTION
p1HpG7-qLR-p2#comment-69250

## Proposed Changes

We might want to add feature to the dotcom plans rather than just enabling it for atomic sites. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?