### PR TITLE
Fixes the redirection we have to Blaze in the Home screen

### DIFF
--- a/client/my-sites/advertising/useAdvertisingUrl.jsx
+++ b/client/my-sites/advertising/useAdvertisingUrl.jsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl, isGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const useAdvertisingUrl = () => {
@@ -8,11 +8,11 @@ const useAdvertisingUrl = () => {
 	const siteAdminUrl = useSelector( ( state ) =>
 		getSiteAdminUrl( state, siteId, 'tools.php?page=advertising' )
 	);
-	const adminInterface = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	const globalSiteViewEnabled = useSelector( ( state ) =>
+		isGlobalSiteViewEnabled( state, siteId )
 	);
 
-	return adminInterface === 'wp-admin' ? siteAdminUrl : `/advertising/${ selectedSiteSlug }`;
+	return globalSiteViewEnabled ? siteAdminUrl : `/advertising/${ selectedSiteSlug }`;
 };
 
 export default useAdvertisingUrl;


### PR DESCRIPTION
The home screen redirection to Blaze for atomic sites is broken. This happens if the site is not part of the dotcom navigation redesign.

We need to make those sites redirect the user to the WPCOM advertising page until we finish ramping up all the sites.

## Proposed Changes

* Change the `useAdvertisingUrl` hook check to use the `wpcom_admin_interface` option for the redierction.

## Testing Instructions

* Open the live preview and go to the home screen for an atomic site (not part of the redesign)
* Click on the Promote with Blaze button in the quick link section (or the Promote card in the sweepable section),
* Verify that you landed in the Advertising page
* Test the same for simple and atomic that belongs to the redesign menu ramp up.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?