### PR TITLE
Pattern Library: Ensure RTL is taken into account for resizing patterns

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -337,9 +337,9 @@ export function PatternPreview( props: PatternPreviewProps ) {
 		<ResizableBox
 			enable={ {
 				top: false,
-				right: isRtl ? false : true,
+				right: ! isRtl,
 				bottom: false,
-				left: isRtl ? true : false,
+				left: isRtl,
 				topRight: false,
 				bottomRight: false,
 				bottomLeft: false,

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -7,7 +7,7 @@ import { ResizableBox, Tooltip } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { Icon, lock } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { useRtl, useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
@@ -313,6 +313,7 @@ export function PatternPreview( props: PatternPreviewProps ) {
 	const isMobile = useMobileBreakpoint();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+	const isRtl = useRtl();
 
 	if ( ! pattern ) {
 		return null;
@@ -336,9 +337,9 @@ export function PatternPreview( props: PatternPreviewProps ) {
 		<ResizableBox
 			enable={ {
 				top: false,
-				right: true,
+				right: isRtl ? false : true,
 				bottom: false,
-				left: false,
+				left: isRtl ? true : false,
 				topRight: false,
 				bottomRight: false,
 				bottomLeft: false,

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -144,24 +144,27 @@
 	}
 }
 
-.pattern-preview__resizer .components-resizable-box__handle-right {
-	bottom: 3rem;
-	height: auto;
-	left: 100%;
-	right: initial;
+.pattern-preview__resizer {
+	.components-resizable-box__handle-left,
+	.components-resizable-box__handle-right {
+		bottom: 3rem;
+		height: auto;
+		left: 100%;
+		right: initial;
 
-	&::after {
-		background-color: #a7aaad;
-		border-radius: 3px;
-		box-shadow: none;
-		height: 50px;
-		right: calc(50% - 3px);
-		top: calc(50% - 8px);
-		width: 6px;
-	}
+		&::after {
+			background-color: #a7aaad;
+			border-radius: 3px;
+			box-shadow: none;
+			height: 50px;
+			right: calc(50% - 3px);
+			top: calc(50% - 8px);
+			width: 6px;
+		}
 
-	&::before {
-		content: none;
+		&::before {
+			content: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Due to lack of support for RTL discovered in pdtkmj-2wZ-p2#comment-4711, pattern resizing was buggy in the affected languages.

This PR supplies a fix by ensuring that the RTL status of the locale is utilised to properly set properties for the resize box. 

Testing
---

Test the resize feature of a pattern when a RTL language like Arabic is enabled. Specify the language by using the special form of the path that supports locale e.g. `/ar/patterns/about` 

<img width="600" alt="Screenshot 2024-04-03 at 17 02 59" src="https://github.com/Automattic/wp-calypso/assets/277661/7fe859d9-c151-4f76-a0ab-ab57dbb2c174">
