### PR TITLE
Stats: Scroll to top for purchase page

### DIFF
--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -106,7 +106,7 @@ const StatsPurchasePage = ( {
 		if ( triggeredEvent ) {
 			recordTracksEvent( triggeredEvent );
 		}
-	}, [ siteSlug, query?.from ] );
+	}, [ siteSlug, query, query?.from ] );
 
 	const commercialProduct = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -83,6 +83,8 @@ const StatsPurchasePage = ( {
 	}, [ siteSlug, isSiteJetpackNotAtomic ] );
 
 	useEffect( () => {
+		// Scroll to top on page load
+		window.scrollTo( 0, 0 );
 		// track different upgrade sources
 		let triggeredEvent;
 
@@ -104,7 +106,7 @@ const StatsPurchasePage = ( {
 		if ( triggeredEvent ) {
 			recordTracksEvent( triggeredEvent );
 		}
-	}, [ siteSlug, query, query?.from ] );
+	}, [ siteSlug, query?.from ] );
 
 	const commercialProduct = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )


### PR DESCRIPTION
Related: p1HpG7-rOR-p2#2-remove-auto-scrolling-when-clicking-on-upgrade

## Proposed Changes

Scroll to top on purchase page load

## Testing Instructions

* Open Calypso Live for a site without valid commercial license
* Scroll to UTM module
* Click Upgrade
* Ensure the purchase page is scrolled to top

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?