### PR TITLE
Removed unnecessary calls to backend API at the hosting-config page

### DIFF
--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -31,10 +31,13 @@ const HostingActivateStatus = ( {
 	const { isTransferring, transferStatus } = useAtomicTransferQuery( siteId ?? 0, {
 		refetchInterval: 5000,
 	} );
+
 	const dispatch = useDispatch();
-	const isTransferCompleted = ! transferInProgress.includes(
-		transferStatus as ( typeof transferInProgress )[ number ]
-	);
+	const isTransferCompleted =
+		! transferInProgress.includes( transferStatus as ( typeof transferInProgress )[ number ] ) &&
+		transferStatus !== transferStates.REVERTED &&
+		transferStatus !== transferStates.NONE &&
+		transferStatus !== undefined;
 	const [ wasTransferring, setWasTransferring ] = useState( false );
 
 	useEffect( () => {

--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -2,7 +2,6 @@ import { translate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
-import { useDispatch } from 'calypso/state';
 import { useAtomicTransferQuery } from 'calypso/state/atomic-transfer/use-atomic-transfer-query';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferInProgress, transferStates } from 'calypso/state/automated-transfer/constants';
@@ -32,7 +31,6 @@ const HostingActivateStatus = ( {
 		refetchInterval: 5000,
 	} );
 
-	const dispatch = useDispatch();
 	const isTransferCompleted =
 		! transferInProgress.includes( transferStatus as ( typeof transferInProgress )[ number ] ) &&
 		transferStatus !== transferStates.REVERTED &&
@@ -46,9 +44,6 @@ const HostingActivateStatus = ( {
 		}
 		if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
 			setWasTransferring( false );
-		}
-		if ( ! isTransferCompleted ) {
-			dispatch( fetchAutomatedTransferStatus( siteId ?? 0 ) );
 		}
 		onTick?.( isTransferring, wasTransferring, isTransferCompleted );
 	}, [ isTransferCompleted, isTransferring, onTick, wasTransferring ] );

--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -2,6 +2,7 @@ import { translate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
+import { useDispatch } from 'calypso/state';
 import { useAtomicTransferQuery } from 'calypso/state/atomic-transfer/use-atomic-transfer-query';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferInProgress, transferStates } from 'calypso/state/automated-transfer/constants';
@@ -31,6 +32,7 @@ const HostingActivateStatus = ( {
 		refetchInterval: 5000,
 	} );
 
+	const dispatch = useDispatch();
 	const isTransferCompleted =
 		! transferInProgress.includes( transferStatus as ( typeof transferInProgress )[ number ] ) &&
 		transferStatus !== transferStates.REVERTED &&
@@ -44,6 +46,9 @@ const HostingActivateStatus = ( {
 		}
 		if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
 			setWasTransferring( false );
+		}
+		if ( ! isTransferCompleted ) {
+			dispatch( fetchAutomatedTransferStatus( siteId ?? 0 ) );
 		}
 		onTick?.( isTransferring, wasTransferring, isTransferCompleted );
 	}, [ isTransferCompleted, isTransferring, onTick, wasTransferring ] );

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -210,7 +210,7 @@ const Hosting = ( props ) => {
 				transferStates.REVERTED,
 			].includes( transferState )
 	);
-	const [ shouldPoolTransferResults, setShouldPoolTransferResults ] = useState( true );
+	const [ shouldPullTransferResults, setShouldPullTransferResults ] = useState( true );
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showHostingActivationBanner = canSiteGoAtomic && ! hasTransfer;
@@ -228,11 +228,11 @@ const Hosting = ( props ) => {
 
 	const trialRequested = () => {
 		setHasTransferring( true );
-		setShouldPoolTransferResults( true );
+		setShouldPullTransferResults( true );
 	};
 
 	const activationRequested = () => {
-		setShouldPoolTransferResults( true );
+		setShouldPullTransferResults( true );
 		clickActivate();
 	};
 
@@ -247,11 +247,11 @@ const Hosting = ( props ) => {
 			}
 
 			if ( isTransferCompleted && ! isTransferring ) {
-				setShouldPoolTransferResults( false );
+				setShouldPullTransferResults( false );
 			}
 
 			if ( ! isSiteAtomic && ! hasTransfer ) {
-				setShouldPoolTransferResults( false );
+				setShouldPullTransferResults( false );
 			}
 		},
 		[ hasTransfer ]
