### PR TITLE
Site Migration: Send intent to at transfer API call

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -120,11 +120,8 @@ const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 			// Ensure we don't have an existing transfer in progress before starting a new one.
 			if ( preTransferCheck?.status !== transferStates.ACTIVE ) {
 				// Initiate transfer
-				if ( isNewSiteMigrationFlow( flow ) ) {
-					await initiateAtomicTransfer( siteId, softwareSet, 'migrate' );
-				} else {
-					await initiateAtomicTransfer( siteId, softwareSet );
-				}
+				const transferIntent = isNewSiteMigrationFlow( flow ) ? 'migrate' : undefined;
+				await initiateAtomicTransfer( siteId, softwareSet, transferIntent );
 			}
 
 			// Poll for transfer status

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -120,7 +120,6 @@ const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 			// Ensure we don't have an existing transfer in progress before starting a new one.
 			if ( preTransferCheck?.status !== transferStates.ACTIVE ) {
 				// Initiate transfer
-				console.log( getIntent() );
 				if ( isNewSiteMigrationFlow( flow ) ) {
 					await initiateAtomicTransfer( siteId, softwareSet, 'migrate' );
 				} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import config from '@automattic/calypso-config';
+import { isNewSiteMigrationFlow } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -34,7 +35,7 @@ export const transferStates = {
 
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
-const BundleTransfer: Step = function BundleTransfer( { navigation } ) {
+const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 	const { submit } = navigation;
 	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
 	const { requestAtomicSoftwareStatus, requestLatestAtomicTransfer, initiateAtomicTransfer } =
@@ -119,7 +120,12 @@ const BundleTransfer: Step = function BundleTransfer( { navigation } ) {
 			// Ensure we don't have an existing transfer in progress before starting a new one.
 			if ( preTransferCheck?.status !== transferStates.ACTIVE ) {
 				// Initiate transfer
-				await initiateAtomicTransfer( siteId, softwareSet );
+				console.log( getIntent() );
+				if ( isNewSiteMigrationFlow( flow ) ) {
+					await initiateAtomicTransfer( siteId, softwareSet, getIntent() );
+				} else {
+					await initiateAtomicTransfer( siteId, softwareSet );
+				}
 			}
 
 			// Poll for transfer status

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -122,7 +122,7 @@ const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 				// Initiate transfer
 				console.log( getIntent() );
 				if ( isNewSiteMigrationFlow( flow ) ) {
-					await initiateAtomicTransfer( siteId, softwareSet, getIntent() );
+					await initiateAtomicTransfer( siteId, softwareSet, 'migrate' );
 				} else {
 					await initiateAtomicTransfer( siteId, softwareSet );
 				}

--- a/client/state/atomic/transfers/actions.ts
+++ b/client/state/atomic/transfers/actions.ts
@@ -31,6 +31,7 @@ export interface InitiateTransfer {
 	pluginFile?: File;
 	themeFile?: File;
 	context?: string;
+	transferIntent?: string;
 }
 
 /**

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -35,6 +35,10 @@ export const mapToRequestBody = ( action ) => {
 		requestBody.context = action.context;
 	}
 
+	if ( action.transferIntent ) {
+		requestBody.transfer_intent = action.transferIntent;
+	}
+
 	return requestBody;
 };
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -527,16 +527,26 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteId,
 	} );
 
-	const atomicTransferStart = ( siteId: number, softwareSet: string | undefined ) => ( {
+	const atomicTransferStart = (
+		siteId: number,
+		softwareSet: string | undefined,
+		transferIntent: string | undefined
+	) => ( {
 		type: 'ATOMIC_TRANSFER_START' as const,
 		siteId,
 		softwareSet,
+		transferIntent,
 	} );
 
-	const atomicTransferSuccess = ( siteId: number, softwareSet: string | undefined ) => ( {
+	const atomicTransferSuccess = (
+		siteId: number,
+		softwareSet: string | undefined,
+		transferIntent: string | undefined
+	) => ( {
 		type: 'ATOMIC_TRANSFER_SUCCESS' as const,
 		siteId,
 		softwareSet,
+		transferIntent,
 	} );
 
 	const atomicTransferFailure = (
@@ -550,27 +560,26 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		error,
 	} );
 
-	function* initiateAtomicTransfer( siteId: number, softwareSet: string | undefined ) {
-		yield atomicTransferStart( siteId, softwareSet );
+	function* initiateAtomicTransfer(
+		siteId: number,
+		softwareSet: string | undefined,
+		transferIntent: string | undefined
+	) {
+		yield atomicTransferStart( siteId, softwareSet, transferIntent );
 		try {
+			const body = {
+				context: softwareSet || 'unknown',
+				software_set: softwareSet ? encodeURIComponent( softwareSet ) : undefined,
+				transfer_intent: transferIntent ? encodeURIComponent( transferIntent ) : undefined,
+			};
+
 			yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/atomic/transfers`,
 				apiNamespace: 'wpcom/v2',
 				method: 'POST',
-				...( softwareSet
-					? {
-							body: {
-								software_set: encodeURIComponent( softwareSet ),
-								context: softwareSet,
-							},
-					  }
-					: {
-							body: {
-								context: 'unknown',
-							},
-					  } ),
+				body,
 			} );
-			yield atomicTransferSuccess( siteId, softwareSet );
+			yield atomicTransferSuccess( siteId, softwareSet, transferIntent );
 		} catch ( _ ) {
 			yield atomicTransferFailure( siteId, softwareSet, AtomicTransferError.INTERNAL );
 		}

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -258,6 +258,7 @@ export const atomicTransferStatus: Reducer< { [ key: number ]: AtomicTransferSta
 			[ action.siteId ]: {
 				status: AtomicTransferStatus.IN_PROGRESS,
 				softwareSet: action.softwareSet,
+				transferIntent: action.transferIntent,
 				errorCode: undefined,
 			},
 		};
@@ -268,6 +269,7 @@ export const atomicTransferStatus: Reducer< { [ key: number ]: AtomicTransferSta
 			[ action.siteId ]: {
 				status: AtomicTransferStatus.SUCCESS,
 				softwareSet: action.softwareSet,
+				transferIntent: action.transferIntent,
 				errorCode: undefined,
 			},
 		};

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -253,7 +253,11 @@ describe( 'Site Actions', () => {
 					apiNamespace: 'wpcom/v2',
 					method: 'POST',
 					path: `/sites/${ siteId }/atomic/transfers`,
-					body: { software_set: softwareSet, context: 'woo-on-plans' },
+					body: {
+						software_set: softwareSet,
+						context: 'woo-on-plans',
+						transfer_intent: transferIntent,
+					},
 				},
 				type: 'WPCOM_REQUEST',
 			};
@@ -274,6 +278,7 @@ describe( 'Site Actions', () => {
 				type: 'ATOMIC_TRANSFER_FAILURE',
 				siteId,
 				softwareSet,
+				transferIntent,
 				error: atomicTransferError,
 			} );
 		} );

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -278,7 +278,6 @@ describe( 'Site Actions', () => {
 				type: 'ATOMIC_TRANSFER_FAILURE',
 				siteId,
 				softwareSet,
-				transferIntent,
 				error: atomicTransferError,
 			} );
 		} );

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -160,27 +160,31 @@ describe( 'Site Actions', () => {
 		it( 'should return a ATOMIC_TRANSFER_START Action', () => {
 			const { atomicTransferStart } = createActions( mockedClientCredentials );
 			const softwareSet = 'woo-on-plans';
+			const transferIntent = 'migrate';
 
 			const expected = {
 				type: 'ATOMIC_TRANSFER_START',
 				siteId,
 				softwareSet,
+				transferIntent,
 			};
 
-			expect( atomicTransferStart( siteId, softwareSet ) ).toEqual( expected );
+			expect( atomicTransferStart( siteId, softwareSet, transferIntent ) ).toEqual( expected );
 		} );
 
 		it( 'should return a ATOMIC_TRANSFER_SUCCESS Action', () => {
 			const { atomicTransferSuccess } = createActions( mockedClientCredentials );
 			const softwareSet = 'woo-on-plans';
+			const transferIntent = 'migrate';
 
 			const expected = {
 				type: 'ATOMIC_TRANSFER_SUCCESS',
 				siteId,
 				softwareSet,
+				transferIntent,
 			};
 
-			expect( atomicTransferSuccess( siteId, softwareSet ) ).toEqual( expected );
+			expect( atomicTransferSuccess( siteId, softwareSet, transferIntent ) ).toEqual( expected );
 		} );
 
 		it( 'should return a ATOMIC_TRANSFER_FAILURE Action', () => {
@@ -202,14 +206,19 @@ describe( 'Site Actions', () => {
 		it( 'should start an Atomic transfer', () => {
 			const { initiateAtomicTransfer } = createActions( mockedClientCredentials );
 			const softwareSet = 'woo-on-plans';
-			const generator = initiateAtomicTransfer( siteId, softwareSet );
+			const transferIntent = 'migrate';
+			const generator = initiateAtomicTransfer( siteId, softwareSet, transferIntent );
 
 			const mockedApiResponse = {
 				request: {
 					apiNamespace: 'wpcom/v2',
 					method: 'POST',
 					path: `/sites/${ siteId }/atomic/transfers`,
-					body: { software_set: softwareSet, context: 'woo-on-plans' },
+					body: {
+						software_set: softwareSet,
+						context: 'woo-on-plans',
+						transfer_intent: transferIntent,
+					},
 				},
 				type: 'WPCOM_REQUEST',
 			};
@@ -219,6 +228,7 @@ describe( 'Site Actions', () => {
 				type: 'ATOMIC_TRANSFER_START',
 				siteId,
 				softwareSet,
+				transferIntent,
 			} );
 
 			// Second iteration: WP_COM_REQUEST is fired
@@ -229,12 +239,14 @@ describe( 'Site Actions', () => {
 				type: 'ATOMIC_TRANSFER_SUCCESS',
 				siteId,
 				softwareSet,
+				transferIntent,
 			} );
 		} );
 		it( 'should fail to transfer a site to Atomic', () => {
 			const { initiateAtomicTransfer } = createActions( mockedClientCredentials );
 			const softwareSet = 'woo-on-plans';
-			const generator = initiateAtomicTransfer( siteId, softwareSet );
+			const transferIntent = 'migrate';
+			const generator = initiateAtomicTransfer( siteId, softwareSet, transferIntent );
 
 			const mockedApiResponse = {
 				request: {

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -263,6 +263,7 @@ describe( 'Site Actions', () => {
 				type: 'ATOMIC_TRANSFER_START',
 				siteId,
 				softwareSet,
+				transferIntent,
 			} );
 
 			// Second iteration: WP_COM_REQUEST is fired


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88147
Related to D143672-code

## Proposed Changes

This adds the site intent to the AT transfer API call made on the new Site Migration flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 * Apply D143672-code on your sandbox
 * Sandbox `public-api`
 * Apply this PR or navigate to the calypso.live link below
 * Go to `/start`
 * Select free plan
 * Open the browser Web developer tools and copy and paste the following code `sessionStorage.setItem('flags', "onboarding/new-migration-flow")`
 * Reload the goals page and select the import intent
 * Go through the flow using any site until you get to the upgrade screen
 * Open network inspector
 * Select the creator plan and go through checkout
 * Verify the POST request to `atomic/transfers` contains a `transfer_intent` query param
 * Navigate to `/wp-admin/site-health.php?tab=debug` & select Database
 * Verify your db has:
   * Charset: `utf8mb4`
   * Collation: `utf8mb4_general_ci`
<img width="794" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/691da46f-6233-499f-9331-147df1bfb98c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?