### PR TITLE
Backup: Add a backup-no-storage card

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -25,6 +25,7 @@ import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupFailed from './status-card/backup-failed';
 import BackupInProgress from './status-card/backup-in-progress';
 import BackupJustCompleted from './status-card/backup-just-completed';
+import BackupNoStorage from './status-card/backup-no-storage';
 import BackupScheduled from './status-card/backup-scheduled';
 import BackupSuccessful from './status-card/backup-successful';
 import NoBackupsOnSelectedDate from './status-card/no-backups-on-selected-date';
@@ -110,17 +111,21 @@ const DailyBackupStatus = ( {
 
 	if ( backup ) {
 		const isSuccessful = hasRealtimeBackups ? isSuccessfulRealtimeBackup : isSuccessfulDailyBackup;
-		return isSuccessful( backup ) ? (
-			<BackupSuccessful
-				backup={ backup }
-				deltas={ deltas }
-				selectedDate={ selectedDate }
-				lastBackupAttemptOnDate={ lastBackupAttemptOnDate }
-				availableActions={ [ 'rewind' ] }
-			/>
-		) : (
-			<BackupFailed backup={ backup } />
-		);
+
+		if ( isSuccessful( backup ) ) {
+			return (
+				<BackupSuccessful
+					backup={ backup }
+					deltas={ deltas }
+					selectedDate={ selectedDate }
+					lastBackupAttemptOnDate={ lastBackupAttemptOnDate }
+					availableActions={ [ 'rewind' ] }
+				/>
+			);
+		} else if ( ! backup.activityIsRewindable ) {
+			return <BackupNoStorage selectedDate={ selectedDate } />;
+		}
+		return <BackupFailed backup={ backup } />;
 	}
 	if ( lastBackupDate ) {
 		// if the storage is full, don't show backup is schdeuled or delayed message to the user.

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -11,6 +11,7 @@ import { Interval, EVERY_SECOND } from 'calypso/lib/interval';
 import {
 	isSuccessfulDailyBackup,
 	isSuccessfulRealtimeBackup,
+	isStorageOrRetentionReached,
 	getBackupErrorCode,
 } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
@@ -122,7 +123,7 @@ const DailyBackupStatus = ( {
 					availableActions={ [ 'rewind' ] }
 				/>
 			);
-		} else if ( ! backup.activityIsRewindable ) {
+		} else if ( isStorageOrRetentionReached( backup ) ) {
 			return <BackupNoStorage selectedDate={ selectedDate } />;
 		}
 		return <BackupFailed backup={ backup } />;

--- a/client/components/jetpack/daily-backup-status/status-card/backup-no-storage.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-no-storage.jsx
@@ -1,4 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import cloudWarningIcon from './icons/cloud-warning.svg';
 
 import './style.scss';
@@ -6,6 +9,8 @@ import './style.scss';
 const BackupNoStorage = ( { selectedDate } ) => {
 	const translate = useTranslate();
 	const displayDate = selectedDate.format( 'll' );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const settingsPathLinkTarget = settingsPath( siteSlug );
 
 	return (
 		<>
@@ -18,6 +23,13 @@ const BackupNoStorage = ( { selectedDate } ) => {
 				<p>
 					{ translate( 'The backup for %(displayDate)s reached the retention or storage limit.', {
 						args: { displayDate },
+					} ) }
+				</p>
+				<p>
+					{ translate( 'Check your {{a}}settings{{/a}} to manage your storage.', {
+						components: {
+							a: <a href={ settingsPathLinkTarget } />,
+						},
 					} ) }
 				</p>
 			</div>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-no-storage.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-no-storage.jsx
@@ -1,0 +1,28 @@
+import { useTranslate } from 'i18n-calypso';
+import cloudWarningIcon from './icons/cloud-warning.svg';
+
+import './style.scss';
+
+const BackupNoStorage = ( { selectedDate } ) => {
+	const translate = useTranslate();
+	const displayDate = selectedDate.format( 'll' );
+
+	return (
+		<>
+			<div className="status-card__message-head">
+				<img src={ cloudWarningIcon } alt="" role="presentation" />
+				<div className="status-card__title">{ translate( 'No backup' ) }</div>
+			</div>
+
+			<div className="status-card__label">
+				<p>
+					{ translate( 'The backup for %(displayDate)s reached the retention or storage limit.', {
+						args: { displayDate },
+					} ) }
+				</p>
+			</div>
+		</>
+	);
+};
+
+export default BackupNoStorage;

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -116,3 +116,9 @@ export const isSuccessfulRealtimeBackup = ( backup ) => {
 		backup.streams && !! backup.streams.filter( ( stream ) => stream.activityIsRewindable ).length;
 	return hasRestorableStreams || backup.activityIsRewindable;
 };
+
+export const isStorageOrRetentionReached = ( backup ) => {
+	return (
+		SUCCESSFUL_BACKUP_ACTIVITIES.includes( backup.activityName ) && ! backup.activityIsRewindable
+	);
+};


### PR DESCRIPTION
Backup: Add a backup-no-storage card for the case when a backup is not rewindable

This PR replaces the card "No backup: The backup attempt was delayed" when there is no backup because the retention or storage limit was reached, adding that information to the card.

<img width="519" alt="Screenshot 2024-03-27 at 16 51 45" src="https://github.com/Automattic/wp-calypso/assets/2747834/409716b3-64d3-4229-af81-d48117296195">

## Proposed Changes

* if there is no backup by retention or storage limit, show the new no-storage cards

## Testing Instructions

* To tests this change, you need as a8c to apply this patch D143188-code
* Verify in Calypso and Jetpack live the card is shown for a backup discarded by retention or storage limit reached

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?