### PR TITLE
(try)(chore)(e2e) Setup docker logging for the `gutenbergCoreE2eBuildType` bash scripts to troubleshoot docker issue in build

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -118,6 +118,7 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 					npm run build:packages
 				""".trimIndent()
 				dockerImage = "%docker_image_ci_e2e_gb_core_on_dotcom%"
+				dockerRunParameters = "-u %env.UID% --log-driver=json-file --log-opt max-size=10m --log-opt max-file=3"
 			}
 
 			bashNodeScript {
@@ -137,6 +138,7 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 					npm run test:e2e:playwright
 				""".trimIndent()
 				dockerImage = "%docker_image_ci_e2e_gb_core_on_dotcom%"
+				dockerRunParameters = "-u %env.UID% --log-driver=json-file --log-opt max-size=10m --log-opt max-file=3"
 			}
 		}
 	})

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -19,6 +19,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.exec
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 
 object WPComTests : Project({
 	id("WPComTests")
@@ -79,6 +80,7 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 
 		artifactRules = """
 			gutenberg/artifacts => artifacts
+			logs/docker-logs.log => logs
 		""".trimIndent()
 
 		vcs {
@@ -140,6 +142,16 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 				dockerImage = "%docker_image_ci_e2e_gb_core_on_dotcom%"
 				dockerRunParameters = "-u %env.UID% --log-driver=json-file --log-opt max-size=10m --log-opt max-file=3"
 			}
+
+			step(ScriptBuildStep {
+				name = "Copy Docker Logs"
+				scriptContent = """
+					#!/bin/bash
+					mkdir -p %system.teamcity.build.checkoutDir%/logs
+					docker logs $(docker ps -ql --no-trunc) > %system.teamcity.build.checkoutDir%/logs/docker-logs.log
+				"""
+				executionMode = BuildStep.ExecutionMode.ALWAYS
+			})
 		}
 	})
 }


### PR DESCRIPTION
Follow-up to:
1. https://github.com/Automattic/wp-calypso/pull/88823 _(setups the `gutenbergCoreE2eBuildType` to use the new base image)_;
2. https://github.com/Automattic/wp-calypso/pull/88104 _(creates the new base image, which has already been uploaded to the registry - left open until the build is confirmed to work well. You can also see the description of that PR for more comprehensive info on the related project that gave origin to this work)_.

### Background info / Why

After uploading the image created in https://github.com/Automattic/wp-calypso/pull/88104, I setup the `gutenbergCoreE2eBuildType` to use it. However, even though the chain of commands in the build works locally, it fails there. I wrote in detail about it here: p9oQ9f-2dW-p2#comment-3108.

Jetbrains replied to the support request, see: https://gist.github.com/fullofcaffeine/42899840e53f08b2372c3f3e603abe55. They're not sure why it's failing in CI, and suggested telling Docker to log what's happening, and I quote:

> it is unclear from the build log why the container exits. Let us take a look at the Docker logs. Please add the following arguments to additional run arguments (a.k.a. dockerRunParameters in DSL) of the Container Wrapper feature:
>
> --log-driver=json-file --log-opt max-size=10m --log-opt max-file=3
> 
>  
> Then, rerun the build. The Docker logs should be stored in the /var/lib/docker/containers/container_id/container_id-json.log file on the Docker host, i.e., build agent machine.

### What

This PR added the login to the docker runs as part of the `bashNodeScript` calls.

**I still don't know how to get hold of the docker logs in the build agent machine, though.**

## Testing Instructions

1. All checks should pass.
2. Check syntax.
3. Merge and verify the build works well, if not, revert.
