### PR TITLE
A4A: Fixing sites dashboard favorites functionality within A4A context

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -36,10 +36,10 @@ export default function A4ASiteSetFavorite( { isFavorite, siteId, siteUrl }: Pro
 	const [ filter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
 		issueTypes: [],
 		showOnlyFavorites: showOnlyFavorites || false,
-	} ); //
+	} );
 	useEffect( () => {
 		const selectedFilters = getSelectedFilters( sitesViewState.filters );
-		//
+
 		setAgencyDashboardFilter( {
 			issueTypes: selectedFilters,
 			showOnlyFavorites: showOnlyFavorites || false,

--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -4,14 +4,20 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Icon, starFilled, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import useToggleFavoriteSiteMutation from 'calypso/data/agency-dashboard/use-toggle-favourite-site-mutation';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
-import SitesOverviewContext from '../context';
-import type { APIError, Site, APIToggleFavorite, ToggleFavoriteOptions } from '../types';
-
+import type {
+	APIError,
+	Site,
+	APIToggleFavorite,
+	ToggleFavoriteOptions,
+	AgencyDashboardFilter,
+} from '../types';
 import './style.scss';
 
 interface Props {
@@ -20,13 +26,27 @@ interface Props {
 	siteUrl: string;
 }
 
-export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props ) {
+export default function A4ASiteSetFavorite( { isFavorite, siteId, siteUrl }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 
-	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
-	const { showOnlyFavorites } = filter;
+	const { sitesViewState, showOnlyFavorites, currentPage, sort } =
+		useContext( SitesDashboardContext );
+	const [ filter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
+		issueTypes: [],
+		showOnlyFavorites: showOnlyFavorites || false,
+	} ); //
+	useEffect( () => {
+		const selectedFilters = getSelectedFilters( sitesViewState.filters );
+		//
+		setAgencyDashboardFilter( {
+			issueTypes: selectedFilters,
+			showOnlyFavorites: showOnlyFavorites || false,
+		} );
+	}, [ sitesViewState.filters, showOnlyFavorites ] );
+	const search = sitesViewState.search;
+
 	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
 	const siblingQueryKey = [
 		'jetpack-agency-dashboard-sites',
@@ -84,7 +104,6 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 
 				// Snapshot the previous value
 				const previousSites = queryClient.getQueryData( queryKey );
-
 				// Optimistically update to the new value
 				queryClient.setQueryData( queryKey, ( oldSites: any ) => {
 					return {

--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/style.scss
@@ -1,0 +1,27 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.site-set-favorite__favorite-icon {
+	position: absolute;
+	top: 6px;
+	color: var(--studio-gray-20) !important;
+}
+
+.site-set-favorite__favorite-icon-active {
+	visibility: visible !important;
+	color: var(--color-primary) !important;
+}
+
+button.button.site-set-favorite__view-favorite {
+	color: var(--studio-white);
+	text-decoration: underline;
+	font-size: inherit;
+	position: relative;
+	top: 4px;
+	left: 4px;
+	padding: 0;
+
+	&:hover {
+		color: var(--studio-white);
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -4,14 +4,20 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Icon, starFilled, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import useToggleFavoriteSiteMutation from 'calypso/data/agency-dashboard/use-toggle-favourite-site-mutation';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
-import SitesOverviewContext from '../context';
-import type { APIError, Site, APIToggleFavorite, ToggleFavoriteOptions } from '../types';
-
+import type {
+	APIError,
+	Site,
+	APIToggleFavorite,
+	ToggleFavoriteOptions,
+	AgencyDashboardFilter,
+} from '../types';
 import './style.scss';
 
 interface Props {
@@ -25,8 +31,22 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 
-	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
-	const { showOnlyFavorites } = filter;
+	const { sitesViewState, showOnlyFavorites, currentPage, sort } =
+		useContext( SitesDashboardContext );
+	const [ filter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
+		issueTypes: [],
+		showOnlyFavorites: showOnlyFavorites || false,
+	} );
+	useEffect( () => {
+		const selectedFilters = getSelectedFilters( sitesViewState.filters );
+		//
+		setAgencyDashboardFilter( {
+			issueTypes: selectedFilters,
+			showOnlyFavorites: showOnlyFavorites || false,
+		} );
+	}, [ sitesViewState.filters, showOnlyFavorites ] );
+	const search = sitesViewState.search;
+
 	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
 	const siblingQueryKey = [
 		'jetpack-agency-dashboard-sites',
@@ -84,12 +104,11 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 
 				// Snapshot the previous value
 				const previousSites = queryClient.getQueryData( queryKey );
-
 				// Optimistically update to the new value
 				queryClient.setQueryData( queryKey, ( oldSites: any ) => {
 					return {
 						...oldSites,
-						sites: oldSites?.sites.map( ( site: Site ) => {
+						sites: oldSites?.sites?.map( ( site: Site ) => {
 							if ( site.blog_id === siteId ) {
 								return {
 									...site,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -1,9 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon, Spinner } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useMemo } from 'react';
 import ReactDOM from 'react-dom';
+import A4ASiteSetFavorite from 'calypso/a8c-for-agencies/sections/sites/site-set-favorite';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
@@ -33,6 +35,7 @@ const SitesDataViews = ( {
 	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );
+	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
@@ -183,11 +186,19 @@ const SitesDataViews = ( {
 					}
 					return (
 						<span className="sites-dataviews__favorite-btn-wrapper">
-							<SiteSetFavorite
-								isFavorite={ item.isFavorite || false }
-								siteId={ item.site.value.blog_id }
-								siteUrl={ item.site.value.url }
-							/>
+							{ isA4AEnabled ? (
+								<A4ASiteSetFavorite
+									isFavorite={ item.isFavorite || false }
+									siteId={ item.site.value.blog_id }
+									siteUrl={ item.site.value.url }
+								/>
+							) : (
+								<SiteSetFavorite
+									isFavorite={ item.isFavorite || false }
+									siteId={ item.site.value.blog_id }
+									siteUrl={ item.site.value.url }
+								/>
+							) }
 						</span>
 					);
 				},


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/146

## Proposed Changes

* This PR makes sure a check for sites is conditional as this was responsible for the mapping error being displayed when attempting to select or unselect a site as a favorite.
* It also moves (copies) the SiteSetFavorite component files to A4A to prevent context issues. The component is renamed to A4ASiteSetFavorite there, as we still need to check to see whether we are in the A4A environment within the dataviews component, as that is shared between both A4A and Jetpack Manage at the moment and that is where we call the SiteSetFavorite component.
* Without using the correct context (so without moving / duplicating the component file and code), the selection was still working with the mapping / conditional fix, but only on page refresh after selecting or unselecting a favorite. 

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* On the sites dashboard, try selecting or unselecting a site as favorite. You should see a confirmation message, and the selection or deselection should be visible.
* You should also be able to test in Jetpack cloud - `yarn start-jetpack-cloud ` and `http://jetpack.cloud.localhost:3000/sites`, as well as `http://jetpack.cloud.localhost:3000/dashboard`, and these should also be working properly.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?