### PR TITLE
Pattern Library: Fix wonky `writing-mode` styles in Firefox, Safari

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -30,6 +30,35 @@ import './style.scss';
 export const DESKTOP_VIEWPORT_WIDTH = 1200;
 export const ASPECT_RATIO = 7 / 4;
 
+// This style is injected into pattern preview iframes to prevent users from navigating away from
+// the pattern preview page and from submitting forms.
+const noClickStyle = {
+	css: 'a, button, input { pointer-events: none; }',
+	isGlobalStyles: true,
+};
+
+// Firefox and Safari have trouble rendering elements in iframes with `writing-mode` styles. This
+// hacky script is injected into pattern preview iframes to force rerender those elements.
+function forceRedraw() {
+	const elements = document.querySelectorAll< HTMLElement >( '[style*="writing-mode"]' );
+
+	elements.forEach( ( element ) => {
+		element.style.display = 'none';
+	} );
+
+	setTimeout( () => {
+		elements.forEach( ( element ) => {
+			element.style.removeProperty( 'display' );
+		} );
+	}, 200 );
+}
+
+const redrawScript = `
+<script defer>
+(${ forceRedraw.toString() })();
+</script>
+`;
+
 // Abstraction for resetting `isPatternCopied` and `isPermalinkCopied` after a given delay
 function useTimeoutToResetBoolean(
 	value: boolean,
@@ -216,6 +245,8 @@ function PatternPreviewFragment( {
 				<PatternRenderer
 					minHeight={ nodeSize.width ? nodeSize.width / ASPECT_RATIO : undefined }
 					patternId={ patternId }
+					scripts={ redrawScript }
+					styles={ [ noClickStyle ] }
 					viewportWidth={ viewportWidth }
 				/>
 			</div>

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -6,21 +6,25 @@ import { usePatternsRendererContext } from './patterns-renderer-context';
 import type { RenderedStyle } from '../types';
 
 interface Props {
-	patternId: string;
-	viewportWidth?: number;
-	viewportHeight?: number;
-	minHeight?: number;
 	maxHeight?: 'none' | number;
+	minHeight?: number;
+	patternId: string;
+	scripts?: string;
+	styles?: RenderedStyle[];
 	transformHtml?: ( patternHtml: string ) => string;
+	viewportHeight?: number;
+	viewportWidth?: number;
 }
 
 const PatternRenderer = ( {
-	patternId,
-	viewportWidth,
-	viewportHeight,
-	minHeight,
 	maxHeight,
+	minHeight,
+	patternId,
+	scripts = '',
+	styles = [],
 	transformHtml,
+	viewportHeight,
+	viewportWidth,
 }: Props ) => {
 	const { renderedPatterns, shouldShufflePosts } = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
@@ -33,17 +37,19 @@ const PatternRenderer = ( {
 		patternHtml = transformHtml( patternHtml );
 	}
 
-	let patternStyles = pattern?.styles ?? [];
+	let patternStyles = pattern?.styles ? [ ...styles, ...pattern.styles ] : [ ...styles ];
 	if ( shouldShufflePosts ) {
 		const css = shufflePosts( patternId, patternHtml );
 		patternStyles = [ ...patternStyles, { css } as RenderedStyle ];
 	}
 
+	const patternScripts = [ pattern?.scripts ?? '', scripts ];
+
 	return (
 		<BlockRendererContainer
 			key={ pattern?.ID }
 			styles={ patternStyles }
-			scripts={ pattern?.scripts ?? '' }
+			scripts={ patternScripts.join( '' ) }
 			viewportWidth={ viewportWidth }
 			maxHeight={ maxHeight }
 			minHeight={ minHeight }

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -37,7 +37,7 @@ const PatternRenderer = ( {
 		patternHtml = transformHtml( patternHtml );
 	}
 
-	let patternStyles = pattern?.styles ? [ ...styles, ...pattern.styles ] : [ ...styles ];
+	let patternStyles = [ ...styles, ...( pattern?.styles ?? [] ) ];
 	if ( shouldShufflePosts ) {
 		const css = shufflePosts( patternId, patternHtml );
 		patternStyles = [ ...patternStyles, { css } as RenderedStyle ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

See pdtkmj-2wZ-p2#comment-4707 pdtkmj-2wZ-p2#comment-4711 pdtkmj-2wZ-p2#comment-4710

Elements with `writing-mode` styles seem to have trouble rendering properly in Firefox and Safari. This PR attempts to fix that by "force re-rendering" those elements.

I also took this opportunity to inject styles into pattern previews that prevent links from being clicked and forms from being submitted.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/header`
2. Ensure that links within pattern previews cannot be clicked
3. Navigate to `/patterns/newsletter`
4. Ensure that forms within pattern previews cannot be submitted
5. In Firefox or Safari, navigate to `/patterns/events`
6. Ensure that the third pattern preview – `Events List` – looks good