### PR TITLE
A4A Sites Dashboard: Adding a spinner for the Dataviews loading state

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -286,26 +286,19 @@ const SitesDataViews = ( {
 		);
 	};
 
-	const tableWrapper = document.getElementsByClassName( 'dataviews-view-table-wrapper' )[ 0 ];
-	if ( tableWrapper ) {
+	const dataviewsWrapper = document.getElementsByClassName( 'dataviews-wrapper' )[ 0 ];
+	if ( dataviewsWrapper ) {
 		// Remove any existing spinner if present
-		const existingSpinner = tableWrapper.querySelector( '.spinner-wrapper' );
+		const existingSpinner = dataviewsWrapper.querySelector( '.spinner-wrapper' );
 		if ( existingSpinner ) {
 			existingSpinner.remove();
 		}
 
-		const spinnerWrapper = document.createElement( 'div' );
+		const spinnerWrapper = dataviewsWrapper.appendChild( document.createElement( 'div' ) );
 		spinnerWrapper.classList.add( 'spinner-wrapper' );
-
-		const secondDataViewsTableChild = tableWrapper.children[ 1 ];
-
-		// Insert the spinner wrapper after the second child element
-		if ( secondDataViewsTableChild ) {
-			secondDataViewsTableChild.insertAdjacentElement( 'afterend', spinnerWrapper );
-
-			// Render the SpinnerWrapper component inside the spinner wrapper
-			ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
-		}
+		// Render the SpinnerWrapper component inside the spinner wrapper
+		ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
+		//}
 	}
 
 	const urlParams = new URLSearchParams( window.location.search );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -1,8 +1,9 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, Spinner } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
+import ReactDOM from 'react-dom';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
@@ -275,6 +276,37 @@ const SitesDataViews = ( {
 		],
 		[ translate ]
 	);
+
+	// Until the DataViews package is updated to support the spinner, we need to manually add the (loading) spinner to the table wrapper for now.
+	const SpinnerWrapper = () => {
+		return (
+			<div className="spinner-wrapper">
+				<Spinner />
+			</div>
+		);
+	};
+
+	const tableWrapper = document.getElementsByClassName( 'dataviews-view-table-wrapper' )[ 0 ];
+	if ( tableWrapper ) {
+		// Remove any existing spinner if present
+		const existingSpinner = tableWrapper.querySelector( '.spinner-wrapper' );
+		if ( existingSpinner ) {
+			existingSpinner.remove();
+		}
+
+		const spinnerWrapper = document.createElement( 'div' );
+		spinnerWrapper.classList.add( 'spinner-wrapper' );
+
+		const secondDataViewsTableChild = tableWrapper.children[ 1 ];
+
+		// Insert the spinner wrapper after the second child element
+		if ( secondDataViewsTableChild ) {
+			secondDataViewsTableChild.insertAdjacentElement( 'afterend', spinnerWrapper );
+
+			// Render the SpinnerWrapper component inside the spinner wrapper
+			ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
+		}
+	}
 
 	const urlParams = new URLSearchParams( window.location.search );
 	const isOnboardingTourActive = urlParams.get( 'tour' ) !== null;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -185,25 +185,27 @@
 .dataviews-wrapper {
 	.dataviews-no-results,
 	.dataviews-loading {
-		padding-left: 16px;
+		padding-top: 1rem;
+		text-align: center;
 	}
 
 	.spinner-wrapper {
 		display: none;
 	}
 
-	.dataviews-view-table-wrapper:has(.dataviews-loading) {
-		.spinner-wrapper {
-			display: block;
-		}
-		.dataviews-loading p {
-			display: none;
-		}
-	}
+}
 
-	.dataviews-view-table-wrapper:has(.dataviews-no-results) {
-		.spinner-wrapper {
-			display: none;
-		}
+.dataviews-wrapper:has(.dataviews-loading) {
+	.spinner-wrapper {
+		display: block;
+	}
+	.dataviews-loading p {
+		display: none;
+	}
+}
+
+.dataviews-wrapper:has(.dataviews-no-results) {
+	.spinner-wrapper {
+		display: none;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -187,4 +187,23 @@
 	.dataviews-loading {
 		padding-left: 16px;
 	}
+
+	.spinner-wrapper {
+		display: none;
+	}
+
+	.dataviews-view-table-wrapper:has(.dataviews-loading) {
+		.spinner-wrapper {
+			display: block;
+		}
+		.dataviews-loading p {
+			display: none;
+		}
+	}
+
+	.dataviews-view-table-wrapper:has(.dataviews-no-results) {
+		.spinner-wrapper {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/50

## Proposed Changes

* This PR adds a default spinner to replace the 'Loading...' text provided by the Dataviews component, when the sites list is in a loading state.
* Side note - this code could also be added to the A4A SitesDashboard component too, works just as well, but I've left it as close to the Dataviews source as possible for now.

## Testing Instructions

To replicate the issue: 
- Run `yarn start-jetpack-cloud` and visit `http://jetpack.cloud.localhost:3000/sites` (the Dataviews package is used by both Jetpack Manage and A4A, but testing the spinner is currently easier in Jetpack Manage).
- Type some garbled string in the search bar, and notice the loading text.

To test the fix:
- Check out this PR, and run the same test. You should notice a loading spinner in the middle of the screen in place of the loading text, which disappears when the 'no results' text is displayed.

To test in the A4A sites dashboard:

- Run `yarn start-a8c-for-agencies` and visit `http://agencies.localhost:3000/sites`.
- Open in an incognito window, and on first load the sites dashboard should show the spinner initially when loading. If not, try changing the rows per page via the View options icon. Each option should show the spinner briefly. Note the color of the spinner in the A4A dashboard has inherited the blue color, which works here.

Blue spinner in A4A dashboard:
<img width="1255" alt="Screenshot 2024-03-26 at 09 50 20" src="https://github.com/Automattic/wp-calypso/assets/16754605/154502d4-e21c-4552-abd1-5184de93b5b0">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?