### PR TITLE
A4A: Fix the grammatical error in the Pressable plan description.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -144,7 +144,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 						translate( '24/7 WordPress hosting support' ),
 						translate( 'WP Cloud platform' ),
 						translate( 'Jetpack Security (optional)' ),
-						translate( 'Free sites migration' ),
+						translate( 'Free site migrations' ),
 					] }
 				/>
 			</div>


### PR DESCRIPTION
This PR fixes a grammatical error in the Pressable plan description as raised here. https://github.com/Automattic/wp-calypso/pull/88889#discussion_r1544318351 

**Before**
<img width="837" alt="Screenshot 2024-04-01 at 2 57 53 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/11f677c2-ef43-4ec3-bc25-9df44fde030f">
**After**
<img width="823" alt="Screenshot 2024-04-01 at 2 58 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/910905f4-ab00-40d3-b7c4-4fa61e1f6375">


## Proposed Changes

* Change the 'Free sites migration' to 'Free site migrations' string.

## Testing Instructions
* Use the A4A live link below and go to `/marketplace/hosting/pressable`.
* Confirm that you can see the correct string.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?ro