### PR TITLE
A4A: Add the Pressable plan viewer.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -13,6 +14,7 @@ import {
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { getHostingLogo } from '../lib/hosting';
 import ShoppingCart from '../shopping-cart';
@@ -23,7 +25,15 @@ import './style.scss';
 export default function PressableOverview() {
 	const translate = useTranslate();
 
-	const { selectedCartItems, onRemoveCartItem } = useShoppingCart();
+	const { selectedCartItems, setSelectedCartItems, onRemoveCartItem } = useShoppingCart();
+
+	const onAddToCart = useCallback(
+		( item: APIProductFamilyProduct ) => {
+			setSelectedCartItems( [ ...selectedCartItems, { ...item, quantity: 1 } ] );
+			page( A4A_MARKETPLACE_LINK );
+		},
+		[ selectedCartItems, setSelectedCartItems ]
+	);
 
 	return (
 		<Layout
@@ -79,7 +89,7 @@ export default function PressableOverview() {
 					</h2>
 				</section>
 
-				<PressableOverviewPlanSelection />
+				<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-short-name.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-short-name.ts
@@ -1,0 +1,3 @@
+export default function getPressableShortName( name: string ) {
+	return name.replace( /(?:Pressable\s|[)(])/gi, '' );
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,0 +1,148 @@
+import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
+import formatCurrency from '@automattic/format-currency';
+import { Button } from '@wordpress/components';
+import { Icon, check, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode, useCallback } from 'react';
+import { getProductPricingInfo } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { getProductsList } from 'calypso/state/products-list/selectors';
+import getPressablePlan from '../lib/get-pressable-plan';
+import getPressableShortName from '../lib/get-pressable-short-name';
+
+type Props = {
+	selectedPlan: APIProductFamilyProduct | null;
+	onSelectPlan: () => void;
+};
+
+function IncludedList( { items }: { items: ReactNode[] } ) {
+	return (
+		<ul className="pressable-overview-plan-selection__details-card-included-list">
+			{ items.map( ( item, index ) => (
+				<li key={ `included-item-${ index }` }>
+					<Icon
+						className="pressable-overview-plan-selection__details-card-included-list-icon"
+						icon={ check }
+						size={ 24 }
+					/>
+					{ item }
+				</li>
+			) ) }
+		</ul>
+	);
+}
+
+export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const info = selectedPlan?.slug ? getPressablePlan( selectedPlan?.slug ) : null;
+
+	const customString = translate( 'Custom' );
+
+	const userProducts = useSelector( getProductsList );
+
+	const { discountedCost } = selectedPlan
+		? getProductPricingInfo( userProducts, selectedPlan, 1 )
+		: { discountedCost: 0 };
+
+	const onChatWithUs = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_chat_with_us_click' ) );
+	}, [ dispatch ] );
+
+	const PRESSABLE_CONTACT_LINK = 'https://pressable.com/request-demo';
+
+	return (
+		<section className="pressable-overview-plan-selection__details">
+			<div className="pressable-overview-plan-selection__details-card">
+				<div className="pressable-overview-plan-selection__details-card-header">
+					<h3 className="pressable-overview-plan-selection__details-card-header-title">
+						{ translate( '%(planName)s plan', {
+							args: {
+								planName: selectedPlan ? getPressableShortName( selectedPlan.name ) : customString,
+							},
+						} ) }
+					</h3>
+
+					{ selectedPlan && (
+						<div className="pressable-overview-plan-selection__details-card-header-price">
+							<strong className="pressable-overview-plan-selection__details-card-header-price-value">
+								{ formatCurrency( discountedCost, selectedPlan.currency ) }
+							</strong>
+							<span className="pressable-overview-plan-selection__details-card-header-price-interval">
+								{ selectedPlan.price_interval === 'day' && translate( 'per plan per day' ) }
+								{ selectedPlan.price_interval === 'month' && translate( 'per plan per month' ) }
+							</span>
+						</div>
+					) }
+				</div>
+
+				<IncludedList
+					items={ [
+						translate( '{{b}}%(count)s{{/b}} WordPress installs', {
+							args: {
+								count: info?.install ?? customString,
+							},
+							components: { b: <b /> },
+						} ),
+						translate( '{{b}}%(count)s{{/b}} visits per month', {
+							args: {
+								count: info ? formatNumber( info.visits ) : customString,
+							},
+							components: { b: <b /> },
+						} ),
+						translate( '{{b}}%(size)s{{/b}} storage per month', {
+							args: {
+								size: info ? `${ info.storage }GB` : customString,
+							},
+							components: { b: <b /> },
+						} ),
+					] }
+				/>
+
+				{ selectedPlan && (
+					<Button
+						className="pressable-overview-plan-selection__details-card-cta-button"
+						onClick={ onSelectPlan }
+						variant="primary"
+					>
+						{ translate( 'Select %(planName)s plan', {
+							args: {
+								planName: selectedPlan ? getPressableShortName( selectedPlan.name ) : customString,
+							},
+						} ) }
+					</Button>
+				) }
+
+				{ ! selectedPlan && (
+					<Button
+						className="pressable-overview-plan-selection__details-card-cta-button"
+						onClick={ onChatWithUs }
+						href={ PRESSABLE_CONTACT_LINK }
+						target="_blank"
+						variant="primary"
+					>
+						{ translate( 'Chat with us' ) } <Icon icon={ external } size={ 16 } />
+					</Button>
+				) }
+			</div>
+
+			<div className="pressable-overview-plan-selection__details-card is-aside">
+				<h3 className="pressable-overview-plan-selection__details-card-header-title">
+					{ translate( 'All plans include:' ) }{ ' ' }
+				</h3>
+
+				<IncludedList
+					items={ [
+						translate( '24/7 WordPress hosting support' ),
+						translate( 'WP Cloud platform' ),
+						translate( 'Jetpack Security (optional)' ),
+						translate( 'Free sites migration' ),
+					] }
+				/>
+			</div>
+		</section>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -63,6 +63,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 							args: {
 								planName: selectedPlan ? getPressableShortName( selectedPlan.name ) : customString,
 							},
+							comment: '%(planName)s is the name of the selected plan.',
 						} ) }
 					</h3>
 
@@ -86,18 +87,21 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 								count: info?.install ?? customString,
 							},
 							components: { b: <b /> },
