### PR TITLE
Fix unsusafe check for document in Server Side Rending context

### DIFF
--- a/packages/help-center/src/hooks/use-zendesk-messaging.ts
+++ b/packages/help-center/src/hooks/use-zendesk-messaging.ts
@@ -50,7 +50,7 @@ export default function useZendeskMessaging(
 	}, [ setMessagingScriptLoaded, enabled, zendeskKey, isMessagingScriptLoaded ] );
 
 	if (
-		document &&
+		typeof document !== 'undefined' &&
 		document.getElementById( ZENDESK_SCRIPT_ID ) &&
 		enabled &&
 		typeof window.zE === 'function' &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87647

## Proposed Changes

The logged /plugins page stopped rendering on the server side caused by an unsafe check for the `document` object. The issue was first signaled [here](https://github.com/Automattic/wp-calypso/pull/87647/files#r1495731330) but the fix doesn't work on the server.

This hopes to fix a potential cause for the traffic loss on /plugins - pau2Xa-5Pt-p2

NOTE: This doesn't cover the plugin details page, where a different error is preventing SSR (fixed in #89723)

#### Logged out /plugins is blank when JS is disabled
<img width="320" alt="Screenshot 2024-04-03 at 12 23 28" src="https://github.com/Automattic/wp-calypso/assets/2749938/5a2fca93-a3d9-49aa-96e6-df031bbb3916">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Disable JS and visit /plugins 
* You should be able to see the Plugins list:

<img width="320" alt="Screenshot 2024-04-03 at 12 09 30" src="https://github.com/Automattic/wp-calypso/assets/2749938/bf657f49-a970-4111-94ae-a789c074d8df">
ee the plugins listing




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
