### PR TITLE
Fix white screen when logging in via 2FA-enabled passwordless account with proxy

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -101,8 +101,14 @@ export async function login( context, next ) {
 		}
 
 		const { searchParams: redirectParams } = getUrlParts( redirect_to );
+		const back = redirectParams.get( 'back' );
 
-		if ( client_id !== redirectParams.get( 'client_id' ) ) {
+		const redirectClientId =
+			redirectParams.get( 'client_id' ) ||
+			// If the client_id is not in the redirect_to URL, check the back URL. This is for the case where the client_id is passed in the back parameter of remote login link when proxy is enabled. See: https://github.com/Automattic/wp-calypso/issues/52940
+			( back ? getUrlParts( back ).searchParams.get( 'client_id' ) : null );
+
+		if ( client_id !== redirectClientId ) {
 			const error = new Error(
 				'The `redirect_to` query parameter is invalid with the given `client_id`.'
 			);
@@ -120,7 +126,6 @@ export async function login( context, next ) {
 			}
 		}
 	}
-
 	enhanceContextWithLogin( context );
 
 	next();

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -126,6 +126,7 @@ export async function login( context, next ) {
 			}
 		}
 	}
+
 	enhanceContextWithLogin( context );
 
 	next();

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -69,7 +69,7 @@ describe( 'login', () => {
 		expect( next ).toHaveBeenCalledWith( expect.objectContaining( { status: 401 } ) );
 	} );
 
