### PR TITLE
A4A: Sites dashboard preview pane plugins section design update

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { external, Icon } from '@wordpress/icons';
 import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
 
@@ -6,17 +7,27 @@ type Props = {
 	featureText: string | React.ReactNode;
 	link: string;
 	linkLabel: string;
+	captionText: string;
 };
 
-export function JetpackPluginsPreview( { featureText, link, linkLabel }: Props ) {
+export function JetpackPluginsPreview( { featureText, link, linkLabel, captionText }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<h3>{ featureText }</h3>
-				<div style={ { marginTop: '40px' } }>
-					<Button href={ link } primary>
-						{ linkLabel }
-					</Button>
+				<div className="site-preview-pane__plugins-content">
+					<h3>{ featureText }</h3>
+					<p className="site-preview-pane__plugins-caption">{ captionText }</p>
+					<div style={ { marginTop: '24px' } }>
+						<Button href={ link } primary>
+							{ linkLabel }
+							<Icon
+								icon={ external }
+								size={ 16 }
+								className="site-preview-pane__plugins-icon"
+								viewBox="0 0 20 20"
+							/>
+						</Button>
+					</div>
 				</div>
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
@@ -18,7 +18,7 @@ export function JetpackPluginsPreview( { featureText, link, linkLabel, captionTe
 					<h3>{ featureText }</h3>
 					<p className="site-preview-pane__plugins-caption">{ captionText }</p>
 					<div style={ { marginTop: '24px' } }>
-						<Button href={ link } primary>
+						<Button href={ link } primary target="_blank">
 							{ linkLabel }
 							<Icon
 								icon={ external }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -98,7 +98,7 @@ export function JetpackPreviewPane( {
 						args: { siteUrl: site.url },
 					} ) }
 					captionText={ translate(
-						"Note: We are currently working to make this section function from the Automattic for Agencies dashboard. in the meantime, you'll be taken to WP-Admin."
+						"Note: We are currently working to make this section function from the Automattic for Agencies dashboard. In the meantime, you'll be taken to WP-Admin."
 					) }
 				/>
 			),

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -92,11 +92,14 @@ export function JetpackPreviewPane( {
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				<JetpackPluginsPreview
-					link={ '/plugins/manage/' + site.url }
-					linkLabel={ translate( 'Manage Plugins' ) }
+					link={ site.url_with_scheme + '/wp-admin/plugins.php' }
+					linkLabel={ translate( 'Manage Plugins in wp-admin' ) }
 					featureText={ translate( 'Manage all plugins installed on %(siteUrl)s', {
 						args: { siteUrl: site.url },
 					} ) }
+					captionText={ translate(
+						"Note: We are currently working to make this section function from the Automattic for Agencies dashboard. in the meantime, you'll be taken to WP-Admin."
+					) }
 				/>
 			),
 			createFeaturePreview(

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -13,4 +13,22 @@
 			justify-content: center;
 		}
 	}
+
+	.site-preview-pane__plugins-content {
+		padding: 16px;
+		box-shadow: 0 0 0 1px #dcdcde;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		border-radius: 0.5rem;
+	}
+
+	.site-preview-pane__plugins-caption {
+		text-align: center;
+		padding-top: 16px;
+		font-size: small;
+	}
+
+	.site-preview-pane__plugins-icon {
+		fill: #fff;
+		padding-left: 8px;
+	}
 }

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -19,10 +19,10 @@
 		box-shadow: 0 0 0 1px #dcdcde;
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 0.5rem;
+		text-align: left;
 	}
 
 	.site-preview-pane__plugins-caption {
-		text-align: center;
 		padding-top: 16px;
 		font-size: small;
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/142

## Proposed Changes

* This PR updates the plugins preview pane section in the sites dashboard to match design specs.

Conversation around the plugins section in Figma here, beyond what is included in the designs themselves: 1UpoqS1KkCtLXVX68TbMSM-fi-6144_260201#747621129

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* Visit the plugins tab when opening the preview pane for a site. It should match the design below, which should also match that which is discussed in the design specs linked above.


<img width="1009" alt="Screenshot 2024-03-29 at 17 03 42" src="https://github.com/Automattic/wp-calypso/assets/16754605/c90f0c0f-fb93-4b31-aee3-0a9f1ed6e588">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?