### PR TITLE
Stats: explicitly exclude UTM from benefit list

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -329,6 +329,9 @@ function StatsBenefitsListing( {
 					</li>
 				) }
 				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
+					{ translate( 'No UTM tracking' ) }
+				</li>
+				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
 					{ translate( 'No access to upcoming advanced features' ) }
 				</li>
 			</ul>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -164,6 +164,7 @@ const StatsBenefitsPersonal = () => {
 				<li>{ translate( 'Email support' ) }</li>
 			</ul>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
+				<li>{ translate( 'No UTM tracking' ) }</li>
 				<li>{ translate( 'No access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'No commercial use' ) }</li>
 			</ul>
@@ -183,6 +184,7 @@ const StatsBenefitsFree = () => {
 				<li>{ translate( 'GDPR compliance' ) }</li>
 			</ul>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
+				<li>{ translate( 'No UTM tracking' ) }</li>
 				<li>{ translate( 'No access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'No Email support (supported by forum)' ) }</li>
 				<li>{ translate( 'No commercial use' ) }</li>


### PR DESCRIPTION
Related: p1HpG7-rOR-p2#1-should-we-include-utms-in-the-non-commercial-interstitial

## Proposed Changes

* Explicitly exclude UTM tracking from Personal and Free benefit list

## Testing Instructions

* Open Calypso Live `/stats/purchase/:siteSlug?fproductType=personal`
* Ensure it's showing No UTM tracking 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?