### PR TITLE
Pattern Library: Update library title on type toggle

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -234,12 +234,17 @@ export const PatternLibrary = ( {
 					<PatternLibraryBody className="pattern-library">
 						<div className="pattern-library__header">
 							<h1 className="pattern-library__title">
-								{ searchTerm
-									? translate_not_yet( '%(count)d pattern', '%(count)d patterns', {
-											count: patterns.length,
-											args: { count: patterns.length },
-									  } )
-									: translate_not_yet( 'Patterns' ) }
+								{ searchTerm &&
+									translate_not_yet( '%(count)d pattern', '%(count)d patterns', {
+										count: patterns.length,
+										args: { count: patterns.length },
+									} ) }
+								{ ! searchTerm &&
+									patternTypeFilter === PatternTypeFilter.PAGES &&
+									translate_not_yet( 'Page Layouts' ) }
+								{ ! searchTerm &&
+									patternTypeFilter === PatternTypeFilter.REGULAR &&
+									translate_not_yet( 'Patterns' ) }
 							</h1>
 
 							{ category && !! categoryObject?.pagePatternCount && (
@@ -267,7 +272,7 @@ export const PatternLibrary = ( {
 									/>
 									<ToggleGroupControlOption
 										className="pattern-library__toggle-option"
-										label={ translate_not_yet( 'Page layouts' ) }
+										label={ translate_not_yet( 'Page Layouts' ) }
 										value={ PatternTypeFilter.PAGES }
 									/>
 								</ToggleGroupControl>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6246

## Proposed Changes

When we switch between pattern/page layouts, the library title should be updated as to match the selection.

|Before|After|
|-------|-----|
|<img width="1108" alt="Screen Shot 2024-03-27 at 1 59 00 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/c7d936c4-3916-47fc-ae72-c54a4f8c80de">|<img width="1126" alt="Screen Shot 2024-03-27 at 1 58 36 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/33285e86-2469-4ab0-8c5f-c299bc14e9cb">|

I've also taken the opportunity to change the toggle label from `Page layouts` to `Page Layouts` (title case) so it matches the treatment in the category nav as well as the library title.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/patterns/about`.
* Toggle between "Patterns" and "Page Layouts".
* Assert that the title is updated to match the selection.
* Perform a search and assert that the title says `{number} patterns`.
