### PR TITLE
Limited Global Styles: Fix E2E test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
@@ -104,7 +104,7 @@ export class FullSiteEditorNavSidebarComponent {
 	 */
 	async setStyleVariation( styleVariationName: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.styleVariation( styleVariationName ) );
+		const locator = editorParent.locator( selectors.styleVariation( styleVariationName ) ).first();
 		await locator.click();
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Fixes the Limited Global Styles E2E test that we had to temporary mute because a recent Gutenberg release changed the DOM and made our CSS selector to fail because there are now more elements sharing the same CSS selector.

To fix the test, we are now picking the first of the elements matching the CSS selector.

## Testing Instructions

- Follow these instructions to locally setup the E2E environment: https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e#quick-start
- Execute the limited GS E2E test: `yarn workspace wp-e2e-tests test -- specs/fse/fse__limited-global-styles.ts
`
- Make sure it passes