### PR TITLE
Draft for multisite plugin picker

### DIFF
--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -17,6 +17,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MAX_SCHEDULES } from './config';
 import { PluginUpdateManagerContextProvider } from './context';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
+import { MultiSitePluginPicker } from './multisite-plugin-picker';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleEdit } from './schedule-edit';
 import { ScheduleList } from './schedule-list';
@@ -24,7 +25,7 @@ import './styles.scss';
 
 interface Props {
 	siteSlug: string;
-	context: 'list' | 'create' | 'edit' | 'logs';
+	context: 'list' | 'create' | 'edit' | 'logs' | 'multisite';
 	scheduleId?: string;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
@@ -83,6 +84,10 @@ export const PluginsUpdateManager = ( props: Props ) => {
 		edit: {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
 			title: translate( 'Edit schedule' ),
+		},
+		multisite: {
+			component: <MultiSitePluginPicker />,
+			title: translate( 'Scheduled Updates' ),
 		},
 	}[ context ];
 

--- a/client/blocks/plugins-update-manager/multisite-plugin-picker/index.tsx
+++ b/client/blocks/plugins-update-manager/multisite-plugin-picker/index.tsx
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+import { PluginPicker } from './plugin-picker';
+import { SitePicker } from './site-picker';
+
+export const MultiSitePluginPicker = () => {
+	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
+
+	return (
+		<div style={ { display: 'flex', gap: '20px' } }>
+			<SitePicker selectedSites={ selectedSites } setSelectedSites={ setSelectedSites } />
+			<PluginPicker selectedSites={ selectedSites } />
+		</div>
+	);
+};

--- a/client/blocks/plugins-update-manager/multisite-plugin-picker/plugin-picker.tsx
+++ b/client/blocks/plugins-update-manager/multisite-plugin-picker/plugin-picker.tsx
@@ -1,0 +1,32 @@
+import { CheckboxControl, Spinner } from '@wordpress/components';
+import { useSitesPluginsQuery } from 'calypso/data/plugins/use-sites-plugins-query';
+
+type Props = {
+	selectedSites: number[];
+};
+
+export const PluginPicker = ( { selectedSites }: Props ) => {
+	const { data: plugins = [], isFetched } = useSitesPluginsQuery( selectedSites );
+
+	return (
+		<div className="form-field">
+			<label htmlFor="plugins">Select plugins ({ plugins.length })</label>
+
+			<div className="checkbox-options">
+				<div className="checkbox-options-container">
+					{ ! isFetched && <Spinner /> }
+
+					{ isFetched &&
+						plugins.map( ( plugin ) => (
+							<CheckboxControl
+								key={ plugin.id }
+								label={ plugin.name }
+								checked={ false }
+								onChange={ () => {} }
+							/>
+						) ) }
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/client/blocks/plugins-update-manager/multisite-plugin-picker/site-picker.tsx
+++ b/client/blocks/plugins-update-manager/multisite-plugin-picker/site-picker.tsx
@@ -1,0 +1,41 @@
+import { CheckboxControl, Spinner } from '@wordpress/components';
+import { useSitesQuery } from 'calypso/data/sites/use-sites-query';
+
+type Props = {
+	selectedSites: number[];
+	setSelectedSites: ( sites: number[] ) => void;
+};
+
+export const SitePicker = ( { selectedSites, setSelectedSites }: Props ) => {
+	const { data: sites = [], isFetched } = useSitesQuery();
+
+	const handleCheckboxChange = ( site: number ) => {
+		if ( selectedSites.includes( site ) ) {
+			setSelectedSites( selectedSites.filter( ( s ) => s !== site ) );
+		} else {
+			setSelectedSites( [ ...selectedSites, site ] );
+		}
+	};
+
+	return (
+		<div className="form-field">
+			<label htmlFor="plugins">Select sites</label>
+
+			<div className="checkbox-options">
+				<div className="checkbox-options-container">
+					{ ! isFetched && <Spinner /> }
+
+					{ isFetched &&
+						sites.map( ( site ) => (
+							<CheckboxControl
+								key={ site.ID }
+								label={ site.name }
+								checked={ selectedSites.includes( site.ID ) }
+								onChange={ () => handleCheckboxChange( site.ID ) }
+							/>
+						) ) }
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/client/data/plugins/use-sites-plugins-query.ts
+++ b/client/data/plugins/use-sites-plugins-query.ts
@@ -1,0 +1,71 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteId } from 'calypso/types';
+
+export type SitePluginsReturn = {
+	name: string;
+	id: string;
+	slug: string;
+};
+
+export type SitePlugin = {
+	active: boolean;
+	author: string;
+	author_url: string;
+	autoupdate: boolean;
+	description: string;
+	display_name: string;
+	name: string;
+	network: boolean;
+	plugin_url: string;
+	slug: string;
+	uninstallable: boolean;
+	version: string;
+};
+
+export type SitesPluginsResponse = {
+	sites: {
+		[ siteId: number ]: SitePlugin[];
+	};
+};
+
+/**
+ * Fetches the plugins for all the user's sites
+ */
+export const useSitesPluginsQuery = (
+	siteIds: SiteId[] = []
+): UseQueryResult< SitePluginsReturn[] > => {
+	return useQuery< SitesPluginsResponse, Error, SitePluginsReturn[] >( {
+		queryKey: [ 'sites-plugins' ],
+		queryFn: () => {
+			return wpcomRequest( {
+				path: `/me/sites/plugins`,
+			} );
+		},
+		meta: {
+			persist: true,
+		},
+		select: ( data ): SitePluginsReturn[] => {
+			// return only the plugins available in siteIds
+			// map to { name, id, string } and remove duplicates
+			const plugins: SitePluginsReturn[] = [];
+			for ( const siteId of siteIds ) {
+				if ( data.sites[ siteId ] ) {
+					for ( const plugin of data.sites[ siteId ] ) {
+						plugins.push( {
+							name: plugin.name,
+							id: plugin.id,
+							slug: plugin.slug,
+						} );
+					}
+				}
+			}
+			// remove duplicates
+			return plugins
+				.filter(
+					( plugin, index, self ) => self.findIndex( ( p ) => p.slug === plugin.slug ) === index
+				)
+				.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+		},
+	} );
+};

--- a/client/data/sites/use-sites-query.ts
+++ b/client/data/sites/use-sites-query.ts
@@ -1,0 +1,14 @@
+import { SiteDetails } from '@automattic/data-stores';
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+
+export const useSitesQuery = () => {
+	return useQuery( {
+		queryKey: [ 'sites' ],
+		queryFn: (): Promise< { sites: SiteDetails[] } > =>
+			wp.req.get( {
+				path: '/me/sites',
+			} ),
+		select: ( data ) => data.sites.filter( ( site ) => site.is_wpcom_atomic === true ),
+	} );
+};

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -153,7 +153,14 @@ export function updatesManager( context, next ) {
 				onNavBack: goToScheduledUpdatesList,
 			} );
 			break;
-
+		case 'multisite':
+			context.primary = createElement( PluginsUpdateManager, {
+				siteSlug,
+				scheduleId,
+				context: 'multisite',
+				onNavBack: () => page.show( `/plugins/scheduled-updates/${ siteSlug }` ),
+			} );
+			break;
 		case 'list':
 		default:
 			context.primary = createElement( PluginsUpdateManager, {


### PR DESCRIPTION
Related to pfuQfP-8G-p2#comment-176

## Proposed Changes

Just a test/prototype to get a feel of how this would feel.

![CleanShot 2024-03-27 at 16 44 32](https://github.com/Automattic/wp-calypso/assets/528287/6130aae2-b538-4508-ba1f-eb72e0458017)

## Testing Instructions

1. Apply this PR
2. Visit http://calypso.localhost:3000/plugins/scheduled-updates/multisite/test 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?