### PR TITLE
Add Reddit tracking event for trial starts in new-hosted-site flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -42,7 +42,7 @@ const hosting: Flow = {
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
 		const getPlanCartItem = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 			[]
 		);
 		const flowName = this.name;
@@ -93,8 +93,7 @@ const hosting: Flow = {
 					setSignupCompleteFlowName( flowName );
 
 					// If the product is a free trial, record the trial start event for ad tracking.
-					const planCartItem = getPlanCartItem();
-					isFreeHostingTrial( planCartItem?.product_slug || '' ) &&
+					isFreeHostingTrial( getPlanCartItem?.product_slug || '' ) &&
 						recordFreeHostingTrialStarted( flowName );
 
 					if ( providedDependencies.goToCheckout ) {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -3,6 +3,7 @@ import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useLayoutEffect } from 'react';
+import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
@@ -86,6 +87,10 @@ const hosting: Flow = {
 					persistSignupDestination( destination );
 					setSignupCompleteSlug( providedDependencies?.siteSlug );
 					setSignupCompleteFlowName( flowName );
+
+					if ( ! providedDependencies.goToCheckout ) {
+						recordFreeHostingTrialStarted( flowName );
+					}
 
 					if ( providedDependencies.goToCheckout ) {
 						return window.location.assign(

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -15,7 +15,7 @@ import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { Flow, ProvidedDependencies } from './internals/types';
-import type { UserSelect } from '@automattic/data-stores';
+import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import './internals/new-hosted-site-flow.scss';
 
@@ -41,6 +41,10 @@ const hosting: Flow = {
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
+		const getPlanCartItem = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
+			[]
+		);
 		const flowName = this.name;
 
 		const goBack = () => {
@@ -88,9 +92,10 @@ const hosting: Flow = {
 					setSignupCompleteSlug( providedDependencies?.siteSlug );
 					setSignupCompleteFlowName( flowName );
 
-					if ( ! providedDependencies.goToCheckout ) {
+					// If the product is a free trial, record the trial start event for ad tracking.
+					const planCartItem = getPlanCartItem();
+					isFreeHostingTrial( planCartItem?.product_slug || '' ) &&
 						recordFreeHostingTrialStarted( flowName );
-					}
 
 					if ( providedDependencies.goToCheckout ) {
 						return window.location.assign(

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -41,7 +41,7 @@ const hosting: Flow = {
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
-		const getPlanCartItem = useSelect(
+		const planCartItem = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 			[]
 		);
@@ -93,8 +93,9 @@ const hosting: Flow = {
 					setSignupCompleteFlowName( flowName );
 
 					// If the product is a free trial, record the trial start event for ad tracking.
-					isFreeHostingTrial( getPlanCartItem?.product_slug || '' ) &&
+					if ( planCartItem && isFreeHostingTrial( planCartItem?.product_slug ) ) {
 						recordFreeHostingTrialStarted( flowName );
+					}
 
 					if ( providedDependencies.goToCheckout ) {
 						return window.location.assign(

--- a/client/lib/analytics/ad-tracking/ad-track-trial-start.ts
+++ b/client/lib/analytics/ad-tracking/ad-track-trial-start.ts
@@ -1,0 +1,44 @@
+import { mayWeTrackByTracker } from '../tracker-buckets';
+
+/**
+ * We'll be accessing rdt from the window object. These definitions are homemade and not from Reddit (not documented, as the example script is JS),
+ * but they make the validation happy.
+ */
+declare global {
+	interface Window {
+		rdt: {
+			callQueue: object[];
+			sendEvent: ( ...args: [ string, string?, object? ] ) => void;
+		} & ( ( ...args: [ string, string?, object? ] ) => void );
+	}
+}
+
+/**
+ * Tracks a lead (free trial) in Reddit.
+ */
+export const redditTrackerFreeTrialStarted = ( trial_flow_name: string ): void => {
+	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
+		return;
+	}
+
+	const params = {
+		products: [
+			{
+				id: 'wpcom_creator_trial',
+				name: trial_flow_name,
+				category: 'free_trial',
+			},
+		],
+	};
+	window.rdt && window.rdt( 'track', 'Lead', params );
+};
+
+/**
+ * Tracks a lead (free trial) in third-party trackers. `flow_name` is the name of the flow the user is coming from, e.g.
+ * "new-hosted-site", which can be supplied to the third-party trackers to identify different flows (depending on the analytics)
+ * provided by the third-party.
+ */
+export const recordFreeHostingTrialStarted = ( flow_name: string ) => {
+	// Reddit.
+	redditTrackerFreeTrialStarted( flow_name );
+};

--- a/client/lib/analytics/ad-tracking/ad-track-trial-start.ts
+++ b/client/lib/analytics/ad-tracking/ad-track-trial-start.ts
@@ -30,7 +30,7 @@ export const redditTrackerFreeTrialStarted = ( trial_flow_name: string ): void =
 			},
 		],
 	};
-	window.rdt && window.rdt( 'track', 'Lead', params );
+	window.rdt( 'track', 'Lead', params );
 };
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #Automattic/martech#2350 and #89002 

~Note: Needs rebase after #89002 will be deployed. The changes in this PR is in commits `56328bb7d95f38555f0556953ebe8ebf24eaa7d2` and `f41c8fa77b3c6ba8357d82cc60ebeaf62d57674d`, but if it's rebased before #89002 is landed in trunk, builds will fail and the testing instructions won't be valid.~

## Proposed Changes

* Adds a file containing tracking code for trial starts. This can hold any third-party trackers, in the same way we we do for purchases, signups, etc.
* Adds a Reddit tracking code to this file.
* My assumption here is that any traffic not going to checkout from this flow will be a free trial, is that correct? As this flow does not send have a path for users selecting a free site (non trial).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable `ad-tracking` and `cookie-banner` in the `development.json` and spin up calypso locally. 
* Go to https://calypso.localhost:3000/start/hosting-start?ref=hosting-lp&section=performance&toStepper=true
* Start a new free Creator trial. 
* When hitting the processing screen, you should see a call to a `Lead` tracking event (among several `PageVisit` events). See the screenshot below.
* No console errors.
* For a "regular" signup (non-trial), ending up on the checkout page, there should be no changes, and no call to the free trial tracking.

![Screenshot 2024-03-28 at 13 18 27](https://github.com/Automattic/wp-calypso/assets/52675688/feb574a8-7513-47a2-84be-6417f58fa466)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
