### PR TITLE
Migration Step: Update site-migration header text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -1,5 +1,6 @@
 import { PLAN_BUSINESS, getPlan, getPlanByPathSlug } from '@automattic/calypso-products';
 import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
 import { UpgradePlan } from 'calypso/blocks/importer/wordpress/upgrade-plan';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -12,6 +13,7 @@ import type { Step } from '../../types';
 const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
 
 	const selectedPlanData = useSelectedPlanUpgradeQuery();
 	const selectedPlanPathSlug = selectedPlanData.data;
@@ -59,8 +61,12 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
 				formattedHeader={
 					<FormattedHeader
 						id="site-migration-instructions-header"
-						headerText="Upgrade your plan"
+						headerText={ translate( 'Take your site to the next level' ) }
+						subHeaderText={ translate(
+							'Migrations are exclusive to the Creator plan. Check out all its benefits, and upgrade to get started.'
+						) }
 						align="center"
+						subHeaderAlign="center"
 					/>
 				}
 				stepContent={ stepContent }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Update header and subheader text for Site Migration step

Design: 5yhaC6umexdQLlLpCrCyEe-fi-2304%3A4453

<img width="856" alt="CleanShot 2024-04-03 at 17 10 28@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/e925d54c-18ca-40d2-9e38-53a71d3d4793">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/setup/site-migration`.
* Enter a site to migrate and click "Continue"
* Add a free site slug to the `siteSlug` param in the URL, select the `Everything (requires a Creator Plan)` option, and then click continue.
* Compare header and subheader text to Design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?