### PR TITLE
Site Migration : Handle "in-progress" state on Customer Home

### DIFF
--- a/client/my-sites/migrate/components/migration-in-progress/index.tsx
+++ b/client/my-sites/migrate/components/migration-in-progress/index.tsx
@@ -1,0 +1,79 @@
+import { Card } from '@automattic/components';
+import { MigrationStatus } from '@automattic/data-stores';
+import { useQuery } from '@tanstack/react-query';
+import { Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { type FC, useEffect } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import wpcom from 'calypso/lib/wp';
+
+interface Props {
+	sourceSite?: string;
+	targetSite: string;
+	siteId: string;
+	targetSiteId: string;
+	onComplete: () => void;
+}
+
+export const MigrationInProgress: FC< Props > = ( props ) => {
+	const translate = useTranslate();
+
+	const { sourceSite, targetSite, targetSiteId, onComplete } = props;
+
+	const {
+		data: { status },
+	} = useQuery( {
+		queryKey: [ 'migrationStatus', targetSiteId ],
+		initialData: { status: null },
+		queryFn: () =>
+			wpcom.req.get( {
+				path: `/sites/${ targetSiteId }/migration-status`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		refetchInterval: 5000, // 5 seconds
+	} );
+
+	useEffect( () => {
+		if ( status === MigrationStatus.DONE || status === MigrationStatus.INACTIVE ) {
+			onComplete();
+		}
+	}, [ onComplete, status ] );
+	//
+
+	return (
+		<Card className="migrate__pane">
+			<img
+				className="migrate__illustration"
+				src="/calypso/images/illustrations/waitTime-plain.svg"
+				alt=""
+			/>
+
+			<FormattedHeader
+				className="migrate__section-header"
+				headerText={ translate( 'Migration in progress' ) }
+				align="center"
+			/>
+			<p>
+				{ translate(
+					"We're moving everything from {{strong}}{{sp}}%(sourceSite)s{{/sp}}{{/strong}} to {{strong}}{{sp}}%(targetSite)s{{/sp}}{{/strong}}.",
+					{
+						args: {
+							sourceSite: sourceSite || translate( 'your source site' ),
+							targetSite,
+						},
+						components: {
+							sp: <span className="migrate__domain" />,
+							strong: <strong />,
+						},
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'You will be inform via email once your site has successfully migrated to its new home.'
+				) }
+			</p>
+			<Spinner />
+		</Card>
+	);
+};

--- a/client/my-sites/migrate/components/migration-in-progress/index.tsx
+++ b/client/my-sites/migrate/components/migration-in-progress/index.tsx
@@ -10,7 +10,6 @@ import wpcom from 'calypso/lib/wp';
 interface Props {
 	sourceSite?: string;
 	targetSite: string;
-	siteId: string;
 	targetSiteId: string;
 	onComplete: () => void;
 }
@@ -68,11 +67,7 @@ export const MigrationInProgress: FC< Props > = ( props ) => {
 					}
 				) }
 			</p>
-			<p>
-				{ translate(
-					'You will be inform via email once your site has successfully migrated to its new home.'
-				) }
-			</p>
+			<p>{ translate( 'We will send you an email when the migration is complete.' ) }</p>
 			<Spinner />
 		</Card>
 	);

--- a/client/my-sites/migrate/components/migration-in-progress/test/index.tsx
+++ b/client/my-sites/migrate/components/migration-in-progress/test/index.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React, { ComponentProps } from 'react';
+import { MigrationInProgress } from '../';
+
+type Props = ComponentProps< typeof MigrationInProgress >;
+
+describe( 'MigrationInProgress', () => {
+	beforeAll( () => nock.disableNetConnect() );
+
+	const renderComponent = ( props: Partial< Props > = {} ) => {
+		const queryClient = new QueryClient();
+		return render(
+			<QueryClientProvider client={ queryClient }>
+				<MigrationInProgress
+					targetSite="new-site.wordpress.com"
+					targetSiteId="some-site-id"
+					sourceSite="source-site.external.com"
+					onComplete={ jest.fn() }
+					{ ...props }
+				/>
+			</QueryClientProvider>
+		);
+	};
+
+	it( 'renders the destination site', () => {
+		renderComponent();
+
+		expect( screen.getByText( /new-site.wordpress.com/ ) ).toBeVisible();
+	} );
+
+	it( 'renders the source site', () => {
+		renderComponent();
+
+		expect( screen.getByText( /source-site.external.com/ ) ).toBeVisible();
+	} );
+
+	it( "renders 'your site' when the source site is not available", () => {
+		renderComponent( { sourceSite: undefined } );
+
+		expect( screen.getByText( /your source site/ ) ).toBeVisible();
+	} );
+
+	it( 'calls onComplete when migration is done', async () => {
+		const onComplete = jest.fn();
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( '/wpcom/v2/sites/some-site-id/migration-status' )
+			.reply( 200, { status: 'done' } );
+
+		renderComponent( { onComplete } );
+
+		await waitFor( () => {
+			expect( onComplete ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -680,8 +680,8 @@ export class SectionMigrate extends Component {
 			case 'in-progress':
 				return (
 					<MigrationInProgress
-						sourceSite={ get( sourceSite, 'domain' ) }
-						targetSite={ get( targetSite, 'domain' ) }
+						sourceSite={ sourceSite?.domain }
+						targetSite={ targetSite?.domain }
 						targetSiteId={ targetSiteId }
 						onComplete={ this.finishMigration }
 					/>

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -33,6 +33,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import { MigrationInProgress } from './components/migration-in-progress';
 import StepConfirmMigration from './step-confirm-migration';
 import StepImportOrMigrate from './step-import-or-migrate';
 import StepSourceSelect from './step-source-select';
@@ -670,12 +671,22 @@ export class SectionMigrate extends Component {
 	}
 
 	render() {
-		const { step, sourceSite, targetSite, targetSiteSlug, translate } = this.props;
+		const { step, sourceSite, targetSite, targetSiteSlug, translate, targetSiteId } = this.props;
 		const sourceSiteSlug = get( sourceSite, 'slug' );
 
 		let migrationElement;
 
 		switch ( this.state.migrationStatus ) {
+			case 'in-progress':
+				return (
+					<MigrationInProgress
+						sourceSite={ get( sourceSite, 'domain' ) }
+						targetSite={ get( targetSite, 'domain' ) }
+						targetSiteId={ targetSiteId }
+						onComplete={ this.finishMigration }
+					/>
+				);
+
 			case 'inactive':
 				switch ( step ) {
 					case 'confirm':


### PR DESCRIPTION
Part of #88864 

## Proposed Changes
* Add support to handle the "in-progress" state on the customer's home.

## Context
Currently, when the user starts a migration using the new flow. We are setting the "in-progress" status on the "site-migrations" table. 

The customer home is getting this status via the `migration-status` endpoint and redirecting the user to /migrate/{SITE) when they try to access some pages like (E.g plugins).

The current customer home is not expecting to handle the "in-progress" status, so the user was receiving an empty page.


## Testing Instructions
* Complete the new migration process
* Go to the site customer's home (E.g.  /home/[YOUR_NEW_SITE].wpcomstaging.com)
* Click on "plugins"
* You should be redirected to `/migrate/[YOUR_NEW_SITE].wpcomstaging.com` 
* You should see the screenshot (1)
* When the migration is completed you should be redirected to the regular customer home page.  (This behavior is equal to the current implementation and I am using almost the same code).


**NOTE:**
1. I am proposing to pool the migration-status endpoint because the migration for small sites is pretty fast, I see a lot of times seeing the screen when the migration is fully completed. 
2. The layout is using the old migrate screen components while we don't have a new layout.
3. Feel free to provide copy suggestions, it is just the first interaction. 


![image](https://github.com/Automattic/wp-calypso/assets/38718/d45428f9-287d-466f-9bf3-a5b0619708f0)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?