### PR TITLE
Site Migration: Add tests to the upgrade plan step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -39,7 +39,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		} );
 	};
 
-	it( 'selects business as default plan', async () => {
+	it( 'selects annual plan as default', async () => {
 		const navigation = { submit: jest.fn() };
 		render( { navigation } );
 
@@ -51,7 +51,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		} );
 	} );
 
-	it( 'selects montly plan', async () => {
+	it( 'selects the monthly plan', async () => {
 		const navigation = { submit: jest.fn() };
 		render( { navigation } );
 
@@ -64,7 +64,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		} );
 	} );
 
-	it( 'selects annually plan', async () => {
+	it( 'selects annual plan', async () => {
 		const navigation = { submit: jest.fn() };
 		render( { navigation } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import React from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import plansReducer from 'calypso/state/plans/reducer';
+import SiteMigrationUpgradePlan from '../';
+import { StepProps } from '../../../types';
+import { mockStepProps, renderStep } from '../../test/helpers';
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site' );
+
+( useSite as jest.Mock ).mockReturnValue( {
+	ID: 'site-id',
+	URL: 'https://site-url.wordpress.com',
+} );
+
+describe( 'SiteMigrationUpgradePlan', () => {
+	const render = ( props?: Partial< StepProps > ) => {
+		const combinedProps = { ...mockStepProps( props ) };
+		return renderStep( <SiteMigrationUpgradePlan { ...combinedProps } />, {
+			reducers: {
+				plans: plansReducer,
+			},
+		} );
+	};
+
+	beforeAll( () => nock.disableNetConnect() );
+
+	it( 'selects business as default plan', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( navigation.submit ).toHaveBeenCalledWith( {
+			goToCheckout: true,
+			plan: 'business',
+		} );
+	} );
+
+	it( 'selects montly plan', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Pay monthly/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( navigation.submit ).toHaveBeenCalledWith( {
+			goToCheckout: true,
+			plan: 'business-monthly',
+		} );
+	} );
+
+	it( 'selects annually plan', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Pay annually/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( navigation.submit ).toHaveBeenCalledWith( {
+			goToCheckout: true,
+			plan: 'business',
+		} );
+	} );
+
+	it( 'selects free trial', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Try 7 days for free/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( navigation.submit ).toHaveBeenCalledWith( {
+			goToCheckout: true,
+			plan: 'business',
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
@@ -80,10 +80,6 @@ describe( 'SiteMigrationUpgradePlan', () => {
 	it( 'selects free trial', async () => {
 		const navigation = { submit: jest.fn() };
 		render( { navigation } );
-
-		await waitFor( () => {
-			expect( screen.getByRole( 'button', { name: /Try 7 days for free/ } ) ).toBeEnabled();
-		} );
 
 		await userEvent.click( screen.getByRole( 'button', { name: /Try 7 days for free/ } ) );
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of  #89041 

## Proposed Changes
* Add automated tests to the site migration upgrade plan step.

## Testing Instructions
* Visual code inspection to detect any missing scenario. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?