### PR TITLE
Rollback hosting trial CTA from plugin upload page

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -202,6 +202,8 @@ const mapStateToProps = ( state ) => {
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
+	// This value is hardcoded to 'false' to disable the free trial banner
+	// see https://github.com/Automattic/wp-calypso/pull/89217
 	const isEligibleForHostingTrial = false;
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -34,7 +34,6 @@ import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id'
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isPluginUploadInProgress from 'calypso/state/selectors/is-plugin-upload-in-progress';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getSiteAdminUrl,
@@ -203,8 +202,7 @@ const mapStateToProps = ( state ) => {
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
-	const isEligibleForHostingTrial =
-		isUserEligibleForFreeHostingTrial( state ) && site?.plan?.is_free;
+	const isEligibleForHostingTrial = false;
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6436-gh-Automattic/dotcom-forge

## Proposed Changes

Remove the **Start your free trial** CTA for logged-in users viewing `/plugins/upload`, in favor of a standard upgrade nudge.  This change also brings back the card describing that an upgrade is necessary to proceed.

For now we aren't removing the underlying logic, just focusing on disabling the CTA itself. If needed, we can remove the logic in a followup PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using a free plan site that does not already support uploading themes, navigate to `/plugins/upload` 
- When the page loads, confirm that CTA button encourages an upgrade to the Creator plan, rather than offering a free trial
- Confirm that clicking on the button opens the checkout page with the Creator plan already added to the cart.
- Confirm that clicking on the button does not open a free trial modal

**Before**
<img width="737" alt="wordpress.com plugin upload page with a 'start your free trial' CTA button" src="https://github.com/Automattic/wp-calypso/assets/13856531/f66a4df2-08d6-42e4-be1f-1037481ee0ac">

**After**
<img width="744" alt="wordpress.com plugin upload page with an 'upgrade and continue' CTA button" src="https://github.com/Automattic/wp-calypso/assets/13856531/4cedf50a-6b60-4b80-af10-e0409efec80f">
