### PR TITLE
A4A: Replace instances of Wordpress.com with WordPress.com

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.ts
@@ -24,7 +24,7 @@ export default function useHostingDescription( slug: string ): {
 				);
 				break;
 			case 'wpcom-hosting':
-				name = translate( 'Wordpress.com' );
+				name = translate( 'WordPress.com' );
 				description = translate(
 					'Unbeatable uptime, unmetered bandwidth, and everything you need to streamline your development process, baked in. Perfect uptime. Fastest WP Bench score. A+ SSL grade.'
 				);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -24,7 +24,7 @@ export default function WpcomOverview() {
 	return (
 		<Layout
 			className="wpcom-overview"
-			title={ translate( 'Wordpress.com hosting' ) }
+			title={ translate( 'WordPress.com hosting' ) }
 			wide
 			withBorder
 			compact
@@ -43,7 +43,7 @@ export default function WpcomOverview() {
 								href: A4A_MARKETPLACE_HOSTING_LINK,
 							},
 							{
-								label: translate( 'Wordpress.com hosting' ),
+								label: translate( 'WordPress.com hosting' ),
 							},
 						] }
 					/>
@@ -60,7 +60,7 @@ export default function WpcomOverview() {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>Wordpress.com hosting here</LayoutBody>
+			<LayoutBody>WordPress.com hosting here</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -56,7 +56,7 @@ const OverviewBodyHosting = () => {
 
 	const wpcom: OfferingItemProps = {
 		//translators: Title for the action card
-		title: translate( 'Wordpress.com' ),
+		title: translate( 'WordPress.com' ),
 		titleIcon: <WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />,
 		description: translate(
 			'From one site to a thousand, build on a platform with perfect uptime, unlimited bandwidth, and the fastest WP Bench score.'
@@ -75,7 +75,7 @@ const OverviewBodyHosting = () => {
 			translate( 'Round-the-clock support from WordPress experts.' ),
 		],
 		// translators: Button navigating to A4A Marketplace
-		buttonTitle: translate( 'Explore Wordpress.com' ),
+		buttonTitle: translate( 'Explore WordPress.com' ),
 		expanded: false,
 		actionHandler: () => {
 			actionHandlerCallback( 'hosting', 'wordpress.com' );


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/236

## Proposed Changes

* Replace `Wordpress.com` with `WordPress.com` in a few places within the A4A codebase.

## Testing Instructions

* Open the A4A live branch.
* Navigate to `/overview`.
* Scroll to the bottom of the page.
* Verify that the WordPress.com collapsible component displays `WordPress.com` instead of `Wordpress.com` in both the title and button.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="802" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/f9557e32-3770-4150-8950-f77e54a237e9">
</td>
<td>
<img width="802" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/f03c9e7c-6cb3-4aab-a835-117bcb7abea7">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?