### PR TITLE
Pattern Library: Don't filter search results by type

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -95,9 +95,11 @@ export const PatternLibrary = ( {
 	const { data: categories = [] } = usePatternCategories( locale );
 	const { data: patterns = [], isFetching: isFetchingPatterns } = usePatterns( locale, category, {
 		select( patterns ) {
-			const patternsByType = filterPatternsByType( patterns, patternTypeFilter );
+			if ( searchTerm ) {
+				return filterPatternsByTerm( patterns, searchTerm );
+			}
 
-			return filterPatternsByTerm( patternsByType, searchTerm );
+			return filterPatternsByType( patterns, patternTypeFilter );
 		},
 	} );
 
@@ -177,6 +179,8 @@ export const PatternLibrary = ( {
 	}, [] );
 
 	const categoryObject = categories?.find( ( { name } ) => name === category );
+	const shouldDisplayPatternTypeToggle =
+		category && ! searchTerm && !! categoryObject?.pagePatternCount;
 
 	const categoryNavList = categories.map( ( category ) => {
 		const patternTypeFilterFallback =
@@ -283,7 +287,7 @@ export const PatternLibrary = ( {
 									} ) }
 							</h1>
 
-							{ category && !! categoryObject?.pagePatternCount && (
+							{ shouldDisplayPatternTypeToggle && (
 								<ToggleGroupControl
 									className="pattern-library__toggle--pattern-type"
 									isBlock

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -353,7 +353,7 @@ export const PatternLibrary = ( {
 							isGridView={ isGridView }
 							key={ `pattern-gallery-${ patternGalleryKey }` }
 							patterns={ patterns }
-							patternTypeFilter={ patternTypeFilter }
+							patternTypeFilter={ searchTerm ? PatternTypeFilter.REGULAR : patternTypeFilter }
 						/>
 
 						{ searchTerm && ! patterns.length && category && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6390

## Proposed Changes

We've previously filtered search results based on pattern type. When searching within a category, this makes for arguably quite weird UX, and when searching all categories, it's downright incorrect (since the pattern type toggle isn't displayed in those cases, meaning users can never see the page layout search results).

This PR makes it so all searches are performed against regular patterns and page layout patterns. For this reason, the pattern type toggle is also hidden while searching now.

A downside to this approach is that regular patterns and page layout patterns can have quite different heights, which can look quite odd when rendered side by side in grid view. I think the overall user experience is still better with this approach, though. cc @matt-west 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns`
2. Search for `about page`
3. Ensure that you get 4 results
4. Navigate to `/patterns/about`
5. Search for `about`
6. Ensure that you get 35 results, with a mix of regular patterns and page layout patterns
