### PR TITLE
A4A: Improve the Pressable plan purchase flow.

### DIFF
--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -16,7 +16,7 @@ export const redirectToOverviewContext: Callback = () => {
 export const requireAccessContext: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const agency = getActiveAgency( state );
-	const { pathname, search } = window.location;
+	const { pathname, search, hash } = window.location;
 
 	if ( agency ) {
 		next();
@@ -26,7 +26,7 @@ export const requireAccessContext: Callback = ( context, next ) => {
 	page.redirect(
 		addQueryArgs(
 			{
-				return: pathname + search,
+				return: pathname + hash + search,
 			},
 			'/landing'
 		)

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -15,13 +15,14 @@ import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { getHostingLogo } from '../lib/hosting';
-import ShoppingCart from '../shopping-cart';
+import ShoppingCart, { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
 import PressableOverviewFeatures from './footer';
 import PressableOverviewPlanSelection from './plan-selection';
 import './style.scss';
@@ -34,8 +35,14 @@ export default function PressableOverview() {
 
 	const onAddToCart = useCallback(
 		( item: APIProductFamilyProduct ) => {
-			setSelectedCartItems( [ ...selectedCartItems, { ...item, quantity: 1 } ] );
-			page( A4A_MARKETPLACE_LINK );
+			// We will need to remove first any existing Pressable plan in the cart as we do not allow multiple Pressable plans to be purchase.
+			const items = selectedCartItems?.filter(
+				( cartItem ) => cartItem.family_slug !== 'pressable-hosting'
+			);
+
+			setSelectedCartItems( [ ...items, { ...item, quantity: 1 } ] );
+
+			page( A4A_MARKETPLACE_PRODUCTS_LINK + CART_URL_HASH_FRAGMENT );
 		},
 		[ selectedCartItems, setSelectedCartItems ]
 	);

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -21,13 +21,29 @@ type Props = {
 	items: ShoppingCartItem[];
 };
 
+const CART_URL_HASH_FRAGMENT = '#cart';
+
 export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props ) {
-	const [ showShoppingCart, setShowShoppingCart ] = useState( false );
+	const [ showShoppingCart, setShowShoppingCart ] = useState(
+		window.location.hash === CART_URL_HASH_FRAGMENT
+	);
 
 	const { paymentMethodRequired } = usePaymentMethod();
 
 	const toggleShoppingCart = () => {
-		setShowShoppingCart( ( prevState ) => ! prevState );
+		setShowShoppingCart( ( prevState ) => {
+			const nextState = ! prevState;
+
+			const hashFragment = nextState ? CART_URL_HASH_FRAGMENT : '';
+
+			window.history.replaceState(
+				null,
+				'',
+				window.location.pathname + window.location.search + hashFragment
+			);
+
+			return nextState;
+		} );
 	};
 
 	const handleOnCheckout = () => {
@@ -55,7 +71,14 @@ export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props
 
 			{ showShoppingCart && (
 				<ShoppingCartMenu
-					onClose={ () => setShowShoppingCart( false ) }
+					onClose={ () => {
+						setShowShoppingCart( false );
+						window.history.replaceState(
+							null,
+							'',
+							window.location.pathname + window.location.search
+						);
+					} }
 					items={ items }
 					onCheckout={ handleOnCheckout }
 					onRemoveItem={ onRemoveItem }

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -21,7 +21,7 @@ type Props = {
 	items: ShoppingCartItem[];
 };
 
-const CART_URL_HASH_FRAGMENT = '#cart';
+export const CART_URL_HASH_FRAGMENT = '#cart';
 
 export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props ) {
 	const [ showShoppingCart, setShowShoppingCart ] = useState(


### PR DESCRIPTION
This pull request aims to improve the purchase flow for the Pressable plan. Currently, the UI allows the addition of multiple Pressable plans to the cart, which should not be the case. The pull request addresses this issue.

Moreover, the pull request automatically shows the shopping cart after selecting a Pressable plan. This is intended to emphasize the idea of an upsell.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/181

## Proposed Changes

* Update the shopping cart to be URL accessible using #cart hash fragment. This is necessary for us to enable auto-display of cart in our flow.
* Update the **Add to Cart** handler to make sure there is only one Pressable plan in the cart and also redirect the user to a URL that has the shopping cart triggered on page load.
* Additional: Fix the Landing page to allow the return URL to support hash fragment.

## Testing Instructions

* Use the live link below and go to `/marketplace/hosting/pressable`.
* Choose any Pressable plan.
   <img width="782" alt="Screenshot 2024-04-03 at 3 03 46 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/fb798346-4942-4a22-b8a2-625307016551">
* Confirm that you are redirected to the Products page with the opened Shopping cart.
   <img width="1555" alt="Screenshot 2024-04-03 at 3 03 38 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b48189b9-3f59-41e5-b297-64e5544531c6">
* Go back to `/marketplace/hosting/pressable` and select different Pressable plan.
* Confirm that the Shopping cart will only show the newly selected Pressable plan.



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?