### PR TITLE
Update the copy for one of the FAQs on the pricing page

### DIFF
--- a/client/my-sites/plans-features-main/components/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/components/jetpack-faq.jsx
@@ -82,11 +82,10 @@ const JetpackFAQ = () => {
 			/>
 
 			<FAQItem
-				question={ translate( 'Does this work with a multisite network?' ) }
+				question={ translate( 'Does Jetpack work with a multisite network?' ) }
 				answer={ translate(
-					'Jetpack’s free features are compatible with WordPress Multisite networks. Paid features' +
-						' also work with Multisite networks, but each site requires its own subscription. Jetpack VaultPress Backup' +
-						' and Jetpack Scan are not currently compatible with Multisite networks.'
+					'Jetpack’s free features are compatible with WordPress Multisite networks. Most paid features also work with Multisite networks, but each site requires its own subscription. Ad network is an exception and will only work with the main site.' +
+						' Jetpack VaultPress Backup, Jetpack Scan, Jetpack Security, and Jetpack Complete are not currently compatible with Multisite networks.'
 				) }
 			/>
 


### PR DESCRIPTION
## Proposed Changes

* Updates the copy for one of the FAQ questions on https://cloud.jetpack.com/pricing?view=products#multisite-network-faq

## Testing Instructions

* Visit the Jetpack pricing page on our test site.
* Make sure this FAQ question is updated an still looks good

![Screenshot 2024-03-26 at 8 34 48 PM](https://github.com/Automattic/wp-calypso/assets/18016357/d56162b9-5a57-4ba4-a870-5bd692b1f64a)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?