### PR TITLE
Implement woo passwordless signup AB test

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { useLocalizeUrl, removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
 import { UniversalNavbarHeader, UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
@@ -30,7 +29,6 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
-import { addQueryArgs } from 'calypso/lib/route';
 import { getOnboardingUrl as getPatternLibraryOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
@@ -355,22 +353,9 @@ export default withCurrentRoute(
 			const isWCCOM = isWooOAuth2Client( oauth2Client ) && wccomFrom !== null;
 			const wooPasswordless = getWooPasswordless( state );
 			const isWooPasswordless =
-				( config.isEnabled( 'woo/passwordless' ) || !! wooPasswordless ) &&
+				!! wooPasswordless &&
 				// Enable woo-passwordless feature for WCCOM only.
 				isWCCOM;
-
-			if (
-				// Wait until the currentRoute is not changed.
-				getCurrentRoute( state ) === currentRoute &&
-				// window.location.pathname === currentRoute &&
-				isWCCOM &&
-				! wooPasswordless &&
-				config.isEnabled( 'woo/passwordless' )
-			) {
-				// Update the URL to include the woo-passwordless query parameter when woo passwordless feature flag is enabled for Woo.
-				const queryParams = { ...currentQuery, 'woo-passwordless': 'yes' };
-				page.replace( addQueryArgs( queryParams, currentRoute ) );
-			}
 
 			return {
 				isJetpackLogin,

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -9,6 +9,7 @@ import {
 	makeLayoutMiddleware,
 } from 'calypso/controller/shared';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
+import signupController from 'calypso/signup/controller';
 import {
 	login,
 	magicLogin,
@@ -67,6 +68,7 @@ export default ( router ) => {
 			redirectLoggedIn,
 			setLocaleMiddleware(),
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+			signupController.redirectWooPasswordless,
 			magicLoginUse,
 			makeLoggedOutLayout
 		);
@@ -75,6 +77,7 @@ export default ( router ) => {
 			[ `/log-in/link/${ lang }`, `/log-in/jetpack/link/${ lang }`, `/log-in/new/link/${ lang }` ],
 			setLocaleMiddleware(),
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+			signupController.redirectWooPasswordless,
 			magicLogin,
 			makeLoggedOutLayout
 		);
@@ -85,6 +88,7 @@ export default ( router ) => {
 		redirectLoggedIn,
 		setLocaleMiddleware(),
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+		signupController.redirectWooPasswordless,
 		qrCodeLogin,
 		makeLoggedOutLayout
 	);
@@ -107,6 +111,7 @@ export default ( router ) => {
 		setLocaleMiddleware(),
 		setHrefLangLinks,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+		signupController.redirectWooPasswordless,
 		login,
 		setShouldServerSideRenderLogin,
 		makeLoggedOutLayout

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -17,6 +17,7 @@ export default function () {
 		controller.saveInitialContext,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
+		controller.redirectWooPasswordless,
 		controller.setSelectedSiteForSignup,
 		controller.start,
 		makeLayout,

--- a/config/production.json
+++ b/config/production.json
@@ -199,7 +199,7 @@
 		"videomaker-trial": true,
 		"videopress-tv": false,
 		"woop": false,
-		"woo/passwordless": false,
+		"woo/passwordless": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/command-palette": true


### PR DESCRIPTION
This PR implements an A/B test for the woo signup.
- username/email/password signup (control)
- paswordless signup (treatment)
 


Related to pbxNRc-3BP-p2
Experiment - 21696-explat-experiment


## Proposed Changes

- This PR implements a `redirectWooPasswordless ` controller to redirect the user to the passwordless signup page if they are in the treatment group.
- Enable `woo-passwordless` feature flag in prod

| Control | Treatment |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/4344253/fa739e89-4ec7-4f99-b489-20cfff3267a4) | ![image](https://github.com/Automattic/wp-calypso/assets/4344253/ced91e6d-f50a-422c-b99c-3f21868b9ce7)|

## Testing Instructions

**Testing the Control**

- Go to https://woo.com/start/#/installation
- Click on `Try Woo Express for free` button
- Please test around signup and login flows

**Testing the Treatment**

- If you're using sandbox, you might need to run git pull on trunk to get the latest cache version for explat.
- Assign you to treatment group (21696-explat-experiment)
- Go to https://woo.com/start/#/installation
- Click on `Try Woo Express for free` button
- Please test around passwordless signup and login flow

