### PR TITLE
A4A: Introduce site details feature pane for sites dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/features.ts
+++ b/client/a8c-for-agencies/sections/sites/features/features.ts
@@ -6,3 +6,4 @@ export const JETPACK_MONITOR_ID = 'jetpack_monitor';
 export const JETPACK_STATS_ID = 'jetpack_stats';
 export const JETPACK_PLUGINS_ID = 'jetpack_plugins';
 export const JETPACK_ACTIVITY_ID = 'jetpack_activity';
+export const SITE_DETAILS_ID = 'site_details';

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -8,6 +8,7 @@ import {
 	JETPACK_PLUGINS_ID,
 	JETPACK_SCAN_ID,
 	JETPACK_STATS_ID,
+	SITE_DETAILS_ID,
 } from 'calypso/a8c-for-agencies/sections/sites/features/features';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { useJetpackAgencyDashboardRecordTrackEvent } from 'calypso/jetpack-cloud/sections/agency-dashboard/hooks';
@@ -21,8 +22,10 @@ import { JetpackMonitorPreview } from './jetpack-monitor';
 import { JetpackPluginsPreview } from './jetpack-plugins';
 import { JetpackStatsPreview } from './jetpack-stats';
 import { JetpackScanPreview } from './scan/jetpack-scan';
-
+import { SiteDetailsPane } from './site-details-pane';
 import './style.scss';
+
+
 
 export function JetpackPreviewPane( {
 	site,
@@ -119,6 +122,14 @@ export function JetpackPreviewPane( {
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				<JetpackActivityPreview siteId={ site.blog_id } />
+			),
+			createFeaturePreview(
+				SITE_DETAILS_ID,
+				translate( 'Details' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<SiteDetailsPane site={ site } />
 			),
 		],
 		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ]

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/index.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { Gravatar } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import SiteTag from './site-tag';
+import SiteTagField from './site-tag-field';
+import './style.scss';
+
+interface Props {
+	site: any;
+}
+
+interface Tag {
+	id: number;
+	slug: string;
+	label: string;
+}
+
+export function SiteDetailsPane( { site }: Props ) {
+	const { a4a_agency_id: agencyId, a4a_site_id: siteId, a4a_site_tags } = site;
+
+	const translate = useTranslate();
+	const user = useSelector( getCurrentUser );
+	const [ tags, setTags ] = useState( a4a_site_tags );
+
+	const onRemoveTag = ( tagId: number ) => {
+		console.log( `DELETE /agency/${ agencyId }/sites/${ siteId }/tags/${ tagId }` );
+		const newTags = tags.filter( ( tag: Tag ) => tag.id !== tagId );
+		setTags( newTags );
+	};
+
+	const onSaveNewTag = ( tagLabel: string ) => {
+		console.log( `POST /agency/${ agencyId }/sites/${ siteId }/tags?label=${ tagLabel }` );
+		setTags( tags.concat( [ { id: 0, label: tagLabel, slug: '' } ] ) );
+	};
+
+	const tagComponents = tags?.map( ( tag: Tag ) => (
+		<SiteTag key={ tag.id } id={ tag.id } label={ tag.label } onRemoveTag={ onRemoveTag } />
+	) );
+
+	return (
+		<div className="site-details-pane">
+			<div className="site-details-pane__tag-section">
+				<h3 className="site-details-pane__section-heading">{ translate( 'Tags' ) }</h3>
+				<div className="site-details-pane__section-description">
+					{ translate( 'Add tags to easily search and filter through sites.' ) }
+				</div>
+				<div className="site-details-pane__tag-list">
+					{ tagComponents }
+					<SiteTagField onSaveNewTag={ onSaveNewTag } />
+				</div>
+			</div>
+			<div className="site-details-pane__notes-section">
+				<h3 className="site-details-pane__section-heading">{ translate( 'Notes' ) }</h3>
+				<div className="site-details-pane__section-description">
+					{ translate( "Add notes to mention any special circumstances for your clients' sites." ) }
+				</div>
+				<div className="site-details-pane__add-note">
+					<Gravatar
+						className="site-details-pane__note-user-icon"
+						user={ user }
+						size={ 32 }
+						alt={ translate( 'Notes user', { textOnly: true } ) }
+					/>
+					<a className="site-details-pane__add-tag-link">{ translate( 'Add a note' ) }</a>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/site-tag-field.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/site-tag-field.scss
@@ -1,0 +1,12 @@
+.site-tag-field {
+	display: inline-block;
+}
+
+.site-tag-field__action {
+	cursor: pointer;
+	margin-right: 0.325rem;
+}
+
+.site-tag-field__text-input {
+	display: inline-block;
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/site-tag-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/site-tag-field.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import './site-tag-field.scss';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+interface Props {
+	onSaveNewTag: Function;
+}
+
+export default function SiteTagField( { onSaveNewTag }: Props ) {
+	const translate = useTranslate();
+	const [ isEditing, setIsEditing ] = useState( false );
+	const [ tagLabel, setTagLabel ] = useState( '' );
+
+	const toggleEdit = () => {
+		if ( isEditing ) {
+			setIsEditing( false );
+		} else {
+			setIsEditing( true );
+		}
+	};
+
+	const handleSave = () => {
+		onSaveNewTag( tagLabel );
+		setIsEditing( false );
+	};
+
+	return (
+		<div className="site-tag-field">
+			{ isEditing && (
+				<>
+					<FormTextInput
+						onChange={ ( e ) => setTagLabel( e.target.value ) }
+						className="site-tag-field__text-input"
+					/>
+					<a className="site-tag-field__action" onClick={ handleSave }>
+						{ translate( 'Save' ) }
+					</a>
+					<a className="site-tag-field__action" onClick={ toggleEdit }>
+						{ translate( 'Cancel' ) }
+					</a>
+				</>
+			) }
+			{ ! isEditing && (
+				<a className="site-tag-field__action" onClick={ toggleEdit }>
+					{ translate( 'Add tag' ) }
+				</a>
+			) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/site-tag.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/site-tag.scss
@@ -1,0 +1,9 @@
+.site-tag {
+	display: inline-block;
+	margin-right: 10px;
+	border: 1px solid #000;
+}
+
+.site-tag__remove {
+	cursor: pointer;
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/site-tag.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/site-tag.tsx
@@ -1,0 +1,24 @@
+import { Icon, closeSmall } from '@wordpress/icons';
+import './site-tag.scss';
+
+interface Props {
+	id: number;
+	onRemoveTag: Function;
+	label: string;
+}
+
+export default function SiteTag( { id, label, onRemoveTag }: Props ) {
+	return (
+		<div className="site-tag">
+			<span className="site-tag__text">{ label }</span>
+			<span className="site-tag__remove">
+				<Icon
+					onClick={ () => {
+						onRemoveTag( id );
+					} }
+					icon={ closeSmall }
+				/>
+			</span>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/style.scss
@@ -1,0 +1,23 @@
+.site-details-pane {
+	padding: 16px 48px;
+}
+
+.site-details-pane__tag-section {
+	margin: 2rem 0;
+}
+
+.site-details-pane__section-heading {
+	margin: 0.5rem 0;
+}
+
+.site-details-pane__section-description {
+	font-size: 0.875rem;
+	font-weight: 400;
+	margin-bottom: 1rem;
+	color: var(--studio-gray);
+}
+
+.site-details-pane__add-tag-link {
+	font-size: 0.875rem;
+	cursor: pointer;
+}


### PR DESCRIPTION
## Proposed Changes

* This is only a proof-of-concept PR at this time. Please hit me up directly if you have questions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
