### PR TITLE
Subscribers: Prevent action bar re-rendering.

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -28,6 +28,7 @@ const ListActionsBar = () => {
 		filterOption,
 		setFilterOption,
 		siteId,
+		grandTotal,
 	} = useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
@@ -36,6 +37,10 @@ const ListActionsBar = () => {
 	const selectedText = translate( 'Subscribers: %s', {
 		args: getOptionLabel( filterOptions, filterOption ) || '',
 	} );
+
+	if ( grandTotal < 3 ) {
+		return <></>;
+	}
 
 	return (
 		<div className="list-actions-bar">

--- a/client/my-sites/subscribers/components/subscriber-list-container/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-list-container/style.scss
@@ -26,7 +26,6 @@
 	.loading-placeholder {
 		@include placeholder();
 		display: inline-block;
-		margin-bottom: 30px;
 
 		&.big {
 			width: 50%;
@@ -40,6 +39,12 @@
 		&.hidden {
 			background-color: transparent;
 			animation: none;
+		}
+	}
+
+	.subscriber-list__loading {
+		.loading-placeholder {
+			margin-bottom: 30px;
 		}
 	}
 }

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -76,12 +76,12 @@ const SubscriberListContainer = ( {
 						</span>
 					</div>
 
-					{ ( total > 3 || searchTerm ) && <SubscriberListActionsBar /> }
+					<SubscriberListActionsBar />
 				</>
 			) }
 			{ isLoading &&
 				new Array( 10 ).fill( null ).map( ( _, index ) => (
-					<div key={ index } data-ignored={ _ }>
+					<div className="subscriber-list__loading" key={ index } data-ignored={ _ }>
 						<div className="loading-placeholder big"></div>
 						<div className="loading-placeholder small"></div>
 						<div className="loading-placeholder small"></div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/88938

I no longer can replicate the issue described in https://github.com/Automattic/wp-calypso/issues/88938 after a couple of hours of debugging and rebasing from trunk. The production version seems to work again.

My suspicion was that somewhere within the last 12 hours, there was a broken build (either React or some dependencies) which causes React to mistakenly thinks that `searchTerm` has changed even though it hasn't, causing a recursive loop and re-rendering of the action bar / search input component.

Eitherway, I made some changes to reduce the potential need to re-render when state changes.

## Proposed Changes

* Prevent the list action bar (containing search input and sort dropdown) from re-rendering whenever the search input is cleared.
* Prevent the list action bar from being pushed down when searching.

## Testing Instructions

* Go to `http://calypso.localhost:3000/subscribers/YOURSITEHERE.wordpress.com`
* Type something in the search input.
  * The search input should not be pushed down.
* Clear the search input.
  * The search input should not disappear and reappear.
  * The cursor should still be focused on the input.

## Screenshot

**Before (clearing):**
https://github.com/Automattic/wp-calypso/assets/1287077/4ccd77ff-dbae-4290-a360-8eae17950252

**After (clearing):**
https://github.com/Automattic/wp-calypso/assets/1287077/a0cbfb62-902f-42b9-bfcf-5656f02207a7

**Before (searching):**
https://github.com/Automattic/wp-calypso/assets/1287077/3ec53d4a-e51a-46e3-9674-1fa5bc9fb8aa

**After (searching):**
https://github.com/Automattic/wp-calypso/assets/1287077/75e5490d-7ae6-4d47-bacb-9f9ff01b367e

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?