### PR TITLE
A4A: Add/a4a/set the filter search sort functionalites with the context v2

### DIFF
--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -21,7 +21,7 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
-		showOnlyFavorites: is_favorite === true || is_favorite === '',
+		showOnlyFavorites: is_favorite === '' || is_favorite === '1' || is_favorite === 'true',
 	};
 	const sort = {
 		field: sort_field,

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -9,13 +9,19 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature;
 	const hideListingInitialState = !! siteUrl;
-	const queryParams = new URLSearchParams( context.querystring );
-	const isFavoriteFilter = queryParams.get( 'is_favorite' ) !== null;
 
-	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;
+	const {
+		s: search,
+		page: contextPage,
+		issue_types,
+		sort_field,
+		sort_direction,
+		is_favorite,
+	} = context.query;
+
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
-		showOnlyFavorites: context.params.filter === 'favorites',
+		showOnlyFavorites: is_favorite === true || is_favorite === '',
 	};
 	const sort = {
 		field: sort_field,
@@ -35,7 +41,6 @@ function configureSitesContext( isFavorites: boolean, context: Context ) {
 			filter={ filter }
 			sort={ sort }
 			showSitesDashboardV2={ true }
-			isFavoriteFilterInitialState={ isFavoriteFilter }
 		>
 			<SitesDashboard />
 		</SitesDashboardProvider>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -42,10 +42,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	setIsPopoverOpen: () => {
 		return undefined;
 	},
-	isFavoriteFilter: false,
-	setIsFavoriteFilter: () => {
-		return undefined;
-	},
 	sort: {
 		field: 'url',
 		direction: 'asc',

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -44,7 +44,7 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	},
 	sort: {
 		field: 'url',
-		direction: 'asc',
+		direction: 'desc',
 	},
 } );
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import {
 	AgencyDashboardFilterOption,
 	DashboardSortInterface,
@@ -11,7 +11,6 @@ interface Props {
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
-	isFavoriteFilterInitialState: boolean;
 	children: ReactNode;
 	path: string;
 	search: string;
@@ -26,7 +25,6 @@ export const SitesDashboardProvider = ( {
 	categoryInitialState,
 	siteUrlInitialState,
 	siteFeatureInitialState,
-	isFavoriteFilterInitialState,
 	children,
 	path,
 	search,
@@ -38,8 +36,6 @@ export const SitesDashboardProvider = ( {
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteUrl, setSelectedSiteUrl ] = useState( siteUrlInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
-	const [ isFavoriteFilter, setIsFavoriteFilter ] = useState( isFavoriteFilterInitialState );
-
 	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
 	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
 	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
@@ -60,10 +56,6 @@ export const SitesDashboardProvider = ( {
 	const onHideLicenseInfo = () => {
 		setCurrentLicenseInfo( null );
 	};
-
-	useEffect( () => {
-		setIsFavoriteFilter( isFavoriteFilterInitialState );
-	}, [ isFavoriteFilterInitialState ] );
 
 	const sitesDashboardContextValue = {
 		selectedCategory: selectedCategory,
@@ -90,8 +82,6 @@ export const SitesDashboardProvider = ( {
 		setMostRecentConnectedSite,
 		isPopoverOpen,
 		setIsPopoverOpen,
-		isFavoriteFilter,
-		setIsFavoriteFilter,
 		showSitesDashboardV2: true,
 	};
 	return (

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -139,6 +139,33 @@ export default function SitesDashboard() {
 
 	}, [ isLoading, isError, sitesViewState.filters, filtersMap ] );*/
 
+	// Build the query string with the search, page, sort, filter, etc.
+	const buildQueryString = useCallback( () => {
+		const urlQuery = new URLSearchParams();
+		if ( search ) {
+			urlQuery.set( 's', search );
+		}
+		if ( currentPage > 1 ) {
+			urlQuery.set( 'page', currentPage.toString() );
+		}
+		if ( sort.field && sort.field !== 'url' ) {
+			urlQuery.set( 'sort_field', sort.field );
+		}
+		if ( sort.direction && sort.direction !== 'asc' ) {
+			urlQuery.set( 'sort_direction', sort.direction );
+		}
+		if ( filter.showOnlyFavorites ) {
+			urlQuery.set( 'is_favorite', '' );
+		}
+		if ( filter.issueTypes && filter.issueTypes.length > 0 ) {
+			urlQuery.set( 'issue_types', filter.issueTypes.join( ',' ) );
+		}
+
+		const queryString = urlQuery.toString();
+
+		return queryString ? `?${ queryString }` : '';
+	}, [ search, currentPage, sort, filter ] );
+
 	useEffect( () => {
 		// If the favorites filter is set, make sure to update the filter and correctly add the is_favorite param to URLs.
 		filter.showOnlyFavorites = isFavoriteFilter;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -185,7 +185,7 @@ export default function SitesDashboard() {
 			url += `/${ category }`;
 		}
 
-		page.replace( url + queryString );
+		page.replace( url + queryString, null, false, false );
 
 		if ( sitesViewState.selectedSite ) {
 			dispatch( setSelectedSiteId( sitesViewState.selectedSite.blog_id ) );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -156,7 +156,7 @@ export default function SitesDashboard() {
 			urlQuery.set( 'sort_direction', sort.direction );
 		}
 		if ( filter.showOnlyFavorites ) {
-			urlQuery.set( 'is_favorite', '' );
+			urlQuery.set( 'is_favorite', 'true' );
 		}
 		if ( filter.issueTypes && filter.issueTypes.length > 0 ) {
 			urlQuery.set( 'issue_types', filter.issueTypes.join( ',' ) );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -18,7 +18,6 @@ import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features
 import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
-import SitesOverviewContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/context';
 import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
 import SiteTopHeaderButtons from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons';
 import SitesDataViews from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews';
@@ -57,16 +56,18 @@ export default function SitesDashboard() {
 		selectedSiteUrl,
 		selectedSiteFeature,
 		setSelectedSiteFeature,
-		isFavoriteFilter,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
+		search,
+		currentPage,
+		filter,
+		sort,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 	const { data: products } = useProductsQuery();
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
-	// eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-	const { search, currentPage, filter, sort } = useContext( SitesOverviewContext );
+
 	const {
 		data: verifiedContacts,
 		refetch: refetchContacts,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -95,6 +95,7 @@ export default function SitesDashboard() {
 		layout: {},
 		selectedSite: undefined,
 	} );
+
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
 		search,
@@ -167,38 +168,36 @@ export default function SitesDashboard() {
 	}, [ search, currentPage, sort, filter ] );
 
 	useEffect( () => {
-		// If the favorites filter is set, make sure to update the filter and correctly add the is_favorite param to URLs.
-		filter.showOnlyFavorites = isFavoriteFilter;
-		const favoritesParam = isFavoriteFilter ? '?is_favorite' : '';
+		// Build the query string
+		const queryString = buildQueryString();
+
+		let url = '/sites';
+
 		// We need a category in the URL if we have a selected site
 		if ( sitesViewState.selectedSite && ! category ) {
 			setCategory( A4A_SITES_DASHBOARD_DEFAULT_CATEGORY );
 		} else if ( category && sitesViewState.selectedSite && selectedSiteFeature ) {
-			page.replace(
-				`/sites/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }${ favoritesParam }`
-			);
+			url += `/${ category }/${ sitesViewState.selectedSite.url }/${ selectedSiteFeature }`;
 		} else if ( category && sitesViewState.selectedSite ) {
-			page.replace(
-				`/sites/${ category }/${ sitesViewState.selectedSite.url }${ favoritesParam }`
-			);
+			url += `/${ category }/${ sitesViewState.selectedSite.url }`;
 		} else if ( category && category !== A4A_SITES_DASHBOARD_DEFAULT_CATEGORY ) {
 			// If the selected category is the default one, we can leave the url a little cleaner, that's why we are comparing to the default category in the condition above.
-			page.replace( `/sites/${ category }${ favoritesParam }` );
-		} else {
-			page.replace( `/sites${ favoritesParam }` );
+			url += `/${ category }`;
 		}
+
+		page.replace( url + queryString );
 
 		if ( sitesViewState.selectedSite ) {
 			dispatch( setSelectedSiteId( sitesViewState.selectedSite.blog_id ) );
 		}
 	}, [
 		filter,
-		isFavoriteFilter,
 		sitesViewState.selectedSite,
 		selectedSiteFeature,
 		category,
 		setCategory,
 		dispatch,
+		buildQueryString,
 	] );
 
 	const closeSitePreviewPane = useCallback( () => {

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -41,7 +41,4 @@ export interface SitesDashboardContextInterface {
 
 	isPopoverOpen: boolean;
 	setIsPopoverOpen: React.Dispatch< React.SetStateAction< boolean > >;
-
-	isFavoriteFilter: boolean;
-	setIsFavoriteFilter: React.Dispatch< React.SetStateAction< boolean > >;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -28,8 +28,8 @@ const SitesDataViews = ( {
 	className,
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
-	const { isFavoriteFilter } = useContext( SitesDashboardContext );
-	const totalSites = isFavoriteFilter ? data?.totalFavorites || 0 : data?.total || 0;
+	const { filter } = useContext( SitesDashboardContext );
+	const totalSites = filter.showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
 	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces.ts
@@ -1,4 +1,4 @@
-import { Site, SiteData } from '../types';
+import { DashboardSortInterface, Site, SiteData } from '../types';
 
 export interface SitesDataResponse {
 	sites: Array< Site >;
@@ -32,7 +32,7 @@ export interface SitesViewState {
 	type: 'table' | 'list' | 'grid';
 	perPage: number;
 	page: number;
-	sort: Sort;
+	sort: DashboardSortInterface;
 	search: string;
 	filters: Filter[];
 	hiddenFields: string[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
