### PR TITLE
Patterns: tracking of pattern permalink activity

### DIFF
--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -12,6 +12,7 @@ import type { AppState } from 'calypso/types';
 type PatternsPageViewTrackerProps = {
 	category: string;
 	searchTerm?: string;
+	patternPermalinkName?: string;
 	patternTypeFilter?: PatternTypeFilter;
 	view?: PatternView;
 	referrer?: string;
@@ -22,6 +23,7 @@ type PatternsPageViewTrackerProps = {
 export function PatternsPageViewTracker( {
 	category,
 	searchTerm,
+	patternPermalinkName,
 	patternTypeFilter,
 	view,
 	referrer,
@@ -57,6 +59,7 @@ export function PatternsPageViewTracker( {
 	useEffect( () => {
 		if ( isDevAccount !== undefined && patternsCount !== undefined ) {
 			recordTracksEvent( 'calypso_pattern_library_view', {
+				name: patternPermalinkName,
 				category,
 				is_logged_in: isLoggedIn,
 				user_is_dev_account: isDevAccount ? '1' : '0',
@@ -74,6 +77,7 @@ export function PatternsPageViewTracker( {
 		isDevAccount,
 		isLoggedIn,
 		patternsCount,
+		patternPermalinkName,
 		patternTypeFilter,
 		referrer,
 		searchTerm,

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -105,13 +105,8 @@ export const PatternLibrary = ( {
 	} );
 
 	let patternPermalinkName;
-	if ( patternPermalinkId && patterns.length ) {
-		for ( const pattern of patterns ) {
-			if ( pattern.ID === patternPermalinkId ) {
-				patternPermalinkName = pattern.name;
-				break;
-			}
-		}
+	if ( patternPermalinkId && ! isFetchingPatterns ) {
+		patternPermalinkName = patterns.find( ( pattern ) => pattern.ID === patternPermalinkId )?.name;
 	}
 
 	const isLoggedIn = useSelector( isUserLoggedIn );

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -90,7 +90,8 @@ export const PatternLibrary = ( {
 	const locale = useLocale();
 	const translate = useTranslate();
 	const navRef = useRef< HTMLDivElement >( null );
-	const { category, searchTerm, isGridView, patternTypeFilter, referrer } = usePatternsContext();
+	const { category, searchTerm, isGridView, patternTypeFilter, referrer, patternPermalinkId } =
+		usePatternsContext();
 
 	const { data: categories = [] } = usePatternCategories( locale );
 	const { data: patterns = [], isFetching: isFetchingPatterns } = usePatterns( locale, category, {
@@ -102,6 +103,16 @@ export const PatternLibrary = ( {
 			return filterPatternsByType( patterns, patternTypeFilter );
 		},
 	} );
+
+	let patternPermalinkName;
+	if ( patternPermalinkId && patterns.length ) {
+		for ( const pattern of patterns ) {
+			if ( pattern.ID === patternPermalinkId ) {
+				patternPermalinkName = pattern.name;
+				break;
+			}
+		}
+	}
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
@@ -204,6 +215,7 @@ export const PatternLibrary = ( {
 		<>
 			<PatternsPageViewTracker
 				category={ category }
+				patternPermalinkName={ patternPermalinkName }
 				patternTypeFilter={ patternTypeFilter }
 				view={ currentView }
 				searchTerm={ searchTerm }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -16,6 +16,7 @@ import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/intern
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { PatternsGetAccessModal } from 'calypso/my-sites/patterns/components/get-access-modal';
 import { patternFiltersClassName } from 'calypso/my-sites/patterns/components/pattern-library';
+import { useRecordPatternsEvent } from 'calypso/my-sites/patterns/hooks/use-record-patterns-event';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -104,6 +105,7 @@ function PatternPreviewFragment( {
 	isGridView,
 	viewportWidth,
 }: PatternPreviewProps ) {
+	const { recordPatternsEvent } = useRecordPatternsEvent();
 	const ref = useRef< HTMLDivElement >( null );
 	const hasScrolledToAnchorRef = useRef< boolean >( false );
 
@@ -269,6 +271,9 @@ function PatternPreviewFragment( {
 						borderless
 						className="pattern-preview__title"
 						onCopy={ () => {
+							recordPatternsEvent( 'calypso_pattern_permalink_copy', {
+								name: pattern.name,
+							} );
 							setIsPermalinkCopied( true );
 						} }
 						text={ getPatternPermalink( pattern ) }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -271,7 +271,7 @@ function PatternPreviewFragment( {
 						borderless
 						className="pattern-preview__title"
 						onCopy={ () => {
-							recordPatternsEvent( 'calypso_pattern_permalink_copy', {
+							recordPatternsEvent( 'calypso_pattern_library_permalink_copy', {
 								name: pattern.name,
 							} );
 							setIsPermalinkCopied( true );

--- a/client/my-sites/patterns/context.ts
+++ b/client/my-sites/patterns/context.ts
@@ -5,6 +5,7 @@ type PatternsContextProps = {
 	searchTerm: string;
 	category: string;
 	isGridView: boolean;
+	patternPermalinkId?: number;
 	patternTypeFilter: PatternTypeFilter;
 	referrer?: string;
 };
@@ -13,6 +14,7 @@ export const PatternsContext = createContext< PatternsContextProps >( {
 	searchTerm: '',
 	category: '',
 	isGridView: false,
+	patternPermalinkId: undefined,
 	patternTypeFilter: PatternTypeFilter.REGULAR,
 	referrer: undefined,
 } );

--- a/client/my-sites/patterns/hooks/use-record-patterns-event.tsx
+++ b/client/my-sites/patterns/hooks/use-record-patterns-event.tsx
@@ -1,0 +1,20 @@
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePatternsContext } from 'calypso/my-sites/patterns/context';
+import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
+
+export const useRecordPatternsEvent = () => {
+	const { category, patternTypeFilter } = usePatternsContext();
+
+	return {
+		recordPatternsEvent: (
+			tracksEventName: string,
+			params: Record< string, string | number | undefined > = {}
+		) => {
+			recordTracksEvent( tracksEventName, {
+				category,
+				type: getTracksPatternType( patternTypeFilter ),
+				...params,
+			} );
+		},
+	};
+};

--- a/client/my-sites/patterns/hooks/use-record-patterns-event.tsx
+++ b/client/my-sites/patterns/hooks/use-record-patterns-event.tsx
@@ -11,7 +11,7 @@ export const useRecordPatternsEvent = () => {
 			params: Record< string, string | number | undefined > = {}
 		) => {
 			recordTracksEvent( tracksEventName, {
-				category,
+				category: category || undefined,
 				type: getTracksPatternType( patternTypeFilter ),
 				...params,
 			} );

--- a/client/my-sites/patterns/hooks/use-record-patterns-event.tsx
+++ b/client/my-sites/patterns/hooks/use-record-patterns-event.tsx
@@ -3,7 +3,7 @@ import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
 
 export const useRecordPatternsEvent = () => {
-	const { category, patternTypeFilter } = usePatternsContext();
+	const { category, isGridView, patternTypeFilter } = usePatternsContext();
 
 	return {
 		recordPatternsEvent: (
@@ -13,6 +13,7 @@ export const useRecordPatternsEvent = () => {
 			recordTracksEvent( tracksEventName, {
 				category: category || undefined,
 				type: getTracksPatternType( patternTypeFilter ),
+				view: isGridView ? 'view' : 'list',
 				...params,
 			} );
 		},

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -11,6 +11,7 @@ import { PatternGalleryClient } from 'calypso/my-sites/patterns/components/patte
 import { PatternLibrary } from 'calypso/my-sites/patterns/components/pattern-library';
 import { PatternsContext } from 'calypso/my-sites/patterns/context';
 import { QUERY_PARAM_SEARCH } from 'calypso/my-sites/patterns/lib/filter-patterns-by-term';
+import { extractPatternIdFromHash } from 'calypso/my-sites/patterns/lib/get-pattern-permalink';
 import {
 	PatternTypeFilter,
 	type RouterContext,
@@ -32,17 +33,6 @@ function renderCategoryNotFound( context: RouterContext, next: RouterNext ) {
 
 	next();
 }
-
-const extractPatternIdFromHash = () => {
-	const pattern = /^#pattern-(\d+)$/;
-	const match = window.location.hash.match( pattern );
-
-	if ( match ) {
-		return parseInt( match[ 1 ], 10 );
-	}
-
-	return undefined;
-};
 
 function renderPatterns( context: RouterContext, next: RouterNext ) {
 	if ( ! context.primary ) {

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -10,8 +10,8 @@ import { PatternsCategoryNotFound } from 'calypso/my-sites/patterns/components/c
 import { PatternGalleryClient } from 'calypso/my-sites/patterns/components/pattern-gallery/client';
 import { PatternLibrary } from 'calypso/my-sites/patterns/components/pattern-library';
 import { PatternsContext } from 'calypso/my-sites/patterns/context';
+import { extractPatternIdFromHash } from 'calypso/my-sites/patterns/lib/extract-pattern-id-from-hash';
 import { QUERY_PARAM_SEARCH } from 'calypso/my-sites/patterns/lib/filter-patterns-by-term';
-import { extractPatternIdFromHash } from 'calypso/my-sites/patterns/lib/get-pattern-permalink';
 import {
 	PatternTypeFilter,
 	type RouterContext,

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -33,6 +33,17 @@ function renderCategoryNotFound( context: RouterContext, next: RouterNext ) {
 	next();
 }
 
+const extractPatternIdFromHash = () => {
+	const pattern = /^#pattern-(\d+)$/;
+	const match = window.location.hash.match( pattern );
+
+	if ( match ) {
+		return parseInt( match[ 1 ], 10 );
+	}
+
+	return undefined;
+};
+
 function renderPatterns( context: RouterContext, next: RouterNext ) {
 	if ( ! context.primary ) {
 		context.primary = (
@@ -43,6 +54,7 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 					isGridView: !! context.query.grid,
 					patternTypeFilter:
 						context.params.type === 'layouts' ? PatternTypeFilter.PAGES : PatternTypeFilter.REGULAR,
+					patternPermalinkId: extractPatternIdFromHash(),
 					referrer: context.query.ref,
 				} }
 			>

--- a/client/my-sites/patterns/lib/extract-pattern-id-from-hash.ts
+++ b/client/my-sites/patterns/lib/extract-pattern-id-from-hash.ts
@@ -1,0 +1,10 @@
+export const extractPatternIdFromHash = () => {
+	const pattern = /^#pattern-(\d+)$/;
+	const match = window.location.hash.match( pattern );
+
+	if ( match ) {
+		return parseInt( match[ 1 ], 10 );
+	}
+
+	return undefined;
+};

--- a/client/my-sites/patterns/lib/get-pattern-permalink.ts
+++ b/client/my-sites/patterns/lib/get-pattern-permalink.ts
@@ -19,14 +19,3 @@ export function getPatternPermalink(
 	url.hash = `#pattern-${ pattern.ID }`;
 	return url.toString();
 }
-
-export const extractPatternIdFromHash = () => {
-	const pattern = /^#pattern-(\d+)$/;
-	const match = window.location.hash.match( pattern );
-
-	if ( match ) {
-		return parseInt( match[ 1 ], 10 );
-	}
-
-	return undefined;
-};

--- a/client/my-sites/patterns/lib/get-pattern-permalink.ts
+++ b/client/my-sites/patterns/lib/get-pattern-permalink.ts
@@ -19,3 +19,14 @@ export function getPatternPermalink(
 	url.hash = `#pattern-${ pattern.ID }`;
 	return url.toString();
 }
+
+export const extractPatternIdFromHash = () => {
+	const pattern = /^#pattern-(\d+)$/;
+	const match = window.location.hash.match( pattern );
+
+	if ( match ) {
+		return parseInt( match[ 1 ], 10 );
+	}
+
+	return undefined;
+};


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6460

## Proposed Changes
1) With this PR we are adding property `name` to `calypso_pattern_library_view` which has pattern name as value if the direct link to pattern was opened.
2) Added tracking event to "copy permalink".
3) Introduced `useRecordPatternsEvent` hook. Reason - we have a lot of copy-paste, so with this hook we can avoid copy-paste (AFAIS it's `category` and `type`); additionally - I see that we always track different properties, so I would consider the list of default props one time and we will not miss them: if we have always `type` so maybe would be good to always additionally include `view`; maybe also would be nice to always include `is_logged_in` and `user_is_dev_account`. @wongasy WDYT about my idea?

## Testing Instructions
1.1) Open `/patterns/events#pattern-14736`
1.2) **Wait a bit**
1.3) Assert that `calypso_pattern_library_view` is tracked w/ property as `name: events-list`
1.4) Open `/patterns/events`
1.5) Assert that `calypso_pattern_library_view` is tracked w/o `name` property

2.1) Click on any pattern permalink to copy it
2.2) Assert that `calypso_pattern_permalink_copy` is tracked with `category: events, type: pattern, name: <PATTERN_NAME>`