### PR TITLE
A4A: Sites Dashboard - Restore search and filter

### DIFF
--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -15,7 +15,7 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
-		showOnlyFavorites: context.params.filter === 'favorites',
+		showOnlyFavorites: isFavoriteFilter,
 	};
 	const sort = {
 		field: sort_field,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -24,6 +24,7 @@ import SiteTopHeaderButtons from 'calypso/jetpack-cloud/sections/agency-dashboar
 import SitesDataViews from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews';
 import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import {
+	AgencyDashboardFilter,
 	AgencyDashboardFilterMap,
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
@@ -56,7 +57,6 @@ export default function SitesDashboard() {
 	const {
 		selectedSiteUrl,
 		selectedSiteFeature,
-		setSelectedSiteFeature,
 		isFavoriteFilter,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
@@ -94,11 +94,15 @@ export default function SitesDashboard() {
 		layout: {},
 		selectedSite: undefined,
 	} );
+
+	const [ agencyDashboardFilter, setAgencyDashboardFilter ] =
+		useState< AgencyDashboardFilter >( filter );
+
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
-		search,
+		sitesViewState.search,
 		sitesViewState.page,
-		filter,
+		agencyDashboardFilter,
 		sort,
 		sitesViewState.perPage
 	);
@@ -121,9 +125,8 @@ export default function SitesDashboard() {
 		},
 		[ setSitesViewState ]
 	);
-	// Filter selection
-	// Todo: restore this code when the filters are implemented
-	/*useEffect( () => {
+
+	useEffect( () => {
 		if ( isLoading || isError ) {
 			return;
 		}
@@ -132,11 +135,14 @@ export default function SitesDashboard() {
 				const filterType =
 					filtersMap.find( ( filterMap ) => filterMap.ref === filter.value )?.filterType ||
 					'all_issues';
-
 				return filterType;
 			} ) || [];
 
-	}, [ isLoading, isError, sitesViewState.filters, filtersMap ] );*/
+		setAgencyDashboardFilter( {
+			issueTypes: filtersSelected,
+			showOnlyFavorites: isFavoriteFilter,
+		} );
+	}, [ isLoading, isError, sitesViewState.filters, isFavoriteFilter ] );
 
 	useEffect( () => {
 		// If the favorites filter is set, make sure to update the filter and correctly add the is_favorite param to URLs.
@@ -177,7 +183,7 @@ export default function SitesDashboard() {
 		if ( sitesViewState.selectedSite ) {
 			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
 		}
-	}, [ sitesViewState, setSelectedSiteFeature ] );
+	}, [ sitesViewState ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {

--- a/client/a8c-for-agencies/sections/sites/sites-overview-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-overview-provider.tsx
@@ -1,0 +1,71 @@
+import { ReactNode, useState } from 'react';
+import SitesOverviewContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/context';
+import {
+	AgencyDashboardFilterOption,
+	DashboardSortInterface,
+	Site,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+interface Props {
+	path: string;
+	search: string;
+	currentPage: number;
+	filter: { issueTypes: Array< AgencyDashboardFilterOption >; showOnlyFavorites: boolean };
+	sort: DashboardSortInterface;
+	children: ReactNode;
+}
+
+export const SitesOverviewProvider = ( {
+	path,
+	search,
+	currentPage,
+	filter,
+	sort,
+	children,
+}: Props ) => {
+	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
+	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
+	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
+	const [ mostRecentConnectedSite, setMostRecentConnectedSite ] = useState< string | null >( null );
+	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
+
+	const handleSetBulkManagementActive = ( isActive: boolean ) => {
+		setIsBulkManagementActive( isActive );
+		if ( ! isActive ) {
+			setSelectedSites( [] );
+		}
+	};
+
+	const onShowLicenseInfo = ( license: string ) => {
+		setCurrentLicenseInfo( license );
+	};
+
+	const onHideLicenseInfo = () => {
+		setCurrentLicenseInfo( null );
+	};
+
+	const sitesOverviewContextValue = {
+		path,
+		search,
+		currentPage,
+		filter,
+		sort,
+		isBulkManagementActive,
+		setIsBulkManagementActive: handleSetBulkManagementActive,
+		selectedSites,
+		setSelectedSites,
+		currentLicenseInfo,
+		showLicenseInfo: onShowLicenseInfo,
+		hideLicenseInfo: onHideLicenseInfo,
+		mostRecentConnectedSite,
+		setMostRecentConnectedSite,
+		isPopoverOpen,
+		setIsPopoverOpen,
+		showSitesDashboardV2: true,
+	};
+	return (
+		<SitesOverviewContext.Provider value={ sitesOverviewContextValue }>
+			{ children }
+		</SitesOverviewContext.Provider>
+	);
+};


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/112

## Proposed Changes

* This PR restores the search and filtering functionalities of the sites dashboard in A4A.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?