### PR TITLE
Revert: "Remove `login/google-login-update` feature flag (#88961)"

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -18,6 +18,7 @@ import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-
 import './style.scss';
 
 const noop = () => {};
+const isNonceEnabled = config.isEnabled( 'login/google-login-update' );
 
 class GoogleSocialButton extends Component {
 	static propTypes = {
@@ -57,36 +58,47 @@ class GoogleSocialButton extends Component {
 	}
 
 	componentDidMount() {
-		const initialize = async () => {
-			try {
-				const response = await wpcomRequest( {
-					path: '/generate-authorization-nonce',
-					apiNamespace: 'wpcom/v2',
-					apiVersion: '2',
-					method: 'GET',
-				} );
-				const nonce = response.nonce;
-				this.setState( { nonce } );
-
-				if ( this.props.authCodeFromRedirect && this.props.serviceFromRedirect !== 'github' ) {
-					this.handleAuthorizationCode( {
-						auth_code: this.props.authCodeFromRedirect,
-						redirect_uri: this.props.redirectUri,
-						state: nonce,
+		if ( isNonceEnabled ) {
+			const initialize = async () => {
+				try {
+					const response = await wpcomRequest( {
+						path: '/generate-authorization-nonce',
+						apiNamespace: 'wpcom/v2',
+						apiVersion: '2',
+						method: 'GET',
 					} );
+					const nonce = response.nonce;
+					this.setState( { nonce } );
+
+					if ( this.props.authCodeFromRedirect && this.props.serviceFromRedirect !== 'github' ) {
+						this.handleAuthorizationCode( {
+							auth_code: this.props.authCodeFromRedirect,
+							redirect_uri: this.props.redirectUri,
+							state: nonce,
+						} );
+					}
+
+					await this.initializeGoogleSignIn();
+				} catch ( error ) {
+					this.props.showErrorNotice(
+						this.props.translate(
+							'Error fetching nonce or initializing Google sign-in. Please try again.'
+						)
+					);
 				}
+			};
 
-				await this.initializeGoogleSignIn();
-			} catch ( error ) {
-				this.props.showErrorNotice(
-					this.props.translate(
-						'Error fetching nonce or initializing Google sign-in. Please try again.'
-					)
-				);
+			initialize();
+		} else {
+			if ( this.props.authCodeFromRedirect && this.props.serviceFromRedirect !== 'github' ) {
+				this.handleAuthorizationCode( {
+					auth_code: this.props.authCodeFromRedirect,
+					redirect_uri: this.props.redirectUri,
+				} );
 			}
-		};
 
-		initialize();
+			this.initializeGoogleSignIn();
+		}
 	}
 
 	async initializeGoogleSignIn() {
@@ -105,7 +117,7 @@ class GoogleSocialButton extends Component {
 			scope: this.props.scope,
 			ux_mode: this.props.uxMode,
 			redirect_uri: this.props.redirectUri,
-			state: this.state.nonce,
+			state: isNonceEnabled ? this.state.nonce : undefined,
 			callback: ( response ) => {
 				if ( response.error ) {
 					this.props.recordTracksEvent( 'calypso_social_button_failure', {
@@ -117,7 +129,11 @@ class GoogleSocialButton extends Component {
 					return;
 				}
 
-				this.handleAuthorizationCode( { auth_code: response.code, state: response.state } );
+				if ( isNonceEnabled ) {
+					this.handleAuthorizationCode( { auth_code: response.code, state: response.state } );
+				} else {
+					this.handleAuthorizationCode( { auth_code: response.code } );
+				}
 			},
 		} );
 

--- a/config/development.json
+++ b/config/development.json
@@ -124,6 +124,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,6 +76,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/social-first": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,

--- a/config/production.json
+++ b/config/production.json
@@ -100,6 +100,7 @@
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -95,6 +95,7 @@
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,6 +93,7 @@
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
+		"login/google-login-update": false,
 		"login/magic-login": true,
 		"login/social-first": true,
 		"logmein": true,


### PR DESCRIPTION
This reverts commit a82a5ddbd8f6065f313979a6c84a508216aa8219.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1711640284211969-slack-C0347E545HR

## Proposed Changes

- This reverts the https://github.com/Automattic/wp-calypso/pull/88961/files
  - The D143449-code along with the https://github.com/Automattic/wp-calypso/pull/88961/files were intended to address the CSRF vulnerability, but unfortunately, they were not successful. Moreover, the changes led to a problem with logging in using Google in some cases.

More on this here: p1711640284211969-slack-C0347E545HR

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It should be enough to review the code changes proposed by this PR and maybe do a spot-check if the PR doesn't introduce any unexpected regression on the Social Logins / Sign-up / Log-in pages (where the Continue with Google button is used).

The whole authorization flow cannot be tested locally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?