### PR TITLE
E2E: fix test that opens page template

### DIFF
--- a/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
@@ -1,0 +1,35 @@
+import { Page } from 'playwright';
+import { EditorComponent } from './editor-component';
+
+const selectors = {
+	primaryFieldByText: ( primaryFieldText: string ) =>
+		`.dataviews-view-table__primary-field:has-text("${ primaryFieldText }")`,
+};
+
+/**
+ * Represents an instance of the WordPress.com FSE Editor's DataViews.
+ * This is used for data layouts (e.g. tables, grids, and lists).
+ */
+export class FullSiteEditorDataViewsComponent {
+	private page: Page;
+	private editor: EditorComponent;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 * @param {EditorComponent} editor The EditorComponent instance.
+	 */
+	constructor( page: Page, editor: EditorComponent ) {
+		this.page = page;
+		this.editor = editor;
+	}
+
+	/**
+	 * Clicks on a button with the exact name.
+	 */
+	async clickPrimaryFieldByExactText( primaryFieldText: string ): Promise< void > {
+		const editorParent = await this.editor.parent();
+		await editorParent.locator( selectors.primaryFieldByText( primaryFieldText ) ).click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -34,6 +34,7 @@ export * from './editor-block-toolbar-component';
 export * from './template-part-list-component';
 export * from './template-part-modal-component';
 export * from './full-side-editor-nav-sidebar-component';
+export * from './full-side-editor-data-views-component';
 export * from './editor-dimensions-component';
 export * from './jetpack-instant-search-modal-component';
 

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -15,6 +15,7 @@ import {
 	BlockToolbarButtonIdentifier,
 	TemplatePartListComponent,
 	FullSiteEditorNavSidebarComponent,
+	FullSiteEditorDataViewsComponent,
 	TemplatePartModalComponent,
 	OpenInlineInserter,
 	EditorInlineBlockInserterComponent,
@@ -56,6 +57,7 @@ export class FullSiteEditorPage {
 	private editorBlockToolbarComponent: EditorBlockToolbarComponent;
 	private fullSiteEditorSavePanelComponent: FullSiteEditorSavePanelComponent;
 	private fullSiteEditorNavSidebarComponent: FullSiteEditorNavSidebarComponent;
+	private fullSiteEditorDataViewsComponent: FullSiteEditorDataViewsComponent;
 	private templatePartModalComponent: TemplatePartModalComponent;
 	private templatePartListComponent: TemplatePartListComponent;
 	private cookieBannerComponent: CookieBannerComponent;
@@ -76,6 +78,10 @@ export class FullSiteEditorPage {
 		this.editorSiteStylesComponent = new EditorSiteStylesComponent( page, this.editor );
 		this.editorBlockToolbarComponent = new EditorBlockToolbarComponent( page, this.editor );
 		this.fullSiteEditorNavSidebarComponent = new FullSiteEditorNavSidebarComponent(
+			page,
+			this.editor
+		);
+		this.fullSiteEditorDataViewsComponent = new FullSiteEditorDataViewsComponent(
 			page,
 			this.editor
 		);
@@ -165,6 +171,13 @@ export class FullSiteEditorPage {
 	 */
 	async clickFullSiteNavigatorButton( text: string ): Promise< void > {
 		await this.fullSiteEditorNavSidebarComponent.clickNavButtonByExactText( text );
+	}
+
+	/**
+	 * Clicks DataViews primary field to open editor.
+	 */
+	async openTemplateEditor( text: string ): Promise< void > {
+		await this.fullSiteEditorDataViewsComponent.clickPrimaryFieldByExactText( text );
 	}
 
 	/**

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -103,8 +103,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 
 		await fullSiteEditorPage.ensureNavigationTopLevel();
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Templates' );
-		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Index' );
-		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );
+		await fullSiteEditorPage.openTemplateEditor( 'Index' );
 	} );
 
 	it( 'Editor canvas loads', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

In WordPress/gutenberg#59792, the FSE page template selection was changed to use [the DataViews component](https://github.com/WordPress/gutenberg/blame/2f88a192d83f4966cc8d0ebf725baf04fb565f10/packages/dataviews/package.json).

This PR updates the test that opens the page template editor.

## Proposed Changes
I created a new `FullSiteEditorDataViewsComponent`, as DataViews will eventually be the new page/post listing component as well.

Note that I didn't get build out a ton of functions/specific selectors here, as the DataViews component has been evolving quite quickly, and we don't want to be continually adapting this test. Specifically, I didn't bother targeting the "Edit" button (which is selectively visible) or the actions dropdown (which also has changed several times). Instead I just made the test click the primary field text, which opens the template editor.

Old layout:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/48a30f74-06af-437d-8a59-f0589f0f25fe)

New layout:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/13d219fe-4efc-4ce7-82e5-563dc0bfd5b5)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run the following from the `fix/e2e/new_fse_template_page` branch:

```
yarn workspace wp-e2e-tests build && JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/fse/fse__temp-smoke-test.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?