### PR TITLE
Stats: Update date picker CSS for small screens

### DIFF
--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -2,6 +2,7 @@
 @import "@automattic/components/src/styles/typography.scss";
 
 $date-control-shortcut-min-width: 140px;
+$date-control-mobile-layout-switch: $break-small;
 
 .stats-date-control-picker-date {
 	margin: 16px;
@@ -42,6 +43,11 @@ $date-control-shortcut-min-width: 140px;
 	padding: 16px;
 	border-left: 1px solid var(--gray-gray-5, #dcdcde);
 	box-sizing: border-box;
+
+	@media (max-width: $date-control-mobile-layout-switch) {
+		border-left: 0 none;
+		border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
+	}
 }
 
 .date-control-picker-shortcuts__list {
@@ -132,6 +138,10 @@ $date-control-shortcut-min-width: 140px;
 	display: flex;
 	min-width: 320px;
 	flex-direction: row-reverse;
+
+	@media (max-width: $date-control-mobile-layout-switch) {
+		flex-direction: column;
+	}
 }
 
 .stats-date-control-picker__popover-wrapper {
@@ -146,6 +156,19 @@ $date-control-shortcut-min-width: 140px;
 
 	.components-button + .components-button {
 		margin-left: 12px;
+	}
+
+	@media (max-width: $date-control-mobile-layout-switch) {
+		flex-direction: column-reverse;
+		justify-content: stretch;
+
+		.components-button {
+			justify-content: center;
+
+			& + .components-button {
+				margin-left: 0;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5118

## Proposed Changes

* Update CSS for small screens for the date picker component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch 
* resize the window to a mobile view when the date picker doesn't fit the screen
* verify that the component fits and is usable

| Before | After |
| --- | --- |
| <img width="476" alt="SCR-20240403-opje" src="https://github.com/Automattic/wp-calypso/assets/112354940/855e510d-bbb7-4272-9f0a-614146528b02"> | <img width="389" alt="SCR-20240403-ooza" src="https://github.com/Automattic/wp-calypso/assets/112354940/a5557a16-843a-4043-917f-a202fcb4be22"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?