### PR TITLE
Fixes the displayed dates for Blaze evergreen campaigns

### DIFF
--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -99,8 +99,8 @@ export const getCampaignStatus = ( status?: string ) => {
 };
 
 const calculateDurationDays = ( start: Date, end: Date ) => {
-	const diffTime = Math.abs( end.getTime() - start.getTime() );
-	return Math.round( diffTime / ( 1000 * 60 * 60 * 24 ) );
+	const diffTime = end.getTime() - start.getTime();
+	return diffTime < 0 ? 0 : Math.round( diffTime / ( 1000 * 60 * 60 * 24 ) );
 };
 
 export const getCampaignDurationDays = ( start_date: string, end_date: string ) => {
@@ -136,7 +136,7 @@ export const getCampaignDurationFormatted = (
 			return `${ dateStartFormatted } - ${ todayFormatted }`;
 		}
 
-		if ( status === 'scheduled' ) {
+		if ( status === 'scheduled' || status === 'created' ) {
 			return '-';
 		}
 	}


### PR DESCRIPTION
We have some bugs related to the dates we show for evergreen campaigns. They mostly happen when the campaign start in the future.
**Current behavior:**

![Screenshot 2024-03-28 at 12 15 17 PM](https://github.com/Automattic/wp-calypso/assets/1258162/53a3b0db-34c1-44a4-8109-afe72b1783bd)
![Screenshot 2024-03-28 at 12 15 37 PM](https://github.com/Automattic/wp-calypso/assets/1258162/d61b01ab-bd76-40de-b14f-76751a09e1b3)
![Screenshot 2024-03-28 at 12 15 55 PM](https://github.com/Automattic/wp-calypso/assets/1258162/ee24a931-1641-4679-ad07-4590d3b92e65)


## Proposed Changes

I am hiding the dates when the campaign has not started or was canceled before the start (negative date difference). I am also hiding them if the campaign is not yet moderated (the same behavior as a scheduled campaign).

The expected result for all the cases will be this one:
![Screenshot 2024-03-28 at 12 20 05 PM](https://github.com/Automattic/wp-calypso/assets/1258162/dca6e6a8-2b2a-4142-bbf9-d7008f090026)


## Testing Instructions

* Open the live preview and navigate to the Advertising section
* Create an Evergreen campaign with a start date in the future (more than 2 days)
* Go to the details of that campaign and validate that the duration is `-`
* Ask anyone of the self-serve team to approve your campaign
* Validate that the duration is also `-` for the campaign (it should be in a scheduled status)
* Cancel the campaign and validate that the duration is still `-`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?