### PR TITLE
Site Migration: Enable feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -207,7 +207,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": false,
+		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -136,7 +136,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": false,
+		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -178,7 +178,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": false,
+		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -172,7 +172,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": false,
+		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/test.json
+++ b/config/test.json
@@ -123,7 +123,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": false,
+		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -170,7 +170,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": false,
+		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,


### PR DESCRIPTION
## Proposed Changes

* Enables the new site migration flow on all environments

## Testing Instructions
 
* Go to /start flow
* Run 'sessionStorage.removeItem('flags', "onboarding/new-migration-flow")' to remove any feature flag value.
* Select a domain
* Select a free plan on "Choose your flavor of WordPress"
* Choose "Import existent content"
* Set the origin site URL on the page "Where will you import from?"
* Select Everything on "What do you want to migrate?"
* Select "Continue" on "Upgrade your plan"
* Pay the plan
* Use the migration instructions links and the migration key.



## Tech Notes
* To run the Pre Release e2e tests you need to trigger the job manually the job changing the CALYPSO_BASE_URL to use the calypso.live URL.

<img width="1401" alt="Screenshot 2024-03-28 at 16 49 40" src="https://github.com/Automattic/wp-calypso/assets/38718/1274391b-6989-4d09-ac32-b3094c5ad591">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?