### PR TITLE
A4A: Remove Jetpack Partner token dependency from A4A

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -79,14 +79,14 @@ export default function SitesDashboard() {
 		} );
 	}, [ sitesViewState.filters, setAgencyDashboardFilter, showOnlyFavorites ] );
 
-	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
+	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded,
-		sitesViewState.search,
-		sitesViewState.page,
-		agencyDashboardFilter,
+		searchQuery: sitesViewState.search,
+		currentPage: sitesViewState.page,
+		filter: agencyDashboardFilter,
 		sort,
-		sitesViewState.perPage
-	);
+		perPage: sitesViewState.perPage,
+	} );
 
 	useEffect( () => {
 		if ( sitesViewState.selectedSite && ! initialSelectedSiteUrl ) {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -16,7 +16,7 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features/overview';
 import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
-import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
+import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
 import SiteTopHeaderButtons from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons';
 import SitesDataViews from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews';
@@ -63,7 +63,7 @@ export default function SitesDashboard() {
 		data: verifiedContacts,
 		refetch: refetchContacts,
 		isError: fetchContactFailed,
-	} = useFetchMonitorVerfiedContacts( isPartnerOAuthTokenLoaded );
+	} = useFetchMonitorVerifiedContacts( isPartnerOAuthTokenLoaded );
 
 	const [ agencyDashboardFilter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
 		issueTypes: [],

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -14,7 +14,6 @@ import LayoutNavigation, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features/overview';
-import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
@@ -26,9 +25,9 @@ import {
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import SitesDashboardContext from '../sites-dashboard-context';
 import SiteNotifications from '../sites-notifications';
@@ -38,9 +37,11 @@ import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
 import './style.scss';
 
 export default function SitesDashboard() {
-	useQueryJetpackPartnerPortalPartner();
 	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
 	const dispatch = useDispatch();
+
+	const agency = useSelector( getActiveAgency );
+	const agencyId = agency ? agency.id : undefined;
 
 	const {
 		sitesViewState,
@@ -57,13 +58,12 @@ export default function SitesDashboard() {
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 	const { data: products } = useProductsQuery();
-	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
 
 	const {
 		data: verifiedContacts,
 		refetch: refetchContacts,
 		isError: fetchContactFailed,
-	} = useFetchMonitorVerifiedContacts( isPartnerOAuthTokenLoaded );
+	} = useFetchMonitorVerifiedContacts( false, agencyId );
 
 	const [ agencyDashboardFilter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
 		issueTypes: [],
@@ -80,12 +80,13 @@ export default function SitesDashboard() {
 	}, [ sitesViewState.filters, setAgencyDashboardFilter, showOnlyFavorites ] );
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
-		isPartnerOAuthTokenLoaded,
+		isPartnerOAuthTokenLoaded: false,
 		searchQuery: sitesViewState.search,
 		currentPage: sitesViewState.page,
 		filter: agencyDashboardFilter,
 		sort,
 		perPage: sitesViewState.perPage,
+		agencyId,
 	} );
 
 	useEffect( () => {

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -35,8 +35,9 @@ interface FetchDashboardSitesArgsInterface {
 }
 
 const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
-	const { isPartnerOAuthTokenLoaded, searchQuery, currentPage, filter, sort, perPage } = args;
-	let query_key = [
+	const { isPartnerOAuthTokenLoaded, searchQuery, currentPage, filter, sort, perPage = 20 } = args;
+
+	const queryKey = [
 		'jetpack-agency-dashboard-sites',
 		searchQuery,
 		currentPage,
@@ -44,13 +45,9 @@ const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
 		sort,
 		perPage,
 	];
-	// If per_page is not provided, we want to remove per_page from the query_key as existing tests don't pass otherwise.
-	if ( ! perPage ) {
-		query_key = [ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ];
-	}
 
 	return useQuery( {
-		queryKey: query_key,
+		queryKey,
 		queryFn: () =>
 			wpcomJpl.req.get(
 				{
@@ -62,7 +59,7 @@ const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
 					...( currentPage && { page: currentPage } ),
 					...agencyDashboardFilterToQueryObject( filter ),
 					...agencyDashboardSortToQueryObject( sort ),
-					per_page: perPage ?? 20,
+					per_page: perPage,
 				}
 			),
 		select: ( data ) => {

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -32,10 +32,19 @@ interface FetchDashboardSitesArgsInterface {
 	filter: AgencyDashboardFilter;
 	sort: DashboardSortInterface;
 	perPage?: number;
+	agencyId?: number;
 }
 
 const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
-	const { isPartnerOAuthTokenLoaded, searchQuery, currentPage, filter, sort, perPage = 20 } = args;
+	const {
+		isPartnerOAuthTokenLoaded,
+		searchQuery,
+		currentPage,
+		filter,
+		sort,
+		perPage = 20,
+		agencyId,
+	} = args;
 
 	const queryKey = [
 		'jetpack-agency-dashboard-sites',
@@ -44,9 +53,15 @@ const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
 		filter,
 		sort,
 		perPage,
+		...( agencyId ? [ agencyId ] : [] ),
 	];
 
+	const isAgencyOrPartnerAuthEnabled =
+		isPartnerOAuthTokenLoaded || ( agencyId !== undefined && agencyId !== null );
+
 	return useQuery( {
+		// Disable eslint rule since TS isn't grasping that agencyId is being optionally added to the array
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey,
 		queryFn: () =>
 			wpcomJpl.req.get(
@@ -60,6 +75,7 @@ const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
 					...agencyDashboardFilterToQueryObject( filter ),
 					...agencyDashboardSortToQueryObject( sort ),
 					per_page: perPage,
+					...( agencyId && { agency_id: agencyId } ),
 				}
 			),
 		select: ( data ) => {
@@ -70,7 +86,7 @@ const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
 				totalFavorites: data.total_favorites,
 			};
 		},
-		enabled: isPartnerOAuthTokenLoaded,
+		enabled: isAgencyOrPartnerAuthEnabled,
 	} );
 };
 

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -25,24 +25,27 @@ const agencyDashboardSortToQueryObject = ( sort: DashboardSortInterface ) => {
 	};
 };
 
-const useFetchDashboardSites = (
-	isPartnerOAuthTokenLoaded: boolean,
-	searchQuery: string,
-	currentPage: number,
-	filter: AgencyDashboardFilter,
-	sort: DashboardSortInterface,
-	per_page?: number
-) => {
+interface FetchDashboardSitesArgsInterface {
+	isPartnerOAuthTokenLoaded: boolean;
+	searchQuery: string;
+	currentPage: number;
+	filter: AgencyDashboardFilter;
+	sort: DashboardSortInterface;
+	perPage?: number;
+}
+
+const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
+	const { isPartnerOAuthTokenLoaded, searchQuery, currentPage, filter, sort, perPage } = args;
 	let query_key = [
 		'jetpack-agency-dashboard-sites',
 		searchQuery,
 		currentPage,
 		filter,
 		sort,
-		per_page,
+		perPage,
 	];
 	// If per_page is not provided, we want to remove per_page from the query_key as existing tests don't pass otherwise.
-	if ( ! per_page ) {
+	if ( ! perPage ) {
 		query_key = [ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ];
 	}
 
@@ -59,7 +62,7 @@ const useFetchDashboardSites = (
 					...( currentPage && { page: currentPage } ),
 					...agencyDashboardFilterToQueryObject( filter ),
 					...agencyDashboardSortToQueryObject( sort ),
-					per_page: per_page ?? 20,
+					per_page: perPage ?? 20,
 				}
 			),
 		select: ( data ) => {

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -1,9 +1,12 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
-import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import type {
 	AgencyDashboardFilter,
 	DashboardSortInterface,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+const client = isEnabled( 'a8c-for-agencies' ) ? wpcom : wpcomJpl;
 
 const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => {
 	return {
@@ -64,7 +67,7 @@ const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey,
 		queryFn: () =>
-			wpcomJpl.req.get(
+			client.req.get(
 				{
 					path: '/jetpack-agency/sites',
 					apiNamespace: 'wpcom/v2',

--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -1,7 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { MonitorContactsResponse } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
-import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+
+const client = isEnabled( 'a8c-for-agencies' ) ? wpcom : wpcomJpl;
 
 const isMultipleEmailEnabled = isEnabled(
 	'jetpack/pro-dashboard-monitor-multiple-email-recipients'
@@ -16,7 +18,7 @@ const useFetchMonitorVerifiedContacts = (
 	return useQuery( {
 		queryKey: [ 'monitor_notification_contacts', agencyId ],
 		queryFn: () =>
-			wpcomJpl.req.get(
+			client.req.get(
 				{
 					path: '/jetpack-agency/contacts',
 					apiNamespace: 'wpcom/v2',

--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -7,14 +7,24 @@ const isMultipleEmailEnabled = isEnabled(
 	'jetpack/pro-dashboard-monitor-multiple-email-recipients'
 );
 
-const useFetchMonitorVerfiedContacts = ( isPartnerOAuthTokenLoaded: boolean ) => {
+const useFetchMonitorVerfiedContacts = (
+	isPartnerOAuthTokenLoaded: boolean,
+	agencyId?: number
+) => {
+	const isAgencyOrPartnerAuthEnabled =
+		isPartnerOAuthTokenLoaded || ( agencyId !== undefined && agencyId !== null );
 	return useQuery( {
-		queryKey: [ 'monitor_notification_contacts' ],
+		queryKey: [ 'monitor_notification_contacts', agencyId ],
 		queryFn: () =>
-			wpcomJpl.req.get( {
-				path: '/jetpack-agency/contacts',
-				apiNamespace: 'wpcom/v2',
-			} ),
+			wpcomJpl.req.get(
+				{
+					path: '/jetpack-agency/contacts',
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					...( agencyId && { agency_id: agencyId } ),
+				}
+			),
 		select: ( contacts: MonitorContactsResponse ) => {
 			return {
 				emails: contacts?.emails
@@ -25,7 +35,7 @@ const useFetchMonitorVerfiedContacts = ( isPartnerOAuthTokenLoaded: boolean ) =>
 					.map( ( sms ) => sms.sms_number ),
 			};
 		},
-		enabled: isPartnerOAuthTokenLoaded && isMultipleEmailEnabled,
+		enabled: isAgencyOrPartnerAuthEnabled && isMultipleEmailEnabled,
 	} );
 };
 

--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -7,7 +7,7 @@ const isMultipleEmailEnabled = isEnabled(
 	'jetpack/pro-dashboard-monitor-multiple-email-recipients'
 );
 
-const useFetchMonitorVerfiedContacts = (
+const useFetchMonitorVerifiedContacts = (
 	isPartnerOAuthTokenLoaded: boolean,
 	agencyId?: number
 ) => {
@@ -39,4 +39,4 @@ const useFetchMonitorVerfiedContacts = (
 	} );
 };
 
-export default useFetchMonitorVerfiedContacts;
+export default useFetchMonitorVerifiedContacts;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -84,13 +84,13 @@ export default function SitesOverview() {
 		setIsBulkManagementActive,
 	} = useContext( SitesOverviewContext );
 
-	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
+	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded,
-		search,
+		searchQuery: search,
 		currentPage,
 		filter,
-		sort
-	);
+		sort,
+	} );
 
 	const {
 		data: verifiedContacts,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -15,7 +15,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
-import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
+import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -96,7 +96,7 @@ export default function SitesOverview() {
 		data: verifiedContacts,
 		refetch: refetchContacts,
 		isError: fetchContactFailed,
-	} = useFetchMonitorVerfiedContacts( isPartnerOAuthTokenLoaded );
+	} = useFetchMonitorVerifiedContacts( isPartnerOAuthTokenLoaded );
 
 	const { data: products } = useProductsQuery();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -9,7 +9,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Notice from 'calypso/components/notice';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
-import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
+import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import { AgencyDashboardFilterMap } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { sitesPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -269,7 +269,7 @@ export default function SitesDashboardV2() {
 		data: verifiedContacts,
 		refetch: refetchContacts,
 		isError: fetchContactFailed,
-	} = useFetchMonitorVerfiedContacts( isPartnerOAuthTokenLoaded );
+	} = useFetchMonitorVerifiedContacts( isPartnerOAuthTokenLoaded );
 
 	const { data: provisioningBlogIds, isLoading: isLoadingProvisioningBlogIds } =
 		useQueryProvisioningBlogIds();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -99,14 +99,14 @@ export default function SitesDashboardV2() {
 		selectedSite: undefined,
 	} );
 
-	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
+	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded,
-		search,
-		sitesViewState.page,
+		searchQuery: search,
+		currentPage: sitesViewState.page,
 		filter,
 		sort,
-		sitesViewState.perPage
-	);
+		perPage: sitesViewState.perPage,
+	} );
 
 	const onSitesViewChange = useCallback(
 		( sitesViewData: SitesViewState ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -75,7 +75,7 @@ describe( '<SitesOverview>', () => {
 		const data = {
 			sites: [],
 			total: 0,
-			perPage: 1,
+			perPage: 20,
 			totalFavorites: 1,
 		};
 		const queryKey = [
@@ -84,6 +84,7 @@ describe( '<SitesOverview>', () => {
 			1,
 			context.filter,
 			context.sort,
+			20,
 		];
 		queryClient.setQueryData( queryKey, data );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/102

## Proposed Changes

* Given that we still need to support Jetpack Manage and A4A, I updated `useFetchDashboardSites` and `useFetchMonitorVerifiedContacts` to make them support the A4A authentication, i.e., based on an agency ID. With these changes, we can remove the dependency on a Jetpack Partner token on A4A.

## Testing Instructions

Ensure no regressions are introduced:
* Visit the dashboard page on Jetpack cloud (live branch).
* Ensure all sites are displayed correctly.
* Visit the dashboard page on A4A (live branch).
* Ensure all sites are displayed correctly.

Ensure we can fetch sites when the user doesn't have an existing Jetpack Partner account
* Create a new WP.com user
* Go to A4A and sign up
* Go to the dashboard page and verifies nothing is broken
* Connect a couple of Jetpack sites to your account
* Verify the sites are displayed in the dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?