### PR TITLE
Stats: Refactor mobile highlight cards

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,5 +1,10 @@
 import config from '@automattic/calypso-config';
-import { ComponentSwapper, CountComparisonCard, ShortenedNumber } from '@automattic/components';
+import {
+	ComponentSwapper,
+	CountComparisonCard,
+	MobileHighlightCardListing,
+	Spinner,
+} from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import useSubscribersOverview from 'calypso/my-sites/stats/hooks/use-subscribers-overview';
@@ -96,18 +101,11 @@ function SubscriberHighlightsStandard( {
 }
 
 function SubscriberHighlightsMobile( { highlights, isLoading }: SubscriberHighlightsRenderProps ) {
-	return (
-		<div className="highlight-cards-list-mobile">
-			{ highlights.map( ( highlight ) => (
-				<div className="highlight-cards-list-mobile__item" key={ highlight.heading }>
-					<span className="highlight-cards-list-mobile__item-heading">{ highlight.heading }</span>
-					<span className="highlight-cards-list-mobile__item-count">
-						{ isLoading ? '-' : <ShortenedNumber value={ highlight.count } /> }
-					</span>
-				</div>
-			) ) }
-		</div>
-	);
+	if ( isLoading ) {
+		return <Spinner />;
+	}
+
+	return <MobileHighlightCardListing highlights={ highlights } />;
 }
 
 export default function SubscribersHighlightSection( { siteId }: { siteId: number | null } ) {

--- a/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
@@ -44,32 +44,3 @@
 		}
 	}
 }
-
-.highlight-cards-list-mobile {
-	display: flex;
-	flex-direction: column;
-	row-gap: 16px;
-	margin: 24px;
-
-	.highlight-cards-list-mobile__item {
-		display: flex;
-		align-items: center;
-		box-shadow: 0 0 0 1px var(--color-border-subtle);
-		border-radius: 5px; /* stylelint-disable-line scales/radii */
-		background: var(--color-surface);
-		padding: 12px;
-	}
-
-	.highlight-cards-list-mobile__item-heading {
-		font-weight: 500;
-		font-size: 0.875rem;
-		line-height: 20px;
-	}
-	.highlight-cards-list-mobile__item-count {
-		margin-left: auto;
-		font-size: 1.5rem;
-		line-height: 32px;
-
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-	}
-}

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -15,11 +15,7 @@ type AnnualHighlightCounts = {
 	followers: number | null;
 };
 
