### PR TITLE
Odyssey Stats: Fix mini carousel banner button routing

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import { PLAN_PREMIUM, getPlan, isFreePlan, isPersonalPlan } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
@@ -38,8 +37,6 @@ const EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS = 'calypso_stats_google_analytics_ba
 
 const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const baseUrl =
-		typeof window !== 'undefined' && window.location.hostname === slug ? config( 'hostname' ) : '';
 
 	const { data: hasNeverPublishedPost, isLoading: isHasNeverPublishedPostLoading } =
 		useHasNeverPublishedPost( selectedSiteId ?? null, true, {
@@ -128,7 +125,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep working on your site.'
 				) }
 				ctaText={ translate( 'Launch your site' ) }
-				href={ `${ baseUrl }/settings/general/${ slug }` }
+				href={ `/settings/general/${ slug }` }
 				key="launch-your-site"
 			/>
 		);
@@ -145,7 +142,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Sites with content get more visitors. We’ve found that adding some personality and introducing yourself is a great start to click with your audience.'
 				) }
 				ctaText={ translate( 'Write a post' ) }
-				href={ `${ baseUrl }/post/${ slug }` }
+				href={ `/post/${ slug }` }
 				key="write-a-post"
 			/>
 		);
@@ -162,7 +159,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Grow your audience by promoting your content. Reach millions of users across Tumblr and WordPress.com'
 				) }
 				ctaText={ translate( 'Create campaign' ) }
-				href={ `${ baseUrl }/advertising/${ slug || '' }` }
+				href={ `/advertising/${ slug || '' }` }
 				key="blaze"
 			/>
 		);
@@ -179,7 +176,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
 				) }
 				ctaText={ translate( 'Get Yoast' ) }
-				href={ `${ baseUrl }/plugins/wordpress-seo-premium/${ slug || '' }` }
+				href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
 				key="yoast"
 			/>
 		);
@@ -203,7 +200,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					// Translators: %(plan) is the name of a plan, e.g. "Explorer" or "Premium"
 					translate( 'Get %(plan)s', { args: { plan: premiumPlanName } } )
 				}
-				href={ `${ baseUrl }/checkout/premium/${ slug || '' }` }
+				href={ `/checkout/premium/${ slug || '' }` }
 				key="google-analytics"
 			/>
 		);

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { PLAN_PREMIUM, getPlan, isFreePlan, isPersonalPlan } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
@@ -37,6 +38,8 @@ const EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS = 'calypso_stats_google_analytics_ba
 
 const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
+	const baseUrl =
+		typeof window !== 'undefined' && window.location.hostname === slug ? config( 'hostname' ) : '';
 
 	const { data: hasNeverPublishedPost, isLoading: isHasNeverPublishedPostLoading } =
 		useHasNeverPublishedPost( selectedSiteId ?? null, true, {
@@ -125,7 +128,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep working on your site.'
 				) }
 				ctaText={ translate( 'Launch your site' ) }
-				href={ `/settings/general/${ slug }` }
+				href={ `${ baseUrl }/settings/general/${ slug }` }
 				key="launch-your-site"
 			/>
 		);
@@ -142,7 +145,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Sites with content get more visitors. We’ve found that adding some personality and introducing yourself is a great start to click with your audience.'
 				) }
 				ctaText={ translate( 'Write a post' ) }
-				href={ `/post/${ slug }` }
+				href={ `${ baseUrl }/post/${ slug }` }
 				key="write-a-post"
 			/>
 		);
@@ -159,7 +162,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Grow your audience by promoting your content. Reach millions of users across Tumblr and WordPress.com'
 				) }
 				ctaText={ translate( 'Create campaign' ) }
-				href={ `/advertising/${ slug || '' }` }
+				href={ `${ baseUrl }/advertising/${ slug || '' }` }
 				key="blaze"
 			/>
 		);
@@ -176,7 +179,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
 				) }
 				ctaText={ translate( 'Get Yoast' ) }
-				href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
+				href={ `${ baseUrl }/plugins/wordpress-seo-premium/${ slug || '' }` }
 				key="yoast"
 			/>
 		);
@@ -200,7 +203,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					// Translators: %(plan) is the name of a plan, e.g. "Explorer" or "Premium"
 					translate( 'Get %(plan)s', { args: { plan: premiumPlanName } } )
 				}
-				href={ `/checkout/premium/${ slug || '' }` }
+				href={ `${ baseUrl }/checkout/premium/${ slug || '' }` }
 				key="google-analytics"
 			/>
 		);

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -98,6 +98,12 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 		showGoogleAnalyticsPromo,
 	] );
 
