### PR TITLE
Pattern Library: More tweaks to Masonry logic

### DIFF
--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -25,12 +25,16 @@ function debounce( callback: () => void ) {
 }
 
 function calculateMasonryLayout( element: HTMLElement ) {
-	const columnCount = getComputedStyle( element ).gridTemplateColumns.split( ' ' ).length;
+	const elementStyle = getComputedStyle( element );
+	const columnCount = elementStyle.gridTemplateColumns.split( ' ' ).length;
+	const parsedRowGap = /(\d+(\.\d+)?)px/.exec( elementStyle.rowGap );
+	const rowGap = parseFloat( parsedRowGap?.[ 1 ] ?? '0' );
+
 	const items = [ ...element.querySelectorAll< HTMLElement >( '.pattern-preview' ) ];
 
 	if ( columnCount === 1 ) {
 		items.forEach( ( item ) => {
-			item.style.removeProperty( 'transform' );
+			item.style.removeProperty( 'margin-top' );
 		} );
 
 		return;
@@ -38,21 +42,26 @@ function calculateMasonryLayout( element: HTMLElement ) {
 
 	// Always reset all items on the first row, since the number of grid columns is variable
 	items.slice( 0, columnCount ).forEach( ( item ) => {
-		item.style.removeProperty( 'transform' );
+		item.style.removeProperty( 'margin-top' );
 	} );
 
 	// We calculate the difference between the top coordinates of each `.pattern-preview` with the
 	// bottom coordinates of the first `.pattern-preview` in the same column. This value is then
-	// used to set a negative `translateY` transform, simulating a Masonry layout
+	// used to set a negative `margin-top`, simulating a Masonry layout
 	items.slice( columnCount ).forEach( ( item, i ) => {
 		const firstRowBottom = items[ i ].getBoundingClientRect().bottom;
 		const thisRowTop = item.getBoundingClientRect().top;
-		const parsedTransform = /translateY\((-?\d+(\.\d+)?px)/.exec( item.style.transform );
-		const currentTransform = parsedTransform?.[ 1 ] ?? '0';
 
-		item.style.transform = `translateY(${
-			firstRowBottom - thisRowTop + parseFloat( currentTransform )
-		}px)`;
+		const parsedMarginTop = /(-?\d+(\.\d+)?)px/.exec( item.style.marginTop );
+		const currentMarginTop = parseFloat( parsedMarginTop?.[ 1 ] ?? '0' );
+
+		const marginTop = firstRowBottom - thisRowTop + rowGap + currentMarginTop;
+
+		if ( marginTop <= -1 ) {
+			item.style.marginTop = `${ marginTop }px`;
+		} else {
+			item.style.removeProperty( 'margin-top' );
+		}
 	} );
 }
 
@@ -61,8 +70,8 @@ type MasonryGalleryProps = PropsWithChildren< {
 	enableMasonry: boolean;
 } >;
 
-// Simulates a Masonry layout by applying negative `translateY` transform on every item that doesn't
-// sit in the first row
+// Simulates a Masonry layout by applying negative `margin-top` on every item that doesn't sit in
+// the first row
 function MasonryGallery( { children, className, enableMasonry }: MasonryGalleryProps ) {
 	const ref = useRef< HTMLDivElement >( null );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to #88842

## Proposed Changes

In #88842, I failed to account for `row-gap` in `.pattern-gallery`. As a result, the vertical margin between items was insufficient. This PR fixes that.

I also failed to account for the fact that by using `transform` instead of `margin-top`, the height of `.pattern-gallery` won't be reduced when items are shifted upwards. This isn't always an issue. Sometimes, items will be laid out so that the tallest item in the last row isn't shifted. Moreover, the extra height in the container is easy to miss. 

Still, the behavior is incorrect, so I decided to revert to `margin-top`, even if it means more work for the browser to recalculate the layout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/layouts/services`
2. Click the grid view button
3. Ensure that the pattern previews lay out properly and that the vertical margin between items looks good
