### PR TITLE
Scheduled updates: Add an empty state to the Logs screen

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-logs.tsx
+++ b/client/blocks/plugins-update-manager/schedule-logs.tsx
@@ -2,8 +2,10 @@ import {
 	__experimentalText as Text,
 	Button,
 	Card,
+	CardBody,
 	CardHeader,
 	Tooltip,
+	Spinner,
 } from '@wordpress/components';
 import { arrowLeft, Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -57,7 +59,10 @@ export const ScheduleLogs = ( props: Props ) => {
 		isPending,
 	} = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const schedule = schedules.find( ( s ) => s.id === scheduleId );
-	const { data: scheduleLogs = [] } = useUpdateScheduleLogsQuery( siteSlug, scheduleId );
+	const { data: scheduleLogs = [], isPending: isPendingLogs } = useUpdateScheduleLogsQuery(
+		siteSlug,
+		scheduleId
+	);
 
 	const goToPluginsPage = useCallback( () => {
 		window.location.href = `${ siteAdminUrl }plugins.php`;
@@ -105,6 +110,14 @@ export const ScheduleLogs = ( props: Props ) => {
 					</Text>
 				</div>
 			</CardHeader>
+			<CardBody>
+				{ isPendingLogs && <Spinner /> }
+				{ ! isPendingLogs && ! scheduleLogs.length && (
+					<div className="empty-state">
+						<Text align="center">{ translate( 'No logs available at the moment.' ) }</Text>
+					</div>
+				) }
+			</CardBody>
 			{ scheduleLogs.map( ( logs, i ) => (
 				<Timeline key={ i }>
 					{ logs.reverse().map( ( log ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89036

## Proposed Changes

* Adds an empty state to the Logs screen
* Adds a spinner component on initial logs fetching

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/{ATOMIC}`
* Check the logs for one of the schedules
* Override [the logs hook and force an empty array](https://github.com/Automattic/wp-calypso/blob/trunk/client/data/plugins/use-update-schedule-logs-query.ts) as result
* Check if there is an empty state screen

<img width="1100" alt="Screenshot 2024-04-05 at 15 40 46" src="https://github.com/Automattic/wp-calypso/assets/1241413/ff1c443b-d145-47a6-a954-910bd9a80bcd">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?