### PR TITLE
DIFM Content Form: add content guidelines dialog

### DIFF
--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Button, Dialog } from '@automattic/components';
+import { Button, ConfettiAnimation, Dialog } from '@automattic/components';
 import styled from '@emotion/styled';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
@@ -56,6 +56,17 @@ const DialogButton = styled( Button )`
 	--color-accent-60: #0e64a5;
 	.gridicon {
 		margin-left: 10px;
+	}
+`;
+
+const LinkButton = styled( Button )`
+	text-decoration: underline;
+	cursor: pointer;
+
+	.formatted-header__subtitle
+		button&[type='button'].button.is-borderless.is-primary.is-transparent:focus {
+		border-color: transparent;
+		box-shadow: none;
 	}
 `;
 
@@ -177,6 +188,8 @@ function WebsiteContentStep( {
 	);
 	const generatedSections = generatedSectionsCallback();
 
+	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
 	const dialogButtons = [
 		<DialogButton onClick={ () => setIsConfirmDialogOpen( false ) }>
 			{ translate( 'Cancel' ) }
@@ -188,6 +201,7 @@ function WebsiteContentStep( {
 
 	return (
 		<>
+			<ConfettiAnimation trigger={ ! prefersReducedMotion } />
 			<Dialog
 				isVisible={ isConfirmDialogOpen }
 				onClose={ () => setIsConfirmDialogOpen( false ) }
@@ -248,13 +262,32 @@ export default function WrapperWebsiteContent(
 
 	const { isLoading, isError, data } = useGetWebsiteContentQuery( queryObject.siteSlug );
 
+	const [ isContentGuidelinesDialogOpen, setIsContentGuidelinesDialogOpen ] = useState( true );
+
 	const headerText = translate( 'Website Content' );
+
+	const subHeaderTextTranslateArgs = {
+		components: {
+			br: <br />,
+			Link: (
+				<LinkButton
+					borderless
+					primary
+					transparent
+					onClick={ () => setIsContentGuidelinesDialogOpen( true ) }
+				/>
+			),
+		},
+	};
+
 	const subHeaderText = data?.isStoreFlow
 		? translate(
-				'Provide content for your website build. You can add products later with the WordPress editor.'
+				'Provide content for your website build. You can add products later with the WordPress editor.{{br}}{{/br}}{{br}}{{/br}}{{Link}}View Content Guidelines{{/Link}}',
+				subHeaderTextTranslateArgs
 		  )
 		: translate(
-				'Provide content for your website build. You will be able to edit all content later using the WordPress editor.'
+				'Provide content for your website build. You will be able to edit all content later using the WordPress editor.{{br}}{{/br}}{{br}}{{/br}}{{Link}}View Content Guidelines{{/Link}}',
+				subHeaderTextTranslateArgs
 		  );
 
 	useEffect( () => {
@@ -289,23 +322,60 @@ export default function WrapperWebsiteContent(
 	}
 
 	return (
-		<StepWrapper
-			headerText={ headerText }
-			subHeaderText={ subHeaderText }
-			fallbackHeaderText={ headerText }
-			fallbackSubHeaderText={ subHeaderText }
-			flowName={ flowName }
-			stepName={ stepName }
-			positionInFlow={ positionInFlow }
-			stepContent={
-				<WebsiteContentStep { ...props } websiteContentServerState={ data } siteId={ siteId } />
-			}
-			goToNextStep={ false }
-			hideFormattedHeader={ false }
-			hideBack={ false }
-			align="left"
-			isHorizontalLayout={ true }
-			isWideLayout={ true }
-		/>
+		<>
+			<Dialog
+				isVisible={ isContentGuidelinesDialogOpen }
+				onClose={ () => setIsContentGuidelinesDialogOpen( false ) }
+				buttons={ [
+					<DialogButton primary onClick={ () => setIsContentGuidelinesDialogOpen( false ) }>
+						{ translate( 'Acknowledge & Continue' ) }
+					</DialogButton>,
+				] }
+			>
+				<DialogContent>
+					<h1>{ translate( 'We look forward to building your site!' ) }</h1>
+					<p>{ translate( 'Please review the following content submission guidelines:' ) }</p>
+					<ul>
+						<li>
+							{ translate(
+								'Do not request content from existing pages, external websites or files, as migrations are not included. '
+							) }
+						</li>
+						<li>
+							{ translate(
+								'Submit the final content within 14 days; otherwise, we will use AI-generated text and stock images to build your site.'
+							) }
+						</li>
+						<li>
+							{ translate( 'Limit page text to under 5000 characters for optimal presentation.' ) }
+						</li>
+						<li>
+							{ translate(
+								'Revisions are not included; however, you can edit all content later using the WordPress editor.'
+							) }
+						</li>
+					</ul>
+				</DialogContent>
+			</Dialog>
+
+			<StepWrapper
+				headerText={ headerText }
+				subHeaderText={ subHeaderText }
+				fallbackHeaderText={ headerText }
+				fallbackSubHeaderText={ subHeaderText }
+				flowName={ flowName }
+				stepName={ stepName }
+				positionInFlow={ positionInFlow }
+				stepContent={
+					<WebsiteContentStep { ...props } websiteContentServerState={ data } siteId={ siteId } />
+				}
+				goToNextStep={ false }
+				hideFormattedHeader={ false }
+				hideBack={ false }
+				align="left"
+				isHorizontalLayout={ true }
+				isWideLayout={ true }
+			/>
+		</>
 	);
 }

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -211,7 +211,10 @@ function WebsiteContentStep( {
 					<h1>{ translate( 'Are you ready to submit your content?' ) }</h1>
 					<p>
 						{ translate(
-							'Click the Submit button if you have finished adding content. We will build your new website and then email you within 4 business days with details about your new site.'
+							"If you have reviewed our content guidelines and added your final content to the form, click “Submit” to send us your content. We'll then build your new site and email you the details within %d business days.",
+							{
+								args: [ 4 ],
+							}
 						) }
 					</p>
 				</DialogContent>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/1552

## Proposed Changes

* Adds a new content guidelines dialog to the DIFM content submission form. The dialog will be open by default when the page is loaded. A link in the sidebar can re-open the dialog if needed.
<img width="798" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/5600c334-288f-4a54-8030-d4cac5d4e84b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/site-content-collection/website-content?siteSlug=<site slug>` for a site with a in-progress DIFM purchase.
* Confirm that the dialog is open when the page is loaded and you can see the confetti animation.
* Confirm that you can close and re-open the dialog.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?