### PR TITLE
Self-service site restore: improve error message and show visual feedback

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -8,6 +8,7 @@ import {
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
+import { Spinner } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { memo, useRef, useState } from 'react';
@@ -245,10 +246,18 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 				} )
 			);
 		},
-		onError: () => {
-			reduxDispatch(
-				errorNotice( __( 'We were unable to restore the site.' ), { duration: 5000 } )
-			);
+		onError: ( error ) => {
+			if ( error.status === 403 ) {
+				reduxDispatch(
+					errorNotice( __( 'Only the original owner can restore a deleted site.' ), {
+						duration: 5000,
+					} )
+				);
+			} else {
+				reduxDispatch(
+					errorNotice( __( 'We were unable to restore the site.' ), { duration: 5000 } )
+				);
+			}
 		},
 	} );
 
@@ -340,14 +349,13 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 				{ site.is_deleted ? (
 					<DeletedStatus>
 						<span>{ __( 'Deleted' ) }</span>
-						<RestoreButton
-							borderless
-							busy={ isRestoring }
-							disabled={ isRestoring }
-							onClick={ handleRestoreSite }
-						>
-							{ __( 'Restore' ) }
-						</RestoreButton>
+						{ isRestoring ? (
+							<Spinner />
+						) : (
+							<RestoreButton borderless onClick={ handleRestoreSite }>
+								{ __( 'Restore' ) }
+							</RestoreButton>
+						) }
 					</DeletedStatus>
 				) : (
 					<WithAtomicTransfer site={ site }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88898

## Proposed Changes

A couple of small improvements as a followup to https://github.com/Automattic/wp-calypso/pull/88898

* Show a spinner when restore is in progress
* Show error message if non-owner tries to delete

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* try and restore a site as orignal owner. Confirm it works and a spinner is shown when the request is in progress
* Try as a user who was the original owner. The request should be rejected and a notice will say `Only the original owner can restore a deleted site.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?