### PR TITLE
Jetpack Start: Utilize partner type to determine the appropriate purchase label to use

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -843,7 +843,15 @@ export function purchaseType( purchase: Purchase ) {
 	}
 
 	if ( isPartnerPurchase( purchase ) ) {
-		return i18n.translate( 'Host Managed Plan' );
+		switch ( purchase.partnerType ) {
+			case 'agency':
+			case 'agency_beta':
+			case 'a4a_agency':
+				return i18n.translate( 'Agency Managed Plan' );
+
+			default:
+				return i18n.translate( 'Host Managed Plan' );
+		}
 	}
 
 	if ( isPlan( purchase ) ) {

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1247,7 +1247,7 @@ class ManagePurchase extends Component<
 						<div className="manage-purchase__price">
 							{ isPartnerPurchase( purchase ) ? (
 								<div className="manage-purchase__contact-partner">
-									{ translate( 'Please contact your site host %(partnerName)s for details', {
+									{ translate( 'Please contact %(partnerName)s for details', {
 										args: {
 											partnerName: getPartnerName( purchase ) ?? '',
 										},

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -79,6 +79,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		),
 		partnerName: purchase.partner_name,
 		partnerSlug: purchase.partner_slug,
+		partnerType: purchase.partner_type,
 		partnerKeyId: purchase.partner_key_id,
 		payment: {
 			name: purchase.payment_name,

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -40,6 +40,7 @@ export interface Purchase {
 	ownershipId?: number;
 	partnerName: string | undefined;
 	partnerSlug: string | undefined;
+	partnerType: string | undefined;
 	payment: PurchasePayment | PurchasePaymentWithCreditCard | PurchasePaymentWithPayPal;
 	pendingTransfer: boolean;
 	priceText: string;
@@ -211,6 +212,7 @@ export interface RawPurchase {
 	ownership_id: number | undefined;
 	partner_name: string | undefined;
 	partner_slug: string | undefined;
+	partner_type: string | undefined;
 	partner_key_id: number | undefined;
 	payment_name: string;
 	payment_type:


### PR DESCRIPTION
Related to https://github.com/orgs/Automattic/projects/946/views/1?pane=issue&itemId=58355873

## Proposed Changes

* Purchases: Reword managed purchases by A4A agencies to be more meaningful.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Apply D144292 and sandbox the API.
* Open up /me/purchases in your local Calypso Blue environment and make sure that A4A purchases are marked with "Agency Managed Plan".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?