### PR TITLE
Migration Creator step: Main CTA is trial

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -117,19 +117,15 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 			) }
 
 			<UpgradePlanDetails>
-				<NextButton isBusy={ isBusy } disabled={ isAddingTrial } onClick={ onCtaClick }>
-					{ ctaText }
-				</NextButton>
-				{ isEnabled( 'plans/migration-trial' ) && (
+				{ isEnabled( 'plans/migration-trial' ) ? (
 					<>
-						<Button
-							busy={ isAddingTrial }
+						<NextButton
+							isBusy={ isAddingTrial }
 							disabled={ ! isEligibleForTrialPlan }
-							transparent={ ! isAddingTrial }
 							onClick={ onFreeTrialClick }
 						>
 							{ translate( 'Try 7 days for free' ) }
-						</Button>
+						</NextButton>
 						{ ! isEligibleForTrialPlan && (
 							<small>
 								{ translate(
@@ -137,7 +133,19 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 								) }
 							</small>
 						) }
+						<Button
+							busy={ isBusy }
+							disabled={ isAddingTrial }
+							transparent={ ! isAddingTrial }
+							onClick={ onCtaClick }
+						>
+							{ ctaText }
+						</Button>
 					</>
+				) : (
+					<NextButton isBusy={ isBusy } onClick={ onCtaClick }>
+						{ ctaText }
+					</NextButton>
 				) }
 			</UpgradePlanDetails>
 		</div>

--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -122,7 +122,7 @@ $business-plan-color: #7f54b3;
 	.import__upgrade-plan-cta {
 		display: flex;
 		flex-direction: column;
-		gap: 1rem;
+		gap: 0.5rem;
 
 		small {
 			text-align: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88970

## Proposed Changes

In the migration flow, we recently improved the plan selection step. With this PR we render the main CTA the trial.

Design: 5yhaC6umexdQLlLpCrCyEe-fi-2515_3098

![image](https://github.com/Automattic/wp-calypso/assets/52076348/9e2ce5e5-4442-49e0-8caf-774056e15ce9)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/setup/import-hosted-site`, add your domain, and select a site that is on a free plan to migrate into.
* Compare design to figma
