### PR TITLE
`CommandPalette`: Hide the page's vertical scrollbar when it's open

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -7,6 +7,13 @@ body.is-focus-sites {
 	overflow: hidden;
 }
 
+html.command-palette-modal-open {
+	overflow: visible;
+}
+body.command-palette-modal-open {
+	overflow: hidden;
+}
+
 /**
  * /*
  * 	Layout Elements

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -215,6 +215,11 @@ export interface CommandPaletteProps {
 	userCapabilities: { [ key: number ]: { [ key: string ]: boolean } };
 }
 
+const COMMAND_PALETTE_MODAL_OPEN_CLASSNAME = 'command-palette-modal-open';
+const toggleModalOpenClassnameOnDocumentHtmlElement = ( isModalOpen: boolean ) => {
+	document.documentElement.classList.toggle( COMMAND_PALETTE_MODAL_OPEN_CLASSNAME, isModalOpen );
+};
+
 const CommandPalette = ( {
 	currentRoute,
 	currentSiteId,
@@ -233,6 +238,8 @@ const CommandPalette = ( {
 	const [ footerMessage, setFooterMessage ] = useState( '' );
 	const [ emptyListNotice, setEmptyListNotice ] = useState( '' );
 	const open = useCallback( () => {
+		toggleModalOpenClassnameOnDocumentHtmlElement( true );
+
 		setIsOpenLocal( true );
 		recordTracksEvent( 'calypso_hosting_command_palette_open', {
 			current_route: currentRoute,
@@ -240,6 +247,8 @@ const CommandPalette = ( {
 	}, [ currentRoute ] );
 	const close = useCallback< CommandPaletteContext[ 'close' ] >(
 		( commandName = '', isExecuted = false ) => {
+			toggleModalOpenClassnameOnDocumentHtmlElement( false );
+
 			setIsOpenLocal( false );
 			onClose?.();
 			recordTracksEvent( 'calypso_hosting_command_palette_close', {
@@ -345,6 +354,7 @@ const CommandPalette = ( {
 			setSelectedCommandName={ setSelectedCommandName }
 		>
 			<Modal
+				bodyOpenClassName={ COMMAND_PALETTE_MODAL_OPEN_CLASSNAME }
 				className="commands-command-menu"
 				overlayClassName="commands-command-menu__overlay"
 				onRequestClose={ closeAndReset }

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -216,6 +216,9 @@ export interface CommandPaletteProps {
 }
 
 const COMMAND_PALETTE_MODAL_OPEN_CLASSNAME = 'command-palette-modal-open';
+// We need to change the `overflow` of the html element because it's set to `scroll` on _reset.scss
+// Ideally, this would be handled by the `@wordpress/components` `Modal` component,
+// but it doesn't have a `htmlOpenClassName` prop
 const toggleModalOpenClassnameOnDocumentHtmlElement = ( isModalOpen: boolean ) => {
 	document.documentElement.classList.toggle( COMMAND_PALETTE_MODAL_OPEN_CLASSNAME, isModalOpen );
 };

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -218,9 +218,11 @@ export interface CommandPaletteProps {
 const COMMAND_PALETTE_MODAL_OPEN_CLASSNAME = 'command-palette-modal-open';
 // We need to change the `overflow` of the html element because it's set to `scroll` on _reset.scss
 // Ideally, this would be handled by the `@wordpress/components` `Modal` component,
-// but it doesn't have a `htmlOpenClassName` prop
+// but it doesn't have a `htmlOpenClassName` prop to go alongside `bodyOpenClassName`.
+// So we need to toggle both classes manually here.
 const toggleModalOpenClassnameOnDocumentHtmlElement = ( isModalOpen: boolean ) => {
 	document.documentElement.classList.toggle( COMMAND_PALETTE_MODAL_OPEN_CLASSNAME, isModalOpen );
+	document.body.classList.toggle( COMMAND_PALETTE_MODAL_OPEN_CLASSNAME, isModalOpen );
 };
 
 const CommandPalette = ( {
@@ -357,7 +359,6 @@ const CommandPalette = ( {
 			setSelectedCommandName={ setSelectedCommandName }
 		>
 			<Modal
-				bodyOpenClassName={ COMMAND_PALETTE_MODAL_OPEN_CLASSNAME }
 				className="commands-command-menu"
 				overlayClassName="commands-command-menu__overlay"
 				onRequestClose={ closeAndReset }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5789

## Proposed Changes

* On wp-admin, scrolling is disabled while the command paletter is open, this PR adjusts the `overflow` property so calypso behaves in the same way.

## Testing Instructions

### Calypso
 
1. Open the calypso live preview
2. Go to `/sites`
3. Scroll down a bit, then open the command palette (Ctrl/Cmd + K)
4. Check that scrolling is disabled
5. Close the command palette
6. Check that scrolling is enabled again

### WP

1. On your sandbox, run `install-plugin.sh command-palette-wp-admin fix/hide-vertical-scrollbar-when-command-palette-opens`
2. Go to https://wordpress.com/wp-admin/
3. Repeat steps 3-6 from the Calypso testing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?