### PR TITLE
Revert "Site Migration: Enable feature flag"

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -207,7 +207,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
+		"onboarding/new-migration-flow": false,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -136,7 +136,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
+		"onboarding/new-migration-flow": false,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -178,7 +178,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
+		"onboarding/new-migration-flow": false,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -172,7 +172,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
+		"onboarding/new-migration-flow": false,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/test.json
+++ b/config/test.json
@@ -123,7 +123,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
+		"onboarding/new-migration-flow": false,
 		"storage-addon": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -170,7 +170,7 @@
 		"stats/type-detection": true,
 		"stats/utm-module": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
+		"onboarding/new-migration-flow": false,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,


### PR DESCRIPTION
A "just in case" PR to revert Automattic/wp-calypso#89010; don't merge unless we need it.