### PR TITLE
Jetpack Cloud: Avoid displaying the Global Sidebar

### DIFF
--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -55,6 +55,10 @@ class MySitesNavigation extends Component {
 				showManageSitesButton: false,
 				showHiddenSites: false,
 			};
+		} else if ( this.props.isGlobalSidebarVisible ) {
+			return this.renderGlobalSidebar();
+		} else if ( this.props.isGlobalSiteSidebarVisible ) {
+			return this.renderGlobalSiteSidebar();
 		} else {
 			asyncSidebar = <AsyncLoad require="calypso/my-sites/sidebar" { ...asyncProps } />;
 
@@ -107,12 +111,6 @@ class MySitesNavigation extends Component {
 	}
 
 	render() {
-		if ( this.props.isGlobalSidebarVisible ) {
-			return this.renderGlobalSidebar();
-		}
-		if ( this.props.isGlobalSiteSidebarVisible ) {
-			return this.renderGlobalSiteSidebar();
-		}
 		return this.renderSidebar();
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1711635638824189-slack-C06DN6QQVAQ

## Proposed Changes

* Fix the sidebar issue on Jetpack Cloud by moving the condition after checking the `jetpack-cloud` flag

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/57deb0e9-ca3f-4b3f-b669-ffe401dddf33) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e4ad60e2-cbf8-460f-a8bf-930de4857bb7) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run yarn start-jetpack-cloud
* Go to http://jetpack.cloud.localhost:3000/ or Jetpack Cloud Live, https://github.com/Automattic/wp-calypso/pull/89011#issuecomment-2025409437
* Select a atomic site with classic view early release
* Make sure the Sidebar is correct
* Go to Calypso via the Calypso Live, https://github.com/Automattic/wp-calypso/pull/89011#issuecomment-2025409437
* Make sure the Global Sidebar works as before
* Pick a atomic site with classic view early release
* Make sure the Global Site Sidebar works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?