### PR TITLE
A4A: Ensuring favorites functionaity works again from dashboard

### DIFF
--- a/client/data/agency-dashboard/use-toggle-favourite-site-mutation.ts
+++ b/client/data/agency-dashboard/use-toggle-favourite-site-mutation.ts
@@ -1,20 +1,24 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
 import {
 	APIError,
 	APIToggleFavorite,
 	ToggleFavoriteOptions,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
-import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+
+const client = isEnabled( 'a8c-for-agencies' ) ? wpcom : wpcomJpl;
 
 function mutationToggleFavoriteSite( {
 	siteId,
 	isFavorite,
+	agencyId,
 }: ToggleFavoriteOptions ): Promise< APIToggleFavorite > {
-	return wpcomJpl.req.post( {
+	return client.req.post( {
 		method: isFavorite ? 'DELETE' : 'POST',
 		path: '/jetpack-agency/sites/favorite',
 		apiNamespace: 'wpcom/v2',
-		body: { site_id: siteId },
+		body: { site_id: siteId, agency_id: agencyId },
 	} );
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -285,6 +285,7 @@ export interface APIToggleFavorite {
 export interface ToggleFavoriteOptions {
 	siteId: number;
 	isFavorite: boolean;
+	agencyId: number;
 }
 
 interface MonitorURLS {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -285,7 +285,7 @@ export interface APIToggleFavorite {
 export interface ToggleFavoriteOptions {
 	siteId: number;
 	isFavorite: boolean;
-	agencyId: number;
+	agencyId?: number;
 }
 
 interface MonitorURLS {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/169

## Proposed Changes

* This PR modifies the client and queryKey as used by sites favorites in A4A to ensure that the agency ID is passed through, and that this is correctly passed to the endpoint.
* The approach is largely similar to that included here: https://github.com/Automattic/wp-calypso/pull/89032/commits/26ef6728f6972293efd94462826d58a72d3d6402
* Note - this is a partial fix, as page refresh is still needed after clicking on a favorites icon (both for removing and adding a favorite). This will be tackled separately - more context in Slack here: p1712066839677589/1712060139.440939-slack-CTXBP902X


## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* From the sites dashboard, add or remove any favorited sites by hovering over the favorites icon in the sites dashboard for those sites. You should see a notice saying you have successfully added or removed the site from favorites.
* Refresh the page to see the change take effect. For changes to take immediate effect, more work will be done later (see the note under proposed changes above).



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?