### PR TITLE
Remove external link icon next to WP Admin link on all sites

### DIFF
--- a/client/sites-dashboard/components/sites-site-admin-link.tsx
+++ b/client/sites-dashboard/components/sites-site-admin-link.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
-import { ExternalLink } from '@wordpress/components';
 
-export const SiteAdminLink = styled( ExternalLink )`
+export const SiteAdminLink = styled.a`
 	display: flex;
 	align-items: center;
 	gap: 4px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

fix https://github.com/Automattic/dotcom-forge/issues/6382

## Proposed Changes

This PR removes external link icon next to WP Admin link on all sites.

| before | after |
|--------|--------|
|<img width="1436" alt="Screenshot 2024-04-03 at 14 59 49" src="https://github.com/Automattic/wp-calypso/assets/5287479/0309f004-900a-41aa-af7d-a41c29fb1c63"> | <img width="1436" alt="Screenshot 2024-04-03 at 14 59 57" src="https://github.com/Automattic/wp-calypso/assets/5287479/30a03f83-42cf-4553-a35a-7c99fc1c5157">| 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Verify the external icon is removed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?