### PR TITLE
E2E: getByRole → locator on page template selector

### DIFF
--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -64,7 +64,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		const editorParent = await editorPage.getEditorParent();
 		pageTemplateToSelect =
-			( await editorParent.getByRole( 'option' ).first().getAttribute( 'aria-label' ) ) ?? '';
+			( await editorParent.locator( '[role="option"]' ).first().getAttribute( 'aria-label' ) ) ??
+			'';
 		await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );
 	} );
 

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -64,8 +64,11 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		const editorParent = await editorPage.getEditorParent();
 		pageTemplateToSelect =
-			( await editorParent.locator( '[role="option"]' ).first().getAttribute( 'aria-label' ) ) ??
-			'';
+			( await editorParent
+				.getByRole( 'listbox', { name: 'Block patterns' } )
+				.getByRole( 'option' )
+				.first()
+				.getAttribute( 'aria-label' ) ) ?? '';
 		await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

On the mobile viewports, the page flow test was failing, as it wasn't able to select the page template.

This is because `getByRole('option')` was being used, which finds both the `<option>` tag and elements with a `[role="option"]` attribute. On mobile, the page template selector adds a dropdown, polluting the locator list with extra elements.

This PR narrows the selector by instead using `locator( '[role="option"]' )`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME=mobile JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/editor/editor__page-basic-flow.ts
yarn workspace wp-e2e-tests build && VIEWPORT_NAME=desktop JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/editor/editor__page-basic-flow.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?