-	it( 'should throw an error if client_id does not match redirect ClientId', async () => {
+	it( 'should throw an error if client_id does not match redirectClientId', async () => {
 		context.query.client_id = '1234';
 		context.query.redirect_to = 'http://public-api.wordpress.com?client_id=different_client_id';
 		await login( context, next );
@@ -87,7 +87,7 @@ describe( 'login', () => {
 		expect( next ).toHaveBeenCalled();
 	} );
 
-	it( 'should get OAuth2Client if client_id matches redirect ClientId', async () => {
+	it( 'should get OAuth2Client if client_id matches redirectClientId', async () => {
 		context.query.client_id = '1234';
 		context.query.redirect_to = 'http://public-api.wordpress.com?client_id=1234';
 		getOAuth2Client.mockReturnValueOnce( {} );

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -58,21 +58,27 @@ describe( 'login', () => {
 
 	it( 'should replace page and return if context.hash and context.hash.client_id exist', async () => {
 		context.hash = { client_id: '1234' };
+
 		await login( context, next );
+
 		expect( page.replace ).toHaveBeenCalled();
 		expect( next ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should throw an error if client_id exists but redirect_to does not', async () => {
 		context.query.client_id = '1234';
+
 		await login( context, next );
+
 		expect( next ).toHaveBeenCalledWith( expect.objectContaining( { status: 401 } ) );
 	} );
 
 	it( 'should throw an error if client_id does not match redirectClientId', async () => {
 		context.query.client_id = '1234';
 		context.query.redirect_to = 'http://public-api.wordpress.com?client_id=different_client_id';
+
 		await login( context, next );
+
 		expect( next ).toHaveBeenCalledWith( expect.objectContaining( { status: 401 } ) );
 	} );
 
@@ -81,6 +87,7 @@ describe( 'login', () => {
 		context.query.redirect_to =
 			'http://jetpack.com?back=https://public-api.wordpress.com?client_id=1234';
 		getOAuth2Client.mockReturnValueOnce( {} );
+
 		await login( context, next );
 
 		expect( getOAuth2Client ).toHaveBeenCalledWith( state, '1234' );
@@ -91,7 +98,9 @@ describe( 'login', () => {
 		context.query.client_id = '1234';
 		context.query.redirect_to = 'http://public-api.wordpress.com?client_id=1234';
 		getOAuth2Client.mockReturnValueOnce( {} );
+
 		await login( context, next );
+
 		expect( getOAuth2Client ).toHaveBeenCalledWith( state, '1234' );
 		expect( next ).toHaveBeenCalled();
 	} );

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -1,4 +1,18 @@
-import { redirectJetpack } from '../controller';
+import page from '@automattic/calypso-router';
+import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
+import { redirectJetpack, login } from '../controller';
+
+jest.mock( 'calypso/state/oauth2-clients/actions', () => ( {
+	...jest.requireActual( 'calypso/state/oauth2-clients/actions' ),
+	fetchOAuth2ClientData: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/oauth2-clients/selectors', () => ( {
+	...jest.requireActual( 'calypso/state/oauth2-clients/selectors' ),
+	getOAuth2Client: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/calypso-router' );
 
 describe( 'redirectJetpack', () => {
 	it( "does not append 'jetpack' to the login path and redirect if it's already present", () => {
@@ -15,6 +29,70 @@ describe( 'redirectJetpack', () => {
 		redirectJetpack( context, next );
 
 		// If a redirect didn't occur, the test passes
+		expect( next ).toHaveBeenCalled();
+	} );
+} );
+
+describe( 'login', () => {
+	let context;
+	let next;
+	let state;
+
+	beforeEach( () => {
+		state = {
+			app: {},
+		};
+
+		context = {
+			query: {},
+			store: {
+				getState: jest.fn().mockReturnValue( state ),
+				dispatch: jest.fn(),
+			},
+			params: {
+				flow: 'login',
+			},
+		};
+		next = jest.fn();
+	} );
+
+	it( 'should replace page and return if context.hash and context.hash.client_id exist', async () => {
+		context.hash = { client_id: '1234' };
+		await login( context, next );
+		expect( page.replace ).toHaveBeenCalled();
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should throw an error if client_id exists but redirect_to does not', async () => {
+		context.query.client_id = '1234';
+		await login( context, next );
+		expect( next ).toHaveBeenCalledWith( expect.objectContaining( { status: 401 } ) );
+	} );
+
+	it( 'should throw an error if client_id does not match redirect ClientId', async () => {
+		context.query.client_id = '1234';
+		context.query.redirect_to = 'http://public-api.wordpress.com?client_id=different_client_id';
+		await login( context, next );
+		expect( next ).toHaveBeenCalledWith( expect.objectContaining( { status: 401 } ) );
+	} );
+
+	it( 'should get OAuth2Client if back parameter is present', async () => {
+		context.query.client_id = '1234';
+		context.query.redirect_to =
+			'http://jetpack.com?back=https://public-api.wordpress.com?client_id=1234';
+		getOAuth2Client.mockReturnValueOnce( {} );
+		await login( context, next );
+
+		expect( getOAuth2Client ).toHaveBeenCalledWith( state, '1234' );
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	it( 'should get OAuth2Client if client_id matches redirect ClientId', async () => {
+		context.query.client_id = '1234';
+		context.query.redirect_to = 'http://public-api.wordpress.com?client_id=1234';
+		getOAuth2Client.mockReturnValueOnce( {} );
+		await login( context, next );
+		expect( getOAuth2Client ).toHaveBeenCalledWith( state, '1234' );
 		expect( next ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1711532969997129/1710911965.854649-slack-C01SFMVEYAK

Normally, the magic link redirects the user to 

- https:\/\/wordpress.com/log-in/authenticator?redirect_to=**https%3A%2F%2Fpublic-api.wordpress.com**%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D95213bab49d8d5c58371a7bac0405ffd4230cd7c7bb1bcffd5cc91df16839819%26**redirect_uri**%3Dhttps%253A%252F%252Fwoo.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fstart%25252F%252523%25252Finstallation%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1%26woo-passwordless%3Dyes&client_id=50916&wccom-from=nux` 

but when proxy is enabled, it redirects user to 

- https:\/\/wordpress.com/log-in/authenticator?redirect_to=**https%3A%2F%2Fjetpack.com**%2Fremote-login.php%3Fwpcom_remote_login%3Dvalidate%26wpcomid%3D20115252%26token%3D7P7A7uhCj90JgIgFDf5qVeEvqFSPKJImYOkzd%252Bs89bOepdr9Df6ZoC2kFg7yuwggtY61woNUP3vABSmsvxd6bEQE%257C1602f4fe406ba2af3ee89613b0b5b50abe7158ee976bdb4e%257Cc3d9b698c9ccce7e9bc228111e3af9ab15b02091b3726d66fa6b1765582e0d33%26host%3Dhttps%253A%252F%252Fjetpack.com%**26back**%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253D95213bab49d8d5c58371a7bac0405ffd4230cd7c7bb1bcffd5cc91df16839819%**2526redirect_uri**%253Dhttps%25253A%25252F%25252Fwoo.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252Fstart%2525252F%25252523%2525252Finstallation%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%253Dnux%2526calypso_env%253Dproduction%2526jetpack-code%2526jetpack-user-id%253D0%2526action%253Doauth2-login%2526from-calypso%253D1%2526woo-passwordless%253Dyes&client_id=50916&wccom-from=nux&woo-passwordless=yes 

Since we don't expect the `redirect_uri` to be changed to `jetpack.com` and the `client_id` is missing in `redirect_to`, an error is thrown when the user tries to log in with a 2FA-enabled passwordless account.

Note that we only log the error on the server side and don't show it to the user. However, I think it's out of this PR's scope to handle the error properly on the client side, and that would require digging deeper into the codebase and understanding the whole flow of routing and error handling, and we may need the Calypso team's help.

## Proposed Changes

- Fix the `redirect_to` check logic to handle the case where the `redirect_to` is a remote link and client_id is passed in the `back` query string
- Add unit tests 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set proxy to true in fbhepr%2Skers%2Sjcpbz%2S.pbasvt%2Sjcpbz%2Qbcgvbaf.cuc%3Se%3Q8opp0956%23302%2Q306-og on your sandbox
* Set up woo start env
* Go to https://woo.com/start/#/installation
* Click on `Try Woo Express for free`
* Go to login screen 
* Login with a 2FA-enabled passwordless account
* Confirm you can use magic login and after 2FA, you are redirected to the Woo Express loading screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?