### PR TITLE
Site Migration: Add hosting intent to trial when on the new site migration flow

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -1,4 +1,4 @@
-import config, { isEnabled } from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, PLAN_BUSINESS, PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
@@ -22,6 +22,7 @@ interface Props {
 	ctaText: string;
 	subTitleText?: string;
 	hideTitleAndSubTitle?: boolean;
+	sendIntentWhenCreatingTrial?: boolean;
 	onFreeTrialSelectionSuccess?: () => void;
 	navigateToVerifyEmailStep: () => void;
 	onCtaClick: () => void;
@@ -40,6 +41,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		ctaText,
 		subTitleText,
 		hideTitleAndSubTitle = false,
+		sendIntentWhenCreatingTrial = false,
 		onFreeTrialSelectionSuccess = () => {},
 		onCtaClick,
 		isBusy,
@@ -62,10 +64,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 	const onFreeTrialClick = () => {
 		if ( migrationTrialEligibility?.error_code === 'email-unverified' ) {
 			navigateToVerifyEmailStep();
-		} else if ( config.isEnabled( 'onboarding/new-migration-flow' ) ) {
-			// If the user is in the new migration flow, we need to add the hosting trial with the intent
-			// so that the site created is UTF-8. I'am adding this check here to avoid changing the existing migration
-			// logic. Once the new migration flow is fully implemented, we can remove this check.
+		} else if ( sendIntentWhenCreatingTrial ) {
 			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY, HOSTING_INTENT_MIGRATE );
 		} else {
 			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY );

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -1,11 +1,13 @@
-import { isEnabled } from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import { getPlan, PLAN_BUSINESS, PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
-import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
+import useAddHostingTrialMutation, {
+	HOSTING_INTENT_MIGRATE,
+} from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -60,6 +62,11 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 	const onFreeTrialClick = () => {
 		if ( migrationTrialEligibility?.error_code === 'email-unverified' ) {
 			navigateToVerifyEmailStep();
+		} else if ( config.isEnabled( 'onboarding/new-migration-flow' ) ) {
+			// If the user is in the new migration flow, we need to add the hosting trial with the intent
+			// so that the site created is UTF-8. I'am adding this check here to avoid changing the existing migration
+			// logic. Once the new migration flow is fully implemented, we can remove this check.
+			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY, HOSTING_INTENT_MIGRATE );
 		} else {
 			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY );
 		}

--- a/client/data/hosting/use-add-hosting-trial-mutation.ts
+++ b/client/data/hosting/use-add-hosting-trial-mutation.ts
@@ -2,27 +2,36 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
+export const HOSTING_INTENT_MIGRATE = 'migrate';
+
+type HostingIntent = typeof HOSTING_INTENT_MIGRATE;
+
 interface Variables {
 	siteId: number;
 	planSlug: string;
+	hostingIntent?: HostingIntent;
 }
 
 export default function useAddHostingTrialMutation(
 	options: UseMutationOptions< unknown, unknown, Variables > = {}
 ) {
 	const mutation = useMutation( {
-		mutationFn: async ( { siteId, planSlug }: Variables ) =>
-			wp.req.post( {
+		mutationFn: async ( { siteId, planSlug, hostingIntent }: Variables ) => {
+			const body = hostingIntent ? { hosting_intent: hostingIntent } : undefined;
+			return wp.req.post( {
 				path: `/sites/${ siteId }/hosting/trial/add/${ planSlug }`,
 				apiNamespace: 'wpcom/v2',
-			} ),
+				body,
+			} );
+		},
 		...options,
 	} );
 
 	const { mutate } = mutation;
 
 	const addHostingTrial = useCallback(
-		( siteId: number, planSlug: string ) => mutate( { siteId, planSlug } ),
+		( siteId: number, planSlug: string, hostingIntent?: HostingIntent ) =>
+			mutate( { siteId, planSlug, hostingIntent } ),
 		[ mutate ]
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -24,6 +24,7 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
 			subTitleText=""
 			isBusy={ false }
 			hideTitleAndSubTitle
+			sendIntentWhenCreatingTrial
 			onCtaClick={ () => {
 				navigation.submit?.( {
 					goToCheckout: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
* https://github.com/Automattic/wp-calypso/pull/88147
* D143480-code
## Proposed Changes

This is an attempt to split https://github.com/Automattic/wp-calypso/pull/88147. The focus of this PR is on the free trial.
This will add a hosting_plan query param to the API call made to set up a site with a migration free trial plan.

It should only add the query param if on the new site migration flow, this way we wont be creating utf8 sites for current import/migrate flow. While it shouldn't hurt, it's out of scope.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or navigate to the calypso.live link below
* Go to `/start`
* Select free plan
* Open the browser Web developer tools and copy and paste the following code `sessionStorage.setItem('flags', "onboarding/new-migration-flow")`
* Reload the goals page and select the import intent
* Go through the flow using any site until you get to the upgrade screen
* Open network inspector
* Select free trial
* Verify the request contains a hosting_plan query param
<img width="618" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/d1a39618-0d97-4891-ae8e-81da1af8bc02">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?