### PR TITLE
Scheduled Updates: Define logs route

### DIFF
--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useIsEligibleForFeature } from 'calypso/blocks/plugins-update-manager/hooks/use-is-eligible-for-feature';
 import { useSiteHasEligiblePlugins } from 'calypso/blocks/plugins-update-manager/hooks/use-site-has-eligible-plugins';
+import { ScheduleLogs } from 'calypso/blocks/plugins-update-manager/schedule-logs';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import MainComponent from 'calypso/components/main';
@@ -23,7 +24,7 @@ import './styles.scss';
 
 interface Props {
 	siteSlug: string;
-	context: 'list' | 'create' | 'edit';
+	context: 'list' | 'create' | 'edit' | 'logs';
 	scheduleId?: string;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
@@ -52,6 +53,10 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	}, [ context, siteSlug ] );
 
 	const { component, title } = {
+		logs: {
+			component: <ScheduleLogs scheduleId={ scheduleId as string } onNavBack={ onNavBack } />,
+			title: translate( 'Scheduled Updates Logs' ),
+		},
 		list: {
 			component: (
 				<ScheduleList

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -1,0 +1,9 @@
+interface Props {
+	scheduleId: string;
+	onNavBack?: () => void;
+}
+export const ScheduleLogs = ( props: Props ) => {
+	const { scheduleId } = props;
+
+	return <>Schedule Logs: { scheduleId }</>;
+};

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -115,18 +115,33 @@ export function plugins( context, next ) {
 export function updatesManager( context, next ) {
 	const siteSlug = context?.params?.site_slug;
 	const scheduleId = context?.params?.schedule_id;
+	const goToScheduledUpdatesList = () => page.show( `/plugins/scheduled-updates/${ siteSlug }` );
 
 	if ( ! siteSlug ) {
 		sites( context, next );
 		return;
 	}
 
+	if ( context.params.action === 'logs' && ! scheduleId ) {
+		goToScheduledUpdatesList();
+		return;
+	}
+
 	switch ( context.params.action ) {
+		case 'logs':
+			context.primary = createElement( PluginsUpdateManager, {
+				siteSlug,
+				scheduleId,
+				context: 'logs',
+				onNavBack: goToScheduledUpdatesList,
+			} );
+			break;
+
 		case 'create':
 			context.primary = createElement( PluginsUpdateManager, {
 				siteSlug,
 				context: 'create',
-				onNavBack: () => page.show( `/plugins/scheduled-updates/${ siteSlug }` ),
+				onNavBack: goToScheduledUpdatesList,
 			} );
 			break;
 
@@ -135,7 +150,7 @@ export function updatesManager( context, next ) {
 				siteSlug,
 				scheduleId,
 				context: 'edit',
-				onNavBack: () => page.show( `/plugins/scheduled-updates/${ siteSlug }` ),
+				onNavBack: goToScheduledUpdatesList,
 			} );
 			break;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89036

## Proposed Changes

* Defines route for the Scheduled Updates Logs feature; route is: `/plugins/scheduled-updates/logs/:site_slug?/:schedule_id`
* Created ScheduleLogs placeholder component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/logs/{site_slug}/{schedule_id}`
* Check if renders a placeholder component
* Go to `/plugins/scheduled-updates/logs/{site_slug}`
* Check if it redirects back to the scheduled updates list screen since ID is not provided

<img width="1084" alt="Screenshot 2024-03-29 at 16 35 01" src="https://github.com/Automattic/wp-calypso/assets/1241413/b48de8cc-c569-4d20-bb47-18cf9519eb2c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?