### PR TITLE
Stats: Update mobile highlights on Insights page

### DIFF
--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -1,7 +1,8 @@
+import { ComponentSwapper, CountComparisonCard } from '@automattic/components';
 import { comment, Icon, paragraph, people, postContent, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import CountComparisonCard from './count-comparison-card';
+
 import './style.scss';
 
 type AnnualHighlightCardsProps = {
@@ -18,7 +19,47 @@ type AnnualHighlightCardsProps = {
 	navigation?: React.ReactNode;
 };
 
+function AnnualHighlightsMobile( { counts } ) {
+	console.log( 'AnnualHighlightsMobile' );
+	const translate = useTranslate();
+	return (
+		<div className="highlight-cards-list">
+			<CountComparisonCard
+				heading={ translate( 'Posts' ) }
+				icon={ <Icon icon={ postContent } /> }
+				count={ counts?.posts ?? null }
+				showValueTooltip
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Words' ) }
+				icon={ <Icon icon={ paragraph } /> }
+				count={ counts?.words ?? null }
+				showValueTooltip
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Likes' ) }
+				icon={ <Icon icon={ starEmpty } /> }
+				count={ counts?.likes ?? null }
+				showValueTooltip
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Comments' ) }
+				icon={ <Icon icon={ comment } /> }
+				count={ counts?.comments ?? null }
+				showValueTooltip
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Subscribers' ) }
+				icon={ <Icon icon={ people } /> }
+				count={ counts?.followers ?? null }
+				showValueTooltip
+			/>
+		</div>
+	);
+}
+
 function AnnualHighlightsStandard( { counts } ) {
+	console.log( 'AnnualHighlightsStandard' );
 	const translate = useTranslate();
 	return (
 		<div className="highlight-cards-list">
@@ -87,7 +128,11 @@ export default function AnnualHighlightCards( {
 				{ navigation }
 			</div>
 
-			<AnnualHighlightsStandard counts={ counts } />
+			<ComponentSwapper
+				breakpoint="<660px"
+				breakpointActiveComponent={ <AnnualHighlightsMobile counts={ counts } /> }
+				breakpointInactiveComponent={ <AnnualHighlightsStandard counts={ counts } /> }
+			/>
 		</div>
 	);
 }

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -1,7 +1,9 @@
-import { ComponentSwapper, CountComparisonCard, ShortenedNumber } from '@automattic/components';
 import { comment, Icon, paragraph, people, postContent, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import ComponentSwapper from '../component-swapper';
+import ShortenedNumber from '../number-formatters';
+import CountComparisonCard from './count-comparison-card';
 
 import './style.scss';
 

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -5,21 +5,31 @@ import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
+type AnnualHighlightCounts = {
+	comments: number | null;
+	likes: number | null;
+	posts: number | null;
+	words: number | null;
+	followers: number | null;
+};
+
+type AnnualHighlightsMobileProps = {
+	counts: AnnualHighlightCounts;
+};
+
+type AnnualHighlightsStandardProps = {
+	counts: AnnualHighlightCounts;
+};
+
 type AnnualHighlightCardsProps = {
 	className?: string;
-	counts: {
-		comments: number | null;
-		likes: number | null;
-		posts: number | null;
-		words: number | null;
-		followers: number | null;
-	};
+	counts: AnnualHighlightCounts;
 	titleHref?: string | null;
 	year?: string | number | null;
 	navigation?: React.ReactNode;
 };
 
-function AnnualHighlightsMobile( { counts } ) {
+function AnnualHighlightsMobile( { counts }: AnnualHighlightsMobileProps ) {
 	console.log( 'AnnualHighlightsMobile' );
 	const translate = useTranslate();
 	return (
@@ -58,7 +68,7 @@ function AnnualHighlightsMobile( { counts } ) {
 	);
 }
 
-function AnnualHighlightsStandard( { counts } ) {
+function AnnualHighlightsStandard( { counts }: AnnualHighlightsStandardProps ) {
 	console.log( 'AnnualHighlightsStandard' );
 	const translate = useTranslate();
 	return (

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -30,7 +30,6 @@ type AnnualHighlightCardsProps = {
 };
 
 function AnnualHighlightsMobile( { counts }: AnnualHighlightsMobileProps ) {
-	console.log( 'AnnualHighlightsMobile' );
 	const translate = useTranslate();
 	return (
 		<div className="highlight-cards-list-mobile">
@@ -88,7 +87,6 @@ function AnnualHighlightsMobile( { counts }: AnnualHighlightsMobileProps ) {
 }
 
 function AnnualHighlightsStandard( { counts }: AnnualHighlightsStandardProps ) {
-	console.log( 'AnnualHighlightsStandard' );
 	const translate = useTranslate();
 	return (
 		<div className="highlight-cards-list">

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -18,6 +18,44 @@ type AnnualHighlightCardsProps = {
 	navigation?: React.ReactNode;
 };
 
+function AnnualHighlightsStandard( { counts } ) {
+	const translate = useTranslate();
+	return (
+		<div className="highlight-cards-list">
+			<CountComparisonCard
+				heading={ translate( 'Posts' ) }
+				icon={ <Icon icon={ postContent } /> }
+				count={ counts?.posts ?? null }
+				showValueTooltip
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Words' ) }
+				icon={ <Icon icon={ paragraph } /> }
+				count={ counts?.words ?? null }
+				showValueTooltip
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Likes' ) }
+				icon={ <Icon icon={ starEmpty } /> }
+				count={ counts?.likes ?? null }
+				showValueTooltip
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Comments' ) }
+				icon={ <Icon icon={ comment } /> }
+				count={ counts?.comments ?? null }
+				showValueTooltip
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Subscribers' ) }
+				icon={ <Icon icon={ people } /> }
+				count={ counts?.followers ?? null }
+				showValueTooltip
+			/>
+		</div>
+	);
+}
+
 export default function AnnualHighlightCards( {
 	className,
 	counts,
@@ -49,38 +87,7 @@ export default function AnnualHighlightCards( {
 				{ navigation }
 			</div>
 
-			<div className="highlight-cards-list">
-				<CountComparisonCard
-					heading={ translate( 'Posts' ) }
-					icon={ <Icon icon={ postContent } /> }
-					count={ counts?.posts ?? null }
-					showValueTooltip
-				/>
-				<CountComparisonCard
-					heading={ translate( 'Words' ) }
-					icon={ <Icon icon={ paragraph } /> }
-					count={ counts?.words ?? null }
-					showValueTooltip
-				/>
-				<CountComparisonCard
-					heading={ translate( 'Likes' ) }
-					icon={ <Icon icon={ starEmpty } /> }
-					count={ counts?.likes ?? null }
-					showValueTooltip
-				/>
-				<CountComparisonCard
-					heading={ translate( 'Comments' ) }
-					icon={ <Icon icon={ comment } /> }
-					count={ counts?.comments ?? null }
-					showValueTooltip
-				/>
-				<CountComparisonCard
-					heading={ translate( 'Subscribers' ) }
-					icon={ <Icon icon={ people } /> }
-					count={ counts?.followers ?? null }
-					showValueTooltip
-				/>
-			</div>
+			<AnnualHighlightsStandard counts={ counts } />
 		</div>
 	);
 }

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -1,4 +1,4 @@
-import { ComponentSwapper, CountComparisonCard } from '@automattic/components';
+import { ComponentSwapper, CountComparisonCard, ShortenedNumber } from '@automattic/components';
 import { comment, Icon, paragraph, people, postContent, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -33,37 +33,56 @@ function AnnualHighlightsMobile( { counts }: AnnualHighlightsMobileProps ) {
 	console.log( 'AnnualHighlightsMobile' );
 	const translate = useTranslate();
 	return (
-		<div className="highlight-cards-list">
-			<CountComparisonCard
-				heading={ translate( 'Posts' ) }
-				icon={ <Icon icon={ postContent } /> }
-				count={ counts?.posts ?? null }
-				showValueTooltip
-			/>
-			<CountComparisonCard
-				heading={ translate( 'Words' ) }
-				icon={ <Icon icon={ paragraph } /> }
-				count={ counts?.words ?? null }
-				showValueTooltip
-			/>
-			<CountComparisonCard
-				heading={ translate( 'Likes' ) }
-				icon={ <Icon icon={ starEmpty } /> }
-				count={ counts?.likes ?? null }
-				showValueTooltip
-			/>
-			<CountComparisonCard
-				heading={ translate( 'Comments' ) }
-				icon={ <Icon icon={ comment } /> }
-				count={ counts?.comments ?? null }
-				showValueTooltip
-			/>
-			<CountComparisonCard
-				heading={ translate( 'Subscribers' ) }
-				icon={ <Icon icon={ people } /> }
-				count={ counts?.followers ?? null }
-				showValueTooltip
-			/>
+		<div className="highlight-cards-list-mobile">
+			<div className="highlight-cards-list-mobile__item" key="posts">
+				<span className="highlight-cards-list-mobile__item-icon">
+					<Icon icon={ postContent } />
+				</span>
+				<span className="highlight-cards-list-mobile__item-heading">{ translate( 'Posts' ) }</span>
+				<span className="highlight-cards-list-mobile__item-count">
+					<ShortenedNumber value={ counts?.posts ?? null } />
+				</span>
+			</div>
+			<div className="highlight-cards-list-mobile__item" key="words">
+				<span className="highlight-cards-list-mobile__item-icon">
+					<Icon icon={ paragraph } />
+				</span>
+				<span className="highlight-cards-list-mobile__item-heading">{ translate( 'Words' ) }</span>
+				<span className="highlight-cards-list-mobile__item-count">
+					<ShortenedNumber value={ counts?.words ?? null } />
+				</span>
+			</div>
+			<div className="highlight-cards-list-mobile__item" key="likes">
+				<span className="highlight-cards-list-mobile__item-icon">
+					<Icon icon={ starEmpty } />
+				</span>
+				<span className="highlight-cards-list-mobile__item-heading">{ translate( 'Likes' ) }</span>
+				<span className="highlight-cards-list-mobile__item-count">
+					<ShortenedNumber value={ counts?.likes ?? null } />
+				</span>
+			</div>
+			<div className="highlight-cards-list-mobile__item" key="comments">
+				<span className="highlight-cards-list-mobile__item-icon">
+					<Icon icon={ comment } />
+				</span>
+				<span className="highlight-cards-list-mobile__item-heading">
+					{ translate( 'Comments' ) }
+				</span>
+				<span className="highlight-cards-list-mobile__item-count">
+					<ShortenedNumber value={ counts?.comments ?? null } />
+				</span>
+			</div>
+			<div className="highlight-cards-list-mobile__item" key="subscribers">
+				<span className="highlight-cards-list-mobile__item-icon">
+					<Icon icon={ people } />
+				</span>
+				<span className="highlight-cards-list-mobile__item-heading">
+					{ translate( 'Subscribers' ) }
+				</span>
+				<span className="highlight-cards-list-mobile__item-count">
+					<ShortenedNumber value={ counts?.followers ?? null } />
+				</span>
+			</div>
 		</div>
 	);
 }

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -451,3 +451,40 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		display: none;
 	}
 }
+
+
+.highlight-cards-list-mobile {
+	display: flex;
+	flex-direction: column;
+	row-gap: 16px;
+	margin: 24px;
+
+	.highlight-cards-list-mobile__item {
+		display: flex;
+		align-items: center;
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+		border-radius: 5px; /* stylelint-disable-line scales/radii */
+		background: var( --color-surface );
+		padding: 12px;
+	}
+
+	.highlight-cards-list-mobile__item-heading {
+		font-weight: 500;
+		font-size: 0.875rem;
+		line-height: 20px;
+	}
+	.highlight-cards-list-mobile__item-count {
+		margin-left: auto;
+		font-size: 1.5rem;
+		line-height: 32px;
+
+		font-family: Recoleta, 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
+	}
+	.highlight-cards-list-mobile__item-icon {
+		padding-right: 12px;
+
+		svg {
+			vertical-align: middle;
+		}
+	}
+}

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -462,9 +462,9 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	.highlight-cards-list-mobile__item {
 		display: flex;
 		align-items: center;
-		box-shadow: 0 0 0 1px var( --color-border-subtle );
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
 		border-radius: 5px; /* stylelint-disable-line scales/radii */
-		background: var( --color-surface );
+		background: var(--color-surface);
 		padding: 12px;
 	}
 
@@ -478,7 +478,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		font-size: 1.5rem;
 		line-height: 32px;
 
-		font-family: Recoleta, 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 	}
 	.highlight-cards-list-mobile__item-icon {
 		padding-right: 12px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87375

## Proposed Changes

Adds mobile version of Annual Highlight cards on the Insights page. Implements the cards per this design:

<img width="664" alt="SCR-20240327-nxjv" src="https://github.com/Automattic/wp-calypso/assets/40267301/dd120585-e2a0-48dc-89d8-586c07bd6441">

**Note:** Updated header layout for mobile will come in a follow-up PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live branch.
* Navigate to the **Stats → Insights** page.
* Use the browser tools to test at different screen sizes. iPad mini and larger should get the standard Desktop UI with horizontal scrolling while smaller screens should get the vertically stacked cards.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?