### PR TITLE
Scheduled updates: Refetch schedules + in progress status

### DIFF
--- a/client/blocks/plugins-update-manager/badge.scss
+++ b/client/blocks/plugins-update-manager/badge.scss
@@ -13,8 +13,26 @@
 		background-color: var(--studio-red-5);
 	}
 
+	&--in-progress {
+		color: var(--studio-blue-80);
+		background-color: var(--studio-blue-5);
+
+		svg {
+			animation: scheduled-updates-rotate 2s linear infinite;
+		}
+	}
+
 	svg {
 		position: relative;
 		top: 4px;
+	}
+}
+
+@keyframes scheduled-updates-rotate {
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(360deg);
 	}
 }

--- a/client/blocks/plugins-update-manager/badge.tsx
+++ b/client/blocks/plugins-update-manager/badge.tsx
@@ -1,4 +1,5 @@
 import { Icon, check, closeSmall, rotateRight } from '@wordpress/icons';
+import classnames from 'classnames';
 import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 
 import './badge.scss';
@@ -9,8 +10,15 @@ interface Props {
 export const Badge = ( props: Props ) => {
 	const { type } = props;
 
+	const className = classnames( 'badge-component', {
+		'badge-component--failed':
+			type === 'failure-and-rollback' || type === 'failure' || type === 'failure-and-rollback-fail',
+		'badge-component--in-progress': type === 'in-progress',
+		'badge-component--success': type === 'success',
+	} );
+
 	return (
-		<span className={ `badge-component badge-component--${ type }` }>
+		<span className={ className }>
 			{ type === 'in-progress' && <Icon icon={ rotateRight } size={ 20 } /> }
 			{ type === 'success' && <Icon icon={ check } size={ 20 } /> }
 			{ type === 'failure-and-rollback' ||

--- a/client/blocks/plugins-update-manager/badge.tsx
+++ b/client/blocks/plugins-update-manager/badge.tsx
@@ -1,17 +1,23 @@
-import { Icon, check, closeSmall } from '@wordpress/icons';
+import { Icon, check, closeSmall, rotateRight } from '@wordpress/icons';
+import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 
 import './badge.scss';
 
 interface Props {
-	type: 'success' | 'failed';
+	type: ScheduleUpdates[ 'last_run_status' ];
 }
 export const Badge = ( props: Props ) => {
 	const { type } = props;
 
 	return (
 		<span className={ `badge-component badge-component--${ type }` }>
+			{ type === 'in-progress' && <Icon icon={ rotateRight } size={ 20 } /> }
 			{ type === 'success' && <Icon icon={ check } size={ 20 } /> }
-			{ type === 'failed' && <Icon icon={ closeSmall } size={ 20 } /> }
+			{ type === 'failure-and-rollback' ||
+			type === 'failure-and-rollback-fail' ||
+			type === 'failure' ? (
+				<Icon icon={ closeSmall } size={ 20 } />
+			) : null }
 		</span>
 	);
 };

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -75,9 +75,8 @@ export const ScheduleListCards = ( props: Props ) => {
 								</Button>
 							) }
 							{ schedule.last_run_status && (
-								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
+								<Badge type={ schedule.last_run_status } />
 							) }
-							{ ! schedule.last_run_status && ! schedule.last_run_timestamp && '-' }
 						</span>
 					</div>
 

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -56,7 +56,7 @@ export const ScheduleListTable = ( props: Props ) => {
 						</td>
 						<td>
 							{ schedule.last_run_status && (
-								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
+								<Badge type={ schedule.last_run_status } />
 							) }
 							{ schedule.last_run_timestamp && (
 								<Button

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -45,7 +45,10 @@ export const ScheduleList = ( props: Props ) => {
 		isLoading: isLoadingSchedules,
 		isFetched,
 		refetch,
-	} = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
+	} = useUpdateScheduleQuery( siteSlug, isEligibleForFeature, {
+		refetchOnWindowFocus: true,
+		refetchInterval: 1000 * 10,
+	} );
 
 	const { deleteUpdateSchedule } = useDeleteUpdateScheduleMutation( siteSlug, {
 		onSuccess: () => refetch(),

--- a/client/blocks/plugins-update-manager/schedule-logs.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-logs.helper.ts
@@ -4,12 +4,13 @@ import type { ScheduleLog } from 'calypso/data/plugins/use-update-schedule-logs-
 
 export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[] ) => {
 	const pluginName =
-		plugins.find( ( p ) => p.plugin === log.context.plugin_name )?.name || log.context.plugin_name;
+		plugins.find( ( p ) => p.plugin === log.context?.plugin_name )?.name ||
+		log.context?.plugin_name;
 	const pluginTranslateArgs = {
 		args: {
 			plugin: pluginName,
-			from: log.context.old_version,
-			to: log.context.new_version,
+			from: log?.context?.old_version,
+			to: log.context?.new_version,
 		},
 	};
 

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -101,6 +101,10 @@
 		td {
 			padding: 0.5rem 0;
 			vertical-align: middle;
+
+			&.last-update {
+				min-width: 200px;
+			}
 		}
 	}
 

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -21,7 +21,9 @@ export type ScheduleUpdates = {
 
 export const useUpdateScheduleQuery = (
 	siteSlug: SiteSlug,
-	isEligibleForFeature: boolean
+	isEligibleForFeature: boolean,
+	refetchInterval: number = 10 * 1000,
+	refetchOnWindowFocus: boolean = true
 ): UseQueryResult< ScheduleUpdates[] > => {
 	const select = ( data: ScheduleUpdates[] ) => {
 		return data.sort( ( a, b ) => {
@@ -48,8 +50,8 @@ export const useUpdateScheduleQuery = (
 			),
 		enabled: !! siteSlug && isEligibleForFeature,
 		retry: false,
-		refetchOnWindowFocus: true,
-		refetchInterval: 10 * 1000,
+		refetchOnWindowFocus,
+		refetchInterval,
 		select,
 	} );
 };

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, UseQueryResult, type QueryObserverOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteSlug } from 'calypso/types';
 
@@ -22,8 +22,7 @@ export type ScheduleUpdates = {
 export const useUpdateScheduleQuery = (
 	siteSlug: SiteSlug,
 	isEligibleForFeature: boolean,
-	refetchInterval: number = 10 * 1000,
-	refetchOnWindowFocus: boolean = true
+	queryOptions: Partial< QueryObserverOptions< ScheduleUpdates[], Error > > = {}
 ): UseQueryResult< ScheduleUpdates[] > => {
 	const select = ( data: ScheduleUpdates[] ) => {
 		return data.sort( ( a, b ) => {
@@ -50,8 +49,8 @@ export const useUpdateScheduleQuery = (
 			),
 		enabled: !! siteSlug && isEligibleForFeature,
 		retry: false,
-		refetchOnWindowFocus,
-		refetchInterval,
 		select,
+		refetchOnWindowFocus: false,
+		...queryOptions,
 	} );
 };

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -9,7 +9,13 @@ export type ScheduleUpdates = {
 	timestamp: number;
 	schedule: 'weekly' | 'daily';
 	args: string[];
-	last_run_status: 'success' | 'failure-and-rollback' | 'failure-and-rollback-fail' | null;
+	last_run_status:
+		| 'in-progress'
+		| 'success'
+		| 'failure'
+		| 'failure-and-rollback'
+		| 'failure-and-rollback-fail'
+		| null;
 	last_run_timestamp: number | null;
 };
 
@@ -42,7 +48,8 @@ export const useUpdateScheduleQuery = (
 			),
 		enabled: !! siteSlug && isEligibleForFeature,
 		retry: false,
-		refetchOnWindowFocus: false,
+		refetchOnWindowFocus: true,
+		refetchInterval: 10 * 1000,
 		select,
 	} );
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/pull/36752

## Proposed Changes

* In the list view of scheduled updates, refresh the data every 10s
* Implement a in-progress status badge

![CleanShot 2024-04-05 at 13 54 02](https://github.com/Automattic/wp-calypso/assets/528287/f33bda2e-ff82-4301-87f3-235f08204cc1)


## Testing Instructions

1. Checkout this branch
2. Check if the last update badge in Scheduled Updates still works (no regressions)
3. To test in progress: apply this PR with Jetpack Beta Tester: https://github.com/Automattic/jetpack/pull/36752


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?