### PR TITLE
Site Preview: Remove site preview from tab index

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -103,6 +103,7 @@ const SitePreview = ( {
 							loading="lazy"
 							title={ __( 'Site Preview' ) }
 							src={ iframeSrcKeepHomepage }
+							tabIndex={ -1 }
 						/>
 					) : (
 						<div className="home-site-preview__thumbnail-placeholder" />


### PR DESCRIPTION
The `SitePreview` component used on both the 'My Home' and 'Checkout' sections allows users to tab into the iframe that is being previewed, this can lead to confusion for people using screen readers and also prevent them from continuing through our UI.

This PR adds the `tabIndex` attribute to the site preview iframe and sets it to `-1` to remove it from the tab index.

Fixes part of https://github.com/Automattic/wp-calypso/issues/89134
## Testing Instructions

* Go to My Home or Checkout and press tab on your keyboard until you reach the SitePreview component
* Ensure that tabbing does not enter into the component's embedded iframe, but instead skips over the Site Preview into the next component in Calypso
