### PR TITLE
A4A: Add (reactivate) the filter/search/sort functionalities with the A4A SitesDashboard context

### DIFF
--- a/client/a8c-for-agencies/sections/sites/constants.ts
+++ b/client/a8c-for-agencies/sections/sites/constants.ts
@@ -1,1 +1,29 @@
+import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import { AgencyDashboardFilterMap } from './types';
+
 export const A4A_SITES_DASHBOARD_DEFAULT_CATEGORY = 'overview';
+
+export const filtersMap: AgencyDashboardFilterMap[] = [
+	{ filterType: 'all_issues', ref: 1 },
+	{ filterType: 'backup_failed', ref: 2 },
+	{ filterType: 'backup_warning', ref: 3 },
+	{ filterType: 'threats_found', ref: 4 },
+	{ filterType: 'site_disconnected', ref: 5 },
+	{ filterType: 'site_down', ref: 6 },
+	{ filterType: 'plugin_updates', ref: 7 },
+];
+
+export const initialSitesViewState: SitesViewState = {
+	type: 'table',
+	perPage: 50,
+	page: 1,
+	sort: {
+		field: 'url',
+		direction: 'desc',
+	},
+	search: '',
+	filters: [],
+	hiddenFields: [ 'status' ],
+	layout: {},
+	selectedSite: undefined,
+};

--- a/client/a8c-for-agencies/sections/sites/constants.ts
+++ b/client/a8c-for-agencies/sections/sites/constants.ts
@@ -1,7 +1,9 @@
 import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import { JETPACK_BOOST_ID } from './features/features';
 import { AgencyDashboardFilterMap } from './types';
 
 export const A4A_SITES_DASHBOARD_DEFAULT_CATEGORY = 'overview';
+export const A4A_SITES_DASHBOARD_DEFAULT_FEATURE = JETPACK_BOOST_ID;
 
 export const filtersMap: AgencyDashboardFilterMap[] = [
 	{ filterType: 'all_issues', ref: 1 },

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -35,7 +35,7 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
 			}
 			path={ context.path }
-			search={ search }
+			searchInitialState={ search }
 			currentPage={ currentPage }
 			issueTypes={ issue_types }
 			sort={ sort }

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -19,10 +19,6 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 		is_favorite,
 	} = context.query;
 
