### PR TITLE
A4A: Sites Dashboard - Fix scan and backup not showing upsell buttons

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -116,7 +116,9 @@ export default function SitesDashboard() {
 				type: 'list',
 			} ) );
 		}
-	}, [ data, isError, isLoading, initialSelectedSiteUrl, setSitesViewState ] );
+		// Omitting sitesViewState to prevent infinite loop
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ data, isError, isLoading, initialSelectedSiteUrl, setSitesViewState, setHideListing ] );
 
 	const onSitesViewChange = useCallback(
 		( sitesViewData: SitesViewState ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -22,7 +22,7 @@ type Props = {
 	disabled?: boolean;
 };
 
-export default function SiteStatsColumn( { type, rows, metadata, disabled }: Props ) {
+export default function SiteStatusColumn( { type, rows, metadata, disabled }: Props ) {
 	const {
 		link,
 		isExternalLink,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -47,7 +47,8 @@ export default function SiteStatsColumn( { type, rows, metadata, disabled }: Pro
 	);
 
 	const partner = useSelector( getCurrentPartner );
-	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
+	const partnerCanIssueLicense =
+		isEnabled( 'a8c-for-agencies' ) || Boolean( partner?.can_issue_licenses ); // FIXME: get this from state when isEnabled( 'a8c-for-agencies' )
 
 	const issueLicenseRedirectUrl = useMemo( () => {
 		return addQueryArgs( `/partner-portal/issue-license/`, {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/178

## Proposed Changes

* This PR makes the  scan and backup upsell buttons show in A4A by ignoring the `partnerCanIssueLicense` variable. A FIXME comment has been added to enable it back when the state is implemented in A4A.

## Testing Instructions

* Go to the A4A Sites Dashboard (`/sites`)
* Ensure that the upsell buttons are shown in the table

![image](https://github.com/Automattic/wp-calypso/assets/37049295/bbef19e0-223a-426f-ae7d-5b40e1493f47)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?