### PR TITLE
Automattic for Agencies: Licenses page enhancements

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts
@@ -7,7 +7,7 @@ export const getFetchLicenseCountsQueryKey = ( agencyId?: number ) => {
 	return [ 'a4a-license-counts', agencyId ];
 };
 
-export default function useFetchLicenseCounts() {
+export default function useFetchLicenseCounts( staleTime = 0 ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
@@ -24,5 +24,6 @@ export default function useFetchLicenseCounts() {
 			),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
+		staleTime,
 	} );
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/empty.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/empty.tsx
@@ -1,0 +1,75 @@
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
+import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.scss';
+
+interface Props {
+	filter: LicenseFilter;
+}
+
+export default function LicenseListEmpty( { filter }: Props ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const { data } = useFetchLicenseCounts( Infinity );
+
+	const hasAssignedLicenses = data?.[ LicenseFilter.Attached ] > 0;
+
+	const partnerCanIssueLicense = true; // FIXME: get this from state
+
+	const licenseFilterStatusTitleMap = {
+		[ LicenseFilter.NotRevoked ]: translate( 'No active licenses' ),
+		[ LicenseFilter.Attached ]: translate( 'No assigned licenses.' ),
+		[ LicenseFilter.Detached ]: translate( 'No unassigned licenses.' ),
+		[ LicenseFilter.Revoked ]: translate( 'No revoked licenses.' ),
+		[ LicenseFilter.Standard ]: translate( 'No standard licenses.' ),
+	};
+
+	const licenseFilterStatusTitle = licenseFilterStatusTitleMap[ filter ] as string;
+
+	const onIssueNewLicense = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_license_list_empty_issue_license_click' ) );
+	};
+
+	return (
+		<div className="license-list__empty-list">
+			<h2>{ licenseFilterStatusTitle }</h2>
+
+			{ filter === LicenseFilter.NotRevoked && (
+				<p>
+					{ translate(
+						'Learn more about {{a}}adding licenses and billing {{icon}}{{/icon}}{{/a}}.',
+						{
+							components: {
+								a: (
+									<a
+										href="https://" // FIXME: add the correct link
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+								icon: <Gridicon icon="external" size={ 16 } />,
+							},
+						}
+					) }
+				</p>
+			) }
+
+			{ filter === LicenseFilter.Detached && hasAssignedLicenses && (
+				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>
+			) }
+
+			<Button
+				disabled={ ! partnerCanIssueLicense }
+				href={ partnerCanIssueLicense ? A4A_MARKETPLACE_LINK : undefined }
+				onClick={ onIssueNewLicense }
+			>
+				{ translate( 'Issue New License' ) }
+			</Button>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/header.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/header.tsx
@@ -1,0 +1,123 @@
+import page from '@automattic/calypso-router';
+import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { PropsWithChildren, useCallback, useContext } from 'react';
+import { internalToPublicLicenseSortField } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { addQueryArgs } from 'calypso/lib/route';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import LicensesOverviewContext from '../licenses-overview/context';
+
+import './style.scss';
+
+function setSortingConfig(
+	newSortField: LicenseSortField,
+	sortField: LicenseSortField,
+	sortDirection: LicenseSortDirection
+): void {
+	let direction = LicenseSortDirection.Descending;
+
+	if ( newSortField === sortField && sortDirection === direction ) {
+		direction = LicenseSortDirection.Ascending;
+	}
+
+	const queryParams = {
+		sort_field: internalToPublicLicenseSortField( newSortField ),
+		sort_direction: direction,
+		page: 1,
+	};
+	const currentPath = window.location.pathname + window.location.search;
+
+	page( addQueryArgs( queryParams, currentPath ) );
+}
+
+interface SortButtonProps {
+	sortField: LicenseSortField;
+	currentSortField: LicenseSortField;
+	currentSortDirection: LicenseSortDirection;
+}
+
+function SortButton( {
+	sortField,
+	currentSortField,
+	currentSortDirection,
+	children,
+}: PropsWithChildren< SortButtonProps > ) {
+	const dispatch = useDispatch();
+	const sort = useCallback( () => {
+		setSortingConfig( sortField, currentSortField, currentSortDirection );
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_license_list_sort_button_click', {
+				sort_field: sortField,
+				current_sort_field: currentSortField,
+				current_sort_direction: currentSortDirection,
+			} )
+		);
+	}, [ dispatch, sortField, currentSortField, currentSortDirection ] );
+
+	return (
+		<h2 className={ classnames( { 'is-selected': sortField === currentSortField } ) }>
+			<button onClick={ sort }>
+				{ children }
+				<Gridicon
+					icon="dropdown"
+					className={ classnames( 'license-list-item__sort-indicator', {
+						[ `is-sort-${ currentSortDirection }` ]: true,
+					} ) }
+				/>
+			</button>
+		</h2>
+	);
+}
+
+export default function LicenseListHeader() {
+	const translate = useTranslate();
+	const { filter, sortField, sortDirection } = useContext( LicensesOverviewContext );
+
+	return (
+		<LicenseListItem header className="license-list__header">
+			<h2>{ translate( 'Product' ) }</h2>
+
+			<h2>{ translate( 'Site' ) }</h2>
+
+			<SortButton
+				sortField={ LicenseSortField.IssuedAt }
+				currentSortField={ sortField }
+				currentSortDirection={ sortDirection }
+			>
+				{ translate( 'Issued on' ) }
+			</SortButton>
+
+			{ filter !== LicenseFilter.Revoked && (
+				<SortButton
+					sortField={ LicenseSortField.AttachedAt }
+					currentSortField={ sortField }
+					currentSortDirection={ sortDirection }
+				>
+					{ translate( 'Assigned on' ) }
+				</SortButton>
+			) }
+
+			{ filter === LicenseFilter.Revoked && (
+				<SortButton
+					sortField={ LicenseSortField.RevokedAt }
+					currentSortField={ sortField }
+					currentSortDirection={ sortDirection }
+				>
+					{ translate( 'Revoked on' ) }
+				</SortButton>
+			) }
+
+			<div>{ /* Intentionally empty header. */ }</div>
+
+			<div>{ /* Intentionally empty header. */ }</div>
+		</LicenseListItem>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -4,8 +4,6 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
 import Pagination from 'calypso/components/pagination';
-import LicenseListEmpty from 'calypso/jetpack-cloud/sections/partner-portal/license-list/empty'; // FIXME: Fix for A4A
-import LicenseListHeader from 'calypso/jetpack-cloud/sections/partner-portal/license-list/header'; // FIXME: Fix for A4A
 import { LicensePreviewPlaceholder } from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
 import { LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -14,6 +12,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
 import LicensePreview from '../license-preview';
 import LicensesOverviewContext from '../licenses-overview/context';
+import LicenseListEmpty from './empty';
+import LicenseListHeader from './header';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -6,6 +6,7 @@ import {
 	LicenseAction,
 	LicenseType,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -24,6 +25,8 @@ export default function useLicenseActions(
 			return [];
 		}
 
+		const siteSlug = urlToSlug( siteUrl );
+
 		const handleClickMenuItem = ( eventName: string ) => {
 			dispatch( recordTracksEvent( eventName ) );
 		};
@@ -32,35 +35,35 @@ export default function useLicenseActions(
 		return [
 			{
 				name: translate( 'Set up site' ),
-				href: '', // FIXME: Add correct URL
+				href: `https://wordpress.com/home/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_site_set_up_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},
 			{
 				name: translate( 'Change domain' ),
-				href: '', // FIXME: Add correct URL
+				href: `https://wordpress.com/domains/manage/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_change_domain_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},
 			{
 				name: translate( 'Hosting configuration' ),
-				href: '', // FIXME: Add correct URL
+				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_hosting_configuration_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},
 			{
 				name: translate( 'Edit site in WP Admin' ),
-				href: '', // FIXME: Add correct URL
+				href: `${ siteUrl }/wp-admin/admin.php?page=jetpack#/dashboard`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_edit_site_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},
 			{
 				name: translate( 'Debug site' ),
-				href: '', // FIXME: Add correct URL
+				href: `https://jptools.wordpress.com/debug/?url=${ siteUrl }`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_debug_site_click' ),
 				isExternalLink: true,
 				isEnabled: licenseState === LicenseState.Attached,

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-state-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-state-filter/index.tsx
@@ -4,19 +4,16 @@ import LayoutNavigation, {
 	LayoutNavigationTabs,
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import { A4A_LICENSES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
 import { internalToPublicLicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/lib/license-filters';
 import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import LicenseListContext from '../licenses-overview/context';
 
-function LicenseStateFilter() {
+function LicenseStateFilter( { data }: { data: Record< LicenseFilter, number > } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { filter } = useContext( LicenseListContext );
-
-	const { data } = useFetchLicenseCounts();
 
 	const navItems = [
 		{

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -57,7 +57,7 @@ export default function LicensesOverview( {
 	const partnerCanIssueLicense = true; // FIXME: get this from state
 
 	const onIssueNewLicenseClick = () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_license_list_ssue_license_click' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_license_list_issue_license_click' ) );
 	};
 
 	const { data, isFetched } = useFetchLicenseCounts();

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -9,17 +9,20 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import LicenseList from '../license-list';
 import LicenseSearch from '../license-search';
 import LicenseStateFilter from '../license-state-filter';
 import LicensesOverviewContext from './context';
 import EmptyState from './empty-state';
-import type {
-	LicenseFilter,
-	LicenseSortDirection,
-	LicenseSortField,
-} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
 import './style.scss';
 
@@ -39,6 +42,7 @@ export default function LicensesOverview( {
 	sortField,
 }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const title = translate( 'Licenses' );
 
@@ -53,10 +57,12 @@ export default function LicensesOverview( {
 	const partnerCanIssueLicense = true; // FIXME: get this from state
 
 	const onIssueNewLicenseClick = () => {
-		// TODO: dispatch action to open issue license modal
+		dispatch( recordTracksEvent( 'calypso_a4a_license_list_ssue_license_click' ) );
 	};
 
-	const showEmptyStateContent = false; // FIXME: get this from state
+	const { data, isFetched } = useFetchLicenseCounts();
+
+	const showEmptyStateContent = isFetched && data?.[ LicenseFilter.NotRevoked ] === 0;
 
 	return (
 		<Layout
@@ -71,13 +77,11 @@ export default function LicensesOverview( {
 				path="/purchases/licenses/:filter"
 				properties={ { filter } }
 			/>
-			{ /*  TODO: <FETCH_LICENSES_HERE /> */ }
 			<LicensesOverviewContext.Provider value={ context }>
 				<LayoutTop withNavigation>
 					<LayoutHeader>
 						<Title>{ title } </Title>
 						<Actions>
-							{ /* TODO: <SHOW_PARTNER_KEY_SELECTION_HERE /> */ }
 							<Button
 								disabled={ ! partnerCanIssueLicense }
 								href={ partnerCanIssueLicense ? A4A_MARKETPLACE_LINK : undefined }
@@ -90,7 +94,7 @@ export default function LicensesOverview( {
 						</Actions>
 					</LayoutHeader>
 
-					<LicenseStateFilter />
+					<LicenseStateFilter data={ data } />
 				</LayoutTop>
 
 				<LayoutBody>

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -22,6 +22,7 @@
 	--color-surface-backdrop: #021a23;
 
 	--color-text-gray: "#333";
+	--color-sidebar-text-alternative: #bbe0fa;
 
 	--color-scary-0: var(--studio-red-0);
 	--color-scary-5: var(--studio-red-5);


### PR DESCRIPTION
## Proposed Changes

This PR makes some enhancements to the A4A Licenses page. Includes:

- Updates the action links
- Minor refactor to the fetch licenses count to fix the empty state
- Refactor the empty state and header by porting the components by A4A

<img width="334" alt="Screenshot 2024-03-26 at 11 52 37 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/09de5d9c-b9e4-4b49-9497-317ed2007172">

<img width="1565" alt="Screenshot 2024-03-26 at 12 50 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f81ac661-63f6-4770-bbf8-4fce772552c6">


## Testing Instructions

- Switch to this branch: `git checkout add/a4a/licenses-page-enhancements` and start the server: `yarn start-a8c-for-agencies`
- Follow the steps here to create the agency ID: D139529-code.
- Go to Purchases > Licenses 
- Manually change the value of isSiteAtomic to true here: https://github.com/Automattic/wp-calypso/blob/c1a919883a63b9f9cfd9b3e88cf5d28fa5c25a92/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx#L120-L121

- Click on the Actions menu and verify that you can click on each action, and that it works as expected.

<img width="334" alt="Screenshot 2024-03-26 at 11 52 37 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/347d7dc8-4c1a-422b-a232-522a8ea1ef5d">

- Go to any tab on the Licenses page where the count is `0` and click the `Issue New License` button > Verify you are redirected to the Marketplace.

<img width="1565" alt="Screenshot 2024-03-26 at 12 50 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/742133bb-3b80-452f-b868-37b8d0bcb60c">

- Search for any random text on the search box and verify the button works as expected, as shown below. Please note the link will be updated later for the `adding licenses and billing` link.

<img width="1574" alt="Screenshot 2024-03-26 at 12 57 31 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/cca63c83-f488-43ca-8d31-0aa836b4e7a9">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?