### PR TITLE
Patterns: fix rendering Footer pattern preview

### DIFF
--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -1,6 +1,9 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
+import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef } from 'react';
+import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
 import { CategoryGalleryServer } from 'calypso/my-sites/patterns/components/category-gallery/server';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 import {
@@ -10,9 +13,85 @@ import {
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/constants';
 import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
-import { PatternTypeFilter, type CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
+import { PatternTypeFilter, Category, CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
+
+type CategoryGalleryItemProps = {
+	category: Category;
+	patternTypeFilter: PatternTypeFilter;
+};
+
+function CategoryGalleryItem( { category, patternTypeFilter }: CategoryGalleryItemProps ) {
+	const translate = useTranslate();
+	const previewRef = useRef< HTMLDivElement >( null );
+	const { renderedPatterns } = usePatternsRendererContext();
+
+	const pattern =
+		patternTypeFilter === PatternTypeFilter.PAGES
+			? category.pagePreviewPattern
+			: category.regularPreviewPattern;
+	const patternId = encodePatternId( pattern?.ID ?? 0 );
+	const renderedPattern = renderedPatterns[ patternId ];
+
+	// This is needed to make iframe lazy loading work in Firefox and Safari, see
+	// https://wp.me/pdtkmj-2wZ#comment-4707
+	useEffect( () => {
+		if ( ! previewRef.current || category.name !== 'footer' ) {
+			return;
+		}
+
+		const element = previewRef.current;
+		const timeoutId = setTimeout( () => {
+			const iframe = element.querySelector( 'iframe' );
+			iframe?.setAttribute( 'loading', 'eager' );
+		}, 1000 );
+
+		return () => {
+			clearTimeout( timeoutId );
+		};
+	}, [ category, renderedPattern?.html ] );
+
+	const patternCount =
+		patternTypeFilter === PatternTypeFilter.PAGES
+			? category.pagePatternCount
+			: category.regularPatternCount;
+
+	return (
+		<LocalizedLink
+			className="patterns-category-gallery__item"
+			href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
+			key={ category.name }
+		>
+			<div
+				className={ classNames( 'patterns-category-gallery__item-preview', {
+					'patterns-category-gallery__item-preview--page-layout':
+						patternTypeFilter === PatternTypeFilter.PAGES,
+					'patterns-category-gallery__item-preview--mirrored': category.name === 'footer',
+				} ) }
+				ref={ previewRef }
+			>
+				<div className="patterns-category-gallery__item-preview-inner">
+					<PatternPreview
+						category={ category.name }
+						className="pattern-preview--category-gallery"
+						pattern={ pattern }
+						patternTypeFilter={ patternTypeFilter }
+						viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
+					/>
+				</div>
+			</div>
+
+			<div className="patterns-category-gallery__item-name">{ category.label }</div>
+			<div className="patterns-category-gallery__item-count">
+				{ translate( '%(count)d pattern', '%(count)d patterns', {
+					count: patternCount,
+					args: { count: patternCount },
+				} ) }
+			</div>
+		</LocalizedLink>
+	);
+}
 
 export const CategoryGalleryClient: CategoryGalleryFC = ( {
 	categories,
@@ -30,8 +109,6 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 				?.filter( ( { regularPreviewPattern } ) => regularPreviewPattern )
 				.map( ( { regularPreviewPattern } ) => `${ regularPreviewPattern?.ID }` ) ?? [],
 	};
-
-	const translate = useTranslate();
 
 	return (
 		<BlockRendererProvider
@@ -57,51 +134,13 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 							'is-page-patterns': patternTypeFilter === PatternTypeFilter.PAGES,
 						} ) }
 					>
-						{ categories?.map( ( category ) => {
-							const patternCount =
-								patternTypeFilter === PatternTypeFilter.PAGES
-									? category.pagePatternCount
-									: category.regularPatternCount;
-
-							return (
-								<LocalizedLink
-									className="patterns-category-gallery__item"
-									href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
-									key={ category.name }
-								>
-									<div
-										className={ classNames( 'patterns-category-gallery__item-preview', {
-											'patterns-category-gallery__item-preview--page-layout':
-												patternTypeFilter === PatternTypeFilter.PAGES,
-											'patterns-category-gallery__item-preview--mirrored':
-												category.name === 'footer',
-										} ) }
-									>
-										<div className="patterns-category-gallery__item-preview-inner">
-											<PatternPreview
-												category={ category.name }
-												className="pattern-preview--category-gallery"
-												pattern={
-													patternTypeFilter === PatternTypeFilter.PAGES
-														? category.pagePreviewPattern
-														: category.regularPreviewPattern
-												}
-												patternTypeFilter={ patternTypeFilter }
-												viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
-											/>
-										</div>
-									</div>
-
-									<div className="patterns-category-gallery__item-name">{ category.label }</div>
-									<div className="patterns-category-gallery__item-count">
-										{ translate( '%(count)d pattern', '%(count)d patterns', {
-											count: patternCount,
-											args: { count: patternCount },
-										} ) }
-									</div>
-								</LocalizedLink>
-							);
-						} ) }
+						{ categories?.map( ( category ) => (
+							<CategoryGalleryItem
+								category={ category }
+								key={ category.name }
+								patternTypeFilter={ patternTypeFilter }
+							/>
+						) ) }
 					</div>
 				</PatternsSection>
 			</PatternsRendererProvider>

--- a/client/my-sites/patterns/components/category-gallery/style.scss
+++ b/client/my-sites/patterns/components/category-gallery/style.scss
@@ -48,12 +48,23 @@
 
 	.patterns-category-gallery__item-preview--mirrored {
 		.patterns-category-gallery__item-preview-inner {
+			// necessary to trigger browser's repainting process to fix the appearance issue in FF and Safari
+			@keyframes initTransform {
+				from {
+					transform: translateY(-8px);
+				}
+				to {
+					transform: translateY(-10px);
+				}
+			}
+
 			align-items: end;
 			border-radius: 0 0 4px 4px;
 			display: grid;
 			margin: 0 30px 20px;
 			transform-origin: center top;
 			transform: translateY(-10px);
+			animation: initTransform 0.1s;
 		}
 	}
 

--- a/client/my-sites/patterns/components/category-gallery/style.scss
+++ b/client/my-sites/patterns/components/category-gallery/style.scss
@@ -48,23 +48,12 @@
 
 	.patterns-category-gallery__item-preview--mirrored {
 		.patterns-category-gallery__item-preview-inner {
-			// necessary to trigger browser's repainting process to fix the appearance issue in FF and Safari
-			@keyframes initTransform {
-				from {
-					transform: translateY(-8px);
-				}
-				to {
-					transform: translateY(-10px);
-				}
-			}
-
 			align-items: end;
 			border-radius: 0 0 4px 4px;
 			display: grid;
 			margin: 0 30px 20px;
 			transform-origin: center top;
 			transform: translateY(-10px);
-			animation: initTransform 0.1s;
 		}
 	}
 

--- a/client/my-sites/patterns/components/category-gallery/style.scss
+++ b/client/my-sites/patterns/components/category-gallery/style.scss
@@ -87,4 +87,14 @@
 		color: #50575e;
 		line-height: 1.6;
 	}
+
+	.pattern-preview {
+		.pattern-preview__renderer {
+			aspect-ratio: auto;
+		}
+
+		.pattern-preview__header {
+			display: none;
+		}
+	}
 }

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -41,7 +41,7 @@
 	}
 
 	&.is-loading .pattern-preview__renderer {
-		aspect-ratio: 7 / 4;
+		aspect-ratio: 7 / 4.5;
 		animation-play-state: paused;
 		width: 100%;
 	}

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -41,7 +41,7 @@
 	}
 
 	&.is-loading .pattern-preview__renderer {
-		aspect-ratio: 7 / 4.5;
+		aspect-ratio: 7 / 4;
 		animation-play-state: paused;
 		width: 100%;
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6400

## Proposed Changes
Now we have a bug - by default `Footer-pattern` preview isn't rendered, and it appears only after mouse-over on it (only FF and Safari).

Long story short - here is the info from ChatGPT:

The behavior you're encountering seems related to how different browsers handle the rendering and repainting of elements affected by CSS transforms, especially with complex elements like iframes. Chrome might be pre-calculating or pre-rendering the transform states more aggressively than Firefox or Safari, leading to the discrepancy in behavior.
A common workaround for issues where CSS transformations don't appear until after an interaction (like a hover) involves forcing the browser to recognize and render the transformation state of the element before any user interaction. This can often be achieved by tricking the browser into thinking the element needs to be repainted or re-composited. 


## Testing Instructions
1) Open `/patterns` in Chrome and assert that Footer's preview still visible
2) Open `/patterns` in Safari and FF, and assert that now it's visible
3) Also we have extra space at the bottom of placeholder, now it always looks good (Turn off JS in your browser to simplify testing the placeholder).
<table>
	<tr>
		<td>BEFORE
		<td>AFTER
	</tr>
	<tr>
		<td><img width="304" alt="Screenshot 2024-04-04 at 13 48 52" src="https://github.com/Automattic/wp-calypso/assets/5598437/112bef47-cb2e-4643-a47b-6ea62f641f5a">
		<td><img width="305" alt="Screenshot 2024-04-04 at 13 48 22" src="https://github.com/Automattic/wp-calypso/assets/5598437/01f7a5f4-aa53-4a8b-bf0a-16c25996de28">
	</tr>
</table>

