### PR TITLE
Migration Plan step: Update upgrade plan CTA copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -1,5 +1,6 @@
 import { PLAN_BUSINESS, getPlan, getPlanByPathSlug } from '@automattic/calypso-products';
 import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
 import { UpgradePlan } from 'calypso/blocks/importer/wordpress/upgrade-plan';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -12,6 +13,7 @@ import type { Step } from '../../types';
 const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
 
 	const selectedPlanData = useSelectedPlanUpgradeQuery();
 	const selectedPlanPathSlug = selectedPlanData.data;
@@ -27,7 +29,7 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
 	const stepContent = (
 		<UpgradePlan
 			site={ siteItem }
-			ctaText=""
+			ctaText={ translate( 'Upgrade and migrate' ) }
 			subTitleText=""
 			isBusy={ false }
 			hideTitleAndSubTitle

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -43,7 +43,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		const navigation = { submit: jest.fn() };
 		render( { navigation } );
 
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Upgrade and migrate/ } ) );
 
 		expect( navigation.submit ).toHaveBeenCalledWith( {
 			goToCheckout: true,
@@ -56,7 +56,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		render( { navigation } );
 
 		await userEvent.click( screen.getByRole( 'button', { name: /Pay monthly/ } ) );
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Upgrade and migrate/ } ) );
 
 		expect( navigation.submit ).toHaveBeenCalledWith( {
 			goToCheckout: true,
@@ -69,7 +69,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		render( { navigation } );
 
 		await userEvent.click( screen.getByRole( 'button', { name: /Pay annually/ } ) );
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Upgrade and migrate/ } ) );
 
 		expect( navigation.submit ).toHaveBeenCalledWith( {
 			goToCheckout: true,
@@ -82,7 +82,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		render( { navigation } );
 
 		await userEvent.click( screen.getByRole( 'button', { name: /Try 7 days for free/ } ) );
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Upgrade and migrate/ } ) );
 
 		expect( navigation.submit ).toHaveBeenCalledWith( {
 			freeTrialSelected: true,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -90,13 +90,6 @@ export class StartImportFlow {
 	}
 
 	/**
-	 * Validates that we've landed on the upgrade plan page (site-migration).
-	 */
-	async validateUpgradePlanPageSiteMigration(): Promise< void > {
-		await this.page.locator( selectors.startBuildingHeader( 'Upgrade your plan' ) ).waitFor();
-	}
-
-	/**
 	 * Validates that we've landed on the upgrade plan page.
 	 */
 	async validateUpgradePlanPage(): Promise< void > {

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -90,6 +90,13 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Validates that we've landed on the upgrade plan page (site-migration).
+	 */
+	async validateUpgradePlanPageSiteMigration(): Promise< void > {
+		await this.page.locator( selectors.startBuildingHeader( 'Upgrade your plan' ) ).waitFor();
+	}
+
+	/**
 	 * Validates that we've landed on the upgrade plan page.
 	 */
 	async validateUpgradePlanPage(): Promise< void > {

--- a/test/e2e/specs/importer/importer__import-focused.ts
+++ b/test/e2e/specs/importer/importer__import-focused.ts
@@ -107,9 +107,9 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 			await startImportFlow.validateSitePickerPage();
 		} );
 
-		it( 'Should select the second site and press `Continue` on modal prompt', async () => {
+		it( 'Should select the second site and press `Upgrade and migrate` on modal prompt', async () => {
 			await page.getByRole( 'button', { name: 'Select this site' } ).nth( 1 ).click();
-			await startImportFlow.clickButton( 'Continue' );
+			await startImportFlow.clickButton( 'Upgrade and migrate' );
 		} );
 
 		it( 'Should render "Upgrade Plan" screen', async () => {
@@ -133,9 +133,9 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 			await startImportFlow.validateSitePickerPage();
 		} );
 
-		it( 'Should select the first site and press `Continue` on modal prompt', async () => {
+		it( 'Should select the first site and press `Upgrade and migrate` on modal prompt', async () => {
 			await page.getByRole( 'button', { name: 'Select this site' } ).first().click();
-			await startImportFlow.clickButton( 'Continue' );
+			await startImportFlow.clickButton( 'Upgrade and migrate' );
 		} );
 
 		it( 'Should render "Migration Ready" screen', async () => {

--- a/test/e2e/specs/importer/importer__import-focused.ts
+++ b/test/e2e/specs/importer/importer__import-focused.ts
@@ -48,7 +48,7 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 		} );
 
 		it( 'Should render "Upgrade Plan" screen', async () => {
-			await startImportFlow.validateUpgradePlanPageSiteMigration();
+			await startImportFlow.validateUpgradePlanPage();
 		} );
 
 		it( 'Should render "Install Jetpack" screen', async () => {
@@ -70,7 +70,7 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 		} );
 
 		it( 'Should render "Upgrade Plan" screen', async () => {
-			await startImportFlow.validateUpgradePlanPageSiteMigration();
+			await startImportFlow.validateUpgradePlanPage();
 		} );
 
 		it( 'Should redirect to "Checkout" page', async () => {
@@ -113,7 +113,7 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 		} );
 
 		it( 'Should render "Upgrade Plan" screen', async () => {
-			await startImportFlow.validateUpgradePlanPageSiteMigration();
+			await startImportFlow.validateUpgradePlanPage();
 		} );
 
 		it( 'Should redirect to "Checkout" page', async () => {

--- a/test/e2e/specs/importer/importer__import-focused.ts
+++ b/test/e2e/specs/importer/importer__import-focused.ts
@@ -48,7 +48,7 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 		} );
 
 		it( 'Should render "Upgrade Plan" screen', async () => {
-			await startImportFlow.validateUpgradePlanPage();
+			await startImportFlow.validateUpgradePlanPageSiteMigration();
 		} );
 
 		it( 'Should render "Install Jetpack" screen', async () => {
@@ -70,7 +70,7 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 		} );
 
 		it( 'Should render "Upgrade Plan" screen', async () => {
-			await startImportFlow.validateUpgradePlanPage();
+			await startImportFlow.validateUpgradePlanPageSiteMigration();
 		} );
 
 		it( 'Should redirect to "Checkout" page', async () => {
@@ -113,7 +113,7 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 		} );
 
 		it( 'Should render "Upgrade Plan" screen', async () => {
-			await startImportFlow.validateUpgradePlanPage();
+			await startImportFlow.validateUpgradePlanPageSiteMigration();
 		} );
 
 		it( 'Should redirect to "Checkout" page', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/89103

## Proposed Changes

* Updates the CTA text from "Continue" to "Upgrade and migrate"

<img width="870" alt="CleanShot 2024-04-03 at 10 43 10@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/44adec27-a750-4e2d-80ad-5d1c532b062f">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/setup/site-migration`.
* Add a free site to the `siteSlug` param, select the `Everything (requires a Creator Plan)` option, and then click continue.
* Verify the CTA copies match the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?