### PR TITLE
A4A: fix "go back" button styling on the payment methods page

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/style.scss
@@ -25,6 +25,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	height: 50px;
 }
 
 .payment-method-form__notice,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/210

## Proposed Changes

* Set a height that matches the one of the sibling button, so it doesn't stretch to the full height of the parent component.

## Testing Instructions

* Run `yarn start-a8c-for-agencies`, or open a live branch.
* Append `/purchases/payment-methods/add?return=/marketplace/checkout` to the URL.
* Verify that both buttons are correctly sized.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="1407" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/868324ef-3630-420d-b592-29992b951423">
</td>
<td>
<img width="1407" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/8b91dec4-384b-468d-aadb-e013c9003e56">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?