### PR TITLE
Self-service site restore: Always show stats off indicator for deleted sites.

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -383,7 +383,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 			<StatsColumnStyled tabletHidden>
 				{ inView && (
 					<>
-						{ hasStatsLoadingError ? (
+						{ hasStatsLoadingError || site.is_deleted ? (
 							<StatsOffIndicator />
 						) : (
 							<a href={ `/stats/day/${ site.slug }` }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
Currently the stats loading indicator is shown at first

* Always show statsOff indicator without showing the loading stats bar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites?status=deleted` and ensure statsOff is always shown

**Before**

![Screenshot 2024-04-03 at 2 49 14 PM](https://github.com/Automattic/wp-calypso/assets/47489215/d26c1b3f-6b34-4ea8-b459-456f2646a402)

**After**
![image](https://github.com/Automattic/wp-calypso/assets/47489215/bb121fc7-da49-490c-9b79-20646527c189)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?