### PR TITLE
Self-service site restore: make wording of error message compatible with D144421

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -249,7 +249,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 		onError: ( error ) => {
 			if ( error.status === 403 ) {
 				reduxDispatch(
-					errorNotice( __( 'Only the original owner can restore a deleted site.' ), {
+					errorNotice( __( 'Only an administrator can restore a deleted site.' ), {
 						duration: 5000,
 					} )
 				);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

<img width="459" alt="Screenshot 2567-04-05 at 15 20 26" src="https://github.com/Automattic/wp-calypso/assets/6851384/cb938ff3-ee68-4093-9b39-3f370bfa1927">

Related to https://github.com/Automattic/wp-calypso/pull/88898

## Proposed Changes
- In D144421-code, we will allow admins to restore sites instead of only the owner. This PR updates the frontend.

## Testing Instructions
- Apply D144421-code
- Delete a site with an editor or non-admin user
- Try and restore the site as an editor

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?