### PR TITLE
clean up `layout/dotcom-nav-redesign` feature toggle

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -124,14 +124,12 @@ function WhatsNewLoader( { loadWhatsNew, siteId } ) {
 			seenWhatsNewAnnouncements &&
 			typeof seenWhatsNewAnnouncements.indexOf === 'function'
 		) {
-			if ( config.isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-				data.forEach( ( item ) => {
-					if ( item.critical && -1 === seenWhatsNewAnnouncements.indexOf( item.announcementId ) ) {
-						setShowWhatsNew( true );
-						return;
-					}
-				} );
-			}
+			data.forEach( ( item ) => {
+				if ( item.critical && -1 === seenWhatsNewAnnouncements.indexOf( item.announcementId ) ) {
+					setShowWhatsNew( true );
+					return;
+				}
+			} );
 		}
 	}, [ data, isLoading, seenWhatsNewAnnouncements, setShowWhatsNew ] );
 

--- a/client/my-sites/advertising/useAdvertisingUrl.jsx
+++ b/client/my-sites/advertising/useAdvertisingUrl.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -13,9 +12,7 @@ const useAdvertisingUrl = () => {
 		getSiteOption( state, siteId, 'wpcom_admin_interface' )
 	);
 
-	return adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
-		? siteAdminUrl
-		: `/advertising/${ selectedSiteSlug }`;
+	return adminInterface === 'wp-admin' ? siteAdminUrl : `/advertising/${ selectedSiteSlug }`;
 };
 
 export default useAdvertisingUrl;

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -46,31 +46,16 @@ class CurrentSite extends Component {
 		const { translate, isRtl } = this.props;
 		const arrowDirection = isRtl ? 'right' : 'left';
 
-		if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-			return (
-				<span className="current-site__switch-sites">
-					<Button borderless href="/sites" onClick={ this.onAllSitesClick }>
-						<span
-							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
-						></span>
-						<span className="current-site__switch-sites-label">{ translate( 'All Sites' ) }</span>
-					</Button>
-				</span>
-			);
-		}
 		return (
-			this.props.siteCount > 1 && (
-				<span className="current-site__switch-sites">
-					<Button borderless onClick={ this.switchSites }>
-						<span
-							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
-						></span>
-						<span className="current-site__switch-sites-label">{ translate( 'Switch Site' ) }</span>
-					</Button>
-				</span>
-			)
+			<span className="current-site__switch-sites">
+				<Button borderless href="/sites" onClick={ this.onAllSitesClick }>
+					<span
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
+					></span>
+					<span className="current-site__switch-sites-label">{ translate( 'All Sites' ) }</span>
+				</Button>
+			</span>
 		);
 	};
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -584,7 +584,7 @@ export class SiteSettingsFormGeneral extends Component {
 			<div className={ classNames( classes ) }>
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
 
-				{ ! ( isEnabled( 'layout/dotcom-nav-redesign' ) && isClassicView ) && (
+				{ ! isClassicView && (
 					<>
 						<SettingsSectionHeader
 							data-tip-target="settings-site-profile-save"

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { localize, translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -20,14 +19,14 @@ import GeneralSettings from './section-general';
 import './style.scss';
 
 const getTitle = ( isClassicView ) => {
-	if ( isEnabled( 'layout/dotcom-nav-redesign' ) && isClassicView ) {
+	if ( isClassicView ) {
 		return translate( 'Settings' );
 	}
 	return translate( 'General Settings' );
 };
 
 const getSubtitle = ( isClassicView ) => {
-	if ( isEnabled( 'layout/dotcom-nav-redesign' ) && isClassicView ) {
+	if ( isClassicView ) {
 		return translate( 'Manage your site settings, including site visibility, and more.' );
 	}
 	return translate(
@@ -52,9 +51,7 @@ const SiteSettingsComponent = ( {
 			<JetpackDevModeNotice />
 			<JetpackBackupCredsBanner event="settings-backup-credentials" />
 			<NavigationHeader
-				screenOptionsTab={
-					isEnabled( 'layout/dotcom-nav-redesign' ) && isClassicView ? false : 'options-general.php'
-				}
+				screenOptionsTab={ isClassicView ? false : 'options-general.php' }
 				navigationItems={ [] }
 				title={ getTitle( isClassicView ) }
 				subtitle={ getSubtitle( isClassicView ) }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	getPlan,
 	FEATURE_SFTP,
@@ -436,8 +435,7 @@ export const SitesEllipsisMenu = ( {
 		getSiteOption( state, site.ID, 'wpcom_admin_interface' )
 	);
 
-	const isWpAdminInterface =
-		isEnabled( 'layout/dotcom-nav-redesign' ) && adminInterface === 'wp-admin';
+	const isWpAdminInterface = adminInterface === 'wp-admin';
 
 	const props: SitesMenuItemProps = {
 		site,

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
 	siteLaunchStatusGroupValues,
@@ -45,7 +44,7 @@ export function sanitizeQueryParameters( context: PageJSContext, next: () => voi
 }
 
 export function sitesDashboard( context: PageJSContext, next: () => void ) {
-	let sitesDashboardGlobalStyles = css`
+	const sitesDashboardGlobalStyles = css`
 		body.is-group-sites-dashboard {
 			background: #ffffff;
 
@@ -60,32 +59,25 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 				overflow: inherit;
 			}
 		}
+
+		// Update body margin to account for the sidebar width
+		@media only screen and ( min-width: 782px ) {
+			div.layout.is-global-sidebar-visible {
+				.layout__primary {
+					margin-inline-start: var( --sidebar-width-max );
+				}
+			}
+		}
+
+		@media only screen and ( max-width: 781px ) {
+			div.layout.is-global-sidebar-visible {
+				.layout__primary {
+					overflow-x: auto;
+				}
+			}
+		}
 	`;
-
-	// Update body margin to account for the sidebar width if the new nav is enabled
-	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-		sitesDashboardGlobalStyles = css`
-			${ sitesDashboardGlobalStyles }
-			@media only screen and ( min-width: 782px ) {
-				div.layout.is-global-sidebar-visible {
-					.layout__primary {
-						margin-inline-start: var( --sidebar-width-max );
-					}
-				}
-			}
-
-			@media only screen and ( max-width: 781px ) {
-				div.layout.is-global-sidebar-visible {
-					.layout__primary {
-						overflow-x: auto;
-					}
-				}
-			}
-		`;
-	}
-	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-		context.secondary = <MySitesNavigation path={ context.path } />;
-	}
+	context.secondary = <MySitesNavigation path={ context.path } />;
 
 	context.primary = (
 		<>

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -1,17 +1,13 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { isGlobalSiteViewEnabled } from '../sites/selectors';
 import type { AppState } from 'calypso/types';
 
 export const getShouldShowGlobalSidebar = ( _: AppState, siteId: number, sectionGroup: string ) => {
-	let shouldShowGlobalSidebar = false;
-	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-		shouldShowGlobalSidebar =
-			sectionGroup === 'me' ||
-			sectionGroup === 'reader' ||
-			sectionGroup === 'sites-dashboard' ||
-			( sectionGroup === 'sites' && ! siteId );
-	}
-	return shouldShowGlobalSidebar;
+	return (
+		sectionGroup === 'me' ||
+		sectionGroup === 'reader' ||
+		sectionGroup === 'sites-dashboard' ||
+		( sectionGroup === 'sites' && ! siteId )
+	);
 };
 
 export const getShouldShowGlobalSiteSidebar = (

--- a/client/state/sites/selectors/is-global-site-view-enabled.ts
+++ b/client/state/sites/selectors/is-global-site-view-enabled.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import getSiteOption from './get-site-option';
 import type { AppState } from 'calypso/types';
 
@@ -9,10 +8,6 @@ import type { AppState } from 'calypso/types';
  * @returns {?boolean}        Whether site has the nav redesign enabled
  */
 export default function isGlobalSiteViewEnabled( state: AppState, siteId: number | null ) {
-	if ( ! isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-		return false;
-	}
-
 	const isAdminInterfaceWPAdmin =
 		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
 	const isClassicEarlyRelease = !! getSiteOption( state, siteId, 'wpcom_classic_early_release' );

--- a/config/development.json
+++ b/config/development.json
@@ -121,7 +121,6 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign": true,
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -72,7 +72,6 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign": true,
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -69,7 +69,6 @@
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"layout/dotcom-nav-redesign": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-test": false,
 		"oauth": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -61,7 +61,6 @@
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"layout/dotcom-nav-redesign": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-test": false,
 		"oauth": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -63,7 +63,6 @@
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"layout/dotcom-nav-redesign": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-test": false,
 		"oauth": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -65,7 +65,6 @@
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
-		"layout/dotcom-nav-redesign": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-test": false,
 		"oauth": true,

--- a/config/production.json
+++ b/config/production.json
@@ -97,7 +97,6 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign": true,
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,7 +91,6 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign": true,
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,

--- a/config/test.json
+++ b/config/test.json
@@ -75,7 +75,6 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign": true,
 		"legal-updates-banner": true,
 		"login/social-first": true,
 		"mailchimp": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -89,7 +89,6 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign": true,
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,


### PR DESCRIPTION
With the project shipped and iteration 2 on the way, I think it's a good time to take out the v1 feature toggle.

It looks like iteration two will also require it's own feature toggle pfsHM7-Ao-p2

### Testing instructions.

Test navigation and other affected features work as before