### PR TITLE
A4A: Minor style changes: Removing Jetpack Manage wording, button style fix

### DIFF
--- a/client/a8c-for-agencies/sections/overview/header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/overview/header-actions/style.scss
@@ -12,6 +12,7 @@
 
 	.button.split-button__main {
 		border-radius: 4px 0 0 4px;
+		border-right: none;
 
 		&:hover {
 			background: #fff;
@@ -21,7 +22,6 @@
 
 	.button.split-button__toggle {
 		border-radius: 0 4px 4 0;
-		border-left: none;
 
 		&:hover {
 			background: #fff;

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
@@ -12,6 +12,7 @@
 
 	.button.split-button__main {
 		border-radius: 4px 0 0 4px;
+		border-right: none;
 
 		&:hover {
 			background: #fff;
@@ -21,7 +22,6 @@
 
 	.button.split-button__toggle {
 		border-radius: 0 4px 4 0;
-		border-left: none;
 
 		&:hover {
 			background: #fff;

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -196,7 +196,13 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 							</li>
 						) ) }
 				</ul>
-				{ hasJetpackPartnerAccess && <b>{ translate( 'Price per Jetpack Manage license:' ) }</b> }
+				{ hasJetpackPartnerAccess && (
+					<b>
+						{ isA4AEnabled
+							? translate( 'Price per license:' )
+							: translate( 'Price per Jetpack Manage license:' ) }
+					</b>
+				) }
 				<div className="upsell-product-card__price-container">
 					<DisplayPrice
 						isFree={ ! isFetchingPrices && originalPrice === 0 }


### PR DESCRIPTION
## Proposed Changes

* This PR changes the wording on upsells from the preview pane in the sites dashboard, to remove mention of Jetpack Manage.
* This PR also changes some CSS to prevent a missing button inner-border.

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* If you are able to view an upsell by clicking on the preview pane for a site and visiting either Scan or Backup, then above the button you should see the wording has changed to 'Price per license' instead of 'Price per Jetpack Manage license'.
* If navigating between sites and overview a few times you may occasionally notice a missing inner button border in the split button in the header, in trunk. Some changed CSS may help prevent that in this PR.

License wording in trunk:


<img width="323" alt="Screenshot 2024-04-05 at 21 32 16" src="https://github.com/Automattic/wp-calypso/assets/16754605/2f0d127a-163b-4257-97df-9a131c44b1c4">

License wording change:
<img width="503" alt="Screenshot 2024-04-05 at 21 15 06" src="https://github.com/Automattic/wp-calypso/assets/16754605/0404cb5f-c912-4d7d-a953-5bd332515d8c">


Header button in trunk:

<img width="191" alt="Screenshot 2024-04-05 at 20 36 56" src="https://github.com/Automattic/wp-calypso/assets/16754605/d34a037f-24ad-47d3-a05d-2fb1e0e415ab">

Header button in this PR:

<img width="209" alt="Screenshot 2024-04-05 at 21 27 35" src="https://github.com/Automattic/wp-calypso/assets/16754605/4afff9af-6d24-4cac-85cf-bfeb9625e482">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)