### PR TITLE
Jetpack Manage: Fix issue with the Monitoring toggle and settings not updating the sites list.

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -38,18 +38,16 @@ interface FetchDashboardSitesArgsInterface {
 	agencyId?: number;
 }
 
-const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
-	const {
-		isPartnerOAuthTokenLoaded,
-		searchQuery,
-		currentPage,
-		filter,
-		sort,
-		perPage = 20,
-		agencyId,
-	} = args;
-
-	const queryKey = [
+const useFetchDashboardSites = ( {
+	isPartnerOAuthTokenLoaded,
+	searchQuery,
+	currentPage,
+	filter,
+	sort,
+	perPage,
+	agencyId,
+}: FetchDashboardSitesArgsInterface ) => {
+	let queryKey = [
 		'jetpack-agency-dashboard-sites',
 		searchQuery,
 		currentPage,
@@ -58,6 +56,18 @@ const useFetchDashboardSites = ( args: FetchDashboardSitesArgsInterface ) => {
 		perPage,
 		...( agencyId ? [ agencyId ] : [] ),
 	];
+
+	// If perPage is not provided, we want to remove perPage from the query_key as existing tests don't pass otherwise.
+	if ( ! perPage ) {
+		queryKey = [
+			'jetpack-agency-dashboard-sites',
+			searchQuery,
+			currentPage,
+			filter,
+			sort,
+			...( agencyId ? [ agencyId ] : [] ),
+		];
+	}
 
 	const isAgencyOrPartnerAuthEnabled =
 		isPartnerOAuthTokenLoaded || ( agencyId !== undefined && agencyId !== null );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/test/notification-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/test/notification-settings.tsx
@@ -19,7 +19,9 @@ jest.mock( '@automattic/calypso-config', () => {
 describe( 'NotificationSettings', () => {
 	const sites = [ site ];
 
-	const initialState = {};
+	const initialState = {
+		a8cForAgencies: { agencies: {} },
+	};
 
 	const mockStore = configureStore();
 	const store = mockStore( initialState );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
@@ -28,7 +28,9 @@ describe( 'ToggleActivateMonitoring', () => {
 		isLargeScreen: false,
 	};
 
-	const initialState = {};
+	const initialState = {
+		a8cForAgencies: { agencies: {} },
+	};
 
 	const mockStore = configureStore();
 	const store = mockStore( initialState );

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -1,7 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext } from 'react';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { setSiteMonitorStatus } from 'calypso/state/jetpack-agency-dashboard/actions';
 import useToggleActivateMonitorMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -20,7 +21,17 @@ export default function useToggleActivateMonitor(
 
 	const queryClient = useQueryClient();
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
-	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
+
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const queryKey = [
+		'jetpack-agency-dashboard-sites',
+		search,
+		currentPage,
+		filter,
+		sort,
+		...( agencyId ? [ agencyId ] : [] ),
+	];
 
 	const toggleActivateMonitoring = useToggleActivateMonitorMutation( {
 		onMutate: async ( { siteId } ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
@@ -1,7 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useContext } from 'react';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import useUpdateMonitorSettingsMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { DEFAULT_DOWNTIME_MONITORING_DURATION } from '../constants';
@@ -23,7 +24,17 @@ export default function useUpdateMonitorSettings(
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
-	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
+
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const queryKey = [
+		'jetpack-agency-dashboard-sites',
+		search,
+		currentPage,
+		filter,
+		sort,
+		...( agencyId ? [ agencyId ] : [] ),
+	];
 
 	const [ status, setStatus ] = useState( 'idle' );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/monitor-activity.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/monitor-activity.test.tsx
@@ -30,6 +30,7 @@ describe( 'MonitorActivity component', () => {
 				},
 			},
 		},
+		a8cForAgencies: { agencies: {} },
 	};
 
 	const mockStore = configureStore();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -2,6 +2,8 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../../hooks';
 import SitesOverviewContext from '../../context';
 import DashboardDataContext from '../../dashboard-data-context';
@@ -27,10 +29,19 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 
 	const { blog_id: siteId, url: siteUrl, is_atomic, url_with_scheme } = site;
 
+	const agencyId = useSelector( getActiveAgencyId );
+
 	// queryKey is needed to optimistically update the site list
 	const queryKey = useMemo(
-		() => [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ],
-		[ filter, search, currentPage, sort ]
+		() => [
+			'jetpack-agency-dashboard-sites',
+			search,
+			currentPage,
+			filter,
+			sort,
+			...( agencyId ? [ agencyId ] : [] ),
+		],
+		[ search, currentPage, filter, sort, agencyId ]
 	);
 	const { installBoost, status } = useInstallBoost( siteId, siteUrl, queryKey );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -164,6 +164,7 @@ describe( '<SiteTable>', () => {
 				[ blogId ]: siteObj,
 			},
 		},
+		a8cForAgencies: { agencies: {} },
 	};
 	const mockStore = configureStore();
 	const store = mockStore( initialState );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -75,7 +75,7 @@ describe( '<SitesOverview>', () => {
 		const data = {
 			sites: [],
 			total: 0,
-			perPage: 20,
+			perPage: 1,
 			totalFavorites: 1,
 		};
 		const queryKey = [
@@ -84,7 +84,6 @@ describe( '<SitesOverview>', () => {
 			1,
 			context.filter,
 			context.sort,
-			20,
 		];
 		queryClient.setQueryData( queryKey, data );
 	};


### PR DESCRIPTION
After we have pushed #89032, making updates on Monitoring does not reflect immediately and will require page refresh. Further investigation leads to a mismatch in the query key when we update sites query.

Related to #89032

## Proposed Changes

* Make sure that the query key matches when 

## Testing Instructions

* Use the Jetpack cloud live link and go to `/dashboard`
* Choose any site and attempt to toggle Monitoring (on or off). 
*  Confirm that the page updates the site status correctly without refreshing.

<img width="117" alt="Screenshot 2024-03-29 at 7 11 46 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/220604b5-3e70-4ded-9a18-21cf98e02ce6">

* Now attempt to Open the Monitoring setting and update the interval.
<img width="594" alt="Screenshot 2024-03-29 at 7 12 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ea421a11-5e66-4dca-840a-bdaa5540350c">

* Confirm that the page updates the site status correctly without refreshing.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?