### PR TITLE
GitHub Deployments: Fix calypso_page_view tracking

### DIFF
--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -22,7 +22,7 @@ import { withEnhancers } from 'calypso/state/utils';
 const debug = debugFactory( 'calypso:analytics:PageViewTracker' );
 const noop = () => {};
 
-export class PageViewTracker extends Component {
+export class UnconnectedPageViewTracker extends Component {
 	static displayName = 'PageViewTracker';
 
 	static propTypes = {
@@ -124,4 +124,4 @@ const mapDispatchToProps = {
 	] ),
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( PageViewTracker );
+export default connect( mapStateToProps, mapDispatchToProps )( UnconnectedPageViewTracker );

--- a/client/lib/analytics/page-view-tracker/test/index.jsx
+++ b/client/lib/analytics/page-view-tracker/test/index.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { render } from '@testing-library/react';
-import { PageViewTracker } from '../';
+import { UnconnectedPageViewTracker as PageViewTracker } from '../';
 
 describe( 'PageViewTracker', () => {
 	beforeEach( () => {

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';

--- a/client/my-sites/github-deployments/deployments/deployment-status.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-status.tsx
@@ -1,4 +1,6 @@
 import { __ } from '@wordpress/i18n';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export const DeployStatus = {
 	STATUS_PENDING: 'pending',
@@ -38,8 +40,17 @@ function getText( status: DeploymentStatusValue ) {
 }
 
 export const DeploymentStatus = ( { status, href }: DeploymentStatusProps ) => {
+	const dispatch = useDispatch();
+
 	return (
 		<a
+			onClick={ () =>
+				dispatch(
+					recordTracksEvent( 'calypso_hosting_github_log_status_click', {
+						status,
+					} )
+				)
+			}
 			href={ href }
 			className={ `github-deployments-status github-deployments-status__${ status }` }
 		>

--- a/client/my-sites/promote-post-i2/components/blaze-page-view-tracker/index.tsx
+++ b/client/my-sites/promote-post-i2/components/blaze-page-view-tracker/index.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
-import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
+import { UnconnectedPageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import { getDSPOrigin } from 'calypso/lib/promote-post';
 import { getSiteFragment } from 'calypso/lib/route';
 import {
@@ -25,7 +25,10 @@ interface Props {
 // This component will pass through all properties to PageViewTracker unconnected component from the analytics library
 // We do this to make it compatible with the Blaze Jetpack version of the dashboard that uses hashbang for navigation
 const BlazePageViewTracker = ( props: Props ) => (
-	<PageViewTracker { ...props } properties={ { ...props.properties, origin: getDSPOrigin() } } />
+	<UnconnectedPageViewTracker
+		{ ...props }
+		properties={ { ...props.properties, origin: getDSPOrigin() } }
+	/>
 );
 
 const mapStateToProps = ( state: Record< string, unknown > ) => {

--- a/client/my-sites/promote-post-i2/components/blaze-page-view-tracker/test/index.jsx
+++ b/client/my-sites/promote-post-i2/components/blaze-page-view-tracker/test/index.jsx
@@ -10,7 +10,7 @@ import BlazePageViewTracker from '../';
 const mockPageViewTrackerProps = jest.fn();
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => ( {
 	...jest.requireActual( 'calypso/lib/analytics/page-view-tracker' ),
-	PageViewTracker: ( props ) => {
+	UnconnectedPageViewTracker: ( props ) => {
 		mockPageViewTrackerProps( props );
 		return null;
 	},

--- a/client/my-sites/site-monitoring/controller.tsx
+++ b/client/my-sites/site-monitoring/controller.tsx
@@ -1,4 +1,3 @@
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -6,12 +5,7 @@ import { SiteMetrics } from './main';
 import type { Callback } from '@automattic/calypso-router';
 
 export const siteMetrics: Callback = ( context, next ) => {
-	context.primary = (
-		<>
-			<PageViewTracker path="/site-monitoring/:site" title="Site Monitoring" delay={ 500 } />
-			<SiteMetrics tab={ context.params.tab } />
-		</>
-	);
+	context.primary = <SiteMetrics tab={ context.params.tab } />;
 	next();
 };
 

--- a/client/my-sites/site-monitoring/controller.tsx
+++ b/client/my-sites/site-monitoring/controller.tsx
@@ -1,4 +1,4 @@
-import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -3,6 +3,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useSelector } from 'calypso/state';
 import { isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -29,6 +30,7 @@ export function SiteMetrics( { tab = 'metrics' }: SiteMetricsProps ) {
 
 	return (
 		<Main className="site-monitoring" fullWidthLayout>
+			<PageViewTracker path="/site-monitoring/:site" title="Site Monitoring" />
 			<DocumentHead title={ titleHeader } />
 			<FormattedHeader
 				className="site-monitoring__formatted-header modernized-header"

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -3,7 +3,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useSelector } from 'calypso/state';
 import { isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -30,7 +29,6 @@ export function SiteMetrics( { tab = 'metrics' }: SiteMetricsProps ) {
 
 	return (
 		<Main className="site-monitoring" fullWidthLayout>
-			<PageViewTracker path="/site-monitoring/:site" title="Site Monitoring" />
 			<DocumentHead title={ titleHeader } />
 			<FormattedHeader
 				className="site-monitoring__formatted-header modernized-header"


### PR DESCRIPTION
## Proposed Changes

Fix tracking by using the correct component, and renaming the unconnected component so it's clear that we're using the wrong component.

<img width="990" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/029d3b54-9092-408f-84fe-2ca06e0b4482">

## Testing Instructions

Check that you see the events being dispatched when using this PR, and that you do not see it in production.