### PR TITLE
Stats: Hide dispute form for new commercial sites

### DIFF
--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -1,0 +1,17 @@
+import { useSelector } from 'calypso/state';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+
+export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: number | null ) {
+	const siteCreatedTimeStamp = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'created_at' )
+	) as string;
+	const isNewSite =
+		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
+	const isExistingSampleSite = siteId && siteId % 100 < 1; // Targeting 1% of existing sites
+
+	return {
+		isNewSite,
+		isExistingSampleSite,
+		isQualified: isNewSite || isExistingSampleSite,
+	};
+}

--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -7,11 +7,9 @@ export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: nu
 	) as string;
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
-	const isExistingSampleSite = siteId && siteId % 100 < 1; // Targeting 1% of existing sites
 
 	return {
 		isNewSite,
-		isExistingSampleSite,
-		isQualified: isNewSite || isExistingSampleSite,
+		isQualified: isNewSite,
 	};
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -296,7 +296,7 @@ const StatsSingleItemPagePurchase = ( {
 	isCommercial,
 }: StatsSingleItemPagePurchaseProps ) => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-	const { isCommercialOwned } = useStatsPurchases( siteId );
+	const { supportCommercialUse } = useStatsPurchases( siteId );
 	const { isNewSite } = useSiteComplusoryPlanSelectionQualifiedCheck( siteId );
 
 	return (
@@ -312,7 +312,7 @@ const StatsSingleItemPagePurchase = ( {
 					from={ from }
 				/>
 			</StatsSingleItemPagePurchaseFrame>
-			{ ! isCommercialOwned && ! ( isNewSite && isCommercial ) && (
+			{ ! supportCommercialUse && ! ( isNewSite && isCommercial ) && (
 				<StatsSingleItemCard>
 					<StatsCommercialFlowOptOutForm
 						isCommercial={ isCommercial }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -10,6 +10,7 @@ import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import useOnDemandCommercialClassificationMutation from '../hooks/use-on-demand-site-identification-mutation';
+import useSiteComplusoryPlanSelectionQualifiedCheck from '../hooks/use-site-complusory-plan-selection-qualified-check';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import { StatsCommercialUpgradeSlider, getTierQuentity } from './stats-commercial-upgrade-slider';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
@@ -296,6 +297,7 @@ const StatsSingleItemPagePurchase = ( {
 }: StatsSingleItemPagePurchaseProps ) => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const { isCommercialOwned } = useStatsPurchases( siteId );
+	const { isNewSite } = useSiteComplusoryPlanSelectionQualifiedCheck( siteId );
 
 	return (
 		<>
@@ -310,7 +312,7 @@ const StatsSingleItemPagePurchase = ( {
 					from={ from }
 				/>
 			</StatsSingleItemPagePurchaseFrame>
-			{ ! isCommercialOwned && (
+			{ ! isCommercialOwned && isCommercial && ! isNewSite && (
 				<StatsSingleItemCard>
 					<StatsCommercialFlowOptOutForm
 						isCommercial={ isCommercial }
@@ -479,7 +481,7 @@ function StatsCommercialFlowOptOutForm( {
 				</ul>
 			</div>
 			<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist-button` }>
-				{ supportsOnDemandCommercialClassification && (
+				{ supportsOnDemandCommercialClassification && isCommercial && (
 					<Button
 						variant="secondary"
 						disabled={ hasRunLessThan3DAgo || isFormSubmissionDisabled() }
@@ -489,6 +491,7 @@ function StatsCommercialFlowOptOutForm( {
 					</Button>
 				) }
 				{ ( ! supportsOnDemandCommercialClassification ||
+					! isCommercial ||
 					( ! isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
 					<Button
 						variant="secondary"
@@ -499,7 +502,7 @@ function StatsCommercialFlowOptOutForm( {
 					</Button>
 				) }
 			</div>
-			{ supportsOnDemandCommercialClassification && (
+			{ supportsOnDemandCommercialClassification && isCommercial && (
 				<>
 					{ errorMessage && (
 						<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>{ errorMessage }</p>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -312,15 +312,16 @@ const StatsSingleItemPagePurchase = ( {
 					from={ from }
 				/>
 			</StatsSingleItemPagePurchaseFrame>
-			{ ! isCommercialOwned && isCommercial && ! isNewSite && (
-				<StatsSingleItemCard>
-					<StatsCommercialFlowOptOutForm
-						isCommercial={ isCommercial }
-						siteId={ siteId }
-						siteSlug={ siteSlug }
-					/>
-				</StatsSingleItemCard>
-			) }
+			{ ! isCommercialOwned ||
+				( isCommercial && ! isNewSite && (
+					<StatsSingleItemCard>
+						<StatsCommercialFlowOptOutForm
+							isCommercial={ isCommercial }
+							siteId={ siteId }
+							siteSlug={ siteSlug }
+						/>
+					</StatsSingleItemCard>
+				) ) }
 		</>
 	);
 };

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -312,7 +312,7 @@ const StatsSingleItemPagePurchase = ( {
 					from={ from }
 				/>
 			</StatsSingleItemPagePurchaseFrame>
-			{ ! isCommercialOwned && ! isNewSite && (
+			{ ! isCommercialOwned && ! ( isNewSite && isCommercial ) && (
 				<StatsSingleItemCard>
 					<StatsCommercialFlowOptOutForm
 						isCommercial={ isCommercial }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -312,16 +312,15 @@ const StatsSingleItemPagePurchase = ( {
 					from={ from }
 				/>
 			</StatsSingleItemPagePurchaseFrame>
-			{ ! isCommercialOwned ||
-				( isCommercial && ! isNewSite && (
-					<StatsSingleItemCard>
-						<StatsCommercialFlowOptOutForm
-							isCommercial={ isCommercial }
-							siteId={ siteId }
-							siteSlug={ siteSlug }
-						/>
-					</StatsSingleItemCard>
-				) ) }
+			{ ! isCommercialOwned && ! isNewSite && (
+				<StatsSingleItemCard>
+					<StatsCommercialFlowOptOutForm
+						isCommercial={ isCommercial }
+						siteId={ siteId }
+						siteSlug={ siteSlug }
+					/>
+				</StatsSingleItemCard>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -6,12 +6,13 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { isJetpackSite, getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	receiveStatNoticeSettings,
 	requestStatNoticeSettings,
 } from 'calypso/state/stats/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useSiteComplusoryPlanSelectionQualifiedCheck from '../hooks/use-site-complusory-plan-selection-qualified-check';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import StatsLoader from './stats-loader';
 
@@ -22,9 +23,6 @@ interface StatsRedirectFlowProps {
 const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const siteCreatedTimeStamp = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'created_at' )
-	) as string;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	const {
@@ -55,16 +53,14 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 
 	const isLoading = ! hasLoadedSitePurchases || isRequestingSitePurchases || isLoadingNotices;
 	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned || supportCommercialUse;
-	const qualifiedUser =
-		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' );
-
+	const { isQualified } = useSiteComplusoryPlanSelectionQualifiedCheck( siteId );
 	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
 	const redirectToPurchase =
 		config.isEnabled( 'stats/checkout-flows-v2' ) &&
 		isSiteJetpackNotAtomic &&
 		! hasPlan &&
 		purchaseNotPostponed &&
-		qualifiedUser;
+		isQualified;
 
 	// TODO: If notices are not used by class components, we don't have any reasons to launch any of those actions anymore. If we do need them, we should consider refactoring them to another component.
 	const dispatch = useDispatch();


### PR DESCRIPTION
## Proposed Changes

* Hide disputation form for new commercial sites p1711556859093899-slack-C0438NHCLSY
* Fix an issue when site is non-commercial but is not able to switch to PWYW

## Testing Instructions

* Create a JN site and connect the site
* Override the site status to commercial
* Open `https://wordpress.com/stats/day/:siteSlug`
* Ensure you are taken to the purchase page
* Ensure the disputation form is hidden
* Remove the status override
* Ensure you could switch to PWYW freely with the `Continue` button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?