### PR TITLE
Pattern Library: Add tracking for when no results are found for a search

### DIFF
--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -16,6 +16,7 @@ type PatternsPageViewTrackerProps = {
 	view?: PatternView;
 	referrer?: string;
 	error?: string;
+	numPatterns: number;
 };
 
 export function PatternsPageViewTracker( {
@@ -25,6 +26,7 @@ export function PatternsPageViewTracker( {
 	view,
 	referrer,
 	error,
+	numPatterns,
 }: PatternsPageViewTrackerProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	// Default to `undefined` while user settings are loading
@@ -61,7 +63,7 @@ export function PatternsPageViewTracker( {
 	}, [ category, isDevAccount, isLoggedIn, patternTypeFilter ] );
 
 	useEffect( () => {
-		if ( isDevAccount !== undefined ) {
+		if ( isDevAccount !== undefined && numPatterns !== undefined ) {
 			recordTracksEvent( 'calypso_pattern_library_view', {
 				category,
 				is_logged_in: isLoggedIn,
@@ -71,6 +73,7 @@ export function PatternsPageViewTracker( {
 				view,
 				referrer,
 				error,
+				num_patterns: debouncedSearchTerm ? numPatterns : undefined,
 			} );
 		}
 

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -111,7 +111,7 @@ export const PatternLibrary = ( {
 	const { category, searchTerm, isGridView, patternTypeFilter, referrer } = usePatternsContext();
 
 	const { data: categories = [] } = usePatternCategories( locale );
-	const { data: patterns = [] } = usePatterns( locale, category, {
+	const { data: patterns } = usePatterns( locale, category, {
 		select( patterns ) {
 			const patternsByType = filterPatternsByType( patterns, patternTypeFilter );
 			return filterPatternsByTerm( patternsByType, searchTerm );
@@ -123,8 +123,8 @@ export const PatternLibrary = ( {
 
 	const recordClickEvent = (
 		tracksEventName: string,
-		view: PatternView,
-		typeFilter: PatternTypeFilter
+		view?: PatternView,
+		typeFilter?: PatternTypeFilter
 	) => {
 		recordTracksEvent( tracksEventName, {
 			category,
@@ -212,6 +212,8 @@ export const PatternLibrary = ( {
 		? `${ searchTerm }-${ category }-${ patternTypeFilter }`
 		: `${ category }-${ patternTypeFilter }`;
 
+	const patternsLength = patterns ? patterns.length : undefined;
+
 	return (
 		<>
 			<PatternsPageViewTracker
@@ -221,6 +223,7 @@ export const PatternLibrary = ( {
 				key={ `${ category }-tracker` }
 				searchTerm={ searchTerm }
 				referrer={ referrer }
+				numPatterns={ patternsLength }
 			/>
 
 			<PatternsDocumentHead category={ category } />
@@ -280,8 +283,8 @@ export const PatternLibrary = ( {
 							<h1 className="pattern-library__title">
 								{ searchTerm &&
 									translate( '%(count)d pattern', '%(count)d patterns', {
-										count: patterns.length,
-										args: { count: patterns.length },
+										count: patternsLength,
+										args: { count: patternsLength },
 									} ) }
 								{ ! searchTerm &&
 									patternTypeFilter === PatternTypeFilter.PAGES &&
@@ -364,11 +367,14 @@ export const PatternLibrary = ( {
 							patternTypeFilter={ patternTypeFilter }
 						/>
 
-						{ searchTerm && ! patterns.length && category && (
+						{ searchTerm && ! patternsLength && category && (
 							<div>
 								<Button
 									className="pattern-gallery__search-all-categories"
-									href={ `/patterns${ window.location.search }` }
+									onClick={ () => {
+										recordClickEvent( 'calypso_pattern_library_search_in_all' );
+										page( `/patterns${ window.location.search }` );
+									} }
 								>
 									{ translate( 'Search in all categories', {
 										comment: 'Button to make search of patterns in all categories',

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -128,6 +128,7 @@ export const PatternLibrary = ( {
 	) => {
 		recordTracksEvent( tracksEventName, {
 			category,
+			search_term: searchTerm ? searchTerm : undefined,
 			is_logged_in: isLoggedIn,
 			type: getTracksPatternType( typeFilter ),
 			user_is_dev_account: isDevAccount ? '1' : '0',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89120

## Proposed Changes

* Track number of patterns available in search result.
* Track click to the "Search in all categories" CTA.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/patterns` and select a pattern category.
* Search for `cta`.
* Assert that the `calypso_pattern_library_view` event is fired reports `num_patterns: 0`.
<img width="1774" alt="Screen Shot 2024-04-02 at 3 59 48 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/9d0c47b8-8d1e-4e9b-9323-f7daf0a13c07">

* Click on the "Search in all categories" CTA.
* Assert that the `calypso_pattern_library_search_in_all` event is fired, reporting `search_term`:

<img width="591" alt="Screen Shot 2024-04-02 at 4 05 35 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/1499ad8b-256b-4539-ad91-a9cceef9863e">

* Assert that the `calypso_pattern_library_view` event is fired for the search results in all categories, reporting the number of results as `num_patterns`.

<img width="1788" alt="Screen Shot 2024-04-02 at 4 00 24 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/7664c3fe-0b3e-498f-a937-d99f6cee18c0">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?