### PR TITLE
A8C For Agencies: Site details pane tab on site flyout

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/features.ts
+++ b/client/a8c-for-agencies/sections/sites/features/features.ts
@@ -6,3 +6,4 @@ export const JETPACK_MONITOR_ID = 'jetpack_monitor';
 export const JETPACK_STATS_ID = 'jetpack_stats';
 export const JETPACK_PLUGINS_ID = 'jetpack_plugins';
 export const JETPACK_ACTIVITY_ID = 'jetpack_activity';
+export const A4A_SITE_DETAILS_ID = 'a4a_site_details';

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import {
@@ -8,6 +9,7 @@ import {
 	JETPACK_PLUGINS_ID,
 	JETPACK_SCAN_ID,
 	JETPACK_STATS_ID,
+	A4A_SITE_DETAILS_ID,
 } from 'calypso/a8c-for-agencies/sections/sites/features/features';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { useJetpackAgencyDashboardRecordTrackEvent } from 'calypso/jetpack-cloud/sections/agency-dashboard/hooks';
@@ -53,8 +55,8 @@ export function JetpackPreviewPane( {
 	}, [] );
 
 	// Jetpack features: Boost, Backup, Monitor, Stats
-	const features = useMemo(
-		() => [
+	const features = useMemo( () => {
+		const f = [
 			createFeaturePreview(
 				JETPACK_BOOST_ID,
 				'Boost',
@@ -120,9 +122,23 @@ export function JetpackPreviewPane( {
 				setSelectedSiteFeature,
 				<JetpackActivityPreview siteId={ site.blog_id } />
 			),
-		],
-		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ]
-	);
+		];
+
+		if ( isEnabled( 'a4a/site-details-pane' ) ) {
+			f.push(
+				createFeaturePreview(
+					A4A_SITE_DETAILS_ID,
+					translate( 'Details' ),
+					true,
+					selectedSiteFeature,
+					setSelectedSiteFeature,
+					null // @todo: Add the actual panel component here
+				)
+			);
+		}
+
+		return f;
+	}, [ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ] );
 
 	return (
 		<SitePreviewPane

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -16,7 +16,8 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"oauth": true,
-		"a4a/mock-api-data": true
+		"a4a/mock-api-data": true,
+		"a4a/site-details-pane": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
## Proposed Changes

* Adds a Details panel tab on the site flyout on the sites dashboard
* This is behind a feature flag and only works on development environments

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run a8c-for-agencies environment locally
* Connect at least one site to your user, so they appear on the dashboard
* Click the sites to have the flyout pane opened
* There should be a "Details" tab in the flyout
* The "Details" tab content is currently empty

![image](https://github.com/Automattic/wp-calypso/assets/5550190/c4665005-e008-435e-ae68-c2697e0f6274)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?