### PR TITLE
A4A: Fix Overview page offering items CTA button hover style.

### DIFF
--- a/client/a8c-for-agencies/components/offering/offering-item.tsx
+++ b/client/a8c-for-agencies/components/offering/offering-item.tsx
@@ -38,7 +38,7 @@ const OfferingItem: React.FC< OfferingItemProps > = ( {
 					</li>
 				) ) }
 			</ul>
-			<Button className="a4a-offering-item__button" onClick={ actionHandler }>
+			<Button className="a4a-offering-item__button" onClick={ actionHandler } primary>
 				{ buttonTitle }
 			</Button>
 		</FoldableCard>

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -83,14 +83,5 @@
 			justify-content: center;
 		}
 	}
-
-	.a4a-offering-item__button {
-		background-color: #0088bf;
-		fill: var(--color-primary-60);
-		border-radius: 4px;
-		color: var(--studio-white);
-		font-weight: 500;
-		font-size: 0.875rem;
-	}
 }
 


### PR DESCRIPTION
This PR fixes the Overview page foldable card's CTA button hover effect.

https://github.com/Automattic/wp-calypso/assets/56598660/e9ca7832-5595-42f4-aa89-e154b4dffd13




Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/187

## Proposed Changes

* Change the A4A Offering item button to a primary button.
* Remove unnecessary CSS overrides.

## Testing Instructions

* Use the live link below, and go to `/overview`.
* Verify that the Foldable card's CTA button has the correct hover effect.

https://github.com/Automattic/wp-calypso/assets/56598660/8af1e477-9228-4abb-a37a-8879f3c8300b


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?