### PR TITLE
A4A: Sites dashboard preview pane monitor section design update

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: Props ) {
 	return (
 		<>
-			<SitePreviewPaneContent>
+			<SitePreviewPaneContent className="site-preview-pane__monitor-content">
 				<MonitorActivity
 					hasMonitor={ site.monitor_settings.monitor_active }
 					site={ site }

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -13,4 +13,49 @@
 			justify-content: center;
 		}
 	}
+
+}
+
+.site-preview-pane__monitor-content {
+
+	text-align: unset !important;
+
+	.expanded-card__header {
+		font-size: 1.25rem;
+		text-overflow: ellipsis;
+		font-weight: 500;
+	}
+
+	.site-expanded-content__card-content-column {
+		max-width: unset;
+	}
+
+	.chart__bars {
+		overflow: hidden;
+		gap: 3px;
+		margin-bottom: 4px;
+	}
+
+	.chart__bar,
+	.chart__bars {
+		transform-origin: 0 100%;
+		border-radius: 2px;
+	}
+
+	.chart__bar {
+		gap: 2px;
+	}
+	.chart__bar-section {
+		left: 0;
+		right: 0;
+		text-align: unset;
+	}
+
+	.expanded-card {
+		max-width: unset !important;
+	}
+
+	.site-expanded-content__chart .chart .chart__bar.site-expanded-content__chart-bar-is-uptime .chart__bar-section {
+		border-radius: 2px;
+	}
 }

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
@@ -46,6 +46,12 @@
 			height: revert;
 		}
 
+		@media (max-width: 850px) {
+			.section-nav__panel {
+				overflow: scroll;
+			}
+		}
+
 		@media (min-width: 481px) {
 			.section-nav-group {
 				.is-dropdown {

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
@@ -46,12 +46,6 @@
 			height: revert;
 		}
 
-		@media (max-width: 850px) {
-			.section-nav__panel {
-				overflow: scroll;
-			}
-		}
-
 		@media (min-width: 481px) {
 			.section-nav-group {
 				.is-dropdown {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/108

## Proposed Changes

* This PR updates the monitor preview pane section in the sites dashboard to match design specs.

Conversation around the monitor section in Figma here, beyond what is included in the designs themselves: 1UpoqS1KkCtLXVX68TbMSM-fi-6144_260181#747619329

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* Visit the monitor tab when opening the preview pane for a site. It should match the design below, which should also match that which is discussed in the design specs linked above.
* 
<img width="636" alt="Screenshot 2024-03-29 at 19 21 42" src="https://github.com/Automattic/wp-calypso/assets/16754605/1b26ac18-66b2-4053-abd7-2670683fc2c1">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?