### PR TITLE
Checkout: Fix keyboard tab directionality and focus styling

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1176,6 +1176,10 @@ const WPCheckoutWrapper = styled.div`
 			min-height: 100vh;
 		}
 	}
+
+	& *:focus {
+		outline: ${ ( props ) => props.theme.colors.outline } solid 2px;
+	}
 `;
 
 const WPCheckoutMainContent = styled.div`


### PR DESCRIPTION
This PR fixed issues 1 and 3 in the related issue below. 

1) As noted in Slack p1712156902368809/1712081436.115269-slack-C0117V2PCAE fixing item 2 had the side effect of making item 1 less of an issue, so for now we'll keep the flow of masterbar -> sidebar -> main column

3) The PR adjusts the CSS selector that applies `:focus` styling on the checkout page. Currently, the focus styling only applies to the main content column, not the sidebar. Since we moved a number of elements from the main column to the sidebar we now need to account for that focus styling there too.

By moving the `:focus` wildcard selector to a parent of both the main column and sidebar, we are able to now style all of the elements correctly.

Related to https://github.com/Automattic/wp-calypso/issues/89134

## Testing Instructions

* Go to Checkout v1 and don't click on the page, tab through the page with your keyboard
* You should see the tabbing highlights the masterbar items first, then proceeds down the main column in order of top to bottom
* Go to Checkout v2, dont click the page and tab with your keyboard
* The order should be masterbar items -> sidebar line items -> main column elements
* All links and dropdowns should have a highlight color applied on focus