### PR TITLE
Pattern Library: Add pagination button

### DIFF
--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -127,7 +127,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 	const isPageLayouts = patternTypeFilter === PatternTypeFilter.PAGES;
 
 	const patternsToDisplay = patterns.slice( 0, patternDisplayCount );
-	const isDisplayingPaginationButton = patternsToDisplay.length < patterns.length;
+	const shouldDisplayPaginationButton = patternsToDisplay.length < patterns.length;
 	const nextPageCount = Math.min(
 		patterns.length - patternsToDisplay.length,
 		PATTERNS_PER_PAGE_COUNT
@@ -169,7 +169,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 						/>
 					) ) }
 
-					{ isDisplayingPaginationButton && (
+					{ shouldDisplayPaginationButton && (
 						<div className="pattern-gallery__pagination-button-wrapper">
 							<Button
 								className="pattern-gallery__pagination-button"

--- a/client/my-sites/patterns/components/pattern-gallery/server.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/server.tsx
@@ -4,14 +4,18 @@ import type { PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
+const PATTERNS_PER_PAGE_COUNT = 9;
+
 export const PatternGalleryServer: PatternGalleryFC = ( { isGridView, patterns = [] } ) => {
+	const patternsToDisplay = patterns.slice( 0, PATTERNS_PER_PAGE_COUNT );
+
 	return (
 		<div
 			className={ classNames( 'pattern-gallery', {
 				'pattern-gallery--grid': isGridView,
 			} ) }
 		>
-			{ patterns?.map( ( pattern ) => (
+			{ patternsToDisplay.map( ( pattern ) => (
 				<PatternPreviewPlaceholder
 					className={ classNames( {
 						'pattern-preview--grid': isGridView,

--- a/client/my-sites/patterns/components/pattern-gallery/style.scss
+++ b/client/my-sites/patterns/components/pattern-gallery/style.scss
@@ -4,6 +4,22 @@
 .pattern-gallery {
 	display: grid;
 	gap: 48px;
+
+	.pattern-gallery__pagination-button-wrapper {
+		display: flex;
+		justify-content: center;
+	}
+
+	.pattern-gallery__pagination-button {
+		border-color: currentColor;
+		color: #3858e9;
+
+		&:enabled:hover,
+		&:focus {
+			border-color: currentColor;
+			color: #1d35b4;
+		}
+	}
 }
 
 .pattern-gallery--grid {
@@ -15,6 +31,11 @@
 
 	@include break-huge {
 		grid-template-columns: repeat(3, 1fr);
+	}
+
+	.pattern-gallery__pagination-button-wrapper {
+		grid-column: span 3;
+		padding-top: 40px;
 	}
 }
 

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -201,6 +201,9 @@ export const PatternLibrary = ( {
 	} );
 
 	const isHomePage = ! category && ! searchTerm;
+	const patternGalleryKey = searchTerm
+		? `${ searchTerm }-${ category }-${ patternTypeFilter }`
+		: `${ category }-${ patternTypeFilter }`;
 
 	return (
 		<>
@@ -351,6 +354,7 @@ export const PatternLibrary = ( {
 								getPatternPermalink( pattern, category, patternTypeFilter, categories )
 							}
 							isGridView={ isGridView }
+							key={ `pattern-gallery-${ patternGalleryKey }` }
 							patterns={ patterns }
 							patternTypeFilter={ patternTypeFilter }
 						/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6279

## Proposed Changes

In the pattern library, patterns are fetched per category without pagination. However, rendering many patterns at once can be strenuous for browsers. To mitigate this, this PR adds a client-side pagination solution that limits the number of patterns that `PatternGallery` initially renders to 9.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/about`
2. For easier testing, switch to grid view
3. Ensure that you see a `Load 9 more patterns` button
4. Click it
5. Ensure that 9 more patterns are displayed
6. Ensure that the button now says `Load 6 more patterns`
