### PR TITLE
Signup: add hotjar to the DIFM content collection flow

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -245,7 +245,12 @@ class Signup extends Component {
 
 	componentDidMount() {
 		debug( 'Signup component mounted' );
-		this.props.flowName === 'website-design-services' && addHotJarScript();
+
+		if (
+			[ 'website-design-services', 'site-content-collection' ].includes( this.props.flowName )
+		) {
+			addHotJarScript();
+		}
 
 		recordSignupStart( this.props.flowName, this.props.refParameter, this.getRecordProps() );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This is a follow-up to #87167. 
* Enables hotjar for the 'site-content-collection' flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since the `'ad-tracking'` config is only enabled in production, manually change the value to `true` and then re-run the Calypso build process.
https://github.com/Automattic/wp-calypso/blob/8abbe89d443c737d8ac47b9b5d243a5cfff096e8/config/development.json#L32
* Go to `http://calypso.localhost:3000/start/site-content-collection/website-content?siteSlug=<site slug>` for a site with an existing DIFM purchase and check the browser network log. Confirm that the hotjar script is loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?