### PR TITLE
Fix Themes filters toolbar CSS wrap

### DIFF
--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -6,7 +6,7 @@
 		background-color: transparent;
 		border-color: transparent;
 		justify-content: space-between;
-		flex-wrap: wrap;
+		flex-wrap: nowrap;
 		display: flex;
 		opacity: 0;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1712169526774829-slack-C06DN6QQVAQ

## Proposed Changes

* Use `flex-wrap: nowrap`

Before | After
--|--
<img width="1064" alt="Screenshot 2024-04-03 at 3 51 56 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/c08c6812-5639-4047-b6a5-b3f7d61ae4ae"> | <img width="1065" alt="Screenshot 2024-04-03 at 3 52 16 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/b7307325-4f08-480b-bf12-c5a84d73fc02">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On production go to /themes/[site_slug]
* Adjust your screen width until you hit the sweet spot where the filters toolbar becomes misaligned.
* Load this PR and go to /themes/[site_slug]
* At the same width, observe the filters toolbar looks correct.
* Consider if any "CSS bleed over" is possible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?