### PR TITLE
Show weekly budget for evergreen campaigns on the campaigns list view

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -51,6 +51,7 @@ export default function CampaignItem( props: Props ) {
 		start_date,
 		campaign_stats,
 		type,
+		is_evergreen,
 	} = campaign;
 
 	const clicks_total = campaign_stats?.clicks_total ?? 0;
@@ -69,13 +70,19 @@ export default function CampaignItem( props: Props ) {
 	const safeUrl = safeImageUrl( content_config.imageUrl );
 	const adCreativeUrl = safeUrl && resizeImageUrl( safeUrl, 108, 0 );
 
-	const { totalBudget, totalBudgetLeft, campaignDays } = useMemo(
-		() => getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents ),
+	const { totalBudget, campaignDays } = useMemo(
+		() =>
+			getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents, is_evergreen ),
 		[ budget_cents, end_date, spent_budget_cents, start_date ]
 	);
 
-	const budgetString =
-		campaignDays && totalBudgetLeft ? `$${ formatCents( totalBudgetLeft ) } ` : '-';
+	let budgetString = '-';
+	if ( is_evergreen && campaignDays ) {
+		budgetString = `$${ formatCents( totalBudget ) } weekly`;
+	} else if ( campaignDays ) {
+		budgetString = `$${ formatCents( totalBudget ) }`;
+	}
+
 	const budgetStringMobile = campaignDays ? `$${ totalBudget } budget` : null;
 	const isWooStore = config.isEnabled( 'is_running_in_woo_site' );
 

--- a/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
@@ -65,7 +65,7 @@ export default function CampaignsTable( props: Props ) {
 			},
 			{
 				key: 'budget',
-				title: translate( 'Budget left' ),
+				title: translate( 'Budget' ),
 			},
 			{
 				key: 'impressions',

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -165,9 +165,15 @@ export const getCampaignBudgetData = (
 	budget_cents: number,
 	start_date: string,
 	end_date: string,
-	spent_budget_cents: number
+	spent_budget_cents: number,
+	is_evergreen = 0
 ) => {
-	const campaignDays = getCampaignDurationDays( start_date, end_date );
+	let campaignDays = 7;
+	if ( is_evergreen ) {
+		campaignDays = 7;
+	} else {
+		campaignDays = getCampaignDurationDays( start_date, end_date );
+	}
 
 	const spentBudgetCents =
 		spent_budget_cents > budget_cents * campaignDays
@@ -177,6 +183,7 @@ export const getCampaignBudgetData = (
 	const totalBudget = ( budget_cents * campaignDays ) / 100;
 	const totalBudgetUsed = spentBudgetCents / 100;
 	const totalBudgetLeft = totalBudget - totalBudgetUsed;
+
 	return {
 		totalBudget,
 		totalBudgetUsed,

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -168,7 +168,7 @@ export const getCampaignBudgetData = (
 	spent_budget_cents: number,
 	is_evergreen = 0
 ) => {
-	let campaignDays = 7;
+	let campaignDays;
 	if ( is_evergreen ) {
 		campaignDays = 7;
 	} else {


### PR DESCRIPTION
## Proposed Changes

* Show the "budget" as weekly for evergreen campaigns, previously this would show lifetime budget.

![Screenshot 2024-03-26 at 19 31 06](https://github.com/Automattic/wp-calypso/assets/6440498/c0519024-2cb5-40b2-938b-74b30c53c98f)


## Testing Instructions

- Load the calypso live link. (You don't need to test this locally)
    - https://calypso.live/?image=registry.a8c.com/calypso/app:commit-b90af28045e0e7e70904fc2049bb7cc61e439a42
- Create an `evergreen` campaign (Run until I stop option) from the DSP widget (screenshot below).
- Ensure that `/advertising/campaigns/site.uk` shows the weekly budget you set (screenshot above)
- Ensure a `! evergreen` campaign, still shows lifetime budget


![Screenshot 2024-03-26 at 19 35 54](https://github.com/Automattic/wp-calypso/assets/6440498/3c4475c8-3c6a-496a-b2ae-bde5a3390d0a)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
