### PR TITLE
Update site landing toggle copy

### DIFF
--- a/client/me/account/toggle-sites-as-landing-page.tsx
+++ b/client/me/account/toggle-sites-as-landing-page.tsx
@@ -38,7 +38,9 @@ function ToggleSitesAsLandingPage() {
 				checked={ !! useSitesAsLandingPage }
 				onChange={ handleToggle }
 				disabled={ isSaving }
-				label={ translate( 'Show me all my sites when logging in to WordPress.com' ) }
+				label={ translate(
+					'Display all my sites instead of just my primary site when I visit WordPress.com.'
+				) }
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6379

## Proposed Changes

* Update site landing page toggle copy on Me -> Account Settings for better clarity.

Before: "'Show me all my sites when logging in to WordPress.com'"
After: "Display all my sites instead of just my primary site when I visit WordPress.com."

<img width="630" alt="Screenshot 2024-04-04 at 3 04 14 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/079c0c0d-c0df-4162-bbba-596315cf353a">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/account
* View the updated copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?