### PR TITLE
Automattic for Agencies: Fix Sign out flow by adding `logout_url`

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -122,6 +122,7 @@ a.a4a-sidebar__external-link {
 	}
 }
 
-.a4a-sidebar svg.all-sites__title-chevron-icon {
+.a4a-sidebar svg.all-sites__title-chevron-icon,
+.a4a-sidebar__profile-dropdown-button-label svg {
 	fill: var(--color-sidebar-text);
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -7,6 +7,7 @@
 	"hostname": "agencies.localhost",
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
+	"logout_url": "https://automattic.com/for/agencies",
 	"site_name": "Automattic For Agencies",
 	"oauth_client_id": 95928,
 	"features": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -5,6 +5,7 @@
 	"client_slug": "browser",
 	"hostname": "agencies.automattic.com",
 	"i18n_default_locale_slug": "en",
+	"logout_url": "https://automattic.com/for/agencies",
 	"site_name": "Automattic For Agencies",
 	"features": {
 		"a8c-for-agencies": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -6,6 +6,7 @@
 	"protocol": "http",
 	"hostname": "agencies.automattic.com",
 	"i18n_default_locale_slug": "en",
+	"logout_url": "https://automattic.com/for/agencies",
 	"site_name": "Automattic For Agencies",
 	"oauth_client_id": 95932,
 	"features": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -6,6 +6,7 @@
 	"protocol": "http",
 	"hostname": "agencies.automattic.com",
 	"i18n_default_locale_slug": "en",
+	"logout_url": "https://automattic.com/for/agencies",
 	"site_name": "Automattic For Agencies",
 	"oauth_client_id": 95931,
 	"features": {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/186

## Proposed Changes

This PR fixes the sign-out flow in A4A.

## Testing Instructions

- Switch to this branch locally and start the server
- Open the URL in incognito > Sign in as usual 
- Verify that the dropdown next to the username is clearly visible
- Click on the username > Click Sign out > Verify you are signed out and redirect to the A4A landing page

<img width="264" alt="Screenshot 2024-04-02 at 12 04 01 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/44c35c6e-97dc-4c0a-b819-ceed0ef35c87">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?