### PR TITLE
Remove lazy-loading and add page-cache in boost feature listings

### DIFF
--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -66,6 +66,7 @@ function getFeatureStrings(
 		case 'boost':
 			return [
 				translate( 'Automated critical CSS generation' ),
+				translate( 'Faster server response with Page Cache' ),
 				translate( 'Reduce image sizes with Image Guide' ),
 				translate( 'Historical site performance chart' ),
 				translate( 'Additional image quality control options' ),
@@ -74,7 +75,6 @@ function getFeatureStrings(
 				translate( 'One-click optimization' ),
 				translate( 'Deferred non-essential JavaScript' ),
 				translate( 'Optimized CSS loading' ),
-				translate( 'Lazy image loading' ),
 				translate( 'CDN for images' ),
 			];
 		case 'complete':

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1000,11 +1000,11 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( '{{div}}{{strong}}Priority support{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}', {
 			components: boostPremiumFeatureComponents,
 		} ),
+		translate( 'Faster server response with Page Cache' ),
 		translate( 'Site performance scores' ),
 		translate( 'One-click optimization' ),
 		translate( 'Defer non-essential JavaScript' ),
 		translate( 'Optimize CSS loading' ),
-		translate( 'Lazy image loading' ),
 	];
 
 	// Intl.ListFormat is not available in Mac OS Safari before Big Sur, so we


### PR DESCRIPTION
## Proposed Changes

* Remove Lazy Loading from feature listings
* Mention Page Cache

## Testing Instructions
* Check /pricing#jetpack_boost_yearly and make sure the change is there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?