### PR TITLE
Patterns: RTL pill nav scroll, adjusted tablet media query and copy changes

### DIFF
--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -43,8 +43,12 @@ export const CategoryPillNavigation = ( {
 		}
 
 		const { scrollLeft, scrollWidth, clientWidth } = listInnerRef.current;
-		setShowLeftArrow( scrollLeft > 0 );
-		setShowRightArrow( Math.ceil( scrollLeft ) < scrollWidth - clientWidth );
+
+		const roundedScrollLeft = Math.floor( scrollLeft );
+		const scrollLeftAbs = Math.abs( roundedScrollLeft ); // adjust RTL negative values
+
+		setShowLeftArrow( scrollLeftAbs > 0 );
+		setShowRightArrow( scrollLeftAbs + 1 < scrollWidth - clientWidth ); // +1 to account for rounding errors
 	};
 
 	const scrollTo = ( direction: 'right' | 'left' ) => {
@@ -139,7 +143,10 @@ export const CategoryPillNavigation = ( {
 
 			<div className="category-pill-navigation__list">
 				{ showLeftArrow && (
-					<Button className="category-pill-navigation__arrow" onClick={ () => scrollTo( 'left' ) }>
+					<Button
+						className="category-pill-navigation__arrow"
+						onClick={ () => scrollTo( ! isRtl ? 'left' : 'right' ) }
+					>
 						<Icon icon={ isRtl ? chevronLeft : chevronRight } size={ 28 } />
 					</Button>
 				) }
@@ -147,7 +154,7 @@ export const CategoryPillNavigation = ( {
 				{ showRightArrow && (
 					<Button
 						className="category-pill-navigation__arrow right"
-						onClick={ () => scrollTo( 'right' ) }
+						onClick={ () => scrollTo( ! isRtl ? 'right' : 'left' ) }
 					>
 						<Icon icon={ isRtl ? chevronLeft : chevronRight } size={ 28 } />
 					</Button>

--- a/client/components/category-pill-navigation/style.scss
+++ b/client/components/category-pill-navigation/style.scss
@@ -84,7 +84,7 @@
 			transform: rotate(0);
 		}
 
-		@media ( max-width: $break-wide ) {
+		@media ( max-width: $break-large ) {
 			width: 0;
 			padding: 0;
 		}

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -1,7 +1,6 @@
 import { Button, Dialog } from '@automattic/components';
-import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
+import { useLocalizeUrl, useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import { buildQueryString } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { usePatternsContext } from 'calypso/my-sites/patterns/context';
@@ -26,7 +25,7 @@ export const PatternsGetAccessModal = ( {
 	tracksEventHandler,
 }: PatternsGetAccessModalProps ) => {
 	const locale = useLocale();
-	const { hasTranslation } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
 	const { category, patternTypeFilter } = usePatternsContext();
@@ -80,7 +79,7 @@ export const PatternsGetAccessModal = ( {
 					</div>
 
 					<div className="patterns-get-access-modal__description">
-						{ hasTranslation(
+						{ hasEnTranslation(
 							'Build sites faster using hundreds of professionally designed layouts. All you need is a WordPress.com account to get started.'
 						)
 							? translate(

--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Dialog } from '@automattic/components';
 import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { buildQueryString } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { usePatternsContext } from 'calypso/my-sites/patterns/context';
@@ -25,6 +26,7 @@ export const PatternsGetAccessModal = ( {
 	tracksEventHandler,
 }: PatternsGetAccessModalProps ) => {
 	const locale = useLocale();
+	const { hasTranslation } = useI18n();
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
 	const { category, patternTypeFilter } = usePatternsContext();
@@ -76,10 +78,17 @@ export const PatternsGetAccessModal = ( {
 								'This string is used as a title for the modal that prompts users to sign up or log in to access the full pattern library.',
 						} ) }
 					</div>
+
 					<div className="patterns-get-access-modal__description">
-						{ translate(
-							"Build sites faster using hundreds of professionally designed layouts. All you need's a WordPress.com account to get started."
-						) }
+						{ hasTranslation(
+							'Build sites faster using hundreds of professionally designed layouts. All you need is a WordPress.com account to get started.'
+						)
+							? translate(
+									'Build sites faster using hundreds of professionally designed layouts. All you need is a WordPress.com account to get started.'
+							  )
+							: translate(
+									"Build sites faster using hundreds of professionally designed layouts. All you need's a WordPress.com account to get started."
+							  ) }
 					</div>
 					<div className="patterns-get-access-modal__upgrade-buttons">
 						<Button


### PR DESCRIPTION
Related to:
https://github.com/Automattic/dotcom-forge/issues/6433
https://github.com/Automattic/dotcom-forge/issues/6447

## Proposed Changes
In this PR we are addressing 3 tasks:
1) scrolling behaviour for pill navigation when the page is rendered as RTL environment
2) Decrease hiding of pill nav arrows to media query as 960px
3) Fixing copy for "Get access" modal

## Testing Instructions
1.1) Open `/patterns`
1.2) Assert that scrolling of pill navigation works well and left/right arrows appearance also works correctly
1.3) Open `/ar/patterns`
1.4) Assert that scrolling of pill navigation still works well and left/right arrows appearance also works correctly

2.1) Resize the browser's window and assert that pill navigation arrows are hidden only when width is <960 (previously it was 1280)

3.1) Open `/<ANY_NON_EN_LANG>/patterns/events` as logged out user
3.2) Scroll lower till you see "Get access" button
3.3) Click on it
3.4) Assert that the copy in the body is still translated
