### PR TITLE
Remove box-shadow from global nav

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -12,7 +12,6 @@ $brand-text: "SF Pro Text", $sans;
 	top: 0;
 	transition: all 220ms ease-out;
 	background-color: var(--color-sidebar-background);
-	box-shadow: 5px 0 8px -5px var(--color-sidebar-border);
 
 	ul.sidebar__menu:not(.is-togglable) {
 		height: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix https://github.com/Automattic/dotcom-forge/issues/6381

## Proposed Changes

This PR removes box-shadow from global nav. 

| before | after |
|--------|--------|
| <img width="304" alt="Screenshot 2024-04-03 at 14 43 48" src="https://github.com/Automattic/wp-calypso/assets/5287479/44e46d5c-44c7-4769-94c6-d630618e026d"> |<img width="314" alt="Screenshot 2024-04-03 at 14 43 41" src="https://github.com/Automattic/wp-calypso/assets/5287479/9c26da86-d221-4fed-9bc5-737834929a07"> | 

The shadow should be added to the content on the right side according to p9Jlb4-btR-p2 but it might be nice to be addressed in https://github.com/Automattic/dotcom-forge/issues/6259.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* See the border is removed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?