### PR TITLE
[Odie] Add referral codes to Odie

### DIFF
--- a/packages/odie-client/src/components/message/custom-a-link.tsx
+++ b/packages/odie-client/src/components/message/custom-a-link.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import { useOdieAssistantContext } from '../../context';
+import { uriTransformer } from './uri-transformer';
 
 import './style.scss';
 
@@ -24,17 +25,19 @@ const CustomALink = ( {
 		'odie-sources-inline': inline,
 	} );
 
+	const transformedHref = uriTransformer( href );
+
 	return (
 		<span className={ classNames }>
 			<a
 				className="odie-sources-link"
-				href={ href }
+				href={ transformedHref }
 				target="_blank"
 				rel="noopener noreferrer"
 				onClick={ () => {
 					trackEvent( 'chat_message_action_click', {
 						action: 'link',
-						href: href,
+						href: transformedHref,
 					} );
 				} }
 			>

--- a/packages/odie-client/src/components/message/uri-transformer.ts
+++ b/packages/odie-client/src/components/message/uri-transformer.ts
@@ -6,6 +6,11 @@
 // and extending the component custom-a-link.tsx to handle it. That's it.
 const protocols = [ 'http', 'https', 'mailto', 'tel', 'prompt' ];
 
+const referralCodes: { [ key: string ]: string } = {
+	https: 'odie',
+	http: 'odie',
+};
+
 /**
  * @param {string} uri
  * @returns {string}
@@ -29,7 +34,10 @@ export function uriTransformer( uri: string ) {
 		const protocol = protocols[ index ];
 
 		if ( colon === protocol.length && url.slice( 0, protocol.length ).toLowerCase() === protocol ) {
-			return url;
+			// Add referral code to the URL
+			const urlObj = new URL( url );
+			urlObj.searchParams.set( 'ref', referralCodes[ protocol ] );
+			return urlObj.toString();
 		}
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/hal-tasks/issues/16

## Proposed Changes

We are adding a referral code to all the links displayed in the Odie Client, either as part of the Wapuu's message, or as part of the Related Guides.

## Testing Instructions

1. Add the wapuu flag
2. Open Help Center
3. Ask: "do you offer a website builder service?"
4. Assert that all the links provided have the query parameter "ref" equals to "odie"

![image](https://github.com/Automattic/wp-calypso/assets/5689927/ed37ed0e-da79-4780-859e-f405fca0f3ea)

i.e:
![image](https://github.com/Automattic/wp-calypso/assets/5689927/b0d7cb97-146e-453b-a31f-18ec09470f73)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
