### PR TITLE
A4A: Add site details feature pane and site tags components

### DIFF
--- a/client/a8c-for-agencies/components/agency-site-tag/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tag/index.tsx
@@ -1,0 +1,16 @@
+import { Badge } from '@automattic/components';
+import { Icon, closeSmall } from '@wordpress/icons';
+
+interface Props {
+	tag: string;
+	onRemoveTag: ( tag: string ) => void;
+}
+
+export default function AgencySiteTag( { tag, onRemoveTag }: Props ) {
+	return (
+		<Badge type="info">
+			{ tag }
+			<Icon onClick={ () => onRemoveTag( tag ) } icon={ closeSmall } />
+		</Badge>
+	);
+}

--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -1,0 +1,43 @@
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import AgencySiteTag from 'calypso/a8c-for-agencies/components/agency-site-tag';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+interface Props {
+	tags: string[];
+	onAddTags: ( newTags: string[] ) => void;
+	onRemoveTag: ( removeTag: string ) => void;
+}
+
+export default function AgencySiteTags( { tags, onAddTags, onRemoveTag }: Props ) {
+	const translate = useTranslate();
+	const [ tagsInput, setTagsInput ] = useState( '' );
+
+	const handleAddTags = () => {
+		setTagsInput( '' );
+		onAddTags( tagsInput.split( ',' ).map( ( s ) => s.trim() ) );
+	};
+
+	return (
+		<div className="agency-site-tags">
+			<Card className="agency-site-tags__tag-controls">
+				<FormTextInput
+					onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+						setTagsInput( e.target.value )
+					}
+					value={ tagsInput }
+					placeholder={ translate( 'Add tags here (separate by commas)' ) }
+				/>
+				<Button primary compact onClick={ handleAddTags }>
+					{ translate( 'Add' ) }
+				</Button>
+			</Card>
+			<Card className="agency-site-tags__tag-list">
+				{ tags.map( ( tag ) => (
+					<AgencySiteTag key={ tag } tag={ tag } onRemoveTag={ onRemoveTag } />
+				) ) }
+			</Card>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
@@ -6,7 +6,9 @@ export default function SiteDetails( { site }: any ) {
 	/* eslint-disable-next-line */
 	const { a4a_agency_id: agencyId, a4a_site_id: siteId, a4a_site_tags: initialTags } = site;
 
-	const [ tags, setTags ] = useState( initialTags.map( ( tag: SiteTagType ) => tag.label ) );
+	const [ tags, setTags ] = useState(
+		initialTags ? initialTags.map( ( tag: SiteTagType ) => tag.label ) : []
+	);
 
 	const onAddTags = ( tagList: string[] ) => {
 		const newTags = tags.concat( tagList );

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import AgencySiteTags from 'calypso/a8c-for-agencies/components/agency-site-tags';
+import SiteTagType from 'calypso/a8c-for-agencies/types/site-tag';
+
+export default function SiteDetails( { site }: any ) {
+	/* eslint-disable-next-line */
+	const { a4a_agency_id: agencyId, a4a_site_id: siteId, a4a_site_tags: initialTags } = site;
+
+	const [ tags, setTags ] = useState( initialTags.map( ( tag: SiteTagType ) => tag.label ) );
+
+	const onAddTags = ( tagList: string[] ) => {
+		const newTags = tags.concat( tagList );
+		setTags( newTags );
+		/* eslint-disable-next-line */
+		console.log( newTags );
+	};
+
+	const onRemoveTag = ( toRemove: string ) => {
+		const newTags = tags.filter( ( tag: string ) => tag !== toRemove );
+		setTags( newTags );
+		/* eslint-disable-next-line */
+		console.log( newTags );
+	};
+
+	return (
+		<div className="site-details">
+			<AgencySiteTags
+				{ ...{
+					tags,
+					onAddTags,
+					onRemoveTag,
+				} }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/features.ts
+++ b/client/a8c-for-agencies/sections/sites/features/features.ts
@@ -1,9 +1,9 @@
 // Jetpack features IDs
-export const JETPACK_BOOST_ID = 'jetpack_boost';
-export const JETPACK_BACKUP_ID = 'jetpack_backup';
-export const JETPACK_SCAN_ID = 'jetpack_scan';
-export const JETPACK_MONITOR_ID = 'jetpack_monitor';
-export const JETPACK_STATS_ID = 'jetpack_stats';
-export const JETPACK_PLUGINS_ID = 'jetpack_plugins';
-export const JETPACK_ACTIVITY_ID = 'jetpack_activity';
-export const A4A_SITE_DETAILS_ID = 'a4a_site_details';
+export const JETPACK_BOOST_ID = 'jetpack-boost';
+export const JETPACK_BACKUP_ID = 'jetpack-backup';
+export const JETPACK_SCAN_ID = 'jetpack-scan';
+export const JETPACK_MONITOR_ID = 'jetpack-monitor';
+export const JETPACK_STATS_ID = 'jetpack-stats';
+export const JETPACK_PLUGINS_ID = 'jetpack-plugins';
+export const JETPACK_ACTIVITY_ID = 'jetpack-activity';
+export const A4A_SITE_DETAILS_ID = 'site-details';

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import SiteDetails from 'calypso/a8c-for-agencies/sections/sites/features/a4a/site-details';
 import {
 	JETPACK_ACTIVITY_ID,
 	JETPACK_BACKUP_ID,
@@ -132,7 +133,7 @@ export function JetpackPreviewPane( {
 					true,
 					selectedSiteFeature,
 					setSelectedSiteFeature,
-					null // @todo: Add the actual panel component here
+					<SiteDetails site={ site } />
 				)
 			);
 		}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/site-details-pane/index.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import AgencySiteTags from 'calypso/a8c-for-agencies/components/agency-site-tags';
+import SiteTagType from 'calypso/a8c-for-agencies/types/site-tag';
+import './style.scss';
+
+interface Props {
+	site: any;
+}
+
+export function SiteDetailsPane( { site }: Props ) {
+	const { a4a_agency_id: agencyId, a4a_site_id: siteId, a4a_site_tags: initialTags } = site;
+
+	const [ tags, setTags ] = useState( initialTags.map( ( tag: SiteTagType ) => tag.label ) );
+
+	const onAddTags = ( newTags: string[] ) => {
+		const newTagList = tags.concat( newTags );
+		setTags( newTagList );
+		/* eslint-disable-next-line */
+		console.log( agencyId, siteId, newTagList );
+	};
+
+	const onRemoveTag = ( removeTag: string ) => {
+		const newTagList = tags.filter( ( tag: string ) => tag !== removeTag );
+		setTags( newTagList );
+		/* eslint-disable-next-line */
+		console.log( agencyId, siteId, newTagList );
+	};
+
+	return (
+		<div className="site-details-pane">
+			<AgencySiteTags { ...{ agencyId, siteId, tags, onAddTags, onRemoveTag } } />
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/types/site-tag.ts
+++ b/client/a8c-for-agencies/types/site-tag.ts
@@ -1,0 +1,5 @@
+export default interface SiteTag {
+	id: number;
+	slug: string;
+	label: string;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds a `types` directory for type defs in a8c-for-agencies.
* Adds the SiteDetails feature in the A4A slide out.
* Adds the tags and tag components.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Explained in person at meetup.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
