### PR TITLE
Ensure we have a fallback CTA in UpgradePlan; re-add site migration tests

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -139,7 +139,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 							transparent={ ! isAddingTrial }
 							onClick={ onCtaClick }
 						>
-							{ ctaText }
+							{ ctaText === '' ? translate( 'Continue' ) : ctaText }
 						</Button>
 					</>
 				) : (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
+import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import plansReducer from 'calypso/state/plans/reducer';
+import SiteMigrationUpgradePlan from '../';
+import { StepProps } from '../../../types';
+import { mockStepProps, renderStep } from '../../test/helpers';
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site' );
+jest.mock( 'calypso/data/plans/use-check-eligibility-migration-trial-plan' );
+jest.mock( 'calypso/data/hosting/use-add-hosting-trial-mutation' );
+
+( useSite as jest.Mock ).mockReturnValue( {
+	ID: 'site-id',
+	URL: 'https://site-url.wordpress.com',
+} );
+
+( useCheckEligibilityMigrationTrialPlan as jest.Mock ).mockReturnValue( {
+	data: { eligible: true },
+} );
+
+( useAddHostingTrialMutation as jest.Mock ).mockImplementation( ( { onSuccess } ) => ( {
+	addHostingTrial: () => onSuccess(),
+} ) );
+
+describe( 'SiteMigrationUpgradePlan', () => {
+	const render = ( props?: Partial< StepProps > ) => {
+		const combinedProps = { ...mockStepProps( props ) };
+		return renderStep( <SiteMigrationUpgradePlan { ...combinedProps } />, {
+			reducers: {
+				plans: plansReducer,
+			},
+		} );
+	};
+
+	it( 'selects annual plan as default', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( navigation.submit ).toHaveBeenCalledWith( {
+			goToCheckout: true,
+			plan: 'business',
+		} );
+	} );
+
+	it( 'selects the monthly plan', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Pay monthly/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( navigation.submit ).toHaveBeenCalledWith( {
+			goToCheckout: true,
+			plan: 'business-monthly',
+		} );
+	} );
+
+	it( 'selects annual plan', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Pay annually/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( navigation.submit ).toHaveBeenCalledWith( {
+			goToCheckout: true,
+			plan: 'business',
+		} );
+	} );
+
+	it( 'selects free trial', async () => {
+		const navigation = { submit: jest.fn() };
+		render( { navigation } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Try 7 days for free/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( navigation.submit ).toHaveBeenCalledWith( {
+			freeTrialSelected: true,
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/89050 - original PR that added Site Migration tests
* https://github.com/Automattic/wp-calypso/pull/89070 - PR that caused the CTA to be empty/`''`
* https://github.com/Automattic/wp-calypso/pull/89092 - PR that reverted the Site Migration tests that failed alongside the PR above

## Proposed Changes

* This PR ensures that we have a default CTA of `Continue` in the `UpgradePlan` component, as we still have at least one caller that was relying on the old behaviour where the `ctaText` prop could be `''`.
* The PR also reinstates the tests added in #89050 (and reverted in #89092), which started failing as a result of #89070 causing the button text to be `''`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Create a new site via `/start`, and pick a free domain and the free plan
* On the Goals step, choose to import your existing website or content
* Enter the URL of a valid WordPress site
* Verify that the CTA now reads "Continue" on the plans page
  - You should _NOT_ see the following:
<img width="749" alt="Screenshot 2024-04-02 at 09 48 48" src="https://github.com/Automattic/wp-calypso/assets/3376401/1adb3e3a-2cf5-421c-b3be-b79e50d4cdb3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
