### PR TITLE
Pattern Library: Fix pattern resizer position

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -149,18 +149,20 @@
 .pattern-preview__resizer {
 	.components-resizable-box__handle-left,
 	.components-resizable-box__handle-right {
-		bottom: 3rem;
+		bottom: 0;
 		height: auto;
 		left: 100%;
 		right: initial;
+		top: 3.4rem;
 
 		&::after {
 			background-color: #a7aaad;
 			border-radius: 3px;
 			box-shadow: none;
 			height: 50px;
-			right: calc(50% - 3px);
-			top: calc(50% - 8px);
+			right: 50%;
+			top: 50%;
+			transform: translate(50%, -50%);
 			width: 6px;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6463

## Proposed Changes

After flipping the previewer and pattern header, the resizer is misplaced. It's especially noticeable for header patterns. This PR aligns the resizer with the preview window.

| Before | After |
|--------|------|
|<img width="1146" alt="Screen Shot 2024-04-05 at 9 09 58 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/5746121a-7736-496e-8ffa-e9c6adf5350a">|<img width="1144" alt="Screen Shot 2024-04-05 at 9 10 20 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/399beabb-c7f1-4e9d-9dce-8b65fcb9f6f0">|

**Side note:** During testing, when resized to mobile width where the pattern name wraps to the second line, things don't quite seem to line up properly. This may not be trivial to fix, and I'd say this isn't a showstopper, we can address this as a separate issue https://github.com/Automattic/dotcom-forge/issues/6464 post-launch.
|Current|Expected|
|--------|------|
|<img width="446" alt="Screen Shot 2024-04-05 at 9 11 08 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/96028c61-ae8c-4b93-9e5d-d43cce990284">|<img width="431" alt="Screen Shot 2024-04-05 at 9 14 00 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/bc3e41ef-8f1c-4672-aa54-4df70c776967">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/patterns/header`.
* Assert that the resizer is aligned with the preview window.
* Validate this for different browsers.
