### PR TITLE
Login: Add email suggestion logic to login input field

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -705,7 +705,7 @@ export class LoginForm extends Component {
 	}
 
 	handleAcceptEmailSuggestion() {
-		this.props.recordTracksEvent( 'calypso_signup_domain_suggestion_confirmation', {
+		this.props.recordTracksEvent( 'calypso_login_email_suggestion_confirmation', {
 			original_email: JSON.stringify( this.state.usernameOrEmail ),
 			suggested_email: JSON.stringify( this.state.emailSuggestion ),
 		} );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -3,11 +3,13 @@ import page from '@automattic/calypso-router';
 import { Button, Card, FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
 import { alert } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { suggestEmailCorrection } from '@automattic/onboarding';
 import { Spinner } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
+import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
-import { capitalize, defer, includes, get } from 'lodash';
+import { capitalize, defer, includes, get, debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import ReactDom from 'react-dom';
@@ -106,6 +108,8 @@ export class LoginForm extends Component {
 	state = {
 		isFormDisabledWhileLoading: true,
 		usernameOrEmail: this.props.socialAccountLinkEmail || this.props.userEmail || '',
+		emailSuggestion: '',
+		emailSuggestionError: false,
 		password: '',
 	};
 
@@ -170,7 +174,40 @@ export class LoginForm extends Component {
 		if ( ! this.props.hasAccountTypeLoaded && isRegularAccount( nextProps.accountType ) ) {
 			! disableAutoFocus && defer( () => this.password && this.password.focus() );
 		}
+
+		if ( nextProps.requestError ) {
+			this.setState( {
+				emailSuggestionError: false,
+				emailSuggestion: '',
+			} );
+		}
 	}
+
+	debouncedEmailSuggestion = debounce( ( email ) => {
+		if ( emailValidator.validate( email ) ) {
+			const { newEmail, wasCorrected } = suggestEmailCorrection( email );
+			if ( wasCorrected ) {
+				this.props.recordTracksEvent( 'calypso_login_email_suggestion_generated', {
+					original_email: JSON.stringify( email ),
+					suggested_email: JSON.stringify( newEmail ),
+				} );
+				this.setState( {
+					emailSuggestionError: true,
+					emailSuggestion: newEmail,
+				} );
+				return;
+			}
+		}
+	}, 500 );
+
+	onChangeUsernameOrEmailField = ( event ) => {
+		this.setState( {
+			emailSuggestionError: false,
+			emailSuggestion: '',
+		} );
+		this.onChangeField( event );
+		this.debouncedEmailSuggestion( event.target.value );
+	};
 
 	onChangeField = ( event ) => {
 		this.props.formUpdate();
@@ -224,7 +261,6 @@ export class LoginForm extends Component {
 		const { onSuccess, redirectTo, domain } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
-
 		this.props
 			.loginUser( usernameOrEmail, password, redirectTo, domain )
 			.then( () => {
@@ -668,6 +704,18 @@ export class LoginForm extends Component {
 		return this.props.requestError.message;
 	}
 
+	handleAcceptEmailSuggestion() {
+		this.props.recordTracksEvent( 'calypso_signup_domain_suggestion_confirmation', {
+			original_email: JSON.stringify( this.state.usernameOrEmail ),
+			suggested_email: JSON.stringify( this.state.emailSuggestion ),
+		} );
+		this.setState( {
+			usernameOrEmail: this.state.emailSuggestion,
+			emailSuggestion: '',
+			emailSuggestionError: false,
+		} );
+	}
+
 	render() {
 		const {
 			accountType,
@@ -803,7 +851,7 @@ export class LoginForm extends Component {
 							className={ classNames( {
 								'is-error': requestError && requestError.field === 'usernameOrEmail',
 							} ) }
-							onChange={ this.onChangeField }
+							onChange={ this.onChangeUsernameOrEmailField }
 							id="usernameOrEmail"
 							name="usernameOrEmail"
 							ref={ this.saveUsernameOrEmailRef }
@@ -832,6 +880,46 @@ export class LoginForm extends Component {
 										}
 									) }
 							</FormInputValidation>
+						) }
+
+						{ ! requestError && this.state.emailSuggestionError && (
+							<FormInputValidation
+								isError
+								text={ this.props.translate(
+									'User does not exist. Did you mean {{suggestedEmail/}}, or would you like to {{newAccountLink}}create a new account{{/newAccountLink}}?',
+									{
+										components: {
+											newAccountLink: (
+												<a
+													href={ addQueryArgs(
+														{
+															user_email: this.state.usernameOrEmail,
+														},
+														signupUrl
+													) }
+												/>
+											),
+											suggestedEmail: (
+												<span
+													className="suggested-email"
+													onKeyDown={ ( e ) => {
+														if ( e.key === 'Enter' ) {
+															this.handleAcceptEmailSuggestion();
+														}
+													} }
+													onClick={ () => {
+														this.handleAcceptEmailSuggestion();
+													} }
+													role="button"
+													tabIndex="0"
+												>
+													{ this.state.emailSuggestion }
+												</span>
+											),
+										},
+									}
+								) }
+							/>
 						) }
 
 						{ isP2Login && this.isPasswordView() && this.renderChangeUsername() }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -901,7 +901,7 @@ export class LoginForm extends Component {
 											),
 											suggestedEmail: (
 												<span
-													className="suggested-email"
+													className="login__form-suggested-email"
 													onKeyDown={ ( e ) => {
 														if ( e.key === 'Enter' ) {
 															this.handleAcceptEmailSuggestion();

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -152,6 +152,10 @@ $breakpoint-mobile: 782px; //Mobile size.
 		color: var(--color-link);
 		cursor: pointer;
 		text-decoration: none;
+
+		&:hover {
+			color: var(--color-link-dark);
+		}
 	}
 }
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -148,9 +148,10 @@ $breakpoint-mobile: 782px; //Mobile size.
 		}
 	}
 
-	.suggested-email {
-		text-decoration: underline;
+	.login__form-suggested-email {
+		color: var(--color-link);
 		cursor: pointer;
+		text-decoration: none;
 	}
 }
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -147,6 +147,11 @@ $breakpoint-mobile: 782px; //Mobile size.
 			margin-bottom: 0;
 		}
 	}
+
+	.suggested-email {
+		text-decoration: underline;
+		cursor: pointer;
+	}
 }
 
 .login__form-change-username {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -201,6 +201,10 @@ body.is-section-accept-invite {
 					color: var(--color-link);
 					cursor: pointer;
 					text-decoration: none;
+
+					&:hover {
+						color: var(--color-link-dark);
+					}
 				}
 
 				button.is-borderless {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -198,8 +198,9 @@ body.is-section-accept-invite {
 				}
 
 				button.signup-form__domain-suggestion-confirmation {
-					text-decoration: underline;
+					color: var(--color-link);
 					cursor: pointer;
+					text-decoration: none;
 				}
 
 				button.is-borderless {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/89192
https://github.com/Automattic/wp-calypso/issues/89172

## Proposed Changes

* Adds email suggestion logic to `/log-in` email input field

<img width="949" alt="CleanShot 2024-04-03 at 17 43 10@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/ef5ba699-83e5-4c79-bebe-d998789d2337">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Navigate to `/log-in/`
* Test the email suggestion logic in the email input field
* Verify an error message appears below the input field.
* Verify the "create an account" link within the form error message works properly
* Verify clicking the underlined email suggestion clears the error message and updates the input field with this new email suggestion
* Verify the `calypso_login_email_suggestion_generated` event is triggered when an email suggestion is provided.
* Verify the `calypso_login_email_suggestion_confirmation` event is triggered when you accept the email suggestion (click the underlined email suggestion).
* Enter an email that does not exist, click "Continue" and verify the email suggestion error message disappears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?