### PR TITLE
Help Center: Remove forum for paid users

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -198,24 +198,25 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				/>
 
 				<div className={ classnames( 'help-center-contact-page__boxes' ) }>
-					<Link to={ forumUrl } onClick={ contactOptionsEventMap[ 'forum' ] }>
-						<div
-							className={ classnames( 'help-center-contact-page__box', 'forum' ) }
-							role="button"
-							tabIndex={ 0 }
-						>
-							<div className="help-center-contact-page__box-icon">
-								<Icon icon={ <Forum /> } />
+					{ ! renderEmail.render && (
+						<Link to={ forumUrl } onClick={ contactOptionsEventMap[ 'forum' ] }>
+							<div
+								className={ classnames( 'help-center-contact-page__box', 'forum' ) }
+								role="button"
+								tabIndex={ 0 }
+							>
+								<div className="help-center-contact-page__box-icon">
+									<Icon icon={ <Forum /> } />
+								</div>
+								<div>
+									<h2>{ forumHeaderText }</h2>
+									<p>
+										{ __( 'Your question and any answers will be public', __i18n_text_domain__ ) }
+									</p>
+								</div>
 							</div>
-							<div>
-								<h2>{ forumHeaderText }</h2>
-								<p>
-									{ __( 'Your question and any answers will be public', __i18n_text_domain__ ) }
-								</p>
-							</div>
-						</div>
-					</Link>
-
+						</Link>
+					) }
 					{ renderChat.render && (
 						<div className={ classnames( { disabled: renderChat.state !== 'AVAILABLE' } ) }>
 							<ConditionalLink


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/88806

## What

 remove the Forum channel option for paid users in Help Center.

## Testing

1. Create a free user
2. Go to the Help Center and `Still need help?`. You should see the forum
3. Use a paid user and do the same. You should only see Email and Chat

