### PR TITLE
Untangle: update command palette subscriber links to Jetpack Cloud for classic view

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -748,7 +748,7 @@ export const useCommandsArrayWpcom = ( {
 				onClick: ( param ) =>
 					commandNavigation(
 						`${
-							siteUsesWpAdminInterface( param.site )
+							param.site.is_wpcom_atomic && siteUsesWpAdminInterface( param.site )
 								? 'https://jetpack.com/redirect/?source=calypso-activity-log&site='
 								: '/activity-log/'
 						}${ param.site.slug }`
@@ -767,7 +767,7 @@ export const useCommandsArrayWpcom = ( {
 				onClick: ( param ) =>
 					commandNavigation(
 						`${
-							siteUsesWpAdminInterface( param.site )
+							param.site.is_wpcom_atomic && siteUsesWpAdminInterface( param.site )
 								? 'https://jetpack.com/redirect/?source=calypso-backups&site='
 								: '/backup/'
 						}${ param.site.slug }`
@@ -1238,7 +1238,13 @@ export const useCommandsArrayWpcom = ( {
 			siteFunctions: {
 				capabilityFilter: SiteCapabilities.MANAGE_OPTIONS,
 				onClick: ( param ) =>
-					commandNavigation( `/subscribers/${ param.site.slug }#add-subscribers` )( param ),
+					commandNavigation(
+						`${
+							param.site.is_wpcom_atomic && siteUsesWpAdminInterface( param.site )
+								? 'https://cloud.jetpack.com/subscribers/'
+								: '/subscribers/'
+						}${ param.site.slug }#add-subscribers`
+					)( param ),
 			},
 			icon: subscriberIcon,
 		},
@@ -1248,7 +1254,14 @@ export const useCommandsArrayWpcom = ( {
 			callback: setStateCallback( 'manageSubscribers', __( 'Select site to manage subscribers' ) ),
 			siteFunctions: {
 				capabilityFilter: SiteCapabilities.MANAGE_OPTIONS,
-				onClick: ( param ) => commandNavigation( `/subscribers/${ param.site.slug }` )( param ),
+				onClick: ( param ) =>
+					commandNavigation(
+						`${
+							param.site.is_wpcom_atomic && siteUsesWpAdminInterface( param.site )
+								? 'https://cloud.jetpack.com/subscribers/'
+								: '/subscribers/'
+						}${ param.site.slug }`
+					)( param ),
 			},
 			icon: subscriberIcon,
 		},

--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -520,7 +520,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			].join( ' ' ),
 			callback: commandNavigation(
 				`${
-					shouldUseWpAdmin
+					isAtomic && shouldUseWpAdmin
 						? 'https://jetpack.com/redirect/?source=calypso-activity-log&site='
 						: '/activity-log/'
 				}:site`
@@ -533,7 +533,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			label: __( 'Open Jetpack Backup', __i18n_text_domain__ ),
 			callback: commandNavigation(
 				`${
-					shouldUseWpAdmin
+					isAtomic && shouldUseWpAdmin
 						? 'https://jetpack.com/redirect/?source=calypso-backups&site='
 						: '/backup/'
 				}:site`
@@ -898,14 +898,22 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 				_x( 'import subscribers', 'Keyword for the Add subscribers command', __i18n_text_domain__ ),
 				_x( 'upload subscribers', 'Keyword for the Add subscribers command', __i18n_text_domain__ ),
 			].join( ' ' ),
-			callback: commandNavigation( '/subscribers/:site#add-subscribers' ),
+			callback: commandNavigation(
+				`${
+					isAtomic && shouldUseWpAdmin ? 'https://cloud.jetpack.com/subscribers/' : '/subscribers/'
+				}:site#add-subscribers`
+			),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			icon: subscriberIcon,
 		},
 		{
 			name: 'manageSubscribers',
 			label: __( 'Manage subscribers', __i18n_text_domain__ ),
-			callback: commandNavigation( '/subscribers/:site' ),
+			callback: commandNavigation(
+				`${
+					isAtomic && shouldUseWpAdmin ? 'https://cloud.jetpack.com/subscribers/' : '/subscribers/'
+				}:site`
+			),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			icon: subscriberIcon,
 		},


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6176

## Proposed Changes

This PR updates the command palette link for subscribers to point to Jetpack Cloud for classic Atomic view.

Here is the latest mapping:

|Command|Default view|Classic view|
|-|-|-|
|Manage subscribers|`/subscribers/:site`|`cloud.jetpack.com/subscribers/:site`|`cloud.jetpack.com/subscribers/:site`|
|Add subscribers|`/subscribers/:site#add-subscribers`|`cloud.jetpack.com/subscribers/:site#add-subscribers`|

---

> [!NOTE]  
> This PR also adds the missing "is Atomic" check for the existing Jetpack Cloud links (Activity Log and Backup). Does not need to be explicitly tested, as if this PR tests well then those links should also work well.


## Testing Instructions

This command palette can be run in two places: Calypso and wp-admin.

### Testing in Calypso

1. Use the Calypso Live URL.
2. Go to `/home/:site` of a Simple site or Atomic site with admin interface set to Default style.
3. Test the scenario in the above table.
4. Repeat with an Atomic site with admin interface set to Classic style.

### Testing in wp-admin

1. Sandbox `widgets.wp.com`.
2. Go to your sandbox.
3. Run: `install-plugin.sh command-palette untangle/subscribers`.
4. Go to `/wp-admin` of a Simple site or Atomic site with admin interface set to Default style.
5. Test the scenario in the above table.
6. Repeat with an Atomic site with admin interface set to Classic style.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?