### PR TITLE
Pattern Library: Change iframe `lazy` attribute for mirrored category preview

### DIFF
--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -1,6 +1,9 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
+import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef } from 'react';
+import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
 import { CategoryGalleryServer } from 'calypso/my-sites/patterns/components/category-gallery/server';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 import {
@@ -10,9 +13,85 @@ import {
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/constants';
 import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
-import { PatternTypeFilter, type CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
+import { PatternTypeFilter, Category, CategoryGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
+
+type CategoryGalleryItemProps = {
+	category: Category;
+	patternTypeFilter: PatternTypeFilter;
+};
+
+function CategoryGalleryItem( { category, patternTypeFilter }: CategoryGalleryItemProps ) {
+	const translate = useTranslate();
+	const previewRef = useRef< HTMLDivElement >( null );
+	const { renderedPatterns } = usePatternsRendererContext();
+
+	const pattern =
+		patternTypeFilter === PatternTypeFilter.PAGES
+			? category.pagePreviewPattern
+			: category.regularPreviewPattern;
+	const patternId = encodePatternId( pattern?.ID ?? 0 );
+	const renderedPattern = renderedPatterns[ patternId ];
+
+	// This is needed to make iframe lazy loading work in Firefox and Safari, see
+	// https://wp.me/pdtkmj-2wZ#comment-4707
+	useEffect( () => {
+		if ( ! previewRef.current || category.name !== 'footer' ) {
+			return;
+		}
+
+		const element = previewRef.current;
+		const timeoutId = setTimeout( () => {
+			const iframe = element.querySelector( 'iframe' );
+			iframe?.setAttribute( 'loading', 'eager' );
+		}, 1000 );
+
+		return () => {
+			clearTimeout( timeoutId );
+		};
+	}, [ category, renderedPattern?.html ] );
+
+	const patternCount =
+		patternTypeFilter === PatternTypeFilter.PAGES
+			? category.pagePatternCount
+			: category.regularPatternCount;
+
+	return (
+		<LocalizedLink
+			className="patterns-category-gallery__item"
+			href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
+			key={ category.name }
+		>
+			<div
+				className={ classNames( 'patterns-category-gallery__item-preview', {
+					'patterns-category-gallery__item-preview--page-layout':
+						patternTypeFilter === PatternTypeFilter.PAGES,
+					'patterns-category-gallery__item-preview--mirrored': category.name === 'footer',
+				} ) }
+				ref={ previewRef }
+			>
+				<div className="patterns-category-gallery__item-preview-inner">
+					<PatternPreview
+						category={ category.name }
+						className="pattern-preview--category-gallery"
+						pattern={ pattern }
+						patternTypeFilter={ patternTypeFilter }
+						viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
+					/>
+				</div>
+			</div>
+
+			<div className="patterns-category-gallery__item-name">{ category.label }</div>
+			<div className="patterns-category-gallery__item-count">
+				{ translate( '%(count)d pattern', '%(count)d patterns', {
+					count: patternCount,
+					args: { count: patternCount },
+				} ) }
+			</div>
+		</LocalizedLink>
+	);
+}
 
 export const CategoryGalleryClient: CategoryGalleryFC = ( {
 	categories,
@@ -30,8 +109,6 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 				?.filter( ( { regularPreviewPattern } ) => regularPreviewPattern )
 				.map( ( { regularPreviewPattern } ) => `${ regularPreviewPattern?.ID }` ) ?? [],
 	};
-
-	const translate = useTranslate();
 
 	return (
 		<BlockRendererProvider
@@ -57,51 +134,13 @@ export const CategoryGalleryClient: CategoryGalleryFC = ( {
 							'is-page-patterns': patternTypeFilter === PatternTypeFilter.PAGES,
 						} ) }
 					>
-						{ categories?.map( ( category ) => {
-							const patternCount =
-								patternTypeFilter === PatternTypeFilter.PAGES
-									? category.pagePatternCount
-									: category.regularPatternCount;
-
-							return (
-								<LocalizedLink
-									className="patterns-category-gallery__item"
-									href={ getCategoryUrlPath( category.name, patternTypeFilter, false ) }
-									key={ category.name }
-								>
-									<div
-										className={ classNames( 'patterns-category-gallery__item-preview', {
-											'patterns-category-gallery__item-preview--page-layout':
-												patternTypeFilter === PatternTypeFilter.PAGES,
-											'patterns-category-gallery__item-preview--mirrored':
-												category.name === 'footer',
-										} ) }
-									>
-										<div className="patterns-category-gallery__item-preview-inner">
-											<PatternPreview
-												category={ category.name }
-												className="pattern-preview--category-gallery"
-												pattern={
-													patternTypeFilter === PatternTypeFilter.PAGES
-														? category.pagePreviewPattern
-														: category.regularPreviewPattern
-												}
-												patternTypeFilter={ patternTypeFilter }
-												viewportWidth={ DESKTOP_VIEWPORT_WIDTH }
-											/>
-										</div>
-									</div>
-
-									<div className="patterns-category-gallery__item-name">{ category.label }</div>
-									<div className="patterns-category-gallery__item-count">
-										{ translate( '%(count)d pattern', '%(count)d patterns', {
-											count: patternCount,
-											args: { count: patternCount },
-										} ) }
-									</div>
-								</LocalizedLink>
-							);
-						} ) }
+						{ categories?.map( ( category ) => (
+							<CategoryGalleryItem
+								category={ category }
+								key={ category.name }
+								patternTypeFilter={ patternTypeFilter }
+							/>
+						) ) }
 					</div>
 				</PatternsSection>
 			</PatternsRendererProvider>

--- a/client/my-sites/patterns/components/category-gallery/style.scss
+++ b/client/my-sites/patterns/components/category-gallery/style.scss
@@ -48,23 +48,12 @@
 
 	.patterns-category-gallery__item-preview--mirrored {
 		.patterns-category-gallery__item-preview-inner {
-			// necessary to trigger browser's repainting process to fix the appearance issue in FF and Safari
-			@keyframes initTransform {
-				from {
-					transform: translateY(-8px);
-				}
-				to {
-					transform: translateY(-10px);
-				}
-			}
-
 			align-items: end;
 			border-radius: 0 0 4px 4px;
 			display: grid;
 			margin: 0 30px 20px;
 			transform-origin: center top;
 			transform: translateY(-10px);
-			animation: initTransform 0.1s;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89204

## Proposed Changes

This is an attempt at a different strategy for fixing the iframe loading issue in Firefox and Safari. I've added a `useEffect` callback that looks up the pattern preview iframe with `querySelector` and changes the `loading` attribute to `eager`. It's quite hacky, but it seems to work reliably.

The diff is a bit large because I had to move a whole chunk of code into a separate `CategoryGalleryItem` to make this work.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns` in Firefox or Safari
2. Ensure that the `Footers` category preview loads correctly, without hovering it
