### PR TITLE
e2e: Fix Jetpack AI Assistant name

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -41,8 +41,8 @@ export class AIAssistantFlow implements BlockFlow {
 		this.validationData = validationData;
 	}
 
-	blockSidebarName = 'AI Assistant (Experimental)';
-	blockEditorSelector = 'div[aria-label="Block: AI Assistant (Experimental)"]';
+	blockSidebarName = 'AI Assistant';
+	blockEditorSelector = 'div[aria-label="Block: AI Assistant"]';
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Automattic/jetpack#36535 changed the label for a block from "AI Assistant (Experimental)" to "AI Assistant". Update the test to match.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?