### PR TITLE
Hiding flow step while onboarding on the /hosting flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -35,6 +35,7 @@ export function generateFlows( {
 			showRecaptcha: true,
 			providesDependenciesInQuery: [ 'toStepper' ],
 			optionalDependenciesInQuery: [ 'toStepper' ],
+			hideProgressIndicator: true,
 		},
 		{
 			name: HOSTING_LP_FLOW,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1711640284211969-slack-C0347E545HR

## Proposed Changes

* Hiding progress indicator on /hosting flow

**Note**: The height difference is due to Google not being authorized on local calypso.


| Before | After |
|--------|--------|
|<img width="937" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/0b51528b-62db-4e99-9109-93b05782e8eb"> | <img width="946" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/7eaa603f-98d1-4166-86e1-7f1c306119fd"> | 
