### PR TITLE
Fixing ui issues on campaigns table for evergreen campaigns

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -77,15 +77,26 @@ export default function CampaignItem( props: Props ) {
 	);
 
 	let budgetString = '-';
+	let budgetStringMobile = '';
 	if ( is_evergreen && campaignDays ) {
-		budgetString = `$${ formatCents( totalBudget ) } weekly`;
+		/* translators: Daily average spend. dailyAverageSpending is the budget */
+		budgetString = sprintf(
+			/* translators: %s is a formatted amount */
+			'%s weekly',
+			`$${ formatCents( totalBudget ) }`
+		);
+		budgetStringMobile = sprintf(
+			/* translators: %s is a formatted amount */
+			'%s weekly budget',
+			`$${ totalBudget }`
+		);
 	} else if ( campaignDays ) {
 		budgetString = `$${ formatCents( totalBudget ) }`;
-	}
-
-	let budgetStringMobile = campaignDays ? `$${ totalBudget } budget` : null;
-	if ( is_evergreen && campaignDays ) {
-		budgetStringMobile = `$${ totalBudget } weekly budget`;
+		budgetStringMobile = sprintf(
+			/* translators: %s is a formatted amount */
+			'%s budget',
+			`$${ totalBudget }`
+		);
 	}
 
 	const isWooStore = config.isEnabled( 'is_running_in_woo_site' );
@@ -190,7 +201,7 @@ export default function CampaignItem( props: Props ) {
 			</td>
 			<td className="campaign-item__ends">
 				<div>
-					{ campaign.end_date && campaign.end_date.length > 0
+					{ campaign.end_date
 						? getCampaignEndText(
 								moment( campaign.end_date ),
 								campaign.status,

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -82,20 +82,20 @@ export default function CampaignItem( props: Props ) {
 		/* translators: Daily average spend. dailyAverageSpending is the budget */
 		budgetString = sprintf(
 			/* translators: %s is a formatted amount */
-			'%s weekly',
-			`$${ formatCents( totalBudget ) }`
+			translate( '$%s weekly' ),
+			formatCents( totalBudget )
 		);
 		budgetStringMobile = sprintf(
 			/* translators: %s is a formatted amount */
-			'%s weekly budget',
-			`$${ totalBudget }`
+			translate( '$%s weekly budget' ),
+			totalBudget
 		);
 	} else if ( campaignDays ) {
 		budgetString = `$${ formatCents( totalBudget ) }`;
 		budgetStringMobile = sprintf(
 			/* translators: %s is a formatted amount */
-			'%s budget',
-			`$${ totalBudget }`
+			translate( '$%s budget' ),
+			totalBudget
 		);
 	}
 

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -73,7 +73,7 @@ export default function CampaignItem( props: Props ) {
 	const { totalBudget, campaignDays } = useMemo(
 		() =>
 			getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents, is_evergreen ),
-		[ budget_cents, end_date, spent_budget_cents, start_date ]
+		[ budget_cents, end_date, spent_budget_cents, start_date, is_evergreen ]
 	);
 
 	let budgetString = '-';

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -83,7 +83,11 @@ export default function CampaignItem( props: Props ) {
 		budgetString = `$${ formatCents( totalBudget ) }`;
 	}
 
-	const budgetStringMobile = campaignDays ? `$${ totalBudget } budget` : null;
+	let budgetStringMobile = campaignDays ? `$${ totalBudget } budget` : null;
+	if ( is_evergreen && campaignDays ) {
+		budgetStringMobile = `$${ totalBudget } weekly budget`;
+	}
+
 	const isWooStore = config.isEnabled( 'is_running_in_woo_site' );
 
 	const getPostType = ( type: string ) => {
@@ -186,11 +190,13 @@ export default function CampaignItem( props: Props ) {
 			</td>
 			<td className="campaign-item__ends">
 				<div>
-					{ getCampaignEndText(
-						moment( campaign.end_date ),
-						campaign.status,
-						campaign?.is_evergreen
-					) }
+					{ campaign.end_date && campaign.end_date.length > 0
+						? getCampaignEndText(
+								moment( campaign.end_date ),
+								campaign.status,
+								campaign?.is_evergreen
+						  )
+						: '-' }
 				</div>
 			</td>
 			<td className="campaign-item__budget">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixing UI issues on Campaigns table. 

First issue was that the table was showing "Invalid date". This was caused because the end_date object was empty and we still were trying to parse it.

The second issue is the addition of the word weekly to the mobile view of the table

## Testing Instructions

- [ ] Create an evergreen campaign
- [ ] Cancel it
- [ ] go to the campaigns table
- [ ] Verify that in the `Ends` column there is no "invalid date" string
- [ ] verify the mobile view

![Screenshot 2024-03-28 at 0 26 06](https://github.com/Automattic/wp-calypso/assets/5014402/42dc59f9-2e40-40da-b0c9-56562cc1b82a)


![Screenshot 2024-03-28 at 0 26 28](https://github.com/Automattic/wp-calypso/assets/5014402/711621ec-5904-415f-b0b2-79d6db44cf93)



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
