### PR TITLE
Plans Next: Fix plan-type-selector sticky behaviour/styling

### DIFF
--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -157,6 +157,16 @@ body.is-section-signup.is-white-signup {
 			border: solid 1px var(--studio-gray-5);
 		}
 	}
+
+	/**
+	 * Following styles are important for stretching the plan type selector to full width when sticky
+	 *   - .is-sticky-plan-type-selector is the class added when the plan type selector is sticky
+	 *   - 15px is the padding added by the layout overrides in modernized-layout.tsx
+	 */
+	.is-sticky-plan-type-selector & {
+		margin-left: -15px;
+		width: 100vw;
+	}
 }
 
 /**
@@ -167,7 +177,7 @@ body.is-section-plans .layout__content .main {
 		padding: 0;
 		.is-2023-pricing-grid .plans-wrapper {
 			margin: 0;
-			padding: 17px max(calc(50% - 612px), 30px);
+			padding: 17px;
 		}
 	}
 }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -164,8 +164,10 @@ body.is-section-signup.is-white-signup {
 	 *   - 15px is the padding added by the layout overrides in modernized-layout.tsx
 	 */
 	.is-sticky-plan-type-selector & {
-		margin-left: -15px;
-		width: 100vw;
+		.is-section-plans & {
+			margin-left: -15px;
+			width: 100vw;
+		}
 	}
 }
 

--- a/packages/plans-grid-next/src/components/plan-type-selector/index.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/index.tsx
@@ -19,6 +19,7 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 			kind,
 		} );
 	}, [] );
+
 	if ( kind === 'interval' ) {
 		return (
 			<StickyContainer

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -3,6 +3,7 @@
 .plan-type-selector {
 	width: fit-content;
 	min-width: 275px;
+	background-color: var(--studio-white);
 }
 
 .is-sticky-plan-type-selector {
@@ -111,7 +112,6 @@
 			overflow: hidden;
 			width: 100%;
 			.components-input-control__container {
-				background-color: var(--studio-white);
 				.components-custom-select-control__button {
 					min-width: 225px;
 					height: auto;

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -137,6 +137,11 @@
 			box-sizing: border-box;
 			border: 1px solid var(--studio-gray-10);
 			margin-top: -2px;
+
+			.is-sticky-plan-type-selector & {
+				border-bottom-right-radius: 0;
+				border-bottom-left-radius: 0;
+			}
 		}
 		.components-custom-select-control__item {
 			grid-template-columns: auto min-content;

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -114,8 +114,11 @@
 			.components-input-control__container {
 				.components-custom-select-control__button {
 					min-width: 225px;
-					height: auto;
 					padding: 0;
+					height: auto;
+					.is-sticky-plan-type-selector & {
+						height: 64px;
+					}
 				}
 				.components-input-control__backdrop {
 					border-color: var(--studio-gray-10);
@@ -161,7 +164,6 @@ div.is-sticky-plan-type-selector .plan-type-selector__interval-type-dropdown {
 		// Display above sticky feature and comparison grid plan headers
 		.components-flex {
 			width: 100vw;
-			height: 64px;
 			padding: 0;
 			border-bottom: 1px solid #e0e0e0;
 			border-bottom-right-radius: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Fixes some styling issues with the plan-type-selector when sticky on mobile. 
- the container would not cover the full width of the screen
- the background color would not cover the container box, allowing for text/content to be visible above the selector when scrolling

### Before

| Before | Before (with red bg) |
|--------|--------|
| <img width="400" alt="Screenshot 2024-03-26 at 11 23 24 AM" src="https://github.com/Automattic/wp-calypso/assets/1705499/83aace35-757a-43e9-abd5-845f33beacf1"> | <img width="400" alt="Screenshot 2024-03-26 at 11 24 56 AM" src="https://github.com/Automattic/wp-calypso/assets/1705499/9585587e-79ba-4f68-9597-861e39b5d89f"> | 

### After

| After | After (with red bg) |
|--------|--------|
| <img width="439" alt="Screenshot 2024-03-26 at 11 25 36 AM" src="https://github.com/Automattic/wp-calypso/assets/1705499/cd8db66c-d6c3-4a74-a534-acb996abfa34"> | <img width="440" alt="Screenshot 2024-03-26 at 11 25 57 AM" src="https://github.com/Automattic/wp-calypso/assets/1705499/be9da2d5-e5cb-43a8-b7d8-494325014fa9"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and `/plans/[ site ]`
* Switch to mobile view and scroll to the bottom to get the plan-type-selector sticky on top
* Open comparison grid and keep scrolling
* Confirm per media above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?