### PR TITLE
Add styles to hide links and CTA buttons

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -22,6 +22,8 @@ import { JetpackPluginsPreview } from './jetpack-plugins';
 import { JetpackScanPreview } from './jetpack-scan';
 import { JetpackStatsPreview } from './jetpack-stats';
 
+import './style.scss';
+
 export function JetpackPreviewPane( {
 	site,
 	closeSitePreviewPane,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
@@ -1,0 +1,8 @@
+.sites-dashboard {
+	.scan .section-nav {
+		display: none;
+	}
+	.activity-log-v2 .button.toolbar__button {
+		display: none !important;
+	}
+}


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/177

## Proposed Changes

This PR hides some non-working links from the feature tabs. This uses CSS `display: none` to hide those elements temporarily until we have a good enough solution for it.

**Scan:**

![image](https://github.com/Automattic/wp-calypso/assets/9832440/b34d6688-b8e1-4285-a0db-b00d8f827614)

**Activity log:**

![image](https://github.com/Automattic/wp-calypso/assets/9832440/418fa2a1-89a8-4b93-9f78-b3f586552d9e)


## Testing Instructions

- Check the style
- Go to your Sites Dashboard section and select a Jetpack site with Scan
- Go to the Scan tab, you won't see the navigation tab with `Scanner` and `History`.
- Go to the Activity tab, and check the items, you won't see the `Actions` menu options

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
