### PR TITLE
E2E: genericize block pattern selection

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts
@@ -38,7 +38,7 @@ export class EditorInlineBlockInserterComponent {
 	/**
 	 * Selects the maching result from the block inserter.
 	 *
-	 * Where mulltiple matches exist (eg. due to partial matching), the first
+	 * Where multiple matches exist (eg. due to partial matching), the first
 	 * result will be chosen.
 	 */
 	async selectBlockInserterResult( name: string ): Promise< void > {

--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -50,6 +50,7 @@ export class EditorTemplateModalComponent {
 		const editorParent = await this.editor.parent();
 		await editorParent
 			.getByRole( 'option', { name: label, exact: true } )
+			.first()
 			.click( { timeout: timeout } );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -49,7 +49,7 @@ const selectors = {
  */
 export class EditorPage {
 	private page: Page;
-	private editor: EditorComponent;
+	public editor: EditorComponent;
 	private editorPublishPanelComponent: EditorPublishPanelComponent;
 	private editorNavSidebarComponent: EditorNavSidebarComponent;
 	private editorToolbarComponent: EditorToolbarComponent;

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -49,7 +49,7 @@ const selectors = {
  */
 export class EditorPage {
 	private page: Page;
-	public editor: EditorComponent;
+	private editor: EditorComponent;
 	private editorPublishPanelComponent: EditorPublishPanelComponent;
 	private editorNavSidebarComponent: EditorNavSidebarComponent;
 	private editorToolbarComponent: EditorToolbarComponent;

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -39,6 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let editorPage: EditorPage;
 	let pagesPage: PagesPage;
 	let publishedUrl: URL;
+	let pageTemplateToSelect: string;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -60,12 +61,14 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		editorPage = new EditorPage( page );
 		// Allow some time for CPU and/or network to catch up.
 		await editorPage.selectTemplateCategory( 'About', { timeout: 20 * 1000 } );
-		await editorPage.selectTemplate( 'About Page 3', { timeout: 15 * 1000 } );
+		pageTemplateToSelect =
+			( await page.getByRole( 'option' ).first().getAttribute( 'aria-label' ) ) ?? '';
+		await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );
 	} );
 
 	it( 'Template content loads into editor', async function () {
 		const editorCanvas = await editorPage.getEditorCanvas();
-		await editorCanvas.locator( `h1:text-is("About Page 3")` ).waitFor();
+		await editorCanvas.locator( `h1:text-is('${ pageTemplateToSelect }')` ).waitFor();
 	} );
 
 	it( 'Open setting sidebar', async function () {
@@ -92,6 +95,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	it( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );
-		await publishedPagePage.validateTextInPost( 'About Page 3' );
+		await publishedPagePage.validateTextInPost( pageTemplateToSelect );
 	} );
 } );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -61,8 +61,10 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		editorPage = new EditorPage( page );
 		// Allow some time for CPU and/or network to catch up.
 		await editorPage.selectTemplateCategory( 'About', { timeout: 20 * 1000 } );
+
+		const editorParent = await editorPage.editor.parent();
 		pageTemplateToSelect =
-			( await page.getByRole( 'option' ).first().getAttribute( 'aria-label' ) ) ?? '';
+			( await editorParent.getByRole( 'option' ).first().getAttribute( 'aria-label' ) ) ?? '';
 		await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );
 	} );
 

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -62,7 +62,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		// Allow some time for CPU and/or network to catch up.
 		await editorPage.selectTemplateCategory( 'About', { timeout: 20 * 1000 } );
 
-		const editorParent = await editorPage.editor.parent();
+		const editorParent = await editorPage.getEditorParent();
 		pageTemplateToSelect =
 			( await editorParent.getByRole( 'option' ).first().getAttribute( 'aria-label' ) ) ?? '';
 		await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -17,7 +17,7 @@ import { Page, Browser, Response } from 'playwright';
 import { skipDescribeIf, skipItIf } from '../../jest-helpers';
 
 const quote =
-	'The problem with quotes on the Internet is that it is hard to verify their authenticity.\n- Abraham Lincoln';
+	'The problem with quotes on the Internet is that it is hard to verify their authenticity.\nby Abraham Lincoln';
 const title = DataHelper.getRandomPhrase();
 const category = 'Uncategorized';
 const tag = 'test-tag';

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -67,7 +67,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Patterns', function () {
-		const patternName = 'About Page 3';
+		const patternName = 'About';
 
 		it( `Add ${ patternName } pattern`, async function () {
 			await editorPage.addPatternFromSidebar( patternName );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Due to multiple variants of the block pattern library existing in the wild, the block pattern tests were inconsistently pass/fail.

This PR uses a more generic block pattern name "About":

* For the page (block) template pattern selection, it chooses the first match.
* For the post block pattern insertion, I was going to add a param to allow the first match to be selected, but it turns out that's already how it works.

There was also an issue with the post text validation: when publishing content that started with a dash, it was converting the line into a list block. I updated the problem test line to avoid this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

All of these should pass:

```
yarn workspace wp-e2e-tests build && TEST_ON_ATOMIC=true ATOMIC_VARIATION=php-new JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__post-basic-flow.ts
yarn workspace wp-e2e-tests build && TEST_ON_ATOMIC=true ATOMIC_VARIATION=php-new JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__page-basic-flow.ts
yarn workspace wp-e2e-tests build && JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__post-basic-flow.ts
yarn workspace wp-e2e-tests build && JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__page-basic-flow.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?