### PR TITLE
A4A: Set the DocumentHead to Jetpack feature tabs in the Preview Pane

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-boost.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-boost.tsx
@@ -1,3 +1,4 @@
+import DocumentHead from 'calypso/components/data/document-head';
 import BoostSitePerformance from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance';
 import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
@@ -12,6 +13,7 @@ type Props = {
 export function JetpackBoostPreview( { site, trackEvent, hasError = false }: Props ) {
 	return (
 		<>
+			<DocumentHead title="Boost" />
 			<SitePreviewPaneContent className="site-preview-pane__boost-content">
 				<BoostSitePerformance site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			</SitePreviewPaneContent>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -1,3 +1,4 @@
+import DocumentHead from 'calypso/components/data/document-head';
 import MonitorActivity from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity';
 import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
@@ -12,6 +13,7 @@ type Props = {
 export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: Props ) {
 	return (
 		<>
+			<DocumentHead title="Monitor" />
 			<SitePreviewPaneContent className="site-preview-pane__monitor-content">
 				<MonitorActivity
 					hasMonitor={ site.monitor_settings.monitor_active }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@automattic/components';
 import { external, Icon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
 import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
 
@@ -11,8 +13,10 @@ type Props = {
 };
 
 export function JetpackPluginsPreview( { featureText, link, linkLabel, captionText }: Props ) {
+	const translate = useTranslate();
 	return (
 		<>
+			<DocumentHead title={ translate( 'Plugins' ) } />
 			<SitePreviewPaneContent>
 				<div className="site-preview-pane__plugins-content">
 					<h3>{ featureText }</h3>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-stats.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-stats.tsx
@@ -1,3 +1,4 @@
+import DocumentHead from 'calypso/components/data/document-head';
 import InsightsStats from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats';
 import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
@@ -11,6 +12,7 @@ type Props = {
 export function JetpackStatsPreview( { site, trackEvent }: Props ) {
 	return (
 		<>
+			<DocumentHead title="Stats" />
 			<SitePreviewPaneContent className="site-preview-pane__stats-content">
 				<InsightsStats
 					stats={ site.site_stats }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -193,7 +193,6 @@ export default function SitesDashboard() {
 
 	return (
 		<Layout
-			title="Sites"
 			className={ classNames(
 				'sites-dashboard',
 				'sites-dashboard__layout',
@@ -202,6 +201,7 @@ export default function SitesDashboard() {
 			wide
 			withBorder={ ! sitesViewState.selectedSite }
 			sidebarNavigation={ <MobileSidebarNavigation /> }
+			title={ sitesViewState.selectedSite ? null : translate( 'Sites' ) }
 		>
 			{ ! hideListing && (
 				<LayoutColumn className="sites-overview" wide>


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/175

## Proposed Changes

This PR adds the title for these Jetpack Features:

- Boost (Product, not translated)
- Monitor (Product, not translated)
- Plugins
- Stats (Product, not translated)

**Issue:** The Sites Dashboard doesn't recover the Title when we close the Preview Pane. 

## Testing Instructions

- Check the code
- Select a site, go through the tabs, and check that the titles are correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
