### PR TITLE
Scheduled updates: Update URL of the Explore plugins CTA

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-list-empty.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-empty.tsx
@@ -1,22 +1,19 @@
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
-import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
+import { useSiteSlug } from './hooks/use-site-slug';
 
 interface Props {
 	canCreateSchedules: boolean;
 	onCreateNewSchedule?: () => void;
 }
 export const ScheduleListEmpty = ( props: Props ) => {
+	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
+
 	const { onCreateNewSchedule, canCreateSchedules } = props;
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins();
-	const siteId = useSelector( getSelectedSiteId );
-	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-	const managePluginsUrl = `${ siteAdminUrl }plugins.php`;
-	const translate = useTranslate();
 
 	return (
 		<div className="empty-state">
@@ -40,9 +37,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 						<Button
 							__next40pxDefaultSize
 							variant={ canCreateSchedules ? 'primary' : 'secondary' }
-							onClick={ () => {
-								window.location.href = managePluginsUrl;
-							} }
+							href={ `/plugins/${ siteSlug }` }
 						>
 							{ translate( 'Explore plugins' ) }
 						</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update CTA to lead to "Add new plugins" page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select an atomic site
* Delete all plugins
* Go to "Scheduled updates" page
* Click on "Explore plugins" button
* Check if redirect to "Add new plugins" page

![Screen Capture on 2024-04-03 at 11-43-27](https://github.com/Automattic/wp-calypso/assets/1241413/5cfe722f-74c2-43ed-b58d-2d3651dc7520)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?