### PR TITLE
A4A: Add the Pressable overview page banner.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -14,7 +14,10 @@ import {
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useShoppingCart from '../hooks/use-shopping-cart';
+import { getHostingLogo } from '../lib/hosting';
 import ShoppingCart from '../shopping-cart';
+
+import './style.scss';
 
 export default function PressableOverview() {
 	const translate = useTranslate();
@@ -60,7 +63,21 @@ export default function PressableOverview() {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>Pressable hosting here</LayoutBody>
+			<LayoutBody>
+				<section className="pressable-overview__banner">
+					<div className="pressable-overview__banner-logo">
+						{ getHostingLogo( 'pressable-hosting' ) }
+					</div>
+
+					<h1 className="pressable-overview__banner-title">
+						{ translate( 'Managed WordPress Hosting' ) }
+					</h1>
+
+					<h2 className="pressable-overview__banner-subtitle">
+						{ translate( 'Scalable plans to help you grow your business.' ) }
+					</h2>
+				</section>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/style.scss
@@ -1,0 +1,30 @@
+.pressable-overview .a4a-layout__body-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 64px;
+	margin-block-start: 48px;
+	margin-block-end: 64px;
+}
+
+
+.pressable-overview__banner {
+	margin: 0 auto;
+	text-align: center;
+}
+
+.pressable-overview__banner-logo {
+	margin-block-end: 32px;
+}
+
+.pressable-overview__banner-title {
+	font-size: 2.25rem;
+	font-weight: 600;
+	line-height: 1.1;
+	margin-block-end: 8px;
+}
+
+.pressable-overview__banner-subtitle {
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.1;
+}


### PR DESCRIPTION
This PR implements the Pressable overview page's banner. 

<img width="882" alt="Screenshot 2024-03-26 at 5 05 05 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d0ab71ec-c495-49ea-87b8-0ae6ba32dc7d">


Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/74

## Proposed Changes

* Add Banner element and styling based on the latest Purchase flow design.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/hosting/pressable`.
* Confirm that the Banner is visible with correct copies and images.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?