### PR TITLE
Remove locale checks for redirects to site-migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/index.ts
@@ -1,17 +1,13 @@
-import { englishLocales } from '@automattic/i18n-utils';
 import { STEPS } from '../internals/steps';
 
 export const shouldRedirectToSiteMigration = (
 	step: string,
 	platform: string,
-	locale: string,
 	origin?: string | null
 ) => {
-	const isEnglishLocale = englishLocales.includes( locale );
 	return (
 		step === STEPS.IMPORT_LIST.slug &&
 		platform === 'wordpress' &&
-		isEnglishLocale &&
 		origin === STEPS.SITE_MIGRATION_IDENTIFY.slug
 	);
 };

--- a/client/landing/stepper/declarative-flow/helpers/test/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/test/index.ts
@@ -6,15 +6,6 @@ describe( 'DeclarativeFlowHelpers', () => {
 			shouldRedirectToSiteMigration(
 				STEPS.IMPORT_LIST.slug,
 				'wordpress',
-				'en',
-				STEPS.SITE_MIGRATION_IDENTIFY.slug
-			)
-		).toBe( true );
-		expect(
-			shouldRedirectToSiteMigration(
-				STEPS.IMPORT_LIST.slug,
-				'wordpress',
-				'en-gb',
 				STEPS.SITE_MIGRATION_IDENTIFY.slug
 			)
 		).toBe( true );
@@ -31,18 +22,6 @@ describe( 'DeclarativeFlowHelpers', () => {
 			shouldRedirectToSiteMigration(
 				STEPS.IMPORT_LIST.slug,
 				'other-platform',
-				'en',
-				STEPS.SITE_MIGRATION_IDENTIFY.slug
-			)
-		).toBe( false );
-	} );
-
-	it( 'returns false when locale is not en', () => {
-		expect(
-			shouldRedirectToSiteMigration(
-				STEPS.IMPORT_LIST.slug,
-				'wordpress',
-				'es',
 				STEPS.SITE_MIGRATION_IDENTIFY.slug
 			)
 		).toBe( false );
@@ -53,7 +32,6 @@ describe( 'DeclarativeFlowHelpers', () => {
 			shouldRedirectToSiteMigration(
 				STEPS.IMPORT_LIST.slug,
 				STEPS.SITE_MIGRATION_IDENTIFY.slug,
-				'en',
 				null
 			)
 		).toBe( false );
@@ -61,7 +39,7 @@ describe( 'DeclarativeFlowHelpers', () => {
 
 	it( 'returns false when the origin is not the site-migration-identify', () => {
 		expect(
-			shouldRedirectToSiteMigration( STEPS.IMPORT_LIST.slug, 'wordpress', 'en', 'other-origin' )
+			shouldRedirectToSiteMigration( STEPS.IMPORT_LIST.slug, 'wordpress', 'other-origin' )
 		).toBe( false );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
-import { useLocale, englishLocales } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
@@ -147,7 +146,6 @@ const siteSetupFlow: Flow = {
 			useDispatch( ONBOARD_STORE );
 		const { setDesignOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
-		const locale = useLocale();
 
 		const exitFlow = ( to: string, options: ExitFlowOptions = {} ) => {
 			setPendingAction( () => {
@@ -327,11 +325,7 @@ const siteSetupFlow: Flow = {
 
 					switch ( intent ) {
 						case SiteIntent.Import:
-							// Temporarily enabled only for English locales while we wait for UI translations.
-							if (
-								config.isEnabled( 'onboarding/new-migration-flow' ) &&
-								englishLocales.includes( locale )
-							) {
+							if ( config.isEnabled( 'onboarding/new-migration-flow' ) ) {
 								return exitFlow(
 									`/setup/site-migration?siteSlug=${ siteSlug }&flags=onboarding/new-migration-flow`
 								);
@@ -392,7 +386,7 @@ const siteSetupFlow: Flow = {
 					const depUrl = ( providedDependencies?.url as string ) || '';
 					const { platform } = providedDependencies as { platform: ImporterMainPlatform };
 
-					if ( shouldRedirectToSiteMigration( currentStep, platform, locale, origin ) ) {
+					if ( shouldRedirectToSiteMigration( currentStep, platform, origin ) ) {
 						return window.location.assign(
 							addQueryArgs(
 								{ siteSlug, siteId, from },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/89016
* https://github.com/Automattic/wp-calypso/pull/89035
* https://github.com/Automattic/wp-calypso/issues/89107
* https://github.com/Automattic/wp-calypso/pull/89006

## Proposed Changes

* This PR removes the locale restrictions on the `site-migration` flow, as we now have all primary translations from https://github.com/Automattic/wp-calypso/pull/89006, as tracked in https://translate.wordpress.com/deliverables/overview/11803816/.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso live or apply this PR to your local environment
* Make sure you change your locale. I used pt-br
* Navigate to `/start`
* Go through the flow until you reach the goals step, and select the import option
* Continue to the flow until you see the migration instruction step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?