### PR TITLE
Patterns: mobile categoryPillNavigation

### DIFF
--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import { SelectDropdown } from '@automattic/components';
 import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
@@ -76,47 +75,33 @@ export const CategoryPillNavigation = ( {
 	}, [ selectedCategoryId ] );
 
 	if ( isMobile ) {
-		const currentUrl =
-			typeof window === 'undefined' ? '' : window.location.pathname + window.location.search;
-
-		const selectedText = [ ...categories, ...( buttons || [] ) ].find(
-			( { link } ) => currentUrl === addLocaleToPathLocaleInFront( link )
-		)?.label;
-
+		const selectedItem =
+			buttons?.find( ( { isActive } ) => isActive ) ||
+			categories.find( ( { id } ) => id === selectedCategoryId );
 		return (
 			<div className="category-pill-navigation">
 				<SelectDropdown
 					className="category-pill-navigation__mobile-select"
-					selectedText={ selectedText }
+					selectedText={ selectedItem?.label }
 				>
-					{ buttons &&
-						buttons.map( ( button ) => {
-							const value = addLocaleToPathLocaleInFront( button.link );
-
-							return (
-								<SelectDropdown.Item
-									key={ button.label }
-									selected={ value === currentUrl }
-									onClick={ () => page( value ) }
-								>
-									{ button.label }
-								</SelectDropdown.Item>
-							);
-						} ) }
-					{ categories &&
-						categories.map( ( category ) => {
-							const value = addLocaleToPathLocaleInFront( category.link );
-
-							return (
-								<SelectDropdown.Item
-									key={ category.id }
-									selected={ value === currentUrl }
-									onClick={ () => page( value ) }
-								>
-									{ category.label }
-								</SelectDropdown.Item>
-							);
-						} ) }
+					{ buttons?.map( ( button ) => (
+						<SelectDropdown.Item
+							key={ button.label }
+							path={ addLocaleToPathLocaleInFront( button.link ) }
+							selected={ button.isActive }
+						>
+							{ button.label }
+						</SelectDropdown.Item>
+					) ) }
+					{ categories?.map( ( category ) => (
+						<SelectDropdown.Item
+							key={ category.id }
+							path={ addLocaleToPathLocaleInFront( category.link ) }
+							selected={ category.id === selectedCategoryId }
+						>
+							{ category.label }
+						</SelectDropdown.Item>
+					) ) }
 				</SelectDropdown>
 			</div>
 		);

--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -1,7 +1,11 @@
+import page from '@automattic/calypso-router';
+import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import { isMobile } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { Icon, chevronRight } from '@wordpress/icons';
 import classnames from 'classnames';
+import FormSelect from 'calypso/components/forms/form-select';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 
 import './style.scss';
@@ -69,6 +73,33 @@ export const CategoryPillNavigation = ( {
 			inline: 'center',
 		} );
 	}, [ selectedCategoryId ] );
