### PR TITLE
Add the right plan to checkout from the site migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -1,8 +1,9 @@
-import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, getPlan, getPlanByPathSlug } from '@automattic/calypso-products';
 import { StepContainer } from '@automattic/onboarding';
 import { UpgradePlan } from 'calypso/blocks/importer/wordpress/upgrade-plan';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useSelectedPlanUpgradeQuery } from 'calypso/data/import-flow/use-selected-plan-upgrade';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -11,7 +12,13 @@ import type { Step } from '../../types';
 const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();
-	const plan = getPlan( PLAN_BUSINESS );
+
+	const selectedPlanData = useSelectedPlanUpgradeQuery();
+	const selectedPlanPathSlug = selectedPlanData.data;
+
+	const plan = selectedPlanPathSlug
+		? getPlanByPathSlug( selectedPlanPathSlug )
+		: getPlan( PLAN_BUSINESS );
 
 	if ( ! siteItem || ! siteSlug || ! plan ) {
 		return;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR updates the logic for the Upgrade Plan step in the `site-migration` Stepper flow to ensure that it adds the correct plan to the cart. Prior to this change, we would always add the annual plan, even if the user selected the monthly payment option.
* The implementation relies on the existing `useSelectedPlanUpgradeQuery()` hook to get the currently selected plan slug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via calypso.live
* Navigate to `/start` and work through the flow to create a new free site
* When you get to the goal selection step, ensure the `onboarding/new-migration-flow` feature flag is enabled.
   - I find the simplest way to do this is to run the following command in the browser console:
```js
window.sessionStorage.setItem('flags', 'onboarding/new-migration-flow')
```
* Click on the option to import your content
* Enter the URL of a valid WordPress site
* Select the "Everything" option
* On the _Upgrade your plan_ page, click on the "Pay monthly" toggle to view the monthly payment option
* Click on the Continue CTA
* Verify that the monthly Creator plan is added to your cart on the Checkout page
* Click on the "Remove from cart" link for the plan, and confirm the removal
* This should drop you back on the _Upgrade your plan_ page
* Click on the "Pay annually" toggle to view the yearly payment option
* Click on the Continue CTA
* Verify that the yearly Creator plan is added to your cart on the Checkout page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
