### PR TITLE
Generate supporter list CSV in backend

### DIFF
--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -1,6 +1,7 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { orderBy } from 'lodash';
 import { useState, useEffect, useCallback } from 'react';
@@ -111,7 +112,11 @@ function CustomerSection() {
 								<span className="supporters-list__since-column" role="columnheader">
 									{ translate( 'Since' ) }
 								</span>
-								<span className="supporters-list__menu-column" role="columnheader"></span>
+								<span className="supporters-list__menu-column" role="columnheader">
+									<Tooltip text={ translate( 'Download list as CSV' ) } delay={ 0 }>
+										<Button href={ downloadCsvLink }>{ translate( 'Export' ) }</Button>
+									</Tooltip>
+								</span>
 							</li>
 							{ orderBy( Object.values( subscribers ), [ 'id' ], [ 'desc' ] ).map( ( sub ) =>
 								renderSubscriber( sub )
@@ -123,7 +128,7 @@ function CustomerSection() {
 							setSubscriberToCancel={ setSubscriberToCancel }
 						/>
 						<div className="memberships__module-footer">
-							<Button href={ downloadCsvLink }>{ translate( 'Download list as CSV' ) }</Button>
+							<Button href={ downloadCsvLink }>{ translate( 'Export as CSV' ) }</Button>
 						</div>
 					</>
 				) }

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -1,10 +1,9 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { saveAs } from 'browser-filesaver';
 import { useTranslate } from 'i18n-calypso';
 import { orderBy } from 'lodash';
-import { useState, useEffect, useCallback, MouseEvent } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { shallowEqual } from 'react-redux';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
@@ -17,6 +16,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { decodeEntities } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestSubscribers } from 'calypso/state/memberships/subscribers/actions';
 import {
@@ -60,54 +60,15 @@ function CustomerSection() {
 		[ dispatch, site, subscribers, totalSubscribers ]
 	);
 
-	function downloadSubscriberList( event: MouseEvent< HTMLButtonElement > ) {
-		event.preventDefault();
-		const fileName = [ site?.slug, 'memberships', 'subscribers' ].join( '_' ) + '.csv';
-
-		const csvData = [
-			[
-				'ID',
-				'status',
-				'start_date',
-				'end_date',
-				'user_name',
-				'user_email',
-				'plan_id',
-				'plan_title',
-				'renewal_price',
-				'currency',
-				'renew_interval',
-				'All time total',
-			]
-				.map( ( field ) => '"' + field + '"' )
-				.join( ',' ),
-		]
-			.concat(
-				Object.values( subscribers ).map( ( row ) =>
-					[
-						row.id,
-						row.status,
-						row.start_date,
-						row.end_date,
-						row.user.name,
-						row.user.user_email,
-						row.plan.connected_account_product_id,
-						row.plan.title,
-						row.plan.renewal_price,
-						row.plan.currency,
-						row.renew_interval,
-						row.all_time_total,
-					]
-						.map( ( field ) => ( field ? '"' + field + '"' : '""' ) )
-						.join( ',' )
-				)
-			)
-			.join( '\n' );
-
-		const blob = new window.Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
-
-		saveAs( blob, fileName );
-	}
+	const downloadCsvLink = addQueryArgs(
+		{
+			page: 'subscribers',
+			blog: site?.ID,
+			blog_subscribers: 'csv',
+			type: 'paid-supporter',
+		},
+		'https://dashboard.wordpress.com/wp-admin/index.php'
+	);
 
 	function renderSubscriberList() {
 		return (
@@ -162,9 +123,7 @@ function CustomerSection() {
 							setSubscriberToCancel={ setSubscriberToCancel }
 						/>
 						<div className="memberships__module-footer">
-							<Button onClick={ downloadSubscriberList }>
-								{ translate( 'Download list as CSV' ) }
-							</Button>
+							<Button href={ downloadCsvLink }>{ translate( 'Download list as CSV' ) }</Button>
 						</div>
 					</>
 				) }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -315,7 +315,14 @@ body.is-section-earn.theme-default.color-scheme {
 }
 
 .memberships__module-footer {
+	display: none;
 	margin-top: 20px;
+}
+
+@media (max-width: $break-small) {
+	.memberships__module-footer {
+		display: block;
+	}
 }
 
 .memberships__module-plans-title,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 369-gh-automattic/gold

## Proposed Changes

* Move the generation of the paid supporters CSV from the frontend to the backend.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D144392-code to your sandbox and make sure `dashboard.wordpress.com` is sandboxed.
* Using the calypso.live link below, click "Tools" then "Monetize" then "Supporters".
* Choose a site with paid supporters if the current site does not have any.
* Click "Export" at the top of the page or scroll to the bottom of the page and click "Export as CSV".
* Open the CSV and make sure it generated correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?