### PR TITLE
Revert "Plugins: Add pre-sales chat for logged-out users"

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -10,7 +10,6 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
@@ -97,8 +96,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.menu || __( 'Plugins' );
-
-	usePresalesChat( 'wpcom', ! isLoggedIn );
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#85775

As requested on peCdcN-zP-p2.

> we’d like to focus our presales time on pages that bring more of the volume we're looking for

### Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/85775