### PR TITLE
A4A: Sites Dashboard - Fix broken Boost table links

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -61,7 +61,8 @@ export default function SitesDashboard() {
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 	const isNarrowView = useBreakpoint( '<660px' );
-	const { data: products } = useProductsQuery();
+	// FIXME: We should switch to a new A4A-specific endpoint when it becomes available, instead of using the public-facing endpoint for A4A
+	const { data: products } = useProductsQuery( true );
 
 	const {
 		data: verifiedContacts,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -1,11 +1,9 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button, Gridicon } from '@automattic/components';
-import { State } from '@automattic/data-stores/src/site/reducer';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useState } from 'react';
 import { useSelector } from 'calypso/state';
-import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../../hooks';
 import DashboardDataContext from '../../dashboard-data-context';
@@ -26,7 +24,6 @@ export default function SiteBoostColumn( { site }: Props ) {
 	const overallScore = site.jetpack_boost_scores?.overall;
 	const hasBoost = site.has_boost;
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site.blog_id ) );
-	const isAtomic = useSelector( ( state: State ) => isSiteAtomic( state, site.blog_id ) );
 
 	const { origin, pathname } = getUrlParts( adminUrl ?? '' );
 	const baseUrl = adminUrl
@@ -51,7 +48,7 @@ export default function SiteBoostColumn( { site }: Props ) {
 					'sites-overview__boost-score',
 					getBoostRatingClass( overallScore )
 				) }
-				href={ isAtomic ? jetpackHref : addBoostHref }
+				href={ site.is_atomic ? jetpackHref : addBoostHref }
 				target="_blank"
 				onClick={ () =>
 					recordEvent( 'boost_column_score_click', {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/205

## Proposed Changes

This PR fixes the Boost links in our sites dashboard table. For atomic sites, we are linking to the main Jetpack page instead of linking to a specific Boost page (manage/add) because we currently lack a way to determine the current state of Boost on atomic sites.

Additionally, this PR changes the "Get Score" button to a "+ Add" button.

## Testing Instructions


* Go to the sites dashboard (/sites).
* Test different scenarios for Boost links:
  * Atomic:
    * With no score calculated (you can have a site like this by creating a Jurassic Ninja site and never visiting its Jetpack admin page).
    * With its score calculated.
    * With Boost installed.
  * WordPress:
    * With no score calculated (you can have a site like this by creating a Jurassic Ninja site and never visiting its Jetpack admin page).
    * With its score calculated.
    * With Boost installed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?