### PR TITLE
Scheduled Updates: Add schedule timeline logs screen

### DIFF
--- a/client/blocks/plugins-update-manager/hooks/use-site-admin-url.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-admin-url.ts
@@ -1,0 +1,10 @@
+import { useSelector } from 'calypso/state';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function useSiteAdminUrl() {
+	const siteId = useSelector( getSelectedSiteId );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+
+	return siteAdminUrl;
+}

--- a/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-date-time-format.ts
@@ -1,5 +1,8 @@
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { phpToMomentDatetimeFormat } from 'calypso/my-sites/site-settings/date-time-format/utils';
+import {
+	phpToMomentDatetimeFormat,
+	phpToMomentMapping,
+} from 'calypso/my-sites/site-settings/date-time-format/utils';
 import { useSiteSettings } from './use-site-settings';
 
 export function useSiteDateTimeFormat( siteSlug: string ) {
@@ -7,6 +10,24 @@ export function useSiteDateTimeFormat( siteSlug: string ) {
 	const { getSiteSetting } = useSiteSettings( siteSlug );
 	const dateFormat = getSiteSetting( 'date_format' );
 	const timeFormat = getSiteSetting( 'time_format' );
+	const phpToMomentMap = phpToMomentMapping as {
+		[ key: string ]: string;
+	};
+
+	function convertPhpToMomentFormat( phpFormat: string ): string {
+		let momentFormat = '';
+
+		for ( let i = 0; i < phpFormat.length; i++ ) {
+			const char = phpFormat.charAt( i );
+			if ( phpToMomentMap[ char ] ) {
+				momentFormat += phpToMomentMap[ char ];
+			} else {
+				momentFormat += char;
+			}
+		}
+
+		return momentFormat;
+	}
 
 	// Prepare timestamp based on site settings
 	const prepareTime = ( unixTimestamp: number ) => {
@@ -36,5 +57,6 @@ export function useSiteDateTimeFormat( siteSlug: string ) {
 		prepareTime,
 		prepareDateTime,
 		isAmPmPhpTimeFormat,
+		convertPhpToMomentFormat,
 	};
 }

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -16,6 +16,7 @@ import {
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
 import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
+import { useSiteDateTimeFormat } from './hooks/use-site-date-time-format';
 import { useSiteSlug } from './hooks/use-site-slug';
 
 interface Props {
@@ -27,6 +28,13 @@ export const ScheduleLogs = ( props: Props ) => {
 	const translate = useTranslate();
 	const { scheduleId, onNavBack } = props;
 
+	const {
+		dateFormat: phpDateFormat,
+		timeFormat: phpTimeFormat,
+		convertPhpToMomentFormat,
+	} = useSiteDateTimeFormat( siteSlug );
+	const dateFormat = convertPhpToMomentFormat( phpDateFormat );
+	const timeFormat = convertPhpToMomentFormat( phpTimeFormat );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { isEligibleForFeature } = useIsEligibleForFeature();
@@ -73,20 +81,20 @@ export const ScheduleLogs = ( props: Props ) => {
 			<Timeline>
 				<TimelineEvent
 					date={ new Date( '30 March 2024, 10:01 am' ) }
-					dateFormat="HH:mm:ss a"
+					dateFormat={ timeFormat }
 					detail="Plugins update completed"
 					icon="checkmark"
 					iconBackground="warning"
 				/>
 				<TimelineEvent
 					date={ new Date( '30 March 2024, 10:00:48 am' ) }
-					dateFormat="HH:mm:ss a"
+					dateFormat={ timeFormat }
 					detail="Gravity Forms updated from 2.5.8 to 2.6.0"
 					icon="checkmark"
 				/>
 				<TimelineEvent
 					date={ new Date( '30 March 2024, 10:00:39 am' ) }
-					dateFormat="HH:mm:ss a"
+					dateFormat={ timeFormat }
 					detail="Move to WordPress.com update from 5.9.3 to 6.0.0 failed [ Rolledback to 5.9.3 ]"
 					icon="sync"
 					iconBackground="warning"
@@ -96,12 +104,13 @@ export const ScheduleLogs = ( props: Props ) => {
 				/>
 				<TimelineEvent
 					date={ new Date( '30 March 2024, 10:00:12 am' ) }
-					dateFormat="HH:mm:ss a"
+					dateFormat={ timeFormat }
 					detail="Elementor Pro updated from 3.0.9 to 3.1.0"
 					icon="checkmark"
 				/>
 				<TimelineEvent
 					date={ new Date( '30 March 2024' ) }
+					dateFormat={ `${ dateFormat } ${ timeFormat }` }
 					detail="Plugins update starts"
 					icon="calendar"
 					disabled
@@ -110,32 +119,33 @@ export const ScheduleLogs = ( props: Props ) => {
 			<Timeline>
 				<TimelineEvent
 					date={ new Date( '27 March 2024, 10:01 am' ) }
-					dateFormat="HH:mm:ss a"
+					dateFormat={ timeFormat }
 					detail="Plugins update completed successfully"
 					icon="checkmark"
 					iconBackground="success"
 				/>
 				<TimelineEvent
 					date={ new Date( '27 March 2024, 10:00:48 am' ) }
-					dateFormat="HH:mm:ss a"
+					dateFormat={ timeFormat }
 					detail="Gravity Forms updated from 2.5.8 to 2.6.0"
 					icon="checkmark"
 				/>
 				<TimelineEvent
 					date={ new Date( '27 March 2024, 10:00:39 am' ) }
-					dateFormat="HH:mm:ss a"
+					dateFormat={ timeFormat }
 					detail="Move to WordPress.com update from 5.9.3 to 6.0.0"
 					icon="checkmark"
 				/>
 				<TimelineEvent
 					date={ new Date( '27 March 2024, 10:00:12 am' ) }
-					dateFormat="HH:mm:ss a"
+					dateFormat={ timeFormat }
 					detail="Elementor Pro updated from 3.0.9 to 3.1.0"
 					icon="checkmark"
 					iconBackground="info"
 				/>
 				<TimelineEvent
-					date={ new Date( '27 March 2024' ) }
+					date={ new Date( '27 March 2024, 10:00:00 am' ) }
+					dateFormat={ `${ dateFormat } ${ timeFormat }` }
 					detail="Plugins update starts"
 					icon="calendar"
 					disabled

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -3,14 +3,33 @@ import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import Timeline from 'calypso/components/timeline';
 import TimelineEvent from 'calypso/components/timeline/timeline-event';
+import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
+import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
+import { useSiteSlug } from './hooks/use-site-slug';
 
 interface Props {
 	scheduleId: string;
 	onNavBack?: () => void;
 }
 export const ScheduleLogs = ( props: Props ) => {
-	const { onNavBack } = props;
+	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
+	const { scheduleId, onNavBack } = props;
+
+	const { prepareScheduleName } = usePrepareScheduleName();
+	const { isEligibleForFeature } = useIsEligibleForFeature();
+	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
+		siteSlug,
+		isEligibleForFeature
+	);
+	const schedule = schedules.find( ( s ) => s.id === scheduleId );
+
+	// If the schedule is not found, navigate back to the list
+	if ( isFetched && ! schedule ) {
+		onNavBack && onNavBack();
+		return null;
+	}
 
 	return (
 		<Card className="plugins-update-manager">
@@ -22,7 +41,9 @@ export const ScheduleLogs = ( props: Props ) => {
 						</Button>
 					) }
 				</div>
-				<Text>{ translate( 'Saturdays at 11:00 - logs' ) }</Text>
+				<Text>
+					{ translate( 'Logs' ) } - { prepareScheduleName( schedule ) }
+				</Text>
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<Timeline>

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -95,35 +95,40 @@ export const ScheduleLogs = ( props: Props ) => {
 					dateFormat={ timeFormat }
 					detail="Plugins update completed"
 					icon="checkmark"
-					iconBackground="warning"
+					iconBackground="success"
 				/>
 				<TimelineEvent
+					className="indent"
 					date={ new Date( '30 March 2024, 10:00:48 am' ) }
 					dateFormat={ timeFormat }
 					detail="Gravity Forms updated from 2.5.8 to 2.6.0"
 					icon="checkmark"
+					iconBackground="success"
 				/>
 				<TimelineEvent
+					className="indent"
 					date={ new Date( '30 March 2024, 10:00:39 am' ) }
 					dateFormat={ timeFormat }
 					detail="Move to WordPress.com update from 5.9.3 to 6.0.0 failed [ Rolledback to 5.9.3 ]"
-					icon="sync"
-					iconBackground="warning"
+					icon="cross"
+					iconBackground="error"
 					actionLabel="Try manual update"
 					actionIsPrimary={ true }
 					onActionClick={ goToPluginsPage }
 				/>
 				<TimelineEvent
+					className="indent"
 					date={ new Date( '30 March 2024, 10:00:12 am' ) }
 					dateFormat={ timeFormat }
 					detail="Elementor Pro updated from 3.0.9 to 3.1.0"
 					icon="checkmark"
+					iconBackground="success"
 				/>
 				<TimelineEvent
 					date={ new Date( '30 March 2024' ) }
 					dateFormat={ `${ dateFormat } ${ timeFormat }` }
 					detail="Plugins update starts"
-					icon="calendar"
+					icon="sync"
 					disabled
 				/>
 			</Timeline>
@@ -136,29 +141,34 @@ export const ScheduleLogs = ( props: Props ) => {
 					iconBackground="success"
 				/>
 				<TimelineEvent
+					className="indent"
 					date={ new Date( '27 March 2024, 10:00:48 am' ) }
 					dateFormat={ timeFormat }
 					detail="Gravity Forms updated from 2.5.8 to 2.6.0"
 					icon="checkmark"
+					iconBackground="success"
 				/>
 				<TimelineEvent
+					className="indent"
 					date={ new Date( '27 March 2024, 10:00:39 am' ) }
 					dateFormat={ timeFormat }
 					detail="Move to WordPress.com update from 5.9.3 to 6.0.0"
 					icon="checkmark"
+					iconBackground="success"
 				/>
 				<TimelineEvent
+					className="indent"
 					date={ new Date( '27 March 2024, 10:00:12 am' ) }
 					dateFormat={ timeFormat }
 					detail="Elementor Pro updated from 3.0.9 to 3.1.0"
 					icon="checkmark"
-					iconBackground="info"
+					iconBackground="success"
 				/>
 				<TimelineEvent
 					date={ new Date( '27 March 2024, 10:00:00 am' ) }
 					dateFormat={ `${ dateFormat } ${ timeFormat }` }
 					detail="Plugins update starts"
-					icon="calendar"
+					icon="sync"
 					disabled
 				/>
 			</Timeline>

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -1,5 +1,11 @@
-import { __experimentalText as Text, Button, Card, CardHeader } from '@wordpress/components';
-import { arrowLeft } from '@wordpress/icons';
+import {
+	__experimentalText as Text,
+	Button,
+	Card,
+	CardHeader,
+	Tooltip,
+} from '@wordpress/components';
+import { arrowLeft, Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import Timeline from 'calypso/components/timeline';
 import TimelineEvent from 'calypso/components/timeline/timeline-event';
@@ -8,6 +14,7 @@ import {
 	useUpdateScheduleQuery,
 } from 'calypso/data/plugins/use-update-schedules-query';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
+import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
 import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
 import { useSiteSlug } from './hooks/use-site-slug';
 
@@ -21,6 +28,7 @@ export const ScheduleLogs = ( props: Props ) => {
 	const { scheduleId, onNavBack } = props;
 
 	const { prepareScheduleName } = usePrepareScheduleName();
+	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
 		siteSlug,
@@ -47,7 +55,21 @@ export const ScheduleLogs = ( props: Props ) => {
 				<Text>
 					{ translate( 'Logs' ) } - { prepareScheduleName( schedule as ScheduleUpdates ) }
 				</Text>
-				<div className="ch-placeholder"></div>
+				<div className="ch-placeholder">
+					<Text isBlock={ true } align="end" lineHeight={ 2.5 }>
+						{ schedule?.args?.length }
+						{ schedule?.args && (
+							<Tooltip
+								text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }
+								position="middle button"
+								delay={ 0 }
+								hideOnClick={ false }
+							>
+								<Icon className="icon-info" icon={ info } size={ 16 } />
+							</Tooltip>
+						) }
+					</Text>
+				</div>
 			</CardHeader>
 			<Timeline>
 				<TimelineEvent

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -61,7 +61,6 @@ export const ScheduleLogs = ( props: Props ) => {
 						{ schedule?.args && (
 							<Tooltip
 								text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }
-								position="middle button"
 								delay={ 0 }
 								hideOnClick={ false }
 							>

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -38,14 +38,18 @@ export const ScheduleLogs = ( props: Props ) => {
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { isEligibleForFeature } = useIsEligibleForFeature();
-	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
-		siteSlug,
-		isEligibleForFeature
-	);
+	const {
+		data: schedules = [],
+		isFetched,
+		isPending,
+	} = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const schedule = schedules.find( ( s ) => s.id === scheduleId );
 
+	if ( isPending ) {
+		return null;
+	}
 	// If the schedule is not found, navigate back to the list
-	if ( isFetched && ! schedule ) {
+	else if ( isFetched && ! schedule ) {
 		onNavBack && onNavBack();
 		return null;
 	}

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { arrowLeft, Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import Timeline from 'calypso/components/timeline';
 import TimelineEvent from 'calypso/components/timeline/timeline-event';
 import {
@@ -16,6 +17,7 @@ import {
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
 import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
+import { useSiteAdminUrl } from './hooks/use-site-admin-url';
 import { useSiteDateTimeFormat } from './hooks/use-site-date-time-format';
 import { useSiteSlug } from './hooks/use-site-slug';
 
@@ -28,6 +30,7 @@ export const ScheduleLogs = ( props: Props ) => {
 	const translate = useTranslate();
 	const { scheduleId, onNavBack } = props;
 
+	const siteAdminUrl = useSiteAdminUrl();
 	const {
 		dateFormat: phpDateFormat,
 		timeFormat: phpTimeFormat,
@@ -44,6 +47,10 @@ export const ScheduleLogs = ( props: Props ) => {
 		isPending,
 	} = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const schedule = schedules.find( ( s ) => s.id === scheduleId );
+
+	const goToPluginsPage = useCallback( () => {
+		window.location.href = `${ siteAdminUrl }plugins.php`;
+	}, [ siteAdminUrl ] );
 
 	if ( isPending ) {
 		return null;
@@ -104,7 +111,7 @@ export const ScheduleLogs = ( props: Props ) => {
 					iconBackground="warning"
 					actionLabel="Try manual update"
 					actionIsPrimary={ true }
-					onActionClick={ () => {} }
+					onActionClick={ goToPluginsPage }
 				/>
 				<TimelineEvent
 					date={ new Date( '30 March 2024, 10:00:12 am' ) }

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -1,20 +1,101 @@
-import { useUpdateScheduleLogsQuery } from 'calypso/data/plugins/use-update-schedule-logs-query';
-import { useSiteSlug } from './hooks/use-site-slug';
+import { __experimentalText as Text, Button, Card, CardHeader } from '@wordpress/components';
+import { arrowLeft } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import Timeline from 'calypso/components/timeline';
+import TimelineEvent from 'calypso/components/timeline/timeline-event';
 
 interface Props {
 	scheduleId: string;
 	onNavBack?: () => void;
 }
 export const ScheduleLogs = ( props: Props ) => {
-	const { scheduleId } = props;
-	const siteSlug = useSiteSlug();
-
-	const { data: logs = [] } = useUpdateScheduleLogsQuery( siteSlug, scheduleId );
+	const { onNavBack } = props;
+	const translate = useTranslate();
 
 	return (
-		<>
-			Schedule Logs: { scheduleId }
-			<pre>{ JSON.stringify( logs, null, 4 ) }</pre>
-		</>
+		<Card className="plugins-update-manager">
+			<CardHeader size="extraSmall">
+				<div className="ch-placeholder">
+					{ onNavBack && (
+						<Button icon={ arrowLeft } onClick={ onNavBack }>
+							{ translate( 'Back' ) }
+						</Button>
+					) }
+				</div>
+				<Text>{ translate( 'Saturdays at 11:00 - logs' ) }</Text>
+				<div className="ch-placeholder"></div>
+			</CardHeader>
+			<Timeline>
+				<TimelineEvent
+					date={ new Date( '30 March 2024, 10:01 am' ) }
+					dateFormat="HH:mm:ss a"
+					detail="Plugins update completed"
+					icon="checkmark"
+					iconBackground="warning"
+				/>
+				<TimelineEvent
+					date={ new Date( '30 March 2024, 10:00:48 am' ) }
+					dateFormat="HH:mm:ss a"
+					detail="Gravity Forms updated from 2.5.8 to 2.6.0"
+					icon="checkmark"
+				/>
+				<TimelineEvent
+					date={ new Date( '30 March 2024, 10:00:39 am' ) }
+					dateFormat="HH:mm:ss a"
+					detail="Move to WordPress.com update from 5.9.3 to 6.0.0 failed [ Rolledback to 5.9.3 ]"
+					icon="sync"
+					iconBackground="warning"
+					actionLabel="Try manual update"
+					actionIsPrimary={ true }
+					onActionClick={ () => {} }
+				/>
+				<TimelineEvent
+					date={ new Date( '30 March 2024, 10:00:12 am' ) }
+					dateFormat="HH:mm:ss a"
+					detail="Elementor Pro updated from 3.0.9 to 3.1.0"
+					icon="checkmark"
+				/>
+				<TimelineEvent
+					date={ new Date( '30 March 2024' ) }
+					detail="Plugins update starts"
+					icon="time"
+					disabled
+				/>
+			</Timeline>
+			<Timeline>
+				<TimelineEvent
+					date={ new Date( '27 March 2024, 10:01 am' ) }
+					dateFormat="HH:mm:ss a"
+					detail="Plugins update completed successfully"
+					icon="checkmark"
+					iconBackground="success"
+				/>
+				<TimelineEvent
+					date={ new Date( '27 March 2024, 10:00:48 am' ) }
+					dateFormat="HH:mm:ss a"
+					detail="Gravity Forms updated from 2.5.8 to 2.6.0"
+					icon="checkmark"
+				/>
+				<TimelineEvent
+					date={ new Date( '27 March 2024, 10:00:39 am' ) }
+					dateFormat="HH:mm:ss a"
+					detail="Move to WordPress.com update from 5.9.3 to 6.0.0"
+					icon="checkmark"
+				/>
+				<TimelineEvent
+					date={ new Date( '27 March 2024, 10:00:12 am' ) }
+					dateFormat="HH:mm:ss a"
+					detail="Elementor Pro updated from 3.0.9 to 3.1.0"
+					icon="checkmark"
+					iconBackground="info"
+				/>
+				<TimelineEvent
+					date={ new Date( '27 March 2024' ) }
+					detail="Plugins update starts"
+					icon="time"
+					disabled
+				/>
+			</Timeline>
+		</Card>
 	);
 };

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -3,7 +3,10 @@ import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import Timeline from 'calypso/components/timeline';
 import TimelineEvent from 'calypso/components/timeline/timeline-event';
-import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import {
+	type ScheduleUpdates,
+	useUpdateScheduleQuery,
+} from 'calypso/data/plugins/use-update-schedules-query';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
 import { useSiteSlug } from './hooks/use-site-slug';
@@ -42,7 +45,7 @@ export const ScheduleLogs = ( props: Props ) => {
 					) }
 				</div>
 				<Text>
-					{ translate( 'Logs' ) } - { prepareScheduleName( schedule ) }
+					{ translate( 'Logs' ) } - { prepareScheduleName( schedule as ScheduleUpdates ) }
 				</Text>
 				<div className="ch-placeholder"></div>
 			</CardHeader>

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -103,7 +103,7 @@ export const ScheduleLogs = ( props: Props ) => {
 				<TimelineEvent
 					date={ new Date( '30 March 2024' ) }
 					detail="Plugins update starts"
-					icon="time"
+					icon="calendar"
 					disabled
 				/>
 			</Timeline>
@@ -137,7 +137,7 @@ export const ScheduleLogs = ( props: Props ) => {
 				<TimelineEvent
 					date={ new Date( '27 March 2024' ) }
 					detail="Plugins update starts"
-					icon="time"
+					icon="calendar"
 					disabled
 				/>
 			</Timeline>

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -76,7 +76,12 @@ export const ScheduleLogs = ( props: Props ) => {
 				</Text>
 				<div className="ch-placeholder">
 					<Text isBlock={ true } align="end" lineHeight={ 2.5 }>
-						{ schedule?.args?.length }
+						{ translate( '%(pluginsNumber)d plugin', '%(pluginsNumber)d plugins', {
+							count: schedule?.args?.length || 0,
+							args: {
+								pluginsNumber: schedule?.args?.length || 0,
+							},
+						} ) }
 						{ schedule?.args && (
 							<Tooltip
 								text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -140,6 +140,10 @@
 			width: 100%;
 		}
 	}
+
+	.timeline {
+		margin-top: 0;
+	}
 }
 
 .plugins-update-manager-spinner {

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -170,12 +170,16 @@
 				}
 			}
 
-			.timeline-event__icon-wrapper::before {
-				display: none;
-			}
-
 			.timeline-event__icon-wrapper {
 				align-content: center;
+
+				&::before {
+					display: none;
+				}
+			}
+
+			.timeline-event__action-button-wrapper {
+				align-self: center;
 			}
 
 			.timeline-event__title {

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -142,7 +142,7 @@
 	}
 
 	.timeline {
-		margin-top: 0;
+		margin: 0;
 	}
 }
 

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -143,6 +143,10 @@
 
 	.timeline {
 		margin: 0;
+
+		.timeline-event.is-disabled {
+			background: var(--studio-gray-0);
+		}
 	}
 }
 

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -144,8 +144,84 @@
 	.timeline {
 		margin: 0;
 
-		.timeline-event.is-disabled {
-			background: var(--studio-gray-0);
+		.timeline-event {
+			padding-top: 0.5rem;
+			padding-bottom: 0.5rem;
+			box-shadow: none;
+			border-bottom: 1px solid #f0f0f0;
+
+			&:last-child {
+				border-bottom: none;
+			}
+
+			&.indent {
+				margin-left: 3rem;
+			}
+
+			&.is-disabled {
+				background: var(--studio-gray-0);
+
+				.timeline-event__icon {
+					background-color: var(--studio-gray-40) !important;
+
+					svg {
+						fill: var(--studio-white) !important;
+					}
+				}
+			}
+
+			.timeline-event__icon-wrapper::before {
+				display: none;
+			}
+
+			.timeline-event__icon-wrapper {
+				align-content: center;
+			}
+
+			.timeline-event__title {
+				font-size: 0.75rem;
+				color: var(--studio-gray-50);
+			}
+
+			.timeline-event__detail {
+				font-weight: 500;
+				font-size: 0.875rem;
+				color: var(--studio-gray-100);
+			}
+		}
+
+		.timeline-event__icon {
+			width: 24px !important;
+			height: 24px !important;
+
+			svg {
+				width: 16px;
+				height: 16px;
+			}
+
+			&.success {
+				background-color: var(--color-success-5) !important;
+
+				svg {
+					fill: var(--color-success-80);
+				}
+			}
+
+			&.warning {
+				background-color: var(--color-warning-5) !important;
+
+				svg {
+					fill: var(--color-warning-80);
+				}
+			}
+
+			&.error {
+				background-color: var(--color-error-5) !important;
+
+				svg {
+					fill: var(--color-error-80);
+				}
+			}
 		}
 	}
 }

--- a/client/components/timeline/timeline-event.jsx
+++ b/client/components/timeline/timeline-event.jsx
@@ -6,6 +6,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 class TimelineEvent extends PureComponent {
 	static propTypes = {
+		className: PropTypes.string,
 		actionIsBusy: PropTypes.bool,
 		actionIsDisabled: PropTypes.bool,
 		actionIsPrimary: PropTypes.bool,
@@ -29,6 +30,7 @@ class TimelineEvent extends PureComponent {
 
 	render() {
 		const {
+			className,
 			actionIsBusy,
 			actionIsDisabled,
 			actionIsPrimary,
@@ -43,7 +45,7 @@ class TimelineEvent extends PureComponent {
 			moment,
 			onActionClick,
 		} = this.props;
-		const cardClasses = classNames( 'timeline-event', { 'is-disabled': disabled } );
+		const cardClasses = classNames( 'timeline-event', className, { 'is-disabled': disabled } );
 		const iconClasses = classNames( 'timeline-event__icon', iconBackground );
 
 		return (

--- a/client/my-sites/site-settings/date-time-format/utils.js
+++ b/client/my-sites/site-settings/date-time-format/utils.js
@@ -28,7 +28,7 @@ export function getLocalizedDate( timezoneString ) {
  * @see http://momentjs.com/docs/#/displaying/format/
  * @type {Object}
  */
-const phpToMomentMapping = {
+export const phpToMomentMapping = {
 	d: 'DD',
 	D: 'ddd',
 	j: 'D',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89036

## Proposed Changes

* Introduced a static screen of the logs with Calypso timeline component: https://wpcalypso.wordpress.com/devdocs/design/timeline

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the calypso live link
* Go to `/plugins/scheduled-updates/logs/{SITE_SLUG}/anything-here`

<img width="1728" alt="Screenshot 2024-04-04 at 14 46 33" src="https://github.com/Automattic/wp-calypso/assets/1241413/862a82d2-dee6-48ae-b0d4-7a33de06646b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?