### PR TITLE
A4A: Implement Sites dashboard empty state.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
@@ -2,6 +2,9 @@ import page from '@automattic/calypso-router';
 import { category, chevronLeft, starEmpty, warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import { useSelector } from 'calypso/state';
+import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import Sidebar from '../sidebar';
 import {
 	A4A_OVERVIEW_LINK,
@@ -18,7 +21,42 @@ type Props = {
 export default function ( { path }: Props ) {
 	const translate = useTranslate();
 
+	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
+
+	const { data, isLoading } = useFetchDashboardSites(
+		isPartnerOAuthTokenLoaded,
+		'',
+		1,
+		{
+			issueTypes: [],
+			showOnlyFavorites: false,
+		},
+		{
+			field: '',
+			direction: '',
+		}
+	);
+
 	const menuItems = useMemo( () => {
+		if ( isLoading || ! data?.sites?.length ) {
+			// We hide the rest of the options when we do not have sites yet.
+			return [
+				createItem(
+					{
+						id: 'sites-all-menu-item',
+						icon: category,
+						path: A4A_SITES_LINK,
+						link: A4A_SITES_LINK,
+						title: translate( 'All' ),
+						trackEventProps: {
+							menu_item: 'Automattic for Agencies / Sites / All',
+						},
+					},
+					path
+				),
+			];
+		}
+
 		return [
 			createItem(
 				{
@@ -58,7 +96,7 @@ export default function ( { path }: Props ) {
 				path
 			),
 		].map( ( item ) => createItem( item, path ) );
-	}, [ path, translate ] );
+	}, [ data?.sites?.length, isLoading, path, translate ] );
 
 	return (
 		<Sidebar

--- a/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
@@ -2,9 +2,7 @@ import page from '@automattic/calypso-router';
 import { category, chevronLeft, starEmpty, warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
-import { useSelector } from 'calypso/state';
-import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
+import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import Sidebar from '../sidebar';
 import {
 	A4A_OVERVIEW_LINK,
@@ -21,24 +19,10 @@ type Props = {
 export default function ( { path }: Props ) {
 	const translate = useTranslate();
 
-	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
-
-	const { data, isLoading } = useFetchDashboardSites(
-		isPartnerOAuthTokenLoaded,
-		'',
-		1,
-		{
-			issueTypes: [],
-			showOnlyFavorites: false,
-		},
-		{
-			field: '',
-			direction: '',
-		}
-	);
+	const noActiveSite = useNoActiveSite();
 
 	const menuItems = useMemo( () => {
-		if ( isLoading || ! data?.sites?.length ) {
+		if ( noActiveSite ) {
 			// We hide the rest of the options when we do not have sites yet.
 			return [
 				createItem(
@@ -96,7 +80,7 @@ export default function ( { path }: Props ) {
 				path
 			),
 		].map( ( item ) => createItem( item, path ) );
-	}, [ data?.sites?.length, isLoading, path, translate ] );
+	}, [ noActiveSite, path, translate ] );
 
 	return (
 		<Sidebar

--- a/client/a8c-for-agencies/hooks/use-no-active-site.ts
+++ b/client/a8c-for-agencies/hooks/use-no-active-site.ts
@@ -1,0 +1,24 @@
+import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function useNoActiveSite() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const { data, isFetched } = useFetchDashboardSites( {
+		isPartnerOAuthTokenLoaded: false,
+		searchQuery: '',
+		currentPage: 1,
+		filter: {
+			issueTypes: [],
+			showOnlyFavorites: false,
+		},
+		sort: {
+			field: '',
+			direction: '',
+		},
+		agencyId,
+	} );
+
+	return isFetched && ! data?.sites?.length;
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function EmptyState() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const title = translate( 'Sites' );
+
+	const pluginDownloadLink = ''; // FIXME: Provide correct download link.
+	const resourceLink = ''; // FIXME: Provide correct resource link.
+
+	return (
+		<Layout title={ title } wide withBorder sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title } </Title>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<div className="sites-dashboard__empty">
+					<A4ALogo className="sites-dashboard__empty-logo" size={ 64 } />
+
+					<p className="sites-dashboard__empty-message">
+						{ translate(
+							'Add all of your sites to your dashboard by installing the Automattic for Agencies connection plugin. Once connected within wp-admin, your sites will automatically sync here.'
+						) }
+					</p>
+
+					<div className="sites-dashboard__empty-actions">
+						<Button
+							href={ pluginDownloadLink }
+							target="_blank"
+							primary
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_sites_dashboard_download_a4a_plugin_click' )
+								)
+							}
+						>
+							{ translate( 'Download A4A Plugin' ) }
+						</Button>
+						<Button
+							href={ resourceLink }
+							target="_blank"
+							onClick={ () =>
+								dispatch( recordTracksEvent( 'calypso_a4a_sites_dashboard_learn_more_click' ) )
+							}
+						>
+							{ translate( 'Learn more' ) } <Icon icon={ external } size={ 18 } />
+						</Button>
+					</div>
+				</div>
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -31,6 +31,7 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import OverviewHeaderActions from '../../overview/header-actions';
 import SitesDashboardContext from '../sites-dashboard-context';
 import SiteNotifications from '../sites-notifications';
+import EmptyState from './empty-state';
 import { getSelectedFilters } from './get-selected-filters';
 import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
 
@@ -181,6 +182,12 @@ export default function SitesDashboard() {
 	const selectedItemProps = {
 		selectedText: selectedItem.label,
 	};
+
+	const isEmpty = data && data.sites.length === 0;
+
+	if ( isEmpty ) {
+		return <EmptyState />;
+	}
 
 	return (
 		<Layout

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -183,7 +183,7 @@ export default function SitesDashboard() {
 		selectedText: selectedItem.label,
 	};
 
-	const isEmpty = data && data.sites.length === 0;
+	const isEmpty = ! isLoading && ! data?.sites?.length;
 
 	if ( isEmpty ) {
 		return <EmptyState />;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -13,6 +13,7 @@ import LayoutNavigation, {
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features/overview';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
@@ -89,6 +90,8 @@ export default function SitesDashboard() {
 		perPage: sitesViewState.perPage,
 		agencyId,
 	} );
+
+	const noActiveSite = useNoActiveSite();
 
 	useEffect( () => {
 		if ( sitesViewState.selectedSite && ! initialSelectedSiteUrl ) {
@@ -183,9 +186,7 @@ export default function SitesDashboard() {
 		selectedText: selectedItem.label,
 	};
 
-	const isEmpty = ! isLoading && ! data?.sites?.length;
-
-	if ( isEmpty ) {
+	if ( noActiveSite ) {
 		return <EmptyState />;
 	}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -1,9 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.a4a-layout__top-wrapper:not(.preview-hidden) {
-	padding-block-start: 24px;
-}
 
 .main.a4a-layout.sites-dashboard {
 	padding-block-start: 0;
@@ -26,6 +23,10 @@
 		position: unset;
 		margin-left: 10px;
 		margin-right: 10px;
+	}
+
+	.a4a-layout__top-wrapper:not(.preview-hidden) {
+		padding-block-start: 24px;
 	}
 
 	@media (min-width: $break-large) {
@@ -981,5 +982,37 @@
 				visibility: visible;
 			}
 		}
+	}
+}
+
+.sites-dashboard__empty {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	align-items: center;
+
+	margin: 24px auto;
+	padding: 64px 0;
+	max-width: 700px;
+	text-align: center;
+}
+
+.sites-dashboard__empty-message {
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.5;
+}
+
+.sites-dashboard__empty-actions {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+
+	margin: 0 auto;
+
+	> .button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -39,6 +39,10 @@
 }
 
 .theme-a8c-for-agencies {
+	.button {
+		border-radius: 4px;
+	}
+
 	.button.is-primary {
 		background-color: var(--studio-automattic-40);
 		border-color: var(--studio-automattic-40);


### PR DESCRIPTION
This pull request adds an empty state for the Sites dashboard. **Note that the CTA buttons will not function until we have the official links.**

**Before**
<img width="1725" alt="Screenshot 2024-03-29 at 2 51 29 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b3435f13-98b4-47ac-b392-8d90fbad72cb">

**After**
<img width="1726" alt="Screenshot 2024-03-29 at 2 50 59 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b0acf293-de5e-4c1c-af8f-59a6abe4abba">


Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/147

## Proposed Changes

* Add an Empty state template for the Sites dashboard.
* Hide Need Attention and Favorites sidebar menu when there is no sites.

## Testing Instructions

* Signup a new A4A account in `/signup`. So you have no sites at the beginning.
* Use the A4A live link below and go to `/sites`.
* Confirm that you can see the Empty message.
* Confirm that the sidebar menu only has the 'All' menu item.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?d