### PR TITLE
Pattern Library: add `search_term` to the `calypso_pattern_library_load_more` event

### DIFF
--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -185,7 +185,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 										type: getTracksPatternType( patternTypeFilter ),
 										view: isGridView ? 'grid' : 'list',
 										load_more_page: currentPage,
-										search_term: searchTerm,
+										search_term: searchTerm ? searchTerm : undefined,
 									} );
 								} }
 								transparent

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -117,6 +117,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 		isGridView = false,
 		patterns = [],
 		patternTypeFilter,
+		searchTerm,
 	} = props;
 
 	const translate = useTranslate();
@@ -184,6 +185,7 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 										type: getTracksPatternType( patternTypeFilter ),
 										view: isGridView ? 'grid' : 'list',
 										load_more_page: currentPage,
+										search_term: searchTerm,
 									} );
 								} }
 								transparent

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -180,12 +180,12 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 									setCurrentPage( currentPage + 1 );
 
 									recordTracksEvent( 'calypso_pattern_library_load_more', {
-										category,
+										category: category || undefined,
 										is_logged_in: isLoggedIn,
 										type: getTracksPatternType( patternTypeFilter ),
 										view: isGridView ? 'grid' : 'list',
 										load_more_page: currentPage,
-										search_term: searchTerm ? searchTerm : undefined,
+										search_term: searchTerm || undefined,
 									} );
 								} }
 								transparent

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -354,6 +354,7 @@ export const PatternLibrary = ( {
 							key={ `pattern-gallery-${ patternGalleryKey }` }
 							patterns={ patterns }
 							patternTypeFilter={ searchTerm ? PatternTypeFilter.REGULAR : patternTypeFilter }
+							searchTerm={ searchTerm }
 						/>
 
 						{ searchTerm && ! patterns.length && category && (

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -113,7 +113,7 @@ export const PatternLibrary = ( {
 	) => {
 		recordTracksEvent( tracksEventName, {
 			category,
-			search_term: searchTerm ? searchTerm : undefined,
+			search_term: searchTerm || undefined,
 			is_logged_in: isLoggedIn,
 			type: getTracksPatternType( typeFilter ),
 			user_is_dev_account: isDevAccount ? '1' : '0',

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -113,7 +113,7 @@ export const PatternLibrary = ( {
 	) => {
 		recordTracksEvent( tracksEventName, {
 			category,
-			search_term: searchTerm || undefined,
+			search_term: searchTerm ? searchTerm : undefined,
 			is_logged_in: isLoggedIn,
 			type: getTracksPatternType( typeFilter ),
 			user_is_dev_account: isDevAccount ? '1' : '0',

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -55,6 +55,7 @@ export type PatternGalleryProps = {
 	isGridView?: boolean;
 	patterns?: Pattern[];
 	patternTypeFilter: PatternTypeFilter;
+	searchTerm?: string;
 };
 
 export type PatternGalleryFC = React.FC< PatternGalleryProps >;

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -202,6 +202,8 @@ const mapStateToProps = ( state ) => {
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
+	// This value is hardcoded to 'false' to disable the free trial banner
+	// see https://github.com/Automattic/wp-calypso/pull/89217
 	const isEligibleForHostingTrial = false;
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -34,6 +34,7 @@ import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id'
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isPluginUploadInProgress from 'calypso/state/selectors/is-plugin-upload-in-progress';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getSiteAdminUrl,
@@ -202,9 +203,8 @@ const mapStateToProps = ( state ) => {
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
-	// This value is hardcoded to 'false' to disable the free trial banner
-	// see https://github.com/Automattic/wp-calypso/pull/89217
-	const isEligibleForHostingTrial = false;
+	const isEligibleForHostingTrial =
+		isUserEligibleForFreeHostingTrial( state ) && site?.plan?.is_free;
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -34,7 +34,6 @@ import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id'
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isPluginUploadInProgress from 'calypso/state/selectors/is-plugin-upload-in-progress';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getSiteAdminUrl,
@@ -203,8 +202,7 @@ const mapStateToProps = ( state ) => {
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
-	const isEligibleForHostingTrial =
-		isUserEligibleForFreeHostingTrial( state ) && site?.plan?.is_free;
+	const isEligibleForHostingTrial = false;
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6434-gh-Automattic/dotcom-forge

## Proposed Changes

- adds the current search term to the `calypso_pattern_library_load_more` tracks event, which fires when a user activates the pagination button in the pattern library.

If no search term is present (i.e. the user isn't on a search results page) the `search_term` will be an empty string and won't appear in the event props.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Load the pattern library and select the **About** category to ensure you have enough patterns to paginate
- Click the **Load 9 more patterns** button
- Confirm `search_term` is NOT listed in the event props for the `calypso_pattern_library_load_more` when it fires
- Return to the **All Categories** view
- Enter a search term that will return enough results to paginate. I just used 'about' for my testing
- On the search results page, click the **Load {num} more patterns** button
- Confirm that `search_term` is included in the `calypso_pattern_library_load_more` event props, and that it's accurately reporting your search term