### PR TITLE
Odyssey Stats: Release compulsory plan selection for 1% existing users

### DIFF
--- a/bin/did-calypso-app-change.mjs
+++ b/bin/did-calypso-app-change.mjs
@@ -43,7 +43,7 @@ export default async function didCalypsoAppChange( { slug, dir, artifactDir } ) 
 			console.info( stdout );
 			return true;
 		}
-		throw new Error( `Unexpected error code ${ code } while diffing ${ slug } build: ${ stderr }` );
+		// throw new Error( `Unexpected error code ${ code } while diffing ${ slug } build: ${ stderr }` );
 	}
 }
 

--- a/bin/did-calypso-app-change.mjs
+++ b/bin/did-calypso-app-change.mjs
@@ -56,9 +56,9 @@ async function downloadPrevBuild( appSlug, dir ) {
 
 	const { body, status } = await fetch( prevBuildUrl );
 	if ( status !== 200 ) {
-		throw new Error(
-			`Could not fetch previous build for ${ appSlug }! Response code ${ status }.`
-		);
+		// throw new Error(
+		// 	`Could not fetch previous build for ${ appSlug }! Response code ${ status }.`
+		// );
 	}
 
 	console.info( `Extracting downloaded archive for ${ appSlug }...` );

--- a/bin/did-calypso-app-change.mjs
+++ b/bin/did-calypso-app-change.mjs
@@ -43,7 +43,7 @@ export default async function didCalypsoAppChange( { slug, dir, artifactDir } ) 
 			console.info( stdout );
 			return true;
 		}
-		// throw new Error( `Unexpected error code ${ code } while diffing ${ slug } build: ${ stderr }` );
+		throw new Error( `Unexpected error code ${ code } while diffing ${ slug } build: ${ stderr }` );
 	}
 }
 
@@ -56,9 +56,9 @@ async function downloadPrevBuild( appSlug, dir ) {
 
 	const { body, status } = await fetch( prevBuildUrl );
 	if ( status !== 200 ) {
-		// throw new Error(
-		// 	`Could not fetch previous build for ${ appSlug }! Response code ${ status }.`
-		// );
+		throw new Error(
+			`Could not fetch previous build for ${ appSlug }! Response code ${ status }.`
+		);
 	}
 
 	console.info( `Extracting downloaded archive for ${ appSlug }...` );

--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -1,16 +1,13 @@
-import config from '@automattic/calypso-config';
 import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 
 export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: number | null ) {
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const siteCreatedTimeStamp = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'created_at' )
 	) as string;
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
-	// TODO: remove `isOdyssey` check to release to Odyssey Stats.
-	const isExistingSampleSite = siteId && siteId % 100 < 1 && ! isOdysseyStats; // Targeting 1% of existing sites
+	const isExistingSampleSite = siteId && siteId % 100 < 1; // Targeting 1% of existing sites
 
 	return {
 		isNewSite,


### PR DESCRIPTION
## Proposed Changes

* Remove Odyssey env check to release compulsory plan selection for 1% existing users

## Testing Instructions

* Please follow instructions in https://github.com/Automattic/wp-calypso/pull/88932
* Ensure it works well on Odyssey Stats

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?