### PR TITLE
Pattern Library: Track views by referrer

### DIFF
--- a/client/my-sites/patterns/components/category-not-found/index.tsx
+++ b/client/my-sites/patterns/components/category-not-found/index.tsx
@@ -2,11 +2,16 @@ import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
+import { PatternsPageViewTracker } from 'calypso/my-sites/patterns/components/page-view-tracker';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 import './style.scss';
 
-export const PatternsCategoryNotFound = () => {
+type PatternsCategoryNotFoundProps = {
+	referrer: string;
+};
+
+export const PatternsCategoryNotFound = ( { referrer }: PatternsCategoryNotFoundProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const translate_not_yet = useTranslate();
 
@@ -14,12 +19,16 @@ export const PatternsCategoryNotFound = () => {
 		'Message displayed when an invalid category was specified while searching block patterns';
 
 	return (
-		<EmptyContent
-			title={ translate_not_yet( "Oops! We can't find this category!", { comment } ) }
-			line={ translate_not_yet( "The category you are looking for doesn't exist.", { comment } ) }
-			action={ translate_not_yet( 'Browse all patterns', { comment } ) }
-			actionURL={ isLoggedIn ? '/patterns' : addLocaleToPathLocaleInFront( '/patterns' ) }
-			illustration="/calypso/images/illustrations/illustration-404.svg"
-		/>
+		<>
+			<PatternsPageViewTracker category="not-found" referrer={ referrer } />
+
+			<EmptyContent
+				title={ translate_not_yet( "Oops! We can't find this category!", { comment } ) }
+				line={ translate_not_yet( "The category you are looking for doesn't exist.", { comment } ) }
+				action={ translate_not_yet( 'Browse all patterns', { comment } ) }
+				actionURL={ isLoggedIn ? '/patterns' : addLocaleToPathLocaleInFront( '/patterns' ) }
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+			/>
+		</>
 	);
 };

--- a/client/my-sites/patterns/components/category-not-found/index.tsx
+++ b/client/my-sites/patterns/components/category-not-found/index.tsx
@@ -9,7 +9,7 @@ import './style.scss';
 
 type PatternsCategoryNotFoundProps = {
 	category: string;
-	referrer: string;
+	referrer?: string;
 };
 
 export const PatternsCategoryNotFound = ( {

--- a/client/my-sites/patterns/components/category-not-found/index.tsx
+++ b/client/my-sites/patterns/components/category-not-found/index.tsx
@@ -8,10 +8,14 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import './style.scss';
 
 type PatternsCategoryNotFoundProps = {
+	category: string;
 	referrer: string;
 };
 
-export const PatternsCategoryNotFound = ( { referrer }: PatternsCategoryNotFoundProps ) => {
+export const PatternsCategoryNotFound = ( {
+	category,
+	referrer,
+}: PatternsCategoryNotFoundProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const translate_not_yet = useTranslate();
 
@@ -20,7 +24,11 @@ export const PatternsCategoryNotFound = ( { referrer }: PatternsCategoryNotFound
 
 	return (
 		<>
-			<PatternsPageViewTracker category="not-found" referrer={ referrer } />
+			<PatternsPageViewTracker
+				category={ category }
+				referrer={ referrer }
+				error="category-not-found"
+			/>
 
 			<EmptyContent
 				title={ translate_not_yet( "Oops! We can't find this category!", { comment } ) }

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -52,30 +52,16 @@ export function PatternsPageViewTracker( {
 	}, [ category, isDevAccount, isLoggedIn, patternTypeFilter ] );
 
 	useEffect( () => {
-		const eventProp = {
+		recordTracksEvent( 'calypso_pattern_library_view', {
+			category,
 			is_logged_in: isLoggedIn,
 			user_is_dev_account: isDevAccount ? '1' : '0',
+			search_term: debouncedSearchTerm,
 			type: getTracksPatternType( patternTypeFilter ),
 			view,
-		};
-
-		if ( category ) {
-			eventProp.category = category;
-		}
-
-		if ( debouncedSearchTerm ) {
-			eventProp.search_term = debouncedSearchTerm;
-		}
-
-		if ( referrer ) {
-			eventProp.referrer = referrer;
-		}
-
-		if ( error ) {
-			eventProp.error = error;
-		}
-
-		recordTracksEvent( 'calypso_pattern_library_view', eventProp );
+			referrer,
+			error,
+		} );
 
 		// We want to avoid resubmitting the event whenever
 		// `category` changes, which is why we deliberately don't include it in the dependency array

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -11,6 +11,7 @@ type PatternsPageViewTrackerProps = {
 	category: string;
 	searchTerm: string;
 	patternTypeFilter: PatternTypeFilter;
+	referrer: string;
 	view: PatternView;
 };
 
@@ -18,6 +19,7 @@ export function PatternsPageViewTracker( {
 	category,
 	searchTerm,
 	patternTypeFilter,
+	referrer,
 	view,
 }: PatternsPageViewTrackerProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -54,6 +56,7 @@ export function PatternsPageViewTracker( {
 			user_is_dev_account: isDevAccount ? '1' : '0',
 			search_term: debouncedSearchTerm,
 			type: getTracksPatternType( patternTypeFilter ),
+			referrer,
 			view,
 		} );
 

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -11,16 +11,18 @@ type PatternsPageViewTrackerProps = {
 	category: string;
 	searchTerm: string;
 	patternTypeFilter: PatternTypeFilter;
-	referrer: string;
 	view: PatternView;
+	referrer?: string;
+	error?: string;
 };
 
 export function PatternsPageViewTracker( {
 	category,
 	searchTerm,
 	patternTypeFilter,
-	referrer,
 	view,
+	referrer,
+	error,
 }: PatternsPageViewTrackerProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
@@ -50,15 +52,24 @@ export function PatternsPageViewTracker( {
 	}, [ category, isDevAccount, isLoggedIn, patternTypeFilter ] );
 
 	useEffect( () => {
-		recordTracksEvent( 'calypso_pattern_library_view', {
+		const eventProp = {
 			category,
 			is_logged_in: isLoggedIn,
 			user_is_dev_account: isDevAccount ? '1' : '0',
 			search_term: debouncedSearchTerm,
 			type: getTracksPatternType( patternTypeFilter ),
-			referrer,
 			view,
-		} );
+		};
+
+		if ( referrer ) {
+			eventProp.referrer = referrer;
+		}
+
+		if ( error ) {
+			eventProp.error = error;
+		}
+
+		recordTracksEvent( 'calypso_pattern_library_view', eventProp );
 
 		// We want to avoid resubmitting the event whenever
 		// `category` changes, which is why we deliberately don't include it in the dependency array

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -9,9 +9,9 @@ import { PatternTypeFilter, PatternView } from '../types';
 
 type PatternsPageViewTrackerProps = {
 	category: string;
-	searchTerm: string;
-	patternTypeFilter: PatternTypeFilter;
-	view: PatternView;
+	searchTerm?: string;
+	patternTypeFilter?: PatternTypeFilter;
+	view?: PatternView;
 	referrer?: string;
 	error?: string;
 };

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -53,13 +53,19 @@ export function PatternsPageViewTracker( {
 
 	useEffect( () => {
 		const eventProp = {
-			category,
 			is_logged_in: isLoggedIn,
 			user_is_dev_account: isDevAccount ? '1' : '0',
-			search_term: debouncedSearchTerm,
 			type: getTracksPatternType( patternTypeFilter ),
 			view,
 		};
+
+		if ( category ) {
+			eventProp.category = category;
+		}
+
+		if ( debouncedSearchTerm ) {
+			eventProp.search_term = debouncedSearchTerm;
+		}
 
 		if ( referrer ) {
 			eventProp.referrer = referrer;

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -75,6 +75,7 @@ type PatternLibraryProps = {
 	isGridView?: boolean;
 	patternGallery: PatternGalleryFC;
 	patternTypeFilter: PatternTypeFilter;
+	referrer: string;
 	searchTerm?: string;
 };
 
@@ -84,6 +85,7 @@ export const PatternLibrary = ( {
 	isGridView,
 	patternGallery: PatternGallery,
 	patternTypeFilter,
+	referrer,
 	searchTerm: urlQuerySearchTerm = '',
 }: PatternLibraryProps ) => {
 	const locale = useLocale();
@@ -187,6 +189,7 @@ export const PatternLibrary = ( {
 				// immediately reset when navigating to a new category, whereas the latter is reset
 				// *after* the first render (which triggers an additional, incorrect, page view)
 				searchTerm={ urlQuerySearchTerm }
+				referrer={ referrer }
 			/>
 
 			<DocumentHead title={ translate_not_yet( 'WordPress Patterns - Category' ) } />

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -75,7 +75,7 @@ type PatternLibraryProps = {
 	isGridView?: boolean;
 	patternGallery: PatternGalleryFC;
 	patternTypeFilter: PatternTypeFilter;
-	referrer: string;
+	referrer?: string;
 	searchTerm?: string;
 };
 

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -19,13 +19,13 @@ export function usePatternSearchTerm(
 
 		if ( searchTerm ) {
 			url.searchParams.set( QUERY_PARAM_SEARCH, searchTerm );
+
+			// Strip out `ref` parameter when updating the URL for search
+			// to ensure the referrer is only be reported in the initial page view.
+			url.searchParams.delete( 'ref' );
 		} else {
 			url.searchParams.delete( QUERY_PARAM_SEARCH );
 		}
-
-		// Strip out `ref` parameter when updating the URL for search
-		// to ensure the referrer is only be reported in the initial page view.
-		url.searchParams.delete( 'ref' );
 
 		if ( url.href !== location.href ) {
 			page( url.href.replace( url.origin, '' ) );

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -23,6 +23,10 @@ export function usePatternSearchTerm(
 			url.searchParams.delete( QUERY_PARAM_SEARCH );
 		}
 
+		// Strip out `ref` parameter when updating the URL for search
+		// to ensure the referrer is only be reported in the initial page view.
+		url.searchParams.delete( 'ref' );
+
 		if ( url.href !== location.href ) {
 			page( url.href.replace( url.origin, '' ) );
 		}

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -22,7 +22,7 @@ import { getPatternCategoriesQueryOptions } from './hooks/use-pattern-categories
 function renderCategoryNotFound( context: RouterContext, next: RouterNext ) {
 	context.primary = (
 		<PatternsWrapper>
-			<PatternsCategoryNotFound />
+			<PatternsCategoryNotFound referrer={ context.query.ref ?? '' } />
 		</PatternsWrapper>
 	);
 
@@ -41,6 +41,7 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 					patternTypeFilter={
 						context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR
 					}
+					referrer={ context.query.ref ?? '' }
 					searchTerm={ context.query[ QUERY_PARAM_SEARCH ] }
 				/>
 			</PatternsWrapper>

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -22,7 +22,10 @@ import { getPatternCategoriesQueryOptions } from './hooks/use-pattern-categories
 function renderCategoryNotFound( context: RouterContext, next: RouterNext ) {
 	context.primary = (
 		<PatternsWrapper>
-			<PatternsCategoryNotFound referrer={ context.query.ref ?? '' } />
+			<PatternsCategoryNotFound
+				category={ context.params.category }
+				referrer={ context.query.ref }
+			/>
 		</PatternsWrapper>
 	);
 
@@ -41,7 +44,7 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 					patternTypeFilter={
 						context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR
 					}
-					referrer={ context.query.ref ?? '' }
+					referrer={ context.query.ref }
 					searchTerm={ context.query[ QUERY_PARAM_SEARCH ] }
 				/>
 			</PatternsWrapper>

--- a/client/my-sites/patterns/lib/get-tracks-pattern-type.ts
+++ b/client/my-sites/patterns/lib/get-tracks-pattern-type.ts
@@ -1,4 +1,11 @@
 import { PatternType, PatternTypeFilter } from '../types';
 
-export const getTracksPatternType = ( patternTypeFilter: PatternTypeFilter ): PatternType =>
-	patternTypeFilter === PatternTypeFilter.REGULAR ? 'pattern' : 'page-layout';
+export const getTracksPatternType = (
+	patternTypeFilter?: PatternTypeFilter
+): PatternType | undefined => {
+	if ( ! patternTypeFilter ) {
+		return undefined;
+	}
+
+	return patternTypeFilter === PatternTypeFilter.REGULAR ? 'pattern' : 'page-layout';
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6134 

## Proposed Changes

To better understand how users are getting to the Pattern Library, we should track the referrer specified in the `ref` query string parameter of the URL.

I also took the opportunity to include tracking of the `calypso_pattern_library_view` event in the category not found page. That should help us spot bad urls and get them fixed quickly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Patterns page

* Navigate to `/patterns?ref=developer-lp`.
* Assert that the `calypso_pattern_library_view` event is fired sending:
    * `referrer=developer-lp`
    * with no `search_term` nor `category` property

<img width="1562" alt="Screen Shot 2024-03-27 at 7 32 09 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/10150c27-d789-4c16-a8d8-b23c19566ce3">

### Patterns search

* Perform a search.
* Assert that `ref` query param is stripped out from the URL and that the `calypso_pattern_library_view` event is fired with **no** `referrer` property

<img width="1496" alt="Screen Shot 2024-03-27 at 7 32 22 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/ace6893f-6443-4c9d-b194-266e85eea867">

### Category not found

* Navigate to `/patterns/map?ref=developer-lp`.
* Assert that you land on the "Category not found" page and the `calypso_pattern_library_view` event is fired sending:
    * `category=map`
    * `referrer=developer-lp`
    * `error=category-not-found`

<img width="1559" alt="Screen Shot 2024-03-27 at 7 32 43 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/2ebf13fa-bff2-44c5-b3f5-235e48e9d237">