+							comment: '%(count)s is the number of WordPress installs.',
 						} ),
 						translate( '{{b}}%(count)s{{/b}} visits per month', {
 							args: {
 								count: info ? formatNumber( info.visits ) : customString,
 							},
 							components: { b: <b /> },
+							comment: '%(count)s is the number of visits per month.',
 						} ),
 						translate( '{{b}}%(size)s{{/b}} storage per month', {
 							args: {
 								size: info ? `${ info.storage }GB` : customString,
 							},
 							components: { b: <b /> },
+							comment: '%(size)s is the amount of storage in gigabytes.',
 						} ),
 					] }
 				/>
@@ -112,6 +116,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 							args: {
 								planName: selectedPlan ? getPressableShortName( selectedPlan.name ) : customString,
 							},
+							comment: '%(planName)s is the name of the selected plan.',
 						} ) }
 					</Button>
 				) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -1,11 +1,20 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
+import PlanSelectionDetails from './details';
 import PlanSelectionFilter from './filter';
 
 import './style.scss';
 
-export default function PressableOverviewPlanSelection() {
+type Props = {
+	onAddToCart: ( plan: APIProductFamilyProduct ) => void;
+};
+
+export default function PressableOverviewPlanSelection( { onAddToCart }: Props ) {
+	const dispatch = useDispatch();
+
 	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
 
 	const onSelectPlan = useCallback(
@@ -26,6 +35,17 @@ export default function PressableOverviewPlanSelection() {
 		}
 	}, [ pressablePlans, setSelectedPlan ] );
 
+	const onPlanAddToCart = useCallback( () => {
+		if ( selectedPlan ) {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_select_plan_click', {
+					slug: selectedPlan?.slug,
+				} )
+			);
+			onAddToCart( selectedPlan );
+		}
+	}, [ dispatch, onAddToCart, selectedPlan ] );
+
 	return (
 		<div className="pressable-overview-plan-selection">
 			<PlanSelectionFilter
@@ -33,6 +53,8 @@ export default function PressableOverviewPlanSelection() {
 				plans={ pressablePlans }
 				onSelectPlan={ onSelectPlan }
 			/>
+
+			<PlanSelectionDetails selectedPlan={ selectedPlan } onSelectPlan={ onPlanAddToCart } />
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -29,6 +29,10 @@
 	}
 }
 
