### PR TITLE
Stats: Add commercial classification triggering button - self service commercial classification

### DIFF
--- a/client/my-sites/stats/hooks/use-on-demand-site-identification-mutation.ts
+++ b/client/my-sites/stats/hooks/use-on-demand-site-identification-mutation.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export function runOnDemandCommercialClassification( siteId: number | null ): Promise< any > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/commercial-classification`,
+	} );
+}
+
+export default function useOnDemandCommercialClassificationMutation( siteId: number | null ) {
+	return useMutation( {
+		mutationKey: [ 'stats', 'commercial-classification', siteId ],
+		mutationFn: () => runOnDemandCommercialClassification( siteId ),
+		retry: 0,
+	} );
+}

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -397,6 +397,7 @@ function StatsCommercialFlowOptOutForm( {
 	};
 	const commercialClassificationLastRunAt = useMemo(
 		() => parseInt( localStorage.getItem( 'commercial_classification__button_clicked' ) ?? '0' ),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ comemercialClassificationRunAt ]
 	);
 	const hasRunLessThan3DAgo =

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -502,7 +502,7 @@ function StatsCommercialFlowOptOutForm( {
 			{ supportsOnDemandCommercialClassification && (
 				<>
 					{ errorMessage && (
-						<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>Error: { errorMessage }</p>
+						<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>{ errorMessage }</p>
 					) }
 					{ isClassificationInProgress && ! errorMessage && (
 						<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -399,17 +399,17 @@ function StatsCommercialFlowOptOutForm( {
 		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 3; // 3 days
 	const isClassificationInProgress =
 		commercialClassificationLastRunAt > 0 &&
-		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60; // 1 hour
+		Date.now() - commercialClassificationLastRunAt < 1000 * 60; // 1 hour
 	const allConditionsChecked =
 		isAdsChecked && isSellingChecked && isBusinessChecked && isDonationChecked;
-	const isFormSubmissionDisabled = () => {
-		return ! allConditionsChecked || comemercialClassificationRunAt === 0;
-	};
+	// const isFormSubmissionDisabled = () => {
+	// 	return ! allConditionsChecked || comemercialClassificationRunAt === 0;
+	// };
 
 	// Message, button text, and handler differ based on isCommercial flag.
 	const formMessage = isCommercial
 		? translate(
-				'Your site is identified as a commercial site, which is not eligible for a non-commercial license, reason(s) being ’%(reasons)s’. If you think this is an error or you’ve removed the commercial identifier, please confirm the information below and reverify (maximum once every 24 hours). If you still have issues, you will be given options to contact support.',
+				'Your site is identified as a commercial site, which is not eligible for a non-commercial license, reason(s) being ’%(reasons)s’. If you think this is an error or you’ve removed the commercial identifier, please confirm the information below and reverify (maximum once every 24 hours).',
 				{
 					args: {
 						reasons:
@@ -485,7 +485,7 @@ function StatsCommercialFlowOptOutForm( {
 				{ ! isClassificationInProgress && (
 					<Button
 						variant="secondary"
-						disabled={ isFormSubmissionDisabled() }
+						// disabled={ isFormSubmissionDisabled() }
 						onClick={ formHandler }
 					>
 						{ formButton }
@@ -498,6 +498,13 @@ function StatsCommercialFlowOptOutForm( {
 			{ isClassificationInProgress && ! errorMessage && (
 				<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
 					{ translate( 'We are verifying your site. Please come back later…' ) }
+				</p>
+			) }
+			{ ! isClassificationInProgress && ! errorMessage && (
+				<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
+					{ translate(
+						'We have finished verify your site. If you still think this is an error, please contact our support.'
+					) }
 				</p>
 			) }
 		</>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -497,7 +497,7 @@ function StatsCommercialFlowOptOutForm( {
 					{ translate( 'We are verifying your site. Please come back later…' ) }
 				</p>
 			) }
-			{ ! isClassificationInProgress && ! errorMessage && (
+			{ ! isClassificationInProgress && commercialClassificationLastRunAt > 0 && ! errorMessage && (
 				<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
 					{ translate(
 						'We have finished verify your site. If you still think this is an error, please contact our support.'

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -363,7 +363,7 @@ function StatsCommercialFlowOptOutForm( {
 		setComemercialClassificationRunAt(
 			parseInt( localStorage.getItem( 'commercial_classification__button_clicked' ) ?? '0' )
 		);
-	} );
+	}, [] );
 
 	const handleSwitchToPersonalClick = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
@@ -489,7 +489,7 @@ function StatsCommercialFlowOptOutForm( {
 					</Button>
 				) }
 				{ ( ! supportsOnDemandCommercialClassification ||
-					( isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
+					( ! isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
 					<Button
 						variant="secondary"
 						disabled={ ! supportsOnDemandCommercialClassification && isFormSubmissionDisabled() }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -405,8 +405,7 @@ function StatsCommercialFlowOptOutForm( {
 	const isClassificationInProgress =
 		commercialClassificationLastRunAt > 0 &&
 		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60; // 1 hour
-	const allConditionsChecked =
-		isAdsChecked && isSellingChecked && isBusinessChecked && isDonationChecked;
+
 	const isFormSubmissionDisabled = () => {
 		return ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked;
 	};
@@ -483,7 +482,7 @@ function StatsCommercialFlowOptOutForm( {
 				{ supportsOnDemandCommercialClassification && (
 					<Button
 						variant="secondary"
-						disabled={ hasRunLessThan3DAgo || ! allConditionsChecked }
+						disabled={ hasRunLessThan3DAgo || isFormSubmissionDisabled() }
 						onClick={ handleCommercialClassification }
 					>
 						{ translate( 'Reverify' ) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -479,7 +479,7 @@ function StatsCommercialFlowOptOutForm( {
 				>
 					{ translate( 'Reverify' ) }
 				</Button>
-				{ ! isClassificationInProgress && (
+				{ ! isClassificationInProgress && commercialClassificationLastRunAt > 0 && (
 					<Button
 						variant="secondary"
 						// disabled={ isFormSubmissionDisabled() }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -396,15 +396,12 @@ function StatsCommercialFlowOptOutForm( {
 		[ comemercialClassificationRunAt ]
 	);
 	const hasRunLessThan3DAgo =
-		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 3; // 3 days
+		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 1; // 1 day
 	const isClassificationInProgress =
 		commercialClassificationLastRunAt > 0 &&
 		Date.now() - commercialClassificationLastRunAt < 1000 * 60; // 1 hour
 	const allConditionsChecked =
 		isAdsChecked && isSellingChecked && isBusinessChecked && isDonationChecked;
-	// const isFormSubmissionDisabled = () => {
-	// 	return ! allConditionsChecked || comemercialClassificationRunAt === 0;
-	// };
 
 	// Message, button text, and handler differ based on isCommercial flag.
 	const formMessage = isCommercial

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -399,7 +399,7 @@ function StatsCommercialFlowOptOutForm( {
 		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 1; // 1 day
 	const isClassificationInProgress =
 		commercialClassificationLastRunAt > 0 &&
-		Date.now() - commercialClassificationLastRunAt < 1000 * 60; // 1 hour
+		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60; // 1 hour
 	const allConditionsChecked =
 		isAdsChecked && isSellingChecked && isBusinessChecked && isDonationChecked;
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -561,3 +561,10 @@ $button-padding: 8px 32px;
 		}
 	}
 }
+
+.stats-purchase-single__error-msg {
+	color: var(--gray-gray-50);
+	font-style: italic;
+	font-size: $font-body-small;
+	margin-top: 24px;
+}

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -63,5 +63,10 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 				// UTM stats are only available for Jetpack sites for now.
 				isSiteJetpackNotAtomic &&
 				version_greater_than_or_equal( statsAdminVersion, '0.17.0-alpha', isOdysseyStats ) ),
+		supportsOnDemandCommercialClassification: version_greater_than_or_equal(
+			statsAdminVersion,
+			'0.18.0-alpha',
+			isOdysseyStats
+		),
 	};
 }


### PR DESCRIPTION
Related to pejTkB-1cd-p2

## Proposed Changes

* Adds a button `Reverify` which triggers the on-demand commercial classification process
* Adds message to identify whether the process is running or finished - simply used 1 hour delay here to simplify it.
* Uses local storage to store the timestamp to prevent users run multiple time, because the API is already throttled.

## Testing Instructions

* Open Calypso Live
* Find a commercial site / or override its status to commercial
* Open purchase page `/stats/purchase/:siteSlug`
* Check all the boxes
* Click `Reverify`
* Ensure it says `We are verifying your site. Please come back later…`
* Remove `commercial_classification__button_clicked` from local storage
* Refresh and  Click `Reverify`
* Ensure it says `Error: Sorry, a request for this site was already queued. Please, try again later.`
* After an hour (or please tweak line 402 to speed it up)
* Ensure you are given the option to contact support

**Please test Odyssey Stats with https://github.com/Automattic/jetpack/pull/36597 as well **



<img width="496" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/13ae12d6-0541-465c-bf3e-d0675430089d">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?