### PR TITLE
Stats: Update usePlanUsageQuery to use query defaults

### DIFF
--- a/client/my-sites/stats/hooks/default-query-params.ts
+++ b/client/my-sites/stats/hooks/default-query-params.ts
@@ -6,9 +6,6 @@ const defaultQueryParams: Partial< UseQueryOptions > = {
 	retryDelay: 3 * 1000, // 3 seconds,
 	retryOnMount: false,
 	refetchOnWindowFocus: false,
-	refetchOnMount: false,
-	refetchInterval: false,
-	refetchIntervalInBackground: false,
 };
 
 const getDefaultQueyrParams = < T1 >() => {

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -1,7 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { PriceTierListItemProps } from '../stats-purchase/types';
-import getDefaultQueryParams from './default-query-params';
 
 interface PeriodUsage {
 	current_start: string | null;
@@ -34,10 +33,8 @@ export default function usePlanUsageQuery(
 	siteId: number | null
 ): UseQueryResult< PlanUsage, unknown > {
 	return useQuery( {
-		...getDefaultQueryParams< PlanUsage >(),
 		queryKey: [ 'stats', 'usage', 'query', siteId ],
 		queryFn: () => queryPlanUsage( siteId ),
 		select: selectPlanUsage,
-		staleTime: 5 * 1000, // 5 seconds
 	} );
 }

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { PriceTierListItemProps } from '../stats-purchase/types';
+import getDefaultQueryParams from './default-query-params';
 
 interface PeriodUsage {
 	current_start: string | null;
@@ -33,6 +34,7 @@ export default function usePlanUsageQuery(
 	siteId: number | null
 ): UseQueryResult< PlanUsage, unknown > {
 	return useQuery( {
+		...getDefaultQueryParams< PlanUsage >(),
 		queryKey: [ 'stats', 'usage', 'query', siteId ],
 		queryFn: () => queryPlanUsage( siteId ),
 		select: selectPlanUsage,

--- a/client/my-sites/stats/pages/providers/global-provider.tsx
+++ b/client/my-sites/stats/pages/providers/global-provider.tsx
@@ -15,10 +15,8 @@ export const StatsGlobalValuesProvider: React.FC< StatsGlobalValuesProviderProps
 	children,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId );
-
-	const { isFetching: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
-
-	const isInternal = ! isFetchingUsage && !! usageData?.is_internal;
+	const { isPending, data: usageData } = usePlanUsageQuery( siteId );
+	const isInternal = ! isPending && !! usageData?.is_internal;
 
 	return (
 		<StatsGlobalValuesContext.Provider value={ isInternal }>

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -29,7 +29,7 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	// Check if blog is internal.
-	const { isFetching: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
+	const { isPending: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
 	const { isLoading: isLoadingFeatureCheck, supportCommercialUse } = useStatsPurchases( siteId );
 	// Fetch UTM metrics with switched UTM parameters.
 	const { isFetching: isFetchingUTM, metrics: data } = useUTMMetricsQuery(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Slack convo:

p1712025715440739-slack-C82FZ5T4G

While the changes here are simple there are lots of edge cases around how the hook is used so it would be great if we could get some extra testing before merging this.

## Proposed Changes

Updates the `usePlanUsageQuery` hook to use the Tanstack query defaults.

- Makes sure the API is called at default intervals to refresh the cached data.
- Makes sure we have fresh data when visiting the Purchase flow.
- Updates call sites so we only see state updates if the data changes.
- Fixes case where UTM module was spinning any time a browser tab was changed. (ie: watching the fetch as opposed to the data)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Stats tab and make sure things behave as expected. Specifically, do you see any loading UI or unexpected page refreshes.
* Visit the Stats tab on a brand new self-hosted site and confirm the redirect to the Purchase page works correctly.
* Visit the Stats tab on a site with an existing plan. Visit the Purchases page and confirm the tiers are correct. Remove the plan, revisit the page, and check the tiers are properly updated.
* If you can think of another scenario, please test it and also update these instructions!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?