### PR TITLE
Enterprise plan: Add UTM params 

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -331,7 +331,11 @@ const PlansFeaturesMain = ( {
 		( cartItems?: MinimalRequestCartProduct[] | null, clickedPlanSlug?: PlanSlug ) => {
 			if ( isWpcomEnterpriseGridPlan( clickedPlanSlug ?? '' ) ) {
 				recordTracksEvent( 'calypso_plan_step_enterprise_click', { flow: flowName } );
-				window.open( 'https://wpvip.com/wordpress-vip-agile-content-platform', '_blank' );
+				const vipLandingPageURL = 'https://wpvip.com/wordpress-vip-agile-content-platform';
+				window.open(
+					`${ vipLandingPageURL }/?utm_source=WordPresscom&utm_medium=automattic_referral&utm_campaign=calypso_signup`,
+					'_blank'
+				);
 				return;
 			}
 			const cartItemForPlan = getPlanCartItem( cartItems );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* The Enterprise plan CTA links to wpvip.com but it is missing UTM params. These existed previously but looks like got missed to carry over at some point in September 2023.

https://github.com/Automattic/wp-calypso/blob/775b5edcb5b2f890358130254bd7e7a9d709b13c/client/my-sites/plan-features-2023-grid/components/actions.tsx#L390-L403

This PR adds back the UTM params.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and click "Learn more" on the Enterprise plan, verify the URL contains UTM params.

