### PR TITLE
Remove hotjar from Jetpack plans page

### DIFF
--- a/client/blocks/importer/components/importing-pane/importing-pane.tsx
+++ b/client/blocks/importer/components/importing-pane/importing-pane.tsx
@@ -11,7 +11,6 @@ import {
 	ImportingPane as ImportingPaneBase,
 	resourcesRemaining,
 } from 'calypso/my-sites/importer/importing-pane';
-import { loadTrackingTool } from 'calypso/state/analytics/actions';
 import { mapAuthor, startImporting } from 'calypso/state/imports/actions';
 import './importing-pane.scss';
 
@@ -105,7 +104,6 @@ class ImportingPane extends ImportingPaneBase {
 }
 
 export default connect( null, {
-	loadTrackingTool,
 	mapAuthor,
 	startImporting,
 } )( localize( ImportingPane ) );

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -12,14 +12,12 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QuerySites from 'calypso/components/data/query-sites';
 import Main from 'calypso/components/main';
 import { MAIN_CONTENT_ID } from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
-import { JPC_PATH_PLANS } from 'calypso/jetpack-connect/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { useDispatch, useSelector } from 'calypso/state';
-import { loadTrackingTool } from 'calypso/state/analytics/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { showMasterbar } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -59,22 +57,6 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 
 	const [ , experimentAssignment ] = useExperiment( 'calypso_jetpack_upsell_page_2022_06' );
 	const showUpsellPage = experimentAssignment?.variationName === 'treatment';
-
-	useEffect( () => {
-		if (
-			/**
-			 * Load the HotJar script on routes 'cloud.jetpack.com/pricing/..' and
-			 * 'wordpress.com/jetpack/connect/plans/:site/..' (Jetpack plugin post-conneciton route)
-			 */
-			isJetpackCloud() ||
-			window.location.pathname.startsWith( JPC_PATH_PLANS )
-		) {
-			// HotJar analytics tracking
-			// https://github.com/Automattic/wp-calypso/blob/trunk/client/state/analytics/README_HotJar.md
-			dispatch( loadTrackingTool( 'HotJar' ) );
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
 
 	useEffect( () => {
 		dispatch(

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -47,7 +47,6 @@ import P2SignupProcessingScreen from 'calypso/signup/p2-processing-screen';
 import SignupProcessingScreen from 'calypso/signup/processing-screen';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 import SignupHeader from 'calypso/signup/signup-header';
-import { loadTrackingTool } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import {
 	isUserLoggedIn,
@@ -131,7 +130,6 @@ class Signup extends Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		isLoggedIn: PropTypes.bool,
 		isEmailVerified: PropTypes.bool,
-		loadTrackingTool: PropTypes.func.isRequired,
 		submitSignupStep: PropTypes.func.isRequired,
 		signupDependencies: PropTypes.object,
 		siteDomains: PropTypes.array,
@@ -980,7 +978,6 @@ export default connect(
 	{
 		submitSignupStep,
 		removeStep,
-		loadTrackingTool,
 		addStep,
 	}
 )( Signup );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Removes hotjar from the Jetpack plans page as it is no longer required. Context: p1712036155233399-slack-C02LK1W8T4Z

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since the script was loaded via a `dispatch` in a `useEffect`, removing the effect should be safe. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?