+	// In case of Odyssey Stats, ensure that we return the absolute URL for redirect.
+	const getCalypsoUrl = ( href ) => {
+		const baseUrl = window?.location?.hostname === slug ? 'https://wordpress.com' : '';
+		return baseUrl + href;
+	};
+
 	// Handle view events upon initial mount and upon paging DotPager.
 	useEffect( () => {
 		if ( viewEvents.length === 0 ) {
@@ -125,7 +131,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep working on your site.'
 				) }
 				ctaText={ translate( 'Launch your site' ) }
-				href={ `/settings/general/${ slug }` }
+				href={ getCalypsoUrl( `/settings/general/${ slug }` ) }
 				key="launch-your-site"
 			/>
 		);
@@ -142,7 +148,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Sites with content get more visitors. We’ve found that adding some personality and introducing yourself is a great start to click with your audience.'
 				) }
 				ctaText={ translate( 'Write a post' ) }
-				href={ `/post/${ slug }` }
+				href={ getCalypsoUrl( `/post/${ slug }` ) }
 				key="write-a-post"
 			/>
 		);
@@ -159,7 +165,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Grow your audience by promoting your content. Reach millions of users across Tumblr and WordPress.com'
 				) }
 				ctaText={ translate( 'Create campaign' ) }
-				href={ `/advertising/${ slug || '' }` }
+				href={ getCalypsoUrl( `/advertising/${ slug || '' }` ) }
 				key="blaze"
 			/>
 		);
@@ -176,7 +182,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
 				) }
 				ctaText={ translate( 'Get Yoast' ) }
-				href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
+				href={ getCalypsoUrl( `/plugins/wordpress-seo-premium/${ slug || '' }` ) }
 				key="yoast"
 			/>
 		);
@@ -200,7 +206,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 					// Translators: %(plan) is the name of a plan, e.g. "Explorer" or "Premium"
 					translate( 'Get %(plan)s', { args: { plan: premiumPlanName } } )
 				}
