### PR TITLE
Untangling: make masterbar in Hosting menus look like wp-admin's

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -666,19 +666,6 @@ class MasterbarLoggedIn extends Component {
 		);
 	}
 
-	renderHosting() {
-		const { siteSlug, translate } = this.props;
-		return (
-			<Item
-				className="masterbar__item-hosting"
-				url={ `/home/${ siteSlug }` }
-				icon={ <span className="dashicons-before dashicons-cloud" /> }
-			>
-				{ translate( 'Hosting' ) }
-			</Item>
-		);
-	}
-
 	render() {
 		const {
 			isInEditor,
@@ -731,7 +718,6 @@ class MasterbarLoggedIn extends Component {
 							: this.renderWordPressIcon() }
 						{ this.renderAllSites() }
 						{ this.renderCurrentSite() }
-						{ this.renderHosting() }
 					</div>
 					<div className="masterbar__section masterbar__section--right">
 						{ this.renderCart() }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -3,6 +3,7 @@ import { isEcommercePlan } from '@automattic/calypso-products/src';
 import page from '@automattic/calypso-router';
 import { Button, Popover } from '@automattic/components';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import { Icon, category } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
@@ -26,6 +27,7 @@ import {
 import {
 	getShouldShowGlobalSidebar,
 	getShouldShowGlobalSiteSidebar,
+	getShouldShowUnifiedSiteSidebar,
 } from 'calypso/state/global-sidebar/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
@@ -40,7 +42,14 @@ import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migratio
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
 import { isTrialExpired } from 'calypso/state/sites/plans/selectors/trials/trials-expiration';
-import { getSiteSlug, isJetpackSite, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import {
+	getSiteSlug,
+	isJetpackSite,
+	getSitePlanSlug,
+	getSiteTitle,
+	getSiteUrl,
+	getSiteAdminUrl,
+} from 'calypso/state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -203,6 +212,10 @@ class MasterbarLoggedIn extends Component {
 
 	preloadMySites = () => {
 		preload( this.props.domainOnlySite ? 'domains' : 'stats' );
+	};
+
+	preloadAllSites = () => {
+		preload( 'sites' );
 	};
 
 	preloadReader = () => {
@@ -612,6 +625,60 @@ class MasterbarLoggedIn extends Component {
 		return null;
 	}
 
+	renderWordPressIcon() {
+		const { siteAdminUrl } = this.props;
+		return (
+			<Item
+				url={ siteAdminUrl }
+				className="masterbar__item-wordpress"
+				icon={ <span className="dashicons-before dashicons-wordpress" /> }
+			/>
+		);
+	}
+
+	renderAllSites() {
+		const { translate } = this.props;
+		return (
+			<Item
+				url="/sites"
+				className="masterbar__item-all-sites"
+				tipTarget="my-sites"
+				icon={ <Icon icon={ category } /> }
+				tooltip={ translate( 'Manage your sites' ) }
+				preloadSection={ this.preloadAllSites }
+			>
+				{ translate( 'All Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
+			</Item>
+		);
+	}
+
+	renderCurrentSite() {
+		const { translate, siteTitle, siteUrl } = this.props;
+		return (
+			<Item
+				className="masterbar__item-current-site"
+				url={ siteUrl }
+				icon={ <span className="dashicons-before dashicons-admin-home" /> }
+				tooltip={ translate( 'Visit your site' ) }
+			>
+				{ siteTitle }
+			</Item>
+		);
+	}
+
+	renderHosting() {
+		const { siteSlug, translate } = this.props;
+		return (
+			<Item
+				className="masterbar__item-hosting"
+				url={ `/home/${ siteSlug }` }
+				icon={ <span className="dashicons-before dashicons-cloud" /> }
+			>
+				{ translate( 'Hosting' ) }
+			</Item>
+		);
+	}
+
 	render() {
 		const {
 			isInEditor,
@@ -652,6 +719,27 @@ class MasterbarLoggedIn extends Component {
 						</div>
 					</Masterbar>
 				</>
+			);
+		}
+
+		if ( this.props.isUnifiedSiteView ) {
+			return (
+				<Masterbar className="masterbar__unified">
+					<div className="masterbar__section masterbar__section--left">
+						{ this.state.isResponsiveMenu
+							? this.renderSidebarMobileMenu()
+							: this.renderWordPressIcon() }
+						{ this.renderAllSites() }
+						{ this.renderCurrentSite() }
+						{ this.renderHosting() }
+					</div>
+					<div className="masterbar__section masterbar__section--right">
+						{ this.renderCart() }
+						{ loadHelpCenterIcon && this.renderHelpCenter() }
+						{ this.renderNotifications() }
+						{ this.renderMe() }
+					</div>
+				</Masterbar>
 			);
 		}
 
@@ -741,12 +829,21 @@ export default connect(
 			sectionGroup,
 			sectionName
 		);
+		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
+			state,
+			currentSelectedSiteId,
+			sectionGroup,
+			sectionName
+		);
 		const isDesktop = isWithinBreakpoint( '>782px' );
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			isEcommerce: isEcommercePlan( sitePlanSlug ),
 			siteSlug: getSiteSlug( state, siteId ),
+			siteTitle: getSiteTitle( state, siteId ),
+			siteUrl: getSiteUrl( state, siteId ),
+			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 			sectionGroup,
 			domainOnlySite: isDomainOnlySite( state, siteId ),
 			hasNoSites: siteCount === 0,
@@ -775,6 +872,7 @@ export default connect(
 			isMobileGlobalNavVisible: shouldShowGlobalSidebar && ! isDesktop,
 			isGlobalView: shouldShowGlobalSidebar,
 			isGlobalSiteView: shouldShowGlobalSiteSidebar,
+			isUnifiedSiteView: shouldShowUnifiedSiteSidebar,
 			isCommandPaletteOpen: getIsCommandPaletteOpen( state ),
 		};
 	},

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -371,7 +371,8 @@ body.is-mobile-app-view {
 		.masterbar__item-content {
 			display: none;
 		}
-		&.masterbar__item--always-show-content .masterbar__item-content {
+		&.masterbar__item--always-show-content .masterbar__item-content,
+		&.masterbar__item-me .masterbar__item-content {
 			display: block;
 		}
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1044,11 +1044,6 @@ a.masterbar__quick-language-switcher {
 		gap: 6px;
 	}
 
-	.masterbar__item-hosting {
-		gap: 6px;
-		background: var(--color-masterbar-item-hover-background);
-	}
-
 	.masterbar__item-notifications {
 		margin-right: 0;
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -285,6 +285,14 @@ body.is-mobile-app-view {
 		padding: 0 0 0 6px;
 	}
 
+	svg {
+		fill: var(--color-masterbar-text);
+	}
+
+	.dashicons-before {
+		height: 20px;
+	}
+
 	&:hover {
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);
@@ -1015,5 +1023,33 @@ a.masterbar__quick-language-switcher {
 		.site__domain {
 			color: var(--color-global-masterbar-text);
 		}
+	}
+}
+
+.masterbar__unified {
+	.masterbar__item-wordpress {
+		padding-left: 7px;
+		padding-right: 1px;
+
+		&:hover {
+			background: var(--color-masterbar-item-background);
+		}
+	}
+
+	.masterbar__item-all-sites {
+		gap: 4px;
+	}
+
+	.masterbar__item-current-site {
+		gap: 6px;
+	}
+
+	.masterbar__item-hosting {
+		gap: 6px;
+		background: var(--color-masterbar-item-hover-background);
+	}
+
+	.masterbar__item-notifications {
+		margin-right: 0;
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1030,10 +1030,6 @@ a.masterbar__quick-language-switcher {
 	.masterbar__item-wordpress {
 		padding-left: 7px;
 		padding-right: 1px;
-
-		&:hover {
-			background: var(--color-masterbar-item-background);
-		}
 	}
 
 	.masterbar__item-all-sites {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6324
- https://github.com/Automattic/dotcom-forge/issues/6262


## Proposed Changes

See: pfsHM7-Ij-p2

### Desktop

Before

![image](https://github.com/Automattic/wp-calypso/assets/1525580/45739f87-3201-4155-bb4b-6f0de2e293dc)

~~After~~

![image](https://github.com/Automattic/wp-calypso/assets/1525580/9698456d-04e2-4380-9951-ad5e772965d6)

(revised:)

<img width="777" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/1f6ca83c-f3b5-4597-9146-187cc5156f2a">


- WP icon links to site's `/wp-admin`.
- All Sites links to `/sites`.
- (Site title) links to the site's frontend.
- ~~"Hosting" indicator links to `/home/<siteSlug>`~~

### Mobile

Before

<img src="https://github.com/Automattic/wp-calypso/assets/1525580/4c22ea4f-80ae-4212-9416-3effab27a60b" width="400">


~~After~~

<img src="https://github.com/Automattic/wp-calypso/assets/1525580/c071a4d0-52eb-451b-878c-0d6005625612" width="400">

(revised:)

<img width="400" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/22d33d96-81fe-4114-b8e9-3ce96ce0a6e1">


## Testing Instructions

1. Prepare an Atomic site.
2. Go to Hosting Configuration and set Admin interface style to Classic.
3. Go to the site's `_cli` and run `wp update option wpcom_classic_early_release 1`.
4. Use the Calypso Live URL and visit any links under `Hosting` (e.g. `/plans`).
5. Verify the masterbar as shown in the above screenshots (both Desktop and Mobile).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?