### PR TITLE
Scheduled updates: Print real logs data into ScheduleLogs component

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-logs.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-logs.helper.ts
@@ -1,0 +1,108 @@
+import { translate } from 'i18n-calypso';
+import type { ScheduleLog } from 'calypso/data/plugins/use-update-schedule-logs-query';
+
+export const getLogDetails = ( log: ScheduleLog ) => {
+	const pluginTranslateArgs = {
+		args: {
+			plugin: log.context.plugin_name,
+			from: log.context.old_version,
+			to: log.context.new_version,
+		},
+	};
+
+	switch ( log.action ) {
+		case 'PLUGIN_UPDATES_START':
+			return translate( 'Plugins update started' );
+		case 'PLUGIN_UPDATES_SUCCESS':
+			return translate( 'Plugins update completed' );
+		case 'PLUGIN_UPDATES_FAILURE':
+			return translate( 'Plugins update failed' );
+
+		case 'PLUGIN_UPDATE_SUCCESS':
+			return translate(
+				'%(plugin)s update from %(from)s to %(to)s completed',
+				pluginTranslateArgs
+			);
+		case 'PLUGIN_UPDATE_FAILURE':
+			return translate( '%(plugin)s update from %(from)s to %(to)s failed', pluginTranslateArgs );
+		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK':
+			return translate( '%(plugin)s rollback completed', pluginTranslateArgs );
+		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK_FAIL':
+			return translate( '%(plugin)s rollback failed', pluginTranslateArgs );
+
+		case 'PLUGIN_SITE_HEALTH_CHECK_SUCCESS':
+			return translate( 'Site health check completed' );
+		case 'PLUGIN_SITE_HEALTH_CHECK_FAILURE':
+			return translate( 'Site health check failed' );
+	}
+};
+
+export const getLogIcon = ( log: ScheduleLog ) => {
+	switch ( log.action ) {
+		case 'PLUGIN_UPDATES_START':
+			return 'sync';
+		case 'PLUGIN_UPDATES_SUCCESS':
+		case 'PLUGIN_UPDATE_SUCCESS':
+		case 'PLUGIN_SITE_HEALTH_CHECK_SUCCESS':
+			return 'checkmark';
+		case 'PLUGIN_UPDATES_FAILURE':
+		case 'PLUGIN_UPDATE_FAILURE':
+		case 'PLUGIN_SITE_HEALTH_CHECK_FAILURE':
+		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK':
+		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK_FAIL':
+			return 'cross';
+	}
+};
+
+export const getLogIconStatus = ( log: ScheduleLog ) => {
+	switch ( log.action ) {
+		case 'PLUGIN_UPDATES_SUCCESS':
+		case 'PLUGIN_UPDATE_SUCCESS':
+		case 'PLUGIN_SITE_HEALTH_CHECK_SUCCESS':
+			return 'success';
+		case 'PLUGIN_UPDATES_FAILURE':
+		case 'PLUGIN_UPDATE_FAILURE':
+		case 'PLUGIN_SITE_HEALTH_CHECK_FAILURE':
+		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK':
+		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK_FAIL':
+			return 'error';
+	}
+};
+
+export const shouldIndentTimelineEvent = ( log: ScheduleLog ) => {
+	switch ( log.action ) {
+		case 'PLUGIN_UPDATES_START':
+		case 'PLUGIN_UPDATES_SUCCESS':
+		case 'PLUGIN_UPDATES_FAILURE':
+			return false;
+		default:
+			return true;
+	}
+};
+
+export function addSecondsToFormat( format: string ) {
+	const hasSeconds = /ss/.test( format );
+
+	if ( hasSeconds ) {
+		return format;
+	}
+
+	const is24HourFormat = /HH?/.test( format );
+
+	if ( is24HourFormat ) {
+		return format + ':ss';
+	}
+
+	// If it's 12-hour format, find 'a' or 'A' at the end and insert ':ss' before it
+	const amPmIndex = format.lastIndexOf( 'a' );
+	if ( amPmIndex !== -1 ) {
+		return format.slice( 0, amPmIndex ).trimEnd() + ':ss ' + format.slice( amPmIndex );
+	}
+	// If 'a' or 'A' is not found, insert 'ss' before the space (if any) at the end
+	const trimmedFormat = format.trimEnd();
+	const lastSpaceIndex = trimmedFormat.lastIndexOf( ' ' );
+	if ( lastSpaceIndex !== -1 ) {
+		return trimmedFormat.slice( 0, lastSpaceIndex ) + ':ss' + trimmedFormat.slice( lastSpaceIndex );
+	}
+	return trimmedFormat + ':ss';
+}

