### PR TITLE
Stats: Shrink navigation header blank gap on mobile

### DIFF
--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -5,10 +5,11 @@
 .navigation-header {
 	box-sizing: border-box;
 	width: 100%;
-	padding: 16px;
+	padding: 0 0 24px 0;
 	margin-bottom: 0;
-	@include break-small {
-		padding: 0 0 24px 0;
+
+	@media (max-width: $break-small ) {
+		padding: 16px;
 	}
 
 	.breadcrumbs {

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -46,8 +46,8 @@
 	box-sizing: border-box;
 	column-gap: 10px;
 
-	@media ( max-width: 660px ) {
-		min-height: 60px;
+	@media ( max-width: $break-small ) {
+		min-height: 40px;
 	}
 
 	> .formatted-header {

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -46,10 +46,6 @@
 	box-sizing: border-box;
 	column-gap: 10px;
 
-	@media ( max-width: $break-small ) {
-		min-height: 40px;
-	}
-
 	> .formatted-header {
 		flex: 1;
 

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -54,7 +54,9 @@ $sidebar-appearance-break-point: 783px;
 
 		@media ( max-width: $break-small ) {
 			margin-bottom: 0;
+			padding-bottom: 0;
 		}
+
 		@media ( min-width: $break-small ) {
 			padding-left: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 			padding-right: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -52,16 +52,19 @@ $sidebar-appearance-break-point: 783px;
 	.navigation-header {
 		margin-bottom: 0;
 		padding-bottom: 24px;
+		padding-left: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
+		padding-right: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 		background-color: var(--studio-white);
 
 		@media ( max-width: $break-small ) {
-			margin-bottom: 0;
-			padding-bottom: 0;
+			// Restore padding to 16px on mobile as per the `.navigation-header` style.
+			padding: 16px;
+			// Reduce gap to the following section on mobile.
+			padding-bottom: 24px;
 		}
 
-		@media ( min-width: $break-small ) {
-			padding-left: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
-			padding-right: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
+		@media ( max-width: $break-mobile ) {
+			padding-bottom: 0;
 		}
 	}
 }

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -36,9 +36,11 @@ $sidebar-appearance-break-point: 783px;
 	> * {
 		padding: 0 max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 
-		@media ( max-width: $break-small ) {
-			padding-left: 0;
-			padding-right: 0;
+		&:not(.navigation-header) {
+			@media ( max-width: $break-small ) {
+				padding-left: 0;
+				padding-right: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88269

## Proposed Changes

* Adjust the navigation gap to make the mobile layout more reasonable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live link.
* Navigate to Stats > Traffic page.
* Resize the browser window to a width of `<= 480px`.
* Ensure the navigation header bar gap looks more condensed.

|Before|After|
|-|-|
|<img width="484" alt="截圖 2024-03-28 下午10 59 41" src="https://github.com/Automattic/wp-calypso/assets/6869813/89af938e-adf3-4554-9b13-975e03b36a3c">|<img width="483" alt="截圖 2024-03-28 下午10 59 14" src="https://github.com/Automattic/wp-calypso/assets/6869813/42a907e7-23ba-426b-975d-7e9070deb404">|

|601px|600px|481px|<= 480px|
|-|-|-|-|
|<img width="681" alt="截圖 2024-03-28 下午11 40 48" src="https://github.com/Automattic/wp-calypso/assets/6869813/9165f8fb-0cdc-4389-b54d-19b5512f82fa">|<img width="691" alt="截圖 2024-03-28 下午11 40 59" src="https://github.com/Automattic/wp-calypso/assets/6869813/95cd765b-c1b2-448c-88fa-a4bc6feaf092">|<img width="567" alt="截圖 2024-03-28 下午11 41 18" src="https://github.com/Automattic/wp-calypso/assets/6869813/a510adea-f5af-4717-8d1a-0600b010298e">|<img width="543" alt="截圖 2024-03-28 下午11 41 26" src="https://github.com/Automattic/wp-calypso/assets/6869813/d8642b4a-9036-4052-a750-e873c2beaf32">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?