### PR TITLE
Fix the right FAQ question

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -228,14 +228,13 @@ const JetpackFAQ: FC = () => {
 					<li>
 						<FoldableFAQ
 							id="multisite-network"
-							question={ translate( 'Does this work with a multisite network?' ) }
+							question={ translate( 'Does Jetpack work with a multisite network?' ) }
 							onToggle={ onFaqToggle }
 							className="jetpack-faq__section"
 						>
 							{ translate(
-								'Jetpack’s free features are compatible with WordPress Multisite networks. Paid features' +
-									' also work with Multisite networks, but each site requires its own subscription. Jetpack VaultPress Backup' +
-									' and Jetpack Scan are not currently compatible with Multisite networks.'
+								'Jetpack’s free features are compatible with WordPress Multisite networks. Most paid features also work with Multisite networks, but each site requires its own subscription. Ad network is an exception and will only work with the main site.' +
+									' Jetpack VaultPress Backup, Jetpack Scan, Jetpack Security, and Jetpack Complete are not currently compatible with Multisite networks.'
 							) }
 						</FoldableFAQ>
 					</li>


### PR DESCRIPTION
## Proposed Changes

* Update the copy in an FAQ question

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the copy in this question on the Jetpack pricing page matches this diff.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?