### PR TITLE
Backup: fix real-time banner icon

### DIFF
--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -183,10 +183,6 @@
 	}
 }
 
-.backups-made-realtime-banner .banner__icons .banner__icon {
-	display: block;
-}
-
 /* Jetpack.com-only changes */
 .is_jetpackcom {
 	.backup__restore-banner {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-backup-team/issues/415

We are displaying the real-time icon twice on the banner that appears in the backup page when a site has credentials configured. The bug started to appear after merging https://github.com/Automattic/wp-calypso/pull/87969, and it is because we are forcing the additional icon to be visible via CSS.

## Proposed Changes

* Remove a CSS that forces the real-time additional icon to be visible. It is currently handled in the [Banner component](https://github.com/Automattic/wp-calypso/blob/714da682e9bec87afa34284eb7a4445a32d92dbf/client/components/banner/index.jsx#L204).

| Before | After |
|---|---|
| ![CleanShot 2024-03-26 at 17 10 30@2x](https://github.com/Automattic/wp-calypso/assets/1488641/6b353dac-d06b-4602-962d-bc0694e2288e) | ![CleanShot 2024-03-26 at 17 11 06@2x](https://github.com/Automattic/wp-calypso/assets/1488641/30b7416f-8aa5-408c-9b15-0056441ce1b3) |

## Testing Instructions

* Spin up a Calypso or Jetpack Cloud live branch
* Using a site with VaultPress Backup and credentials configured, navigate to the Backup
* You should see the banner on top with the fix

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?