### PR TITLE
Site Migration: Check locale before starting migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/index.ts
@@ -3,11 +3,13 @@ import { STEPS } from '../internals/steps';
 export const shouldRedirectToSiteMigration = (
 	step: string,
 	platform: string,
+	locale: string,
 	origin?: string | null
 ) => {
 	return (
 		step === STEPS.IMPORT_LIST.slug &&
 		platform === 'wordpress' &&
+		locale === 'en' &&
 		origin === STEPS.SITE_MIGRATION_IDENTIFY.slug
 	);
 };

--- a/client/landing/stepper/declarative-flow/helpers/test/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/test/index.ts
@@ -6,6 +6,7 @@ describe( 'DeclarativeFlowHelpers', () => {
 			shouldRedirectToSiteMigration(
 				STEPS.IMPORT_LIST.slug,
 				'wordpress',
+				'en',
 				STEPS.SITE_MIGRATION_IDENTIFY.slug
 			)
 		).toBe( true );
@@ -22,6 +23,18 @@ describe( 'DeclarativeFlowHelpers', () => {
 			shouldRedirectToSiteMigration(
 				STEPS.IMPORT_LIST.slug,
 				'other-platform',
+				'en',
+				STEPS.SITE_MIGRATION_IDENTIFY.slug
+			)
+		).toBe( false );
+	} );
+
+	it( 'returns false when locale is not en', () => {
+		expect(
+			shouldRedirectToSiteMigration(
+				STEPS.IMPORT_LIST.slug,
+				'wordpress',
+				'es',
 				STEPS.SITE_MIGRATION_IDENTIFY.slug
 			)
 		).toBe( false );
@@ -32,6 +45,7 @@ describe( 'DeclarativeFlowHelpers', () => {
 			shouldRedirectToSiteMigration(
 				STEPS.IMPORT_LIST.slug,
 				STEPS.SITE_MIGRATION_IDENTIFY.slug,
+				'en',
 				null
 			)
 		).toBe( false );
@@ -39,7 +53,7 @@ describe( 'DeclarativeFlowHelpers', () => {
 
 	it( 'returns false when the origin is not the site-migration-identify', () => {
 		expect(
-			shouldRedirectToSiteMigration( STEPS.IMPORT_LIST.slug, 'wordpress', 'other-origin' )
+			shouldRedirectToSiteMigration( STEPS.IMPORT_LIST.slug, 'wordpress', 'en', 'other-origin' )
 		).toBe( false );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
+import { useLocale, englishLocales } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
@@ -146,6 +147,7 @@ const siteSetupFlow: Flow = {
 			useDispatch( ONBOARD_STORE );
 		const { setDesignOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
+		const locale = useLocale();
 
 		const exitFlow = ( to: string, options: ExitFlowOptions = {} ) => {
 			setPendingAction( () => {
@@ -325,7 +327,11 @@ const siteSetupFlow: Flow = {
 
 					switch ( intent ) {
 						case SiteIntent.Import:
-							if ( config.isEnabled( 'onboarding/new-migration-flow' ) ) {
+							// Temporarily enabled only for English locales while we wait for UI translations.
+							if (
+								config.isEnabled( 'onboarding/new-migration-flow' ) &&
+								englishLocales.includes( locale )
+							) {
 								return exitFlow(
 									`/setup/site-migration?siteSlug=${ siteSlug }&flags=onboarding/new-migration-flow`
 								);

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -392,7 +392,7 @@ const siteSetupFlow: Flow = {
 					const depUrl = ( providedDependencies?.url as string ) || '';
 					const { platform } = providedDependencies as { platform: ImporterMainPlatform };
 
-					if ( shouldRedirectToSiteMigration( currentStep, platform, origin ) ) {
+					if ( shouldRedirectToSiteMigration( currentStep, platform, locale, origin ) ) {
 						return window.location.assign(
 							addQueryArgs(
 								{ siteSlug, siteId, from },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to discussion here p1711638644649799-slack-C0Q664T29

## Proposed Changes

* Check for the locale before redirecting to the new site migration flow; we don't have translations for non-EN locales yet.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/start`
* go through the flow until you get to the goals step
* Enable the flag in session storage via the console and refresh the page
* Select the Import goal
* You should be redirected to the site migration flow (you'll see `site-migration` in the URL)
* Now go to `/me` and select a non-English locale (like French or Spanish) and save settings
* Go back to `/start`
* Go through the flow until you get to the goals step
* Enable the flag in session storage via the console and refresh the page
* Select the Import goal
* You should be redirected to the `importerWordPress` step rather than site migration

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?