### PR TITLE
A4A: Overview page styling updates

### DIFF
--- a/client/a8c-for-agencies/components/layout/body.tsx
+++ b/client/a8c-for-agencies/components/layout/body.tsx
@@ -1,12 +1,16 @@
+import classNames from 'classnames';
 import { ReactNode } from 'react';
 
 type Props = {
 	children: ReactNode;
+	className?: string;
 };
 
-export default function LayoutBody( { children }: Props ) {
+export default function LayoutBody( { children, className }: Props ) {
+	const wrapperClass = classNames( className, 'a4a-layout__body' );
+
 	return (
-		<div className="a4a-layout__body">
+		<div className={ wrapperClass }>
 			<div className="a4a-layout__body-wrapper">{ children }</div>
 		</div>
 	);

--- a/client/a8c-for-agencies/components/layout/header.tsx
+++ b/client/a8c-for-agencies/components/layout/header.tsx
@@ -6,6 +6,7 @@ import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 type Props = {
 	showStickyContent?: boolean;
 	children: ReactNode;
+	className?: string;
 };
 
 export function LayoutHeaderTitle( { children }: Props ) {
@@ -28,7 +29,7 @@ export function LayoutHeaderBreadcrumb( { items }: { items: BreadcrumbItem[] } )
 	);
 }
 
-export default function LayoutHeader( { showStickyContent, children }: Props ) {
+export default function LayoutHeader( { showStickyContent, children, className }: Props ) {
 	const headerBreadcrumb = Children.toArray( children ).find(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( child: any ) => child.type === LayoutHeaderBreadcrumb
@@ -52,6 +53,7 @@ export default function LayoutHeader( { showStickyContent, children }: Props ) {
 	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
 
 	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+	const wrapperClass = classNames( className, 'a4a-layout__viewport' );
 
 	const [ minHeaderHeight, setMinHeaderHeight ] = useState( 0 );
 
@@ -79,7 +81,7 @@ export default function LayoutHeader( { showStickyContent, children }: Props ) {
 
 	return (
 		<div
-			className="a4a-layout__viewport"
+			className={ wrapperClass }
 			{ ...outerDivProps }
 			style={ showStickyContent ? { minHeight: `${ minHeaderHeight }px` } : {} }
 		>

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -45,6 +45,10 @@
 			border: none;
 			padding-block-start: 0;
 		}
+		.foldable-card.is-expanded .foldable-card__content {
+			border: none;
+			padding: 0;
+		}
 	}
 
 	.a4a-offering-item__card-list {

--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -11,6 +11,7 @@ import {
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+
 import './styles.scss';
 
 const OverviewBodyHosting = () => {

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
@@ -83,7 +83,7 @@ export default function OverviewBodyIntroCards( { onFinish = () => {} } ) {
 	};
 
 	return (
-		<Card>
+		<Card className="a4a-intro-cards__wrapper">
 			<div>
 				<DotPager
 					className="intro-cards"

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
@@ -20,3 +20,10 @@
 		}
 	}
 }
+
+.a4a-intro-cards__wrapper {
+	border-radius: 4px;
+	.button {
+		border-radius: 4px;
+	}
+}

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -7,6 +7,7 @@ import { OfferingItemProps } from 'calypso/a8c-for-agencies/components/offering/
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+
 import './style.scss';
 
 const A4A_PRODUCTS_MARKETPLACE_LINK = '/marketplace/products';

--- a/client/a8c-for-agencies/sections/overview/header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/overview/header-actions/style.scss
@@ -2,4 +2,17 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
+
+	.button {
+		border-radius: 4px;
+	}
+
+	.split-button__main {
+		border-radius: 4px 0 0 4px;
+	}
+
+	.split-button__toggle {
+		border-radius: 0 4px 4px 0;
+	}
+
 }

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -11,6 +11,7 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import OverviewBody from './body';
 import OverviewHeaderActions from './header-actions';
 import OverviewSidebar from './sidebar';
+import './style.scss';
 
 export default function Overview() {
 	const translate = useTranslate();
@@ -19,15 +20,19 @@ export default function Overview() {
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
 			<LayoutTop>
-				<LayoutHeader>
-					<Title>{ title }</Title>
-					<Actions>
-						<OverviewHeaderActions />
-					</Actions>
-				</LayoutHeader>
+				<div className="a4a-overview-header">
+					<LayoutHeader>
+						<Title>{ title }</Title>
+						<Actions>
+							<OverviewHeaderActions />
+						</Actions>
+					</LayoutHeader>
+				</div>
 			</LayoutTop>
 			<LayoutBody>
-				<ContentSidebar mainContent={ <OverviewBody /> } rightSidebar={ <OverviewSidebar /> } />
+				<div className="a4a-overview-content">
+					<ContentSidebar mainContent={ <OverviewBody /> } rightSidebar={ <OverviewSidebar /> } />
+				</div>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -20,19 +20,15 @@ export default function Overview() {
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
 			<LayoutTop>
-				<div className="a4a-overview-header">
-					<LayoutHeader>
-						<Title>{ title }</Title>
-						<Actions>
-							<OverviewHeaderActions />
-						</Actions>
-					</LayoutHeader>
-				</div>
+				<LayoutHeader className="a4a-overview-header">
+					<Title>{ title }</Title>
+					<Actions>
+						<OverviewHeaderActions />
+					</Actions>
+				</LayoutHeader>
 			</LayoutTop>
-			<LayoutBody>
-				<div className="a4a-overview-content">
-					<ContentSidebar mainContent={ <OverviewBody /> } rightSidebar={ <OverviewSidebar /> } />
-				</div>
+			<LayoutBody className="a4a-overview-content">
+				<ContentSidebar mainContent={ <OverviewBody /> } rightSidebar={ <OverviewSidebar /> } />
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/overview/style.scss
+++ b/client/a8c-for-agencies/sections/overview/style.scss
@@ -1,0 +1,8 @@
+.a4a-overview-content {
+	padding-block-start: 1rem;
+}
+
+.a4a-overview-header {
+	border-block-end: 1px solid var(--color-neutral-5);
+	padding-block-end: 32px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/307

## Proposed Changes
There are a number of improvements to the overview page suggested here:
- Round all buttons as per design
- Round all `Card`'s as per design
- Add bottom border to the sticky header for better UI. Currently, overlap looks a bit messy during scrolling (cc @jeffgolenski )

<img width="999" alt="Screenshot 2024-03-26 at 9 32 58 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/abe06486-3b24-4577-b13b-3987b502a848">

---

**Final Look**
<img width="958" alt="Screenshot 2024-03-26 at 9 32 11 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/9f4ed715-23c0-4606-9f36-11623c22bc7f">

**Note**
This PR doesn't address mobile view, to keep the things simple.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up the branch locally
- Navigate to http://agencies.localhost:3000/overview and check the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?