### PR TITLE
Added new GitHub Deployments text to plans page

### DIFF
--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -1556,20 +1556,10 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_SFTP_DATABASE ]: {
 		getSlug: () => FEATURE_SFTP_DATABASE,
 		getTitle: () => i18n.translate( 'SFTP, SSH, WP-CLI, and Database access' ),
-		getDescription: () => {
-			const localeSlug = i18n.getLocaleSlug();
-			const hasTranslation =
-				( localeSlug && englishLocales.includes( localeSlug ) ) ||
-				i18n.hasTranslation(
-					'A set of developer tools that give you more control over your site, simplify debugging, and make it easier to integrate with each step of your workflow.'
-				);
-
-			return hasTranslation
-				? i18n.translate(
-						'A set of developer tools that give you more control over your site, simplify debugging, and make it easier to integrate with each step of your workflow.'
-				  )
-				: '';
-		},
+		getDescription: () =>
+			i18n.translate(
+				'A set of developer tools that give you more control over your site, simplify debugging, and make it easier to integrate with each step of your workflow.'
+			),
 	},
 
 	[ PREMIUM_DESIGN_FOR_STORES ]: {
@@ -2045,7 +2035,16 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_DEV_TOOLS ]: {
 		getSlug: () => FEATURE_DEV_TOOLS,
-		getTitle: () => i18n.translate( 'SFTP/SSH, WP-CLI, Git tools' ),
+		getTitle: () => {
+			const localeSlug = i18n.getLocaleSlug();
+			const shouldShowNewString =
+				( localeSlug && englishLocales.includes( localeSlug ) ) ||
+				i18n.hasTranslation( 'SFTP/SSH, WP-CLI, Git commands and GitHub Deployments' );
+
+			return shouldShowNewString
+				? i18n.translate( 'SFTP/SSH, WP-CLI, Git commands and GitHub Deployments' )
+				: i18n.translate( 'SFTP/SSH, WP-CLI, Git tools' );
+		},
 		getDescription: () =>
 			i18n.translate( 'Use familiar developer tools to manage and deploy your site.' ),
 	},
@@ -2295,16 +2294,7 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_PREMIUM_CONTENT_JP ]: {
 		getSlug: () => FEATURE_PREMIUM_CONTENT_JP,
-		getTitle: () => {
-			const localeSlug = i18n.getLocaleSlug();
-			const shouldShowNewString =
-				( localeSlug && englishLocales.includes( localeSlug ) ) ||
-				i18n.hasTranslation( 'Paid content gating' );
-
-			return shouldShowNewString
-				? i18n.translate( 'Paid content gating' )
-				: i18n.translate( 'Gated content' );
-		},
+		getTitle: () => i18n.translate( 'Paid content gating' ),
 		getDescription: () => i18n.translate( 'Sell access to premium content, right from your site.' ),
 	},
 	[ FEATURE_VIDEOPRESS_JP ]: {
@@ -2715,13 +2705,7 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_SENSEI_STORAGE ]: {
 		getSlug: () => FEATURE_SENSEI_STORAGE,
-		getTitle: () => {
-			// If we have the new CTA translated or the locale is EN, return the new string, otherwise use the simpler already translated one.
-			return i18n.hasTranslation( '50GB file and video storage' ) ||
-				[ 'en', 'en-gb' ].includes( i18n.getLocaleSlug() || '' )
-				? i18n.translate( '50 GB file and video storage' )
-				: i18n.translate( '50 GB Storage' );
-		},
+		getTitle: () => i18n.translate( '50 GB file and video storage' ),
 	},
 	[ FEATURE_SENSEI_HOSTING ]: {
 		getSlug: () => FEATURE_SENSEI_HOSTING,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6083

## Proposed Changes

* Changed the text from `SFTP/SSH, WP-CLI, Git tools` to `SFTP/SSH, WP-CLI, Git commands and GitHub Deployments`
* Added it conditionally to keep backward compatibility
* Removed old translation logic

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open http://calypso.localhost:3000/plans/your-free-site and ensure it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?