### PR TITLE
Plugin updates manager: Add Logs button to menu

### DIFF
--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -29,11 +29,20 @@ interface Props {
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 	onEditSchedule: ( id: string ) => void;
+	onShowLogs: ( id: string ) => void;
 }
 
 export const PluginsUpdateManager = ( props: Props ) => {
 	const translate = useTranslate();
-	const { siteSlug, context, scheduleId, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
+	const {
+		siteSlug,
+		context,
+		scheduleId,
+		onNavBack,
+		onCreateNewSchedule,
+		onEditSchedule,
+		onShowLogs,
+	} = props;
 	const siteId = useSelector( getSelectedSiteId );
 
 	const { isEligibleForFeature, isSitePlansLoaded } = useIsEligibleForFeature();
@@ -43,7 +52,6 @@ export const PluginsUpdateManager = ( props: Props ) => {
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins( siteSlug );
-
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
 	useEffect( () => {
 		recordTracksEvent( 'calypso_scheduled_updates_page_view', {
@@ -63,6 +71,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 					onNavBack={ onNavBack }
 					onCreateNewSchedule={ onCreateNewSchedule }
 					onEditSchedule={ onEditSchedule }
+					onShowLogs={ onShowLogs }
 				/>
 			),
 			title: translate( 'Scheduled Updates' ),

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -37,6 +37,10 @@ export const ScheduleListCards = ( props: Props ) => {
 								onClick: () => onEditClick( schedule.id ),
 							},
 							{
+								title: translate( 'Logs' ),
+								onClick: () => onShowLogs( schedule.id ),
+							},
+							{
 								title: translate( 'Remove' ),
 								onClick: () => onRemoveClick( schedule.id ),
 							},
@@ -54,19 +58,6 @@ export const ScheduleListCards = ( props: Props ) => {
 								onClick={ () => onEditClick && onEditClick( schedule.id ) }
 							>
 								{ prepareScheduleName( schedule ) }
-							</Button>
-						</strong>
-					</div>
-
-					<div className="schedule-list--card-label">
-						<label htmlFor="name">{ translate( 'Logs' ) }</label>
-						<strong id="name">
-							<Button
-								className="schedule-name"
-								variant="link"
-								onClick={ () => onShowLogs && onShowLogs( schedule.id ) }
-							>
-								{ translate( 'View logs' ) }
 							</Button>
 						</strong>
 					</div>

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -13,12 +13,13 @@ import { useSiteSlug } from './hooks/use-site-slug';
 interface Props {
 	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
+	onShowLogs: ( id: string ) => void;
 }
 export const ScheduleListCards = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const translate = useTranslate();
-	const { onEditClick, onRemoveClick } = props;
+	const { onEditClick, onShowLogs, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
@@ -53,6 +54,19 @@ export const ScheduleListCards = ( props: Props ) => {
 								onClick={ () => onEditClick && onEditClick( schedule.id ) }
 							>
 								{ prepareScheduleName( schedule ) }
+							</Button>
+						</strong>
+					</div>
+
+					<div className="schedule-list--card-label">
+						<label htmlFor="name">{ translate( 'Logs' ) }</label>
+						<strong id="name">
+							<Button
+								className="schedule-name"
+								variant="link"
+								onClick={ () => onShowLogs && onShowLogs( schedule.id ) }
+							>
+								{ translate( 'View logs' ) }
 							</Button>
 						</strong>
 					</div>

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -19,7 +19,7 @@ export const ScheduleListCards = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const translate = useTranslate();
-	const { onEditClick, onShowLogs, onRemoveClick } = props;
+	const { onEditClick, onRemoveClick, onShowLogs } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -13,13 +13,14 @@ import { ellipsis } from './icons';
 interface Props {
 	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
+	onShowLogs: ( id: string ) => void;
 }
 export const ScheduleListTable = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 
-	const { onEditClick, onRemoveClick } = props;
+	const { onEditClick, onRemoveClick, onShowLogs } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
@@ -89,6 +90,10 @@ export const ScheduleListTable = ( props: Props ) => {
 									{
 										title: translate( 'Edit' ),
 										onClick: () => onEditClick( schedule.id ),
+									},
+									{
+										title: translate( 'Logs' ),
+										onClick: () => onShowLogs( schedule.id ),
 									},
 									{
 										title: translate( 'Remove' ),

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -26,6 +26,7 @@ interface Props {
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 	onEditSchedule: ( id: string ) => void;
+	onShowLogs: ( id: string ) => void;
 }
 export const ScheduleList = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
@@ -35,7 +36,7 @@ export const ScheduleList = ( props: Props ) => {
 	const { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading } =
 		useSiteHasEligiblePlugins();
 
-	const { onNavBack, onCreateNewSchedule, onEditSchedule } = props;
+	const { onNavBack, onCreateNewSchedule, onEditSchedule, onShowLogs } = props;
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< undefined | string >();
 
@@ -62,8 +63,7 @@ export const ScheduleList = ( props: Props ) => {
 		siteHasEligiblePluginsLoading;
 
 	const showScheduleListEmpty =
-		schedules.length === 0 &&
-		( ! isEligibleForFeature && ! isEligibleForFeatureLoading ) ||
+		( schedules.length === 0 && ! isEligibleForFeature && ! isEligibleForFeatureLoading ) ||
 		( ! siteHasEligiblePlugins && ! siteHasEligiblePluginsLoading ) ||
 		( isFetched &&
 			! isLoadingCanCreateSchedules &&
@@ -128,11 +128,13 @@ export const ScheduleList = ( props: Props ) => {
 									<ScheduleListCards
 										onRemoveClick={ openRemoveDialog }
 										onEditClick={ onEditSchedule }
+										onShowLogs={ onShowLogs }
 									/>
 								) : (
 									<ScheduleListTable
 										onRemoveClick={ openRemoveDialog }
 										onEditClick={ onEditSchedule }
+										onShowLogs={ onShowLogs }
 									/>
 								) }
 							</>

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -162,6 +162,7 @@ export function updatesManager( context, next ) {
 				onCreateNewSchedule: () => page.show( `/plugins/scheduled-updates/create/${ siteSlug }` ),
 				onEditSchedule: ( id ) =>
 					page.show( `/plugins/scheduled-updates/edit/${ siteSlug }/${ id }` ),
+				onShowLogs: ( id ) => page.show( `/plugins/scheduled-updates/logs/${ siteSlug }/${ id }` ),
 			} );
 			break;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89036

🚧⚠️ Do not merge until we're ready to launch ⚠️🚧

## Proposed Changes

- Adds the Logs button to the menu of both the list & cards.

| Desktop | Mobile |
|-|-|
| ![CleanShot 2024-04-05 at 08 39 21@2x](https://github.com/Automattic/wp-calypso/assets/528287/c826fdae-efc9-4f0e-882a-a1b88ecba3d1) | ![CleanShot 2024-04-05 at 08 42 28@2x](https://github.com/Automattic/wp-calypso/assets/528287/623596be-f0ff-4b51-96f4-d727ed9f5efe) |

## Testing Instructions

- Apply this PR
- Check if the menu item is there on desktop, and the link is there on mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?