### PR TITLE
Updated transfer status handler on the hosting page

### DIFF
--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -47,17 +47,11 @@ const HostingActivateStatus = ( {
 		! endStates.includes( transferStatus as TransferStates ) &&
 		transferStatus !== transferStates.NULL;
 
-	// console.log( 'isTransferring: ', isTransferring );
-	// console.log( 'transferStatus: ', transferStatus );
-	// console.log( 'automatedTransferStatus: ', automatedTransferStatus );
-
 	const dispatch = useDispatch();
 	const isTransferCompleted = endStates.includes(
 		transferStatus as ( typeof transferInProgress )[ number ]
 	);
 	const [ wasTransferring, setWasTransferring ] = useState( false );
-
-	// console.log( 'isTransferCompleted: ', isTransferCompleted );
 
 	useEffect( () => {
 		if ( isTransferring && ! wasTransferring ) {
@@ -67,11 +61,14 @@ const HostingActivateStatus = ( {
 			setWasTransferring( false );
 		}
 		if ( ! isTransferCompleted ) {
-			// console.log( 'will dispatch fetchAutomatedTransferStatus' );
 			dispatch( fetchAutomatedTransferStatus( siteId ?? 0 ) );
 		}
 		onTick?.( isTransferring, wasTransferring, isTransferCompleted );
 	}, [ isTransferCompleted, isTransferring, onTick, wasTransferring ] );
+
+	if ( isTransferCompleted ) {
+		return null;
+	}
 
 	const getLoadingText = () => {
 		switch ( context ) {

--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -33,6 +33,7 @@ const endStates: TransferStates[] = [
 	transferStates.FAILURE,
 	transferStates.ERROR,
 	transferStates.REVERTED,
+	transferStates.NULL,
 ];
 
 const HostingActivateStatus = ( {
@@ -45,7 +46,7 @@ const HostingActivateStatus = ( {
 
 	const isTransferring =
 		! endStates.includes( transferStatus as TransferStates ) &&
-		transferStatus !== transferStates.NULL;
+		transferStatus !== transferStates.INQUIRING;
 
 	const dispatch = useDispatch();
 	const isTransferCompleted = endStates.includes(

--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -67,10 +67,6 @@ const HostingActivateStatus = ( {
 		onTick?.( isTransferring, wasTransferring, isTransferCompleted );
 	}, [ isTransferCompleted, isTransferring, onTick, wasTransferring ] );
 
-	if ( isTransferCompleted ) {
-		return null;
-	}
-
 	const getLoadingText = () => {
 		switch ( context ) {
 			case 'theme':
@@ -95,6 +91,10 @@ const HostingActivateStatus = ( {
 
 	if ( transferStatus === transferStates.ERROR ) {
 		return <Notice status="is-error" showDismiss={ false } text={ getErrorText() } icon="bug" />;
+	}
+
+	if ( isTransferCompleted ) {
+		return null;
 	}
 
 	if ( isTransferring || keepAlive ) {

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -210,7 +210,6 @@ const Hosting = ( props ) => {
 				transferStates.REVERTED,
 			].includes( transferState )
 	);
-	const [ shouldPullTransferResults, setShouldPullTransferResults ] = useState( true );
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showHostingActivationBanner = canSiteGoAtomic && ! hasTransfer;
@@ -228,11 +227,9 @@ const Hosting = ( props ) => {
 
 	const trialRequested = () => {
 		setHasTransferring( true );
-		setShouldPullTransferResults( true );
 	};
 
 	const activationRequested = () => {
-		setShouldPullTransferResults( true );
 		clickActivate();
 	};
 
@@ -244,14 +241,6 @@ const Hosting = ( props ) => {
 
 			if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
 				fetchUpdatedData();
-			}
-
-			if ( isTransferCompleted && ! isTransferring ) {
-				setShouldPullTransferResults( false );
-			}
-
-			if ( ! isSiteAtomic && ! hasTransfer ) {
-				setShouldPullTransferResults( false );
 			}
 		},
 		[ hasTransfer ]
@@ -350,15 +339,13 @@ const Hosting = ( props ) => {
 				title={ translate( 'Hosting' ) }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
-			{ shouldPullTransferResults &&
-				! showHostingActivationBanner &&
-				! isTrialAcknowledgeModalOpen && (
-					<HostingActivateStatus
-						context="hosting"
-						onTick={ requestUpdatedSiteData }
-						keepAlive={ ! isSiteAtomic && hasTransfer }
-					/>
-				) }
+			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (
+				<HostingActivateStatus
+					context="hosting"
+					onTick={ requestUpdatedSiteData }
+					keepAlive={ ! isSiteAtomic && hasTransfer }
+				/>
+			) }
 			{ ! isBusinessTrial && banner }
 			{ isBusinessTrial && ( ! hasTransfer || isSiteAtomic ) && (
 				<TrialBanner

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -229,10 +229,6 @@ const Hosting = ( props ) => {
 		setHasTransferring( true );
 	};
 
-	const activationRequested = () => {
-		clickActivate();
-	};
-
 	const requestUpdatedSiteData = useCallback(
 		( isTransferring, wasTransferring, isTransferCompleted ) => {
 			if ( isTransferring && ! hasTransfer ) {
@@ -281,10 +277,7 @@ const Hosting = ( props ) => {
 					icon="globe"
 				>
 					<TrackComponentView eventName="calypso_hosting_configuration_activate_impression" />
-					<NoticeAction
-						onClick={ activationRequested }
-						href={ `/hosting-config/activate/${ siteSlug }` }
-					>
+					<NoticeAction onClick={ clickActivate } href={ `/hosting-config/activate/${ siteSlug }` }>
 						{ translate( 'Activate' ) }
 					</NoticeAction>
 				</Notice>

--- a/client/my-sites/hosting/test/hosting-activate-status.jsx
+++ b/client/my-sites/hosting/test/hosting-activate-status.jsx
@@ -8,7 +8,8 @@ import configureStore from 'redux-mock-store';
 import { transferStates } from '../../../state/automated-transfer/constants';
 import HostingActivateStatus from '../hosting-activate-status';
 
-const initialState = {
+const mockTransferStatus = transferStates.NONE;
+const mockInitialState = {
 	sites: {
 		items: [],
 		requesting: {},
@@ -26,29 +27,18 @@ const initialState = {
 	notices: {
 		items: [],
 	},
-};
-
-let mockIsTransferring = true;
-let mockTransferStatus = '';
-
-jest.mock( 'calypso/state/atomic-transfer/use-atomic-transfer-query', () => {
-	return {
-		useAtomicTransferQuery: ( siteId ) => {
-			if ( siteId === initialState.ui.selectedSiteId ) {
-				return {
-					isTransferring: mockIsTransferring,
-					transferStatus: mockTransferStatus,
-				};
-			}
+	automatedTransfer: {
+		[ 1 ]: {
+			status: mockTransferStatus,
 		},
-	};
-} );
+	},
+};
 
 describe( 'index', () => {
 	test( 'Transfer status COMPLETED should return isTransferCompleted true', async () => {
-		mockTransferStatus = transferStates.COMPLETED;
+		mockInitialState.automatedTransfer[ 1 ].status = transferStates.COMPLETED;
 		const mockStore = configureStore();
-		const store = mockStore( initialState );
+		const store = mockStore( mockInitialState );
 
 		const onTick = jest.fn();
 
@@ -58,13 +48,13 @@ describe( 'index', () => {
 			</Provider>
 		);
 
-		expect( onTick ).toHaveBeenCalledWith( true, false, true );
+		expect( onTick ).toHaveBeenCalledWith( false, false, true );
 	} );
 
-	test( 'Transfer status NONE should return isTransferCompleted false', async () => {
-		mockTransferStatus = transferStates.NONE;
+	test( 'Transfer status NONE should return isTransferCompleted true', async () => {
+		mockInitialState.automatedTransfer[ 1 ].status = transferStates.NONE;
 		const mockStore = configureStore();
-		const store = mockStore( initialState );
+		const store = mockStore( mockInitialState );
 
 		const onTick = jest.fn();
 
@@ -74,13 +64,13 @@ describe( 'index', () => {
 			</Provider>
 		);
 
-		expect( onTick ).toHaveBeenCalledWith( true, false, false );
+		expect( onTick ).toHaveBeenCalledWith( false, false, true );
 	} );
 
 	test( 'Should show the transferring notice when the site is transferring to Atomic based on context', async () => {
-		mockTransferStatus = transferStates.PENDING;
+		mockInitialState.automatedTransfer[ 1 ].status = transferStates.PENDING;
 		const mockStore = configureStore();
-		const store = mockStore( initialState );
+		const store = mockStore( mockInitialState );
 
 		render(
 			<Provider store={ store }>
@@ -113,10 +103,8 @@ describe( 'index', () => {
 
 	test( 'Should show error status and the transfer fails', async () => {
 		const mockStore = configureStore();
-		const store = mockStore( initialState );
-
-		mockIsTransferring = true;
-		mockTransferStatus = transferStates.ERROR;
+		mockInitialState.automatedTransfer[ 1 ].status = transferStates.ERROR;
+		const store = mockStore( mockInitialState );
 
 		render(
 			<Provider store={ store }>

--- a/client/state/automated-transfer/constants.ts
+++ b/client/state/automated-transfer/constants.ts
@@ -16,6 +16,7 @@ export const transferStates = {
 	RELOCATING: 'relocating_switcheroo',
 	COMPLETE: 'complete',
 	COMPLETED: 'completed', // there seems to be two spellings for this state
+	NULL: null,
 	/**
 	 * Similar to 'none' there is no existing transfer, but this is when the site has been already reverted from atomic
 	 */
@@ -29,6 +30,7 @@ export const transferStates = {
 } as const;
 
 export const transferInProgress = [
+	transferStates.START,
 	transferStates.PENDING,
 	transferStates.ACTIVE,
 	transferStates.PROVISIONED,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5884
Follow-up of https://github.com/Automattic/wp-calypso/pull/89126

## Proposed Changes

* We're using only the `/automated-transfers/status` endpoint for checking the transfer status
* We're handling the component show status inside of it since we don't have the re-render issue anymore


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure we call the `/automated-transfers/status` only when necessary (we may call it 4 times before stopping)
* Ensure `/atomic/transfers/latest` endpoint is not called anymore
* Ensure /hosting-config, themes upload and plugin upload screens works for the states we use it:
  - New simple sites are migrating to atomic
  - Ensure Atomic sites don’t pull (only one time)
  - Simple Atomic sites (creator plan not migrated yet) work as expected
  - Reverted free site to trial: Ensure it only pulls after requesting a trial and successfully continues to pull after it stops after the transition is completed.
 
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?