### PR TITLE
Automattic for Agencies: Fix the issue with Pressable plan list items not showing up

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -1,6 +1,9 @@
+import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import { useTranslate } from 'i18n-calypso';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import { useLicenseLightboxData } from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/hooks/use-license-lightbox-data';
 import getProductIcon from 'calypso/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon';
+import getPressablePlan from '../pressable-overview/lib/get-pressable-plan';
 import type { ShoppingCartItem } from '../types';
 
 export default function ProductInfo( { product }: { product: ShoppingCartItem } ) {
@@ -8,19 +11,46 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 
 	const { title, product: productInfo } = useLicenseLightboxData( product );
 
-	if ( ! productInfo ) {
+	let productIcon =
+		productInfo?.productSlug && getProductIcon( { productSlug: productInfo?.productSlug } );
+	let productTitle = title;
+	let productDescription = productInfo?.lightboxDescription;
+
+	if ( product.family_slug === 'pressable-hosting' ) {
+		const presablePlan = getPressablePlan( product.slug );
+		if ( ! presablePlan ) {
+			return null;
+		}
+
+		productIcon = pressableIcon;
+		productTitle = product.name;
+		productDescription = translate(
+			'Plan with %(install)d WordPress installs, %(visits)s visits per month, and %(storage)dGB of storage per month.',
+			{
+				args: {
+					install: presablePlan.install,
+					visits: formatNumber( presablePlan.visits ),
+					storage: presablePlan.storage,
+				},
+				comment:
+					'The `install`, `visits` & `storage` are the count of WordPress installs, visits per month, and storage per month in the plan description.',
+			}
+		);
+	}
+
+	if ( ! productDescription ) {
 		return null;
 	}
 
 	return (
 		<div className="product-info">
 			<div className="product-info__icon">
-				<img src={ getProductIcon( { productSlug: productInfo.productSlug } ) } alt={ title } />
+				<img src={ productIcon } alt={ title } />
 			</div>
 			<div className="product-info__text-content">
 				<div className="product-info__header">
-					<label htmlFor={ title } className="product-info__label">
-						{ title }
+					<label htmlFor={ productTitle } className="product-info__label">
+						{ productTitle }
 					</label>
 					<span className="product-info__count">
 						{ translate( '%(numLicenses)d plan', '%(numLicenses)d plans', {
@@ -32,7 +62,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 						} ) }
 					</span>
 				</div>
-				<p className="product-info__description">{ productInfo.lightboxDescription }</p>
+				<p className="product-info__description">{ productDescription }</p>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/167

## Proposed Changes

This PR fixes the issue with Pressable plan list items not showing up

## Testing Instructions

- Open the Calyso live link for A4A.
- Follow the steps here to create the agency ID: D139529-code.
- Visit `/marketplace/hosting/pressable` > Add a few Pressable plans > Click the Cart and go to `Checkout` > Verify that the Pressable plan items are shown as displayed below:

<img width="944" alt="Screenshot 2024-04-01 at 4 40 32 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/99e89210-f2c7-4ff8-8cb7-2753f4b5aa1d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?