### PR TITLE
Help Center: Add close and back log events

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -51,6 +52,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 
 	const onDismiss = () => {
 		setIsVisible( false );
+		recordTracksEvent( `calypso_inlinehelp_close` );
 	};
 
 	const toggleVisible = () => {

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -42,6 +42,7 @@ export const HelpCenterEmbedResult: React.FC = () => {
 			result_url: link,
 			post_id: postId,
 			blog_id: blogId,
+			search_query: query,
 		} );
 		if ( canNavigateBack ) {
 			navigate( -1 );

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -38,6 +38,11 @@ export const HelpCenterEmbedResult: React.FC = () => {
 	}, [ query, link, sectionName, postId, blogId ] );
 
 	const redirectBack = () => {
+		recordTracksEvent( `calypso_inlinehelp_navigate_back`, {
+			result_url: link,
+			post_id: postId,
+			blog_id: blogId,
+		} );
 		if ( canNavigateBack ) {
 			navigate( -1 );
 		} else if ( query ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Currently Help center fires `calypso_inlinehelp_close` only when clicking on the `?` icon, this PR adds the same event also when clicking on `X` and `calypso_inlinehelp_navigate_back`  when clicking(navigating) `back`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link
* Navigate to any site you have and open the Help center
* Make sure you have tracks vigilante PCYsg-T9m-p2 installed 
* When closing the help center using `x` it should fire `calypso_inlinehelp_close`
* When navigating back using the back button, it should fire `calypso_inlinehelp_navigate_back`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?