### PR TITLE
A4A: Add Require access context to verify agency access.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -18,3 +18,4 @@ export const A4A_INVOICES_LINK = `${ A4A_PURCHASES_LINK }/invoices`;
 export const A4A_PAYMENT_METHODS_LINK = `${ A4A_PURCHASES_LINK }/payment-methods`;
 export const A4A_PAYMENT_METHODS_ADD_LINK = `${ A4A_PURCHASES_LINK }/payment-methods/add`;
 export const A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK = `${ A4A_MARKETPLACE_LINK }/download-products`;
+export const A4A_SIGNUP_LINK = '/signup';

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -1,5 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
+import { addQueryArgs } from 'calypso/lib/route';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 export const redirectToOverviewContext: Callback = () => {
 	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
@@ -9,4 +11,24 @@ export const redirectToOverviewContext: Callback = () => {
 	}
 	window.location.href = 'https://automattic.com/for/agencies';
 	return;
+};
+
+export const requireAccessContext: Callback = ( context, next ) => {
+	const state = context.store.getState();
+	const agency = getActiveAgency( state );
+	const { pathname, search } = window.location;
+
+	if ( agency ) {
+		next();
+		return;
+	}
+
+	page.redirect(
+		addQueryArgs(
+			{
+				return: pathname + search,
+			},
+			'/landing'
+		)
+	);
 };

--- a/client/a8c-for-agencies/sections/landing/controller.tsx
+++ b/client/a8c-for-agencies/sections/landing/controller.tsx
@@ -1,0 +1,8 @@
+import { type Callback } from '@automattic/calypso-router';
+import Landing from './landing';
+
+export const landingContext: Callback = ( context, next ) => {
+	context.primary = <Landing />;
+
+	next();
+};

--- a/client/a8c-for-agencies/sections/landing/index.tsx
+++ b/client/a8c-for-agencies/sections/landing/index.tsx
@@ -1,0 +1,7 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { landingContext } from './controller';
+
+export default function () {
+	page( '/landing', landingContext, makeLayout, clientRender );
+}

--- a/client/a8c-for-agencies/sections/landing/landing.tsx
+++ b/client/a8c-for-agencies/sections/landing/landing.tsx
@@ -1,25 +1,56 @@
+import page from '@automattic/calypso-router';
+import { Spinner } from '@wordpress/components';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
-
-import './style.scss';
+import {
+	A4A_OVERVIEW_LINK,
+	A4A_SIGNUP_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency, hasFetchedAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 export default function Landing() {
 	const translate = useTranslate();
-	const title = translate( 'Landing page.' );
+	const title = translate( 'Automattic for Agencies' );
+
+	const hasFetched = useSelector( hasFetchedAgency );
+	const agency = useSelector( getActiveAgency );
+
+	useEffect( () => {
+		if ( ! hasFetched ) {
+			return;
+		}
+
+		if ( agency ) {
+			const returnQuery = getQueryArg( window.location.href, 'return' ) as string;
+
+			if ( returnQuery ) {
+				page.redirect( returnQuery );
+			}
+
+			page.redirect( A4A_OVERVIEW_LINK );
+		}
+
+		page.redirect( A4A_SIGNUP_LINK );
+	}, [ agency, hasFetched ] );
 
 	return (
 		<Layout title={ title } wide>
 			<LayoutTop>
-				<LayoutHeader className="a4a-overview-header">
+				<LayoutHeader>
 					<Title>{ title }</Title>
 				</LayoutHeader>
 			</LayoutTop>
-			<LayoutBody>Fetching..</LayoutBody>
+			<LayoutBody>
+				<Spinner />
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/landing/landing.tsx
+++ b/client/a8c-for-agencies/sections/landing/landing.tsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+
+import './style.scss';
+
+export default function Landing() {
+	const translate = useTranslate();
+	const title = translate( 'Landing page.' );
+
+	return (
+		<Layout title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader className="a4a-overview-header">
+					<Title>{ title }</Title>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>Fetching..</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/overview/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/index.tsx
@@ -1,7 +1,8 @@
 import page from '@automattic/calypso-router';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { overviewContext } from './controller';
 
 export default function () {
-	page( '/overview', overviewContext, makeLayout, clientRender );
+	page( '/overview', requireAccessContext, overviewContext, makeLayout, clientRender );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -700,6 +700,13 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
+		name: 'a8c-for-agencies-landing',
+		paths: [ '/landing' ],
+		module: 'calypso/a8c-for-agencies/sections/landing',
+		group: 'a8c-for-agencies',
+		enableLoggedOut: true,
+	},
+	{
 		name: 'a8c-for-agencies-auth',
 		paths: [ '/connect', '/connect/oauth/token' ],
 		module: 'calypso/a8c-for-agencies/sections/auth',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -158,6 +158,7 @@
 	"sections": {
 		"a8c-for-agencies": false,
 		"a8c-for-agencies-auth": false,
+		"a8c-for-agencies-landing": false,
 		"a8c-for-agencies-overview": false,
 		"a8c-for-agencies-plugins": false,
 		"a8c-for-agencies-sites": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -21,6 +21,7 @@
 	"sections": {
 		"a8c-for-agencies": true,
 		"a8c-for-agencies-auth": true,
+		"a8c-for-agencies-landing": true,
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -15,6 +15,7 @@
 	"sections": {
 		"a8c-for-agencies": true,
 		"a8c-for-agencies-auth": true,
+		"a8c-for-agencies-landing": true,
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -17,6 +17,7 @@
 	"sections": {
 		"a8c-for-agencies": true,
 		"a8c-for-agencies-auth": true,
+		"a8c-for-agencies-landing": true,
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,


### PR DESCRIPTION
This pull request proposes a `requireAccessContext` middleware that will be implemented to check agency permission. This approach is similar to how Jetpack Manage's partner portal [requireAccessContext](https://github.com/Automattic/wp-calypso/blob/fcd5ae91e1a6b152c700f2d5047d8bcc65e00265/client/jetpack-cloud/sections/partner-portal/controller.tsx#L197) works, where the user is redirected to an interstitial page that acts as a guard to ensure the user has the necessary permissions.

We will only apply the `requireAccessContext` middleware on the Overview page for POC. If we agree on this approach, I will create a separate pull request to add the middleware to the rest of the pages.

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/168

## Proposed Changes

* Add an A4A Landing section, which will allow us to set up the Interstitial page.
* Adds `requireAccessContext` controller, which will be responsible for redirecting users to the landing page (`/landing`) everytime it access a restricted page.
* Upon loading the Landing page, the page will verify if the current user has permission by fetching the Agency object. If the agency object is null, the user will be redirected to the Signup page. Otherwise, the user proceeds to access the intended page.

## Testing Instructions
You are required to test this in your local machine as oAuth do not work properly in Horizon.

* Checkout this branch:  `yarn checkout add/a4a/agency-id-checker`
* Spin up A4A locally: `yarn start-a8c-for-agencies`
* Open an Incognito Browser and go to http://agencies.localhost:3000/overview
* Confirm that you will be redirected to the Auth page (Connect WPCOM account).
* Create a fresh WPCOM account when connecting.
* After you have connected your account, confirm that you are redirected to the Signup page.
* Complete the Signup form.
* Confirm that you have are redirected to the Overview page.
* Test that with your Agency account; every time you access the Overview page, you are redirected to the landing page briefly. 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?