### PR TITLE
Stats: Patch missing summary module relevant styles to the Email Stats summary page

### DIFF
--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -9,6 +9,7 @@ import StatsModule from '../stats-module';
 import PageViewTracker from '../stats-page-view-tracker';
 import statsStringsFactory from '../stats-strings';
 import '../summary/style.scss';
+import '../stats-module/summary-nav.scss';
 
 const StatsStrings = statsStringsFactory();
 
@@ -42,13 +43,15 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 				path={ `/stats/${ module }/:site` }
 				title={ `Stats > ${ titlecase( module ) }` }
 			/>
-			<NavigationHeader navigationItems={ navigationItems } />
+			<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
 
 			<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">
-				<div className="stats-summary-nav__header">
-					<div>
-						<div className="stats-section-title">
-							<h3>{ translate( 'Stats for Emails' ) }</h3>
+				<div className="stats-summary-nav">
+					<div className="stats-summary-nav__header">
+						<div>
+							<div className="stats-section-title">
+								<h3>{ translate( 'Stats for Emails' ) }</h3>
+							</div>
 						</div>
 					</div>
 				</div>
@@ -74,6 +77,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 					mainItemLabel={ translate( 'Latest Emails' ) }
 					hideSummaryLink
 					metricLabel={ translate( 'Clicks' ) }
+					listItemClassName="stats__summary--narrow-mobile"
 				/>
 				<JetpackColophon />
 			</div>

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -54,7 +54,9 @@ const StatsCard = ( {
 	// Show Card title on one line and all other column header(s) below:
 	// (main item, optional additional columns and value)
 	const splitHeaderNode = (
-		<div className={ `${ BASE_CLASS_NAME }-header ${ BASE_CLASS_NAME }-header--split` }>
+		<div
+			className={ `${ BASE_CLASS_NAME }-header ${ headerClassName } ${ BASE_CLASS_NAME }-header--split` }
+		>
 			<div className={ `${ BASE_CLASS_NAME }-header--main` }>
 				{ titleNode }
 				{ toggleControl }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86955 

## Proposed Changes

* Add missing class names related to the summary module.
* Load missing corresponding summary nav styles.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live link.
* Navigate to the Email Stats summary page: `/stats/day/emails/{site-slug}`.
* Resize the browser window from full size to mobile size.
* Ensure the layout looks reasonable and aligned with other Stats modules.

|Before|After|
|-|-|
|<img width="1014" alt="截圖 2024-03-29 上午12 15 22" src="https://github.com/Automattic/wp-calypso/assets/6869813/d91a3f0f-1c2c-40e7-874c-5bfe9f4f512e">|<img width="991" alt="截圖 2024-03-29 上午12 23 15" src="https://github.com/Automattic/wp-calypso/assets/6869813/979b83e1-3dfb-42f2-9f68-02e22416c8b7">|

|Posts & pages module|Email Stats module|
|-|-|
|<img width="735" alt="截圖 2024-03-29 上午12 31 05" src="https://github.com/Automattic/wp-calypso/assets/6869813/7be95dd3-e2fa-448b-86dc-87a0be5b39ae">|<img width="763" alt="截圖 2024-03-29 上午12 31 15" src="https://github.com/Automattic/wp-calypso/assets/6869813/2ca6b431-27fb-44f9-a76f-4fd612fb0374">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?