### PR TITLE
Migration plan step: Update trial position

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -79,6 +79,53 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		);
 	}, [] );
 
+	const renderCTAs = () => {
+		const cta = ctaText === '' ? translate( 'Continue' ) : ctaText;
+		const trialText = translate( 'Try 7 days for free' );
+
+		if ( ! isEnabled( 'plans/migration-trial' ) ) {
+			return (
+				<NextButton isBusy={ isBusy } onClick={ onCtaClick }>
+					{ cta }
+				</NextButton>
+			);
+		}
+
+		if ( isEligibleForTrialPlan ) {
+			return (
+				<>
+					<NextButton isBusy={ isAddingTrial } onClick={ onFreeTrialClick }>
+						{ trialText }
+					</NextButton>
+					<Button
+						busy={ isBusy }
+						disabled={ isAddingTrial }
+						transparent={ ! isAddingTrial }
+						onClick={ onCtaClick }
+					>
+						{ cta }
+					</Button>
+				</>
+			);
+		}
+
+		return (
+			<>
+				<NextButton isBusy={ isBusy } onClick={ onCtaClick }>
+					{ cta }
+				</NextButton>
+				<Button disabled={ true } transparent={ true }>
+					{ trialText }
+				</Button>
+				<small>
+					{ translate(
+						'Free trials are a one-time offer and you’ve already enrolled in one in the past.'
+					) }
+				</small>
+			</>
+		);
+	};
+
 	return (
 		<div className="import__upgrade-plan">
 			{ ! hideTitleAndSubTitle && (
@@ -116,38 +163,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 				</div>
 			) }
 
-			<UpgradePlanDetails>
-				{ isEnabled( 'plans/migration-trial' ) ? (
-					<>
-						<NextButton
-							isBusy={ isAddingTrial }
-							disabled={ ! isEligibleForTrialPlan }
-							onClick={ onFreeTrialClick }
-						>
-							{ translate( 'Try 7 days for free' ) }
-						</NextButton>
-						{ ! isEligibleForTrialPlan && (
-							<small>
-								{ translate(
-									'Free trials are a one-time offer and you’ve already enrolled in one in the past.'
-								) }
-							</small>
-						) }
-						<Button
-							busy={ isBusy }
-							disabled={ isAddingTrial }
-							transparent={ ! isAddingTrial }
-							onClick={ onCtaClick }
-						>
-							{ ctaText === '' ? translate( 'Continue' ) : ctaText }
-						</Button>
-					</>
-				) : (
-					<NextButton isBusy={ isBusy } onClick={ onCtaClick }>
-						{ ctaText }
-					</NextButton>
-				) }
-			</UpgradePlanDetails>
+			<UpgradePlanDetails>{ renderCTAs() }</UpgradePlanDetails>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/89102

## Proposed Changes

If the user is not eligible for a trial we now have this:

![image](https://github.com/Automattic/wp-calypso/assets/52076348/15582bea-2564-4985-8eb6-186179670a07)

With this PR, in this case we swap the CTA and the trial.

![image](https://github.com/Automattic/wp-calypso/assets/52076348/731721fd-edaa-40ef-aba1-f411304b30bb)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch.
* Navigate to `/setup/import-hosted-site`, add your domain, and select a site that is on a free plan to migrate into.
* Compare design to figma

To quick test a not eligible user, set [isEligibleForTrialPlan](https://github.com/Automattic/wp-calypso/blob/update/trial-cta/client/blocks/importer/wordpress/upgrade-plan/index.tsx#L53) to false
