### PR TITLE
A4A: Sites dashboard preview pane Boost section design update

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-boost.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-boost.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function JetpackBoostPreview( { site, trackEvent, hasError = false }: Props ) {
 	return (
 		<>
-			<SitePreviewPaneContent>
+			<SitePreviewPaneContent className="site-preview-pane__boost-content">
 				<BoostSitePerformance site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -109,4 +109,8 @@
 	.site-expanded-content__card-content-column {
 		margin-right: 32px;
 	}
+
+	.site-expanded-content__card-content-score-title {
+		text-align: left;
+	}
 }

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -6,11 +6,22 @@
 	overflow-y: auto;
 
 	.expanded-card {
-		max-width: 320px;
 		width: auto;
+		max-width: unset !important;
 
 		.site-expanded-content__card-footer {
-			justify-content: center;
+			justify-content: unset !important;
+		}
+
+		.expanded-card__header {
+			font-size: 1.25rem;
+			text-overflow: ellipsis;
+			font-weight: 500;
+			text-align: left;
+		}
+
+		.site-expanded-content__card-content-score {
+			text-align: left;
 		}
 	}
 
@@ -30,20 +41,23 @@
 	.site-preview-pane__plugins-icon {
 		fill: #fff;
 		padding-left: 8px;
-
 	}
 
+}
+
+.site-preview-pane__stats-content,
+.site-preview-pane__boost-content {
+	.site-expanded-content__card-content-column {
+		flex: unset;
+		margin-right: 24px;
+		max-width: 285px;
+	}
 }
 
 .site-preview-pane__monitor-content {
 
 	text-align: unset !important;
 
-	.expanded-card__header {
-		font-size: 1.25rem;
-		text-overflow: ellipsis;
-		font-weight: 500;
-	}
 
 	.site-expanded-content__card-content-column {
 		max-width: unset;
@@ -70,9 +84,6 @@
 		text-align: unset;
 	}
 
-	.expanded-card {
-		max-width: unset !important;
-	}
 
 	.site-expanded-content__chart .chart .chart__bar.site-expanded-content__chart-bar-is-uptime .chart__bar-section {
 		border-radius: 2px;
@@ -80,32 +91,15 @@
 }
 
 .site-preview-pane__stats-content {
-	.expanded-card__header {
-		font-size: 1.25rem;
-		font-weight: 500;
-		text-align: left;
-		text-overflow: ellipsis;
-	}
-
-	.site-expanded-content__card-content-column {
-		flex: unset;
-		margin-right: 24px;
-		max-width: unset;
-	}
-
-	.site-expanded-content__card-content-score {
-		text-align: left;
-	}
-
-	.expanded-card .site-expanded-content__card-footer {
-		justify-content: unset !important;
-	}
 
 	.shortened-number {
 		font-size: 2rem;
 	}
+}
+
+.site-preview-pane__boost-content {
 
 	.expanded-card {
-		max-width: unset !important;
+		padding: 16px 24px !important;
 	}
 }

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -49,7 +49,6 @@
 .site-preview-pane__boost-content {
 	.site-expanded-content__card-content-column {
 		flex: unset;
-		margin-right: 24px;
 		max-width: 285px;
 	}
 }
@@ -95,11 +94,19 @@
 	.shortened-number {
 		font-size: 2rem;
 	}
+
+	.site-expanded-content__card-content-column {
+		margin-right: 24px;
+	}
 }
 
 .site-preview-pane__boost-content {
 
 	.expanded-card {
 		padding: 16px 24px !important;
+	}
+
+	.site-expanded-content__card-content-column {
+		margin-right: 32px;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -1,5 +1,5 @@
-import { Button, Gridicon, Tooltip } from '@automattic/components';
-import { Icon, help } from '@wordpress/icons';
+import { Button, Tooltip } from '@automattic/components';
+import { Icon, help, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useMemo } from 'react';
@@ -198,7 +198,15 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 								primary={ ctaButton.primary }
 								compact
 							>
-								{ ctaButton.label } { !! ctaButton.href && <Gridicon icon="external" /> }
+								{ ctaButton.label }{ ' ' }
+								{ !! ctaButton.href && (
+									<Icon
+										icon={ external }
+										size={ 16 }
+										className="site-preview-pane__boost-icon"
+										viewBox="0 0 20 20"
+									/>
+								) }
 							</Button>
 						) ) }
 					</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -1,5 +1,5 @@
-import { Button, Tooltip } from '@automattic/components';
-import { Icon, help, external } from '@wordpress/icons';
+import { Button, Gridicon, Tooltip } from '@automattic/components';
+import { Icon, help } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useMemo } from 'react';
@@ -198,15 +198,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 								primary={ ctaButton.primary }
 								compact
 							>
-								{ ctaButton.label }{ ' ' }
-								{ !! ctaButton.href && (
-									<Icon
-										icon={ external }
-										size={ 16 }
-										className="site-preview-pane__boost-icon"
-										viewBox="0 0 20 20"
-									/>
-								) }
+								{ ctaButton.label } { !! ctaButton.href && <Gridicon icon="external" /> }
 							</Button>
 						) ) }
 					</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/107

## Proposed Changes

* This PR updates the Boost preview pane section in the sites dashboard to match design specs.
* It also refactors some styles in the site-preview-pane-content style sheet to prevent duplication.

Conversation around the Boost section in Figma here, beyond what is included in the designs themselves: 1UpoqS1KkCtLXVX68TbMSM-fi-6144_260177#747618678

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* Visit the Boost tab when opening the preview pane for a site. It should match the design below, which should also match that which is discussed in the design specs linked above.
* It would also be worth testing Monitor, Scan and Plugins tabs to make sure the designs there are still the same after the refactor.

<img width="628" alt="Screenshot 2024-04-01 at 15 40 27" src="https://github.com/Automattic/wp-calypso/assets/16754605/7cc6fe5c-7ba5-41d5-976b-90803f7eeeaf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?