@@ -350,7 +350,7 @@ const Hosting = ( props ) => {
 				title={ translate( 'Hosting' ) }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
-			{ shouldPoolTransferResults &&
+			{ shouldPullTransferResults &&
 				! showHostingActivationBanner &&
 				! isTrialAcknowledgeModalOpen && (
 					<HostingActivateStatus

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -210,6 +210,7 @@ const Hosting = ( props ) => {
 				transferStates.REVERTED,
 			].includes( transferState )
 	);
+	const [ shouldPoolTransferResults, setShouldPoolTransferResults ] = useState( true );
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showHostingActivationBanner = canSiteGoAtomic && ! hasTransfer;
@@ -227,6 +228,12 @@ const Hosting = ( props ) => {
 
 	const trialRequested = () => {
 		setHasTransferring( true );
+		setShouldPoolTransferResults( true );
+	};
+
+	const activationRequested = () => {
+		setShouldPoolTransferResults( true );
+		clickActivate();
 	};
 
 	const requestUpdatedSiteData = useCallback(
@@ -238,8 +245,16 @@ const Hosting = ( props ) => {
 			if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
 				fetchUpdatedData();
 			}
+
+			if ( isTransferCompleted && ! isTransferring ) {
+				setShouldPoolTransferResults( false );
+			}
+
+			if ( ! isSiteAtomic && ! hasTransfer ) {
+				setShouldPoolTransferResults( false );
+			}
 		},
-		[]
+		[ hasTransfer ]
 	);
 
 	const getUpgradeBanner = () => {
@@ -277,7 +292,10 @@ const Hosting = ( props ) => {
 					icon="globe"
 				>
 					<TrackComponentView eventName="calypso_hosting_configuration_activate_impression" />
-					<NoticeAction onClick={ clickActivate } href={ `/hosting-config/activate/${ siteSlug }` }>
+					<NoticeAction
+						onClick={ activationRequested }
+						href={ `/hosting-config/activate/${ siteSlug }` }
+					>
 						{ translate( 'Activate' ) }
 					</NoticeAction>
 				</Notice>
@@ -332,13 +350,15 @@ const Hosting = ( props ) => {
 				title={ translate( 'Hosting' ) }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
-			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (
-				<HostingActivateStatus
-					context="hosting"
-					onTick={ requestUpdatedSiteData }
-					keepAlive={ ! isSiteAtomic && hasTransfer }
-				/>
-			) }
+			{ shouldPoolTransferResults &&
+				! showHostingActivationBanner &&
+				! isTrialAcknowledgeModalOpen && (
+					<HostingActivateStatus
+						context="hosting"
+						onTick={ requestUpdatedSiteData }
+						keepAlive={ ! isSiteAtomic && hasTransfer }
+					/>
+				) }
 			{ ! isBusinessTrial && banner }
 			{ isBusinessTrial && ( ! hasTransfer || isSiteAtomic ) && (
 				<TrialBanner

--- a/client/my-sites/hosting/test/hosting-activate-status.jsx
+++ b/client/my-sites/hosting/test/hosting-activate-status.jsx
@@ -45,6 +45,38 @@ jest.mock( 'calypso/state/atomic-transfer/use-atomic-transfer-query', () => {
 } );
 
 describe( 'index', () => {
+	test( 'Transfer status COMPLETED should return isTransferCompleted true', async () => {
+		mockTransferStatus = transferStates.COMPLETED;
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		const onTick = jest.fn();
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus onTick={ onTick } context="hosting" />
+			</Provider>
+		);
+
+		expect( onTick ).toHaveBeenCalledWith( true, false, true );
+	} );
+
+	test( 'Transfer status NONE should return isTransferCompleted false', async () => {
+		mockTransferStatus = transferStates.NONE;
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		const onTick = jest.fn();
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus onTick={ onTick } context="hosting" />
+			</Provider>
+		);
+
+		expect( onTick ).toHaveBeenCalledWith( true, false, false );
+	} );
+
 	test( 'Should show the transferring notice when the site is transferring to Atomic based on context', async () => {
 		mockTransferStatus = transferStates.PENDING;
 		const mockStore = configureStore();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5884

## Proposed Changes

* Avoid unnecessary updates on the /hosting-config page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure we call the `/atomic/transfers/latest` endpoint only when necessary
* Ensure the screen works for the states we use it:

  - Reverted free site to trial: Ensure it only pulls after requesting a trial and successfully continues to pull after it stops after the transition is completed.
  - Ensure Atomic sites don’t pull (only one time)
  - New simple sites only pull once
  - New simple sites are migrating to atomic
  - Simple Atomic sites (creator plan not migrated yet) work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?