### PR TITLE
Stats: add ecommerce to commercial reasons

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -423,7 +423,7 @@ function StatsCommercialFlowOptOutForm( {
 							commercialReasons
 								?.map(
 									( reason: string ) =>
-										COMMERCIAL_REASONS[ reason as keyof typeof COMMERCIAL_REASONS ] ?? 'Unknown'
+										COMMERCIAL_REASONS[ reason as keyof typeof COMMERCIAL_REASONS ] ?? reason
 								)
 								.join( ' and/or ' ) ?? 'Unknown',
 					},

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -348,6 +348,7 @@ function StatsCommercialFlowOptOutForm( {
 		'commercial-dext': translate( 'Commercial Domain Extension' ),
 		'contact-details': translate( 'Contact Details' ),
 		'manual-override': translate( 'Manual Override' ),
+		ecommerce: translate( 'Ecommerce' ),
 	};
 	const { supportsOnDemandCommercialClassification } = useSelector( ( state ) =>
 		getEnvStatsFeatureSupportChecks( state, siteId )


### PR DESCRIPTION
## Proposed Changes

- Add missing Ecommerce to commercial reasons.

fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Swrgcnpx%2Qfvgr%2Qcebsvyrf%2Spbzzrepvny%2Spynff.wrgcnpx%2Qpbzzrepvny%2Qpenjyre.cuc%3Se%3Q633585qo%231252-og

- Show raw message if not found

## Testing Instructions

* Spin up a JN site with WooCommerce + Jetpack
* Connect site
* Open Purchase page on Calypso Live `/stats/purchase/:siteSlug`
* Ensure you see something similar to

<img width="615" alt="Screenshot 2024-04-04 at 9 08 47 AM" src="https://github.com/Automattic/wp-calypso/assets/1425433/e47769ab-732e-47e3-a722-68bd85f42fc7">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?