### PR TITLE
Revert site switcher removal in #87585

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -42,38 +42,6 @@ class CurrentSite extends Component {
 		this.props.recordTracksEvent( 'calypso_sidebar_all_sites_click' );
 	};
 
-	renderSiteSwitcher = () => {
-		const { translate, isRtl } = this.props;
-		const arrowDirection = isRtl ? 'right' : 'left';
-
-		if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-			return (
-				<span className="current-site__switch-sites">
-					<Button borderless href="/sites" onClick={ this.onAllSitesClick }>
-						<span
-							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
-						></span>
-						<span className="current-site__switch-sites-label">{ translate( 'All Sites' ) }</span>
-					</Button>
-				</span>
-			);
-		}
-		return (
-			this.props.siteCount > 1 && (
-				<span className="current-site__switch-sites">
-					<Button borderless onClick={ this.switchSites }>
-						<span
-							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
-						></span>
-						<span className="current-site__switch-sites-label">{ translate( 'Switch Site' ) }</span>
-					</Button>
-				</span>
-			)
-		);
-	};
-
 	render() {
 		const { selectedSite, translate, anySiteSelected } = this.props;
 
@@ -102,10 +70,24 @@ class CurrentSite extends Component {
 			/* eslint-enable wpcalypso/jsx-classname-namespace, jsx-a11y/anchor-is-valid */
 		}
 
+		const arrowDirection = this.props.isRtl ? 'right' : 'left';
+
 		return (
 			<Card className="current-site">
 				<div role="button" tabIndex="0" aria-hidden="true" onClick={ this.expandUnifiedNavSidebar }>
-					{ this.renderSiteSwitcher() }
+					{ this.props.siteCount > 1 && (
+						<span className="current-site__switch-sites">
+							<Button borderless onClick={ this.switchSites }>
+								<span
+									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+									className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
+								></span>
+								<span className="current-site__switch-sites-label">
+									{ translate( 'Switch site' ) }
+								</span>
+							</Button>
+						</span>
+					) }
 
 					{ selectedSite ? (
 						<div>


### PR DESCRIPTION
Reverts https://github.com/Automattic/wp-calypso/pull/87585

Related to pfsHM7-Bd-p2#comment-913 testing.

## Proposed Changes

* testing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?