-	const filter = {
-		issueTypes: issue_types?.split( ',' ),
-		showOnlyFavorites: is_favorite === '' || is_favorite === '1' || is_favorite === 'true',
-	};
 	const sort = {
 		field: sort_field,
 		direction: sort_direction,
@@ -35,10 +31,13 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 			siteUrlInitialState={ siteUrl }
 			siteFeatureInitialState={ siteFeature }
 			hideListingInitialState={ hideListingInitialState }
+			showOnlyFavoritesInitialState={
+				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
+			}
 			path={ context.path }
 			search={ search }
 			currentPage={ currentPage }
-			filter={ filter }
+			issueTypes={ issue_types }
 			sort={ sort }
 			showSitesDashboardV2={ true }
 		>

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -21,7 +21,7 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
-		showOnlyFavorites: is_favorite === true || is_favorite === '',
+		showOnlyFavorites: is_favorite === '' || is_favorite === '1' || is_favorite === 'true',
 	};
 	const sort = {
 		field: sort_field,

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -1,13 +1,17 @@
 import { Context, type Callback } from '@automattic/calypso-router';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import SitesSidebar from '../../components/sidebar-menu/sites';
+import {
+	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
+	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
+} from './constants';
 import SitesDashboard from './sites-dashboard';
 import { SitesDashboardProvider } from './sites-dashboard-provider';
 
 function configureSitesContext( context: Context ) {
-	const category = context.params.category;
+	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;
 	const siteUrl = context.params.siteUrl;
-	const siteFeature = context.params.feature;
+	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
 	const hideListingInitialState = !! siteUrl;
 
 	const {
@@ -35,7 +39,7 @@ function configureSitesContext( context: Context ) {
 				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
 			}
 			path={ context.path }
-			searchInitialState={ search }
+			searchQuery={ search }
 			currentPage={ currentPage }
 			issueTypes={ issue_types }
 			sort={ sort }

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -9,13 +9,19 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature;
 	const hideListingInitialState = !! siteUrl;
-	const queryParams = new URLSearchParams( context.querystring );
-	const isFavoriteFilter = queryParams.get( 'is_favorite' ) !== null;
 
-	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;
+	const {
+		s: search,
+		page: contextPage,
+		issue_types,
+		sort_field,
+		sort_direction,
+		is_favorite,
+	} = context.query;
+
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
-		showOnlyFavorites: context.params.filter === 'favorites',
+		showOnlyFavorites: is_favorite === true || is_favorite === '',
 	};
 	const sort = {
 		field: sort_field,
@@ -35,7 +41,6 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 			filter={ filter }
 			sort={ sort }
 			showSitesDashboardV2={ true }
-			isFavoriteFilterInitialState={ isFavoriteFilter }
 		>
 			<SitesDashboard />
 		</SitesDashboardProvider>

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -4,7 +4,7 @@ import SitesSidebar from '../../components/sidebar-menu/sites';
 import SitesDashboard from './sites-dashboard';
 import { SitesDashboardProvider } from './sites-dashboard-provider';
 
-function configureSitesContext( isFavorites: boolean, context: Context ) {
+function configureSitesContext( context: Context ) {
 	const category = context.params.category;
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature;
@@ -52,6 +52,6 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 }
 
 export const sitesContext: Callback = ( context, next ) => {
-	configureSitesContext( false, context );
+	configureSitesContext( context );
 	next();
 };

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -11,6 +11,7 @@ import {
 } from 'calypso/a8c-for-agencies/sections/sites/features/features';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { useJetpackAgencyDashboardRecordTrackEvent } from 'calypso/jetpack-cloud/sections/agency-dashboard/hooks';
+import { A4A_SITES_DASHBOARD_DEFAULT_FEATURE } from '../../constants';
 import SitePreviewPane, { createFeaturePreview } from '../../site-preview-pane';
 import { PreviewPaneProps } from '../../site-preview-pane/types';
 import { JetpackActivityPreview } from './activity';
@@ -42,7 +43,7 @@ export function JetpackPreviewPane( {
 
 	useEffect( () => {
 		if ( selectedSiteFeature === undefined ) {
-			setSelectedSiteFeature( JETPACK_BOOST_ID );
+			setSelectedSiteFeature( A4A_SITES_DASHBOARD_DEFAULT_FEATURE );
 		}
 		return () => {
 			setSelectedSiteFeature( undefined );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -25,7 +25,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 
 	currentPage: 1,
 	path: '',
-	search: '',
 	isBulkManagementActive: false,
 	showSitesDashboardV2: false,
 	setIsBulkManagementActive: () => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+import { initialSitesViewState } from './constants';
 import type { SitesDashboardContextInterface } from './types';
 
 const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
@@ -13,6 +14,11 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 
 	hideListing: undefined,
 	setHideListing: () => {},
+
+	sitesViewState: initialSitesViewState,
+	setSitesViewState: () => {
+		return undefined;
+	},
 
 	currentPage: 1,
 	path: '',

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -42,10 +42,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	setIsPopoverOpen: () => {
 		return undefined;
 	},
-	isFavoriteFilter: false,
-	setIsFavoriteFilter: () => {
-		return undefined;
-	},
 	sort: {
 		field: 'url',
 		direction: 'asc',

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -15,6 +15,9 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	hideListing: undefined,
 	setHideListing: () => {},
 
+	showOnlyFavorites: undefined,
+	setShowOnlyFavorites: () => {},
+
 	sitesViewState: initialSitesViewState,
 	setSitesViewState: () => {
 		return undefined;
@@ -23,7 +26,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	currentPage: 1,
 	path: '',
 	search: '',
-	filter: { issueTypes: [], showOnlyFavorites: false },
 	isBulkManagementActive: false,
 	showSitesDashboardV2: false,
 	setIsBulkManagementActive: () => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -6,9 +6,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	selectedCategory: undefined,
 	setSelectedCategory: () => {},
 
-	selectedSiteUrl: undefined,
-	setSelectedSiteUrl: () => {},
-
 	selectedSiteFeature: undefined,
 	setSelectedSiteFeature: () => {},
 
@@ -23,6 +20,7 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 		return undefined;
 	},
 
+	initialSelectedSiteUrl: '',
 	currentPage: 1,
 	path: '',
 	isBulkManagementActive: false,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -13,7 +13,7 @@ interface Props {
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
-	searchInitialState: string;
+	searchQuery: string;
 	children: ReactNode;
 	path: string;
 	issueTypes: string;
@@ -30,14 +30,13 @@ export const SitesDashboardProvider = ( {
 	siteFeatureInitialState,
 	children,
 	path,
-	searchInitialState,
+	searchQuery,
 	issueTypes,
 	currentPage,
 	sort,
 }: Props ) => {
 	const [ hideListing, setHideListing ] = useState( hideListingInitialState );
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
-	const [ selectedSiteUrl, setSelectedSiteUrl ] = useState( siteUrlInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
 	const [ showOnlyFavorites, setShowOnlyFavorites ] = useState( showOnlyFavoritesInitialState );
 	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
@@ -45,6 +44,7 @@ export const SitesDashboardProvider = ( {
 	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
 	const [ mostRecentConnectedSite, setMostRecentConnectedSite ] = useState< string | null >( null );
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
+	const [ initialSelectedSiteUrl, setInitialSelectedSiteUrl ] = useState( siteUrlInitialState );
 
 	const handleSetBulkManagementActive = ( isActive: boolean ) => {
 		setIsBulkManagementActive( isActive );
@@ -64,10 +64,16 @@ export const SitesDashboardProvider = ( {
 	const [ sitesViewState, setSitesViewState ] = useState< SitesViewState >( {
 		...initialSitesViewState,
 		page: currentPage,
-		search: searchInitialState,
+		search: searchQuery,
 	} );
 
 	useEffect( () => {
+		setInitialSelectedSiteUrl( siteUrlInitialState );
+		if ( ! siteUrlInitialState ) {
+			setShowOnlyFavorites( () => showOnlyFavoritesInitialState );
+			setHideListing( false );
+		}
+
 		const issueTypesArray = issueTypes?.split( ',' );
 
 		setSitesViewState( ( previousState ) => ( {
@@ -80,24 +86,22 @@ export const SitesDashboardProvider = ( {
 						value: filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref || 1,
 					};
 				} ) || [],
+			search: searchQuery,
+			...( siteUrlInitialState ? {} : { selectedSite: undefined } ),
+			...( siteUrlInitialState ? {} : { type: 'table' } ),
 		} ) );
-	}, [ issueTypes ] );
-
-	useEffect( () => {
-		setShowOnlyFavorites( () => showOnlyFavoritesInitialState );
-
-		setSitesViewState( ( previousState ) => ( {
-			...previousState,
-			filters: [],
-			search: '',
-		} ) );
-	}, [ showOnlyFavoritesInitialState ] );
+	}, [
+		setSitesViewState,
+		showOnlyFavoritesInitialState,
+		searchQuery,
+		issueTypes,
+		siteUrlInitialState,
+		setInitialSelectedSiteUrl,
+	] );
 
 	const sitesDashboardContextValue = {
 		selectedCategory: selectedCategory,
 		setSelectedCategory: setSelectedCategory,
-		selectedSiteUrl: selectedSiteUrl,
-		setSelectedSiteUrl: setSelectedSiteUrl,
 		selectedSiteFeature: selectedSiteFeature,
 		setSelectedSiteFeature: setSelectedSiteFeature,
 		hideListing: hideListing,
@@ -108,6 +112,7 @@ export const SitesDashboardProvider = ( {
 		currentPage,
 		sort,
 		isBulkManagementActive,
+		initialSelectedSiteUrl: initialSelectedSiteUrl,
 		setIsBulkManagementActive: handleSetBulkManagementActive,
 		selectedSites,
 		setSelectedSites,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -13,9 +13,9 @@ interface Props {
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
+	searchInitialState: string;
 	children: ReactNode;
 	path: string;
-	search: string;
 	issueTypes: string;
 	currentPage: number;
 	sort: DashboardSortInterface;
@@ -30,7 +30,7 @@ export const SitesDashboardProvider = ( {
 	siteFeatureInitialState,
 	children,
 	path,
-	search,
+	searchInitialState,
 	issueTypes,
 	currentPage,
 	sort,
@@ -64,7 +64,7 @@ export const SitesDashboardProvider = ( {
 	const [ sitesViewState, setSitesViewState ] = useState< SitesViewState >( {
 		...initialSitesViewState,
 		page: currentPage,
-		search: search,
+		search: searchInitialState,
 	} );
 
 	useEffect( () => {
@@ -89,6 +89,7 @@ export const SitesDashboardProvider = ( {
 		setSitesViewState( ( previousState ) => ( {
 			...previousState,
 			filters: [],
+			search: '',
 		} ) );
 	}, [ showOnlyFavoritesInitialState ] );
 
@@ -104,7 +105,6 @@ export const SitesDashboardProvider = ( {
 		showOnlyFavorites: showOnlyFavorites,
 		setShowOnlyFavorites: setShowOnlyFavorites,
 		path,
-		search,
 		currentPage,
 		sort,
 		isBulkManagementActive,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,9 +1,11 @@
 import { ReactNode, useState } from 'react';
+import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import {
 	AgencyDashboardFilterOption,
 	DashboardSortInterface,
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { filtersMap, initialSitesViewState } from './constants';
 import SitesDashboardContext from './sites-dashboard-context';
 
 interface Props {
@@ -57,6 +59,20 @@ export const SitesDashboardProvider = ( {
 		setCurrentLicenseInfo( null );
 	};
 
+	const [ sitesViewState, setSitesViewState ] = useState< SitesViewState >( {
+		...initialSitesViewState,
+		page: currentPage,
+		search: search,
+		filters:
+			filter?.issueTypes?.map( ( issueType ) => {
+				return {
+					field: 'status',
+					operator: 'in',
+					value: filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref || 1,
+				};
+			} ) || [],
+	} );
+
 	const sitesDashboardContextValue = {
 		selectedCategory: selectedCategory,
 		setSelectedCategory: setSelectedCategory,
@@ -82,6 +98,8 @@ export const SitesDashboardProvider = ( {
 		setMostRecentConnectedSite,
 		isPopoverOpen,
 		setIsPopoverOpen,
+		sitesViewState,
+		setSitesViewState,
 		showSitesDashboardV2: true,
 	};
 	return (

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import {
 	AgencyDashboardFilterOption,
 	DashboardSortInterface,
@@ -11,7 +11,6 @@ interface Props {
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
-	isFavoriteFilterInitialState: boolean;
 	children: ReactNode;
 	path: string;
 	search: string;
@@ -26,7 +25,6 @@ export const SitesDashboardProvider = ( {
 	categoryInitialState,
 	siteUrlInitialState,
 	siteFeatureInitialState,
-	isFavoriteFilterInitialState,
 	children,
 	path,
 	search,
@@ -38,8 +36,6 @@ export const SitesDashboardProvider = ( {
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteUrl, setSelectedSiteUrl ] = useState( siteUrlInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
-	const [ isFavoriteFilter, setIsFavoriteFilter ] = useState( isFavoriteFilterInitialState );
-
 	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
 	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
 	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
@@ -60,10 +56,6 @@ export const SitesDashboardProvider = ( {
 	const onHideLicenseInfo = () => {
 		setCurrentLicenseInfo( null );
 	};
-
-	useEffect( () => {
-		setIsFavoriteFilter( isFavoriteFilterInitialState );
-	}, [ isFavoriteFilterInitialState ] );
 
 	const sitesDashboardContextValue = {
 		selectedCategory: selectedCategory,
@@ -90,8 +82,6 @@ export const SitesDashboardProvider = ( {
 		setMostRecentConnectedSite,
 		isPopoverOpen,
 		setIsPopoverOpen,
-		isFavoriteFilter,
-		setIsFavoriteFilter,
 		showSitesDashboardV2: true,
 	};
 	return (

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters.tsx
@@ -1,0 +1,14 @@
+import { Filter } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import { filtersMap } from '../constants';
+
+export function getSelectedFilters( filters: Filter[] ) {
+	return (
+		filters?.map( ( filter ) => {
+			const filterType =
+				filtersMap.find( ( filterMap ) => filterMap.ref === filter.value )?.filterType ||
+				'all_issues';
+
+			return filterType;
+		} ) || []
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -139,6 +139,33 @@ export default function SitesDashboard() {
 
 	}, [ isLoading, isError, sitesViewState.filters, filtersMap ] );*/
 
+	// Build the query string with the search, page, sort, filter, etc.
+	const buildQueryString = useCallback( () => {
+		const urlQuery = new URLSearchParams();
+		if ( search ) {
+			urlQuery.set( 's', search );
+		}
+		if ( currentPage > 1 ) {
+			urlQuery.set( 'page', currentPage.toString() );
+		}
+		if ( sort.field && sort.field !== 'url' ) {
+			urlQuery.set( 'sort_field', sort.field );
+		}
+		if ( sort.direction && sort.direction !== 'asc' ) {
+			urlQuery.set( 'sort_direction', sort.direction );
+		}
+		if ( filter.showOnlyFavorites ) {
+			urlQuery.set( 'is_favorite', '' );
+		}
+		if ( filter.issueTypes && filter.issueTypes.length > 0 ) {
+			urlQuery.set( 'issue_types', filter.issueTypes.join( ',' ) );
+		}
+
+		const queryString = urlQuery.toString();
+
+		return queryString ? `?${ queryString }` : '';
+	}, [ search, currentPage, sort, filter ] );
+
 	useEffect( () => {
 		// If the favorites filter is set, make sure to update the filter and correctly add the is_favorite param to URLs.
 		filter.showOnlyFavorites = isFavoriteFilter;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import React, { useContext, useEffect, useState, useCallback } from 'react';
+import React, { useContext, useEffect, useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
@@ -22,31 +22,18 @@ import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboar
 import SiteTopHeaderButtons from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons';
 import SitesDataViews from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews';
 import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
-import {
-	AgencyDashboardFilterMap,
-	Site,
-} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { useDispatch, useSelector } from 'calypso/state';
 import { updateDashboardURLQueryArgs } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { A4A_SITES_DASHBOARD_DEFAULT_CATEGORY } from '../constants';
+import { A4A_SITES_DASHBOARD_DEFAULT_CATEGORY, filtersMap } from '../constants';
 import SitesDashboardContext from '../sites-dashboard-context';
 import SiteNotifications from '../sites-notifications';
 
 import './style.scss';
-
-const filtersMap: AgencyDashboardFilterMap[] = [
-	{ filterType: 'all_issues', ref: 1 },
-	{ filterType: 'backup_failed', ref: 2 },
-	{ filterType: 'backup_warning', ref: 3 },
-	{ filterType: 'threats_found', ref: 4 },
-	{ filterType: 'site_disconnected', ref: 5 },
-	{ filterType: 'site_down', ref: 6 },
-	{ filterType: 'plugin_updates', ref: 7 },
-];
 
 export default function SitesDashboard() {
 	useQueryJetpackPartnerPortalPartner();
@@ -54,6 +41,8 @@ export default function SitesDashboard() {
 	const dispatch = useDispatch();
 
 	const {
+		sitesViewState,
+		setSitesViewState,
 		selectedSiteUrl,
 		selectedSiteFeature,
 		setSelectedSiteFeature,
@@ -74,28 +63,6 @@ export default function SitesDashboard() {
 		refetch: refetchContacts,
 		isError: fetchContactFailed,
 	} = useFetchMonitorVerfiedContacts( isPartnerOAuthTokenLoaded );
-
-	const [ sitesViewState, setSitesViewState ] = useState< SitesViewState >( {
-		type: 'table',
-		perPage: 50,
-		page: currentPage,
-		sort: {
-			field: 'url',
-			direction: 'desc',
-		},
-		search: search,
-		filters:
-			filter?.issueTypes?.map( ( issueType ) => {
-				return {
-					field: 'status',
-					operator: 'in',
-					value: filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref || 1,
-				};
-			} ) || [],
-		hiddenFields: [ 'status' ],
-		layout: {},
-		selectedSite: undefined,
-	} );
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -61,6 +61,7 @@ export default function SitesDashboard() {
 		sitesViewState,
 		setSitesViewState,
 		selectedSiteUrl,
+		setSelectedSiteUrl,
 		selectedSiteFeature,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
@@ -204,8 +205,9 @@ export default function SitesDashboard() {
 	const closeSitePreviewPane = useCallback( () => {
 		if ( sitesViewState.selectedSite ) {
 			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
+			setSelectedSiteUrl( '' );
 		}
-	}, [ sitesViewState, setSitesViewState ] );
+	}, [ sitesViewState, setSitesViewState, setSelectedSiteUrl ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -27,6 +27,7 @@ import {
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { useDispatch, useSelector } from 'calypso/state';
+import { updateDashboardURLQueryArgs } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
@@ -124,8 +125,7 @@ export default function SitesDashboard() {
 		[ setSitesViewState ]
 	);
 	// Filter selection
-	// Todo: restore this code when the filters are implemented
-	/*useEffect( () => {
+	useEffect( () => {
 		if ( isLoading || isError ) {
 			return;
 		}
@@ -138,7 +138,16 @@ export default function SitesDashboard() {
 				return filterType;
 			} ) || [];
 
-	}, [ isLoading, isError, sitesViewState.filters, filtersMap ] );*/
+		updateDashboardURLQueryArgs( { filter: filtersSelected || [] } );
+	}, [ isLoading, isError, sitesViewState.filters ] ); // filtersMap omitted as dependency due to rendering loop and continuous console errors, even if wrapped in useMemo.
+
+	// Search query
+	useEffect( () => {
+		if ( isLoading || isError ) {
+			return;
+		}
+		updateDashboardURLQueryArgs( { search: sitesViewState.search } );
+	}, [ isLoading, isError, sitesViewState.search ] );
 
 	// Build the query string with the search, page, sort, filter, etc.
 	const buildQueryString = useCallback( () => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -68,6 +68,8 @@ export default function SitesDashboard() {
 		currentPage,
 		sort,
 		showOnlyFavorites,
+		hideListing,
+		setHideListing,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
@@ -206,8 +208,9 @@ export default function SitesDashboard() {
 		if ( sitesViewState.selectedSite ) {
 			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
 			setSelectedSiteUrl( '' );
+			setHideListing( false );
 		}
-	}, [ sitesViewState, setSitesViewState, setSelectedSiteUrl ] );
+	}, [ sitesViewState, setSitesViewState, setSelectedSiteUrl, setHideListing ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {
@@ -243,48 +246,50 @@ export default function SitesDashboard() {
 			withBorder={ ! sitesViewState.selectedSite }
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 		>
-			<LayoutColumn className="sites-overview" wide>
-				<LayoutTop withNavigation>
-					<LayoutHeader>
-						<Title>{ translate( 'Sites' ) }</Title>
-						<Actions>
-							{ /* TODO: This component is from Jetpack Manage and it was not ported yet, just using it here as a placeholder, it looks broken but it is enough for our purposes at the moment. */ }
-							<SiteTopHeaderButtons />
-						</Actions>
-					</LayoutHeader>
-					<LayoutNavigation { ...selectedItemProps }>
-						<NavigationTabs { ...selectedItemProps } items={ navItems } />
-					</LayoutNavigation>
-				</LayoutTop>
+			{ ! hideListing && (
+				<LayoutColumn className="sites-overview" wide>
+					<LayoutTop withNavigation>
+						<LayoutHeader>
+							<Title>{ translate( 'Sites' ) }</Title>
+							<Actions>
+								{ /* TODO: This component is from Jetpack Manage and it was not ported yet, just using it here as a placeholder, it looks broken but it is enough for our purposes at the moment. */ }
+								<SiteTopHeaderButtons />
+							</Actions>
+						</LayoutHeader>
+						<LayoutNavigation { ...selectedItemProps }>
+							<NavigationTabs { ...selectedItemProps } items={ navItems } />
+						</LayoutNavigation>
+					</LayoutTop>
 
-				<SiteNotifications />
+					<SiteNotifications />
 
-				<DashboardDataContext.Provider
-					value={ {
-						verifiedContacts: {
-							emails: verifiedContacts?.emails ?? [],
-							phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
-							refetchIfFailed: () => {
-								if ( fetchContactFailed ) {
-									refetchContacts();
-								}
-								return;
+					<DashboardDataContext.Provider
+						value={ {
+							verifiedContacts: {
+								emails: verifiedContacts?.emails ?? [],
+								phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+								refetchIfFailed: () => {
+									if ( fetchContactFailed ) {
+										refetchContacts();
+									}
+									return;
+								},
 							},
-						},
-						products: products ?? [],
-						isLargeScreen: isLargeScreen || false,
-					} }
-				>
-					<SitesDataViews
-						className="sites-overview__content"
-						data={ data }
-						isLoading={ isLoading }
-						isLargeScreen={ isLargeScreen || false }
-						onSitesViewChange={ onSitesViewChange }
-						sitesViewState={ sitesViewState }
-					/>
-				</DashboardDataContext.Provider>
-			</LayoutColumn>
+							products: products ?? [],
+							isLargeScreen: isLargeScreen || false,
+						} }
+					>
+						<SitesDataViews
+							className="sites-overview__content"
+							data={ data }
+							isLoading={ isLoading }
+							isLargeScreen={ isLargeScreen || false }
+							onSitesViewChange={ onSitesViewChange }
+							sitesViewState={ sitesViewState }
+						/>
+					</DashboardDataContext.Provider>
+				</LayoutColumn>
+			) }
 
 			{ sitesViewState.selectedSite && (
 				<LayoutColumn className="site-preview-pane" wide>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -185,7 +185,7 @@ export default function SitesDashboard() {
 			url += `/${ category }`;
 		}
 
-		page.replace( url + queryString );
+		page.replace( url + queryString, null, false, false );
 
 		if ( sitesViewState.selectedSite ) {
 			dispatch( setSelectedSiteId( sitesViewState.selectedSite.blog_id ) );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -156,7 +156,7 @@ export default function SitesDashboard() {
 			urlQuery.set( 'sort_direction', sort.direction );
 		}
 		if ( filter.showOnlyFavorites ) {
-			urlQuery.set( 'is_favorite', '' );
+			urlQuery.set( 'is_favorite', 'true' );
 		}
 		if ( filter.issueTypes && filter.issueTypes.length > 0 ) {
 			urlQuery.set( 'issue_types', filter.issueTypes.join( ',' ) );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -18,7 +18,6 @@ import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features
 import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
-import SitesOverviewContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/context';
 import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
 import SiteTopHeaderButtons from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons';
 import SitesDataViews from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews';
@@ -57,16 +56,18 @@ export default function SitesDashboard() {
 		selectedSiteUrl,
 		selectedSiteFeature,
 		setSelectedSiteFeature,
-		isFavoriteFilter,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
+		search,
+		currentPage,
+		filter,
+		sort,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 	const { data: products } = useProductsQuery();
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
-	// eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-	const { search, currentPage, filter, sort } = useContext( SitesOverviewContext );
+
 	const {
 		data: verifiedContacts,
 		refetch: refetchContacts,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -30,7 +30,6 @@ import {
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { useDispatch, useSelector } from 'calypso/state';
-import { updateDashboardURLQueryArgs } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
@@ -65,7 +64,6 @@ export default function SitesDashboard() {
 		selectedSiteFeature,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
-		search,
 		currentPage,
 		sort,
 		showOnlyFavorites,
@@ -97,7 +95,7 @@ export default function SitesDashboard() {
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
-		search,
+		sitesViewState.search,
 		sitesViewState.page,
 		agencyDashboardFilter,
 		sort,
@@ -136,21 +134,13 @@ export default function SitesDashboard() {
 		[ setSitesViewState ]
 	);
 
-	// Search query
-	useEffect( () => {
-		if ( isLoading || isError ) {
-			return;
-		}
-		updateDashboardURLQueryArgs( { search: sitesViewState.search } );
-	}, [ isLoading, isError, sitesViewState.search ] );
-
 	// Build the query string with the search, page, sort, filter, etc.
 	const buildQueryString = useCallback( () => {
 		const urlQuery = new URLSearchParams();
 		const selectedFilters = getSelectedFilters( sitesViewState.filters );
 
-		if ( search ) {
-			urlQuery.set( 's', search );
+		if ( sitesViewState.search ) {
+			urlQuery.set( 's', sitesViewState.search );
 		}
 		if ( currentPage > 1 ) {
 			urlQuery.set( 'page', currentPage.toString() );
@@ -173,7 +163,7 @@ export default function SitesDashboard() {
 		return queryString ? `?${ queryString }` : '';
 	}, [
 		sitesViewState.filters,
-		search,
+		sitesViewState.search,
 		currentPage,
 		sort.field,
 		sort.direction,
@@ -183,7 +173,6 @@ export default function SitesDashboard() {
 	useEffect( () => {
 		// Build the query string
 		const queryString = buildQueryString();
-
 		let url = '/sites';
 
 		// We need a category in the URL if we have a selected site

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -74,7 +74,13 @@ export default function SitesDashboard() {
 	);
 
 	useEffect( () => {
-		if ( ! isLoading && ! isError && data && selectedSiteUrl ) {
+		if (
+			! isLoading &&
+			! isError &&
+			data &&
+			selectedSiteUrl &&
+			sitesViewState.selectedSite?.url !== selectedSiteUrl
+		) {
 			const site = data.sites.find( ( site: Site ) => site.url === selectedSiteUrl );
 
 			setSitesViewState( ( prevState ) => ( {
@@ -83,7 +89,14 @@ export default function SitesDashboard() {
 				type: 'list',
 			} ) );
 		}
-	}, [ data, isError, isLoading, selectedSiteUrl ] );
+	}, [
+		data,
+		isError,
+		isLoading,
+		selectedSiteUrl,
+		setSitesViewState,
+		sitesViewState.selectedSite?.url,
+	] );
 
 	const onSitesViewChange = useCallback(
 		( sitesViewData: SitesViewState ) => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -95,6 +95,7 @@ export default function SitesDashboard() {
 		layout: {},
 		selectedSite: undefined,
 	} );
+
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
 		search,
@@ -167,38 +168,36 @@ export default function SitesDashboard() {
 	}, [ search, currentPage, sort, filter ] );
 
 	useEffect( () => {
-		// If the favorites filter is set, make sure to update the filter and correctly add the is_favorite param to URLs.
-		filter.showOnlyFavorites = isFavoriteFilter;
-		const favoritesParam = isFavoriteFilter ? '?is_favorite' : '';
+		// Build the query string
+		const queryString = buildQueryString();
+
+		let url = '/sites';
+
 		// We need a category in the URL if we have a selected site
 		if ( sitesViewState.selectedSite && ! category ) {
 			setCategory( A4A_SITES_DASHBOARD_DEFAULT_CATEGORY );
 		} else if ( category && sitesViewState.selectedSite && selectedSiteFeature ) {
-			page.replace(
-				`/sites/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }${ favoritesParam }`
-			);
+			url += `/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }`;
 		} else if ( category && sitesViewState.selectedSite ) {
-			page.replace(
-				`/sites/${ category }/${ sitesViewState.selectedSite.url }${ favoritesParam }`
-			);
+			url += `/${ category }/${ sitesViewState.selectedSite.url }`;
 		} else if ( category && category !== A4A_SITES_DASHBOARD_DEFAULT_CATEGORY ) {
 			// If the selected category is the default one, we can leave the url a little cleaner, that's why we are comparing to the default category in the condition above.
-			page.replace( `/sites/${ category }${ favoritesParam }` );
-		} else {
-			page.replace( `/sites${ favoritesParam }` );
+			url += `/${ category }`;
 		}
+
+		page.replace( url + queryString );
 
 		if ( sitesViewState.selectedSite ) {
 			dispatch( setSelectedSiteId( sitesViewState.selectedSite.blog_id ) );
 		}
 	}, [
 		filter,
-		isFavoriteFilter,
 		sitesViewState.selectedSite,
 		selectedSiteFeature,
 		category,
 		setCategory,
 		dispatch,
+		buildQueryString,
 	] );
 
 	const closeSitePreviewPane = useCallback( () => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -20,13 +20,7 @@ const buildQueryString = ( {
 	sort: DashboardSortInterface;
 	showOnlyFavorites?: boolean;
 } ) => {
-	let queryArgs = '';
-
-	if ( showOnlyFavorites ) {
-		queryArgs += 'is_favorite';
-	}
-
-	const urlQuery = new URLSearchParams( queryArgs );
+	const urlQuery = new URLSearchParams();
 
 	if ( search ) {
 		urlQuery.set( 's', search );
@@ -49,7 +43,11 @@ const buildQueryString = ( {
 		urlQuery.set( 'issue_types', selectedFilters.join( ',' ) );
 	}
 
-	return urlQuery.toString() ? `?${ urlQuery }` : '';
+	let queryString = urlQuery.toString();
+	if ( showOnlyFavorites ) {
+		queryString = queryString ? `is_favorite&${ queryString }` : 'is_favorite';
+	}
+	return queryString ? `?${ queryString }` : '';
 };
 
 export const updateSitesDashboardUrl = ( {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -1,0 +1,118 @@
+import page from '@automattic/calypso-router';
+import { Filter } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import {
+	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
+	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
+} from '../constants';
+import { DashboardSortInterface, Site } from '../types';
+import { getSelectedFilters } from './get-selected-filters';
+
+const buildQueryString = ( {
+	filters,
+	search,
+	currentPage,
+	sort,
+	showOnlyFavorites,
+}: {
+	filters: Filter[];
+	search: string;
+	currentPage: number;
+	sort: DashboardSortInterface;
+	showOnlyFavorites?: boolean;
+} ) => {
+	let queryArgs = '';
+
+	if ( showOnlyFavorites ) {
+		queryArgs += 'is_favorite';
+	}
+
+	const urlQuery = new URLSearchParams( queryArgs );
+
+	if ( search ) {
+		urlQuery.set( 's', search );
+	}
+
+	if ( currentPage > 1 ) {
+		urlQuery.set( 'page', currentPage.toString() );
+	}
+
+	if ( sort.field && sort.field !== 'url' ) {
+		urlQuery.set( 'sort_field', sort.field );
+
+		if ( sort.direction && sort.direction !== 'asc' ) {
+			urlQuery.set( 'sort_direction', sort.direction );
+		}
+	}
+
+	if ( filters && filters.length > 0 ) {
+		const selectedFilters = getSelectedFilters( filters );
+		urlQuery.set( 'issue_types', selectedFilters.join( ',' ) );
+	}
+
+	return urlQuery.toString() ? `?${ urlQuery }` : '';
+};
+
+export const updateSitesDashboardUrl = ( {
+	category,
+	setCategory,
+	filters,
+	selectedSite,
+	selectedSiteFeature,
+	search,
+	currentPage,
+	sort,
+	showOnlyFavorites,
+}: {
+	category?: string;
+	setCategory: ( category: string ) => void;
+	filters: Filter[];
+	selectedSite?: Site;
+	selectedSiteFeature?: string;
+	search: string;
+	currentPage: number;
+	sort: DashboardSortInterface;
+	showOnlyFavorites?: boolean;
+} ) => {
+	// We need a category in the URL if we have a selected site
+	if ( selectedSite && ! category ) {
+		setCategory( A4A_SITES_DASHBOARD_DEFAULT_CATEGORY );
+		return;
+	}
+
+	const baseUrl = '/sites';
+	let url = baseUrl;
+	let shouldAddQueryArgs = true;
+	// We are not using { addQueryArgs } from 'calypso/lib/url'; because it doesn't support empty keys (e.g. /sites?is_favorite)
+	const queryString = buildQueryString( {
+		filters,
+		search,
+		currentPage,
+		sort,
+		showOnlyFavorites,
+	} );
+
+	if (
+		category &&
+		selectedSite &&
+		selectedSiteFeature &&
+		selectedSiteFeature !== A4A_SITES_DASHBOARD_DEFAULT_FEATURE
+	) {
+		// If the selected feature is the default one, we can leave the url a little cleaner, that's why we are comparing to the default feature in the condition above.
+		url = `${ baseUrl }/${ category }/${ selectedSite.url }/${ selectedSiteFeature }`;
+		shouldAddQueryArgs = false;
+	} else if ( category && selectedSite ) {
+		url = `${ baseUrl }/${ category }/${ selectedSite.url }`;
+		shouldAddQueryArgs = false;
+	} else if ( category && category !== A4A_SITES_DASHBOARD_DEFAULT_CATEGORY ) {
+		// If the selected category is the default one, we can leave the url a little cleaner, that's why we are comparing to the default category in the condition above.
+		url = `${ baseUrl }/${ category }`;
+	}
+
+	if ( shouldAddQueryArgs ) {
+		url += queryString;
+	}
+
+	if ( page.current !== url ) {
+		page.replace( url );
+	}
+};

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -41,7 +41,4 @@ export interface SitesDashboardContextInterface {
 
 	isPopoverOpen: boolean;
 	setIsPopoverOpen: React.Dispatch< React.SetStateAction< boolean > >;
-
-	isFavoriteFilter: boolean;
-	setIsFavoriteFilter: React.Dispatch< React.SetStateAction< boolean > >;
 }

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -1,3 +1,4 @@
+import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import {
 	AgencyDashboardFilterOption,
 	DashboardSortInterface,
@@ -15,6 +16,9 @@ export interface SitesDashboardContextInterface {
 
 	selectedSiteFeature?: string;
 	setSelectedSiteFeature: ( siteFeature: string | undefined ) => void;
+
+	sitesViewState: SitesViewState;
+	setSitesViewState: React.Dispatch< React.SetStateAction< SitesViewState > >;
 
 	hideListing?: boolean;
 	setHideListing: ( hideListing: boolean ) => void;

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -10,9 +10,6 @@ export interface SitesDashboardContextInterface {
 	selectedCategory?: string;
 	setSelectedCategory: ( category: string ) => void;
 
-	selectedSiteUrl?: string;
-	setSelectedSiteUrl: ( siteUrl: string ) => void;
-
 	selectedSiteFeature?: string;
 	setSelectedSiteFeature: ( siteFeature: string | undefined ) => void;
 
@@ -25,6 +22,7 @@ export interface SitesDashboardContextInterface {
 	showOnlyFavorites?: boolean;
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 
+	initialSelectedSiteUrl?: string;
 	path: string;
 	currentPage: number;
 	sort: DashboardSortInterface;

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -26,7 +26,6 @@ export interface SitesDashboardContextInterface {
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 
 	path: string;
-	search: string;
 	currentPage: number;
 	sort: DashboardSortInterface;
 	showSitesDashboardV2: boolean;

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -1,6 +1,5 @@
 import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import {
-	AgencyDashboardFilterOption,
 	DashboardSortInterface,
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
@@ -23,10 +22,12 @@ export interface SitesDashboardContextInterface {
 	hideListing?: boolean;
 	setHideListing: ( hideListing: boolean ) => void;
 
+	showOnlyFavorites?: boolean;
+	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
+
 	path: string;
 	search: string;
 	currentPage: number;
-	filter: { issueTypes: Array< AgencyDashboardFilterOption >; showOnlyFavorites: boolean };
 	sort: DashboardSortInterface;
 	showSitesDashboardV2: boolean;
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -28,8 +28,8 @@ const SitesDataViews = ( {
 	className,
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
-	const { filter } = useContext( SitesDashboardContext );
-	const totalSites = filter.showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
+	const { showOnlyFavorites } = useContext( SitesDashboardContext );
+	const totalSites = showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
 	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -28,8 +28,8 @@ const SitesDataViews = ( {
 	className,
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
-	const { isFavoriteFilter } = useContext( SitesDashboardContext );
-	const totalSites = isFavoriteFilter ? data?.totalFavorites || 0 : data?.total || 0;
+	const { filter } = useContext( SitesDashboardContext );
+	const totalSites = filter.showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
 	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );


### PR DESCRIPTION


Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/112

## Proposed Changes

This PR fixes several problems with filters/search/routes and our context variables.

## Testing Instructions

- Check the code
- Test all the Scan links. They should work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?