### PR TITLE
Remove italics from some Jetpack product names

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/test/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/test/index.tsx
@@ -78,6 +78,6 @@ describe( '<PlanUpgradeSection />', () => {
 
 		expect( personalHeader.outerHTML ).toContain( 'Premium' );
 		expect( antiSpamHeader.outerHTML ).toContain( 'Anti-spam' );
-		expect( backupDailyHeader.outerHTML ).toContain( 'Backup <em>Daily</em>' );
+		expect( backupDailyHeader.outerHTML ).toContain( 'Backup <span>Daily</span>' );
 	} );
 } );

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -92,22 +92,22 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: (
 			<>
-				VaultPress Backup <em>Daily</em>
+				VaultPress Backup <span>Daily</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: (
 			<>
-				VaultPress Backup <em>Daily</em>
+				VaultPress Backup <span>Daily</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: (
 			<>
-				VaultPress Backup <em style={ { whiteSpace: 'nowrap' } }>Real-time</em>
+				VaultPress Backup <span style={ { whiteSpace: 'nowrap' } }>Real-time</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: (
 			<>
-				VaultPress Backup <em style={ { whiteSpace: 'nowrap' } }>Real-time</em>
+				VaultPress Backup <span style={ { whiteSpace: 'nowrap' } }>Real-time</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_BACKUP_T0_YEARLY ]: 'VaultPress Backup',
@@ -122,12 +122,12 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 		[ PRODUCT_JETPACK_BOOST_MONTHLY ]: 'Boost',
 		[ PRODUCT_JETPACK_SCAN_REALTIME ]: (
 			<>
-				Scan <em style={ { whiteSpace: 'nowrap' } }>Real-time</em>
+				Scan <span style={ { whiteSpace: 'nowrap' } }>Real-time</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_SCAN_REALTIME_MONTHLY ]: (
 			<>
-				Scan <em style={ { whiteSpace: 'nowrap' } }>Real-time</em>
+				Scan <span style={ { whiteSpace: 'nowrap' } }>Real-time</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_SCAN_BI_YEARLY ]: 'Scan',
@@ -141,17 +141,17 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: 'Search',
 		[ PRODUCT_JETPACK_ANTI_SPAM_BI_YEARLY ]: (
 			<>
-				Akismet <em style={ { whiteSpace: 'nowrap' } }>Anti-spam</em>
+				Akismet <span style={ { whiteSpace: 'nowrap' } }>Anti-spam</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_ANTI_SPAM ]: (
 			<>
-				Akismet <em style={ { whiteSpace: 'nowrap' } }>Anti-spam</em>
+				Akismet <span style={ { whiteSpace: 'nowrap' } }>Anti-spam</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: (
 			<>
-				Akismet <em style={ { whiteSpace: 'nowrap' } }>Anti-spam</em>
+				Akismet <span style={ { whiteSpace: 'nowrap' } }>Anti-spam</span>
 			</>
 		),
 		[ PRODUCT_JETPACK_VIDEOPRESS_BI_YEARLY ]: 'VideoPress',


### PR DESCRIPTION
## Proposed Changes

* Updates translation strings for Jetpack product names to use `<span>` instead of `<em>`

## Testing Instructions

* Check the error on the Jetpack pricing page: https://cloud.jetpack.com/pricing
* You can see that "Anti-spam" is in italics in "Akismet Anti-Spam"
* Confirm that this PR fixes the italics

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?