### PR TITLE
A4A: Deactivating bulk selection in the sites dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -26,6 +26,10 @@
 		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-subtitle {
 			display: none;
 		}
+
+		.dataviews-view-table {
+			padding-left: 48px;
+		}
 	}
 
 	@media (max-width: $break-large) {
@@ -88,6 +92,10 @@
 					margin-top: 16px;
 				}
 			}
+		}
+
+		.dataviews-view-table {
+			padding-left: 16px;
 		}
 
 		.components-button.is-compact.has-icon:not(.has-text).dataviews-filters-button {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -227,6 +227,8 @@ const SitesDataViews = ( {
 
 	// Actions: Pause Monitor, Resume Monitor, Custom Notification, Reset Notification
 	// todo - refactor: extract actions, along fields, to the upper component
+	// Currently not in use until bulk selections are properly implemented.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const actions = useMemo(
 		() => [
 			{
@@ -321,7 +323,7 @@ const SitesDataViews = ( {
 				} }
 				onChangeView={ onSitesViewChange }
 				supportedLayouts={ [ 'table' ] }
-				actions={ actions }
+				actions={ [] } // Replace with actions when bulk selections are implemented.
 				isLoading={ isLoading }
 			/>
 		</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/153

## Proposed Changes

* This PR removes the action const with various bulk edit action possibilities from the DataViews component. The actions const had not been properly implemented yet, so until properly implemented it is being hidden.
* Styling additions have been added to make sure the dashboard continues to have paddings matching design specs, as removing the bulk selection checkboxes also removed padding.

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* If testing in trunk, you should see the 'Bulk Edit' link showing at the top right of your screen near the View Options icon. You should also have the ability to bulk select sites from the column to the right of the sites column.
* With this branch checked out, the Bulk Edit link is removed and the bulk selection checkboxes also removed.

With bulk selection in place:
<img width="1473" alt="Screenshot 2024-03-28 at 10 42 27" src="https://github.com/Automattic/wp-calypso/assets/16754605/fd0ab8aa-bcb5-4580-9298-e41c8a1ba4ab">

With bulk selection removed:

<img width="1490" alt="Screenshot 2024-03-28 at 10 41 13" src="https://github.com/Automattic/wp-calypso/assets/16754605/e234f26f-8683-4424-9286-ab44b72e5f14">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?