### PR TITLE
A4A: Ensure Favorites submenu item functionality works

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -1,7 +1,7 @@
 export const A4A_OVERVIEW_LINK = '/overview';
 export const A4A_SITES_LINK = '/sites';
 export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';
-export const A4A_SITES_LINK_FAVORITE = '/sites/favorite';
+export const A4A_SITES_LINK_FAVORITE = '/sites?is_favorite';
 export const A4A_SITES_CONNECT_URL_LINK = '/sites/connect-url';
 export const A4A_PLUGINS_LINK = '/plugins';
 export const A4A_MARKETPLACE_LINK = '/marketplace';

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -9,6 +9,8 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature;
 	const hideListingInitialState = !! siteUrl;
+	const queryParams = new URLSearchParams( context.querystring );
+	const isFavoriteFilter = queryParams.get( 'is_favorite' ) !== null;
 
 	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;
 	const filter = {
@@ -33,6 +35,7 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 			filter={ filter }
 			sort={ sort }
 			showSitesDashboardV2={ true }
+			isFavoriteFilterInitialState={ isFavoriteFilter }
 		>
 			<SitesDashboard />
 		</SitesDashboardProvider>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -42,6 +42,10 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	setIsPopoverOpen: () => {
 		return undefined;
 	},
+	isFavoriteFilter: false,
+	setIsFavoriteFilter: () => {
+		return undefined;
+	},
 	sort: {
 		field: 'url',
 		direction: 'asc',

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import {
 	AgencyDashboardFilterOption,
 	DashboardSortInterface,
@@ -11,6 +11,7 @@ interface Props {
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
+	isFavoriteFilterInitialState: boolean;
 	children: ReactNode;
 	path: string;
 	search: string;
@@ -25,6 +26,7 @@ export const SitesDashboardProvider = ( {
 	categoryInitialState,
 	siteUrlInitialState,
 	siteFeatureInitialState,
+	isFavoriteFilterInitialState,
 	children,
 	path,
 	search,
@@ -36,6 +38,7 @@ export const SitesDashboardProvider = ( {
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteUrl, setSelectedSiteUrl ] = useState( siteUrlInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
+	const [ isFavoriteFilter, setIsFavoriteFilter ] = useState( isFavoriteFilterInitialState );
 
 	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
 	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
@@ -57,6 +60,10 @@ export const SitesDashboardProvider = ( {
 	const onHideLicenseInfo = () => {
 		setCurrentLicenseInfo( null );
 	};
+
+	useEffect( () => {
+		setIsFavoriteFilter( isFavoriteFilterInitialState );
+	}, [ isFavoriteFilterInitialState ] );
 
 	const sitesDashboardContextValue = {
 		selectedCategory: selectedCategory,
@@ -83,9 +90,10 @@ export const SitesDashboardProvider = ( {
 		setMostRecentConnectedSite,
 		isPopoverOpen,
 		setIsPopoverOpen,
+		isFavoriteFilter,
+		setIsFavoriteFilter,
 		showSitesDashboardV2: true,
 	};
-
 	return (
 		<SitesDashboardContext.Provider value={ sitesDashboardContextValue }>
 			{ children }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -62,10 +62,6 @@ export default function SitesDashboard() {
 		setSelectedCategory: setCategory,
 	} = useContext( SitesDashboardContext );
 
-	// TODO: this is just an example
-	// eslint-disable-next-line no-console
-	console.log( ' is_favorite param = ' + isFavoriteFilter );
-
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 	const { data: products } = useProductsQuery();
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -143,26 +143,37 @@ export default function SitesDashboard() {
 	}, [ isLoading, isError, sitesViewState.filters, filtersMap ] );*/
 
 	useEffect( () => {
+		// If the favorites filter is set, make sure to update the filter and correctly add the is_favorite param to URLs.
+		filter.showOnlyFavorites = isFavoriteFilter;
+		const favoriteParam = isFavoriteFilter ? '?is_favorite' : '';
 		// We need a category in the URL if we have a selected site
 		if ( sitesViewState.selectedSite && ! category ) {
 			setCategory( A4A_SITES_DASHBOARD_DEFAULT_CATEGORY );
 		} else if ( category && sitesViewState.selectedSite && selectedSiteFeature ) {
 			page.replace(
-				`/sites/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }`
+				`/sites/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }${ favoriteParam }`
 			);
 		} else if ( category && sitesViewState.selectedSite ) {
-			page.replace( `/sites/${ category }/${ sitesViewState.selectedSite.url }` );
+			page.replace( `/sites/${ category }/${ sitesViewState.selectedSite.url }${ favoriteParam }` );
 		} else if ( category && category !== A4A_SITES_DASHBOARD_DEFAULT_CATEGORY ) {
 			// If the selected category is the default one, we can leave the url a little cleaner, that's why we are comparing to the default category in the condition above.
-			page.replace( `/sites/${ category }` );
+			page.replace( `/sites/${ category }${ favoriteParam }` );
 		} else {
-			page.replace( '/sites' );
+			page.replace( `/sites${ favoriteParam }` );
 		}
 
 		if ( sitesViewState.selectedSite ) {
 			dispatch( setSelectedSiteId( sitesViewState.selectedSite.blog_id ) );
 		}
-	}, [ sitesViewState.selectedSite, selectedSiteFeature, category, setCategory, dispatch ] );
+	}, [
+		filter,
+		isFavoriteFilter,
+		sitesViewState.selectedSite,
+		selectedSiteFeature,
+		category,
+		setCategory,
+		dispatch,
+	] );
 
 	const closeSitePreviewPane = useCallback( () => {
 		if ( sitesViewState.selectedSite ) {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -145,21 +145,23 @@ export default function SitesDashboard() {
 	useEffect( () => {
 		// If the favorites filter is set, make sure to update the filter and correctly add the is_favorite param to URLs.
 		filter.showOnlyFavorites = isFavoriteFilter;
-		const favoriteParam = isFavoriteFilter ? '?is_favorite' : '';
+		const favoritesParam = isFavoriteFilter ? '?is_favorite' : '';
 		// We need a category in the URL if we have a selected site
 		if ( sitesViewState.selectedSite && ! category ) {
 			setCategory( A4A_SITES_DASHBOARD_DEFAULT_CATEGORY );
 		} else if ( category && sitesViewState.selectedSite && selectedSiteFeature ) {
 			page.replace(
-				`/sites/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }${ favoriteParam }`
+				`/sites/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }${ favoritesParam }`
 			);
 		} else if ( category && sitesViewState.selectedSite ) {
-			page.replace( `/sites/${ category }/${ sitesViewState.selectedSite.url }${ favoriteParam }` );
+			page.replace(
+				`/sites/${ category }/${ sitesViewState.selectedSite.url }${ favoritesParam }`
+			);
 		} else if ( category && category !== A4A_SITES_DASHBOARD_DEFAULT_CATEGORY ) {
 			// If the selected category is the default one, we can leave the url a little cleaner, that's why we are comparing to the default category in the condition above.
-			page.replace( `/sites/${ category }${ favoriteParam }` );
+			page.replace( `/sites/${ category }${ favoritesParam }` );
 		} else {
-			page.replace( `/sites${ favoriteParam }` );
+			page.replace( `/sites${ favoritesParam }` );
 		}
 
 		if ( sitesViewState.selectedSite ) {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -57,9 +57,14 @@ export default function SitesDashboard() {
 		selectedSiteUrl,
 		selectedSiteFeature,
 		setSelectedSiteFeature,
+		isFavoriteFilter,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
 	} = useContext( SitesDashboardContext );
+
+	// TODO: this is just an example
+	// eslint-disable-next-line no-console
+	console.log( ' is_favorite param = ' + isFavoriteFilter );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 	const { data: products } = useProductsQuery();

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -41,4 +41,7 @@ export interface SitesDashboardContextInterface {
 
 	isPopoverOpen: boolean;
 	setIsPopoverOpen: React.Dispatch< React.SetStateAction< boolean > >;
+
+	isFavoriteFilter: boolean;
+	setIsFavoriteFilter: React.Dispatch< React.SetStateAction< boolean > >;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -27,8 +27,9 @@ const SitesDataViews = ( {
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
 
-	const totalSites =
-		window.location.pathname === '/sites/favorites' ? data?.totalFavorites || 0 : data?.total || 0;
+	const totalSites = window.location.search.includes( 'is_favorite' )
+		? data?.totalFavorites || 0
+		: data?.total || 0;
 
 	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
@@ -44,7 +45,7 @@ const SitesDataViews = ( {
 		},
 		[ onSitesViewChange, sitesViewState ]
 	);
-
+	//
 	const renderField = useCallback(
 		( column: AllowedTypes, item: SiteInfo ) => {
 			if ( isLoading ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -2,8 +2,9 @@ import { Button, Gridicon, Spinner } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import ReactDOM from 'react-dom';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
@@ -14,6 +15,7 @@ import SiteSetFavorite from '../site-set-favorite';
 import SiteSort from '../site-sort';
 import { AllowedTypes, Site } from '../types';
 import { SitesDataViewsProps, SiteInfo } from './interfaces';
+
 import './style.scss';
 
 const SitesDataViews = ( {
@@ -26,11 +28,8 @@ const SitesDataViews = ( {
 	className,
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
-
-	const totalSites = window.location.search.includes( 'is_favorite' )
-		? data?.totalFavorites || 0
-		: data?.total || 0;
-
+	const { isFavoriteFilter } = useContext( SitesDashboardContext );
+	const totalSites = isFavoriteFilter ? data?.totalFavorites || 0 : data?.total || 0;
 	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -45,7 +45,7 @@ const SitesDataViews = ( {
 		},
 		[ onSitesViewChange, sitesViewState ]
 	);
-	//
+
 	const renderField = useCallback(
 		( column: AllowedTypes, item: SiteInfo ) => {
 			if ( isLoading ) {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/141

## Proposed Changes

* This PR adds the functionality to make sure the favorites submenu item works. 
* Retrieving the isFavoriteFilter context to use in the Sites Dashboard is thanks largely to this PR - https://github.com/Automattic/wp-calypso/pull/88917
* The PR also makes sure that any URLs created with category or feature names appended, will also include the favorites filter if relevant, and remove it otherwise.
* This PR does not take into account other filters as these have not yet been implemented, and this may change some aspects of how the favorites are checked  in the Sites Dashboard, however this is a standalone implementation initially. An example of how routes will change is that the query param may need to start with & instead of ? (eg `/sites/:category?s=search_text&issue_types=issue1&is_favorite`), but that will be followed up with when looking at filters.

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* To test, click on the 'Favorites' submenu item, making sure you have some sites selected as favorites. If you don't already, favorite some sites via Jetpack Manage (as the favorites selection in A4A doesn't work properly yet).
* You should see `?is_favorite` appended to the URL, and the sites list should reflect the favorites. 
* If you open up the preview pane for any site, the list of favorites should remain unchanged. 
* If you change the selected site, the list of favorites should remain unchanged.
* If you navigate to 'All' or 'Needs Attention', the favorites list should no longer display.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?