### PR TITLE
Akismet checkout: Adjust flex values for better dropdown text wrapping

### DIFF
--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -114,6 +114,7 @@ const CurrentOptionContainer = styled.div< { shouldUseCheckoutV2: boolean } >`
 	font-size: ${ ( props ) => props.theme.fontSize.small };
 	font-weight: ${ ( props ) => props.theme.weights.normal };
 	justify-content: space-between;
+	flex-wrap: wrap;
 	line-height: 20px;
 	width: 100%;
 	column-gap: 20px;
@@ -124,14 +125,15 @@ const CurrentOptionContainer = styled.div< { shouldUseCheckoutV2: boolean } >`
 `;
 
 const Price = styled.span< { shouldUseCheckoutV2: boolean } >`
-	flex: 1 0 auto;
-	text-align: right;
+	flex: 1 0 fit-content;
 	color: #646970;
 	> span {
 		font-size: calc( ${ ( props ) => props.theme.fontSize.small } - 1px );
 	}
 
-	${ ( props ) => ( props.shouldUseCheckoutV2 ? `text-align: initial;` : `text-align: right;` ) }
+	@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
+		${ ( props ) => ( props.shouldUseCheckoutV2 ? `text-align: initial;` : `text-align: right;` ) }
+	}
 `;
 
 export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDropDownProps > = ( {
@@ -347,7 +349,7 @@ export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDr
 		if ( selectedQuantity !== AkBusinessDropdownPosition ) {
 			return isMobile()
 				? translate(
-						'{{span}}%(quantity)d licenses @ %(actualAmountQuantityOneDisplay)s/ea. ={{/span}} %(actualAmountDisplay)s',
+						'{{span}}%(quantity)d licenses @ %(actualAmountQuantityOneDisplay)s/ea. = %(actualAmountDisplay)s{{/span}}',
 						{
 							args: {
 								quantity: selectedQuantity,
@@ -365,7 +367,7 @@ export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDr
 						}
 				  )
 				: translate(
-						'{{span}}%(quantity)d licenses @ %(actualAmountQuantityOneDisplay)s per license ={{/span}} %(actualAmountDisplay)s',
+						'{{span}}%(quantity)d licenses @ %(actualAmountQuantityOneDisplay)s per license = %(actualAmountDisplay)s{{/span}}',
 						{
 							args: {
 								quantity: selectedQuantity,

--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -127,12 +127,14 @@ const CurrentOptionContainer = styled.div< { shouldUseCheckoutV2: boolean } >`
 const Price = styled.span< { shouldUseCheckoutV2: boolean } >`
 	flex: 1 0 fit-content;
 	color: #646970;
+	text-align: start;
+
 	> span {
 		font-size: calc( ${ ( props ) => props.theme.fontSize.small } - 1px );
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
-		${ ( props ) => ( props.shouldUseCheckoutV2 ? `text-align: initial;` : `text-align: right;` ) }
+		${ ( props ) => ( props.shouldUseCheckoutV2 ? `text-align: initial;` : `text-align: end;` ) }
 	}
 `;
 


### PR DESCRIPTION
I noticed while working on a separate checkout mobile styling issue that Akismet's 'Sites' dropdown overflows its boundaries on smaller devices, but by updating the flex values for this dropdown we're able to wrap it more elegantly onto the next line:

| Before | After |
| ----- | ----- |
| <img width="328" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/2cddc08b-9975-4973-839a-7aca72f0fe9e"> | <img width="333" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/1a12b4c9-60d2-408f-bfe0-12a692ac2816"> |

## Testing Instructions

* Add an Akismet product to your cart (use this link http://calypso.localhost:3000/checkout/akismet/ak_pro5h_yearly:-q-1)
* Ensure the Sites dropdown properly drops down on to the next line as the device width gets smaller
* The text should also become `text-align: start` instead of `end` at smaller sizes
* Ensure Dotcom and Jetpack dropdowns aren't negatively affected (unlikely since they use different dropdown components)
* Switch to an RTL language and ensure the text styling is switched (instead of align right, should align left etc)

