### PR TITLE
A4A: Adding horizontal scroll for sites preview pane navigation

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
@@ -46,6 +46,12 @@
 			height: revert;
 		}
 
+		@media (max-width: 850px) {
+			.section-nav__panel {
+				overflow: scroll;
+			}
+		}
+
 		@media (min-width: 481px) {
 			.section-nav-group {
 				.is-dropdown {

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
@@ -48,7 +48,7 @@
 
 		@media (max-width: 850px) {
 			.section-nav__panel {
-				overflow: scroll;
+				overflow-x: auto;
 			}
 		}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/144

## Proposed Changes

* This PR updates the navigation tabs in the site preview pane to have a horizontal scroll, but only on a very limited screen width where the navigation begins to disappear off the side of the page and before the navigation becomes a dropdown ( 816px through to 850px ).


## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* Visit the sites preview pane tab, open up the browser inspector, and reduce the width of the browser window to somewhere between 816 and 850px. Refresh the page to make sure you're seeing the correct design. You should then see a scrollbar when hovering over the navigation.

<img width="526" alt="Screenshot 2024-04-01 at 11 52 11" src="https://github.com/Automattic/wp-calypso/assets/16754605/1b853d8e-8135-4db6-8827-4ebfcb27471f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?