### PR TITLE
Patterns: add shadow to sticky nav

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { Icon, category as iconCategory, menu as iconMenu } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
@@ -161,6 +162,29 @@ export const PatternLibrary = ( {
 		setSearchFormKey( category );
 	}, [ category ] );
 
+	const [ isSticky, setIsSticky ] = useState( false );
+	const navRef = useRef< HTMLElement >( null );
+	const prevNavTopValue = useRef( 0 );
+
+	useEffect( () => {
+		const handleScroll = () => {
+			if ( ! navRef.current ) {
+				return;
+			}
+
+			const navbarPosition = navRef.current.getBoundingClientRect().top;
+
+			setIsSticky( navbarPosition === prevNavTopValue.current );
+
+			prevNavTopValue.current = navbarPosition;
+		};
+
+		window.addEventListener( 'scroll', handleScroll, { passive: true } );
+		return () => {
+			window.removeEventListener( 'scroll', handleScroll );
+		};
+	}, [] );
+
 	const categoryObject = categories?.find( ( { name } ) => name === category );
 
 	const categoryNavList = categories.map( ( category ) => {
@@ -207,7 +231,12 @@ export const PatternLibrary = ( {
 			/>
 
 			<div className="pattern-library__wrapper">
-				<div className="pattern-library__pill-navigation">
+				<div
+					className={ classNames( 'pattern-library__pill-navigation', {
+						'pattern-library__pill-navigation--sticky': isSticky,
+					} ) }
+					ref={ navRef }
+				>
 					<CategoryPillNavigation
 						selectedCategoryId={ category }
 						buttons={ [

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -163,7 +163,7 @@ export const PatternLibrary = ( {
 	}, [ category ] );
 
 	const [ isSticky, setIsSticky ] = useState( false );
-	const navRef = useRef< HTMLElement >( null );
+	const navRef = useRef< HTMLDivElement >( null );
 	const prevNavTopValue = useRef( 0 );
 
 	useEffect( () => {

--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -11,6 +11,11 @@
 	position: sticky;
 	top: 0;
 	z-index: 3;
+	transition: box-shadow 0.2s linear;
+
+	&.pattern-library__pill-navigation--sticky {
+		box-shadow: 0 0 8px hsla(0, 0%, 0%, 0.08);
+	}
 
 	.category-pill-navigation {
 		@include patterns-page-width;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6318

## Proposed Changes
With this PR we are adding bottom shadow to CategoryPillNavigation, when it's ticky.

## Testing Instructions
1) Open `/patterns` page
2) Scroll up and down and assert that you see navigation bottom shadow only when it's sticky
3) Log out and assert the same as a guest
<img width="1497" alt="Screenshot 2024-03-28 at 13 48 56" src="https://github.com/Automattic/wp-calypso/assets/5598437/703ed485-1a7e-4a69-88f0-8eb2da5ba36a">
