### PR TITLE
A4A: Add a placeholder page when checking access permission.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-placeholder/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar-placeholder/index.tsx
@@ -4,6 +4,7 @@ import Sidebar, {
 	SidebarV2Footer as SidebarFooter,
 } from 'calypso/layout/sidebar-v2';
 
+import '../sidebar/style.scss'; // Need to import styling from sidebar.
 import './style.scss';
 
 export default function A4ASidebarPlaceholder() {

--- a/client/a8c-for-agencies/components/sidebar-placeholder/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar-placeholder/index.tsx
@@ -1,0 +1,26 @@
+import Sidebar, {
+	SidebarV2Header as SidebarHeader,
+	SidebarV2Main as SidebarMain,
+	SidebarV2Footer as SidebarFooter,
+} from 'calypso/layout/sidebar-v2';
+
+import './style.scss';
+
+export default function A4ASidebarPlaceholder() {
+	return (
+		<Sidebar className="a4a-sidebar a4a-sidebar-placeholder">
+			<SidebarHeader className="a4a-sidebar__header">
+				<div className="a4a-sidebar-placeholder__header-icon"></div>
+			</SidebarHeader>
+
+			<SidebarMain>
+				<div className="a4a-sidebar-placeholder__menu-item"></div>
+				<div className="a4a-sidebar-placeholder__menu-item"></div>
+			</SidebarMain>
+
+			<SidebarFooter>
+				<div className="a4a-sidebar-placeholder__menu-item"></div>
+			</SidebarFooter>
+		</Sidebar>
+	);
+}

--- a/client/a8c-for-agencies/components/sidebar-placeholder/style.scss
+++ b/client/a8c-for-agencies/components/sidebar-placeholder/style.scss
@@ -1,0 +1,25 @@
+@mixin loading-effect {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-sidebar-menu-selected-background);
+}
+
+.a4a-sidebar-placeholder {
+	.sidebar-v2__main,
+	.sidebar-v2__footer {
+		padding-inline: 8px;
+	}
+}
+
+.a4a-sidebar-placeholder__header-icon {
+	@include loading-effect;
+	width: 32px;
+	height: 32px;
+}
+
+.a4a-sidebar-placeholder__menu-item {
+	@include loading-effect;
+	width: 100%;
+	height: 32px;
+	margin-block-end: 4px;
+	border-radius: 4px;
+}

--- a/client/a8c-for-agencies/sections/landing/controller.tsx
+++ b/client/a8c-for-agencies/sections/landing/controller.tsx
@@ -1,8 +1,9 @@
 import { type Callback } from '@automattic/calypso-router';
+import SidebarPlaceholder from 'calypso/a8c-for-agencies/components/sidebar-placeholder';
 import Landing from './landing';
 
 export const landingContext: Callback = ( context, next ) => {
 	context.primary = <Landing />;
-
+	context.secondary = <SidebarPlaceholder />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/landing/landing.tsx
+++ b/client/a8c-for-agencies/sections/landing/landing.tsx
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { Spinner } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -15,6 +14,8 @@ import {
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency, hasFetchedAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+import './style.scss';
 
 export default function Landing() {
 	const translate = useTranslate();
@@ -43,14 +44,20 @@ export default function Landing() {
 	}, [ agency, hasFetched ] );
 
 	return (
-		<Layout title={ title } wide>
+		<Layout className="a4a-landing" title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>{ title }</Title>
+					<Title>
+						<div className="a4a-landing__title-placeholder"></div>
+					</Title>
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>
-				<Spinner />
+				<div className="a4a-landing__section-placeholder">
+					<div className="a4a-landing__section-placeholder-title"></div>
+					<div className="a4a-landing__section-placeholder-body"></div>
+					<div className="a4a-landing__section-placeholder-footer"></div>
+				</div>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/landing/style.scss
+++ b/client/a8c-for-agencies/sections/landing/style.scss
@@ -1,0 +1,40 @@
+@mixin loading-effect {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-neutral-10);
+}
+
+.a4a-landing__title-placeholder {
+	@include loading-effect;
+
+	width: 300px;
+	height: 43px;
+}
+
+.a4a-landing__section-placeholder {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.a4a-landing__section-placeholder-title {
+	@include loading-effect;
+
+	width: 100%;
+	height: 32px;
+}
+
+
+.a4a-landing__section-placeholder-body {
+	@include loading-effect;
+
+	width: 100%;
+	height: 200px;
+}
+
+.a4a-landing__section-placeholder-footer {
+	@include loading-effect;
+
+	width: 20%;
+	min-width: 100px;
+	height: 43px;
+}


### PR DESCRIPTION
After we added guards to check user permissions, this caused our pages to load with a slight delay. This PR includes a placeholder page to display during this delay and improve user experience.


https://github.com/Automattic/wp-calypso/assets/56598660/e95637c3-360b-41d9-ad39-05e20b18b2e1


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/190

## Proposed Changes

* Implement a sidebar placeholder component.
* Implement placeholder content on the Landing page where the pre-check happens.

## Testing Instructions

* Use the live link below and go to `/overview`.
* Confirm that in a brief moment, you see the placeholder page.
* If you wish to extend the moment where we display the placeholder page, set some internet throttle speed on your browser.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?