--- a/client/blocks/plugins-update-manager/schedule-logs.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-logs.helper.ts
@@ -22,10 +22,9 @@ export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[] ) => {
 			return translate( 'Plugins update failed' );
 
 		case 'PLUGIN_UPDATE_SUCCESS':
-			return translate(
-				'%(plugin)s update from %(from)s to %(to)s completed',
-				pluginTranslateArgs
-			);
+			return log.message === 'already_up_to_date'
+				? translate( '%(plugin)s is already up to date', pluginTranslateArgs )
+				: translate( '%(plugin)s update from %(from)s to %(to)s completed', pluginTranslateArgs );
 		case 'PLUGIN_UPDATE_FAILURE':
 			return translate( '%(plugin)s update from %(from)s to %(to)s failed', pluginTranslateArgs );
 		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK':

--- a/client/blocks/plugins-update-manager/schedule-logs.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-logs.helper.ts
@@ -1,10 +1,13 @@
 import { translate } from 'i18n-calypso';
+import type { CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
 import type { ScheduleLog } from 'calypso/data/plugins/use-update-schedule-logs-query';
 
-export const getLogDetails = ( log: ScheduleLog ) => {
+export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[] ) => {
+	const pluginName =
+		plugins.find( ( p ) => p.plugin === log.context.plugin_name )?.name || log.context.plugin_name;
 	const pluginTranslateArgs = {
 		args: {
-			plugin: log.context.plugin_name,
+			plugin: pluginName,
 			from: log.context.old_version,
 			to: log.context.new_version,
 		},

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -122,7 +122,8 @@ export const ScheduleLogs = ( props: Props ) => {
 							className={ shouldIndentTimelineEvent( log ) ? 'indent' : '' }
 							disabled={ log.action === 'PLUGIN_UPDATES_START' }
 							actionLabel={
-								log.action === 'PLUGIN_UPDATE_FAILURE'
+								// show a button only for the most recent update failure
+								i === 0 && log.action === 'PLUGIN_UPDATE_FAILURE'
 									? translate( 'Try manual update' )
 									: undefined
 							}

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import Timeline from 'calypso/components/timeline';
 import TimelineEvent from 'calypso/components/timeline/timeline-event';
+import { useUpdateScheduleLogsQuery } from 'calypso/data/plugins/use-update-schedule-logs-query';
 import {
 	type ScheduleUpdates,
 	useUpdateScheduleQuery,
@@ -20,6 +21,13 @@ import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
 import { useSiteAdminUrl } from './hooks/use-site-admin-url';
 import { useSiteDateTimeFormat } from './hooks/use-site-date-time-format';
 import { useSiteSlug } from './hooks/use-site-slug';
+import {
+	getLogDetails,
+	getLogIcon,
+	getLogIconStatus,
+	addSecondsToFormat,
+	shouldIndentTimelineEvent,
+} from './schedule-logs.helper';
 
 interface Props {
 	scheduleId: string;
@@ -37,7 +45,7 @@ export const ScheduleLogs = ( props: Props ) => {
 		convertPhpToMomentFormat,
 	} = useSiteDateTimeFormat( siteSlug );
 	const dateFormat = convertPhpToMomentFormat( phpDateFormat );
-	const timeFormat = convertPhpToMomentFormat( phpTimeFormat );
+	const timeFormat = addSecondsToFormat( convertPhpToMomentFormat( phpTimeFormat ) );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { isEligibleForFeature } = useIsEligibleForFeature();
@@ -47,6 +55,7 @@ export const ScheduleLogs = ( props: Props ) => {
 		isPending,
 	} = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const schedule = schedules.find( ( s ) => s.id === scheduleId );
+	const { data: scheduleLogs = [] } = useUpdateScheduleLogsQuery( siteSlug, scheduleId );
 
 	const goToPluginsPage = useCallback( () => {
 		window.location.href = `${ siteAdminUrl }plugins.php`;
@@ -94,89 +103,33 @@ export const ScheduleLogs = ( props: Props ) => {
 					</Text>
 				</div>
 			</CardHeader>
-			<Timeline>
-				<TimelineEvent
-					date={ new Date( '30 March 2024, 10:01 am' ) }
-					dateFormat={ timeFormat }
-					detail="Plugins update completed"
-					icon="checkmark"
-					iconBackground="success"
-				/>
-				<TimelineEvent
-					className="indent"
-					date={ new Date( '30 March 2024, 10:00:48 am' ) }
-					dateFormat={ timeFormat }
-					detail="Gravity Forms updated from 2.5.8 to 2.6.0"
-					icon="checkmark"
-					iconBackground="success"
-				/>
-				<TimelineEvent
-					className="indent"
-					date={ new Date( '30 March 2024, 10:00:39 am' ) }
-					dateFormat={ timeFormat }
-					detail="Move to WordPress.com update from 5.9.3 to 6.0.0 failed [ Rolledback to 5.9.3 ]"
-					icon="cross"
-					iconBackground="error"
-					actionLabel="Try manual update"
-					actionIsPrimary={ true }
-					onActionClick={ goToPluginsPage }
-				/>
-				<TimelineEvent
-					className="indent"
-					date={ new Date( '30 March 2024, 10:00:12 am' ) }
-					dateFormat={ timeFormat }
-					detail="Elementor Pro updated from 3.0.9 to 3.1.0"
-					icon="checkmark"
-					iconBackground="success"
-				/>
-				<TimelineEvent
-					date={ new Date( '30 March 2024' ) }
-					dateFormat={ `${ dateFormat } ${ timeFormat }` }
-					detail="Plugins update starts"
-					icon="sync"
-					disabled
-				/>
-			</Timeline>
-			<Timeline>
-				<TimelineEvent
-					date={ new Date( '27 March 2024, 10:01 am' ) }
-					dateFormat={ timeFormat }
-					detail="Plugins update completed successfully"
-					icon="checkmark"
-					iconBackground="success"
-				/>
-				<TimelineEvent
-					className="indent"
-					date={ new Date( '27 March 2024, 10:00:48 am' ) }
-					dateFormat={ timeFormat }
-					detail="Gravity Forms updated from 2.5.8 to 2.6.0"
-					icon="checkmark"
-					iconBackground="success"
-				/>
-				<TimelineEvent
-					className="indent"
-					date={ new Date( '27 March 2024, 10:00:39 am' ) }
-					dateFormat={ timeFormat }
-					detail="Move to WordPress.com update from 5.9.3 to 6.0.0"
-					icon="checkmark"
-					iconBackground="success"
-				/>
-				<TimelineEvent
-					className="indent"
-					date={ new Date( '27 March 2024, 10:00:12 am' ) }
-					dateFormat={ timeFormat }
-					detail="Elementor Pro updated from 3.0.9 to 3.1.0"
-					icon="checkmark"
-					iconBackground="success"
-				/>
-				<TimelineEvent
-					date={ new Date( '27 March 2024, 10:00:00 am' ) }
-					dateFormat={ `${ dateFormat } ${ timeFormat }` }
-					detail="Plugins update starts"
-					icon="sync"
-					disabled
-				/>
-			</Timeline>
+			{ scheduleLogs.map( ( logs, i ) => (
+				<Timeline key={ i }>
+					{ logs.reverse().map( ( log ) => (
+						<TimelineEvent
+							key={ log.timestamp }
+							date={ log.date }
+							dateFormat={
+								log.action === 'PLUGIN_UPDATES_START'
+									? `${ dateFormat } ${ timeFormat }`
+									: timeFormat
+							}
+							detail={ getLogDetails( log ) }
+							icon={ getLogIcon( log ) }
+							iconBackground={ getLogIconStatus( log ) }
+							className={ shouldIndentTimelineEvent( log ) ? 'indent' : '' }
+							disabled={ log.action === 'PLUGIN_UPDATES_START' }
+							actionLabel={
+								log.action === 'PLUGIN_UPDATE_FAILURE'
+									? translate( 'Try manual update' )
+									: undefined
+							}
+							actionIsPrimary={ true }
+							onActionClick={ goToPluginsPage }
+						/>
+					) ) }
+				</Timeline>
+			) ) }
 		</Card>
 	);
 };

--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import Timeline from 'calypso/components/timeline';
 import TimelineEvent from 'calypso/components/timeline/timeline-event';
+import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import { useUpdateScheduleLogsQuery } from 'calypso/data/plugins/use-update-schedule-logs-query';
 import {
 	type ScheduleUpdates,
@@ -48,6 +49,7 @@ export const ScheduleLogs = ( props: Props ) => {
 	const timeFormat = addSecondsToFormat( convertPhpToMomentFormat( phpTimeFormat ) );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
+	const { data: plugins = [] } = useCorePluginsQuery( siteSlug, true, true );
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const {
 		data: schedules = [],
@@ -114,7 +116,7 @@ export const ScheduleLogs = ( props: Props ) => {
 									? `${ dateFormat } ${ timeFormat }`
 									: timeFormat
 							}
-							detail={ getLogDetails( log ) }
+							detail={ getLogDetails( log, plugins ) }
 							icon={ getLogIcon( log ) }
 							iconBackground={ getLogIconStatus( log ) }
 							className={ shouldIndentTimelineEvent( log ) ? 'indent' : '' }

--- a/client/blocks/plugins-update-manager/test/schedule-logs.helper.test.tsx
+++ b/client/blocks/plugins-update-manager/test/schedule-logs.helper.test.tsx
@@ -1,0 +1,15 @@
+import { addSecondsToFormat } from '../schedule-logs.helper';
+
+describe( 'Schedule logs helpers', () => {
+	test( 'addSecondsToFormat', () => {
+		expect( addSecondsToFormat( 'h:mm' ) ).toBe( 'h:mm:ss' );
+		expect( addSecondsToFormat( 'h:mm a' ) ).toBe( 'h:mm:ss a' );
+		expect( addSecondsToFormat( 'h:mm:ss' ) ).toBe( 'h:mm:ss' );
+		expect( addSecondsToFormat( 'h:mm:ss a' ) ).toBe( 'h:mm:ss a' );
+		expect( addSecondsToFormat( 'h:mm a z' ) ).toBe( 'h:mm:ss a z' );
+		expect( addSecondsToFormat( 'h:mm:ss a z' ) ).toBe( 'h:mm:ss a z' );
+		expect( addSecondsToFormat( 'h:mm z' ) ).toBe( 'h:mm:ss z' );
+		expect( addSecondsToFormat( 'HH:mm' ) ).toBe( 'HH:mm:ss' );
+		expect( addSecondsToFormat( 'HH:mm:ss' ) ).toBe( 'HH:mm:ss' );
+	} );
+} );

--- a/client/data/plugins/use-update-schedule-logs-query.ts
+++ b/client/data/plugins/use-update-schedule-logs-query.ts
@@ -2,26 +2,37 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteSlug } from 'calypso/types';
 
+export type ScheduleLogAction =
+	| 'PLUGIN_UPDATES_START'
+	| 'PLUGIN_UPDATES_SUCCESS'
+	| 'PLUGIN_UPDATES_FAILURE'
+	| 'PLUGIN_UPDATE_SUCCESS'
+	| 'PLUGIN_UPDATE_FAILURE'
+	| 'PLUGIN_SITE_HEALTH_CHECK_SUCCESS'
+	| 'PLUGIN_SITE_HEALTH_CHECK_FAILURE'
+	| 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK'
+	| 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK_FAIL';
+
 type ScheduleLogsApiReturn = {
 	timestamp: number;
-	action: string;
+	action: ScheduleLogAction;
 	message: string | null;
-	context: unknown;
+	context: { [ key: string ]: string | number };
 }[][];
 
-type ScheduleLogs = {
+export type ScheduleLog = {
 	date: Date;
 	timestamp: number;
-	action: string;
+	action: ScheduleLogAction;
 	message: string | null;
-	context: unknown;
-}[][];
+	context: { [ key: string ]: string | number };
+};
 
 export const useUpdateScheduleLogsQuery = (
 	siteSlug: SiteSlug,
 	scheduleId: string
-): UseQueryResult< ScheduleLogs > => {
-	return useQuery< ScheduleLogsApiReturn, Error, ScheduleLogs >( {
+): UseQueryResult< ScheduleLog[][] > => {
+	return useQuery< ScheduleLogsApiReturn, Error, ScheduleLog[][] >( {
 		queryKey: [ 'scheduled-logs', scheduleId, siteSlug ],
 		queryFn: () =>
 			wpcomRequest( {
@@ -32,7 +43,7 @@ export const useUpdateScheduleLogsQuery = (
 		enabled: !! siteSlug && !! scheduleId,
 		retry: false,
 		refetchOnWindowFocus: false,
-		select: ( data: ScheduleLogsApiReturn ): ScheduleLogs => {
+		select: ( data: ScheduleLogsApiReturn ): ScheduleLog[][] => {
 			return data
 				.map( ( run ) => {
 					return run.map( ( log ) => ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89036

## Proposed Changes

* Hydrates schedule logs with real data

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Setup you sandbox
* Go to `/plugins/scheduled-updates/{ATOMIC}`
* Check your schedule id from the browser dev tool
* Go to `/plugins/scheduled-updates/logs/{ATOMIC}/{LOG_ID}`
* Check the hydrated screen
* Check timestamps format
* Change the time format site preference
* Check if it's changed on the logs screen

<img width="1082" alt="Screenshot 2024-04-05 at 11 12 17" src="https://github.com/Automattic/wp-calypso/assets/1241413/f9f1ba78-eac2-4d8d-8e47-8bc93f902f83">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?