### PR TITLE
Fix woo express `redirect_to` and passwordless 2fa button spacing

### DIFF
--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -76,9 +76,12 @@ const wooexpress: Flow = {
 		}
 
 		const getLoginUrl = () => {
-			const redirectTo = addQueryArgs( '/setup/wooexpress', {
-				...Object.fromEntries( queryParams ),
-			} );
+			const redirectTo = addQueryArgs(
+				`${ window.location.protocol }//${ window.location.host }/setup/wooexpress`,
+				{
+					...Object.fromEntries( queryParams ),
+				}
+			);
 
 			let logInUrl = login( {
 				locale,

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1253,6 +1253,7 @@ $breakpoint-mobile: 660px;
 			letter-spacing: -0.025px;
 			color: var(--studio-gray-60);
 			-webkit-font-smoothing: initial;
+			text-align: center;
 
 			a {
 				color: $woo-purple-50;
@@ -1704,6 +1705,16 @@ $breakpoint-mobile: 660px;
 					width: 100%;
 				}
 
+				.verification-code-form__help-text {
+					@media screen and ( max-width: 660px ) {
+						max-width: 450px;
+					}
+
+					@media ( max-width: $break-mobile ) {
+						max-width: $max-width;
+					}
+				}
+
 				.security-key-form__help-text,
 				.security-key-form__add-wait-for-key {
 					margin-bottom: 48px;
@@ -1711,7 +1722,26 @@ $breakpoint-mobile: 660px;
 					p:first-child {
 						margin-bottom: 12px;
 					}
+
+					@media screen and ( max-width: 660px ) {
+						text-align: center;
+						max-width: 450px;
+					}
+
+					@media ( max-width: $break-mobile ) {
+						text-align: left;
+						max-width: $max-width;
+					}
 				}
+			}
+
+			.two-factor-authentication__small-print {
+				max-width: $max-width;
+				color: $gray-50;
+				text-align: center;
+				font-style: normal;
+				font-weight: 400;
+				line-height: 18px;
 			}
 
 			.two-factor-authentication__actions.card {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1719,6 +1719,9 @@ $breakpoint-mobile: 660px;
 				border: 0;
 				margin-bottom: 32px;
 				clip-path: none;
+				display: flex;
+				flex-direction: column;
+				gap: 16px;
 
 				.button {
 					min-height: 48px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

- A `Continue with a backup code` button was added last week in https://github.com/Automattic/wp-calypso/pull/87128, and the spacing was not correct. The button was too close to other buttons in the woo passwordless 2FA screen. This PR fixes the button's spacing.

Before:

<img src="https://github.com/Automattic/wp-calypso/assets/4344253/9b1d824b-130d-41ba-b63a-275b7a5d3125" width="400px" />


After:

<img src="https://github.com/Automattic/wp-calypso/assets/4344253/258fa3bb-cc22-4fd9-88f5-45dbaa43fe50" width="400px" />



- Fix the `redirect_to` query parameter for the woo express passowrdless magic link login. Change the `redirect_to` query parameter to full URL instead of relative URL because the relative URL is not working in the magic link redirect.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up woo-start-env
* Log out from woo.com or use incognito mode
* Go to woo.com and click on login
* Log in with a 2fa enabled account
* Confirm the "Continue with a backup code" button spacing looks good

* Log out from wordpress.com but keep logged in to woo.com
* Go to nux installaion page https://woo.com/start/#/installation
* Click on `Try Woo Express for free`
* Log in with a passwordless account
* Go to the magic link email and click on the link
* Confirm you are redirected to the Woo Express loading screen


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?