### PR TITLE
A4A: Remove the site selector in the sidebar.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/marketplace.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/marketplace.tsx
@@ -60,7 +60,6 @@ export default function ( { path }: Props ) {
 				},
 			} }
 			menuItems={ menuItems }
-			withSiteSelector
 			withGetHelpLink
 		/>
 	);

--- a/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
@@ -86,7 +86,6 @@ export default function ( { path }: Props ) {
 				},
 			} }
 			menuItems={ menuItems }
-			withSiteSelector
 			withGetHelpLink
 		/>
 	);

--- a/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
@@ -95,7 +95,6 @@ export default function ( { path }: Props ) {
 				},
 			} }
 			menuItems={ menuItems }
-			withSiteSelector
 			withGetHelpLink
 		/>
 	);

--- a/client/a8c-for-agencies/components/sidebar/header/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/index.tsx
@@ -1,20 +1,9 @@
-import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import AllSites from 'calypso/blocks/all-sites';
-import Site from 'calypso/blocks/site';
 import { SidebarV2Header as SidebarHeader } from 'calypso/layout/sidebar-v2';
-import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import { AppState } from 'calypso/types';
 import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from '../../a4a-logo';
 import ProfileDropdown from './profile-dropdown';
 
 type Props = {
-	forceAllSitesView?: boolean;
-	simple?: boolean;
+	withProfileDropdown?: boolean;
 };
 
 const AllSitesIcon = () => (
@@ -25,75 +14,11 @@ const AllSitesIcon = () => (
 	/>
 );
 
-// NOTE: This hook is a little hacky, to get around the "outside click"
-// close behavior that happens inside `<SiteSelector />`. Instead of
-// using the `getCurrentLayoutFocus` selector, we use internal state to
-// derive whether or not the site selector should be visible.
-const useShowSiteSelector = ( {
-	forceAllSitesView,
-	selectedSiteId,
-}: {
-	forceAllSitesView: boolean;
-	selectedSiteId: number | null;
-} ) => {
-	const SITES_FOCUS = 'sites';
-
-	const isSiteSelectorVisible = useSelector(
-		( state: AppState ) => getCurrentLayoutFocus( state ) === SITES_FOCUS
-	);
-	const dispatch = useDispatch();
-
-	return useCallback( () => {
-		dispatch(
-			forceAllSitesView
-				? recordTracksEvent( 'calypso_a4a_sidebar_switch_site_all_click' )
-				: recordTracksEvent( 'calypso_a4a_sidebar_switch_site_single_click', {
-						site_id: selectedSiteId,
-				  } )
-		);
-
-		// NOTE: If the selector is visible, dismissal will happen automatically
-		// when the user clicks outside the bounds of its root element
-		if ( ! isSiteSelectorVisible ) {
-			dispatch( setLayoutFocus( SITES_FOCUS ) );
-		}
-	}, [ dispatch, forceAllSitesView, isSiteSelectorVisible, selectedSiteId ] );
-};
-
-const Header = ( { forceAllSitesView = false, simple }: Props ) => {
-	const translate = useTranslate();
-	const selectedSiteId = useSelector( getSelectedSiteId );
-
-	const showSiteSelector = useShowSiteSelector( { forceAllSitesView, selectedSiteId } );
-
-	if ( simple ) {
-		return (
-			<div className="a4a-sidebar__header">
-				<AllSitesIcon />
-			</div>
-		);
-	}
-
+const Header = ( { withProfileDropdown }: Props ) => {
 	return (
 		<SidebarHeader className="a4a-sidebar__header">
-			{ forceAllSitesView ? (
-				<AllSites
-					showIcon
-					showChevronDownIcon
-					showCount={ false }
-					icon={ <AllSitesIcon /> }
-					title={ translate( 'All Sites' ) }
-					onSelect={ showSiteSelector }
-				/>
-			) : (
-				<Site
-					showChevronDownIcon
-					className="a4a-sidebar__selected-site"
-					siteId={ selectedSiteId }
-					onSelect={ showSiteSelector }
-				/>
-			) }
-			<ProfileDropdown compact />
+			<AllSitesIcon />
+			{ withProfileDropdown && <ProfileDropdown compact /> }
 		</SidebarHeader>
 	);
 };

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -1,6 +1,11 @@
 // Rules in this file inspired by:
 // client/components/jetpack/profile-dropdown/style.scss
 
+.a4a-sidebar__header {
+	display: flex;
+	justify-content: space-between;
+}
+
 .a4a-sidebar__profile-dropdown {
 	position: relative;
 }
@@ -122,7 +127,6 @@ a.a4a-sidebar__external-link {
 	}
 }
 
-.a4a-sidebar svg.all-sites__title-chevron-icon,
 .a4a-sidebar__profile-dropdown-button-label svg {
 	fill: var(--color-sidebar-text);
 }

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -12,7 +12,6 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SidebarHeader from './header';
 import ProfileDropdown from './header/profile-dropdown';
-import SiteSelector from './site-selector';
 
 import './style.scss';
 
@@ -38,7 +37,6 @@ type Props = {
 		label: string;
 		onClick: () => void;
 	};
-	withSiteSelector?: boolean;
 	withGetHelpLink?: boolean;
 	withUserProfileFooter?: boolean;
 };
@@ -50,7 +48,6 @@ const A4ASidebar = ( {
 	title,
 	description,
 	backButtonProps,
-	withSiteSelector,
 	withGetHelpLink,
 	withUserProfileFooter,
 }: Props ) => {
@@ -59,7 +56,7 @@ const A4ASidebar = ( {
 
 	return (
 		<Sidebar className={ classNames( 'a4a-sidebar', className ) }>
-			<SidebarHeader simple={ ! withSiteSelector } forceAllSitesView />
+			<SidebarHeader withProfileDropdown={ ! withUserProfileFooter } />
 
 			<SidebarMain>
 				<SidebarNavigator initialPath={ path }>
@@ -110,8 +107,6 @@ const A4ASidebar = ( {
 					{ withUserProfileFooter && <ProfileDropdown dropdownPosition="up" /> }
 				</ul>
 			</SidebarFooter>
-
-			{ withSiteSelector && <SiteSelector /> }
 		</Sidebar>
 	);
 };


### PR DESCRIPTION
After some discussions, it was determined that the Site selector is no longer relevant to the A4A information architecture. This PR removes it from the sidebar.

**Before**
<img width="275" alt="Screenshot 2024-04-04 at 6 40 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ce9b1361-aa7e-48ae-8cc8-2e1ca4d48927">

**After**
<img width="274" alt="Screenshot 2024-04-04 at 6 40 13 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/58d7f66e-f939-4b46-9f3e-6917d1dcaa7d">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/206

## Proposed Changes

* Update the A4A Sidebar to remove any reference on the Site selector, including props.
* Use the `withUserProfileFooter` prop to determine when to display the Profile dropdown in the Sidebar header.

## Testing Instructions

* Use the A4A live link below and go to `/sites`, `/marketplace` and `/purchases`.
* Confirm that the Site selector is no longer visible.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?