### PR TITLE
Patterns: update breakpoint to prevent native scrollbar

### DIFF
--- a/client/my-sites/patterns/components/copy-paste-info/style.scss
+++ b/client/my-sites/patterns/components/copy-paste-info/style.scss
@@ -9,7 +9,7 @@
 	scroll-snap-type: x proximity;
 	scroll-padding-left: 24px;
 
-	@media ( max-width: $break-wide ) {
+	@media ( max-width: $break-huge ) {
 		padding: 0 24px;
 	}
 }

--- a/client/my-sites/patterns/components/copy-paste-info/style.scss
+++ b/client/my-sites/patterns/components/copy-paste-info/style.scss
@@ -5,13 +5,11 @@
 	display: flex;
 	gap: 24px;
 	overflow: auto;
-	padding: 0 110px;
 	scroll-snap-type: x proximity;
 	scroll-padding-left: 24px;
-
-	@media ( max-width: $break-huge ) {
-		padding: 0 24px;
-	}
+	max-width: 1220px;
+	margin: 0 auto;
+	padding: 0 24px;
 }
 
 .section-patterns-info__item {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6435-gh-Automattic/dotcom-forge

## Proposed Changes

Update the breakpoint to decrease padding of the "Copy, paste, customize—it’s easy like that" to `$break-huge` (1440px) to prevent a native scrollbar from appearing.

The scrollbar was caused by the wider padding of the section, which was previously not being changed until the `$break-wide` (1280px) breakpoint. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- load `/patterns` and scroll down to the "Copy, paste, customize—it’s easy like that" section.
- alter your viewport width gradually, and watch as you approach and pass below 1440px viewport width
- confirm that no horizontal scrollbar appears until about 1255px or so which (I **think**) is desired behavior for smaller screens
