### PR TITLE
Checkoutv2: Implement AB test for JP and AK

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -24,16 +24,14 @@ export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);
 
-	const isWPcomCheckout =
+	const isJetpackOrAkismetCheckout =
 		useSelector( getSectionName ) === 'checkout' &&
-		! isJetpackCheckout() &&
-		! isAkismetCheckout() &&
-		! isJetpackNotAtomic;
+		( isJetpackCheckout() || isJetpackNotAtomic || isAkismetCheckout() );
 
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
 		'calypso_launch_checkout_v2',
 		{
-			isEligible: isWPcomCheckout && ! hasCheckoutVersion( '2' ),
+			isEligible: isJetpackOrAkismetCheckout && ! hasCheckoutVersion( '2' ),
 		}
 	);
 


### PR DESCRIPTION
This PR implements a hook to load the Checkout V2 AB test for just Jetpack and Akismet Checkout.

This code allows you to see the checkout v2 treatment without the feature flag. You can assign yourself to the treatment by following these steps: PCYsg-SwK-p2 (scroll down to 'Manually assign with Abacus assignment bookmarklet').

Related to https://github.com/Automattic/wp-calypso/pull/87812

### Testing Instructions

- Go to Checkout and ensure the v1 version looks correct - look for any style or functionality bleed
- Assign yourself to the treatment group according to the instructions in the link above
- Go to Checkout again and make sure the v2 styles and functionality match those found under the checkout v2 feature flag
- Test a number of products and use cases to ensure that styling remains the same between the feature flagged v2 and the non-flagged 'treatment' v2