### PR TITLE
Calypso users: Remove mapping when no email

### DIFF
--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -28,7 +28,9 @@ function TeamMembers( props: Props ) {
 	const siteId = site?.ID as number;
 
 	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, siteId ) );
-	const pendingInvitesEmails = pendingInvites?.map( ( invite ) => invite.user?.email );
+	const pendingInvitesEmails = pendingInvites
+		?.filter( ( invite ) => invite.user?.email )
+		.map( ( invite ) => invite.user?.email );
 
 	const listKey = [ 'team-members', site?.ID, search ].join( '-' );
 	const { data, fetchNextPage, isLoading, isFetchingNextPage, hasNextPage } = usersQuery;


### PR DESCRIPTION
Context: p1711977348609499/1709741482.266719-slack-C02T4NVL4JJ

## Problem

In a site when some users do not have an email, the process of filtering out users who have a pending invitation had a bug. The mapping mapped some of the elements as false, causing errors.
The result was that the users were not shown.

## Solution

Fixed the filtering for pending emails.

## Testing

1. Start a support session [here](https://bunkyolanguagehub.education/) and go to users in Calypso view.
2. Check that in prod it is shown only the Administrator, while in localhost( or live link ) you will see all the 29 users.