-type AnnualHighlightsMobileProps = {
-	counts: AnnualHighlightCounts;
-};
-
-type AnnualHighlightsStandardProps = {
+type AnnualHighlightsProps = {
 	counts: AnnualHighlightCounts;
 };
 
@@ -31,7 +27,7 @@ type AnnualHighlightCardsProps = {
 	navigation?: React.ReactNode;
 };
 
-function AnnualHighlightsMobile( { counts }: AnnualHighlightsMobileProps ) {
+function AnnualHighlightsMobile( { counts }: AnnualHighlightsProps ) {
 	const translate = useTranslate();
 
 	const highlights = [
@@ -45,7 +41,7 @@ function AnnualHighlightsMobile( { counts }: AnnualHighlightsMobileProps ) {
 	return <MobileHighlightCardListing highlights={ highlights } />;
 }
 
-function AnnualHighlightsStandard( { counts }: AnnualHighlightsStandardProps ) {
+function AnnualHighlightsStandard( { counts }: AnnualHighlightsProps ) {
 	const translate = useTranslate();
 	return (
 		<div className="highlight-cards-list">

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -2,8 +2,8 @@ import { comment, Icon, paragraph, people, postContent, starEmpty } from '@wordp
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import ComponentSwapper from '../component-swapper';
-import ShortenedNumber from '../number-formatters';
 import CountComparisonCard from './count-comparison-card';
+import MobileHighlightCardListing from './mobile-highlight-cards';
 
 import './style.scss';
 
@@ -33,59 +33,16 @@ type AnnualHighlightCardsProps = {
 
 function AnnualHighlightsMobile( { counts }: AnnualHighlightsMobileProps ) {
 	const translate = useTranslate();
-	return (
-		<div className="highlight-cards-list-mobile">
-			<div className="highlight-cards-list-mobile__item" key="posts">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ postContent } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">{ translate( 'Posts' ) }</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.posts ?? null } />
-				</span>
-			</div>
-			<div className="highlight-cards-list-mobile__item" key="words">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ paragraph } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">{ translate( 'Words' ) }</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.words ?? null } />
-				</span>
-			</div>
-			<div className="highlight-cards-list-mobile__item" key="likes">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ starEmpty } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">{ translate( 'Likes' ) }</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.likes ?? null } />
-				</span>
-			</div>
-			<div className="highlight-cards-list-mobile__item" key="comments">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ comment } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">
-					{ translate( 'Comments' ) }
-				</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.comments ?? null } />
-				</span>
-			</div>
-			<div className="highlight-cards-list-mobile__item" key="subscribers">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ people } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">
-					{ translate( 'Subscribers' ) }
-				</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.followers ?? null } />
-				</span>
-			</div>
-		</div>
-	);
+
+	const highlights = [
+		{ heading: translate( 'Posts' ), count: counts?.posts, icon: postContent },
+		{ heading: translate( 'Words' ), count: counts?.words, icon: paragraph },
+		{ heading: translate( 'Likes' ), count: counts?.likes, icon: starEmpty },
+		{ heading: translate( 'Comments' ), count: counts?.comments, icon: comment },
+		{ heading: translate( 'Subscribers' ), count: counts?.followers, icon: people },
+	];
+
+	return <MobileHighlightCardListing highlights={ highlights } />;
 }
 
 function AnnualHighlightsStandard( { counts }: AnnualHighlightsStandardProps ) {

--- a/packages/components/src/highlight-cards/mobile-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/mobile-highlight-cards.tsx
@@ -21,19 +21,19 @@ function MobileHighlightCard( { heading, count, previousCount, icon }: MobileHig
 	const displayTrendline = count !== null && previousCount !== null;
 	const displayIcon = icon !== undefined;
 	return (
-		<div className="highlight-cards-list-mobile__item">
+		<div className="mobile-highlight-cards__item">
 			{ displayIcon && (
-				<span className="highlight-cards-list-mobile__item-icon">
+				<span className="mobile-highlight-cards__item-icon">
 					<Icon icon={ icon } />
 				</span>
 			) }
-			<span className="highlight-cards-list-mobile__item-heading">{ heading }</span>
+			<span className="mobile-highlight-cards__item-heading">{ heading }</span>
 			{ displayTrendline && (
-				<span className="highlight-cards-list-mobile__item-trend">
+				<span className="mobile-highlight-cards__item-trend">
 					<TrendComparison count={ count ?? null } previousCount={ previousCount ?? null } />
 				</span>
 			) }
-			<span className="highlight-cards-list-mobile__item-count">
+			<span className="mobile-highlight-cards__item-count">
 				<ShortenedNumber value={ count ?? null } />
 			</span>
 		</div>
@@ -48,7 +48,7 @@ export default function MobileHighlightCardListing( {
 	highlights,
 }: MobileHighlightCardListingProps ) {
 	return (
-		<div className="highlight-cards-list-mobile">
+		<div className="mobile-highlight-cards-listing">
 			{ highlights.map( ( highlight ) => (
 				<MobileHighlightCard
 					key={ highlight.heading }

--- a/packages/components/src/highlight-cards/mobile-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/mobile-highlight-cards.tsx
@@ -1,0 +1,63 @@
+import { Icon } from '@wordpress/icons';
+import ShortenedNumber from '../number-formatters';
+import { TrendComparison } from './count-comparison-card';
+import './style.scss';
+
+type MobileHighlightCardProps = {
+	heading: string;
+	count: number | null;
+	previousCount?: number | null;
+	icon?: any;
+};
+
+function MobileHighlightCard( { heading, count, previousCount, icon }: MobileHighlightCardProps ) {
+	// We require at minimum a heading and a count.
+	const isValidHighlight = count !== null || heading.length > 0;
+	if ( ! isValidHighlight ) {
+		return null;
+	}
+	// We require two counts to display a trendline.
+	// The icon is optional.
+	const displayTrendline = count !== null && previousCount !== null;
+	const displayIcon = icon !== undefined;
+	return (
+		<div className="highlight-cards-list-mobile__item">
+			{ displayIcon && (
+				<span className="highlight-cards-list-mobile__item-icon">
+					<Icon icon={ icon } />
+				</span>
+			) }
+			<span className="highlight-cards-list-mobile__item-heading">{ heading }</span>
+			{ displayTrendline && (
+				<span className="highlight-cards-list-mobile__item-trend">
+					<TrendComparison count={ count ?? null } previousCount={ previousCount ?? null } />
+				</span>
+			) }
+			<span className="highlight-cards-list-mobile__item-count">
+				<ShortenedNumber value={ count ?? null } />
+			</span>
+		</div>
+	);
+}
+
+type MobileHighlightCardListingProps = {
+	highlights: MobileHighlightCardProps[];
+};
+
+export default function MobileHighlightCardListing( {
+	highlights,
+}: MobileHighlightCardListingProps ) {
+	return (
+		<div className="highlight-cards-list-mobile">
+			{ highlights.map( ( highlight ) => (
+				<MobileHighlightCard
+					key={ highlight.heading }
+					heading={ highlight.heading }
+					count={ highlight.count }
+					previousCount={ highlight.previousCount }
+					icon={ highlight.icon }
+				/>
+			) ) }
+		</div>
+	);
+}

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -494,8 +494,8 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 .mobile-highlight-cards-listing {
 	display: flex;
 	flex-direction: column;
-	row-gap: 16px;
-	margin: 24px;
+	row-gap: 8px;
+	margin: 16px;
 
 	.mobile-highlight-cards__item {
 		display: flex;

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -452,45 +452,6 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	}
 }
 
-.highlight-cards-list-mobile {
-	display: flex;
-	flex-direction: column;
-	row-gap: 16px;
-	margin: 24px;
-
-	.highlight-cards-list-mobile__item {
-		display: flex;
-		align-items: center;
-		box-shadow: 0 0 0 1px var(--color-border-subtle);
-		border-radius: 5px; /* stylelint-disable-line scales/radii */
-		background: var(--color-surface);
-		padding: 12px;
-	}
-
-	.highlight-cards-list-mobile__item-heading {
-		font-weight: 500;
-		font-size: 0.875rem;
-		line-height: 20px;
-	}
-	.highlight-cards-list-mobile__item-count {
-		margin-left: auto;
-		font-size: 1.5rem;
-		line-height: 32px;
-
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-	}
-	.highlight-cards-list-mobile__item-icon {
-		padding-right: 12px;
-
-		svg {
-			vertical-align: middle;
-		}
-	}
-	.highlight-cards-list-mobile__item-trend {
-		padding-left: 8px;
-	}
-}
-
 .mobile-highlight-cards-listing {
 	display: flex;
 	flex-direction: column;

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -477,7 +477,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		font-size: 1.5rem;
 		line-height: 32px;
 
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-family: $highlight-card-count-font;
 	}
 	.mobile-highlight-cards__item-icon {
 		padding-right: 12px;

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -490,3 +490,42 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		padding-left: 8px;
 	}
 }
+
+.mobile-highlight-cards-listing {
+	display: flex;
+	flex-direction: column;
+	row-gap: 16px;
+	margin: 24px;
+
+	.mobile-highlight-cards__item {
+		display: flex;
+		align-items: center;
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+		border-radius: 5px; /* stylelint-disable-line scales/radii */
+		background: var(--color-surface);
+		padding: 12px;
+	}
+
+	.mobile-highlight-cards__item-heading {
+		font-weight: 500;
+		font-size: 0.875rem;
+		line-height: 20px;
+	}
+	.mobile-highlight-cards__item-count {
+		margin-left: auto;
+		font-size: 1.5rem;
+		line-height: 32px;
+
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+	}
+	.mobile-highlight-cards__item-icon {
+		padding-right: 12px;
+
+		svg {
+			vertical-align: middle;
+		}
+	}
+	.mobile-highlight-cards__item-trend {
+		padding-left: 8px;
+	}
+}

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -201,32 +201,44 @@ type WeeklyHighlighCardsMobileProps = {
 
 function WeeklyHighlighCardsMobile( { counts, previousCounts }: WeeklyHighlighCardsMobileProps ) {
 	const translate = useTranslate();
+	const highlights = [
+		{
+			heading: translate( 'Visitors' ),
+			count: counts?.visitors,
+			previousCount: previousCounts?.visitors,
+			icon: people,
+		},
+		{
+			heading: translate( 'Views' ),
+			count: counts?.views,
+			previousCount: previousCounts?.views,
+			icon: eye,
+		},
+		{
+			heading: translate( 'Likes' ),
+			count: counts?.likes,
+			previousCount: previousCounts?.likes,
+			icon: starEmpty,
+		},
+		{
+			heading: translate( 'Comments' ),
+			count: counts?.comments,
+			previousCount: previousCounts?.comments,
+			icon: commentContent,
+		},
+	];
+
 	return (
 		<div className="highlight-cards-list-mobile">
-			<MobileHighlightCard
-				heading={ translate( 'Visitors' ) }
-				icon={ people }
-				count={ counts?.visitors ?? null }
-				previousCount={ previousCounts?.visitors ?? null }
-			/>
-			<MobileHighlightCard
-				heading={ translate( 'Views' ) }
-				icon={ eye }
-				count={ counts?.views ?? null }
-				previousCount={ previousCounts?.views ?? null }
-			/>
-			<MobileHighlightCard
-				heading={ translate( 'Likes' ) }
-				icon={ starEmpty }
-				count={ counts?.likes ?? null }
-				previousCount={ previousCounts?.likes ?? null }
-			/>
-			<MobileHighlightCard
-				heading={ translate( 'Comments' ) }
-				icon={ commentContent }
-				count={ counts?.comments ?? null }
-				previousCount={ previousCounts?.comments ?? null }
-			/>
+			{ highlights.map( ( highlight ) => (
+				<MobileHighlightCard
+					key={ highlight.heading }
+					heading={ highlight.heading }
+					count={ highlight.count }
+					previousCount={ highlight.previousCount }
+					icon={ highlight.icon }
+				/>
+			) ) }
 		</div>
 	);
 }

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -203,70 +203,30 @@ function WeeklyHighlighCardsMobile( { counts, previousCounts }: WeeklyHighlighCa
 	const translate = useTranslate();
 	return (
 		<div className="highlight-cards-list-mobile">
-			<div className="highlight-cards-list-mobile__item" key="visitors">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ people } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">
-					{ translate( 'Visitors' ) }
-				</span>
-				<span className="highlight-cards-list-mobile__item-trend">
-					<TrendComparison
-						count={ counts?.visitors ?? null }
-						previousCount={ previousCounts?.visitors ?? null }
-					/>
-				</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.visitors ?? null } />
-				</span>
-			</div>
-			<div className="highlight-cards-list-mobile__item" key="views">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ eye } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">{ translate( 'Views' ) }</span>
-				<span className="highlight-cards-list-mobile__item-trend">
-					<TrendComparison
-						count={ counts?.views ?? null }
-						previousCount={ previousCounts?.views ?? null }
-					/>
-				</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.views ?? null } />
-				</span>
-			</div>
-			<div className="highlight-cards-list-mobile__item" key="likes">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ starEmpty } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">{ translate( 'Likes' ) }</span>
-				<span className="highlight-cards-list-mobile__item-trend">
-					<TrendComparison
-						count={ counts?.likes ?? null }
-						previousCount={ previousCounts?.likes ?? null }
-					/>
-				</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.likes ?? null } />
-				</span>
-			</div>
-			<div className="highlight-cards-list-mobile__item" key="comments">
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ commentContent } />
-				</span>
-				<span className="highlight-cards-list-mobile__item-heading">
-					{ translate( 'Comments' ) }
-				</span>
-				<span className="highlight-cards-list-mobile__item-trend">
-					<TrendComparison
-						count={ counts?.comments ?? null }
-						previousCount={ previousCounts?.comments ?? null }
-					/>
-				</span>
-				<span className="highlight-cards-list-mobile__item-count">
-					<ShortenedNumber value={ counts?.comments ?? null } />
-				</span>
-			</div>
+			<MobileHighlightCard
+				heading={ translate( 'Visitors' ) }
+				icon={ people }
+				count={ counts?.visitors ?? null }
+				previousCount={ previousCounts?.visitors ?? null }
+			/>
+			<MobileHighlightCard
+				heading={ translate( 'Views' ) }
+				icon={ eye }
+				count={ counts?.views ?? null }
+				previousCount={ previousCounts?.views ?? null }
+			/>
+			<MobileHighlightCard
+				heading={ translate( 'Likes' ) }
+				icon={ starEmpty }
+				count={ counts?.likes ?? null }
+				previousCount={ previousCounts?.likes ?? null }
+			/>
+			<MobileHighlightCard
+				heading={ translate( 'Comments' ) }
+				icon={ commentContent }
+				count={ counts?.comments ?? null }
+				previousCount={ previousCounts?.comments ?? null }
+			/>
 		</div>
 	);
 }
@@ -380,6 +340,46 @@ export default function WeeklyHighlightCards( {
 					/>
 				}
 			/>
+		</div>
+	);
+}
+
+function MobileHighlightCard( {
+	heading,
+	count,
+	previousCount,
+	icon,
+}: {
+	heading: string;
+	count: number | null;
+	previousCount?: number | null;
+	icon?: any;
+} ) {
+	// We require at minimum a heading and a count.
+	const isValidHighlight = count !== null || heading.length > 0;
+	if ( ! isValidHighlight ) {
+		return null;
+	}
+	// We require two counts to display a trendline.
+	// The icon is optional.
+	const displayTrendline = count !== null && previousCount !== null;
+	const displayIcon = icon !== undefined;
+	return (
+		<div className="highlight-cards-list-mobile__item">
+			{ displayIcon && (
+				<span className="highlight-cards-list-mobile__item-icon">
+					<Icon icon={ icon } />
+				</span>
+			) }
+			<span className="highlight-cards-list-mobile__item-heading">{ heading }</span>
+			{ displayTrendline && (
+				<span className="highlight-cards-list-mobile__item-trend">
+					<TrendComparison count={ count ?? null } previousCount={ previousCount ?? null } />
+				</span>
+			) }
+			<span className="highlight-cards-list-mobile__item-count">
+				<ShortenedNumber value={ count ?? null } />
+			</span>
 		</div>
 	);
 }

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -12,10 +12,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useCallback } from 'react';
 import ComponentSwapper from '../component-swapper';
 import { eye } from '../icons';
