### PR TITLE
Add/reddit advertising tracking base pixel

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -89,3 +89,6 @@ export const WOOEXPRESS_AFFILIATE_VENDOR_ID = '67386441';
 export const WPCOM_AFFILIATE_VENDOR_ID = '67402';
 
 export const WPCOM_CLARITY_URI = 'https://www.clarity.ms/tag/j0cc1i1dba';
+
+export const REDDIT_TRACKING_SCRIPT = 'https://www.redditstatic.com/ads/pixel.js';
+export const WPCOM_REDDIT_PIXEL_ID = 'a2_e2nbora1pqet';

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -91,4 +91,4 @@ export const WPCOM_AFFILIATE_VENDOR_ID = '67402';
 export const WPCOM_CLARITY_URI = 'https://www.clarity.ms/tag/j0cc1i1dba';
 
 export const REDDIT_TRACKING_SCRIPT_URL = 'https://www.redditstatic.com/ads/pixel.js';
-export const WPCOM_REDDIT_PIXEL_ID = 'a2_e2nbora1pqet';
+export const WPCOM_REDDIT_PIXEL_ID = 'a2_ehx23cq176s3';

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -90,5 +90,5 @@ export const WPCOM_AFFILIATE_VENDOR_ID = '67402';
 
 export const WPCOM_CLARITY_URI = 'https://www.clarity.ms/tag/j0cc1i1dba';
 
-export const REDDIT_TRACKING_SCRIPT = 'https://www.redditstatic.com/ads/pixel.js';
+export const REDDIT_TRACKING_SCRIPT_URL = 'https://www.redditstatic.com/ads/pixel.js';
 export const WPCOM_REDDIT_PIXEL_ID = 'a2_e2nbora1pqet';

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -19,6 +19,7 @@ import {
 	PINTEREST_SCRIPT_URL,
 	GOOGLE_GTM_SCRIPT_URL,
 	WPCOM_CLARITY_URI,
+	REDDIT_TRACKING_SCRIPT_URL,
 } from './constants';
 import { setup } from './setup';
 
@@ -113,6 +114,10 @@ function getTrackingScriptsToLoad() {
 
 	if ( mayWeTrackByTracker( 'clarity' ) ) {
 		scripts.push( WPCOM_CLARITY_URI );
+	}
+
+	if ( mayWeTrackByTracker( 'reddit' ) ) {
+		scripts.push( REDDIT_TRACKING_SCRIPT_URL );
 	}
 
 	return scripts;

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -20,6 +20,7 @@ import {
 	GOOGLE_GTM_SCRIPT_URL,
 	WPCOM_CLARITY_URI,
 	REDDIT_TRACKING_SCRIPT_URL,
+	WPCOM_REDDIT_PIXEL_ID,
 } from './constants';
 import { setup } from './setup';
 
@@ -161,6 +162,15 @@ function initLoadedTrackingScripts() {
 		const currentUser = getCurrentUser();
 		const params = currentUser ? { em: currentUser.hashedPii.email } : {};
 		window.pintrk( 'load', TRACKING_IDS.pinterestInit, params );
+	}
+
+	if ( mayWeTrackByTracker( 'reddit' ) ) {
+		const params = {
+			optOut: false,
+			useDecimalCurrencyValues: true,
+		};
+
+		window.rdt( 'init', WPCOM_REDDIT_PIXEL_ID, params );
 	}
 
 	debug( 'loadTrackingScripts: init done' );

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -78,6 +78,12 @@ export async function retarget( urlPath ) {
 		window.adRoll.trackPageview();
 	}
 
+	// Reddit
+	if ( mayWeTrackByTracker( 'reddit' ) ) {
+		debug( 'retarget: [Reddit]' );
+		window.rdt( 'track', 'PageVisit' );
+	}
+
 	// Rate limited retargeting (secondary trackers)
 
 	const nowTimestamp = Date.now() / 1000;

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -8,6 +8,7 @@ import {
 	ADROLL_PURCHASE_PIXEL_URL_1,
 	ADROLL_PURCHASE_PIXEL_URL_2,
 	TRACKING_IDS,
+	WPCOM_REDDIT_PIXEL_ID,
 } from './constants';
 
 export function setup() {
@@ -84,6 +85,11 @@ export function setup() {
 
 		if ( mayWeInitTracker( 'clarity' ) ) {
 			setupClarityGlobal();
+		}
+
+		// Reddit
+		if ( mayWeInitTracker( 'reddit' ) ) {
+			setupRedditGlobal();
 		}
 	}
 }
@@ -209,6 +215,26 @@ function setupAdRollGlobal() {
 			},
 		};
 	}
