### PR TITLE
Scheduled updates: Make the last run timestamp clickable and redirect to logs page

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -66,9 +66,13 @@ export const ScheduleListCards = ( props: Props ) => {
 						<label htmlFor="last-update">{ translate( 'Last update' ) }</label>
 						<span id="last-update">
 							{ schedule.last_run_timestamp && (
-								<a href={ `/plugins/scheduled-updates/logs/${ siteSlug }/${ schedule.id }` }>
+								<Button
+									className="schedule-last-run"
+									variant="link"
+									onClick={ () => onShowLogs( schedule.id ) }
+								>
 									{ prepareDateTime( schedule.last_run_timestamp ) }
-								</a>
+								</Button>
 							) }
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -65,7 +65,11 @@ export const ScheduleListCards = ( props: Props ) => {
 					<div className="schedule-list--card-label">
 						<label htmlFor="last-update">{ translate( 'Last update' ) }</label>
 						<span id="last-update">
-							{ schedule.last_run_timestamp && prepareDateTime( schedule.last_run_timestamp ) }
+							{ schedule.last_run_timestamp && (
+								<a href={ `/plugins/scheduled-updates/logs/${ siteSlug }/${ schedule.id }` }>
+									{ prepareDateTime( schedule.last_run_timestamp ) }
+								</a>
+							) }
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -59,9 +59,13 @@ export const ScheduleListTable = ( props: Props ) => {
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
 							{ schedule.last_run_timestamp && (
-								<a href={ `/plugins/scheduled-updates/logs/${ siteSlug }/${ schedule.id }` }>
+								<Button
+									className="schedule-last-run"
+									variant="link"
+									onClick={ () => onShowLogs( schedule.id ) }
+								>
 									{ prepareDateTime( schedule.last_run_timestamp ) }
-								</a>
+								</Button>
 							) }
 							{ ! schedule.last_run_status && ! schedule.last_run_timestamp && '-' }
 						</td>

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -58,7 +58,11 @@ export const ScheduleListTable = ( props: Props ) => {
 							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
-							{ schedule.last_run_timestamp && prepareDateTime( schedule.last_run_timestamp ) }
+							{ schedule.last_run_timestamp && (
+								<a href={ `/plugins/scheduled-updates/logs/${ siteSlug }/${ schedule.id }` }>
+									{ prepareDateTime( schedule.last_run_timestamp ) }
+								</a>
+							) }
 							{ ! schedule.last_run_status && ! schedule.last_run_timestamp && '-' }
 						</td>
 						<td>{ prepareDateTime( schedule.timestamp ) }</td>

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -96,6 +96,10 @@
 			padding: 0.5rem 0;
 			vertical-align: middle;
 		}
+
+		a {
+			color: var(--studio-gray-60);
+		}
 	}
 
 	.schedule-list--card {

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -79,6 +79,12 @@
 		color: var(--studio-gray-100);
 	}
 
+	button.schedule-last-run {
+		font-size: 0.875rem;
+		text-decoration: none;
+		color: var(--studio-gray-60);
+	}
+
 	table {
 		th,
 		td {
@@ -95,10 +101,6 @@
 		td {
 			padding: 0.5rem 0;
 			vertical-align: middle;
-		}
-
-		a {
-			color: var(--studio-gray-60);
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89036
Related to https://github.com/Automattic/wp-calypso/pull/89234

🚧⚠️ Do not merge until we're ready to launch ⚠️🚧

## Proposed Changes

* Make the last run timestamp clickable

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/{ATOMIC}`
* Check if the last update timestamp is clickable
* Check if leads to the logs page

<img width="621" alt="Screenshot 2024-04-05 at 11 29 28" src="https://github.com/Automattic/wp-calypso/assets/1241413/a1a3de25-4999-4646-aa42-d42d5336e9aa">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?