### PR TITLE
Automattic for Agencies: Implement Payment Methods pagination

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/context.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/context.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+import type { PaymentMethodOverviewContext as PaymentMethodOverviewContextInterface } from './types';
+
+export const PaymentMethodOverviewContext = createContext< PaymentMethodOverviewContextInterface >(
+	{
+		paging: undefined,
+		setPaging: () => {
+			return undefined;
+		},
+	}
+);

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-delete-card.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-delete-card.ts
@@ -10,7 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import useStoredCards, { getFetchStoredCardsKey } from './use-stored-cards';
+import { getFetchStoredCardsKey } from './use-stored-cards';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
 const NOTIFICATION_DURATION = 3000;
@@ -45,13 +45,8 @@ function useDeleteCardMutation< TContext = unknown >(
 	} );
 }
 
-export function useDeleteCard( card: PaymentMethod ) {
+export function useDeleteCard( card: PaymentMethod, allStoredCards: PaymentMethod[] ) {
 	const [ isDeleteDialogVisible, setIsDeleteDialogVisible ] = useState( false );
-
-	// Fetch the stored cards from the cache if they are available.
-	const {
-		data: { allStoredCards },
-	} = useStoredCards( Infinity );
 
 	const dispatch = useDispatch();
 	const translate = useTranslate();

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards-pagination.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards-pagination.ts
@@ -1,12 +1,12 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useCursorPagination } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
-import { useDispatch } from 'calypso/state';
 
 type Props = {
 	storedCards: PaymentMethod[];
 	enabled: boolean;
 	hasMoreStoredCards: boolean;
+	setPaging: ( paging: { startingAfter: string; endingBefore: string } ) => void;
 };
 
 /**
@@ -38,11 +38,8 @@ export default function useStoredCardsPagination( {
 	storedCards,
 	enabled,
 	hasMoreStoredCards,
+	setPaging,
 }: Props ) {
-	const dispatch = useDispatch();
-
-	const [ paging, setPaging ] = useState( { startingAfter: '', endingBefore: '' } );
-
 	const onPageClickCallback = useCallback(
 		( page: number, direction: 'next' | 'prev' ) => {
 			// Set a cursor for use in pagination.
@@ -56,10 +53,6 @@ export default function useStoredCardsPagination( {
 		hasMoreStoredCards,
 		onPageClickCallback
 	);
-
-	useEffect( () => {
-		// FIXME: Dispatch an action to fetch the next page of stored cards.
-	}, [ dispatch, paging ] );
 
 	return {
 		page,

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards.ts
@@ -4,13 +4,23 @@ import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import formatStoredCards from '../../lib/format-stored-cards';
 
-export const getFetchStoredCardsKey = ( agencyId?: number ) => [ 'a4a-stored-cards', agencyId ];
+interface Paging {
+	startingAfter: string;
+	endingBefore: string;
+}
 
-export default function useStoredCards( staleTime: number = 0 ) {
+export const getFetchStoredCardsKey = ( agencyId?: number, paging?: Paging ) => [
+	'a4a-stored-cards',
+	paging,
+	agencyId,
+];
+
+export default function useStoredCards( paging?: Paging, options?: { staleTime: number } ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: getFetchStoredCardsKey( agencyId ),
+		...options,
+		queryKey: getFetchStoredCardsKey( agencyId, paging ),
 		queryFn: () =>
 			wpcom.req.get(
 				{
@@ -19,12 +29,15 @@ export default function useStoredCards( staleTime: number = 0 ) {
 				},
 				{
 					...( agencyId && { agency_id: agencyId } ),
+					...( paging && {
+						starting_after: paging.startingAfter,
+						ending_before: paging.endingBefore,
+					} ),
 				}
 			),
 		enabled: !! agencyId,
 		select: formatStoredCards,
 		refetchOnWindowFocus: false,
-		staleTime: staleTime,
 		initialData: {
 			items: [],
 			per_page: 0,

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -17,17 +17,21 @@ import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/pay
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { PaymentMethodOverviewContext } from '../context';
 import useStoredCards from '../hooks/use-stored-cards';
 import useStoredCardsPagination from '../hooks/use-stored-cards-pagination';
 import EmptyState from './empty-state';
 import LoadingState from './loading-state';
 import StoredCreditCard from './stored-credit-card';
+import type { StoredCardPaging } from '../types';
 
 import './style.scss';
 
 export default function PaymentMethodOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const [ paging, setPaging ] = useState< StoredCardPaging | undefined >( undefined );
 
 	const {
 		data: {
@@ -39,12 +43,13 @@ export default function PaymentMethodOverview() {
 			hasMoreStoredCards,
 		},
 		isFetching,
-	} = useStoredCards();
+	} = useStoredCards( paging );
 
 	const { page, showPagination, onPageClick } = useStoredCardsPagination( {
 		storedCards: allStoredCards,
 		enabled: ! isFetching,
 		hasMoreStoredCards,
+		setPaging,
 	} );
 
 	const onAddNewCardClick = useCallback( () => {
@@ -58,7 +63,7 @@ export default function PaymentMethodOverview() {
 
 		if ( hasStoredCards ) {
 			return (
-				<>
+				<PaymentMethodOverviewContext.Provider value={ { paging, setPaging } }>
 					<div className="payment-method-overview__stored-cards">
 						{ primaryStoredCard && <StoredCreditCard creditCard={ primaryStoredCard } /> }
 						{ secondaryStoredCards.map( ( card: PaymentMethod, index: number ) => (
@@ -82,7 +87,7 @@ export default function PaymentMethodOverview() {
 							perPage={ pageSize }
 						/>
 					) }
-				</>
+				</PaymentMethodOverviewContext.Provider>
 			);
 		}
 
@@ -94,6 +99,7 @@ export default function PaymentMethodOverview() {
 		onPageClick,
 		page,
 		pageSize,
+		paging,
 		primaryStoredCard,
 		secondaryStoredCards,
 		showPagination,

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
@@ -1,10 +1,11 @@
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useContext, type FunctionComponent } from 'react';
 import { PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
+import { PaymentMethodOverviewContext } from '../../context';
 import useStoredCards from '../../hooks/use-stored-cards';
 import DeletePrimaryCardConfirmation from './delete-primary-confirmation';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
-import type { FunctionComponent } from 'react';
 
 import './style.scss';
 
@@ -25,11 +26,13 @@ const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const { paging } = useContext( PaymentMethodOverviewContext );
+
 	// Fetch the stored cards from the cache if they are available.
 	const {
 		data: { allStoredCards },
 		isFetching,
-	} = useStoredCards( Infinity );
+	} = useStoredCards( paging, { staleTime: Infinity } );
 
 	return (
 		<Dialog

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
@@ -1,10 +1,13 @@
 import { PaymentLogo } from '@automattic/wpcom-checkout';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { PaymentMethodOverviewContext } from '../../context';
 import { useDeleteCard } from '../../hooks/use-delete-card';
 import { useSetAsPrimaryCard } from '../../hooks/use-set-as-primary-card';
+import useStoredCards from '../../hooks/use-stored-cards';
 import StoredCreditCardDeleteDialog from '../stored-credit-card-delete-dialog';
 import CreditCardActions from './credit-card-actions';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
@@ -35,8 +38,16 @@ export default function StoredCreditCard( {
 		: translate( 'Secondary Card' );
 
 	const { isSetAsPrimaryCardPending, setAsPrimaryCard } = useSetAsPrimaryCard();
+
+	const { paging } = useContext( PaymentMethodOverviewContext );
+
+	// Fetch the stored cards from the cache if they are available.
+	const {
+		data: { allStoredCards },
+	} = useStoredCards( paging, { staleTime: Infinity } );
+
 	const { isDeleteDialogVisible, setIsDeleteDialogVisible, handleDelete, isDeleteInProgress } =
-		useDeleteCard( creditCard );
+		useDeleteCard( creditCard, allStoredCards );
 
 	const dispatch = useDispatch();
 	const cardActions = [

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/style.scss
@@ -82,14 +82,14 @@
 		pointer-events: none;
 	}
 
-	.payment-method-overview__pagination--has-prev {
+	&.payment-method-overview__pagination--has-prev {
 		.pagination__list-item.is-left {
 			opacity: 1;
 			pointer-events: initial;
 		}
 	}
 
-	.payment-method-overview__pagination--has-next {
+	&.payment-method-overview__pagination--has-next {
 		.pagination__list-item.is-right {
 			opacity: 1;
 			pointer-events: initial;

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/types.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/types.ts
@@ -1,0 +1,8 @@
+export interface StoredCardPaging {
+	startingAfter: string;
+	endingBefore: string;
+}
+export interface PaymentMethodOverviewContext {
+	paging?: StoredCardPaging;
+	setPaging: ( paging: { startingAfter: string; endingBefore: string } ) => void;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/308

## Proposed Changes

This PR implements Pagination for the A4A Payment Methods page. Also includes some refactoring to the code that is needed for the pagination to work.

<img width="1583" alt="Screenshot 2024-03-27 at 2 17 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f05abc21-8de4-481d-9c7f-e23dea56e3a3">

## Testing Instructions

NOTE: there is an existing issue with the pagination API that always returns the first page data when clicked on `Previous`. We will not be fixing it now as this issue will be there only if a user has more than 60 cards as the pagination per-page size is currently set to 30.

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Follow the instructions here to test this easily: 33f5c-pb
- Click on Purchases > Click on Payment Methods > Add a payment method if you haven't added earlier.
- Verify you can see the Next button when there is more than 1 page > Click the `Next` button and verify that you can now see the `Previous` button is enabled. Click the previous button and verify that the items are loaded as expected. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?