+
+	if ( isMobile() ) {
+		return (
+			<div className="category-pill-navigation">
+				<FormSelect
+					className="category-pill-navigation__mobile-select"
+					value={ window.location.pathname + window.location.search }
+					onChange={ ( event: React.ChangeEvent< HTMLSelectElement > ) => {
+						page( event.target.value );
+					} }
+				>
+					{ buttons &&
+						buttons.map( ( button ) => (
+							<option key={ button.label } value={ addLocaleToPathLocaleInFront( button.link ) }>
+								{ button.label }
+							</option>
+						) ) }
+					{ categories &&
+						categories.map( ( category ) => (
+							<option key={ category.id } value={ addLocaleToPathLocaleInFront( category.link ) }>
+								{ category.label }
+							</option>
+						) ) }
+				</FormSelect>
+			</div>
+		);
+	}
 
 	return (
 		<div className="category-pill-navigation">

--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -1,5 +1,5 @@
 import { SelectDropdown } from '@automattic/components';
-import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import { addLocaleToPathLocaleInFront, useLocale } from '@automattic/i18n-utils';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { useEffect, useState, useRef } from '@wordpress/element';
@@ -29,6 +29,7 @@ export const CategoryPillNavigation = ( {
 	categories,
 	selectedCategoryId,
 }: CategoryPillNavigationProps ) => {
+	const locale = useLocale();
 	const isMobile = useMobileBreakpoint();
 	const [ showLeftArrow, setShowLeftArrow ] = useState( false );
 	const [ showRightArrow, setShowRightArrow ] = useState( false );
@@ -87,7 +88,7 @@ export const CategoryPillNavigation = ( {
 					{ buttons?.map( ( button ) => (
 						<SelectDropdown.Item
 							key={ button.label }
-							path={ addLocaleToPathLocaleInFront( button.link ) }
+							path={ addLocaleToPathLocaleInFront( button.link, locale ) }
 							selected={ button.isActive }
 						>
 							{ button.label }
@@ -96,7 +97,7 @@ export const CategoryPillNavigation = ( {
 					{ categories?.map( ( category ) => (
 						<SelectDropdown.Item
 							key={ category.id }
-							path={ addLocaleToPathLocaleInFront( category.link ) }
+							path={ addLocaleToPathLocaleInFront( category.link, locale ) }
 							selected={ category.id === selectedCategoryId }
 						>
 							{ category.label }

--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -1,11 +1,11 @@
 import page from '@automattic/calypso-router';
+import { SelectDropdown } from '@automattic/components';
 import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
-import { isMobile } from '@automattic/viewport';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { Icon, chevronRight } from '@wordpress/icons';
 import classnames from 'classnames';
-import FormSelect from 'calypso/components/forms/form-select';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 
 import './style.scss';
@@ -30,6 +30,7 @@ export const CategoryPillNavigation = ( {
 	categories,
 	selectedCategoryId,
 }: CategoryPillNavigationProps ) => {
+	const isMobile = useMobileBreakpoint();
 	const [ showLeftArrow, setShowLeftArrow ] = useState( false );
 	const [ showRightArrow, setShowRightArrow ] = useState( false );
 	const listRef = useRef< HTMLDivElement | null >( null );
@@ -74,29 +75,49 @@ export const CategoryPillNavigation = ( {
 		} );
 	}, [ selectedCategoryId ] );
 
-	if ( isMobile() ) {
+	if ( isMobile ) {
+		const currentUrl =
+			typeof window === 'undefined' ? '' : window.location.pathname + window.location.search;
+
+		const selectedText = [ ...categories, ...( buttons || [] ) ].find(
+			( { link } ) => currentUrl === addLocaleToPathLocaleInFront( link )
+		)?.label;
+
 		return (
 			<div className="category-pill-navigation">
-				<FormSelect
+				<SelectDropdown
 					className="category-pill-navigation__mobile-select"
-					value={ window.location.pathname + window.location.search }
-					onChange={ ( event: React.ChangeEvent< HTMLSelectElement > ) => {
-						page( event.target.value );
-					} }
+					selectedText={ selectedText }
 				>
 					{ buttons &&
-						buttons.map( ( button ) => (
-							<option key={ button.label } value={ addLocaleToPathLocaleInFront( button.link ) }>
-								{ button.label }
-							</option>
-						) ) }
+						buttons.map( ( button ) => {
+							const value = addLocaleToPathLocaleInFront( button.link );
+
+							return (
+								<SelectDropdown.Item
+									key={ button.label }
+									selected={ value === currentUrl }
+									onClick={ () => page( value ) }
+								>
+									{ button.label }
+								</SelectDropdown.Item>
+							);
+						} ) }
 					{ categories &&
-						categories.map( ( category ) => (
-							<option key={ category.id } value={ addLocaleToPathLocaleInFront( category.link ) }>
-								{ category.label }
-							</option>
-						) ) }
-				</FormSelect>
+						categories.map( ( category ) => {
+							const value = addLocaleToPathLocaleInFront( category.link );
+
+							return (
+								<SelectDropdown.Item
+									key={ category.id }
+									selected={ value === currentUrl }
+									onClick={ () => page( value ) }
+								>
+									{ category.label }
+								</SelectDropdown.Item>
+							);
+						} ) }
+				</SelectDropdown>
 			</div>
 		);
 	}

--- a/client/components/category-pill-navigation/style.scss
+++ b/client/components/category-pill-navigation/style.scss
@@ -109,6 +109,6 @@
 	margin-left: auto;
 }
 
-.category-pill-navigation__mobile-select {
+.category-pill-navigation__mobile-select .select-dropdown__container {
 	width: 100%;
 }

--- a/client/components/category-pill-navigation/style.scss
+++ b/client/components/category-pill-navigation/style.scss
@@ -108,3 +108,7 @@
 	flex: none;
 	margin-left: auto;
 }
+
+.category-pill-navigation__mobile-select {
+	width: 100%;
+}

--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -36,10 +36,7 @@
 		position: static;
 
 		.category-pill-navigation {
-			.category-pill-navigation__mobile-select {
-				margin: 0 24px;
-				width: calc(100% - 48px);
-			}
+			padding: 24px;
 		}
 	}
 }

--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -31,6 +31,17 @@
 			}
 		}
 	}
+
+	@media ( max-width: $break-mobile ) {
+		position: static;
+
+		.category-pill-navigation {
+			.category-pill-navigation__mobile-select {
+				margin: 0 24px;
+				width: calc(100% - 48px);
+			}
+		}
+	}
 }
 
 .pattern-library__pill-navigation + .patterns-section {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6150

## Proposed Changes
With this PR we are adjusting CategoryPillNavigation for mobile, according to the latest design BnTfb6hzKcRTb2LBtuPwKe-fi-599_14086

## Testing Instructions
1. Open any /patterns/about page (or any another)
2. Assert that CategoryPillNavigation looks good <br /><img width="1498" alt="Screenshot 2024-03-27 at 16 14 08" src="https://github.com/Automattic/wp-calypso/assets/5598437/da68f055-a181-443e-bf9c-ff0e5161686c">
3. Check table version and assert that it looks still good <br /> <img width="699" alt="Screenshot 2024-03-27 at 16 14 57" src="https://github.com/Automattic/wp-calypso/assets/5598437/d9bc4346-0056-4f25-9f0d-9bac87508a35">
4. Check mobile version <=480 and assert that you see `Select` component instead <br /> NB: you need to reload the page, since there is JS condition instead of CSS <br /><img width="316" alt="Screenshot 2024-03-27 at 16 16 23" src="https://github.com/Automattic/wp-calypso/assets/5598437/c8e64c57-f098-44ef-8de3-9af7dde1fca0">
5. Try to change the category and assert that it works and active category in the select is correct


