### PR TITLE
A4A: Hide Plugins entry from the sidebar

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/main.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/main.tsx
@@ -1,10 +1,9 @@
-import { category, home, plugins, tag, currencyDollar } from '@wordpress/icons';
+import { category, home, tag, currencyDollar } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import Sidebar from '../sidebar';
 import {
 	A4A_OVERVIEW_LINK,
-	A4A_PLUGINS_LINK,
 	A4A_SITES_LINK,
 	A4A_MARKETPLACE_LINK,
 	A4A_PURCHASES_LINK,
@@ -40,6 +39,8 @@ export default function ( { path }: Props ) {
 				},
 				withChevron: true,
 			},
+			/*
+			// Hide this section until we support plugin management in A4A
 			{
 				icon: plugins,
 				path: '/',
@@ -49,6 +50,7 @@ export default function ( { path }: Props ) {
 					menu_item: 'Automattic for Agencies / Plugins',
 				},
 			},
+			*/
 			{
 				icon: tag,
 				path: A4A_MARKETPLACE_LINK,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/160

## Proposed Changes

* Hide the Plugins entry sidebar menu option until we have support for this feature in A4A.

## Testing Instructions

* Start your local environment with `yarn start-a8c-for-agencies`, or use a live branch.
* Navigate to `/overview`.
* Verify the sidebar doesn't have an entry for plugins.


<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1258" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/5f7a2d1c-2094-453d-a800-d9079e444de8">
</td>
<td>
<img width="1258" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/4e2f9641-f98a-4165-9a9d-619ecdc3ba45">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?