### PR TITLE
Marketplace Test: Fix the page render when there are no sites

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -129,7 +129,7 @@ export default function MarketplaceTest() {
 		selectedSiteId && dispatch( requestEligibility( selectedSiteId ) );
 	};
 
-	const { ID, URL, domain, options = {} } = selectedSite;
+	const { ID, URL, domain, options = {} } = selectedSite || {};
 	const { is_wpcom_atomic, is_automated_transfer } = options;
 
 	const allBlockingMessages = getBlockingMessages( translate );


### PR DESCRIPTION
## Proposed Changes

Fix the page to render when there are no sites

## Testing Instructions


* Go to `/marketplace/test` (no selected site)
* The site should render
* On the current trunk version, an error is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?