### PR TITLE
I18N: Add context to "Privacy Settings" to differentiate between Site privacy settings and Data privacy settings.

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -88,7 +88,7 @@ class Help extends PureComponent {
 			},
 			{
 				link: localizeUrl( 'https://wordpress.com/support/settings/privacy-settings/' ),
-				title: this.props.translate( 'Privacy Settings' ),
+				title: this.props.translate( 'Privacy Settings', { context: 'Site visibility settings' } ),
 				description: this.props.translate(
 					'Limit your site’s visibility or make it completely private.'
 				),

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -294,7 +294,9 @@ export class SiteSettingsFormSEO extends Component {
 							);
 						} )() }
 					>
-						<NoticeAction href={ generalTabUrl }>{ translate( 'Privacy Settings' ) }</NoticeAction>
+						<NoticeAction href={ generalTabUrl }>
+							{ translate( 'Privacy Settings', { context: 'Site visibility settings' } ) }
+						</NoticeAction>
 					</Notice>
 				) }
 				{ conflictedSeoPlugin && (


### PR DESCRIPTION
There are 2 types of privacy settings:

Site privacy settings: refers site visibility (coming soon, public, private)
Data privacy settings: refers to data privacy (GDPR)
In some languages, like German, these need different translations (Privatsphäre, Datenschutz).



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add context to this string so translators can handle them differently based on the context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
