### PR TITLE
Address woo passwordless UI feedback

### DIFF
--- a/client/blocks/authentication/social/style.scss
+++ b/client/blocks/authentication/social/style.scss
@@ -64,6 +64,7 @@
 	}
 }
 
+.is-woo-passwordless .auth-form__social,
 .auth-form__social.is-social-first {
 	.auth-form__social-buttons-container {
 		gap: 16px;

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -451,7 +451,13 @@ class Login extends Component {
 						</p>
 					);
 				} else if ( this.showContinueAsUser() && this.props.isWooPasswordless ) {
-					headerText = <h3>{ translate( 'Get started in minutes' ) }</h3>;
+					headerText = (
+						<h3>
+							{ wccomFrom === 'nux'
+								? translate( 'Get started in minutes' )
+								: translate( 'Log in to your account' ) }
+						</h3>
+					);
 					postHeader = (
 						<p className="login__header-subtitle">
 							{ translate( 'First, select the account you’d like to use.' ) }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1399,20 +1399,15 @@ $breakpoint-mobile: 660px;
 					height: 48px;
 					padding: 8px 16px;
 					align-items: center;
-					gap: 60px;
 					align-self: stretch;
 					border-radius: 8px; // stylelint-disable-line scales/radii
-					border: 2px solid var(--studio-gray-10);
+					border: 2px solid var(--studio-gray-10) !important;
 					width: 100%;
 					margin: 0;
 					text-decoration: none;
 
 					&:hover {
 						background: var(--studio-gray-0, #f6f7f7);
-					}
-
-					svg {
-						margin: 0;
 					}
 				}
 
@@ -1422,7 +1417,6 @@ $breakpoint-mobile: 660px;
 					font-weight: 500;
 					line-height: 24px;
 					color: var(--studio-gray-100);
-					margin: 0;
 				}
 
 				.social-icons {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdibGW-2Wi-p2#comment-2274 and pdibGW-2Wi-p2#comment-2279


## Proposed Changes

* Update heading to `Log in to your account` for woo.com continue as user screen.

![Screenshot 2024-04-05 at 14 36 56](https://github.com/Automattic/wp-calypso/assets/4344253/93296608-21a3-4607-a727-b39e95783280)

- Align the text of the social buttons to the center (followed Dotcom’s)

![Screenshot 2024-04-05 at 18 28 57](https://github.com/Automattic/wp-calypso/assets/4344253/240ad990-2b85-4f4c-b9c5-59d2124dd2ec)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Logged in with a passwordless user on wp.com
* Go to https://woo.com/sso?next=%2F
* Observe that the heading is `Log in to your account` 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?