### PR TITLE
Dotcom page patterns: Show v2 page patterns in the pages modal with all themes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -290,27 +290,16 @@ class Starter_Page_Templates {
 	public function get_page_templates( string $locale ) {
 		$page_template_data   = get_transient( $this->get_templates_cache_key( $locale ) );
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
-		$is_assembler_v2_site = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true ) || isset( $_GET['v2_patterns'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
-		if ( $is_assembler_v2_site || false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || false !== $override_source_site ) {
-			$request_params = array(
-				'site'         => $override_source_site,
-				'tags'         => 'layout',
-				'pattern_meta' => 'is_web',
-			);
-
-			if ( $is_assembler_v2_site ) {
-				$request_params = array(
-					'site'       => 'dotcompatterns.wordpress.com',
-					'categories' => 'page',
-					'post_type'  => 'wp_block',
-				);
-			}
-
+		if ( false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || false !== $override_source_site ) {
 			$request_url = esc_url_raw(
 				add_query_arg(
-					$request_params,
+					array(
+						'site'       => $override_source_site ?? 'dotcompatterns.wordpress.com',
+						'categories' => 'page',
+						'post_type'  => 'wp_block',
+					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $locale
 				)
 			);
@@ -330,7 +319,7 @@ class Starter_Page_Templates {
 			$page_template_data = json_decode( wp_remote_retrieve_body( $response ), true );
 
 			// Only save to cache if we have not overridden the source site.
-			if ( ! $is_assembler_v2_site && false === $override_source_site ) {
+			if ( false === $override_source_site ) {
 				set_transient( $this->get_templates_cache_key( $locale ), $page_template_data, DAY_IN_SECONDS );
 			}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -27,7 +27,7 @@ class Starter_Page_Templates {
 	 *
 	 * @var string
 	 */
-	public $templates_cache_key;
+	public $templates_cache_key = 'starter_page_templates';
 
 	/**
 	 * Starter_Page_Templates constructor.
@@ -43,24 +43,13 @@ class Starter_Page_Templates {
 	}
 
 	/**
-	 * Gets the cache key for templates array, after setting it if it hasn't been set yet.
+	 * Gets the cache key for templates array.
 	 *
 	 * @param string $locale The templates locale.
 	 *
 	 * @return string
 	 */
 	public function get_templates_cache_key( string $locale ) {
-		if ( empty( $this->templates_cache_key ) ) {
-			$this->templates_cache_key = implode(
-				'_',
-				array(
-					'starter_page_templates',
-					A8C_ETK_PLUGIN_VERSION,
-					get_option( 'site_vertical', 'default' ),
-				)
-			);
-		}
-
 		return $this->templates_cache_key . '_' . $locale;
 	}
 
@@ -290,9 +279,10 @@ class Starter_Page_Templates {
 	public function get_page_templates( string $locale ) {
 		$page_template_data   = get_transient( $this->get_templates_cache_key( $locale ) );
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
+		$disable_cache        = is_automattician() || false !== $override_source_site || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE );
 
-		// Load fresh data if we don't have any or vertical_id doesn't match.
-		if ( false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || false !== $override_source_site ) {
+		// Load fresh data if is automattician or we don't have any data.
+		if ( $disable_cache || false === $page_template_data ) {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
@@ -318,9 +308,9 @@ class Starter_Page_Templates {
 
 			$page_template_data = json_decode( wp_remote_retrieve_body( $response ), true );
 
-			// Only save to cache if we have not overridden the source site.
-			if ( false === $override_source_site ) {
-				set_transient( $this->get_templates_cache_key( $locale ), $page_template_data, DAY_IN_SECONDS );
+			// Only save to cache when is not disabled.
+			if ( ! $disable_cache ) {
+				set_transient( $this->get_templates_cache_key( $locale ), $page_template_data, 5 * MINUTE_IN_SECONDS );
 			}
 
 			return $page_template_data;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->


## Proposed Changes

* Show v2 page patterns in the pages modal with all themes

|BEFORE|AFTER|
|-|-|
|<img width="1728" alt="Screenshot 2567-03-28 at 00 02 08" src="https://github.com/Automattic/wp-calypso/assets/1881481/3ca4ec85-a8bc-4f45-8701-a495844c207c">|<img width="1728" alt="Screenshot 2567-03-28 at 00 00 00" src="https://github.com/Automattic/wp-calypso/assets/1881481/46f17fda-f354-4b3c-92d1-e7f66d6728cd">|



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a simple site and the public api
* Apply this patch with `install-plugin.sh etk fix/use-dotcom-pattern-library`
* Make sure you have a theme other than Assembler active on your site
* Create a new page via `{ YOUR SITE }/wp-admin/post-new.php?post_type=page` to see the pages modal 
* Verify you see the same patterns and categories as when you have the Assembler theme active

**Test on Atomic**
- Download the ETK plugin from Teamcity
- Upload it on an Atomic site
- Access `{ YOUR SITE }/wp-admin/post-new.php?post_type=page` to see the pages modal 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?