### PR TITLE
E2E: Use page template that exists

### DIFF
--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -60,12 +60,12 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		editorPage = new EditorPage( page );
 		// Allow some time for CPU and/or network to catch up.
 		await editorPage.selectTemplateCategory( 'About', { timeout: 20 * 1000 } );
-		await editorPage.selectTemplate( 'About me', { timeout: 15 * 1000 } );
+		await editorPage.selectTemplate( 'About Page 3', { timeout: 15 * 1000 } );
 	} );
 
 	it( 'Template content loads into editor', async function () {
 		const editorCanvas = await editorPage.getEditorCanvas();
-		await editorCanvas.locator( `h1:text-is("About me")` ).waitFor();
+		await editorCanvas.locator( `h1:text-is("About Page 3")` ).waitFor();
 	} );
 
 	it( 'Open setting sidebar', async function () {
@@ -92,6 +92,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	it( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );
-		await publishedPagePage.validateTextInPost( 'About Me' );
+		await publishedPagePage.validateTextInPost( 'About Page 3' );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The E2E tests were looking for a page template ("About Me") that doesn't exist. This updates tests to use "About Page 3" instead.

## Proposed Changes

Getting the fix together was easy. Figuring out why it was needed, less so...I did extensive searches of the codebase for various keywords, but they were nowhere to be found.

Finally, I worked my way through the code and discovered that the templates are pulled from a WP.com site (PCYsg-LZl-p2).

For the "About" category, it would grab any templates that are tagged as synced and that belong to both the "Page" and "About" category. Currently there are 5. I wasn't able to find any documentation regarding the deletion of the original "About Me" template, but it's not important which template is used in this test anyway.

This is the page the test is working on:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/bc431865-536f-4686-9a84-0e6059f59000)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build && JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__page-basic-flow.ts
```
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?