### PR TITLE
A4A: Sites dashboard - making sure parent has no height so dataviews loading spinner appears near the top

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -202,6 +202,10 @@
 	.dataviews-loading p {
 		display: none;
 	}
+
+	.dataviews-view-table-wrapper {
+		height: 0 !important;
+	}
 }
 
 .dataviews-wrapper:has(.dataviews-no-results) {


### PR DESCRIPTION
Follow on PR to https://github.com/Automattic/wp-calypso/pull/88896

## Proposed Changes

* This PR adds a height of 0 to the dataviews-view-table-wrapper class when the dataviews-loading class exists. In the A4A dashboard only, the wrapper has a calculated height which pushed the spinner down the page.

## Testing Instructions

- Run `yarn start-a8c-for-agencies` and visit `http://agencies.localhost:3000/sites`.
- Open in an incognito window, and on first load the sites dashboard should show the spinner initially when loading. If not, try changing the rows per page via the View options icon. Each option should show the spinner briefly. Note the color of the spinner in the A4A dashboard has inherited the blue color, which works here.

Blue spinner in A4A dashboard:
<img width="1255" alt="Screenshot 2024-03-26 at 09 50 20" src="https://github.com/Automattic/wp-calypso/assets/16754605/154502d4-e21c-4552-abd1-5184de93b5b0">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?