### PR TITLE
Fix stuck on the login screen when continuing as another user

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -214,8 +214,7 @@ class Login extends Component {
 			! fromSite &&
 			! twoFactorEnabled &&
 			! loginEmailAddress &&
-			currentUser &&
-			! this.state.continueAsAnotherUser
+			currentUser
 		);
 	};
 
@@ -285,7 +284,7 @@ class Login extends Component {
 	};
 
 	handleContinueAsAnotherUser = () => {
-		this.setState( { continueAsAnotherUser: true } );
+		this.props.redirectToLogout( window.location.href );
 	};
 
 	rebootAfterLogin = () => {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -122,7 +122,6 @@ class Login extends Component {
 
 	state = {
 		isBrowserSupported: isWebAuthnSupported(),
-		continueAsAnotherUser: false,
 	};
 
 	static defaultProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/89230


When a user is already logged in, and click on the "Continue" button at the login screen, we send the magic link and redirect them to the "Check your email" screen, but they are already logged in, so they are redirected back to the login screen.

https://github.com/Automattic/wp-calypso/blob/d838d6bd0a32a3604a6d99c6c14f15b21ece9a99/client/login/controller.js#L138-L140 

When we login with an a11n account and continue as another passwordless user, we also get stuck on the login screen and are unable to receive the magic link.

## Proposed Changes

* Log out user before continuing as another user to avoid being stuck on the login screen for passwordless user login

I think this is the best solution for now, but I'm open to other suggestions. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Logged in with a passwordless user on wp.com
* Go to https://woo.com/sso?next=%2F
* Click on `Sign in as a different user`
* Using same or different passwordless account to login
* Confirm that you are redirected to the "Check your email" screen
* Confirm that you receive the magic link


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?