### PR TITLE
Plugin Update Manager: Create useUpdateScheduleLogsQuery

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -1,9 +1,20 @@
+import { useUpdateScheduleLogsQuery } from 'calypso/data/plugins/use-update-schedule-logs-query';
+import { useSiteSlug } from './hooks/use-site-slug';
+
 interface Props {
 	scheduleId: string;
 	onNavBack?: () => void;
 }
 export const ScheduleLogs = ( props: Props ) => {
 	const { scheduleId } = props;
+	const siteSlug = useSiteSlug();
 
-	return <>Schedule Logs: { scheduleId }</>;
+	const { data: logs = [] } = useUpdateScheduleLogsQuery( siteSlug, scheduleId );
+
+	return (
+		<>
+			Schedule Logs: { scheduleId }
+			<pre>{ JSON.stringify( logs, null, 4 ) }</pre>
+		</>
+	);
 };

--- a/client/data/plugins/use-update-schedule-logs-query.ts
+++ b/client/data/plugins/use-update-schedule-logs-query.ts
@@ -1,0 +1,49 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteSlug } from 'calypso/types';
+
+type ScheduleLogsApiReturn = {
+	timestamp: string;
+	action: string;
+	message: string | null;
+	context: unknown;
+}[][];
+
+type ScheduleLogs = {
+	date: Date;
+	timestamp: string;
+	action: string;
+	message: string | null;
+	context: unknown;
+}[][];
+
+export const useUpdateScheduleLogsQuery = (
+	siteSlug: SiteSlug,
+	scheduleId: string
+): UseQueryResult< ScheduleLogs > => {
+	return useQuery< ScheduleLogsApiReturn, Error, ScheduleLogs >( {
+		queryKey: [ 'scheduled-logs', scheduleId, siteSlug ],
+		queryFn: () =>
+			wpcomRequest( {
+				path: `/sites/${ siteSlug }/update-schedules/${ scheduleId }/logs`,
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+			} ),
+		enabled: !! siteSlug && !! scheduleId,
+		retry: false,
+		refetchOnWindowFocus: false,
+		select: ( data: ScheduleLogsApiReturn ): ScheduleLogs => {
+			return data
+				.map( ( run ) => {
+					return run.map( ( log ) => ( {
+						date: new Date( parseInt( log.timestamp, 10 ) * 1000 ),
+						timestamp: log.timestamp,
+						action: log.action,
+						message: log.message,
+						context: log.context,
+					} ) );
+				} )
+				.reverse();
+		},
+	} );
+};

--- a/client/data/plugins/use-update-schedule-logs-query.ts
+++ b/client/data/plugins/use-update-schedule-logs-query.ts
@@ -3,7 +3,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteSlug } from 'calypso/types';
 
 type ScheduleLogsApiReturn = {
-	timestamp: string;
+	timestamp: number;
 	action: string;
 	message: string | null;
 	context: unknown;
@@ -11,7 +11,7 @@ type ScheduleLogsApiReturn = {
 
 type ScheduleLogs = {
 	date: Date;
-	timestamp: string;
+	timestamp: number;
 	action: string;
 	message: string | null;
 	context: unknown;
@@ -36,7 +36,7 @@ export const useUpdateScheduleLogsQuery = (
 			return data
 				.map( ( run ) => {
 					return run.map( ( log ) => ( {
-						date: new Date( parseInt( log.timestamp, 10 ) * 1000 ),
+						date: new Date( log.timestamp * 1000 ),
 						timestamp: log.timestamp,
 						action: log.action,
 						message: log.message,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89036

## Proposed Changes

- Add the `useUpdateScheduleLogsQuery`
- Besides the API call this query reverses the array + adds a date property containing a `Date` representation of the `timestamp`
- Adds a temporary output to the logs page for debugging

We could look into typing the context in the future.

## Testing Instructions

1. Apply this PR
2. Visit `http://calypso.localhost:3000/plugins/scheduled-updates/logs/<slug>/<schedule-id>`

![CleanShot 2024-04-04 at 11 44 35@2x](https://github.com/Automattic/wp-calypso/assets/528287/d0f7111f-d845-4c95-86b0-d1dc58a704d0)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?