### PR TITLE
Scheduled Updates: Add support link to the jetpack sites upsell banner

### DIFF
--- a/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
@@ -3,9 +3,11 @@ import {
 	getPlan,
 	WPCOM_FEATURES_SCHEDULED_UPDATES,
 } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { SCHEDULED_UPDATES_SUPPORT } from 'calypso/lib/url/support';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -48,7 +50,18 @@ const UpsellNudgeNotice = () => {
 
 	const getJetpackMigrateNudge = () => {
 		const titleText = translate(
-			'Thank you for you interest in scheduling plugin updates. Migrate your site to WordPress.com to get started!'
+			'Thank you for you interest in scheduling plugin updates. Migrate your site to WordPress.com to get started! {{a}}Read more about Scheduled updates{{/a}}.',
+			{
+				components: {
+					a: (
+						<a
+							href={ localizeUrl( SCHEDULED_UPDATES_SUPPORT ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
 		);
 
 		const href = addQueryArgs( `/setup/import-hosted-site/import`, {

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -57,6 +57,7 @@ export const PRIVACY_PROTECTION = `${ root }/domains/domain-registrations-and-pr
 export const PUBLIC_VS_PRIVATE = `${ root }/domains/register-domain/#public-versus-private-registration-and-gdpr`;
 export const REFUNDS = `${ root }/refunds/`;
 export const REGISTER_DOMAIN = `${ root }/domains/register-domain/`;
+export const SCHEDULED_UPDATES_SUPPORT = `${ root }/plugins/update-a-plugin-or-theme/#schedule-plugin-updates`;
 export const SETTING_PRIMARY_DOMAIN = `${ root }/domains/set-a-primary-address/`;
 export const SETTING_UP_PREMIUM_SERVICES = `${ root }/setting-up-premium-services/`;
 export const SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN = `${ root }/set-up-email-authentication-for-your-domain/`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88859

## Proposed Changes

* Include a "Read more about Scheduled updates" link in the banner.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN site and connect to your WP.com account.
* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/<site-slug>`
* You should see upsell banner as following image:
![Screen Shot 2024-03-26 at 9 05 37 PM](https://github.com/Automattic/wp-calypso/assets/4074459/99231ffb-dab2-4f0f-9de8-b216cf7ad9f6)
* Click on "Read more about Scheduled updates" link and make sure it points to the support page correctly. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?