### PR TITLE
A4A: Add isFavoriteFilter context attribute to SitesDashboardContext

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -1,7 +1,7 @@
 export const A4A_OVERVIEW_LINK = '/overview';
 export const A4A_SITES_LINK = '/sites';
 export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';
-export const A4A_SITES_LINK_FAVORITE = '/sites/favorite';
+export const A4A_SITES_LINK_FAVORITE = '/sites?is_favorite';
 export const A4A_SITES_CONNECT_URL_LINK = '/sites/connect-url';
 export const A4A_PLUGINS_LINK = '/plugins';
 export const A4A_MARKETPLACE_LINK = '/marketplace';

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -9,6 +9,8 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature;
 	const hideListingInitialState = !! siteUrl;
+	const queryParams = new URLSearchParams( context.querystring );
+	const isFavoriteFilter = queryParams.get( 'is_favorite' ) !== null;
 
 	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;
 	const filter = {
@@ -33,6 +35,7 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 			filter={ filter }
 			sort={ sort }
 			showSitesDashboardV2={ true }
+			isFavoriteFilterInitialState={ isFavoriteFilter }
 		>
 			<SitesDashboard />
 		</SitesDashboardProvider>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -42,6 +42,10 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	setIsPopoverOpen: () => {
 		return undefined;
 	},
+	isFavoriteFilter: false,
+	setIsFavoriteFilter: () => {
+		return undefined;
+	},
 	sort: {
 		field: 'url',
 		direction: 'asc',

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import {
 	AgencyDashboardFilterOption,
 	DashboardSortInterface,
@@ -11,6 +11,7 @@ interface Props {
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
+	isFavoriteFilterInitialState: boolean;
 	children: ReactNode;
 	path: string;
 	search: string;
@@ -25,6 +26,7 @@ export const SitesDashboardProvider = ( {
 	categoryInitialState,
 	siteUrlInitialState,
 	siteFeatureInitialState,
+	isFavoriteFilterInitialState,
 	children,
 	path,
 	search,
@@ -36,6 +38,7 @@ export const SitesDashboardProvider = ( {
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteUrl, setSelectedSiteUrl ] = useState( siteUrlInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
+	const [ isFavoriteFilter, setIsFavoriteFilter ] = useState( isFavoriteFilterInitialState );
 
 	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
 	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
@@ -57,6 +60,10 @@ export const SitesDashboardProvider = ( {
 	const onHideLicenseInfo = () => {
 		setCurrentLicenseInfo( null );
 	};
+
+	useEffect( () => {
+		setIsFavoriteFilter( isFavoriteFilterInitialState );
+	}, [ isFavoriteFilterInitialState ] );
 
 	const sitesDashboardContextValue = {
 		selectedCategory: selectedCategory,
@@ -83,9 +90,10 @@ export const SitesDashboardProvider = ( {
 		setMostRecentConnectedSite,
 		isPopoverOpen,
 		setIsPopoverOpen,
+		isFavoriteFilter,
+		setIsFavoriteFilter,
 		showSitesDashboardV2: true,
 	};
-
 	return (
 		<SitesDashboardContext.Provider value={ sitesDashboardContextValue }>
 			{ children }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -57,9 +57,14 @@ export default function SitesDashboard() {
 		selectedSiteUrl,
 		selectedSiteFeature,
 		setSelectedSiteFeature,
+		isFavoriteFilter,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
 	} = useContext( SitesDashboardContext );
+
+	// TODO: this is just an example
+	// eslint-disable-next-line no-console
+	console.log( ' is_favorite param = ' + isFavoriteFilter );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 	const { data: products } = useProductsQuery();

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -41,4 +41,7 @@ export interface SitesDashboardContextInterface {
 
 	isPopoverOpen: boolean;
 	setIsPopoverOpen: React.Dispatch< React.SetStateAction< boolean > >;
+
+	isFavoriteFilter: boolean;
+	setIsFavoriteFilter: React.Dispatch< React.SetStateAction< boolean > >;
 }


### PR DESCRIPTION
This is a DRAFT

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?