### PR TITLE
Use old copy translation for site landing toggle unless new copy has been translated

### DIFF
--- a/client/me/account/toggle-sites-as-landing-page.tsx
+++ b/client/me/account/toggle-sites-as-landing-page.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -32,15 +33,22 @@ function ToggleSitesAsLandingPage() {
 		);
 	}
 
+	const oldCopy = translate( 'Show me all my sites when logging in to WordPress.com' );
+	const updatedCopy = translate(
+		'Display all my sites instead of just my primary site when I visit WordPress.com.'
+	);
+
+	const hasTranslationForNewCopy = useHasEnTranslation()(
+		'Display all my sites instead of just my primary site when I visit WordPress.com.'
+	);
+
 	return (
 		<div>
 			<ToggleControl
 				checked={ !! useSitesAsLandingPage }
 				onChange={ handleToggle }
 				disabled={ isSaving }
-				label={ translate(
-					'Display all my sites instead of just my primary site when I visit WordPress.com.'
-				) }
+				label={ hasTranslationForNewCopy ? updatedCopy : oldCopy }
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6379

## Proposed Changes

* I merged the copy update in https://github.com/Automattic/wp-calypso/pull/89218 but forgot to wait for translations.
* This PR uses the old copy unless a translation of the new copy is available.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/account
* View the updated copy in English
* Change the language and view that it uses the old translated copy


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?