### PR TITLE
Fixes a problem with tracking on the blaze card in the home screen

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/promote-post/index.js
+++ b/client/my-sites/customer-home/cards/tasks/promote-post/index.js
@@ -1,11 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import blazeIllustration from 'calypso/assets/images/customer-home/illustration--blaze.svg';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import { TASK_PROMOTE_POST } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const PromotePost = () => {
 	const translate = useTranslate();


### PR DESCRIPTION
We are getting some errors in Sentry with the following message `Cannot read properties of undefined (reading 'type').`

The error was added on my last PR on https://github.com/Automattic/wp-calypso/pull/88858/files#diff-ed974067b87e428a6e2a036710373cb573b414ab7414efe95b75c9bffb9829c3R4.

The problem is that I am using the incorrect `recordTracksEvent`, and dispatching an object that is not a valid action. 

## Proposed Changes

* Import the `recordTracksEvent` function from the correct package. The one that generates a correct redux action (`calypso/state/analytics/actions`).

## Testing Instructions

Code review should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?