### PR TITLE
Global sidebar - add a border

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -79,7 +79,7 @@ $brand-text: "SF Pro Text", $sans;
 
 		.global-sidebar {
 			overflow: unset;
-			border-right: 1px solid var(--studio-gray-20);
+			border-right: 1px solid var(--color-sidebar-border);
 		}
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -79,6 +79,7 @@ $brand-text: "SF Pro Text", $sans;
 
 		.global-sidebar {
 			overflow: unset;
+			border-right: 1px solid var(--studio-gray-20);
 		}
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -47,7 +47,7 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-menu-hover-text: var(--studio-black);
 		--color-sidebar-menu-hover-background: #eee;
 		--color-sidebar-submenu-background: var(--studio-gray-5);
-		--color-sidebar-border: var(--studio-gray-10);
+		--color-sidebar-border: var(--studio-gray-5);
 		--color-sidebar-submenu-text: var(--color-sidebar-text);
 		--color-sidebar-submenu-selected-text: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-submenu-hover-text: var(--color-sidebar-text);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1712257739355239-slack-C03NLNTPZ2 T

## Proposed Changes

* We initially shipped this with a box shadow border
* that was ripped out
* now we want to add a regular border for the time being

Some division is necessary at this global level since the sidebar color and content colors in reader and /me are the same color. Without a border we have no separation. Design has hyper focused this new color scheme for the sidebar on /sites specifically and has not followed up with how to handle the inconsistencies it presents elsewhere (/reader and /me). Due to that WE SHOULD NOT remove broders altogether until we have a solution that doesnt make /reader and /me look entirely broken.

AFTER

<img width="405" alt="Screenshot 2024-04-05 at 9 23 25 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/0cd6cb0e-09df-4c20-9b69-9fb36ec99e71">
<img width="592" alt="Screenshot 2024-04-05 at 9 23 32 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b61d4bc2-fa21-4c82-b0db-df72769118c3">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the global sidebar has a border and there is a clear distinction of where the sidebar ends and content area begins in the reader and /me

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?