### PR TITLE
Pattern Library: Add a string repository

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -21,6 +21,8 @@ import {
 	filterPatternsByTerm,
 } from 'calypso/my-sites/patterns/hooks/use-pattern-search-term';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
+import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
+import { getTranslatedString } from 'calypso/my-sites/patterns/lib/strings';
 import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
 import {
 	PatternTypeFilter,
@@ -33,7 +35,6 @@ import {
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import { getTracksPatternType } from '../../lib/get-tracks-pattern-type';
 
 import './style.scss';
 
@@ -176,94 +177,7 @@ export const PatternLibrary = ( {
 
 	const isHomePage = ! category && ! searchTerm;
 
-	const PATTERN_SEO_CONTENT: Record< Category[ 'name' ], { title: string } > = {
-		default: {
-			title: translate( 'WordPress Patterns', {
-				comment: 'Pattern Library home page title',
-				textOnly: true,
-			} ),
-		},
-		header: {
-			title: translate( 'WordPress Header Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		footer: {
-			title: translate( 'WordPress Footer Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		about: {
-			title: translate( 'WordPress About Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		posts: {
-			title: translate( 'WordPress Blog Post Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		contact: {
-			title: translate( 'WordPress Contact Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		events: {
-			title: translate( 'WordPress Events Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		gallery: {
-			title: translate( 'WordPress Gallery Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		intro: {
-			title: translate( 'WordPress Intro Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		menu: {
-			title: translate( 'WordPress Menu Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		newsletter: {
-			title: translate( 'WordPress Newsletter Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		services: {
-			title: translate( 'WordPress Services Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		store: {
-			title: translate( 'WordPress Store Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-		testimonials: {
-			title: translate( 'WordPress Testimonial Patterns', {
-				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} ),
-		},
-	};
-
-	const seoContent = category ? PATTERN_SEO_CONTENT[ category ] : PATTERN_SEO_CONTENT.default;
+	const pageTitleTranslationKey = category ? `${ category }_page_title` : 'default_page_title';
 
 	return (
 		<>
@@ -278,7 +192,7 @@ export const PatternLibrary = ( {
 				searchTerm={ urlQuerySearchTerm }
 			/>
 
-			<DocumentHead title={ seoContent.title } />
+			<DocumentHead title={ getTranslatedString( translate, pageTitleTranslationKey as any ) } />
 
 			<PatternsHeader
 				description={ translate(

--- a/client/my-sites/patterns/lib/strings.ts
+++ b/client/my-sites/patterns/lib/strings.ts
@@ -14,7 +14,8 @@ type Key =
 	| 'newsletter_page_title'
 	| 'services_page_title'
 	| 'store_page_title'
-	| 'testimonials_page_title';
+	| 'testimonials_page_title'
+	| 'fredrik_test';
 
 export function getTranslatedString( translate: I18N[ 'translate' ], key: Key ): string {
 	switch ( key ) {
@@ -99,6 +100,12 @@ export function getTranslatedString( translate: I18N[ 'translate' ], key: Key ):
 		case 'testimonials_page_title':
 			return translate( 'WordPress Testimonial Patterns', {
 				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'fredrik_test':
+			return translate( 'Fredrik Lorem Ipsum Hello', {
+				comment: 'Test string',
 				textOnly: true,
 			} );
 	}

--- a/client/my-sites/patterns/lib/strings.ts
+++ b/client/my-sites/patterns/lib/strings.ts
@@ -14,8 +14,7 @@ type Key =
 	| 'newsletter_page_title'
 	| 'services_page_title'
 	| 'store_page_title'
-	| 'testimonials_page_title'
-	| 'fredrik_test';
+	| 'testimonials_page_title';
 
 export function getTranslatedString( translate: I18N[ 'translate' ], key: Key ): string {
 	switch ( key ) {
@@ -100,12 +99,6 @@ export function getTranslatedString( translate: I18N[ 'translate' ], key: Key ):
 		case 'testimonials_page_title':
 			return translate( 'WordPress Testimonial Patterns', {
 				comment: 'Pattern Library category page title',
-				textOnly: true,
-			} );
-
-		case 'fredrik_test':
-			return translate( 'Fredrik Lorem Ipsum Hello', {
-				comment: 'Test string',
 				textOnly: true,
 			} );
 	}

--- a/client/my-sites/patterns/lib/strings.ts
+++ b/client/my-sites/patterns/lib/strings.ts
@@ -1,0 +1,105 @@
+import { I18N } from 'i18n-calypso';
+
+type Key =
+	| 'default_page_title'
+	| 'header_page_title'
+	| 'footer_page_title'
+	| 'about_page_title'
+	| 'posts_page_title'
+	| 'contact_page_title'
+	| 'events_page_title'
+	| 'gallery_page_title'
+	| 'intro_page_title'
+	| 'menu_page_title'
+	| 'newsletter_page_title'
+	| 'services_page_title'
+	| 'store_page_title'
+	| 'testimonials_page_title';
+
+export function getTranslatedString( translate: I18N[ 'translate' ], key: Key ): string {
+	switch ( key ) {
+		case 'default_page_title':
+			return translate( 'WordPress Patterns', {
+				comment: 'Pattern Library home page title',
+				textOnly: true,
+			} );
+
+		case 'header_page_title':
+			return translate( 'WordPress Header Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'footer_page_title':
+			return translate( 'WordPress Footer Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'about_page_title':
+			return translate( 'WordPress About Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'posts_page_title':
+			return translate( 'WordPress Blog Post Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'contact_page_title':
+			translate( 'WordPress Contact Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'events_page_title':
+			return translate( 'WordPress Events Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'gallery_page_title':
+			return translate( 'WordPress Gallery Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'intro_page_title':
+			return translate( 'WordPress Intro Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'menu_page_title':
+			return translate( 'WordPress Menu Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'newsletter_page_title':
+			return translate( 'WordPress Newsletter Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'services_page_title':
+			return translate( 'WordPress Services Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'store_page_title':
+			return translate( 'WordPress Store Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+
+		case 'testimonials_page_title':
+			return translate( 'WordPress Testimonial Patterns', {
+				comment: 'Pattern Library category page title',
+				textOnly: true,
+			} );
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88871

## Proposed Changes

This is just a small example thus far, but it's meant to show how we could implement a "translated string repository" for the Pattern Library, similar to how we did with Tumblr Domains. 

The upsides to this approach, as I see it:
- Adding translation comments improves quality but takes up space in the code. This approach entirely mitigates the space issue.
- It's easy to ensure we use the exact same strings when intended. For example, we don't want `Page layouts` in one place and `Page Layouts` in another.

I confirmed with 1ad1859f369035056fbe19c65d40ac4076d7f7fd that our translation pipeline will pick up new strings added to `client/my-sites/patterns/lib/strings.ts`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*