### PR TITLE
Continue with Google: Add disabled state to the button

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -252,6 +252,7 @@ class GoogleSocialButton extends Component {
 						onClick={ this.handleClick }
 						onMouseEnter={ this.showError }
 						onMouseLeave={ this.hideError }
+						disabled={ isDisabled }
 					>
 						<GoogleIcon
 							isDisabled={ isDisabled }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/89008.

## Proposed Changes

* add disabled state to the _Continue with Google_ button

## Testing Instructions

The change is quite tricky to test (please see the steps below) so we can focus on testing just whether the _Continue with Google_ loads as expected when navigating to http://calypso.localhost:3000/log-in.

Full instructions:

1. Check out the PR locally and build it.
2. Make the following changes in the backend: 33fa3-pb/.
3. Head over to `test/e2e/specs/onboarding/signup__woo-google.ts` and make the following change:

```diff
diff --git a/test/e2e/specs/onboarding/signup__woo-google.ts b/test/e2e/specs/onboarding/signup__woo-google.ts
index a0f445e8c9..3fee698255 100644
--- a/test/e2e/specs/onboarding/signup__woo-google.ts
+++ b/test/e2e/specs/onboarding/signup__woo-google.ts
@@ -24,7 +24,7 @@ declare const browser: Browser;

 skipDescribeIf(
        // We can only run this spec for wordpress.com or wpcalypso.wordpress.com because only these two are allowed to use Google login.
-       ! [ 'https://wordpress.com', 'https://wpcalypso.wordpress.com' ].includes(
+       ! [ 'https://wordpress.com', 'https://wpcalypso.wordpress.com', 'http://calypso.localhost:3000' ].includes(
                envVariables.CALYPSO_BASE_URL
        )
 )(
```

4. In terminal, navigate to `/test/e2e` and run there the following command: `CALYPSO_BASE_URL='http://calypso.localhost:3000' yarn debug /test/e2e/specs/onboarding/signup__woo-google.ts`.
5. The test shouldn't pass, but the Google authorization popup window should open.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?