### PR TITLE
Align headers vertically centered on comparisons page

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/style.scss
+++ b/client/jetpack-cloud/sections/comparison/table/style.scss
@@ -212,6 +212,10 @@
 		}
 	}
 
+	.feature-heading {
+		vertical-align: middle;
+	}
+
 	.feature-heading__icon-container {
 		display: none;
 	}


### PR DESCRIPTION
## Proposed Changes

* Add a line of CSS to vertically center the headers on the comparison table

## Testing Instructions

1. Open the Claypso live link
2. Go to `/features/comparison`
3. Make sure VaultPress Backup and VideoPress are centered
![Screenshot 2024-03-29 at 1 22 43 PM](https://github.com/Automattic/wp-calypso/assets/65001528/99992be9-6436-409e-9bc8-b2f539a5dae8)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?