### PR TITLE
Stats: Roll out compulsory plan selection for 1% of users (Calypso Stats only)

### DIFF
--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -7,9 +7,11 @@ export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: nu
 	) as string;
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
+	const isExistingSampleSite = siteId && siteId % 100 < 1; // Targeting 1% of existing sites
 
 	return {
 		isNewSite,
-		isQualified: isNewSite,
+		isExistingSampleSite,
+		isQualified: isNewSite || isExistingSampleSite,
 	};
 }

--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -1,13 +1,16 @@
+import config from '@automattic/calypso-config';
 import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 
 export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: number | null ) {
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const siteCreatedTimeStamp = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'created_at' )
 	) as string;
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
-	const isExistingSampleSite = siteId && siteId % 100 < 1; // Targeting 1% of existing sites
+	// TODO: remove `isOdyssey` check to release to Odyssey Stats.
+	const isExistingSampleSite = siteId && siteId % 100 < 1 && ! isOdysseyStats; // Targeting 1% of existing sites
 
 	return {
 		isNewSite,

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -53,7 +53,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 
 	const isLoading = ! hasLoadedSitePurchases || isRequestingSitePurchases || isLoadingNotices;
 	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned || supportCommercialUse;
-	const { isQualified } = useSiteComplusoryPlanSelectionQualifiedCheck( siteId );
+	const { isNewSite, isQualified } = useSiteComplusoryPlanSelectionQualifiedCheck( siteId );
 	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
 	const redirectToPurchase =
 		config.isEnabled( 'stats/checkout-flows-v2' ) &&
@@ -84,6 +84,8 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		const queryParams = new URLSearchParams();
 
 		queryParams.set( 'productType', 'commercial' );
+		// `cmp-red` means `compulsory redirection` here.
+		queryParams.set( 'from', `cmp-red${ isNewSite ? '-new-site' : '' }` );
 		if ( currentParams.has( 'irclickid' ) ) {
 			queryParams.set( 'irclickid', currentParams.get( 'irclickid' ) || '' );
 		}


### PR DESCRIPTION
Related: p1HpG7-rsg-p2

## Proposed Changes

* Extends audience by targeting site with ID mod 100 equals 0, which is 1% of all existing sites
* Add `from` param to track users are directed to the purchase page by compulsory redirection

## Testing Instructions

* Find a site whoes ID ends with `0` and which doesn't have any Stats commercial subscription; otherwise you'll need to tweak here:
https://github.com/Automattic/wp-calypso/pull/88932/files#diff-08acb11539336fbe6898d7df1053097dbfacd0cbf03266581040b43a7c629e4fR10
* Open `https://wordpress.com/stats/:siteSlug`
* Ensure you are redirected to the purchase page
* Ensure you can switch product if the site is not commercial
* Ensure you can reverify commercial status by clicking the button
* Wait for an hour or tweak here
https://github.com/Automattic/wp-calypso/blob/36229356776d76c5b7a40c56860a28795ad01b16/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx#L410
* Ensure you click `Contact Support` takes you to the Jetpack support form

**Repeat the steps for a new JN site**
**Repeat the above in Odyssey Stats with bleeding Jetpack plugin**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?