### PR TITLE
A4A: Hide the Overview top navbar if it has only 1 item

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -238,7 +238,9 @@ export default function SitesDashboard() {
 						} }
 					>
 						<SitesDataViews
-							className="sites-overview__content"
+							className={ classNames( 'sites-overview__content', {
+								'is-hiding-navigation': navItems.length <= 1,
+							} ) }
 							data={ data }
 							isLoading={ isLoading }
 							isLargeScreen={ isLargeScreen || false }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -200,12 +200,11 @@ export default function SitesDashboard() {
 				! sitesViewState.selectedSite && 'preview-hidden'
 			) }
 			wide
-			withBorder={ ! sitesViewState.selectedSite }
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 		>
 			{ ! hideListing && (
 				<LayoutColumn className="sites-overview" wide>
-					<LayoutTop withNavigation>
+					<LayoutTop withNavigation={ navItems.length > 1 }>
 						<LayoutHeader>
 							{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
 							<Actions>
@@ -213,9 +212,11 @@ export default function SitesDashboard() {
 								<OverviewHeaderActions />
 							</Actions>
 						</LayoutHeader>
-						<LayoutNavigation { ...selectedItemProps }>
-							<NavigationTabs { ...selectedItemProps } items={ navItems } />
-						</LayoutNavigation>
+						{ navItems.length > 1 && (
+							<LayoutNavigation { ...selectedItemProps }>
+								<NavigationTabs { ...selectedItemProps } items={ navItems } />
+							</LayoutNavigation>
+						) }
 					</LayoutTop>
 
 					<SiteNotifications />

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -220,7 +220,7 @@
 		&.sites-dashboard__layout {
 			.dataviews-view-table-wrapper {
 				overflow-y: auto;
-				max-height: calc(100vh - 255px); /* 255px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
+				max-height: calc(100vh - 170px); /* 170px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
 			}
 		}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -447,6 +447,10 @@
 
 			.sites-overview__content {
 				margin-top: 24px;
+
+				&.is-hiding-navigation {
+					margin-top: 48px; // If there is no navigation bar we need to add a bigger margin.
+				}
 			}
 		}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -220,7 +220,12 @@
 		&.sites-dashboard__layout {
 			.dataviews-view-table-wrapper {
 				overflow-y: auto;
-				max-height: calc(100vh - 170px); /* 170px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
+				max-height: calc(100vh - 255px); /* 255px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
+			}
+
+			.is-hiding-navigation .dataviews-view-table-wrapper {
+				overflow-y: auto;
+				max-height: calc(100vh - 182px); /* 182px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
 			}
 		}
 


### PR DESCRIPTION
Resolve: https://github.com/Automattic/automattic-for-agencies-dev/issues/200

## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/9832440/80603da6-9546-4c48-a370-d2ff3eab0e4c)

This PR hides the Overview navigation bar if it has only 1 item. 

**Other issues detected**

- The table row, its left side should fill the whole field, and just padding the first TD (on the left) and the last one (on the right)


## Testing Instructions

- Check the code
- The top Overview navigation bar should be hidden

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
