### PR TITLE
A4A: Fix the issue with the Backup, Scan and Activity feature tabs

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/activity/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/activity/index.tsx
@@ -7,14 +7,14 @@ import 'calypso/my-sites/activity/activity-log-v2/style.scss';
 import './style.scss';
 
 type Props = {
-	sideId: number;
+	siteId: number;
 };
 
-export function JetpackActivityPreview( { sideId }: Props ) {
+export function JetpackActivityPreview( { siteId }: Props ) {
 	const dispatch = useDispatch();
 
-	if ( sideId ) {
-		dispatch( setSelectedSiteId( sideId ) );
+	if ( siteId ) {
+		dispatch( setSelectedSiteId( siteId ) );
 	}
 	return (
 		<SitePreviewPaneContent>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/activity/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/activity/index.tsx
@@ -1,10 +1,21 @@
 import ActivityLogV2 from 'calypso/my-sites/activity/activity-log-v2';
+import { useDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import SitePreviewPaneContent from '../../../site-preview-pane/site-preview-pane-content';
 
 import 'calypso/my-sites/activity/activity-log-v2/style.scss';
 import './style.scss';
 
-export function JetpackActivityPreview() {
+type Props = {
+	sideId: number;
+};
+
+export function JetpackActivityPreview( { sideId }: Props ) {
+	const dispatch = useDispatch();
+
+	if ( sideId ) {
+		dispatch( setSelectedSiteId( sideId ) );
+	}
 	return (
 		<SitePreviewPaneContent>
 			<ActivityLogV2 />

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-backup.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-backup.tsx
@@ -4,14 +4,14 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
 
 type Props = {
-	sideId: number;
+	siteId: number;
 };
 
-export function JetpackBackupPreview( { sideId }: Props ) {
+export function JetpackBackupPreview( { siteId }: Props ) {
 	const dispatch = useDispatch();
 
-	if ( sideId ) {
-		dispatch( setSelectedSiteId( sideId ) );
+	if ( siteId ) {
+		dispatch( setSelectedSiteId( siteId ) );
 	}
 
 	return (

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-backup.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-backup.tsx
@@ -1,7 +1,19 @@
 import BackupsPage from 'calypso/my-sites/backup/main';
+import { useDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
 
-export function JetpackBackupPreview() {
+type Props = {
+	sideId: number;
+};
+
+export function JetpackBackupPreview( { sideId }: Props ) {
+	const dispatch = useDispatch();
+
+	if ( sideId ) {
+		dispatch( setSelectedSiteId( sideId ) );
+	}
+
 	return (
 		<>
 			<SitePreviewPaneContent>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -67,7 +67,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<JetpackBackupPreview sideId={ site.blog_id } />
+				<JetpackBackupPreview siteId={ site.blog_id } />
 			),
 			createFeaturePreview(
 				JETPACK_SCAN_ID,
@@ -75,7 +75,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<JetpackScanPreview sideId={ site.blog_id } />
+				<JetpackScanPreview siteId={ site.blog_id } />
 			),
 			createFeaturePreview(
 				JETPACK_MONITOR_ID,
@@ -113,7 +113,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<JetpackActivityPreview sideId={ site.blog_id } />
+				<JetpackActivityPreview siteId={ site.blog_id } />
 			),
 		],
 		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ]

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -67,7 +67,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<JetpackBackupPreview />
+				<JetpackBackupPreview sideId={ site.blog_id } />
 			),
 			createFeaturePreview(
 				JETPACK_SCAN_ID,
@@ -113,7 +113,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<JetpackActivityPreview />
+				<JetpackActivityPreview sideId={ site.blog_id } />
 			),
 		],
 		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ]

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-scan.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-scan.tsx
@@ -6,6 +6,8 @@ import {
 	showUnavailableForVaultPressSites,
 	scan,
 } from 'calypso/my-sites/scan/controller';
+import { useDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 
 import 'calypso/my-sites/scan/style.scss';
 
@@ -40,6 +42,12 @@ export function JetpackScanPreview( { sideId }: Props ) {
 			site: sideId,
 		},
 	};
+
+	const dispatch = useDispatch();
+
+	if ( sideId ) {
+		dispatch( setSelectedSiteId( sideId ) );
+	}
 
 	processContextsChain( contextsChain, context );
 

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-scan.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-scan.tsx
@@ -12,7 +12,7 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import 'calypso/my-sites/scan/style.scss';
 
 type Props = {
-	sideId: number;
+	siteId: number;
 };
 type ContextHandler = ( context: object, next: () => void ) => void;
 
@@ -26,7 +26,7 @@ function processContextsChain( contextsChain: ContextHandler[], context: object 
 	next( 0 );
 }
 
-export function JetpackScanPreview( { sideId }: Props ) {
+export function JetpackScanPreview( { siteId }: Props ) {
 	const contextsChain: ContextHandler[] = [
 		showNotAuthorizedForNonAdmins,
 		showJetpackIsDisconnected,
@@ -39,14 +39,14 @@ export function JetpackScanPreview( { sideId }: Props ) {
 	const context = {
 		primary: null,
 		params: {
-			site: sideId,
+			site: siteId,
 		},
 	};
 
 	const dispatch = useDispatch();
 
-	if ( sideId ) {
-		dispatch( setSelectedSiteId( sideId ) );
+	if ( siteId ) {
+		dispatch( setSelectedSiteId( siteId ) );
 	}
 
 	processContextsChain( contextsChain, context );
@@ -54,7 +54,7 @@ export function JetpackScanPreview( { sideId }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				{ sideId ? context.primary : <div>Loading Scan page...</div> }
+				{ siteId ? context.primary : <div>Loading Scan page...</div> }
 			</SitePreviewPaneContent>
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -65,7 +65,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<JetpackScanPreview sideId={ site.blog_id } />
+				<JetpackScanPreview siteId={ site.blog_id } />
 			),
 			createFeaturePreview(
 				'jetpack_monitor',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-scan.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-scan.tsx
@@ -10,7 +10,7 @@ import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-conte
 import 'calypso/my-sites/scan/style.scss';
 
 type Props = {
-	sideId: number;
+	siteId: number;
 };
 type ContextHandler = ( context: object, next: () => void ) => void;
 
@@ -24,7 +24,7 @@ function processContextsChain( contextsChain: ContextHandler[], context: object 
 	next( 0 );
 }
 
-export function JetpackScanPreview( { sideId }: Props ) {
+export function JetpackScanPreview( { siteId }: Props ) {
 	const contextsChain: ContextHandler[] = [
 		showNotAuthorizedForNonAdmins,
 		showJetpackIsDisconnected,
@@ -37,7 +37,7 @@ export function JetpackScanPreview( { sideId }: Props ) {
 	const context = {
 		primary: null,
 		params: {
-			site: sideId,
+			site: siteId,
 		},
 	};
 
@@ -46,7 +46,7 @@ export function JetpackScanPreview( { sideId }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				{ sideId ? context.primary : <div>Loading Scan page...</div> }
+				{ siteId ? context.primary : <div>Loading Scan page...</div> }
 			</SitePreviewPaneContent>
 		</>
 	);


### PR DESCRIPTION
Resolve: https://github.com/Automattic/automattic-for-agencies-dev/issues/172

## Proposed Changes

This PR fixes a new issue introduced recently with the Backup, Scan, and Activity feature tabs.

The fix is about forcing the site selection before displaying those tabs.

## Testing Instructions

- Check the code
- Ensure that the tabs Backup, Scan, and Activity are working again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
