### PR TITLE
Automattic for Agencies: Implement API integration for Payment Methods page

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/lib/format-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/lib/format-stored-cards.ts
@@ -1,0 +1,17 @@
+import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+
+export default function formatStoredCards( data: {
+	items: PaymentMethod[];
+	per_page: number;
+	has_more: boolean;
+} ) {
+	const allStoredCards = data.items ?? [];
+	return {
+		allStoredCards,
+		primaryStoredCard: allStoredCards.find( ( card ) => card.is_default ) ?? null,
+		secondaryStoredCards: allStoredCards.filter( ( card ) => ! card.is_default ),
+		pageSize: data.per_page ?? 0,
+		hasStoredCards: allStoredCards.length > 0,
+		hasMoreStoredCards: data.has_more ?? false,
+	};
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-delete-card.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-delete-card.ts
@@ -1,21 +1,108 @@
-import { useCallback, useState } from 'react';
+import {
+	useMutation,
+	UseMutationOptions,
+	UseMutationResult,
+	useQueryClient,
+} from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState, useEffect } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import useStoredCards, { getFetchStoredCardsKey } from './use-stored-cards';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+
+const NOTIFICATION_DURATION = 3000;
+
+interface APIResponse {
+	success: boolean;
+}
+
+interface DeleteCardProps {
+	paymentMethodId: string;
+	primaryPaymentMethodId?: string;
+}
+
+function useDeleteCardMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, Error, DeleteCardProps, TContext >
+): UseMutationResult< APIResponse, Error, DeleteCardProps, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIResponse, Error, DeleteCardProps, TContext >( {
+		...options,
+		mutationFn: ( { paymentMethodId, primaryPaymentMethodId } ) =>
+			wpcom.req.post( {
+				method: 'DELETE',
+				apiNamespace: 'wpcom/v2',
+				path: `/jetpack-licensing/stripe/payment-method`,
+				body: {
+					...( agencyId && { agency_id: agencyId } ),
+					payment_method_id: paymentMethodId,
+					primary_payment_method_id: primaryPaymentMethodId,
+				},
+			} ),
+	} );
+}
 
 export function useDeleteCard( card: PaymentMethod ) {
 	const [ isDeleteDialogVisible, setIsDeleteDialogVisible ] = useState( false );
-	const [ isDeleteInProgress ] = useState( false );
+
+	// Fetch the stored cards from the cache if they are available.
+	const {
+		data: { allStoredCards },
+	} = useStoredCards( Infinity );
+
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const { mutate, isPending, isSuccess, isError, error } = useDeleteCardMutation( {
+		retry: false,
+	} );
+	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const nextPrimaryPaymentMethod = ( allStoredCards || [] ).find(
+		( currCard: PaymentMethod ) => currCard.id !== card.id
+	);
 
 	const handleDelete = useCallback( () => {
-		setIsDeleteDialogVisible( false );
+		mutate( {
+			paymentMethodId: card.id,
+			primaryPaymentMethodId: nextPrimaryPaymentMethod?.id,
+		} );
+	}, [ card.id, mutate, nextPrimaryPaymentMethod?.id ] );
 
-		// FIXME: Need to implement the actual API call.
-		card;
-	}, [ card ] );
+	useEffect( () => {
+		if ( isSuccess ) {
+			queryClient.invalidateQueries( {
+				queryKey: getFetchStoredCardsKey( agencyId ),
+			} );
+			dispatch(
+				successNotice( translate( 'Payment method deleted successfully' ), {
+					duration: NOTIFICATION_DURATION,
+					id: 'payment-method-deleted-successfully',
+				} )
+			);
+			setIsDeleteDialogVisible( false );
+		}
+	}, [ agencyId, dispatch, isSuccess, queryClient, translate ] );
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice( error.message, {
+					duration: NOTIFICATION_DURATION,
+					id: 'payment-method-deleted-error',
+				} )
+			);
+		}
+	}, [ dispatch, error?.message, isError, translate ] );
 
 	return {
 		isDeleteDialogVisible,
 		setIsDeleteDialogVisible,
 		handleDelete,
-		isDeleteInProgress,
+		isDeleteInProgress: isPending,
 	};
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-save-card.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-save-card.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
-import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
-import { useDispatch } from 'calypso/state';
+import wpcom from 'calypso/lib/wp';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 type Props = {
@@ -13,15 +14,17 @@ export function useSaveCard( {
 	stripeSetupIntentId,
 }: Props ): ( token: string ) => Promise< unknown > {
 	const dispatch = useDispatch();
+	const agencyId = useSelector( getActiveAgencyId );
 
 	return useCallback(
 		async ( token: string ) => {
-			const response = await wpcomJpl.req.post(
+			const response = await wpcom.req.post(
 				{
 					apiNamespace: 'wpcom/v2',
-					path: '/jetpack-licensing/stripe/payment-method', // FIXME: Update this to the correct endpoint.
+					path: '/jetpack-licensing/stripe/payment-method',
 				},
 				{
+					...( agencyId && { agency_id: agencyId } ),
 					payment_method_id: token,
 					use_as_primary_payment_method: useAsPrimaryPaymentMethod,
 					stripe_setup_intent_id: stripeSetupIntentId,
@@ -36,6 +39,6 @@ export function useSaveCard( {
 			dispatch( recordTracksEvent( 'calypso_a4a_add_new_credit_card' ) );
 			return response;
 		},
-		[ dispatch, stripeSetupIntentId, useAsPrimaryPaymentMethod ]
+		[ agencyId, dispatch, stripeSetupIntentId, useAsPrimaryPaymentMethod ]
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards.ts
@@ -1,67 +1,34 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { useEffect, useState } from 'react';
-import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import formatStoredCards from '../../lib/format-stored-cards';
 
-// FIXME: Need to hook this up to the real API.
-export default function useStoredCards() {
-	const showDummyData = isEnabled( 'a4a/mock-api-data' );
+export const getFetchStoredCardsKey = ( agencyId?: number ) => [ 'a4a-stored-cards', agencyId ];
 
-	const [ isFetching, setIsFetching ] = useState( showDummyData );
+export default function useStoredCards( staleTime: number = 0 ) {
+	const agencyId = useSelector( getActiveAgencyId );
 
-	// FIXME: Don't forget to remove this fake loading delay for dummy data
-	useEffect( () => {
-		// Simulate a fake loading delay.
-		setTimeout( () => {
-			setIsFetching( false );
-		}, 1000 );
-	}, [] );
-
-	if ( showDummyData ) {
-		const allStoredCards: PaymentMethod[] = [
-			{
-				id: '1',
-				card: {
-					brand: 'mastercard',
-					exp_month: 12,
-					exp_year: 2027,
-					last4: '1234',
+	return useQuery( {
+		queryKey: getFetchStoredCardsKey( agencyId ),
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: '/jetpack-licensing/stripe/payment-methods',
 				},
-				is_default: true,
-				name: 'Primary Card',
-				created: new Date().toString(),
-			},
-			{
-				id: '2',
-				card: {
-					brand: 'visa',
-					exp_month: 12,
-					exp_year: 2027,
-					last4: '5678',
-				},
-				is_default: false,
-				name: 'Secondary Card',
-				created: new Date().toString(),
-			},
-		];
-
-		return {
-			allStoredCards,
-			primaryStoredCard: allStoredCards.find( ( card ) => card.is_default ),
-			secondaryStoredCards: allStoredCards.filter( ( card ) => ! card.is_default ),
-			isFetching,
-			pageSize: 1,
-			hasStoredCards: !! allStoredCards.length,
-			hasMoreStoredCards: false,
-		};
-	}
-
-	return {
-		allStoredCards: [],
-		primaryStoredCard: null,
-		secondaryStoredCards: [],
-		isFetching,
-		pageSize: 0,
-		hasStoredCards: false,
-		hasMoreStoredCards: false,
-	};
+				{
+					...( agencyId && { agency_id: agencyId } ),
+				}
+			),
+		enabled: !! agencyId,
+		select: formatStoredCards,
+		refetchOnWindowFocus: false,
+		staleTime: staleTime,
+		initialData: {
+			items: [],
+			per_page: 0,
+			has_more: false,
+		},
+	} );
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/index.tsx
@@ -69,7 +69,10 @@ export default function CreditCardFields() {
 		},
 	};
 
-	const { allStoredCards: paymentMethods, isFetching: isFetchingPaymentMethods } = useStoredCards();
+	const {
+		data: { primaryStoredCard },
+		isFetching: isFetchingPaymentMethods,
+	} = useStoredCards();
 
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
@@ -103,8 +106,8 @@ export default function CreditCardFields() {
 				/>
 
 				<SetAsPrimaryPaymentMethod
-					isChecked={ useAsPrimaryPaymentMethod || paymentMethods.length === 0 }
-					isDisabled={ isFetchingPaymentMethods || isDisabled || paymentMethods.length === 0 }
+					isChecked={ useAsPrimaryPaymentMethod || ! primaryStoredCard }
+					isDisabled={ isFetchingPaymentMethods || isDisabled || ! primaryStoredCard }
 					onChange={ setUseAsPrimaryPaymentMethod }
 				/>
 			</div>

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
@@ -30,13 +30,15 @@ export default function PaymentMethodOverview() {
 	const dispatch = useDispatch();
 
 	const {
-		allStoredCards,
-		primaryStoredCard,
-		secondaryStoredCards,
+		data: {
+			allStoredCards,
+			primaryStoredCard,
+			secondaryStoredCards,
+			pageSize,
+			hasStoredCards,
+			hasMoreStoredCards,
+		},
 		isFetching,
-		pageSize,
-		hasStoredCards,
-		hasMoreStoredCards,
 	} = useStoredCards();
 
 	const { page, showPagination, onPageClick } = useStoredCardsPagination( {

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
@@ -13,6 +13,7 @@ interface Props {
 	isVisible: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
+	isDeleteInProgress?: boolean;
 }
 
 const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
@@ -20,10 +21,15 @@ const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
 	isVisible,
 	onClose,
 	onConfirm,
+	isDeleteInProgress,
 } ) => {
 	const translate = useTranslate();
 
-	const { allStoredCards, isFetching } = useStoredCards();
+	// Fetch the stored cards from the cache if they are available.
+	const {
+		data: { allStoredCards },
+		isFetching,
+	} = useStoredCards( Infinity );
 
 	return (
 		<Dialog
@@ -35,7 +41,7 @@ const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
 					{ translate( 'Go back' ) }
 				</Button>,
 
-				<Button disabled={ isFetching } onClick={ onConfirm } primary scary>
+				<Button disabled={ isDeleteInProgress } onClick={ onConfirm } primary scary>
 					{ translate( 'Delete payment method' ) }
 				</Button>,
 			] }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
@@ -121,6 +121,7 @@ export default function StoredCreditCard( {
 					isVisible={ true }
 					onClose={ () => setIsDeleteDialogVisible( false ) }
 					onConfirm={ handleDelete }
+					isDeleteInProgress={ isDeleteInProgress }
 				/>
 			) }
 		</>


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/304

## Proposed Changes

This PR implements API for the A4A Payment Methods page. Includes:

- Fetch stored credit cards
- Add a new credit card
- Delete credit card
- Set as a primary card

<img width="1571" alt="Screenshot 2024-03-26 at 11 16 53 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4ab7e40a-a7ea-476b-9fc2-24cbdf394655">

## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Click on Purchases > Click on Payment Methods > Verify you can see an empty page as shown below:

<img width="1533" alt="Screenshot 2024-03-26 at 11 12 42 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/09dacfbd-ca39-4252-9016-9dd080b6ab36">

- Click the `Add a card` button and verify that you can see the form as shown below > Add a new card and verify that it works as expected.

<img width="1533" alt="Screenshot 2024-03-26 at 11 12 47 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/210d20d3-752d-49c5-9efb-1a81913f4c38">

<img width="1583" alt="Screenshot 2024-03-26 at 11 21 21 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/cd647b3e-f41a-4de7-8e90-e769aeab6ac8">

- Go and add another card by clicking the `Add new card` button

<img width="1571" alt="Screenshot 2024-03-26 at 11 16 53 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0913203c-056d-444a-ab18-b40dfb440126">

- Verify Set as new card and Delete card(both primary & secondary card) works as expected.

<img width="1583" alt="Screenshot 2024-03-26 at 11 27 23 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ab44bbda-ec8c-4468-98d3-c1b00812ae2a">

<img width="614" alt="Screenshot 2024-03-26 at 11 19 01 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/131150d8-cfd7-466a-9f19-ff9cf796d54f">

<img width="618" alt="Screenshot 2024-03-26 at 11 20 00 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1b104a7c-9291-460d-8e32-379630667376">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?