### PR TITLE
Updating the stats tab in the preview pane to match design specs

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-stats.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-stats.tsx
@@ -11,7 +11,7 @@ type Props = {
 export function JetpackStatsPreview( { site, trackEvent }: Props ) {
 	return (
 		<>
-			<SitePreviewPaneContent>
+			<SitePreviewPaneContent className="site-preview-pane__stats-content">
 				<InsightsStats
 					stats={ site.site_stats }
 					siteUrlWithScheme={ site.url_with_scheme }

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -32,3 +32,34 @@
 		padding-left: 8px;
 	}
 }
+
+.site-preview-pane__stats-content {
+	.expanded-card__header {
+		font-size: 1.25rem;
+		font-weight: 500;
+		text-align: left;
+		text-overflow: ellipsis;
+	}
+
+	.site-expanded-content__card-content-column {
+		flex: unset;
+		margin-right: 24px;
+		max-width: unset;
+	}
+
+	.site-expanded-content__card-content-score {
+		text-align: left;
+	}
+
+	.expanded-card .site-expanded-content__card-footer {
+		justify-content: unset !important;
+	}
+
+	.shortened-number {
+		font-size: 2rem;
+	}
+
+	.expanded-card {
+		max-width: unset !important;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
@@ -1,5 +1,5 @@
 import { Button, ShortenedNumber } from '@automattic/components';
-import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
+import { Icon, arrowUp, arrowDown, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import ExpandedCard from './expanded-card';
@@ -88,6 +88,12 @@ export default function InsightsStats( { stats, siteUrlWithScheme, trackEvent }:
 						compact
 					>
 						{ translate( 'See all stats' ) }
+						<Icon
+							icon={ external }
+							size={ 14 }
+							className="site-preview-pane__stats-icon"
+							viewBox="0 0 20 20"
+						/>
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/109

## Proposed Changes

* This PR updates the stats preview pane section in the sites dashboard to match design specs.
* Note - the designs do not include an external link icon, but the link goes to wp-admin, so for consistency with all other similar buttons I've added an external link icon.

Conversation around the stats section in Figma here, beyond what is included in the designs themselves:  1UpoqS1KkCtLXVX68TbMSM-fi-6144_260191#747621639

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* Visit the stats tab when opening the preview pane for a site. It should match the design below, which should also match that which is discussed in the design specs linked above (with the addition of the external link icon).

<img width="682" alt="Screenshot 2024-04-01 at 11 05 27" src="https://github.com/Automattic/wp-calypso/assets/16754605/7f7ad869-bed5-44a1-8947-d28b17cad33b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?