### PR TITLE
show w sites link at global site view as well

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -621,7 +621,6 @@ class MasterbarLoggedIn extends Component {
 			loadHelpCenterIcon,
 			currentSelectedSiteId,
 			isGlobalSiteView,
-			isGlobalView,
 		} = this.props;
 		const { isMobile } = this.state;
 
@@ -635,7 +634,7 @@ class MasterbarLoggedIn extends Component {
 					<Masterbar className="masterbar__global-nav">
 						<div className="masterbar__section masterbar__section--left">
 							{ this.renderSidebarMobileMenu() }
-							{ isGlobalView && this.renderGlobalMySites() }
+							{ this.renderGlobalMySites() }
 							{ isGlobalSiteView && currentSelectedSiteId && (
 								<Site
 									siteId={ currentSelectedSiteId }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds the "W" my sites link to the mobile masterbar in global site view.
* There is currently no other link to the sites page in this viewport. I spoke with @davemart-in late last week when we were shipping color scheme changes, and he suggested we add this button between the hamburger menu and site card in the masterbar here.

BEFORE

<img width="579" alt="Screenshot 2024-03-26 at 1 55 19 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e2e10620-1b87-4556-b315-680315bedfd6">


AFTER

<img width="695" alt="Screenshot 2024-03-26 at 1 54 52 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/2098f4d2-d585-4f23-b4b0-49354c1c37e9">





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* select an atomic site with early opt-in access for global site view
* reduce the viewport to tablet/mobile widths.
* verify the masterbar has the "W" link that goes to all sites.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
