### PR TITLE
A4A: Remove WPCOM hosting option.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -31,9 +31,7 @@ export default function HostingList( { selectedSite }: Props ) {
 		[ pressablePlans ]
 	);
 
-	const cheapestWPCOMPlan = cheapestPressablePlan
-		? { ...cheapestPressablePlan, family_slug: 'wpcom-hosting' }
-		: null; // FIXME: Need to fetch from API
+	const cheapestWPCOMPlan = null; // FIXME: Need to fetch from API
 
 	const onProductSearch = useCallback(
 		( value: string ) => {


### PR DESCRIPTION
This PR removes the option for WPCOM Hosting on the Hosting page since we don't have a design for the WPCOM page yet.

**Before**
<img width="1598" alt="Screenshot 2024-03-27 at 6 22 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/3bc5bd08-6209-4c02-afb7-33e87aa6d58d">
**After**
<img width="1604" alt="Screenshot 2024-03-27 at 6 22 42 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4071df4d-470b-4610-99d5-12c62a4382b4">


## Proposed Changes

* Remove the temporary hack to force the WPCOM hosting option to show up.

## Testing Instructions


* Use the live link below and go to `/marketplace/hosting`.
* Confirm that the WPCOM option is not available and only Pressable hosting is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
