### PR TITLE
A4A: Arranged the 'Next steps' checklist based on availability of active site.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
@@ -6,6 +6,7 @@ import {
 	A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
 	A4A_SITES_LINK_WALKTHROUGH_TOUR,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -26,6 +27,8 @@ export default function OverviewBodyNextSteps() {
 		}
 		return false;
 	};
+
+	const noActiveSite = useNoActiveSite();
 
 	const tasks: Task[] = [
 		{
@@ -58,19 +61,27 @@ export default function OverviewBodyNextSteps() {
 			title: translate( 'Explore the marketplace' ),
 			useCalypsoPath: true,
 		},
-		{
-			calypso_path: A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
-			completed: checkTourCompletion( 'addSiteStep1' ),
-			disabled: false,
-			actionDispatch: () => {
-				dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_add_sites_click' ) );
-				dispatch( savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'addSiteStep1' ], true ) );
-			},
-			id: 'add_sites',
-			title: translate( 'Learn how to add new sites' ),
-			useCalypsoPath: true,
-		},
 	];
+
+	const addNewSiteTask: Task = {
+		calypso_path: A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
+		completed: checkTourCompletion( 'addSiteStep1' ),
+		disabled: false,
+		actionDispatch: () => {
+			dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_add_sites_click' ) );
+			dispatch( savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'addSiteStep1' ], true ) );
+		},
+		id: 'add_sites',
+		title: translate( 'Learn how to add new sites' ),
+		useCalypsoPath: true,
+	};
+
+	// If we do not have an active site, we want to show the add new site task first in the list.
+	if ( noActiveSite ) {
+		tasks.unshift( addNewSiteTask );
+	} else {
+		tasks.push( addNewSiteTask );
+	}
 
 	const numberOfTasks = tasks.length;
 	const completedTasks = tasks.filter( ( task ) => task.completed ).length;


### PR DESCRIPTION
As per requirement, when the current user does not have an active site, we will need to move **"Learn how to add new sites"** to the first item of the "Next Steps" checklist on the Overview page.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/147

## Proposed Changes

* Update `OverviewBodyNextSteps` component to arrange tasks list based on available site. If no site is active, we will have **"Learn how to add new sites"** task as the first item. Otherwise, we show it as the last item.

## Testing Instructions

* Create a new WPCOM account and connect it to the A4A portal. Make sure you completed the signup.
* Use the live link below and go to `/overview`.
* With your new account without an active site, confirm that the Next steps checklist shows **"Learn how to add new sites"** tasks as the first item. 
<img width="1073" alt="Screenshot 2024-04-02 at 2 43 30 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/5565ed69-c03f-4ee7-bcca-402109567144">

* Connect a site to your account.
* Go back to the overview page.
* Confirm that the Next steps checklist shows **"Learn how to add new sites"** tasks as the last item.
<img width="1140" alt="Screenshot 2024-04-02 at 2 43 08 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/72405a93-240d-414f-9657-3540fd317550">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?