### PR TITLE
Checkout: Fix prominence of dropdown picker

### DIFF
--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -95,8 +95,9 @@ const Dropdown = styled.div`
 const OptionList = styled.ul`
 	position: absolute;
 	width: 100%;
-	z-index: 1;
+	z-index: 4;
 	margin: 0;
+	box-shadow: rgba( 0, 0, 0, 0.16 ) 0px 1px 4px;
 
 	${ Option } {
 		margin-top: -1px;

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -70,8 +70,9 @@ export const Dropdown = styled.div< { shouldUseCheckoutV2: boolean } >`
 export const OptionList = styled.ul`
 	position: absolute;
 	width: 100%;
-	z-index: 1;
+	z-index: 4;
 	margin: 0;
+	box-shadow: rgba( 0, 0, 0, 0.16 ) 0px 1px 4px;
 
 	${ Option } {
 		margin-top: -1px;

--- a/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
@@ -44,6 +44,7 @@ export const StripeFieldWrapper = styled.span< { hasError?: boolean } >`
 		border: 1px solid
 			${ ( props ) =>
 				props.hasError ? props.theme.colors.error : props.theme.colors.borderColor };
+		border-radius: 3px;
 		padding: 12px 10px;
 		line-height: 1.2;
 	}
@@ -71,10 +72,21 @@ export const CreditCardFieldsWrapper = styled.div< { isLoaded?: boolean } >`
 	position: relative;
 	display: ${ ( props ) => ( props.isLoaded ? 'block' : 'none' ) };
 	position: relative;
+
+	& input[type='text'],
+	input[type='url'],
+	input[type='password'],
+	input[type='email'],
+	input[type='tel'],
+	input[type='number'],
+	input[type='search'] {
+		border-radius: 3px;
+	}
 `;
 
 export const CreditCardField = styled( Field )`
 	margin-top: 16px;
+	border-radius: 3px;
 
 	:first-of-type {
 		margin-top: 0;


### PR DESCRIPTION
Currently, the checkout dropdowns do not feature any `box-shadow`s which can lead to situations where longer dropdowns can overlap other dropdown fields and cause confusion (see related issue).

Related to https://github.com/Automattic/wp-calypso/issues/84984

This PR adds a very slight drop shadow to the dropdown `ul` to ensure there is a visual distinction between successive dropdowns on a small page:

| Before | After |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/423464d5-6c3f-4120-9d24-5e4eaaaf08e1) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/5153a889-382e-445e-8c55-cc8cff41a10c) |

| Before | After |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/a75fca0d-4d79-4b84-8d15-bfe132af68da) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/d193b42a-4d0f-4c38-9ed1-4df08a1a5cc9) |

**Akismet**

| Billing term | Number of sites |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/87c04179-6cf3-40a1-9b8b-56fee62f7fcf) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/a7566003-4e01-4747-93ae-1db6bbad09bc) |

**Jetpack**

| Desktop | Mobile |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/a62dfe57-a048-4dbb-b10d-ba69ea74f1e1) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/51d8de93-bdf5-4fdd-a930-fa3ea0479192) |


## Testing Instructions

* Go to checkout and test a few products with multiple billing variants
* Change the size of the window to try and overlap dropdowns one on top of the other
* Ensure that the drop shadow is providing a level of distinction between dropdowns

