### PR TITLE
Site Migration: Implement new layout to the migration in progress view

### DIFF
--- a/client/my-sites/migrate/components/migration-in-progress/index.tsx
+++ b/client/my-sites/migrate/components/migration-in-progress/index.tsx
@@ -1,23 +1,20 @@
-import { Card } from '@automattic/components';
 import { MigrationStatus } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
-import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect } from 'react';
-import FormattedHeader from 'calypso/components/formatted-header';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import wpcom from 'calypso/lib/wp';
+import './style.scss';
 
 interface Props {
-	sourceSite?: string;
-	targetSite: string;
-	targetSiteId: string;
+	targetSiteId: number;
 	onComplete: () => void;
 }
 
 export const MigrationInProgress: FC< Props > = ( props ) => {
 	const translate = useTranslate();
 
-	const { sourceSite, targetSite, targetSiteId, onComplete } = props;
+	const { targetSiteId, onComplete } = props;
 
 	const {
 		data: { status },
@@ -40,35 +37,16 @@ export const MigrationInProgress: FC< Props > = ( props ) => {
 	//
 
 	return (
-		<Card className="migrate__pane">
-			<img
-				className="migrate__illustration"
-				src="/calypso/images/illustrations/waitTime-plain.svg"
-				alt=""
-			/>
-
-			<FormattedHeader
-				className="migrate__section-header"
-				headerText={ translate( 'Migration in progress' ) }
-				align="center"
-			/>
+		<div className="migration-in-progress">
+			<h2 className="migration-in-progress__title">
+				{ translate( 'We are migrating your site' ) }
+			</h2>
 			<p>
 				{ translate(
-					"We're moving everything from {{strong}}{{sp}}%(sourceSite)s{{/sp}}{{/strong}} to {{strong}}{{sp}}%(targetSite)s{{/sp}}{{/strong}}.",
-					{
-						args: {
-							sourceSite: sourceSite || translate( 'your source site' ),
-							targetSite,
-						},
-						components: {
-							sp: <span className="migrate__domain" />,
-							strong: <strong />,
-						},
-					}
+					'Feel free to close this window. We’ll email you when your new site is ready.'
 				) }
 			</p>
-			<p>{ translate( 'We will send you an email when the migration is complete.' ) }</p>
-			<Spinner />
-		</Card>
+			<LoadingEllipsis className="migration-in-progress__loading" />
+		</div>
 	);
 };

--- a/client/my-sites/migrate/components/migration-in-progress/style.scss
+++ b/client/my-sites/migrate/components/migration-in-progress/style.scss
@@ -1,0 +1,35 @@
+@import "@automattic/typography/styles/fonts";
+
+.migration-in-progress {
+	height: calc(100svh - 120px);
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	padding: 0 20px;
+	box-sizing: border-box;
+	p {
+		margin: 0;
+	}
+}
+
+.migration-in-progress__title {
+	font-family: $brand-serif;
+	font-weight: 400;
+	font-size: 1.75rem;
+	line-height: 2;
+	color: var(--studio-gray-100);
+	margin: 0;
+}
+
+.migration-in-progress__loading {
+	height: 20px;
+	margin-top: 32px;
+}
+
+// Remove extra top spacing form the loading bar
+.migration-in-progress__loading > div {
+	top: 0;
+}

--- a/client/my-sites/migrate/components/migration-in-progress/test/index.tsx
+++ b/client/my-sites/migrate/components/migration-in-progress/test/index.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import React, { ComponentProps } from 'react';
 import { MigrationInProgress } from '../';
@@ -20,24 +20,6 @@ describe( 'MigrationInProgress', () => {
 			</QueryClientProvider>
 		);
 	};
-
-	it( 'renders the destination site', () => {
-		renderComponent();
-
-		expect( screen.getByText( /new-site.wordpress.com/ ) ).toBeVisible();
-	} );
-
-	it( 'renders the source site', () => {
-		renderComponent();
-
-		expect( screen.getByText( /source-site.external.com/ ) ).toBeVisible();
-	} );
-
-	it( "renders 'your site' when the source site is not available", () => {
-		renderComponent( { sourceSite: undefined } );
-
-		expect( screen.getByText( /your source site/ ) ).toBeVisible();
-	} );
 
 	it( 'calls onComplete when migration is done', async () => {
 		const onComplete = jest.fn();

--- a/client/my-sites/migrate/components/migration-in-progress/test/index.tsx
+++ b/client/my-sites/migrate/components/migration-in-progress/test/index.tsx
@@ -24,7 +24,7 @@ describe( 'MigrationInProgress', () => {
 	it( 'calls onComplete when migration is done', async () => {
 		const onComplete = jest.fn();
 		nock( 'https://public-api.wordpress.com:443' )
-			.get( '/wpcom/v2/sites/some-site-id/migration-status' )
+			.get( '/wpcom/v2/sites/123/migration-status' )
 			.reply( 200, { status: 'done' } );
 
 		renderComponent( { onComplete } );

--- a/client/my-sites/migrate/components/migration-in-progress/test/index.tsx
+++ b/client/my-sites/migrate/components/migration-in-progress/test/index.tsx
@@ -16,13 +16,7 @@ describe( 'MigrationInProgress', () => {
 		const queryClient = new QueryClient();
 		return render(
 			<QueryClientProvider client={ queryClient }>
-				<MigrationInProgress
-					targetSite="new-site.wordpress.com"
-					targetSiteId="some-site-id"
-					sourceSite="source-site.external.com"
-					onComplete={ jest.fn() }
-					{ ...props }
-				/>
+				<MigrationInProgress targetSiteId={ 123 } onComplete={ jest.fn() } { ...props } />
 			</QueryClientProvider>
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #88957

## Proposed Changes

*  Implement the new layout

## Testing Instructions
* Complete the new migration process
* Go to the site customer's home (E.g.  /home/[YOUR_NEW_SITE].wpcomstaging.com)
* Click on "plugins"
* You should be redirected to `/migrate/[YOUR_NEW_SITE].wpcomstaging.com` 
* You should see the updated in-progress view equal to the screenshots. 

### Screenshots
**Mobile**
![image](https://github.com/Automattic/wp-calypso/assets/38718/94196c69-3812-40d8-8cb0-595ae698102d)

**Desktop**
![image](https://github.com/Automattic/wp-calypso/assets/38718/49908153-08b8-4da7-9ab5-0a270ed9640d)





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?