### PR TITLE
A4A: Sites dashboard Preview Pane remember filters and sort upon closing + fix loop issue

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -22,6 +22,20 @@ interface Props {
 	showSitesDashboardV2: boolean;
 }
 
+const buildFilters = ( { issueTypes }: { issueTypes: string } ) => {
+	const issueTypesArray = issueTypes?.split( ',' );
+
+	return (
+		issueTypesArray?.map( ( issueType ) => {
+			return {
+				field: 'status',
+				operator: 'in',
+				value: filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref || 1,
+			};
+		} ) || []
+	);
+};
+
 export const SitesDashboardProvider = ( {
 	hideListingInitialState = false,
 	showOnlyFavoritesInitialState = false,
@@ -65,6 +79,7 @@ export const SitesDashboardProvider = ( {
 		...initialSitesViewState,
 		page: currentPage,
 		search: searchQuery,
+		filters: buildFilters( { issueTypes } ),
 	} );
 
 	useEffect( () => {
@@ -74,22 +89,12 @@ export const SitesDashboardProvider = ( {
 			setHideListing( false );
 		}
 
-		const issueTypesArray = issueTypes?.split( ',' );
 		setSitesViewState( ( previousState ) => ( {
 			...previousState,
 			...( siteUrlInitialState
 				? {}
 				: {
-						filters:
-							issueTypesArray?.map( ( issueType ) => {
-								return {
-									field: 'status',
-									operator: 'in',
-									value:
-										filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref ||
-										1,
-								};
-							} ) || [],
+						filters: buildFilters( { issueTypes } ),
 				  } ),
 			...( siteUrlInitialState ? {} : { search: searchQuery } ),
 			...( siteUrlInitialState ? {} : { selectedSite: undefined } ),

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -75,18 +75,23 @@ export const SitesDashboardProvider = ( {
 		}
 
 		const issueTypesArray = issueTypes?.split( ',' );
-
 		setSitesViewState( ( previousState ) => ( {
 			...previousState,
-			filters:
-				issueTypesArray?.map( ( issueType ) => {
-					return {
-						field: 'status',
-						operator: 'in',
-						value: filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref || 1,
-					};
-				} ) || [],
-			search: searchQuery,
+			...( siteUrlInitialState
+				? {}
+				: {
+						filters:
+							issueTypesArray?.map( ( issueType ) => {
+								return {
+									field: 'status',
+									operator: 'in',
+									value:
+										filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref ||
+										1,
+								};
+							} ) || [],
+				  } ),
+			...( siteUrlInitialState ? {} : { search: searchQuery } ),
 			...( siteUrlInitialState ? {} : { selectedSite: undefined } ),
 			...( siteUrlInitialState ? {} : { type: 'table' } ),
 		} ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/164
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/171

## Proposed Changes

* This PR addresses two critical issues:
  * Preservation of Search Query Parameters and Filters in Preview Pane:
    * **Issue**: Opening the preview pane resulted in the loss of search query parameters and filters.
    * **Fix**: Search and filter data are now retained within the sitesViewState context upon site selection, ensuring consistent user experience.
  * Prevention of Infinite Loop on Manual URL Entry:
    * **Issue**: Directly entering a URL led to an infinite loading loop.
    * **Fix**: Correctly initializing the sitesViewState context with necessary filters resolves this issue, preventing the loop and stabilizing page behavior.

## Testing Instructions

### 1
* Go to our sites dashboard ( `/sites`)
* Search for some string that will find a site (e.g. `my_jurassic_ninja`)
* Select a site
* The dashboard's URL should change to match the selected site url, but the filter should still be active
* Close the preview pane
* The dashboard's URL should match the current search query, which should still be active

### 2
* Select a filter ( e.g. `Needs Attention`)
* Select a site
* The dashboard's URL should change to match the selected site url, but the filter should still be active
* Close the preview pane
* The dashboard's URL should match the current filter, which should still be active

### 3
* Do both at the same time (search and filter)
* Select a site
* The dashboard's URL should change to match the selected site url, but the filter should still be active
* Close the preview pane
* The dashboard's URL should match both the current search, and current filter, both of which should still be active

### 4
* Copy paste the URL for each of these 3 steps
* The page should load properly, and not enter in a loop.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?