### PR TITLE
Me: Make the back button point to the previous page

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -296,6 +296,7 @@ export class ReaderSidebar extends Component {
 			onClick: this.handleClick,
 			requireBackLink: true,
 			backLinkText: i18n.translate( 'All sites' ),
+			backLinkHref: '/sites',
 		};
 		return (
 			<GlobalSidebar { ...props }>

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -6,6 +6,8 @@ import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentPropsWithoutRef, useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { getSection } from 'calypso/state/ui/selectors';
 import { MEDIA_QUERIES } from '../utils';
 import { SitesSearch } from './sites-search';
 import { SitesSortingDropdown } from './sites-sorting-dropdown';
@@ -121,6 +123,19 @@ export const SitesContentControls = ( {
 }: SitesContentControlsProps ) => {
 	const { __ } = useI18n();
 	const searchRef = useRef< SearchImperativeHandle >( null );
+	const section = useSelector( getSection );
+	const handleSearch = ( term: string ) => {
+		const queryParams = { search: term?.trim(), page: undefined };
+
+		// There is a chance that the URL is not up to date when it mounts, so delay
+		// the onQueryParamChange call to avoid it getting the incorrect URL and then
+		// redirecting back to the previous path.
+		if ( window.location.pathname.startsWith( `/${ section?.group }` ) ) {
+			onQueryParamChange( queryParams );
+		} else {
+			window.setTimeout( () => onQueryParamChange( queryParams ) );
+		}
+	};
 
 	useSearchShortcut( () => {
 		searchRef.current?.focus();
@@ -130,7 +145,7 @@ export const SitesContentControls = ( {
 		<FilterBar>
 			<SitesSearch
 				searchIcon={ <SearchIcon /> }
-				onSearch={ ( term ) => onQueryParamChange( { search: term?.trim(), page: undefined } ) }
+				onSearch={ handleSearch }
 				isReskinned
 				placeholder={ __( 'Search by name or domain…' ) }
 				disableAutocorrect={ true }

--- a/client/state/ui/selectors/get-section.js
+++ b/client/state/ui/selectors/get-section.js
@@ -1,9 +1,15 @@
 import 'calypso/state/ui/init';
 
 /**
+ * @typedef {Object} Section
+ * @property {string} name - The name of the section
+ * @property {string[]} paths - The URL paths of the section
+ * @property {string} module - The module path of the section
+ * @property {string} group - The group of the section
+ *
  * Returns the current section.
  * @param  {Object}  state Global state tree
- * @returns {Object}        Current section
+ * @returns {Section}        Current section
  */
 export default function getSection( state ) {
 	return state.ui.section || false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6306

## Proposed Changes

* Make the back button on the Profile page point to the previous path instead of `/sites`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Profile page, `/me`
* Click the `< Back` button on the sidebar
* Make sure you go to the All Sites page
* Go to any page on your site, e.g.: /settings/general/<your_site>
* Go to the Profile page again
* Make sure you go back to the previous page
* Go to Reader page
* Click the `< All sites` button on the sidebar
* Make sure you go to the All Sites page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?