+.pressable-overview-plan-selection__details-card {
+	border-radius: 4px;
+}
+
 .pressable-overview-plan-selection__details-card:not(.is-aside) {
 	flex-grow: 1;
 	background: var(--studio-automattic-0);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -10,6 +10,97 @@
 	}
 }
 
+.pressable-overview-plan-selection__details {
+	margin-block-start: 32px;
+	margin-block-end: 64px;
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+
+	> * {
+		padding: 24px;
+		display: flex;
+		flex-direction: column;
+		gap: 32px;
+	}
+
+	@include break-large {
+		flex-direction: row;
+	}
+}
+
+.pressable-overview-plan-selection__details-card:not(.is-aside) {
+	flex-grow: 1;
+	background: var(--studio-automattic-0);
+}
+
+.pressable-overview-plan-selection__details-card.is-aside {
+	border: 1px solid var(--color-neutral-5);
+	flex-grow: 1;
+
+	@include break-large {
+		width: 300px;
+		flex-grow: 0;
+	}
+}
+
+.pressable-overview-plan-selection__details-card-header-title {
+	font-size: 1rem;
+	line-height: 1.4;
+	font-weight: 600;
+}
+
+.pressable-overview-plan-selection__details-card-header-price {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.pressable-overview-plan-selection__details-card-header-price-value {
+	font-size: 2rem;
+	line-height: 1;
+	font-weight: 600;
+	display: block;
+}
+
+.pressable-overview-plan-selection__details-card-header-price-interval {
+	font-size: 0.75rem;
+	line-height: 0.85;
+	font-weight: 400;
+	color: var(--color-neutral-60);
+}
+
+.pressable-overview-plan-selection__details-card-included-list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+	margin: 0;
+	padding: 0;
+	list-style: none;
+
+	li {
+		font-size: 1rem;
+		line-height: 1.6;
+		font-weight: 400;
+	}
+}
+
+.pressable-overview-plan-selection__details-card-included-list-icon {
+	margin-inline-end: 4px;
+	fill: var(--color-primary-40);
+	margin-block-end: -6px;
+}
+
+.pressable-overview-plan-selection__details-card-cta-button {
+	display: flex;
+	justify-content: center;
+	border-radius: 4px;
+	font-weight: 600;
+	font-size: 0.875rem;
+	min-height: 40px;
+}
+
 .pressable-overview-plan-selection__filter-type {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
This PR implements the Pressable plan viewer in the overview page.

**Selecting a plan**
<img width="873" alt="Screenshot 2024-03-26 at 5 13 25 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d914d124-6fd1-4957-b120-a7ac21a76683">
**Selecting more option**
<img width="850" alt="Screenshot 2024-03-26 at 5 13 32 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/dbdafb79-1a7b-4eef-96a7-65c8ecdc6cde">


Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/74

## Proposed Changes

* Add the Pressable plan details component for rendering the plan information.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/hosting/pressable`.
* Confirm that the plan viewer is visible below the plan selector.
* Select any plan using the selector and confirm the viewer renders the correct plan information. Refer to https://pressable.com/pricing/ as a reference.
* Click the **Select plan** button and confirm that the plan is added to the Shopping cart, and the page redirects to `/marketplace/products.`
* Select the **More** option and click the Chat with us button.
* Confirm you are redirected to https://pressable.com/request-demo/


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?