### PR TITLE
Stats: Adjust the Stats purchase page layout on mobile

### DIFF
--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -7,7 +7,7 @@
 $stats-background-color: #fdfdfd;
 $stats-sections-max-width: 1224px;
 $stats-layout-contnet-padding-top: 79px;
-$sidebar-appearance-break-point: 783px;
+$sidebar-appearance-break-point: $break-medium;
 
 // Elements above main layout content per pages
 .stats__section-header,

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -424,11 +424,6 @@ $button-padding: 8px 32px;
 	}
 
 	.components-button {
-		@media (max-width: $break-small) {
-			width: 100%;
-			justify-content: center;
-		}
-
 		&.is-primary {
 			border-radius: 4px;
 			color: var(--jp-white);
@@ -561,6 +556,13 @@ $button-padding: 8px 32px;
 
 	.components-button + button.components-button {
 		margin: 0;
+	}
+
+	button {
+		@media (max-width: $break-small) {
+			width: 100%;
+			justify-content: center;
+		}
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -190,24 +190,24 @@ $button-padding: 8px 32px;
 	}
 
 	.stats-purchase-wizard__card-inner--right {
-		display: flex;
+		display: none;
 		align-items: center;
 		background: #f9f9f6;
 		border-top-right-radius: 4px;
 		border-bottom-right-radius: 4px;
 		flex: 1 1 var(--stats-purchase-right-width);
 
-		// Hide the right side on a smaller content area due to the sidebar menu.
-		@media (max-width: $break-large) {
-			display: none;
-		}
-
-		@media (max-width: $break-medium) {
+		@media (min-width: $break-small) {
 			display: flex;
 		}
 
-		@media (max-width: $break-small) {
+		@media (min-width: $break-medium) {
 			display: none;
+		}
+
+		// Hide the right side on a smaller content area due to the sidebar menu.
+		@media (min-width: $break-large) {
+			display: flex;
 		}
 
 		> * {

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -424,6 +424,11 @@ $button-padding: 8px 32px;
 	}
 
 	.components-button {
+		@media (max-width: $break-small) {
+			width: 100%;
+			justify-content: center;
+		}
+
 		&.is-primary {
 			border-radius: 4px;
 			color: var(--jp-white);
@@ -434,11 +439,6 @@ $button-padding: 8px 32px;
 			line-height: 24px;
 			padding: $button-padding;
 			height: auto;
-
-			@media (max-width: $break-small) {
-				width: 100%;
-				justify-content: center;
-			}
 
 			&:hover,
 			&:active,

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -9,9 +9,7 @@ $button-padding: 8px 32px;
 	--jp-white: #fff;
 	--jp-green-50: #008710;
 	--gray-gray-50: #646970;
-	--stats-purchase-left-min-width: 500px;
-	--stats-purchase-left-max-width: 700px;
-	--stats-purchase-right-width: 456px;
+	--stats-purchase-right-width: 256px;
 
 	// Apply Jetpack dedicated styling upon the Calypso theme base.
 	&:not(.stats-purchase-page--is-wpcom) {
@@ -170,6 +168,7 @@ $button-padding: 8px 32px;
 
 	.stats-purchase-wizard__card {
 		display: flex;
+
 		h1,
 		.components-panel__header h2 {
 			color: var(--studio-black);
@@ -182,27 +181,37 @@ $button-padding: 8px 32px;
 
 	.stats-purchase-wizard__card-inner--left {
 		padding: 64px;
-		min-width: var(--stats-purchase-left-min-width);
-		max-width: var(--stats-purchase-left-max-width);
-		width: 60%;
 		box-sizing: border-box;
+		flex: 1 2 auto;
+
+		@media (max-width: $break-medium) {
+			padding: 32px 24px;
+		}
 	}
 
 	.stats-purchase-wizard__card-inner--right {
 		display: flex;
 		align-items: center;
-		width: var(--stats-purchase-right-width);
 		background: #f9f9f6;
 		border-top-right-radius: 4px;
 		border-bottom-right-radius: 4px;
+		flex: 2 1 var(--stats-purchase-right-width);
+
+		// Hide the right side on a smaller content area due to the sidebar menu.
+		@media (max-width: $break-large) {
+			display: none;
+		}
+
+		@media (max-width: $break-medium) {
+			display: flex;
+		}
+
+		@media (max-width: $break-small) {
+			display: none;
+		}
 
 		> * {
 			z-index: 2;
-		}
-
-		img,
-		svg {
-			min-width: 400px;
 		}
 	}
 
@@ -230,6 +239,7 @@ $button-padding: 8px 32px;
 			margin-bottom: 8px;
 			padding-left: 28px;
 			background: no-repeat 0 50%;
+			background-position-y: top;
 
 			display: flex;
 			align-items: center;
@@ -424,6 +434,11 @@ $button-padding: 8px 32px;
 			line-height: 24px;
 			padding: $button-padding;
 			height: auto;
+
+			@media (max-width: $break-small) {
+				width: 100%;
+				justify-content: center;
+			}
 
 			&:hover,
 			&:active,

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -9,7 +9,7 @@ $button-padding: 8px 32px;
 	--jp-white: #fff;
 	--jp-green-50: #008710;
 	--gray-gray-50: #646970;
-	--stats-purchase-right-width: 256px;
+	--stats-purchase-right-width: 456px;
 
 	// Apply Jetpack dedicated styling upon the Calypso theme base.
 	&:not(.stats-purchase-page--is-wpcom) {
@@ -182,7 +182,7 @@ $button-padding: 8px 32px;
 	.stats-purchase-wizard__card-inner--left {
 		padding: 64px;
 		box-sizing: border-box;
-		flex: 1 2 auto;
+		flex: 2 1 auto;
 
 		@media (max-width: $break-medium) {
 			padding: 32px 24px;
@@ -195,7 +195,7 @@ $button-padding: 8px 32px;
 		background: #f9f9f6;
 		border-top-right-radius: 4px;
 		border-bottom-right-radius: 4px;
-		flex: 2 1 var(--stats-purchase-right-width);
+		flex: 1 1 var(--stats-purchase-right-width);
 
 		// Hide the right side on a smaller content area due to the sidebar menu.
 		@media (max-width: $break-large) {

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -1,4 +1,5 @@
 @use "sass:math";
+@import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography.scss";
 
 $slider-height: 40px;
@@ -112,23 +113,39 @@ $track-height: 4px;
 .tier-upgrade-slider__step-callouts {
 	display: flex;
 	justify-content: space-between;
+	align-items: end;
 
 	h2 {
 		font-size: $font-body-small;
 		font-weight: 600;
+
+		@media (max-width: $break-medium) {
+			font-size: $font-body-extra-small;
+		}
 	}
+
 	p {
 		font-size: $font-headline-small;
 		font-weight: bold;
 		margin: 0;
+
+		@media (max-width: $break-medium) {
+			font-size: $font-title-medium;
+		}
 	}
+
 	.right-aligned {
 		text-align: right;
 	}
+
 	.full-price-label {
 		font-size: $font-title-medium;
 		color: var(--studio-gray-40);
 		text-decoration: line-through;
+
+		@media (max-width: $break-medium) {
+			font-size: $font-body-large;
+		}
 	}
 
 	svg {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84885

## Proposed Changes

* Make the purchase page layout more responsive to the window size.
* Adjust the font size on a smaller screen.

<img width="488" alt="截圖 2024-04-04 上午12 30 31" src="https://github.com/Automattic/wp-calypso/assets/6869813/36fef680-3329-4843-a0da-70e03f978e56">
<img width="497" alt="截圖 2024-04-04 上午12 30 38" src="https://github.com/Automattic/wp-calypso/assets/6869813/c5b73a60-bc9e-4848-b025-0f5bf4d6b5a7">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to the Stats **personal / commercial** purchase page: `/stats/purchase/{site-slug}?productType=personal(commercial)`.
* Resize the browser window to any width.
* Ensure the page layout is responsive and works well for mobile viewports.

|Full size|>= 960px|>= 782px|> 600px|<= 600px|
|-|-|-|-|-|
|<img width="1307" alt="full_size" src="https://github.com/Automattic/wp-calypso/assets/6869813/0aa069c6-d182-4016-99f2-ae36acbe5871">|<img width="664" alt="width_961" src="https://github.com/Automattic/wp-calypso/assets/6869813/d535ffae-4bf5-4158-9a63-f5426d7222a0">|<img width="471" alt="width_782" src="https://github.com/Automattic/wp-calypso/assets/6869813/a9d50d33-a0cb-4b87-a590-1bbd8898773f">|<img width="651" alt="width_780" src="https://github.com/Automattic/wp-calypso/assets/6869813/1d9d3af4-0172-4ff2-ab20-4d74ffcbe128">|<img width="454" alt="width_453" src="https://github.com/Automattic/wp-calypso/assets/6869813/04474580-8d26-4533-a0b9-b90e938bcf33">|

|Full size|>= 960px|>= 782px|> 600px|<= 600px|
|-|-|-|-|-|
|<img width="1205" alt="截圖 2024-04-04 上午12 21 05" src="https://github.com/Automattic/wp-calypso/assets/6869813/cca72c81-d945-4335-ab36-f0eb5bc60143">|<img width="605" alt="截圖 2024-04-04 上午12 21 48" src="https://github.com/Automattic/wp-calypso/assets/6869813/1606e047-0481-4457-a5da-57b242dc7cec">|<img width="514" alt="截圖 2024-04-04 上午12 22 09" src="https://github.com/Automattic/wp-calypso/assets/6869813/bea23ded-0dee-40ed-8058-f8bcb7af41ff">|<img width="683" alt="截圖 2024-04-04 上午12 22 23" src="https://github.com/Automattic/wp-calypso/assets/6869813/18367c1c-df89-45f3-8a5b-445ba58eeaeb">|<img width="469" alt="截圖 2024-04-04 上午12 22 40" src="https://github.com/Automattic/wp-calypso/assets/6869813/f87bbcb3-878f-47f8-8cee-591ec3f1d334">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?