### PR TITLE
Monetize: move export supporters button to fix issues with infinite scroll

### DIFF
--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -1,5 +1,6 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
+import { Tooltip } from '@wordpress/components';
 import { saveAs } from 'browser-filesaver';
 import { useTranslate } from 'i18n-calypso';
 import { orderBy } from 'lodash';
@@ -140,7 +141,13 @@ function CustomerSection() {
 								<span className="supporters-list__since-column" role="columnheader">
 									{ translate( 'Since' ) }
 								</span>
-								<span className="supporters-list__menu-column" role="columnheader"></span>
+								<span className="supporters-list__menu-column" role="columnheader">
+									<Tooltip text={ translate( 'Download list as CSV' ) } delay={ 0 }>
+										<Button onClick={ downloadSubscriberList } compact>
+											{ translate( 'Export' ) }
+										</Button>
+									</Tooltip>
+								</span>
 							</li>
 							{ orderBy( Object.values( subscribers ), [ 'id' ], [ 'desc' ] ).map( ( sub ) =>
 								renderSubscriber( sub )
@@ -151,11 +158,6 @@ function CustomerSection() {
 							subscriberToCancel={ subscriberToCancel }
 							setSubscriberToCancel={ setSubscriberToCancel }
 						/>
-						<div className="memberships__module-footer">
-							<Button onClick={ downloadSubscriberList }>
-								{ translate( 'Download list as CSV' ) }
-							</Button>
-						</div>
 					</>
 				) }
 			</div>

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -158,6 +158,9 @@ function CustomerSection() {
 							subscriberToCancel={ subscriberToCancel }
 							setSubscriberToCancel={ setSubscriberToCancel }
 						/>
+						<div className="memberships__module-footer">
+							<Button onClick={ downloadSubscriberList }>{ translate( 'Export as CSV' ) }</Button>
+						</div>
 					</>
 				) }
 			</div>

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -314,6 +314,17 @@ body.is-section-earn.theme-default.color-scheme {
 	}
 }
 
+.memberships__module-footer {
+	display: none;
+	margin-top: 20px;
+}
+
+@media (max-width: $break-small) {
+	.memberships__module-footer {
+		display: block;
+	}
+}
+
 .memberships__module-plans-title,
 .memberships__products-card-title {
 	color: var(--color-neutral-100);

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -314,10 +314,6 @@ body.is-section-earn.theme-default.color-scheme {
 	}
 }
 
-.memberships__module-footer {
-	margin-top: 20px;
-}
-
 .memberships__module-plans-title,
 .memberships__products-card-title {
 	color: var(--color-neutral-100);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/89108

## Proposed Changes

* Moves export button from footer to header, to avoid issues with infinite scrolling on longer lists.
* Change button copy to simpler "Export" to be in line with other export functionality elsewhere (content, subscribers).

<img width="1321" alt="Screenshot 2024-04-02 at 14 20 35" src="https://github.com/Automattic/wp-calypso/assets/87168/43192477-2061-41f8-a648-020e35e93205">
<img width="1301" alt="Screenshot 2024-04-02 at 14 21 00" src="https://github.com/Automattic/wp-calypso/assets/87168/823a17f6-cd3d-468a-9aea-8221ad9e7565">

I left the mobile version as-is for now:

<img width="468" alt="Screenshot 2024-04-02 at 14 39 14" src="https://github.com/Automattic/wp-calypso/assets/87168/9d7cd1aa-764d-45d9-ad8f-ae72634db54d">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With paid subscribers on the site, load `/earn/supporters/SITE` with different screen sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?