### PR TITLE
Domains: Enable NS records editing for subdomains

### DIFF
--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -19,6 +19,7 @@ import { fetchDns } from 'calypso/state/domains/dns/actions';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import DnsAddNew from './dns-add-new';
 
@@ -101,7 +102,7 @@ class AddDnsRecord extends Component {
 	};
 
 	renderMain() {
-		const { dns, selectedDomainName, selectedSite, translate } = this.props;
+		const { domains, dns, selectedDomainName, selectedSite, translate } = this.props;
 		const dnsSupportPageLink = (
 			<ExternalLink
 				href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) }
@@ -118,6 +119,7 @@ class AddDnsRecord extends Component {
 			}
 		);
 		const recordBeingEdited = this.getRecordBeingEdited();
+		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
 
 		return (
 			<Main wideLayout className="add-dns-record">
@@ -126,6 +128,7 @@ class AddDnsRecord extends Component {
 				<div className="add-dns-record__main">
 					<DnsAddNew
 						isSubmittingForm={ dns.isSubmittingForm }
+						selectedDomain={ selectedDomain }
 						selectedDomainName={ selectedDomainName }
 						selectedSiteSlug={ selectedSite?.slug }
 						goBack={ this.goBack }
@@ -161,10 +164,12 @@ class AddDnsRecord extends Component {
 export default connect(
 	( state, { selectedDomainName } ) => {
 		const selectedSite = getSelectedSite( state );
+		const domains = getDomainsBySiteId( state, selectedSite?.ID );
 		const dns = getDomainDns( state, selectedDomainName );
 
 		return {
 			selectedSite,
+			domains,
 			dns,
 			currentRoute: getCurrentRoute( state ),
 		};

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -20,6 +20,7 @@ import ARecord from './a-record';
 import AliasRecord from './alias-record';
 import CnameRecord from './cname-record';
 import MxRecord from './mx-record';
+import NsRecord from './ns-record';
 import SrvRecord from './srv-record';
 import TxtRecord from './txt-record';
 
@@ -39,7 +40,7 @@ class DnsAddNew extends React.Component {
 
 	constructor( props ) {
 		super( props );
-		const { translate, selectedDomainName } = props;
+		const { translate, selectedDomain, selectedDomainName } = props;
 
 		this.dnsRecords = [
 			{
@@ -120,13 +121,25 @@ class DnsAddNew extends React.Component {
 					protocol: '_tcp',
 				},
 			},
+			{
+				component: NsRecord,
+				types: [ 'NS' ],
+				description: translate(
+					'NS (name server) records are used to delegate the authoritative DNS servers for a subdomain.'
+				),
+				initialFields: {
+					name: '',
+					ttl: 86400,
+					data: '',
+				},
+			},
 		];
 
 		this.formStateController = formState.Controller( {
 			initialFields: this.getFieldsForType( initialState.type ),
 			onNewState: this.setFormState,
 			validatorFunction: ( fieldValues, onComplete ) => {
-				onComplete( null, validateAllFields( fieldValues, selectedDomainName ) );
+				onComplete( null, validateAllFields( fieldValues, selectedDomainName, selectedDomain ) );
 			},
 		} );
 
@@ -204,7 +217,7 @@ class DnsAddNew extends React.Component {
 
 	onAddOrUpdateDnsRecord = ( event ) => {
 		event.preventDefault();
-		const { recordToEdit, selectedDomainName, translate } = this.props;
+		const { recordToEdit, selectedDomain, selectedDomainName, translate } = this.props;
 
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			if ( hasErrors ) {
@@ -213,7 +226,8 @@ class DnsAddNew extends React.Component {
 
 			const normalizedData = getNormalizedData(
 				formState.getAllFieldValues( this.state.fields ),
-				selectedDomainName
+				selectedDomainName,
+				selectedDomain
 			);
 
 			if ( recordToEdit ) {
@@ -274,6 +288,7 @@ class DnsAddNew extends React.Component {
 	renderFields( selectedRecordType ) {
 		return (
 			<selectedRecordType.component
+				selectedDomain={ this.props.selectedDomain }
 				selectedDomainName={ this.props.selectedDomainName }
 				show={ true }
 				fieldValues={ formState.getAllFieldValues( this.state.fields ) }

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -18,6 +18,7 @@ import DomainConnectInfoDialog from './domain-connect-info-dialog';
 class DnsRecordsList extends Component {
 	static propTypes = {
 		dns: PropTypes.object.isRequired,
+		selectedDOmain: PropTypes.object.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
@@ -230,12 +231,13 @@ class DnsRecordsList extends Component {
 	}
 
 	render() {
-		const { dns, selectedDomainName, selectedSite } = this.props;
+		const { dns, selectedDomain, selectedDomainName, selectedSite } = this.props;
 		const { dialog } = this.state;
 
 		let domainConnectRecordIsEnabled = false;
 		const dnsRecordsList = dns.records.map( ( dnsRecord, index ) => {
-			if ( 'NS' === dnsRecord.type ) {
+			// We want to hide root NS records for root domains, but not for subdomains
+			if ( 'NS' === dnsRecord.type && ! selectedDomain.isSubdomain && isRootRecord ) {
 				return;
 			}
 

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -236,6 +236,8 @@ class DnsRecordsList extends Component {
 
 		let domainConnectRecordIsEnabled = false;
 		const dnsRecordsList = dns.records.map( ( dnsRecord, index ) => {
+			const isRootRecord = dnsRecord.name === `${ selectedDomainName }.`;
+
 			// We want to hide root NS records for root domains, but not for subdomains
 			if ( 'NS' === dnsRecord.type && ! selectedDomain.isSubdomain && isRootRecord ) {
 				return;

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -271,6 +271,7 @@ class DnsRecords extends Component {
 						<DnsRecordsList
 							dns={ dns }
 							selectedSite={ selectedSite }
+							selectedDomain={ selectedDomain }
 							selectedDomainName={ selectedDomainName }
 						/>
 						<EmailSetup selectedDomainName={ selectedDomainName } />

--- a/client/my-sites/domains/domain-management/dns/ns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/ns-record.jsx
@@ -27,9 +27,6 @@ class NsRecord extends Component {
 		const isDataValid = isValid( 'data' );
 		const isTTLValid = isValid( 'ttl' );
 
-		console.log( 'QWUIOEUQWIOEUQWIOEUQIWOUEIOQW' );
-		console.log( selectedDomain );
-
 		const nameLabel = selectedDomain?.isSubdomain
 			? translate( 'Name (optional)', { context: 'Dns Record' } )
 			: translate( 'Name', { context: 'Dns Record' } );

--- a/client/my-sites/domains/domain-management/dns/ns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/ns-record.jsx
@@ -1,0 +1,98 @@
+import { FormInputValidation, FormLabel } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+class NsRecord extends Component {
+	static propTypes = {
+		fieldValues: PropTypes.object.isRequired,
+		onChange: PropTypes.func.isRequired,
+		selectedDomain: PropTypes.object.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		show: PropTypes.bool.isRequired,
+	};
+
+	render() {
+		const { fieldValues, isValid, onChange, selectedDomain, selectedDomainName, show, translate } =
+			this.props;
+		const classes = classnames( { 'is-hidden': ! show } );
+		const isNameValid = isValid( 'name' );
+		const isDataValid = isValid( 'data' );
+		const isTTLValid = isValid( 'ttl' );
+
+		console.log( 'QWUIOEUQWIOEUQWIOEUQIWOUEIOQW' );
+		console.log( selectedDomain );
+
+		const nameLabel = selectedDomain?.isSubdomain
+			? translate( 'Name (optional)', { context: 'Dns Record' } )
+			: translate( 'Name', { context: 'Dns Record' } );
+
+		return (
+			<div className={ classes }>
+				<FormFieldset>
+					<FormLabel>{ nameLabel }</FormLabel>
+					<FormTextInputWithAffixes
+						name="name"
+						placeholder={ translate( 'Enter subdomain', {
+							context:
+								'Placeholder shown when entering the optional subdomain part of a new DNS record',
+						} ) }
+						isError={ ! isNameValid }
+						onChange={ onChange }
+						value={ fieldValues.name }
+						suffix={ '.' + selectedDomainName }
+					/>
+					{ ! isNameValid && <FormInputValidation text={ translate( 'Invalid Name' ) } isError /> }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>{ translate( 'Host' ) }</FormLabel>
+					<FormTextInput
+						name="data"
+						onChange={ onChange }
+						value={ fieldValues.data }
+						placeholder={ translate( 'e.g. %(example)s', {
+							args: { example: 'ns1.example.com' },
+						} ) }
+					/>
+					{ ! isDataValid && <FormInputValidation text={ translate( 'Invalid Host' ) } isError /> }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>TTL (time to live)</FormLabel>
+					<FormTextInput
+						name="ttl"
+						isError={ ! isTTLValid }
+						onChange={ onChange }
+						value={ fieldValues.ttl }
+						defaultValue={ 3600 }
+						placeholder={ 3600 }
+					/>
+					{ ! isTTLValid && (
+						<FormInputValidation
+							text={ translate( 'Invalid TTL value - Use a value between 300 and 86400' ) }
+							isError
+						/>
+					) }
+				</FormFieldset>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state ) => {
+	const selectedSite = getSelectedSite( state );
+	const domains = getDomainsBySiteId( state, selectedSite?.ID );
+
+	return {
+		selectedSite,
+		domains,
+	};
+} )( localize( NsRecord ) );

--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -12,7 +12,13 @@ import type { DnsDetailsProps } from './types';
 
 import './style.scss';
 
-const DnsDetails = ( { dns, selectedDomainName, currentRoute, selectedSite }: DnsDetailsProps ) => {
+const DnsDetails = ( {
+	dns,
+	selectedDomain,
+	selectedDomainName,
+	currentRoute,
+	selectedSite,
+}: DnsDetailsProps ) => {
 	const showPlaceholder = ! dns.hasLoadedFromServer;
 	const translate = useTranslate();
 
@@ -46,14 +52,20 @@ const DnsDetails = ( { dns, selectedDomainName, currentRoute, selectedSite }: Dn
 
 	const renderDomains = () => {
 		let domainConnectRecordIsEnabled = false;
+
 		const domains = dns.records.map( ( dnsRecord, index ) => {
-			if ( 'NS' === dnsRecord.type ) {
+			const isRootRecord = dnsRecord.name === `${ selectedDomainName }.`;
+
+			// We want to hide root NS records for root domains, but not for subdomains
+			if ( 'NS' === dnsRecord.type && ! selectedDomain.isSubdomain && isRootRecord ) {
 				return;
 			}
+
 			if ( isDomainConnectRecord( dnsRecord ) ) {
 				domainConnectRecordIsEnabled = true;
 				return;
 			}
+
 			return (
 				<DnsRecordItem
 					key={ index }
@@ -62,6 +74,7 @@ const DnsDetails = ( { dns, selectedDomainName, currentRoute, selectedSite }: Dn
 				/>
 			);
 		} );
+
 		return (
 			<>
 				{ domains }

--- a/client/my-sites/domains/domain-management/settings/dns/types.ts
+++ b/client/my-sites/domains/domain-management/settings/dns/types.ts
@@ -1,7 +1,9 @@
-import { DnsRequest, DnsRecord } from 'calypso/lib/domains/types';
+import { DnsRequest, DnsRecord, ResponseDomain } from 'calypso/lib/domains/types';
 import type { SiteDetails } from '@automattic/data-stores';
+
 export type DnsDetailsProps = {
 	dns: DnsRequest;
+	selectedDomain: ResponseDomain;
 	selectedDomainName: string;
 	selectedSite: SiteDetails;
 	currentRoute: string;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -407,8 +407,14 @@ const Settings = ( {
 			! domain ||
 			domain.type === domainTypes.SITE_REDIRECT ||
 			domain.transferStatus === transferStatus.PENDING_ASYNC ||
-			! domain.canManageDnsRecords
+			! domain.canManageDnsRecords ||
+			! domains
 		) {
+			return null;
+		}
+
+		const selectedDomain = domains.find( ( domain ) => selectedDomainName === domain.name );
+		if ( ! selectedDomain ) {
 			return null;
 		}
 
@@ -424,6 +430,7 @@ const Settings = ( {
 							{ renderExternalNameserversNotice( 'DNS' ) }
 							<DnsRecords
 								dns={ dns }
+								selectedDomain={ selectedDomain }
 								selectedDomainName={ selectedDomainName }
 								selectedSite={ selectedSite }
 								currentRoute={ currentRoute }

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -1,9 +1,10 @@
 import { filter, mapValues } from 'lodash';
 
-function validateAllFields( fieldValues, domainName ) {
+function validateAllFields( fieldValues, domainName, domain ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
 		const isValid = validateField( {
 			value,
+			domain,
 			domainName,
 			name: fieldName,
 			type: fieldValues.type,
@@ -13,10 +14,11 @@ function validateAllFields( fieldValues, domainName ) {
 	} );
 }
 
-function validateField( { name, value, type, domainName } ) {
+// LEOTABA 2024-04-05: This is where DNS records are validated
+function validateField( { name, value, type, domain, domainName } ) {
 	switch ( name ) {
 		case 'name':
-			return isValidName( value, type, domainName );
+			return isValidName( value, type, domainName, domain );
 		case 'target':
 			return isValidDomain( value, type );
 		case 'data':
@@ -54,8 +56,8 @@ function isValidDomain( name, type ) {
 	return /^([a-z0-9-_]{1,63}\.)*[a-z0-9-]{1,63}\.[a-z]{2,63}(\.)?$/i.test( name );
 }
 
-function isValidName( name, type, domainName ) {
-	if ( isRootDomain( name, domainName ) && canBeRootDomain( type ) ) {
+function isValidName( name, type, domainName, domain ) {
+	if ( isRootDomain( name, domainName ) && canBeRootDomain( type, domain ) ) {
 		return true;
 	}
 
@@ -81,16 +83,22 @@ function isValidData( data, type ) {
 		case 'ALIAS':
 		case 'CNAME':
 		case 'MX':
+		case 'NS':
 			return isValidDomain( data );
 		case 'TXT':
 			return data.length > 0 && data.length <= 2048;
 	}
 }
 
-function getNormalizedData( record, selectedDomainName ) {
+function getNormalizedData( record, selectedDomainName, selectedDomain ) {
 	const normalizedRecord = Object.assign( {}, record );
 	normalizedRecord.data = getFieldWithDot( record.data );
-	normalizedRecord.name = getNormalizedName( record.name, record.type, selectedDomainName );
+	normalizedRecord.name = getNormalizedName(
+		record.name,
+		record.type,
+		selectedDomainName,
+		selectedDomain
+	);
 	if ( record.target ) {
 		normalizedRecord.target = getFieldWithDot( record.target );
 	}
@@ -98,10 +106,10 @@ function getNormalizedData( record, selectedDomainName ) {
 	return normalizedRecord;
 }
 
-function getNormalizedName( name, type, selectedDomainName ) {
+function getNormalizedName( name, type, selectedDomainName, selectedDomain ) {
 	const endsWithDomain = name.endsWith( '.' + selectedDomainName );
 
-	if ( isRootDomain( name, selectedDomainName ) && canBeRootDomain( type ) ) {
+	if ( isRootDomain( name, selectedDomainName ) && canBeRootDomain( type, selectedDomain ) ) {
 		return selectedDomainName + '.';
 	}
 
@@ -123,7 +131,12 @@ function isRootDomain( name, domainName ) {
 	return ! name || rootDomainVariations.includes( name );
 }
 
-function canBeRootDomain( type ) {
+function canBeRootDomain( type, domain ) {
+	// Root NS records can be edited only for subdomains
+	if ( type === 'NS' && domain?.isSubdomain ) {
+		return true;
+	}
+
 	return [ 'A', 'AAAA', 'ALIAS', 'MX', 'SRV', 'TXT' ].includes( type );
 }
 

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -14,7 +14,6 @@ function validateAllFields( fieldValues, domainName, domain ) {
 	} );
 }
 
-// LEOTABA 2024-04-05: This is where DNS records are validated
 function validateField( { name, value, type, domain, domainName } ) {
 	switch ( name ) {
 		case 'name':


### PR DESCRIPTION
## Proposed Changes

This PR enables adding NS records in Calypso.

NS records can now be added to a domain or subdomain in the DNS management page. If you are adding an NS record to a root domain, you'll need to provide a `name` for the record, since the root NS records for a root domain cannot be changed. If you're adding NS records to a subdomain, the `name` field is optional since you can update either the subdomain's root records or a subdomain of the subdomain's.

### Screenshots

- Adding NS records to root domain

> <img width="716" alt="Screenshot 2024-04-08 at 10 34 42" src="https://github.com/Automattic/wp-calypso/assets/5324818/6374df81-7e65-4cf8-a158-43baeacc038f">

> ![Markup on 2024-04-08 at 10:37:32](https://github.com/Automattic/wp-calypso/assets/5324818/3ec8cc60-fc9c-4fc4-a0f6-2af4cc041efb)

- Adding NS records to a mapped subdomain

> <img width="707" alt="Screenshot 2024-04-08 at 10 35 11" src="https://github.com/Automattic/wp-calypso/assets/5324818/0ce0bdbe-4dd8-468a-aed6-50ece36b139d">

> ![Markup on 2024-04-08 at 10:59:33](https://github.com/Automattic/wp-calypso/assets/5324818/7b1b0d8b-8a7f-4b45-bf40-487f713dac8b)

> ![Markup on 2024-04-08 at 10:59:53](https://github.com/Automattic/wp-calypso/assets/5324818/bceeb838-b32e-4eb8-8f03-dbde901fac58)

- If there are no custom NS records in a mapped subdomain, the "Handled by WordPress.com" row should be shown (only when managing the DNS of mapped subdomains)

![Markup on 2024-04-08 at 10:43:21](https://github.com/Automattic/wp-calypso/assets/5324818/a0e56a7f-1f12-4541-af5b-5b6a9b1e572f)

## Testing Instructions

Note: this PR depends on D144574-code, so please apply it to your sandbox

- Open the live Calypso link or build this branch locally
- Go to the domain management page of a root domain
- Go to the DNS management page and try adding, updating and removing NS records
- Ensure you can't leave the `name` field empty
- Go to the domain management page of a mapped subdomain
- Go to the DNS management page and try adding, updating and removing NS records
- Try adding NS records with and without the `name` field

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?