### PR TITLE
Subscriber Imports: Move Gate to a single component

### DIFF
--- a/client/components/subscribers-validation-gate/index.tsx
+++ b/client/components/subscribers-validation-gate/index.tsx
@@ -1,0 +1,32 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC, ReactNode } from 'react';
+import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
+import StagingGate from 'calypso/components/staging-gate';
+import { useSelector } from 'calypso/state';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import type { SiteId } from 'calypso/types';
+
+interface Props {
+	siteId: SiteId | null;
+	children: ReactNode;
+}
+
+const SubscriberValidationGate: FC< Props > = ( { children, siteId } ) => {
+	const translate = useTranslate();
+	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
+
+	return isStagingSite ? (
+		<StagingGate siteId={ siteId }>{ children }</StagingGate>
+	) : (
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		<EmailVerificationGate
+			noticeText={ translate( 'You must verify your email to add subscribers.' ) }
+			noticeStatus="is-warning"
+		>
+			{ children }
+		</EmailVerificationGate>
+	);
+};
+
+export default SubscriberValidationGate;

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -5,15 +5,14 @@ import { useIsEnglishLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
-import { useEffect, useState, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
-import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import StagingGate from 'calypso/components/staging-gate';
+import SubscriberValidationGate from 'calypso/components/subscribers-validation-gate';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import GiftSubscriptionModal from 'calypso/my-sites/subscribers/components/gift-modal/gift-modal';
 import { SubscriberListContainer } from 'calypso/my-sites/subscribers/components/subscriber-list-container';
@@ -180,23 +179,6 @@ const SubscribersPage = ( {
 		setGiftUsername( display_name );
 	};
 
-	const Gate = ( props: { children: ReactNode } ) => {
-		const { children } = props;
-
-		return isStagingSite ? (
-			<StagingGate siteId={ siteId }>{ children }</StagingGate>
-		) : (
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-expect-error
-			<EmailVerificationGate
-				noticeText={ translate( 'You must verify your email to add subscribers.' ) }
-				noticeStatus="is-warning"
-			>
-				{ children }
-			</EmailVerificationGate>
-		);
-	};
-
 	return (
 		<SubscribersPageProvider
 			siteId={ siteId }
@@ -218,7 +200,7 @@ const SubscribersPage = ( {
 					selectedSiteId={ selectedSite?.ID }
 					disableCta={ isUnverified || isStagingSite }
 				/>
-				<Gate>
+				<SubscriberValidationGate siteId={ siteId }>
 					<SubscriberListContainer
 						siteId={ siteId }
 						onClickView={ onClickView }
@@ -246,7 +228,7 @@ const SubscribersPage = ( {
 					) }
 					{ selectedSite && <AddSubscribersModal site={ selectedSite } /> }
 					{ selectedSite && <MigrateSubscribersModal /> }
-				</Gate>
+				</SubscriberValidationGate>
 			</Main>
 		</SubscribersPageProvider>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88861

## Proposed Changes

* Moving the Gate component into a new file so it won't be recognized as a new component when the parent component is rendered.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/subscribers/<site-slug>
* Using one with, staging, unverified, and normals to upload a CSV
* Make sure there's no regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?