### PR TITLE
Reduce size of partner screenshots in theme picker

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -41,16 +41,12 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 
 	if ( design.is_externally_managed && design.screenshot ) {
 		const fit = '479,360';
+		// We're stubbing out the high res version here as part of a size reduction experiment.
+		// See #88786 and TODO for discussion / info.
 		const themeImgSrc = photon( design.screenshot, { fit } ) || design.screenshot;
-		const themeImgSrcDoubleDpi = photon( design.screenshot, { fit, zoom: 2 } ) || design.screenshot;
+		// const themeImgSrcDoubleDpi = photon( design.screenshot, { fit, zoom: 2 } ) || design.screenshot;
 
-		return (
-			<img
-				src={ themeImgSrc }
-				srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
-				alt={ design.description }
-			/>
-		);
+		return <img src={ themeImgSrc } srcSet={ `${ themeImgSrc } 2x` } alt={ design.description } />;
 	}
 
 	return (

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -46,7 +46,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 		const themeImgSrc = photon( design.screenshot, { fit } ) || design.screenshot;
 		// const themeImgSrcDoubleDpi = photon( design.screenshot, { fit, zoom: 2 } ) || design.screenshot;
 
-		return <img src={ themeImgSrc } srcSet={ `${ themeImgSrc } 2x` } alt={ design.description } />;
+		return <img src={ themeImgSrc } srcSet={ `${ themeImgSrc }` } alt={ design.description } />;
 	}
 
 	return (


### PR DESCRIPTION
This reduces the resolution and sizes of images in the theme picker for images that do not use mShots (which seems to be limited to partner themes?). This is analogous to #88786 for images that aren't loaded via mShots.

#88786 reduced the total image payload size to `~4MB` down from something like `50MB`. However, it only impacts `mShots` images. Now, on the default/main theme picker page, we have 84 themes display and the two themes that do not use `mShots` account for ~12% of the image weight. This change reduces the size of the images for those two themes and brings the sizes and resolutions in line with other images in the theme picker.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88786

## Proposed Changes

* This presents static images at the native resolution `(479,360)` instead of at `2x`. If we re-enable `2x` sizes, it might make sense to limit those to `devicePixelRatio >= 2` since I get these high res images even on my non-Retina display.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This change is observable by setting up a new site and navigating to http://calypso.localhost:3000/setup/update-design/designSetup?siteSlug={yoursitehere} during the process.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
