### PR TITLE
Site Migration: Add tests to the site-migration-plugin install

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
@@ -74,6 +74,7 @@ const SiteMigrationPluginInstall: Step = ( { navigation } ) => {
 			} );
 
 			setProgress( 1 );
+			return true;
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
@@ -88,7 +88,7 @@ describe( 'SiteMigrationPluginInstall', () => {
 		expect( getProgress() ).toBe( 1 );
 	} );
 
-	it( 'pools the plugin endpoint until have information about the plugins', async () => {
+	it( 'polls the plugin endpoint until we have information about the plugins', async () => {
 		jest.spyOn( global, 'setTimeout' ).mockImplementation( quickerSetTimeout );
 		render();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
@@ -62,7 +62,7 @@ describe( 'SiteMigrationPluginInstall', () => {
 		expect( getProgress() ).toBe( 1 );
 	} );
 
-	it( 'installs the and active plugin when it is not installed', async () => {
+	it( 'installs and activates the plugin when it is not installed', async () => {
 		jest.spyOn( global, 'setTimeout' ).mockImplementation( quickerSetTimeout );
 		render();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+import { waitFor } from '@testing-library/react';
+import { select } from '@wordpress/data';
+import nock from 'nock';
+import React, { ComponentProps } from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import SiteMigrationPluginInstall from '..';
+import { ONBOARD_STORE } from '../../../../../stores';
+import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
+
+type Props = ComponentProps< typeof SiteMigrationPluginInstall >;
+
+const render = ( props?: Partial< Props >, renderOptions?: RenderStepOptions ) => {
+	const combinedProps = { ...mockStepProps( props ) };
+	return renderStep( <SiteMigrationPluginInstall { ...combinedProps } />, renderOptions );
+};
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site' );
+
+( useSite as jest.Mock ).mockReturnValue( {
+	ID: 123,
+} );
+
+const originalSetTimeout = global.setTimeout;
+const quickerSetTimeout = ( fn: NodeJS.TimerHandle, time: number ) =>
+	originalSetTimeout( fn, time / 100 );
+
+describe( 'SiteMigrationPluginInstall', () => {
+	beforeAll( () => {
+		nock.disableNetConnect();
+	} );
+	afterEach( () => jest.clearAllMocks() );
+
+	it( 'continues the flow when the plugin is installed', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalledWith() );
+	} );
+
+	it( 'sets the proper pending action', async () => {
+		jest.spyOn( global, 'setTimeout' ).mockImplementation( quickerSetTimeout );
+		render();
+
+		const { getProgress, getPendingAction } = select( ONBOARD_STORE );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( '/rest/v1.1/sites/123/plugins?http_envelope=1' )
+			.once()
+			.reply( 200, { plugins: [ { slug: 'migrate-guru' } ] } );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/rest/v1.2/sites/123/plugins/migrate-guru%2fmigrateguru', { active: true } )
+			.reply( 200 );
+
+		const result = getPendingAction()();
+		await expect( result ).resolves.toBe( true );
+
+		expect( nock.isDone() ).toBe( true );
+		expect( getProgress() ).toBe( 1 );
+	} );
+
+	it( 'installs the and active plugin when it is not installed', async () => {
+		jest.spyOn( global, 'setTimeout' ).mockImplementation( quickerSetTimeout );
+		render();
+
+		const { getProgress, getPendingAction } = select( ONBOARD_STORE );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( '/rest/v1.1/sites/123/plugins?http_envelope=1' )
+			.once()
+			.reply( 200, { plugins: [] } );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/rest/v1.2/sites/123/plugins/migrate-guru/install' )
+			.reply( 200 );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/rest/v1.2/sites/123/plugins/migrate-guru%2fmigrateguru', { active: true } )
+			.reply( 200 );
+
+		const result = getPendingAction()();
+		await expect( result ).resolves.toBe( true );
+
+		expect( nock.isDone() ).toBe( true );
+		expect( getProgress() ).toBe( 1 );
+	} );
+
+	it( 'pools the plugin endpoint until have information about the plugins', async () => {
+		jest.spyOn( global, 'setTimeout' ).mockImplementation( quickerSetTimeout );
+		render();
+
+		const { getProgress, getPendingAction } = select( ONBOARD_STORE );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( '/rest/v1.1/sites/123/plugins?http_envelope=1' )
+			.times( 2 ) // Returns error 2 times
+			.reply( 500, 'Internal Server Error' )
+			.get( '/rest/v1.1/sites/123/plugins?http_envelope=1' )
+			.reply( 200, { plugins: [ { slug: 'migrate-guru' } ] } ); // Returns success
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/rest/v1.2/sites/123/plugins/migrate-guru%2fmigrateguru', { active: true } )
+			.reply( 200 );
+
+		const result = getPendingAction()();
+		await expect( result ).resolves.toBe( true );
+
+		expect( nock.isDone() ).toBe( true );
+		expect( getProgress() ).toBe( 1 );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of  #89041 

## Proposed Changes
* Add automated tests to the site-migration-plugin-install step.

## Testing Instructions
* Visual code inspection to detect any missing scenario. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?