### PR TITLE
DIFM Design picker: update copy & styles

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -8,7 +8,7 @@ import DesignPicker, {
 	useCategorization,
 	useThemeDesignsQuery,
 } from '@automattic/design-picker';
-import { englishLocales, translationExists } from '@automattic/i18n-utils';
+import { englishLocales } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -93,10 +93,13 @@ export default function DesignPickerStep( props ) {
 		};
 	}, [ props.stepSectionName ] );
 
-	const designs = useMemo(
-		() => shuffle( apiThemes.filter( ( theme ) => ! isBlankCanvasDesign( theme ) ) ),
-		[ apiThemes ]
-	);
+	const designs = useMemo( () => {
+		const filteredThemes = apiThemes.filter( ( theme ) => ! isBlankCanvasDesign( theme ) );
+		if ( useDIFMThemes ) {
+			return filteredThemes;
+		}
+		return shuffle( filteredThemes );
+	}, [ apiThemes, useDIFMThemes ] );
 
 	const getEventPropsByDesign = ( design ) => ( {
 		theme: design?.stylesheet ?? `pub/${ design?.theme }`,
@@ -222,6 +225,10 @@ export default function DesignPickerStep( props ) {
 	}
 
 	function headerText() {
+		if ( useDIFMThemes ) {
+			return translate( 'Design' );
+		}
+
 		if ( showDesignPickerCategories ) {
 			return translate( 'Themes' );
 		}
@@ -236,8 +243,10 @@ export default function DesignPickerStep( props ) {
 			);
 		}
 
-		if ( useDIFMThemes && translationExists( 'Select a theme to suggest a style.' ) ) {
-			return translate( 'Select a theme to suggest a style.' );
+		if ( useDIFMThemes ) {
+			return translate(
+				'Our designs are custom, based on the content you submit after checkout. Optionally, select a design to suggest inspiration.'
+			);
 		}
 
 		const text = translate( 'Choose a starting theme. You can change it later.' );

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -245,7 +245,7 @@ export default function DesignPickerStep( props ) {
 
 		if ( useDIFMThemes ) {
 			return translate(
-				'Our designs are custom, based on the content you submit after checkout. Optionally, select a design to suggest inspiration.'
+				'We create a custom design based on the content you submit after checkout. Optionally, select a design to suggest inspiration.'
 			);
 		}
 

--- a/client/signup/steps/design-picker/let-us-choose.tsx
+++ b/client/signup/steps/design-picker/let-us-choose.tsx
@@ -50,14 +50,12 @@ const LetUsChoose = ( { flowName, designs, onSelect }: Props ) => {
 		} );
 	}
 
-	const title = translate(
-		"Can't decide? No problem, we can create the perfect design for your site!"
-	);
+	const title = translate( 'Unsure? Let us choose, and we’ll create the perfect design!' );
 
 	return (
 		<LetUsChooseContainer>
 			<div>{ preventWidows( title ) }</div>
-			<LetUsChooseButton variant="secondary" onClick={ onClick }>
+			<LetUsChooseButton variant="primary" onClick={ onClick }>
 				{ translate( 'Let us choose' ) }
 			</LetUsChooseButton>
 		</LetUsChooseContainer>

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -53,6 +53,17 @@
 			// Overrides some very specific selectors in /client/signup/style.scss
 			margin: 12px 0 48px !important;
 		}
+
+		@supports ( display: grid ) {
+			.design-picker__grid {
+				@include break-medium {
+					grid-template-columns: 1fr 1fr;
+				}
+				@include break-large {
+					grid-template-columns: 1fr 1fr 1fr;
+				}
+			}
+		}
 	}
 
 	.action-buttons {

--- a/client/state/difm/assemblers.ts
+++ b/client/state/difm/assemblers.ts
@@ -88,7 +88,14 @@ export function buildDIFMWebsiteContentRequestDTO(
 		siteInformationSection: { siteLogoUrl: site_logo_url, searchTerms: search_terms },
 		feedbackSection: { genericFeedback: generic_feedback },
 	} = websiteContent;
-	const pagesDTO = pages.map( ( page ) => mapRecordKeysRecursively( page, camelToSnakeCase ) );
+	const pagesDTO = pages
+		.map( ( page ) => {
+			return {
+				...page,
+				media: page.media.filter( ( mediaItem ) => !! mediaItem.url ),
+			};
+		} )
+		.map( ( page ) => mapRecordKeysRecursively( page, camelToSnakeCase ) );
 	return {
 		pages: pagesDTO,
 		site_logo_url: site_logo_url ?? '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh1Xd-2AB-p2#comment-2757
Fixes https://github.com/Automattic/martech/issues/2859
Fixes https://github.com/Automattic/martech/issues/2805

## Proposed Changes

* Changed the default layout on the DIFM design picker step to a 3-column grid, which reduces to a 2-column grid on smaller screens.
* Updated the header and subheader text for this step.
* Disabled shuffling of themes for this step.
* Changed the "Let us choose" button to the primary variant and updated the copy for the section.
* Minor improvement on the website content step: send only non-empty media items to the server.

<img width="1912" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/de421be4-a09a-4522-ad45-1a0730d950d8">
<img width="902" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b8f79f8a-78dd-4816-9ef9-079d5567d0aa">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and proceed through the steps till you reach the design picker step.
* Confirm that you see a 3-column layout, which adjusts to a 2-column layout on smaller screens.
* Confirm that the header and subheader text have been updated.
* Confirm that clicking on back and viewing this step again does not change the order of themes that are shown.
* Confirm that the "Let us choose" button is a primary button and the copy for the section matches the screenshot.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?