### PR TITLE
Sidebar Menu: Allow Jetpack redirect URLs to fix the link of Subscribers

### DIFF
--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -23,6 +23,8 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 		url?.replace( /^https?:\/\//, '' )
 	);
 
+	const isSafeJetpackRedirectUrl = /^https:\/\/jetpack\.com\/redirect\//.test( url );
+
 	// Gives WP Admin Customizer a chance to return to where we started from.
 	if ( isSafeWpAdminUrl && url?.includes( 'wp-admin/customize.php' ) ) {
 		url = addQueryArgs(
@@ -33,7 +35,7 @@ const sanitizeUrl = ( url, wpAdminUrl ) => {
 		);
 	}
 
-	if ( isSafeInternalUrl || isSafeWpAdminUrl ) {
+	if ( isSafeInternalUrl || isSafeWpAdminUrl || isSafeJetpackRedirectUrl ) {
 		return url;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6342

## Proposed Changes

* The Jetpack > Subscribers doesn't point to the Subscribers page on Jetpack Manage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /settings/<your_site> on your atomic site without the `wpcom_classic_early_release` flag
* Change the Admin Interface Style to "Classic Style"
* Select Jetpack > Subscribers on the sidebar
* Make sure it redirects to the Subscriber page on Jetpack Manage

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?