### PR TITLE
E2E: Use different block pattern

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -67,7 +67,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Patterns', function () {
-		const patternName = 'About Me';
+		const patternName = 'About Page 3';
 
 		it( `Add ${ patternName } pattern`, async function () {
 			await editorPage.addPatternFromSidebar( patternName );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

As in #89061, a block pattern referenced in E2E tests had been removed.

## Proposed Changes

This PR switches the test from using the "About Me" block pattern to instead use "About Page 3".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build && TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__post-basic-flow.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?