### PR TITLE
A4A: Fix the issue with the shopping cart not cleared after checkout.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -36,7 +36,11 @@ export default function Checkout() {
 		?.toString()
 		.split( ',' );
 
-	const { isReady, submitForm } = useSubmitForm( selectedSite, suggestedProductSlugs );
+	const { isReady, submitForm } = useSubmitForm( {
+		selectedSite,
+		suggestedProductSlugs,
+		onSuccessCallback: onClearCart,
+	} );
 
 	const sortedSelectedItems = useMemo( () => {
 		return Object.values(

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -59,6 +59,7 @@ const useGetLicenseIssuedMessage = () => {
 };
 
 type UseIssueAndAssignLicensesOptions = {
+	onSuccess?: () => void;
 	onIssueError?: ( ( error: APIError ) => void ) | ( () => void );
 	onAssignError?: ( ( error: Error ) => void ) | ( () => void );
 };
@@ -103,6 +104,9 @@ function useIssueAndAssignLicenses(
 				} )
 			);
 
+			// We have issued the licenses successfully so we can now call onSuccess callback regardless if it was able to assign it.
+			options.onSuccess?.();
+
 			const issuedKeys = issuedLicenses.map( ( { license_key } ) => license_key );
 
 			// TODO: Move dispatch events and redirects outside this function
@@ -146,6 +150,7 @@ function useIssueAndAssignLicenses(
 		isAssignReady,
 		isIssueReady,
 		issueLicenses,
+		options,
 		selectedSite?.ID,
 	] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-submit-form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-submit-form.tsx
@@ -14,12 +14,21 @@ import useIssueAndAssignLicenses from '../../hooks/use-issue-and-assign-licenses
 import { IssueLicenseRequest } from '../../hooks/use-issue-licenses';
 import type { SiteDetails } from '@automattic/data-stores';
 
-const useSubmitForm = ( selectedSite?: SiteDetails | null, suggestedProductSlugs?: string[] ) => {
+type Props = {
+	selectedSite?: SiteDetails | null;
+	suggestedProductSlugs?: string[];
+	onSuccessCallback?: () => void;
+};
+
+const useSubmitForm = ( { selectedSite, suggestedProductSlugs, onSuccessCallback }: Props ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const { issueAndAssignLicenses, isReady: isIssueAndAssignLicensesReady } =
 		useIssueAndAssignLicenses( selectedSite, {
+			onSuccess: () => {
+				onSuccessCallback?.();
+			},
 			onIssueError: ( error: APIError ) => {
 				if ( error.code === 'missing_valid_payment_method' ) {
 					dispatch(

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -184,7 +184,7 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 		[ dispatch, handleSelectBundleLicense, quantity, selectedCartItems, setSelectedCartItems ]
 	);
 
-	const { isReady } = useSubmitForm( selectedSite, suggestedProductSlugs );
+	const { isReady } = useSubmitForm( { selectedSite, suggestedProductSlugs } );
 
 	const isSelected = useCallback(
 		( slug: string | string[] ) =>


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/150

## Proposed Changes

* Extend the `useSubmitForm` and `useIssueAndAssign` hooks to support success callback. 
* Add a success callback that clears the shopping cart when Purchase submission is successful.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace`.
* Pick random products and add them to the cart.
* Proceed to checkout your cart.
* After a successful checkout, return to the Marketplace page. `/marketplace`.
* Confirm that the cart is now empty and does not retain the previous state.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?