### PR TITLE
Pattern Library: Show clear icon in search field as soon as user starts typing

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -101,7 +101,7 @@
 			}
 		}
 
-		&.is-open.is-filled {
+		&:has(.search__input[value]:not([value=""])) {
 			.search__open-icon {
 				display: none;
 			}

--- a/client/my-sites/patterns/components/search-field/index.tsx
+++ b/client/my-sites/patterns/components/search-field/index.tsx
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
 import { usePatternsContext } from 'calypso/my-sites/patterns/context';
@@ -37,7 +36,6 @@ export const PatternsSearchField = ( { isCollapsible = false }: PatternsSearchFi
 
 	return (
 		<Search
-			additionalClasses={ classNames( { 'is-filled': !! searchTerm } ) }
 			initialValue={ searchTerm }
 			key={ `search-${ category }` }
 			onSearch={ handleSearch }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6386

## Proposed Changes

| Before | After |
| - | - |
| <video src="https://github.com/Automattic/wp-calypso/assets/1101677/e23ddede-e9e2-4580-8c14-f49c7231576a"></video> | <video src="https://github.com/Automattic/wp-calypso/assets/1101677/04600c9a-c8b5-4be5-a351-a58b23a0589d"></video> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the search field in the category pill navigation
2. Start typing
3. Ensure that the clear icon is shown immediately
