### PR TITLE
Checkout: Add min-height to SubmitFooterWrapper

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -578,6 +578,7 @@ export const SubmitButtonWrapper = styled.div`
 // Set right padding so that text doesn't overlap with inline help floating button.
 export const SubmitFooterWrapper = styled.div`
 	padding-right: 0;
+	min-height: 45px;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		padding-right: 0;


### PR DESCRIPTION
The SubmitFooterWrapper tends to get obscured by the Zendesk support widget on mobile width devices. The first attempt to resolve this was done in https://github.com/Automattic/wp-calypso/pull/88819/ but it didn't quite fix the issue entirely. Instead, it handled the spacing requirements of the _x axis_ but we still needed to manage spacing requirements on the _y axis_.

| Before | After |
| ----- | ----- |
| <img width="425" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/3a2cd637-f5a3-4112-8f6c-eb83fc4ea315"> | <img width="425" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/eb718d1e-333f-494e-9f14-e539eda67414"> |


This PR adds a `min-height` that prevents the ZD button from overlapping the payment button. Using min height also allows the money back guarantee text to grow without breaking the layout and provides a little extra white space to the bottom of the page which makes it feel less congested.

Related to https://github.com/Automattic/wp-calypso/pull/88819/

## Testing Instructions

* Go to checkout and ensure the submit wrapper footer looks correct at desktop size
* Begin to shrink the width of the browser down to 425px (or lower!) and ensure the ZD button doesn't overlap the payment button
* The text should also adjust if the button is about to clip over it
* Go to Jetpack/Akismet checkouts and do the same (with Jetpack, they use a separate footer but it shares the same SubmitFooterWrapper component, there shouldn't be a noticeable difference here)
