### PR TITLE
Checkout: Remove variant picker arrow margin in v2

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -17,7 +17,8 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 
 	.gridicon {
 		fill: #a7aaad;
-		${ ( props ) => ( props.shouldUseCheckoutV2 ? `margin-left: 0;` : `margin-left: 14px;` ) };
+		${ ( props ) =>
+			props.shouldUseCheckoutV2 ? `margin-inline-start: 0;` : `margin-inline-start: 14px;` };
 	}
 
 	${ ( props ) =>

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -17,7 +17,7 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 
 	.gridicon {
 		fill: #a7aaad;
-		margin-left: 14px;
+		${ ( props ) => ( props.shouldUseCheckoutV2 ? `margin-left: 0;` : `margin-left: 14px;` ) };
 	}
 
 	${ ( props ) =>

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -153,7 +153,10 @@ export const Label = styled.span< { shouldUseCheckoutV2: boolean } >`
 	display: flex;
 	white-space: nowrap;
 
-	${ ( props ) => ( props.shouldUseCheckoutV2 ? 'font-size: 14px' : 'font-size: inherit' ) };
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
+			? 'font-size: 14px; white-space: normal; text-align: start'
+			: 'font-size: inherit' };
 
 	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
 	@media ( max-width: 480px ) {


### PR DESCRIPTION
Looks like a `margin-left: 14px` value somehow slipped past all of the v2 testing, or perhaps was recently introduced by some other changes upstream in the CSS code for the variant picker:

![image](https://github.com/Automattic/wp-calypso/assets/16580129/de069786-9724-44ff-813c-fb1efd912ee4)

Updated the margin to:

- Not show on v2 checkout
- On v1, use `margin-inline-start` since it is currently suboptimal in production for RTL users - this should fix that
- Update Label styles to wrap long labels (which was also causing the arrow to shrink)

## Testing Instructions

* Go to checkout v1 with a product or plan in cart, ensure it has variants
* Ensure the dropdown, its label, its arrow, and any introductory text all appear as they should. There should also be `margin-left: 14px` on the CurrentOption component's `svg` element
* Go to Checkout v2 - ensure the margin-left is removed
* Ensure that any long text labels proper wrap onto the next line (i.e the seven year variant of a domain)  
![image](https://github.com/Automattic/wp-calypso/assets/16580129/497f32d0-099a-4b96-a675-f7efd3752f28)
* Go to `/me/account` and set language to an RTL language like Hebrew
* Repeat previous steps but switch the expected margin direction to "right"

