### PR TITLE
Command Palette: Fix global nav opening

### DIFF
--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -25,6 +25,7 @@ export const CommandPaletteContextProvider: FC< PropsWithChildren< CommandPalett
 	useCommands,
 	userCapabilities,
 	useSites,
+	isOpenGlobal,
 } ) => {
 	return (
 		<CommandPaletteContext.Provider
@@ -36,6 +37,7 @@ export const CommandPaletteContextProvider: FC< PropsWithChildren< CommandPalett
 				useCommands,
 				userCapabilities,
 				useSites,
+				isOpenGlobal,
 			} }
 		>
 			{ children }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6437

## Proposed Changes

Adds the missing `isOpenGlobal` prop to the new context provider of the command palette introduced in #88672.

## Testing Instructions

- Use the Calypso live link below
- Go to a page with the Global Nav enabled (e.g. `/me`).
- Click on the "search" icon
- Make sure the command palette shows up