-				href={ `/checkout/premium/${ slug || '' }` }
+				href={ getCalypsoUrl( `/checkout/premium/${ slug || '' }` ) }
 				key="google-analytics"
 			/>
 		);

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
@@ -22,17 +21,11 @@ const MiniCarouselBlock = ( {
 	dismissText,
 } ) => {
 	const dispatch = useDispatch();
-	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
 
 	const onClick = useCallback( () => {
 		recordTracksEvent( clickEvent );
-		if ( ! isOdysseyStats ) {
-			page( href );
-		}
-
-		// If it is Odyssey, redirect since the path might not be registered in the router.
-		location.href = href;
-	}, [ clickEvent, href, isOdysseyStats ] );
+		page( href );
+	}, [ clickEvent, href ] );
 
 	const onDismiss = useCallback( () => {
 		recordTracksEvent( dismissEvent );

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
+import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -10,6 +11,8 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { dismissBlock } from './actions';
 
 import './mini-carousel-block.scss';
+
+const debug = debugFactory( 'mini-carousel-block' );
 
 const MiniCarouselBlock = ( {
 	clickEvent,
@@ -28,6 +31,7 @@ const MiniCarouselBlock = ( {
 	const onClick = useCallback( () => {
 		const isHrefRelative = href.startsWith( '/' );
 		recordTracksEvent( clickEvent );
+		debug( 'onClick', { href, hostname, isHrefRelative, isWpcomDomain } );
 
 		// Use Calypso router when the page is under a WPCOM domain.
 		if ( isWpcomDomain && isHrefRelative ) {

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
@@ -21,11 +22,17 @@ const MiniCarouselBlock = ( {
 	dismissText,
 } ) => {
 	const dispatch = useDispatch();
+	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
 
 	const onClick = useCallback( () => {
 		recordTracksEvent( clickEvent );
-		page( href );
-	}, [ clickEvent, href ] );
+		if ( ! isOdysseyStats ) {
+			page( href );
+		}
+
+		// If it is Odyssey, redirect since the path might not be registered in the router.
+		location.href = href;
+	}, [ clickEvent, href, isOdysseyStats ] );
 
 	const onDismiss = useCallback( () => {
 		recordTracksEvent( dismissEvent );

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
@@ -21,11 +22,22 @@ const MiniCarouselBlock = ( {
 	dismissText,
 } ) => {
 	const dispatch = useDispatch();
+	const hostname = config( 'hostname' );
+	const isWpcomDomain = typeof window !== 'undefined' && window.location.hostname === hostname;
 
 	const onClick = useCallback( () => {
+		const isHrefRelative = href.startsWith( '/' );
 		recordTracksEvent( clickEvent );
-		page( href );
-	}, [ clickEvent, href ] );
+
+		// Use Calypso router when the page is under a WPCOM domain.
+		if ( isWpcomDomain && isHrefRelative ) {
+			page( href );
+			return;
+		}
+
+		// Otherwise, use the browser API to navigate to the href.
+		location.href = isHrefRelative ? `${ hostname }${ href }` : href;
+	}, [ clickEvent, href, hostname, isWpcomDomain ] );
 
 	const onDismiss = useCallback( () => {
 		recordTracksEvent( dismissEvent );

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -1,9 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
-import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -11,8 +9,6 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { dismissBlock } from './actions';
 
 import './mini-carousel-block.scss';
-
-const debug = debugFactory( 'mini-carousel-block' );
 
 const MiniCarouselBlock = ( {
 	clickEvent,
@@ -25,23 +21,11 @@ const MiniCarouselBlock = ( {
 	dismissText,
 } ) => {
 	const dispatch = useDispatch();
-	const hostname = config( 'hostname' );
-	const isWpcomDomain = typeof window !== 'undefined' && window.location.hostname === hostname;
 
 	const onClick = useCallback( () => {
-		const isHrefRelative = href.startsWith( '/' );
 		recordTracksEvent( clickEvent );
-		debug( 'onClick', { href, hostname, isHrefRelative, isWpcomDomain } );
-
-		// Use Calypso router when the page is under a WPCOM domain.
-		if ( isWpcomDomain && isHrefRelative ) {
-			page( href );
-			return;
-		}
-
-		// Otherwise, use the browser API to navigate to the href.
-		location.href = isHrefRelative ? `${ hostname }${ href }` : href;
-	}, [ clickEvent, href, hostname, isWpcomDomain ] );
+		page( href );
+	}, [ clickEvent, href ] );
 
 	const onDismiss = useCallback( () => {
 		recordTracksEvent( dismissEvent );

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
+import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -9,6 +10,8 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { dismissBlock } from './actions';
 
 import './mini-carousel-block.scss';
+
+const debug = debugFactory( 'stats:mini-carousel' );
 
 const MiniCarouselBlock = ( {
 	clickEvent,
@@ -23,6 +26,8 @@ const MiniCarouselBlock = ( {
 	const dispatch = useDispatch();
 
 	const onClick = useCallback( () => {
+		debug( 'onClick', { href } );
+
 		recordTracksEvent( clickEvent );
 		page( href );
 	}, [ clickEvent, href ] );

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -2,7 +2,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
-import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -10,8 +9,6 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { dismissBlock } from './actions';
 
 import './mini-carousel-block.scss';
-
-const debug = debugFactory( 'stats:mini-carousel' );
 
 const MiniCarouselBlock = ( {
 	clickEvent,
@@ -26,8 +23,6 @@ const MiniCarouselBlock = ( {
 	const dispatch = useDispatch();
 
 	const onClick = useCallback( () => {
-		debug( 'onClick', { href } );
-
 		recordTracksEvent( clickEvent );
 		if ( href.startsWith( '/' ) ) {
 			page( href );

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -29,7 +29,12 @@ const MiniCarouselBlock = ( {
 		debug( 'onClick', { href } );
 
 		recordTracksEvent( clickEvent );
-		page( href );
+		if ( href.startsWith( '/' ) ) {
+			page( href );
+			return;
+		}
+
+		location.href = href;
 	}, [ clickEvent, href ] );
 
 	const onDismiss = useCallback( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6355

## Proposed Changes

This PR fixes the button links in the Odyssey Stats page for Classic Simple sites. The issue is caused due to the links are relative paths meant to be handled by the Calypso router. However, the Odyssey Stats app uses its own instance of the Calypso router. Furthermore, the classic view is wp-admin and not Calypso.

To solve this issue, we reconstruct the button links to absolute URLs that are then redirected using the browser API instead of the Calypso router.

Alternatively, instead of fixing the routing issue we could hide the banner for Classic Simple. The downside is that we would lose the upsell opportunity.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `install-plugin.sh odyssey-stats fix/odyssey-stats-mini-carousel-button-link-routing` on your sandbox.
* Head to a Classic Simple site.
* Head to Jetpack > Stats App.
* Click the "Get Yoast" button in the Yoast banner.
* Ensure that you are redirected to the Plugins marketplace.
* Ensure that the button links works as before for Calypso Simple sites (wordpress.com/stats).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?