-import ShortenedNumber from '../number-formatters';
 import Popover from '../popover';
 import { comparingInfoBarsChart, comparingInfoRangeChart } from './charts';
-import CountComparisonCard, { TrendComparison } from './count-comparison-card';
+import CountComparisonCard from './count-comparison-card';
+import MobileHighlightCardListing from './mobile-highlight-cards';
 
 import './style.scss';
 
@@ -228,19 +228,7 @@ function WeeklyHighlighCardsMobile( { counts, previousCounts }: WeeklyHighlighCa
 		},
 	];
 
-	return (
-		<div className="highlight-cards-list-mobile">
-			{ highlights.map( ( highlight ) => (
-				<MobileHighlightCard
-					key={ highlight.heading }
-					heading={ highlight.heading }
-					count={ highlight.count }
-					previousCount={ highlight.previousCount }
-					icon={ highlight.icon }
-				/>
-			) ) }
-		</div>
-	);
+	return <MobileHighlightCardListing highlights={ highlights } />;
 }
 
 export default function WeeklyHighlightCards( {
@@ -352,46 +340,6 @@ export default function WeeklyHighlightCards( {
 					/>
 				}
 			/>
-		</div>
-	);
-}
-
-function MobileHighlightCard( {
-	heading,
-	count,
-	previousCount,
-	icon,
-}: {
-	heading: string;
-	count: number | null;
-	previousCount?: number | null;
-	icon?: any;
-} ) {
-	// We require at minimum a heading and a count.
-	const isValidHighlight = count !== null || heading.length > 0;
-	if ( ! isValidHighlight ) {
-		return null;
-	}
-	// We require two counts to display a trendline.
-	// The icon is optional.
-	const displayTrendline = count !== null && previousCount !== null;
-	const displayIcon = icon !== undefined;
-	return (
-		<div className="highlight-cards-list-mobile__item">
-			{ displayIcon && (
-				<span className="highlight-cards-list-mobile__item-icon">
-					<Icon icon={ icon } />
-				</span>
-			) }
-			<span className="highlight-cards-list-mobile__item-heading">{ heading }</span>
-			{ displayTrendline && (
-				<span className="highlight-cards-list-mobile__item-trend">
-					<TrendComparison count={ count ?? null } previousCount={ previousCount ?? null } />
-				</span>
-			) }
-			<span className="highlight-cards-list-mobile__item-count">
-				<ShortenedNumber value={ count ?? null } />
-			</span>
 		</div>
 	);
 }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -49,6 +49,7 @@ export {
 	BETWEEN_PAST_EIGHT_AND_FIFTEEN_DAYS,
 	BETWEEN_PAST_THIRTY_ONE_AND_SIXTY_DAYS,
 } from './highlight-cards/weekly-highlight-cards';
+export { default as MobileHighlightCardListing } from './highlight-cards/mobile-highlight-cards';
 export { default as AppPromoCard } from './app-promo-card';
 export { default as ShortenedNumber } from './number-formatters';
 export { default as formattedNumber } from './number-formatters/formatted-number';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87375.

## Proposed Changes

Introduces `MobileHighlightCard` and `MobileHighlightCardListing` and updates the Traffic, Insights, & Subscriber pages to use the new components.

- New components are part of the components package.
- CSS has been tweaked to match updated designs. — p1HpG7-rv4-p2
- Duplicate CSS has been removed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live branch.
* Navigate to the **Stats → Traffic** page.
* Use the browser tools to test at different screen sizes. iPad mini and larger should get the standard Desktop UI with horizontal scrolling while smaller screens should get the vertically stacked cards.
* Confirm **Traffic**, **Insights**, & **Subscriber** pages all display and behave correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?