### PR TITLE
Stats: Fix continue for non-commercial

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -479,7 +479,7 @@ function StatsCommercialFlowOptOutForm( {
 				</ul>
 			</div>
 			<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist-button` }>
-				{ supportsOnDemandCommercialClassification && (
+				{ supportsOnDemandCommercialClassification && isCommercial && (
 					<Button
 						variant="secondary"
 						disabled={ hasRunLessThan3DAgo || isFormSubmissionDisabled() }
@@ -489,6 +489,7 @@ function StatsCommercialFlowOptOutForm( {
 					</Button>
 				) }
 				{ ( ! supportsOnDemandCommercialClassification ||
+					! isCommercial ||
 					( ! isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
 					<Button
 						variant="secondary"
@@ -499,7 +500,7 @@ function StatsCommercialFlowOptOutForm( {
 					</Button>
 				) }
 			</div>
-			{ supportsOnDemandCommercialClassification && (
+			{ supportsOnDemandCommercialClassification && isCommercial && (
 				<>
 					{ errorMessage && (
 						<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>{ errorMessage }</p>


### PR DESCRIPTION
## Proposed Changes

We should show Continue button for non-commercial site

## Testing Instructions

* Open Calypso Live Stats purchase page for a non-commercial site `/stats/purchase/:siteSlug?productType=commercial`
* Ensure you are able to switch to non-commercial products

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?