### PR TITLE
Pattern Library: Make pattern previews clickable

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -22,6 +22,14 @@
 	justify-content: space-between;
 	position: relative;
 
+	iframe {
+		pointer-events: initial !important;
+	}
+
+	> div[aria-hidden="true"] {
+		pointer-events: initial !important;
+	}
+
 	.pattern-preview__renderer {
 		background: var(--color-surface);
 		border-radius: 4px;

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -22,11 +22,7 @@
 	justify-content: space-between;
 	position: relative;
 
-	iframe {
-		pointer-events: initial !important;
-	}
-
-	> div[aria-hidden="true"] {
+	&:not(.pattern-preview--category-gallery) iframe {
 		pointer-events: initial !important;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6205

## Proposed Changes

This PR makes the content of pattern previews clickable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/gallery?grid=1`
2. Ensure that you can interact with the gallery in the second pattern preview