### PR TITLE
A4A: Update the Billing page to fetch data from Jetpack Licensing API

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-billing-summary.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-billing-summary.ts
@@ -123,6 +123,7 @@ export default function useFetchBillingSummary(
 			// @link https://react-query.tanstack.com/guides/query-retries
 			return 3 > failureCount;
 		},
+		enabled: !! agencyId,
 		...options,
 	} );
 


### PR DESCRIPTION
This PR updates the Billing page to fetch from 

Closes https://github.com/Automattic/jetpack-genesis/issues/306

## Proposed Changes

* Update the `useFetchBillingSummary` hook to fetch from Jetpack Licensing API using Agency ID.

## Testing Instructions

* Use the A4A live link below and go to `/purchases/billing`.
* Confirm that the page fetches from `/jetpack-licensing/licenses/billing` and renders the billing summary correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?