### PR TITLE
Automattic for Agencies: Check if payment method is required and redirect to add payment page

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/assign-license-step-progress/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license-step-progress/index.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import LayoutStepper from 'calypso/a8c-for-agencies/components/layout/stepper';
 import { useSelector } from 'calypso/state';
 import getSites from 'calypso/state/selectors/get-sites';
+import usePaymentMethod from '../../purchases/payment-methods/hooks/use-payment-method';
 import type { SiteDetails } from '@automattic/data-stores';
 
 type StepKey =
@@ -31,7 +32,7 @@ const AssignLicenseStepProgress = ( {
 	isBundleLicensing,
 }: Props ) => {
 	const translate = useTranslate();
-	const paymentMethodRequired = true; // TODO: Get this from the store.
+	const { paymentMethodRequired } = usePaymentMethod();
 	const sites = useSelector( getSites ).length;
 
 	const steps: Step[] = [

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-licenses.tsx
@@ -1,3 +1,4 @@
+import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method';
 import { APIError, APILicense } from 'calypso/state/partner-portal/types';
 import useIssueLicenseMutation from '../../hooks/use-issue-license-mutation';
 
@@ -25,7 +26,7 @@ type UseIssueLicensesOptions = {
 	onError?: ( ( error: APIError ) => void ) | ( () => void );
 };
 const useIssueLicenses = ( options: UseIssueLicensesOptions = {} ) => {
-	const paymentMethodRequired = false; // FIXME: Fix this with actual data
+	const { paymentMethodRequired } = usePaymentMethod();
 
 	const { mutateAsync, isIdle } = useIssueLicenseMutation( {
 		onError: options.onError ?? NO_OP,

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-submit-form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-submit-form.tsx
@@ -3,6 +3,7 @@ import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { A4A_PAYMENT_METHODS_ADD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method';
 import { serializeQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
 import { containEquivalentItems } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-submit-form';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -44,7 +45,8 @@ const useSubmitForm = ( selectedSite?: SiteDetails | null, suggestedProductSlugs
 			onAssignError: ( error: Error ) =>
 				dispatch( errorNotice( error.message, { isPersistent: true } ) ),
 		} );
-	const paymentMethodRequired = false; // FIXME: Fix this with actual data
+
+	const { paymentMethodRequired } = usePaymentMethod();
 
 	const maybeTrackUnsuggestedSelection = useCallback(
 		( selectedLicenses: IssueLicenseRequest[] ) => {

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -1,8 +1,14 @@
+import page from '@automattic/calypso-router';
 import { Badge } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useState } from 'react';
+import {
+	A4A_MARKETPLACE_CHECKOUT_LINK,
+	A4A_PAYMENT_METHODS_ADD_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import usePaymentMethod from '../../purchases/payment-methods/hooks/use-payment-method';
 import ShoppingCartIcon from './shopping-cart-icon';
 import ShoppingCartMenu from './shopping-cart-menu';
 import type { ShoppingCartItem } from '../types';
@@ -18,8 +24,18 @@ type Props = {
 export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props ) {
 	const [ showShoppingCart, setShowShoppingCart ] = useState( false );
 
+	const { paymentMethodRequired } = usePaymentMethod();
+
 	const toggleShoppingCart = () => {
 		setShowShoppingCart( ( prevState ) => ! prevState );
+	};
+
+	const handleOnCheckout = () => {
+		if ( paymentMethodRequired ) {
+			page( `${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_MARKETPLACE_CHECKOUT_LINK }` );
+			return;
+		}
+		onCheckout();
 	};
 
 	return (
@@ -41,7 +57,7 @@ export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props
 				<ShoppingCartMenu
 					onClose={ () => setShowShoppingCart( false ) }
 					items={ items }
-					onCheckout={ onCheckout }
+					onCheckout={ handleOnCheckout }
 					onRemoveItem={ onRemoveItem }
 				/>
 			) }

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/index.tsx
@@ -21,7 +21,6 @@ export default function InvoicesOverview() {
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title } </Title>
-					{ /* TODO: <SHOW_PARTNER_KEY_SELECTION_HERE /> */ }
 				</LayoutHeader>
 			</LayoutTop>
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -18,6 +18,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSite } from 'calypso/state/sites/selectors';
+import usePaymentMethod from '../../payment-methods/hooks/use-payment-method';
 import LicenseDetails from '../license-details';
 import BundleDetails from '../license-details/bundle-details';
 import LicensesOverviewContext from '../licenses-overview/context';
@@ -76,7 +77,7 @@ export default function LicensePreview( {
 		dispatch( recordTracksEvent( 'calypso_a4a_license_list_copy_license_click' ) );
 	}, [ dispatch, translate ] );
 
-	const paymentMethodRequired = false; // FIXME: Fix this with actual data
+	const { paymentMethodRequired } = usePaymentMethod();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method.ts
@@ -1,0 +1,14 @@
+import useStoredCards from './use-stored-cards';
+
+export default function usePaymentMethod() {
+	// Fetch the stored cards from the cache if they are available.
+	const {
+		data: { allStoredCards },
+	} = useStoredCards( undefined, { staleTime: Infinity } );
+
+	const hasValidPaymentMethod = allStoredCards?.length > 0;
+
+	return {
+		paymentMethodRequired: ! hasValidPaymentMethod,
+	};
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-return-url.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-return-url.ts
@@ -1,7 +1,10 @@
 import page from '@automattic/calypso-router';
 import { getQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
-import { A4A_PURCHASES_LINK } from '../../../../components/sidebar-menu/lib/constants';
+import {
+	A4A_PURCHASES_LINK,
+	A4A_MARKETPLACE_CHECKOUT_LINK,
+} from '../../../../components/sidebar-menu/lib/constants';
 
 type Props = {
 	redirect: boolean;
@@ -12,7 +15,9 @@ export function useReturnUrl( { redirect }: Props ) {
 		if ( redirect ) {
 			const returnQuery = getQueryArg( window.location.href, 'return' ) as string;
 			const returnUrl =
-				returnQuery && returnQuery.startsWith( A4A_PURCHASES_LINK )
+				returnQuery &&
+				( returnQuery.startsWith( A4A_PURCHASES_LINK ) ||
+					returnQuery.startsWith( A4A_MARKETPLACE_CHECKOUT_LINK ) )
 					? returnQuery
 					: A4A_PURCHASES_LINK;
 

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/lib/get-stripe-configuration.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/lib/get-stripe-configuration.ts
@@ -7,7 +7,7 @@ export async function getStripeConfiguration(
 	return await wp.req.get(
 		{
 			apiNamespace: 'wpcom/v2',
-			path: '/jetpack/stripe/configuration', // FIXME: Update this to the correct endpoint.
+			path: '/jetpack/stripe/configuration',
 		},
 		requestArgs
 	);

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -247,6 +247,9 @@ function PaymentMethodForm() {
 				A4A_MARKETPLACE_LINK
 			);
 		}
+		if ( returnQueryArg.startsWith( A4A_MARKETPLACE_LINK ) ) {
+			return A4A_MARKETPLACE_LINK;
+		}
 		return A4A_PAYMENT_METHODS_LINK;
 	};
 

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -38,7 +38,9 @@ import { APIError } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
 import { useAssignNewCardProcessor } from '../../hooks/use-assign-new-card-processor';
 import { useCreateStoredCreditCardMethod } from '../../hooks/use-create-stored-credit-card';
+import usePaymentMethod from '../../hooks/use-payment-method';
 import { useReturnUrl } from '../../hooks/use-return-url';
+import useStoredCards from '../../hooks/use-stored-cards';
 import { getStripeConfiguration } from '../../lib/get-stripe-configuration';
 import CreditCardLoading from '../credit-card-fields/credit-card-loading';
 
@@ -65,7 +67,7 @@ function PaymentMethodForm() {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
-	const paymentMethodRequired = true; // FIXME: This is a placeholder value, it should be fetched from the store.
+	const { paymentMethodRequired } = usePaymentMethod();
 
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
 	const {
@@ -80,6 +82,8 @@ function PaymentMethodForm() {
 		stripeConfiguration,
 		stripe,
 	} );
+
+	const { refetch: refetchStoredCards } = useStoredCards( undefined, { staleTime: Infinity } );
 
 	const paymentMethods = useMemo(
 		() => [ stripeMethod ].filter( isValueTruthy ),
@@ -192,11 +196,11 @@ function PaymentMethodForm() {
 		// product - will make sure there will be a license issuing for that product
 		//
 		if ( returnQueryArg || products ) {
-			// FIXME: Need to refetch the stored cards.
+			refetchStoredCards();
 		} else {
 			page( A4A_PAYMENT_METHODS_LINK );
 		}
-	}, [ returnQueryArg, products ] );
+	}, [ returnQueryArg, products, refetchStoredCards ] );
 
 	useEffect( () => {
 		if ( paymentMethodRequired ) {

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -25,7 +25,3 @@ export function isFetchingAgency( state: A4AStore ): boolean {
 export function getAgencyRequestError( state: A4AStore ): APIError | null {
 	return state.a8cForAgencies.agencies.error;
 }
-
-export function hasValidPaymentMethod(): boolean {
-	return true; // FIXME: Replace with actual implementation
-}


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/152

## Proposed Changes

This PR checks if a payment method is required and redirects to the add payment page.

## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Delete all the payment methods from the Payment Methods page
- Visit the Marketplace > Click Checkout > Verify that you are redirected to the add payment methods page > Add a new card > Verify that you are redirected to the checkout page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?