### PR TITLE
Pattern Library: Update copy for pattern library

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -223,7 +223,7 @@ export const PatternLibrary = ( {
 					<CategoryGallery
 						title={ translate_not_yet( 'Ship faster, ship more' ) }
 						description={ translate_not_yet(
-							'Choose from a library of beautiful, functional design patterns to build exactly the page you—or your client—need, in no time.'
+							'Choose from a library of beautiful, functional design patterns to build exactly the pages you need—or your client needs—in no time.'
 						) }
 						categories={ categories }
 						patternTypeFilter={ PatternTypeFilter.REGULAR }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6314

## Proposed Changes

The pattern library copy needs to be updated as per this comment EFPBPUypL1lxFdMCRSr1IX-fi-6540_4438#749107161.

From:

>Choose from a library of beautiful, functional design patterns to build exactly the page you—or your client—need, in no time.

To:

>Choose from a library of beautiful, functional design patterns to build exactly the pages you need—or your client needs—in no time.

|Before|After|
|------|-----|
|<img width="1285" alt="Screen Shot 2024-03-27 at 9 14 25 AM" src="https://github.com/Automattic/wp-calypso/assets/104910361/62023bc8-fe87-46d1-a388-ea3455bf3ab9">|<img width="1306" alt="Screen Shot 2024-03-27 at 9 14 08 AM" src="https://github.com/Automattic/wp-calypso/assets/104910361/05ab1bec-27eb-4d34-a906-589fffa6269f">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Navigate to `/patterns` and verify you're seeing the updated copy.
