### PR TITLE
Global Nav: Update sites dashboard to include flyout panel

### DIFF
--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -12,8 +12,13 @@ import { SiteComingSoon } from './sites-site-coming-soon';
 import type { SitesDisplayMode } from './sites-display-mode-switcher';
 import type { SiteExcerptData } from '@automattic/sites';
 
-const NoIcon = styled.div( {
+const NoIconLargeText = styled.div( {
 	fontSize: 'xx-large',
+	textTransform: 'uppercase',
+} );
+
+const NoIconSmallText = styled.div( {
+	fontSize: 'small',
 	textTransform: 'uppercase',
 } );
 
@@ -26,16 +31,20 @@ interface SiteItemThumbnailProps extends Omit< ComponentProps< typeof SiteThumbn
 	site: SiteExcerptData;
 	alt?: string;
 	showPlaceholder?: boolean;
+	isSmall?: boolean;
 }
 
 export const SiteItemThumbnail = ( {
 	displayMode,
 	showPlaceholder,
 	site,
+	isSmall,
 	...props
 }: SiteItemThumbnailProps ) => {
 	const { __ } = useI18n();
 	const classes = classNames( props.className, disallowSelection );
+
+	const NoIcon = isSmall ? NoIconSmallText : NoIconLargeText;
 
 	// Allow parent component to lazy load the entire component.
 	if ( showPlaceholder === true ) {
@@ -126,6 +135,7 @@ export const SiteItemThumbnail = ( {
 			mShotsUrl={ shouldUseScreenshot ? siteUrl : undefined }
 			alt={ site.title || __( 'Site thumbnail' ) }
 			bgColorImgUrl={ site.icon?.img }
+			isSmall={ isSmall }
 		>
 			{ renderFallback() }
 		</SiteThumbnail>

--- a/client/sites-dashboard/components/sites-table-narrow.tsx
+++ b/client/sites-dashboard/components/sites-table-narrow.tsx
@@ -1,0 +1,101 @@
+import styled from '@emotion/styled';
+import { useLayoutEffect, useRef, useState } from 'react';
+import SitesTableRowLoading from './sites-table-row-loading';
+import SitesTableRowNarrow from './sites-table-row-narrow';
+import type { SiteExcerptData } from '@automattic/sites';
+
+const N_LOADING_ROWS = 3;
+
+interface SitesTableProps {
+	className?: string;
+	sites: SiteExcerptData[];
+	isLoading?: boolean;
+}
+
+const Table = styled.table`
+	border-collapse: collapse;
+	table-layout: fixed;
+	position: relative;
+`;
+
+export function SitesTableNarrow( { className, sites, isLoading = false }: SitesTableProps ) {
+	const headerRef = useRef< HTMLTableSectionElement >( null );
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ isHeaderStuck, setIsHeaderStuck ] = useState( false );
+	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
+
+	// Measure height of masterbar as we need it for the THead styles
+	useLayoutEffect( () => {
+		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
+
+		if ( ! masterbarElement ) {
+			return;
+		}
+
+		if ( ! window.ResizeObserver ) {
+			setMasterbarHeight( masterbarElement.offsetHeight );
+			return;
+		}
+
+		let lastHeight = masterbarElement.offsetHeight;
+
+		const observer = new ResizeObserver(
+			( [ masterbar ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
+				const currentHeight = masterbar.contentRect.height;
+
+				if ( currentHeight !== lastHeight ) {
+					setMasterbarHeight( currentHeight );
+					lastHeight = currentHeight;
+				}
+			}
+		);
+
+		observer.observe( masterbarElement );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
+
+	// Detect when the header becomes "sticky" so we can show the shadow
+	useLayoutEffect( () => {
+		if ( ! headerRef.current || ! window.IntersectionObserver ) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			( [ entry ] ) => setIsHeaderStuck( entry.intersectionRatio < 1 ),
+			{
+				rootMargin: `-${ masterbarHeight + 1 }px 0px 0px 0px`,
+				threshold: [ 1 ],
+			}
+		);
+
+		observer.observe( headerRef.current );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [ masterbarHeight ] );
+
+	return (
+		<Table className={ className }>
+			<tbody>
+				{ isLoading &&
+					Array( N_LOADING_ROWS )
+						.fill( null )
+						.map( ( _, i ) => (
+							<SitesTableRowLoading
+								key={ i }
+								columns={ 6 }
+								delayMS={ i * 150 }
+								logoProps={ { width: 108, height: 78 } }
+							/>
+						) ) }
+				{ sites.map( ( site ) => (
+					<SitesTableRowNarrow site={ site } key={ site.ID }></SitesTableRowNarrow>
+				) ) }
+			</tbody>
+		</Table>
+	);
+}

--- a/client/sites-dashboard/components/sites-table-row-narrow.tsx
+++ b/client/sites-dashboard/components/sites-table-row-narrow.tsx
@@ -9,6 +9,7 @@ import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-m
 import { useDispatch, useSelector } from 'calypso/state';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	displaySiteUrl,
 	getDashboardUrl,
@@ -33,6 +34,10 @@ interface SiteTableRowProps {
 const Row = styled.tr`
 	line-height: 2em;
 	border-block-end: 1px solid #eee;
+`;
+
+const RowSelected = styled( Row )`
+	border-left: 4px solid var( --studio-blue-50 );
 `;
 
 const Column = styled.td< { tabletHidden?: boolean } >`
@@ -116,9 +121,10 @@ function SitesTableNarrowRow( { site }: SiteTableRowProps ) {
 	};
 
 	const title = __( 'View Site Details' );
-
+	const isSiteSelected = useSelector( ( state ) => getSelectedSiteId( state ) === site.ID );
+	const RowStyledComponent = isSiteSelected ? RowSelected : Row;
 	return (
-		<Row ref={ ref }>
+		<RowStyledComponent ref={ ref }>
 			<Column>
 				<SiteListTile
 					contentClassName={ css`
@@ -126,7 +132,12 @@ function SitesTableNarrowRow( { site }: SiteTableRowProps ) {
 					` }
 					leading={
 						<ListTileLeading href={ dashboardUrl } title={ title } onClick={ onSiteClick }>
-							<SiteItemThumbnail displayMode="list" showPlaceholder={ ! inView } site={ site } />
+							<SiteItemThumbnail
+								displayMode="list"
+								showPlaceholder={ ! inView }
+								site={ site }
+								isSmall={ true }
+							/>
 						</ListTileLeading>
 					}
 					title={
@@ -157,7 +168,7 @@ function SitesTableNarrowRow( { site }: SiteTableRowProps ) {
 					}
 				/>
 			</Column>
-		</Row>
+		</RowStyledComponent>
 	);
 }
 export default memo( SitesTableNarrowRow );

--- a/client/sites-dashboard/components/sites-table-row-narrow.tsx
+++ b/client/sites-dashboard/components/sites-table-row-narrow.tsx
@@ -1,0 +1,163 @@
+import { ListTile } from '@automattic/components';
+import { css } from '@emotion/css';
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import { memo } from 'react';
+import * as React from 'react';
+import { useInView } from 'react-intersection-observer';
+import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
+import { useDispatch, useSelector } from 'calypso/state';
+import { isTrialSite } from 'calypso/state/sites/plans/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import {
+	displaySiteUrl,
+	getDashboardUrl,
+	isStagingSite,
+	MEDIA_QUERIES,
+	siteDefaultInterface,
+	getSiteWpAdminUrl,
+} from '../utils';
+import SitesP2Badge from './sites-p2-badge';
+import { SiteAdminLink } from './sites-site-admin-link';
+import { SiteItemThumbnail } from './sites-site-item-thumbnail';
+import { SiteName } from './sites-site-name';
+import { SiteUrl, Truncated } from './sites-site-url';
+import SitesStagingBadge from './sites-staging-badge';
+import { ThumbnailLink } from './thumbnail-link';
+import type { SiteExcerptData } from '@automattic/sites';
+
+interface SiteTableRowProps {
+	site: SiteExcerptData;
+}
+
+const Row = styled.tr`
+	line-height: 2em;
+	border-block-end: 1px solid #eee;
+`;
+
+const Column = styled.td< { tabletHidden?: boolean } >`
+	padding-block-start: 12px;
+	padding-block-end: 12px;
+	padding-inline-end: 12px;
+	vertical-align: middle;
+	font-size: 14px;
+	line-height: 20px;
+	letter-spacing: -0.24px;
+	color: var( --studio-gray-60 );
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+
+	${ MEDIA_QUERIES.hideTableRows } {
+		${ ( props ) => props.tabletHidden && 'display: none;' };
+		padding-inline-end: 0;
+	}
+
+	.stats-sparkline__bar {
+		fill: var( --studio-gray-60 );
+	}
+`;
+
+const SiteListTile = styled( ListTile )`
+	margin-inline-end: 0;
+
+	${ MEDIA_QUERIES.hideTableRows } {
+		margin-inline-end: 12px;
+	}
+`;
+
+const ListTileLeading = styled( ThumbnailLink )`
+	${ MEDIA_QUERIES.hideTableRows } {
+		margin-inline-end: 12px;
+	}
+`;
+
+const ListTileTitle = styled.div`
+	display: flex;
+	align-items: center;
+	margin-block-end: 8px;
+`;
+
+const ListTileSubtitle = styled.div`
+	display: flex;
+	align-items: center;
+
+	&:not( :last-child ) {
+		margin-block-end: 2px;
+	}
+`;
+
+function SitesTableNarrowRow( { site }: SiteTableRowProps ) {
+	const { __ } = useI18n();
+	const { ref, inView } = useInView( { triggerOnce: true } );
+
+	const isP2Site = site.options?.is_wpforteams_site;
+	const isWpcomStagingSite = isStagingSite( site );
+	const isTrialSitePlan = useSelector( ( state ) => isTrialSite( state, site.ID ) );
+
+	const computeDashboardUrl = ( site: SiteExcerptData ) => {
+		if ( siteDefaultInterface( site ) === 'wp-admin' ) {
+			return getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug );
+		}
+		return getDashboardUrl( site.slug );
+	};
+	const dashboardUrl = computeDashboardUrl( site );
+
+	let siteUrl = site.URL;
+	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
+		siteUrl = site.options?.unmapped_url;
+	}
+
+	const dispatch = useDispatch();
+	const onSiteClick = ( event: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => {
+		event.stopPropagation();
+		event.preventDefault();
+		dispatch( setSelectedSiteId( site.ID ) );
+	};
+
+	const title = __( 'View Site Details' );
+
+	return (
+		<Row ref={ ref }>
+			<Column>
+				<SiteListTile
+					contentClassName={ css`
+						min-width: 0;
+					` }
+					leading={
+						<ListTileLeading href={ dashboardUrl } title={ title } onClick={ onSiteClick }>
+							<SiteItemThumbnail displayMode="list" showPlaceholder={ ! inView } site={ site } />
+						</ListTileLeading>
+					}
+					title={
+						<ListTileTitle>
+							<SiteName href={ dashboardUrl } title={ title } onClick={ onSiteClick }>
+								{ site.title }
+							</SiteName>
+							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
+							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
+							{ isTrialSitePlan && (
+								<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
+							) }
+						</ListTileTitle>
+					}
+					subtitle={
+						<>
+							<ListTileSubtitle>
+								<SiteUrl href={ siteUrl } title={ siteUrl }>
+									<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
+								</SiteUrl>
+							</ListTileSubtitle>
+							<ListTileSubtitle>
+								<SiteAdminLink href={ getSiteWpAdminUrl( site ) } title={ __( 'Visit WP Admin' ) }>
+									{ __( 'WP Admin' ) }
+								</SiteAdminLink>
+							</ListTileSubtitle>
+						</>
+					}
+				/>
+			</Column>
+		</Row>
+	);
+}
+export default memo( SitesTableNarrowRow );

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -80,7 +80,6 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 		}
 	`;
 	context.secondary = <MySitesNavigation path={ context.path } />;
-
 	context.primary = (
 		<>
 			<Global styles={ sitesDashboardGlobalStyles } />

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -13,12 +13,12 @@ export const getShouldShowGlobalSidebar = ( _: AppState, siteId: number, section
 
 export const getShouldShowCollapsedGlobalSidebar = (
 	state: AppState,
-	siteId: number,
+	siteId: number | null,
 	sectionGroup: string
 ) => {
 	// Global sidebar should be collapsed when in sites dashboard and a site is selected.
 	return (
-		isEnabled( 'layout/dotcom-nav-redesign-v2' ) && sectionGroup === 'sites-dashboard' && siteId
+		isEnabled( 'layout/dotcom-nav-redesign-v2' ) && sectionGroup === 'sites-dashboard' && !! siteId
 	);
 };
 

--- a/packages/components/src/list-tile/style.scss
+++ b/packages/components/src/list-tile/style.scss
@@ -4,6 +4,10 @@
 	margin-right: 20px;
 }
 
+.is-global-sidebar-collapsed .list-tile {
+	align-items: flex-start;
+}
+
 .list-tile__leading {
 	margin-right: 20px;
 }

--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -8,8 +8,10 @@ import { getTextColorFromBackground } from './utils';
 export type SizeCss = { width: number; height: number };
 
 export const DEFAULT_THUMBNAIL_SIZE = { width: 106, height: 76.55 };
+export const MIN_THUMBNAIL_SIZE = { width: 50, height: 30 };
 
 const DEFAULT_CLASSNAME = css( DEFAULT_THUMBNAIL_SIZE );
+const MIN_CLASSNAME = css( MIN_THUMBNAIL_SIZE );
 
 const VIEWPORT_BASE = 1200;
 
@@ -26,6 +28,7 @@ type Props = {
 	bgColorImgUrl?: string;
 	viewport?: number;
 	mshotsOption?: MShotsOptions;
+	isSmall?: boolean;
 };
 
 export const SiteThumbnail = ( {
@@ -41,6 +44,7 @@ export const SiteThumbnail = ( {
 	sizesAttr = '',
 	viewport = VIEWPORT_BASE,
 	mshotsOption,
+	isSmall,
 }: Props ) => {
 	const options: MShotsOptions = {
 		vpw: viewport,
@@ -59,7 +63,7 @@ export const SiteThumbnail = ( {
 	const classes = classnames(
 		'site-thumbnail',
 		isLoading ? 'site-thumbnail-loading' : 'site-thumbnail-visible',
-		DEFAULT_CLASSNAME,
+		isSmall ? MIN_CLASSNAME : DEFAULT_CLASSNAME,
 		className
 	);
 


### PR DESCRIPTION
Fixes issue https://github.com/Automattic/dotcom-forge/issues/6259

## Description

As a part of Nav Redesign i2 when you click a site from the table in /sites, we need to slide the entire sites table to the left and expose a flyout panel with information on the site.

The collapsed sidebar has already been completed with https://github.com/Automattic/wp-calypso/pull/88865

![transition](https://github.com/Automattic/dotcom-forge/assets/5634774/0672e48f-a557-4fdd-9877-df808afca7ff)

The flyout panel is supposed to show the global site view content area but this not sure if we still want to do this since the tabs are not wanted - pfsHM7-Aq-p2#comment-893

## Testing Instructions
* Go to http://calypso.localhost:3000/sites?flags=layout/dotcom-nav-redesign-v2 and click on either the site thumbnail or site name and you should see the sites list compress and the flyout panel appear.