### PR TITLE
Site Migration: Update site migraton flow to conditionally verify the account email

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -26,6 +26,7 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_PLUGIN_INSTALL,
 			STEPS.PROCESSING,
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
+			STEPS.VERIFY_EMAIL,
 			STEPS.SITE_MIGRATION_INSTRUCTIONS,
 			STEPS.ERROR,
 		];
@@ -207,7 +208,15 @@ const siteMigration: Flow = {
 					return navigate( STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug );
 				}
 
+				case STEPS.VERIFY_EMAIL.slug: {
+					return navigate( STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug );
+				}
+
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
+					if ( providedDependencies?.verifyEmail ) {
+						return navigate( STEPS.VERIFY_EMAIL.slug );
+					}
+
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = addQueryArgs(
 							{
@@ -230,10 +239,6 @@ const siteMigration: Flow = {
 							siteId,
 							siteSlug,
 						} );
-					}
-					if ( providedDependencies?.verifyEmail ) {
-						// not yet implemented
-						return;
 					}
 				}
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -122,6 +122,38 @@ describe( 'Site Migration Flow', () => {
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );
+
+		it( 'redirects from upgrade-plan to verifyEmail if user is unverified', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+				dependencies: {
+					verifyEmail: true,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.VERIFY_EMAIL.slug }`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects from verifyEmail back to upgrade-plan', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.VERIFY_EMAIL.slug,
+				dependencies: {
+					verifyEmail: true,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }`,
+				state: null,
+			} );
+		} );
 	} );
 
 	describe( 'goBack', () => {


### PR DESCRIPTION
In the event that a new user with an unverified email goes through the migration flow, we now take them to the step to verify their email before continuing to allow them to purchase a Creator Plan or trial.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the Fixes #87735linked issue.
-->

Related to #87735

## Proposed Changes

This updates the Site Migration flow so that unverified users have to verify their email before continuing with the migration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can checkout this branch locally or use the calypso.live url.

## Verify the flow still works for a verified user

* Using an existing, verified account, go to `/start`.
* On the "Goals" step, pick the "Import existing content or website" goal.
* Enter any WordPress website for "Where will you import from?" (Jurassic Ninja is fine here).
* Select "Everything" for "What do you want to migrate?".
* Either purchase a Creator plan or select the 7-day trial.
* Verify that, after processing, you end up on the "Ready to migrate your site?" instructions page.

## Verify the flow for an unverified user

* In an incognito window, go to `/start`.
* Select "Continue with Email" on the "Create your account" page.
![image](https://github.com/Automattic/wp-calypso/assets/917632/aed1382a-4bef-42e0-9e81-a4dfbd36546b)
* Enter an valid email address that doesn't belong to an existing WordPress.com account. (If you have a Gmail address like `bob@gmail.com`, you can do something like `bob+verifytest@gmail.com`).
* Select a "Free" plan.
* On the "Goals" step, pick the "Import existing content or website" goal.
* Enter any WordPress website for "Where will you import from?" (Jurassic Ninja is fine here).
* Select "Everything" for "What do you want to migrate?".
* On the plan upgrade step, click "Try 7 days for free"
![image](https://github.com/Automattic/wp-calypso/assets/917632/02d6be25-bf9d-494b-ba3a-7717a1ab903b)
* You should be taken to the verify your email address step.
![image](https://github.com/Automattic/wp-calypso/assets/917632/55734785-9221-421a-b501-5c3661bdd742)
* Click the "Resend verification email".
* Now go to your email and locate the WordPress.com verification email.
* Copy the verifcation link and paste it into a new incognito tab in your browser. Make sure the "Verify your email address" step is still open in another incognito window.
* After verifying your email, the "Verify your email address" step should send you back to the plan upgrade step.
* On the plan upgrade step, click "Try 7 days for free".
* * Verify that, after processing, you end up on the "Ready to migrate your site?" instructions page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?