### PR TITLE
A4A: Add the Pressable plan selector.

### DIFF
--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -4,7 +4,7 @@ import './style.scss';
 
 export type Option = {
 	label: string;
-	value: number;
+	value: number | string | null;
 	sub?: string;
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/constants.ts
@@ -1,0 +1,2 @@
+export const FILTER_TYPE_INSTALL = 'install';
+export const FILTER_TYPE_VISITS = 'visits';

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -16,6 +16,7 @@ import {
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { getHostingLogo } from '../lib/hosting';
 import ShoppingCart from '../shopping-cart';
+import PressableOverviewPlanSelection from './plan-selection';
 
 import './style.scss';
 
@@ -77,6 +78,8 @@ export default function PressableOverview() {
 						{ translate( 'Scalable plans to help you grow your business.' ) }
 					</h2>
 				</section>
+
+				<PressableOverviewPlanSelection />
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -1,0 +1,61 @@
+export type PressablePlan = {
+	slug: string;
+	install: number;
+	visits: number;
+	storage: number;
+};
+
+const PLAN_DATA: Record< string, PressablePlan > = {
+	'jetpack-pressable-personal': {
+		slug: 'jetpack-pressable-personal',
+		install: 1,
+		visits: 30000,
+		storage: 20,
+	},
+	'jetpack-pressable-starter': {
+		slug: 'jetpack-pressable-starter',
+		install: 3,
+		visits: 50000,
+		storage: 30,
+	},
+	'jetpack-pressable-advanced': {
+		slug: 'jetpack-pressable-advanced',
+		install: 5,
+		visits: 75000,
+		storage: 35,
+	},
+	'jetpack-pressable-pro': {
+		slug: 'jetpack-pressable-pro',
+		install: 10,
+		visits: 150000,
+		storage: 50,
+	},
+	'jetpack-pressable-premium': {
+		slug: 'jetpack-pressable-premium',
+		install: 20,
+		visits: 400000,
+		storage: 80,
+	},
+	'jetpack-pressable-business': {
+		slug: 'jetpack-pressable-business',
+		install: 50,
+		visits: 1000000,
+		storage: 200,
+	},
+	'jetpack-pressable-business-80': {
+		slug: 'jetpack-pressable-business-80',
+		install: 80,
+		visits: 1600000,
+		storage: 275,
+	},
+	'jetpack-pressable-business-100': {
+		slug: 'jetpack-pressable-business-100',
+		install: 100,
+		visits: 2000000,
+		storage: 325,
+	},
+};
+
+export default function getPressablePlan( slug: string ) {
+	return PLAN_DATA[ slug ];
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -1,0 +1,15 @@
+import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
+import { FILTER_TYPE_INSTALL } from '../constants';
+import { FilterType } from '../types';
+import { PressablePlan } from './get-pressable-plan';
+
+export default function getSliderOptions( type: FilterType, plans: PressablePlan[] ) {
+	return plans
+		.sort( ( planA, planB ) => planA.install - planB.install ) // Ensure our options are sorted by install count
+		.map( ( plan ) => {
+			return {
+				label: `${ type === FILTER_TYPE_INSTALL ? plan.install : formatNumber( plan.visits ) }`,
+				value: plan.slug,
+			};
+		} );
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -1,0 +1,98 @@
+import { Button } from '@wordpress/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo, useState } from 'react';
+import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { FILTER_TYPE_INSTALL, FILTER_TYPE_VISITS } from '../constants';
+import getPressablePlan from '../lib/get-pressable-plan';
+import getSliderOptions from '../lib/get-slider-options';
+import { FilterType } from '../types';
+
+type Props = {
+	selectedPlan: APIProductFamilyProduct | null;
+	plans: APIProductFamilyProduct[];
+	onSelectPlan: ( plan: APIProductFamilyProduct | null ) => void;
+};
+
+export default function PlanSelectionFilter( { selectedPlan, plans, onSelectPlan }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
+
+	const options = useMemo(
+		() => [
+			...getSliderOptions(
+				filterType,
+				plans.map( ( plan ) => getPressablePlan( plan.slug ) )
+			),
+			{
+				label: translate( 'More' ),
+				value: null,
+			},
+		],
+		[ filterType, plans, translate ]
+	);
+
+	const onSelectOption = useCallback(
+		( option: Option ) => {
+			const plan = plans.find( ( plan ) => plan.slug === option.value ) ?? null;
+			recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_select_plan', {
+				slug: plan?.slug,
+			} );
+			onSelectPlan( plan );
+		},
+		[ onSelectPlan, plans ]
+	);
+
+	const selectedOption = options.findIndex(
+		( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null )
+	);
+
+	const onSelectInstallFilterType = useCallback( () => {
+		setFilterType( FILTER_TYPE_INSTALL );
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_filter_by_install_click' )
+		);
+	}, [ dispatch ] );
+
+	const onSelectVisitFilterType = useCallback( () => {
+		setFilterType( FILTER_TYPE_VISITS );
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_filter_by_visits_click' )
+		);
+	}, [ dispatch ] );
+
+	return (
+		<section className="pressable-overview-plan-selection__filter">
+			<div className="pressable-overview-plan-selection__filter-type">
+				<strong className="pressable-overview-plan-selection__filter-label">
+					{ translate( 'Filter by:' ) }
+				</strong>
+
+				<Button
+					className={ classNames( 'pressable-overview-plan-selection__filter-button', {
+						'is-selected': filterType === FILTER_TYPE_INSTALL,
+					} ) }
+					onClick={ onSelectInstallFilterType }
+				>
+					{ translate( 'WordPress installs' ) }
+				</Button>
+
+				<Button
+					className={ classNames( 'pressable-overview-plan-selection__filter-button', {
+						'is-selected': filterType === FILTER_TYPE_VISITS,
+					} ) }
+					onClick={ onSelectVisitFilterType }
+				>
+					{ translate( 'Number of visits' ) }
+				</Button>
+			</div>
+
+			<A4ASlider value={ selectedOption } onChange={ onSelectOption } options={ options } />
+		</section>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from 'react';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import useProductAndPlans from '../../hooks/use-product-and-plans';
+import PlanSelectionFilter from './filter';
+
+import './style.scss';
+
+export default function PressableOverviewPlanSelection() {
+	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
+
+	const onSelectPlan = useCallback(
+		( plan: APIProductFamilyProduct | null ) => {
+			setSelectedPlan( plan );
+		},
+		[ setSelectedPlan ]
+	);
+
+	const { pressablePlans } = useProductAndPlans( {
+		selectedSite: null,
+		productSearchQuery: '',
+	} );
+
+	useEffect( () => {
+		if ( pressablePlans?.length ) {
+			setSelectedPlan( pressablePlans[ 0 ] );
+		}
+	}, [ pressablePlans, setSelectedPlan ] );
+
+	return (
+		<div className="pressable-overview-plan-selection">
+			<PlanSelectionFilter
+				selectedPlan={ selectedPlan }
+				plans={ pressablePlans }
+				onSelectPlan={ onSelectPlan }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -1,0 +1,45 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.pressable-overview-plan-selection {
+	width: 100%;
+
+	@include break-large {
+		width: 800px;
+		margin-inline: auto;
+	}
+}
+
+.pressable-overview-plan-selection__filter-type {
+	display: flex;
+	flex-direction: row;
+	gap: 16px;
+
+	align-items: center;
+	justify-content: center;
+}
+
+.components-button.pressable-overview-plan-selection__filter-button {
+	border: 1.5px solid var(--studio-black);
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.1;
+
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 29px;
+	padding: 6px 12px;
+
+	&.is-selected {
+		background: var(--studio-black);
+		color: var(--color-text-inverted);
+	}
+
+	&:focus {
+		box-shadow: none;
+	}
+
+	&:focus-visible {
+		background: var(--color-neutral-60);
+		color: var(--color-text-inverted);
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/types.ts
@@ -1,0 +1,1 @@
+export type FilterType = 'install' | 'visits';


### PR DESCRIPTION
This PR implements the Pressable plan selector in the overview page. 

<img width="992" alt="Screenshot 2024-03-26 at 5 08 42 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ac16eb22-57a4-4b52-9ed7-b6a498b47d95"> 
<img width="800" alt="Screenshot 2024-03-26 at 5 09 30 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/240bf0a3-500a-496c-b1da-82a4bc55d44d">



Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/74

## Proposed Changes

* Add the Pressable plan selector component using the A4A slider as based component.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/hosting/pressable`.
* Confirm that the plan selector is visible below the banner.
* Confirm that switching the Filter by toggle updates the unit measure.
* Confirm that the slider works as expected when moving left to right.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?