### PR TITLE
Hide 2 year upsell if discount is non-positive

### DIFF
--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -234,6 +234,10 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 
 	const { percentSavings, priceBreakdown, finalBreakdown } = calculatedDiscounts;
 
+	if ( percentSavings <= 0 ) {
+		return null;
+	}
+
 	const hasIntroductoryOffers = priceBreakdown.some(
 		( breakdown ) => breakdown.isIntroductoryOffer
 	);


### PR DESCRIPTION
## Proposed Changes

* Add check to conditionally hide 2 year upsell if discount is 0 or less

## Testing Instructions

1. Spin up a jurassic ninja site and purchase a Jetpack Boost 2 year plan
2. Go to the Store Admin and cancel the Jetpack Boost plan
3. Go back to your jurassic ninja site and go to checkout again with a Jetpack Boost 1 year plan
4. Make sure the upsell does not show
![image](https://github.com/Automattic/wp-calypso/assets/65001528/9a5ae964-c646-45ed-8542-1bcf7c4d7897)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?