### PR TITLE
Pattern Library: Pass `redirect_to` param to signup and login URLs

### DIFF
--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -26,7 +26,10 @@ export const PatternsGetAccessModal = ( {
 		typeof window !== 'undefined' ? location.href.replace( location.origin, '' ) : '';
 
 	const signupUrl = localizeUrl(
-		`//wordpress.com/start/account/user?${ buildQueryString( { redirect_to: redirectUrl } ) }`,
+		`//wordpress.com/start/account/user?${ buildQueryString( {
+			redirect_to: redirectUrl,
+			ref: 'pattern-library',
+		} ) }`,
 		locale,
 		isLoggedIn
 	);

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -1,7 +1,10 @@
 import { Button, Dialog } from '@automattic/components';
 import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
+import { buildQueryString } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { usePatternsContext } from 'calypso/my-sites/patterns/context';
+import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
 
 import './style.scss';
 
@@ -17,12 +20,25 @@ export const PatternsGetAccessModal = ( {
 	tracksEventHandler,
 }: PatternsGetAccessModalProps ) => {
 	const locale = useLocale();
+	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
+	const { category, isGridView, patternTypeFilter } = usePatternsContext();
 
 	const isLoggedIn = false;
-	const startUrl = localizeUrl( '//wordpress.com/start/account/user', locale, isLoggedIn );
-	const loginUrl = localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn );
-	const translate = useTranslate();
+	const redirectUrl =
+		getCategoryUrlPath( category, patternTypeFilter ) + ( isGridView ? '?grid=1' : '' );
+
+	const signupUrl = localizeUrl(
+		`//wordpress.com/start/account/user?${ buildQueryString( { redirect_to: redirectUrl } ) }`,
+		locale,
+		isLoggedIn
+	);
+
+	const loginUrl = localizeUrl(
+		`//wordpress.com/log-in?${ buildQueryString( { redirect_to: redirectUrl } ) }`,
+		locale,
+		isLoggedIn
+	);
 
 	return (
 		<Dialog
@@ -44,6 +60,7 @@ export const PatternsGetAccessModal = ( {
 				>
 					<Icon icon={ iconClose } size={ 24 } />
 				</button>
+
 				<div className="patterns-get-access-modal__inner">
 					<div className="patterns-get-access-modal__title">
 						{ translate( 'Unlock the full pattern library', {
@@ -59,7 +76,7 @@ export const PatternsGetAccessModal = ( {
 					<div className="patterns-get-access-modal__upgrade-buttons">
 						<Button
 							primary
-							href={ startUrl }
+							href={ signupUrl }
 							onClick={ () => tracksEventHandler( 'calypso_pattern_library_get_access_signup' ) }
 						>
 							{ translate( 'Create a free account' ) }

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -3,8 +3,6 @@ import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
 import { buildQueryString } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { usePatternsContext } from 'calypso/my-sites/patterns/context';
-import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
 
 import './style.scss';
 
@@ -22,11 +20,10 @@ export const PatternsGetAccessModal = ( {
 	const locale = useLocale();
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
-	const { category, isGridView, patternTypeFilter } = usePatternsContext();
 
 	const isLoggedIn = false;
 	const redirectUrl =
-		getCategoryUrlPath( category, patternTypeFilter ) + ( isGridView ? '?grid=1' : '' );
+		typeof window !== 'undefined' ? location.href.replace( location.origin, '' ) : '';
 
 	const signupUrl = localizeUrl(
 		`//wordpress.com/start/account/user?${ buildQueryString( { redirect_to: redirectUrl } ) }`,

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -3,27 +3,34 @@ import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
 import { buildQueryString } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { usePatternsContext } from 'calypso/my-sites/patterns/context';
+import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
+import { getPatternPermalink } from 'calypso/my-sites/patterns/lib/get-pattern-permalink';
+import { Pattern } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
 type PatternsGetAccessModalProps = {
 	isOpen: boolean;
 	onClose: () => void;
+	pattern: Pattern;
 	tracksEventHandler: ( eventName: string ) => void;
 };
 
 export const PatternsGetAccessModal = ( {
 	isOpen,
 	onClose,
+	pattern,
 	tracksEventHandler,
 }: PatternsGetAccessModalProps ) => {
 	const locale = useLocale();
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
+	const { category, patternTypeFilter } = usePatternsContext();
+	const { data: categories = [] } = usePatternCategories( locale );
 
 	const isLoggedIn = false;
-	const redirectUrl =
-		typeof window !== 'undefined' ? location.href.replace( location.origin, '' ) : '';
+	const redirectUrl = getPatternPermalink( pattern, category, patternTypeFilter, categories );
 
 	const signupUrl = localizeUrl(
 		`//wordpress.com/start/account/user?${ buildQueryString( {

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { getPatternPermalink } from 'calypso/my-sites/patterns/lib/get-pattern-permalink';
+import { URL_REFERRER_PARAM } from 'calypso/my-sites/patterns/paths';
 import { Pattern } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
@@ -35,7 +36,7 @@ export const PatternsGetAccessModal = ( {
 	const signupUrl = localizeUrl(
 		`//wordpress.com/start/account/user?${ buildQueryString( {
 			redirect_to: redirectUrl,
-			ref: 'pattern-library',
+			ref: URL_REFERRER_PARAM,
 		} ) }`,
 		locale,
 		isLoggedIn

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -21,12 +21,12 @@ import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 import { filterPatternsByTerm } from 'calypso/my-sites/patterns/lib/filter-patterns-by-term';
+import { getPatternPermalink } from 'calypso/my-sites/patterns/lib/get-pattern-permalink';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
 import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
 import {
 	PatternTypeFilter,
 	PatternView,
-	type Category,
 	type CategoryGalleryFC,
 	type Pattern,
 	type PatternGalleryFC,
@@ -50,25 +50,6 @@ function filterPatternsByType( patterns: Pattern[], type: PatternTypeFilter ) {
 
 		return type === PatternTypeFilter.PAGES ? isPage : ! isPage;
 	} );
-}
-
-// We intentionally disregard grid view when copying the pattern permalink. Our assumption is that
-// it will be more confusing for users to land in grid view when they have a single-pattern permalink
-function getPatternPermalink(
-	pattern: Pattern,
-	activeCategory: string,
-	patternTypeFilter: PatternTypeFilter,
-	categories: Category[]
-) {
-	// Get the first pattern category that is also included in the `usePatternCategories` data
-	const patternCategory = Object.keys( pattern.categories ).find( ( categorySlug ) =>
-		categories.find( ( { name } ) => name === categorySlug )
-	);
-	const pathname = getCategoryUrlPath( activeCategory || patternCategory || '', patternTypeFilter );
-
-	const url = new URL( pathname, location.origin );
-	url.hash = `#pattern-${ pattern.ID }`;
-	return url.toString();
 }
 
 // Scroll to anchoring position of category pill navigation element

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -270,6 +270,7 @@ function PatternPreviewFragment( {
 			<PatternsGetAccessModal
 				isOpen={ isAuthModalOpen }
 				onClose={ () => setIsAuthModalOpen( false ) }
+				pattern={ pattern }
 				tracksEventHandler={ recordGetAccessEvent }
 			/>
 		</div>

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -25,8 +25,8 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 	context.primary = (
 		<PatternsContext.Provider
 			value={ {
-				searchTerm: context.query[ QUERY_PARAM_SEARCH ] || '',
-				category: context.params.category,
+				searchTerm: context.query[ QUERY_PARAM_SEARCH ] ?? '',
+				category: context.params.category ?? '',
 				isGridView: !! context.query.grid,
 				patternTypeFilter:
 					context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR,

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -38,8 +38,8 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 		context.primary = (
 			<PatternsContext.Provider
 				value={ {
-					searchTerm: context.query[ QUERY_PARAM_SEARCH ] || '',
-					category: context.params.category,
+					searchTerm: context.query[ QUERY_PARAM_SEARCH ] ?? '',
+					category: context.params.category ?? '',
 					isGridView: !! context.query.grid,
 					patternTypeFilter:
 						context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR,

--- a/client/my-sites/patterns/lib/get-pattern-permalink.ts
+++ b/client/my-sites/patterns/lib/get-pattern-permalink.ts
@@ -1,0 +1,21 @@
+import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
+import { PatternTypeFilter, Category, Pattern } from 'calypso/my-sites/patterns/types';
+
+// We intentionally disregard grid view when generating pattern permalinks. Our assumption is that
+// it will be more confusing for users to land in grid view when they have a single-pattern permalink
+export function getPatternPermalink(
+	pattern: Pattern,
+	activeCategory: string,
+	patternTypeFilter: PatternTypeFilter,
+	categories: Category[]
+) {
+	// Get the first pattern category that is also included in the `usePatternCategories` data
+	const patternCategory = Object.keys( pattern.categories ).find( ( categorySlug ) =>
+		categories.find( ( { name } ) => name === categorySlug )
+	);
+	const pathname = getCategoryUrlPath( activeCategory || patternCategory || '', patternTypeFilter );
+
+	const url = new URL( pathname, location.origin );
+	url.hash = `#pattern-${ pattern.ID }`;
+	return url.toString();
+}

--- a/client/my-sites/patterns/paths.ts
+++ b/client/my-sites/patterns/paths.ts
@@ -1,4 +1,5 @@
 import { addLocaleToPathLocaleInFront, localizeUrl } from '@automattic/i18n-utils';
+import { buildQueryString } from '@wordpress/url';
 import { PatternTypeFilter } from 'calypso/my-sites/patterns/types';
 import type { Locale } from '@automattic/i18n-utils';
 
@@ -16,5 +17,11 @@ export function getCategoryUrlPath(
 }
 
 export function getOnboardingUrl( locale: Locale, isLoggedIn: boolean ) {
-	return localizeUrl( 'https://wordpress.com/setup/assembler-first', locale, isLoggedIn );
+	return localizeUrl(
+		`https://wordpress.com/setup/assembler-first?${ buildQueryString( {
+			ref: 'pattern-library',
+		} ) }`,
+		locale,
+		isLoggedIn
+	);
 }

--- a/client/my-sites/patterns/paths.ts
+++ b/client/my-sites/patterns/paths.ts
@@ -3,6 +3,8 @@ import { buildQueryString } from '@wordpress/url';
 import { PatternTypeFilter } from 'calypso/my-sites/patterns/types';
 import type { Locale } from '@automattic/i18n-utils';
 
+export const URL_REFERRER_PARAM = 'pattern-library';
+
 export function getCategoryUrlPath(
 	categorySlug: string,
 	type: PatternTypeFilter,
@@ -19,7 +21,7 @@ export function getCategoryUrlPath(
 export function getOnboardingUrl( locale: Locale, isLoggedIn: boolean ) {
 	return localizeUrl(
 		`https://wordpress.com/setup/assembler-first?${ buildQueryString( {
-			ref: 'pattern-library',
+			ref: URL_REFERRER_PARAM,
 		} ) }`,
 		locale,
 		isLoggedIn


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6366 and https://github.com/Automattic/dotcom-forge/issues/6250

## Proposed Changes

This PR makes it so that the `Create a free account` and `Log in` links in the `Get access` modal will ultimately redirect the user back to the page they were looking at.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open an incognito window
2. Navigate to `/patterns`
3. Search for `contact`
4. Scroll down until you see a `Get access` button
5. Click it
6. Complete signup
7. Ensure that you are redirected back to the search page
8. Repeat the same process, but try it with a category page (instead of a search page) and with logging in instead of signing up
