### PR TITLE
Add /site-profiler/report/ route

### DIFF
--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -20,6 +20,7 @@ import './styles.scss';
 
 interface Props {
 	routerDomain?: string;
+	hash?: string;
 }
 
 export default function SiteProfiler( props: Props ) {

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -54,3 +54,22 @@ export const siteProfilerContext: Callback = ( context, next ) => {
 
 	next();
 };
+
+export const siteProfilerReportContext: Callback = ( context, next ) => {
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+	const pathName = context.pathname || '';
+	const routerParams = pathName.split( '/site-profiler/report/' )[ 1 ]?.trim() || '';
+	const routerDomain = routerParams.split( '/' ).slice( 1 ).join( '/' );
+
+	context.primary = (
+		<>
+			<Main fullWidthLayout>
+				<SiteProfiler routerDomain={ routerDomain } hash={ context.params.hash ?? '' } />
+			</Main>
+
+			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } />
+		</>
+	);
+
+	next();
+};

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -64,7 +64,7 @@ export const siteProfilerReportContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<Main fullWidthLayout>
-				<SiteProfiler routerDomain={ routerDomain } hash={ context.params.hash ?? '' } />
+				<SiteProfiler routerDomain={ routerDomain } hash={ context.params.hash } />
 			</Main>
 
 			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } />

--- a/client/site-profiler/index.web.ts
+++ b/client/site-profiler/index.web.ts
@@ -10,6 +10,7 @@ import {
 	featureFlagFirewall,
 	handleDomainQueryParam,
 	redirectToBaseSiteProfilerRoute,
+	siteProfilerReportContext,
 } from 'calypso/site-profiler/controller';
 
 export default function ( router: typeof clientRouter ) {
@@ -27,6 +28,16 @@ export default function ( router: typeof clientRouter ) {
 		makeLayout,
 		clientRender,
 	];
+
+	const siteProfilerReportMiddleware = [
+		featureFlagFirewall,
+		siteProfilerReportContext,
+		makeLayout,
+		clientRender,
+	];
+
+	router( '/site-profiler/report/:hash/:domain', ...siteProfilerReportMiddleware );
+	router( '/site-profiler/report/:hash/:domain/*', ...siteProfilerReportMiddleware );
 
 	router( `/site-profiler/${ lang }/:domain?`, ...langSiteProfilerMiddleware );
 	router( `/${ lang }/site-profiler/:domain?`, ...langSiteProfilerMiddleware );


### PR DESCRIPTION
## Proposed Changes

Fixes https://github.com/Automattic/dotcom-forge/issues/6411

Add the `/site-profiler/report/` route.
For now this route shows the same result as in `/site-profiler` and passes down the `hash` property. 

![CleanShot 2024-04-04 at 17 02 13@2x](https://github.com/Automattic/wp-calypso/assets/5039531/9d8c729d-de7e-4046-8ff2-988f167bef9f)

## Testing Instructions


* Check the `/site-profiler` route still working as in production, passing a domain or not
*  Check the `/site-profiler` route still working as in production, passing a language or not

---

* Go to `/site-profiler/report/:hash/:domain`
* Guarantee this shows the same result as `/site-profiler/:domain`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?