### PR TITLE
Stats: Fixed various warnings from console

### DIFF
--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useSelector } from 'calypso/state';
-import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
+import { getSiteStatsViewSummaryMemoized } from 'calypso/state/stats/lists/selectors';
 import StatsHeatMapLegend from '../stats-heap-map/legend';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import Months from '../stats-views/months';
@@ -21,7 +21,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 	const query = { quantity: -1, stat_fields: 'views' };
 	const translate = useTranslate();
 	const [ chartOption, setChartOption ] = useState( 'total' );
-	const viewData = useSelector( ( state ) => getSiteStatsViewSummary( state, siteId ) );
+	const viewData = useSelector( ( state ) => getSiteStatsViewSummaryMemoized( state, siteId ) );
 	const monthViewOptions = useMemo( () => {
 		return [
 			{ value: 'total', label: translate( 'Months and years' ) },

--- a/client/my-sites/stats/hooks/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/use-stats-purchases.ts
@@ -6,12 +6,14 @@ import {
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	PRODUCT_JETPACK_STATS_YEARLY,
 } from '@automattic/calypso-products';
+import { createSelector } from '@automattic/state-utils';
 import { useMemo } from 'react';
 import { useSelector } from 'calypso/state';
 import {
 	isFetchingSitePurchases,
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
+	getPurchases,
 } from 'calypso/state/purchases/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -32,8 +34,13 @@ const isProductOwned = ( ownedPurchases: Purchase[], searchedProduct: string ) =
 	return filterPurchasesByProducts( ownedPurchases, [ searchedProduct ] ).length > 0;
 };
 
+const getPurchasesBySiteId = createSelector(
+	( state, siteId ) => getSitePurchases( state, siteId ),
+	getPurchases
+);
+
 export default function useStatsPurchases( siteId: number | null ) {
-	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+	const sitePurchases = useSelector( ( state ) => getPurchasesBySiteId( state, siteId ) );
 	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );
 	const hasLoadedSitePurchases = useSelector( hasLoadedSitePurchasesFromServer );
 

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_GOOGLE_ANALYTICS, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { merge } from 'lodash';
-import { Component } from 'react';
+import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -94,10 +94,9 @@ class StatsSummary extends Component {
 				statType = 'statsReferrers';
 
 				summaryView = (
-					<>
+					<Fragment key="referrers-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
 						<StatsModule
-							key="referrers-summary"
 							path={ path }
 							moduleStrings={ StatsStrings.referrers }
 							period={ this.props.period }
@@ -106,7 +105,7 @@ class StatsSummary extends Component {
 							summary
 							listItemClassName={ listItemClassName }
 						/>
-					</>
+					</Fragment>
 				);
 				break;
 
@@ -116,10 +115,9 @@ class StatsSummary extends Component {
 				statType = 'statsClicks';
 
 				summaryView = (
-					<>
+					<Fragment key="clicks-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
 						<StatsModule
-							key="clicks-summary"
 							path={ path }
 							moduleStrings={ StatsStrings.clicks }
 							period={ this.props.period }
@@ -128,7 +126,7 @@ class StatsSummary extends Component {
 							summary
 							listItemClassName={ listItemClassName }
 						/>
-					</>
+					</Fragment>
 				);
 				break;
 
@@ -138,10 +136,9 @@ class StatsSummary extends Component {
 				statType = 'statsCountryViews';
 
 				summaryView = (
-					<>
+					<Fragment key="countries-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
 						<Countries
-							key="countries-summary"
 							path={ path }
 							period={ this.props.period }
 							query={ moduleQuery }
@@ -163,7 +160,7 @@ class StatsSummary extends Component {
 								showIcon={ true }
 							/>
 						</div>
-					</>
+					</Fragment>
 				);
 				break;
 
@@ -173,10 +170,9 @@ class StatsSummary extends Component {
 				statType = 'statsTopPosts';
 
 				summaryView = (
-					<>
+					<Fragment key="posts-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
 						<StatsModule
-							key="posts-summary"
 							path={ path }
 							moduleStrings={ StatsStrings.posts }
 							period={ this.props.period }
@@ -185,7 +181,7 @@ class StatsSummary extends Component {
 							summary
 							listItemClassName={ listItemClassName }
 						/>
-					</>
+					</Fragment>
 				);
 				break;
 
@@ -197,10 +193,9 @@ class StatsSummary extends Component {
 				// TODO: should be refactored so that className doesn't have to be passed in
 				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				summaryView = (
-					<>
+					<Fragment key="authors-summary">
 						{ this.renderSummaryHeader( path, statType, true, query ) }
 						<StatsModule
-							key="authors-summary"
 							path={ path }
 							moduleStrings={ StatsStrings.authors }
 							period={ this.props.period }
@@ -210,7 +205,7 @@ class StatsSummary extends Component {
 							summary
 							listItemClassName={ listItemClassName }
 						/>
-					</>
+					</Fragment>
 				);
 				/* eslint-enable wpcalypso/jsx-classname-namespace */
 				break;
@@ -221,11 +216,10 @@ class StatsSummary extends Component {
 				statType = 'statsVideoPlays';
 
 				summaryView = (
-					<>
+					<Fragment key="videopress-stats-module">
 						{ /* For CSV button to work, video page needs to pass custom data to the button.
 								It can't use the shared header as long as the CSV download button stays there. */ }
 						<VideoPressStatsModule
-							key="videopress-stats-module"
 							path={ path }
 							moduleStrings={ StatsStrings.videoplays }
 							period={ this.props.period }
@@ -234,7 +228,7 @@ class StatsSummary extends Component {
 							summary
 							listItemClassName={ listItemClassName }
 						/>
-					</>
+					</Fragment>
 				);
 				break;
 
@@ -244,10 +238,9 @@ class StatsSummary extends Component {
 				statType = 'statsFileDownloads';
 
 				summaryView = (
-					<>
+					<Fragment key="filedownloads-summary">
 						{ this.renderSummaryHeader( path, statType, true, query ) }
 						<StatsModule
-							key="filedownloads-summary"
 							path={ path }
 							moduleStrings={ StatsStrings.filedownloads }
 							period={ this.props.period }
@@ -256,7 +249,7 @@ class StatsSummary extends Component {
 							summary
 							listItemClassName={ listItemClassName }
 						/>
-					</>
+					</Fragment>
 				);
 				break;
 
@@ -307,10 +300,9 @@ class StatsSummary extends Component {
 				statType = 'statsSearchTerms';
 
 				summaryView = (
-					<>
+					<Fragment key="search-terms-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
 						<StatsModule
-							key="search-terms-summary"
 							path={ path }
 							moduleStrings={ StatsStrings.search }
 							period={ this.props.period }
@@ -319,7 +311,7 @@ class StatsSummary extends Component {
 							summary
 							listItemClassName={ listItemClassName }
 						/>
-					</>
+					</Fragment>
 				);
 				break;
 			case 'annualstats':

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { createSelector } from '@automattic/state-utils';
 import version_compare from 'calypso/lib/version-compare';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
@@ -11,7 +12,7 @@ const version_greater_than_or_equal = (
 	return !! ( ! isOdysseyStats || ( version && version_compare( version, compareVersion, '>=' ) ) );
 };
 
-export default function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
+function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
 	const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {
@@ -57,3 +58,16 @@ export default function getEnvStatsFeatureSupportChecks( state: object, siteId: 
 		),
 	};
 }
+
+const getEnvStatsFeatureSupportChecksMemoized = createSelector(
+	getEnvStatsFeatureSupportChecks,
+	( state, siteId ) => [
+		getJetpackStatsAdminVersion( state, siteId ),
+		isJetpackSite( state, siteId, {
+			treatAtomicAsJetpackSite: false,
+		} ),
+		config.isEnabled( 'is_running_in_jetpack_site' ),
+	]
+);
+
+export default getEnvStatsFeatureSupportChecksMemoized;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import treeSelect from '@automattic/tree-select';
 import { get, map, flatten } from 'lodash';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -243,6 +244,11 @@ export function getSiteStatsViewSummary( state, siteId ) {
 
 	return viewSummary;
 }
+
+export const getSiteStatsViewSummaryMemoized = createSelector(
+	getSiteStatsViewSummary,
+	( state, siteId ) => [ siteId ]
+);
 
 export const getMostPopularDatetime = ( state, siteId, query ) => {
 	const insightsData = getSiteStatsNormalizedData( state, siteId, 'statsInsights', query );

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -72,6 +72,7 @@ const HorizontalBarListItem = ( {
 					? label.map( ( item ) => (
 							<>
 								<Icon
+									key={ item.labelIcon }
 									className="stats-icon"
 									icon={ item.labelIcon === 'folder' ? file : tag }
 									size={ 22 }

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -2,7 +2,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { Icon, chevronDown, chevronUp, tag, file } from '@wordpress/icons';
 import classnames from 'classnames';
 import { numberFormat } from 'i18n-calypso';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import ShortenedNumber from '../number-formatters';
 import type { HorizontalBarListItemProps } from './types';
 
@@ -70,15 +70,14 @@ const HorizontalBarListItem = ( {
 			<>
 				{ label.length > 1
 					? label.map( ( item ) => (
-							<>
+							<Fragment key={ item.labelIcon }>
 								<Icon
-									key={ item.labelIcon }
 									className="stats-icon"
 									icon={ item.labelIcon === 'folder' ? file : tag }
 									size={ 22 }
 								/>
 								<span>{ decodeEntities( item.label ) }</span>
-							</>
+							</Fragment>
 					  ) )
 					: label[ 0 ].label }
 			</>

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -69,8 +69,8 @@ const HorizontalBarListItem = ( {
 		labelText = (
 			<>
 				{ label.length > 1
-					? label.map( ( item ) => (
-							<Fragment key={ item.labelIcon }>
+					? label.map( ( item, index ) => (
+							<Fragment key={ index }>
 								<Icon
 									className="stats-icon"
 									icon={ item.labelIcon === 'folder' ? file : tag }


### PR DESCRIPTION
## Proposed Changes

* Use `createSelector` to memorize selected objects
* Adds missing keys for several places

Most of these warnings have been bugging me ever since we started working on Stats... Phew...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build locally
* Navigate through pages
* Ensure Insights page works well
* Ensure no more warnings pop up in the console except for the React 18 one
`Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?