### PR TITLE
A4A: Fix the issue with the Monitoring toggle and Set Favorite button not reflecting changes in the Dashboard. 

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -55,6 +55,7 @@ export default function A4ASiteSetFavorite( { isFavorite, siteId, siteUrl }: Pro
 		currentPage,
 		filter,
 		sort,
+		sitesViewState.perPage,
 		...( agencyId ? [ agencyId ] : [] ),
 	];
 

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -1,6 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext } from 'react';
+import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { setSiteMonitorStatus } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -22,16 +25,31 @@ export default function useToggleActivateMonitor(
 	const queryClient = useQueryClient();
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
 
+	const { sitesViewState, sort: sortV2, showOnlyFavorites } = useContext( SitesDashboardContext );
+
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const queryKey = [
-		'jetpack-agency-dashboard-sites',
-		search,
-		currentPage,
-		filter,
-		sort,
-		...( agencyId ? [ agencyId ] : [] ),
-	];
+	const queryKey = isEnabled( 'a8c-for-agencies' )
+		? [
+				'jetpack-agency-dashboard-sites',
+				sitesViewState.search,
+				sitesViewState.page,
+				{
+					issueTypes: getSelectedFilters( sitesViewState.filters ),
+					showOnlyFavorites: showOnlyFavorites || false,
+				},
+				sortV2,
+				sitesViewState.perPage,
+				...( agencyId ? [ agencyId ] : [] ),
+		  ]
+		: [
+				'jetpack-agency-dashboard-sites',
+				search,
+				currentPage,
+				filter,
+				sort,
+				...( agencyId ? [ agencyId ] : [] ),
+		  ];
 
 	const toggleActivateMonitoring = useToggleActivateMonitorMutation( {
 		onMutate: async ( { siteId } ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
@@ -1,6 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useContext } from 'react';
+import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import useUpdateMonitorSettingsMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation';
@@ -25,16 +28,31 @@ export default function useUpdateMonitorSettings(
 	const queryClient = useQueryClient();
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
 
+	const { sitesViewState, sort: sortV2, showOnlyFavorites } = useContext( SitesDashboardContext );
+
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const queryKey = [
-		'jetpack-agency-dashboard-sites',
-		search,
-		currentPage,
-		filter,
-		sort,
-		...( agencyId ? [ agencyId ] : [] ),
-	];
+	const queryKey = isEnabled( 'a8c-for-agencies' )
+		? [
+				'jetpack-agency-dashboard-sites',
+				sitesViewState.search,
+				sitesViewState.page,
+				{
+					issueTypes: getSelectedFilters( sitesViewState.filters ),
+					showOnlyFavorites: showOnlyFavorites || false,
+				},
+				sortV2,
+				sitesViewState.perPage,
+				...( agencyId ? [ agencyId ] : [] ),
+		  ]
+		: [
+				'jetpack-agency-dashboard-sites',
+				search,
+				currentPage,
+				filter,
+				sort,
+				...( agencyId ? [ agencyId ] : [] ),
+		  ];
 
 	const [ status, setStatus ] = useState( 'idle' );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -1,6 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useMemo } from 'react';
+import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import ExternalLink from 'calypso/components/external-link';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -23,6 +26,9 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 	const translate = useTranslate();
 
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
+
+	const { sitesViewState, sort: sortV2, showOnlyFavorites } = useContext( SitesDashboardContext );
+
 	const { isLargeScreen } = useContext( DashboardDataContext );
 
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], isLargeScreen );
@@ -33,15 +39,29 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 
 	// queryKey is needed to optimistically update the site list
 	const queryKey = useMemo(
-		() => [
-			'jetpack-agency-dashboard-sites',
-			search,
-			currentPage,
-			filter,
-			sort,
-			...( agencyId ? [ agencyId ] : [] ),
-		],
-		[ search, currentPage, filter, sort, agencyId ]
+		() =>
+			isEnabled( 'a8c-for-agencies' )
+				? [
+						'jetpack-agency-dashboard-sites',
+						sitesViewState?.search,
+						sitesViewState?.page,
+						{
+							issueTypes: getSelectedFilters( sitesViewState?.filters ),
+							showOnlyFavorites: showOnlyFavorites || false,
+						},
+						sortV2,
+						sitesViewState?.perPage,
+						...( agencyId ? [ agencyId ] : [] ),
+				  ]
+				: [
+						'jetpack-agency-dashboard-sites',
+						search,
+						currentPage,
+						filter,
+						sort,
+						...( agencyId ? [ agencyId ] : [] ),
+				  ],
+		[ sitesViewState, showOnlyFavorites, sortV2, agencyId, search, currentPage, filter, sort ]
 	);
 	const { installBoost, status } = useInstallBoost( siteId, siteUrl, queryKey );
 


### PR DESCRIPTION
This pull request addresses an issue with the Monitoring toggle and Set as Favorite button in the Site table. The issue was that changes to their status were not immediately reflected without a page refresh. This bug was caused by discrepancies that arose due to a query key mismatch, similar to the issue addressed in https://github.com/Automattic/wp-calypso/pull/89039 (Jetpack Manage). This PR fixes the discrepancies and resolves the bug.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/185
## Proposed Changes

* Update `useToggleActivateMonitor` and `useUpdateMonitorSettings` to account for the A4A-specific query key.
* Update the **A4A SiteSetFavorite** component to include `perPage` in the query key.
* Update the **Boost License modal** component to account for the A4A-specific query key. (This cannot be tested due to a bug preventing us from opening the modal. This is addressed on a separate PR https://github.com/Automattic/wp-calypso/pull/89171. Let's test that the Jetpack Manage is not broken with this change.)

## Testing Instructions

* Use the A4A live link below and go to `/sites` to access the Site table.
* Test that when toggling the Monitoring toggle, the page updates accordingly.
* Test that when changing the Monitoring interval in the Monitoring setting, the page updates accordingly.
* Test that when toggling the Set as Favorite button, the page updates accordingly.
* Finally, open the Jetpack cloud live link and go to `/dashboard`.
* Test that the changes did not introduce regression.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?