### PR TITLE
Stats: Reduce min-wdith to fix module width for iPhones

### DIFF
--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -4,7 +4,7 @@
 @import "calypso/my-sites/stats/modernized-layout-styles.scss";
 @import "calypso/my-sites/stats/theme-override-mixin.scss";
 
-$stats-card-min-width: 500px;
+$stats-card-min-width: 390px;
 
 // Module container
 @include breakpoint-deprecated( ">960px" ) {

--- a/packages/components/src/horizontal-bar-list/_stats-variables.scss
+++ b/packages/components/src/horizontal-bar-list/_stats-variables.scss
@@ -19,7 +19,6 @@ $stats-avatar-size: 20px;
 $stats-avatar-spacer: 8px;
 
 @mixin additional-columns-wrapper() {
-	//display: flex;
 	text-align: right;
 	gap: 0 4px;
 	padding: 0 4px;

--- a/packages/components/src/horizontal-bar-list/_stats-variables.scss
+++ b/packages/components/src/horizontal-bar-list/_stats-variables.scss
@@ -19,11 +19,12 @@ $stats-avatar-size: 20px;
 $stats-avatar-spacer: 8px;
 
 @mixin additional-columns-wrapper() {
-	display: flex;
+	//display: flex;
 	text-align: right;
 	gap: 0 4px;
 	padding: 0 4px;
 	font-weight: 400;
+	flex: 0 0 75px;
 
 	> div,
 	> span {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88267

## Proposed Changes

* reduce module min-width and apply fixed width to additional columns for horizontal bars

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch
* navigate to a blog with data for the `emails` module
* verify that the module has `opens` and `clicks` columns visible on a narrow screen (for example, an iPhone - 390px width)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?