### PR TITLE
Site Migration: Add the from query param on the checkout destination query param

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -127,6 +127,7 @@ const siteMigration: Flow = {
 		);
 		const siteSlugParam = useSiteSlugParam();
 		const urlQueryParams = useQuery();
+		const fromQueryParam = urlQueryParams.get( 'from' );
 
 		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
 		const exitFlow = ( to: string ) => {
@@ -210,8 +211,8 @@ const siteMigration: Flow = {
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = addQueryArgs(
 							{
-								flags: 'onboarding/new-migration-flow',
 								siteSlug,
+								from: fromQueryParam,
 							},
 							`/setup/site-migration/${ STEPS.BUNDLE_TRANSFER.slug }`
 						);

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -1,12 +1,14 @@
 /**
  * @jest-environment jsdom
  */
+import { goToCheckout } from '../../utils/checkout';
 import { STEPS } from '../internals/steps';
 import siteMigrationFlow from '../site-migration-flow';
 import { getFlowLocation, renderFlow } from './helpers';
 // we need to save the original object for later to not affect tests from other files
 const originalLocation = window.location;
 
+jest.mock( '../../utils/checkout' );
 describe( 'Site Migration Flow', () => {
 	beforeAll( () => {
 		Object.defineProperty( window, 'location', {
@@ -65,6 +67,27 @@ describe( 'Site Migration Flow', () => {
 				state: {
 					bundleProcessing: true,
 				},
+			} );
+		} );
+
+		it( 'redirects the user to the checkout page with the correct destination params', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentURL:
+					'/setup/site-migration-upgrade-plan?siteSlug=example.wordpress.com&from=https://site-to-be-migrated.com',
+				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+				dependencies: {
+					goToCheckout: true,
+				},
+			} );
+
+			expect( goToCheckout ).toHaveBeenCalledWith( {
+				destination:
+					'/setup/site-migration/bundleTransfer?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com',
+				flowName: 'site-migration',
+				siteSlug: 'example.wordpress.com',
+				stepName: 'site-migration-upgrade-plan',
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #89015 

## Proposed Changes
* Add from query param on the checkout destination query param.

## Context
The upgrade/checkout page uses the "destination" query parameter to redirect the user back to the site migration flow. However, the source site was not being passed on the destination parameter, causing issues with the site migration instructions page.


## Testing Instructions
* Go to /start flow
* Select a domain
* Select a free plan on "Choose your flavor of WordPress"
* Choose "Import existent content"
* Set the origin site URL on the page "Where will you import from?"
* Select Everything on "What do you want to migrate?"
* Select "Continue" on "Upgrade your plan"
* Pay the plan
* Check if the instruction page links are working and if the `from` was properly set.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?