### PR TITLE
Manage Purchases: Hide "Excludes Tax" for Free Purchases

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -82,7 +82,7 @@ export default function PurchaseMeta( {
 			? translate( 'Renewal Price' )
 			: translate( 'Price' );
 
-	const hideTaxString = isIncludedWithPlan( purchase );
+	const hideTaxString = isIncludedWithPlan( purchase ) || isOneTimePurchase( purchase );
 
 	// To-do: There isn't currently a way to get the taxName based on the country.
 	// The country is not included in the purchase information envelope

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -82,7 +82,8 @@ export default function PurchaseMeta( {
 			? translate( 'Renewal Price' )
 			: translate( 'Price' );
 
-	const hideTaxString = isIncludedWithPlan( purchase ) || isOneTimePurchase( purchase );
+	const hideRenewalPriceSection = isOneTimePurchase( purchase );
+	const hideTaxString = isIncludedWithPlan( purchase );
 
 	// To-do: There isn't currently a way to get the taxName based on the country.
 	// The country is not included in the purchase information envelope
@@ -109,19 +110,21 @@ export default function PurchaseMeta( {
 		<>
 			<ul className="manage-purchase__meta">
 				<PurchaseMetaOwner owner={ owner } />
-				<li>
-					<em className="manage-purchase__detail-label">{ renewalPriceHeader }</em>
-					<span className="manage-purchase__detail">
-						<PurchaseMetaPrice purchase={ purchase } />
-						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
-					</span>
-					{ ! hideTaxString && (
-						<span>
-							<abbr title={ excludeTaxStringTitle }>{ excludeTaxStringAbbreviation }</abbr>
+				{ ! hideRenewalPriceSection && (
+					<li>
+						<em className="manage-purchase__detail-label">{ renewalPriceHeader }</em>
+						<span className="manage-purchase__detail">
+							<PurchaseMetaPrice purchase={ purchase } />
+							<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
 						</span>
-					) }
-					<PurchaseMetaAutoRenewCouponDetail purchase={ purchase } />
-				</li>
+						{ ! hideTaxString && (
+							<span>
+								<abbr title={ excludeTaxStringTitle }>{ excludeTaxStringAbbreviation }</abbr>
+							</span>
+						) }
+						<PurchaseMetaAutoRenewCouponDetail purchase={ purchase } />
+					</li>
+				) }
 				<PurchaseMetaExpiration
 					purchase={ purchase }
 					site={ site ?? undefined }

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -82,6 +82,8 @@ export default function PurchaseMeta( {
 			? translate( 'Renewal Price' )
 			: translate( 'Price' );
 
+	const hideTaxString = isIncludedWithPlan( purchase );
+
 	// To-do: There isn't currently a way to get the taxName based on the country.
 	// The country is not included in the purchase information envelope
 	// We should add this information so we can utilize useTaxName to retrieve the correct taxName
@@ -113,9 +115,11 @@ export default function PurchaseMeta( {
 						<PurchaseMetaPrice purchase={ purchase } />
 						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
 					</span>
-					<span>
-						<abbr title={ excludeTaxStringTitle }>{ excludeTaxStringAbbreviation }</abbr>
-					</span>
+					{ ! hideTaxString && (
+						<span>
+							<abbr title={ excludeTaxStringTitle }>{ excludeTaxStringAbbreviation }</abbr>
+						</span>
+					) }
 					<PurchaseMetaAutoRenewCouponDetail purchase={ purchase } />
 				</li>
 				<PurchaseMetaExpiration


### PR DESCRIPTION
Fixes #89121 and fixes #88872

## Proposed Changes

* Hides the "excludes tax" string for purchases that are free. 

## Testing Instructions

* Connect a domain to a site with a paid plan (you don't actually need a domain - just need to follow the process!)
* Go to Me > Purchases
* Confirm that "Excludes tax" no longer appears under the "Renewal price", but that it does with other purchases

| Before | After |
|--------|--------|
| <img width="1059" alt="Screenshot 2024-04-04 at 06 53 55" src="https://github.com/Automattic/wp-calypso/assets/43215253/36b40165-93a6-4051-8695-86c3bbca36fc"> | <img width="1072" alt="Screenshot 2024-04-04 at 06 52 17" src="https://github.com/Automattic/wp-calypso/assets/43215253/772c5c5e-eb20-4a86-b277-2dc321136250"> |

cc @DavidRothstein, @JessBoctor, @sirbrillig  