### PR TITLE
[WIP] Continue with Google: Fix

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -124,6 +124,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,6 +76,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/social-first": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,

--- a/config/production.json
+++ b/config/production.json
@@ -100,6 +100,7 @@
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -95,6 +95,7 @@
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,6 +93,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/social-first": true,
 		"logmein": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/88633.

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?