### PR TITLE
Add wpcomstaging to allowed origin

### DIFF
--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -538,7 +538,8 @@ function isAllowedOrigin( urlOrigin ) {
 	return (
 		wpcomAllowedOrigins.includes( urlOrigin ) ||
 		/^https:\/\/[a-z0-9-]+\.calypso\.live$/.test( urlOrigin ) ||
-		/^https:\/\/([a-z0-9-]+\.)+wordpress\.com$/.test( urlOrigin )
+		/^https:\/\/([a-z0-9-]+\.)+wordpress\.com$/.test( urlOrigin ) ||
+		/^https:\/\/([a-z0-9-]+\.)+wpcomstaging\.com$/.test( urlOrigin )
 	);
 }
 


### PR DESCRIPTION
## Proposed Changes

* Add wpcomstaging to allowed origin

This is useful so that requests coming from blog.wpcomstaging.com can be routed to the public-api

## Testing Instructions

- Run a site that is staging.
- Verify the API calls are being routed to the public-api

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
