### PR TITLE
Automattic for Agencies: Add site button enhancements

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -34,6 +34,9 @@ const AddNewSiteButton = ( {
 }: Props ): JSX.Element => {
 	const translate = useTranslate();
 
+	/** @todo Remove this line once the A4A_SITES_CONNECT_URL_LINK URL exists. */
+	const showAddSitesByURLButton = false;
+
 	return (
 		<SplitButton
 			popoverContext={ popoverContext }
@@ -56,11 +59,15 @@ const AddNewSiteButton = ( {
 				<span>{ translate( 'Connect a site to Jetpack' ) }</span>
 			</PopoverMenuItem>
 
-			{ /** @todo The A4A_SITES_CONNECT_URL_LINK URL does not exist yet. It will need to be migrated over from cloud.jetpack.com/dashboard/connect-url. */ }
-			<PopoverMenuItem onClick={ onClickUrlMenuItem } href={ A4A_SITES_CONNECT_URL_LINK }>
-				<Gridicon icon="domains" size={ 18 } />
-				<span>{ translate( 'Add sites by URL' ) }</span>
-			</PopoverMenuItem>
+			{ showAddSitesByURLButton && (
+				<>
+					{ /** @todo The A4A_SITES_CONNECT_URL_LINK URL does not exist yet. It will need to be migrated over from cloud.jetpack.com/dashboard/connect-url. */ }
+					<PopoverMenuItem onClick={ onClickUrlMenuItem } href={ A4A_SITES_CONNECT_URL_LINK }>
+						<Gridicon icon="domains" size={ 18 } />
+						<span>{ translate( 'Add sites by URL' ) }</span>
+					</PopoverMenuItem>
+				</>
+			) }
 		</SplitButton>
 	);
 };

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -43,6 +43,14 @@
 		border-radius: 4px;
 	}
 
+	.button.split-button__toggle {
+		border-radius: 0 4px 4px 0;
+	}
+
+	.button.split-button__main {
+		border-radius: 4px 0 0 4px;
+	}
+
 	.button.is-primary {
 		background-color: var(--studio-automattic-40);
 		border-color: var(--studio-automattic-40);


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/179
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/197

## Proposed Changes

This PR:

- Hides the "Add sites by URL" button as it is not implemented yet.
- Fixes the border-radius issue on the split buttons.

## Testing Instructions

- Open the Calyso live link for A4A.
- Go to the Overview > Refresh the page > Verify that the split button: Add new site is not broken.
- Click the dropdown on the button > Verify that the  "Add sites by URL" button is not visible.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="323" alt="Screenshot 2024-04-03 at 2 30 47 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8e28429f-ff69-40db-8669-4387e4e213e9">
</td>
<td>
<img width="341" alt="Screenshot 2024-04-03 at 2 29 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d96e7bc4-c21a-4447-8ff4-2d4370878431">
</td>
</tr>
<tr>
<td>
<img width="441" alt="Screenshot 2024-04-03 at 2 30 38 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d2a1e3ec-2e0e-47fc-9f4a-1f454146fb68">
</td>
<td>
<img width="441" alt="Screenshot 2024-04-03 at 2 30 07 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3f5892c2-54a9-4f4e-815c-ea9db666bc10">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?