### PR TITLE
Continue with Google: Move nonce retrieval to button `onClick` handler

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -175,7 +175,13 @@ class GoogleSocialButton extends Component {
 			const nonce = response.nonce;
 			this.setState( { nonce } );
 
-			if ( this.props.authCodeFromRedirect && this.props.serviceFromRedirect !== 'github' ) {
+			const currentPath = window.location.pathname;
+
+			if (
+				this.props.authCodeFromRedirect &&
+				this.props.serviceFromRedirect !== 'github' &&
+				currentPath !== '/me/security/social-login'
+			) {
 				this.handleAuthorizationCode( {
 					auth_code: this.props.authCodeFromRedirect,
 					redirect_uri: this.props.redirectUri,

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -46,7 +46,7 @@ class GoogleSocialButton extends Component {
 		showError: false,
 		errorRef: null,
 		eventTimeStamp: null,
-		isDisabled: isNonceEnabled ? false : true,
+		isDisabled: ! isNonceEnabled,
 	};
 
 	constructor( props ) {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -196,20 +196,11 @@ class GoogleSocialButton extends Component {
 		event.preventDefault();
 		event.stopPropagation();
 
-		if ( this.state.error && this.state.eventTimeStamp !== event.timeStamp ) {
-			this.setState( {
-				showError: ! this.state.showError,
-				errorRef: event.currentTarget,
-				eventTimeStamp: event.timeStamp,
-			} );
-		}
-
 		if ( this.state.isDisabled ) {
 			return;
 		}
 
 		await this.fetchNonceAndInitializeGoogleSignIn();
-
 		this.props.onClick( event );
 
 		if ( this.state.error ) {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/88633.

## Proposed Changes

* move the nonce (state) retrieval to the button `onClick` handler
* add nonce (state) to the `handleAuthorizationCode` that happens on the component mount (if the page with the component is opened with necessary redirect parameters)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The PR cannot be fully tested before merging due to limitations outlined in D142283-code. The aim is to fully test the flows after merging - when the code is in staging (before deploying to production).

However, we can partially test the changes with the help of **Node.js server run at port 443** (setup steps here: PCYsg-5YE-p2).

ℹ️ When testing with `wordpress.com` locally, please change the `isNonceEnabled` constant to `true`: 

```js
const isNonceEnabled = true;
```

This is because wordpress.com ignores feature flags set through the URL.

---

Apart from the above, please review the code itself to notice any potential issues.

While having the PR checked out and built, we can also navigate to login / signup flows to check for regressions with and without having the feature flag enabled:

Log-in page (when logged out)
- http://calypso.localhost:3000/log-in?flags=login/google-login-update
- http://calypso.localhost:3000/log-in?flags=-login/google-login-update

Sign-up page (when logged out)
- http://calypso.localhost:3000/start/account/user-social?flags=login/google-login-update
- http://calypso.localhost:3000/start/account/user-social?flags=-login/google-login-update

Social Logins page (when logged in already)
- http://calypso.localhost:3000/me/security/social-login?flags=login/google-login-update
- http://calypso.localhost:3000/me/security/social-login?flags=-login/google-login-update

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?