+}
+
+/**
+ * Sets up the base Reddit advertising pixel.
+ */
+function setupRedditGlobal() {
+	const params = {
+		optOut: false,
+		useDecimalCurrencyValues: true,
+	};
+
+	window.rdt =
+		window.rdt ||
+		function ( ...args ) {
+			window.rdt.sendEvent ? window.rdt.sendEvent( ...args ) : window.rdt.callQueue.push( args );
+		};
+
+	window.rdt.callQueue = [];
+
+	window.rdt( 'init', WPCOM_REDDIT_PIXEL_ID, params );
 }
 
 function setupGtag() {

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -8,7 +8,6 @@ import {
 	ADROLL_PURCHASE_PIXEL_URL_1,
 	ADROLL_PURCHASE_PIXEL_URL_2,
 	TRACKING_IDS,
-	WPCOM_REDDIT_PIXEL_ID,
 } from './constants';
 
 export function setup() {
@@ -221,11 +220,6 @@ function setupAdRollGlobal() {
  * Sets up the base Reddit advertising pixel.
  */
 function setupRedditGlobal() {
-	const params = {
-		optOut: false,
-		useDecimalCurrencyValues: true,
-	};
-
 	window.rdt =
 		window.rdt ||
 		function ( ...args ) {
@@ -233,8 +227,6 @@ function setupRedditGlobal() {
 		};
 
 	window.rdt.callQueue = [];
-
-	window.rdt( 'init', WPCOM_REDDIT_PIXEL_ID, params );
 }
 
 function setupGtag() {

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -33,6 +33,7 @@ const allAdTrackers = [
 	'adroll',
 	'parsely',
 	'clarity',
+	'reddit',
 ] as const;
 
 const sessionAdTrackers = [ 'hotjar' ];
@@ -61,6 +62,7 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	pinterest: Bucket.ADVERTISING,
 	twitter: Bucket.ADVERTISING,
 	facebook: Bucket.ADVERTISING,
+	reddit: Bucket.ADVERTISING,
 
 	// Advertising trackers (only Jetpack Cloud or on Jetpack Checkout):
 	linkedin: isJetpackCloud() || isJetpackCheckout() ? Bucket.ADVERTISING : null,
@@ -99,6 +101,7 @@ export const AdTrackersInitGuards: Partial< { [ key in AdTracker ]: () => boolea
 	quora: () => 'qp' in window,
 	adroll: () => 'adRoll' in window,
 	clarity: () => 'clarity' in window,
+	reddit: () => 'rdt' in window,
 };
 
 const isTrackerIntialized = ( tracker: AdTracker ): boolean => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #Automattic/martech#2350

## Proposed Changes

* Adds the base Reddit pixel as part of the trackers/pixel init script.
* Fires a `pageVisit` event for page views in Calypso.
* The actual pixel ID will have to change before the merging the code, but it can be tested and debugged with the current pixel ID.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable `ad-tracking` and `cookie-banner` in the `development.json` file (or via URL flags). 
* When accepting the GDPR banner (all "buckets").
    * `https://www.redditstatic.com/ads/pixel.js` is loaded and `window.rdt` is defined with no console errors.
    * A page view event (GET request, see example below) is sent to Reddit.
    * You can observe this page view in the Reddit ads panel (see screenshot below)
* Before accepting the GDPR banner, or when partially accepting it (excluding advertising trackers), observe:
    * Script is not loaded.
    * No `pageVisit` event is sent.  

Example GET request for a page view event.
```
https://alb.reddit.com/rp.gif?ts=1711626130798&id=a2_e2nbora1pqet&event=PageVisit&m.itemCount=&m.value=&m.valueDecimal=&m.currency=&m.transactionId=&m.customEventName=&m.products=&m.conversionId=&uuid=68b80dec-14e0-4a84-8b01-4eff221b0193&aaid=&em=&external_id=&idfa=&integration=reddit&opt_out=0&sh=3440&sw=1440&v=rdt_c9439d84&dpm=&dpcc=&dprc=
```

![Screenshot 2024-03-28 at 12 38 37](https://github.com/Automattic/wp-calypso/assets/52675688/eabfef66-b9ca-46ea-beac-b037a2f073b9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
