### PR TITLE
A4A: Fix site tag design

### DIFF
--- a/client/a8c-for-agencies/components/agency-site-tag/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tag/index.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@automattic/components';
 import { Icon, closeSmall } from '@wordpress/icons';
+import './style.scss';
 
 interface Props {
 	tag: string;
@@ -8,9 +9,13 @@ interface Props {
 
 export default function AgencySiteTag( { tag, onRemoveTag }: Props ) {
 	return (
-		<Badge type="info">
-			{ tag }
-			<Icon onClick={ () => onRemoveTag( tag ) } icon={ closeSmall } />
+		<Badge className="agency-site-tag" type="info">
+			<span className="agency-site-tag__text">{ tag }</span>
+			<Icon
+				className="agency-site-tag__close"
+				onClick={ () => onRemoveTag( tag ) }
+				icon={ closeSmall }
+			/>
 		</Badge>
 	);
 }

--- a/client/a8c-for-agencies/components/agency-site-tag/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tag/index.tsx
@@ -9,13 +9,15 @@ interface Props {
 
 export default function AgencySiteTag( { tag, onRemoveTag }: Props ) {
 	return (
-		<Badge className="agency-site-tag" type="info">
-			<span className="agency-site-tag__text">{ tag }</span>
-			<Icon
-				className="agency-site-tag__close"
-				onClick={ () => onRemoveTag( tag ) }
-				icon={ closeSmall }
-			/>
-		</Badge>
+		<li className="agency-site-tag">
+			<Badge type="info">
+				<span className="agency-site-tag__text">{ tag }</span>
+				<Icon
+					className="agency-site-tag__close"
+					onClick={ () => onRemoveTag( tag ) }
+					icon={ closeSmall }
+				/>
+			</Badge>
+		</li>
 	);
 }

--- a/client/a8c-for-agencies/components/agency-site-tag/style.scss
+++ b/client/a8c-for-agencies/components/agency-site-tag/style.scss
@@ -1,0 +1,26 @@
+.agency-site-tag {
+	margin-right: 1rem;
+}
+
+.agency-site-tag.badge {
+	background: var(--studio-gray-5);
+	border-radius: 2px;
+	padding: 5px 14px 11px 11px;
+}
+
+.agency-site-tag__text,
+.agency-site-tag__close {
+	display: inline;
+	vertical-align: middle;
+}
+
+.agency-site-tag__text {
+	font-size: 0.75rem;
+}
+
+.agency-site-tag__close {
+	cursor: pointer;
+	position: relative;
+	left: 9px;
+	top: 1px;
+}

--- a/client/a8c-for-agencies/components/agency-site-tag/style.scss
+++ b/client/a8c-for-agencies/components/agency-site-tag/style.scss
@@ -1,5 +1,6 @@
 .agency-site-tag {
-	margin-right: 1rem;
+	margin-right: 0.875rem;
+	margin-bottom: 0.875rem;
 }
 
 .agency-site-tag.badge {

--- a/client/a8c-for-agencies/components/agency-site-tag/style.scss
+++ b/client/a8c-for-agencies/components/agency-site-tag/style.scss
@@ -1,11 +1,12 @@
 .agency-site-tag {
 	margin-right: 0.875rem;
 	margin-bottom: 0.875rem;
+	list-style-type: none;
 }
 
-.agency-site-tag.badge {
+.agency-site-tag > .badge {
 	background: var(--studio-gray-5);
-	border-radius: 2px;
+	border-radius: 4px;
 	padding: 5px 14px 11px 11px;
 }
 
@@ -16,7 +17,7 @@
 }
 
 .agency-site-tag__text {
-	font-size: 0.75rem;
+	font-size: 0.875rem;
 }
 
 .agency-site-tag__close {

--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -21,19 +21,20 @@ export default function AgencySiteTags( { tags, onAddTags, onRemoveTag }: Props 
 
 	return (
 		<div className="agency-site-tags">
-			<Card className="agency-site-tags__tag-controls">
+			<Card className="agency-site-tags__controls">
 				<FormTextInput
+					className="agency-site-tags__input"
 					onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
 						setTagsInput( e.target.value )
 					}
 					value={ tagsInput }
 					placeholder={ translate( 'Add tags here (separate by commas)' ) }
 				/>
-				<Button primary compact onClick={ handleAddTags }>
+				<Button primary compact onClick={ handleAddTags } className="agency-site-tags__button">
 					{ translate( 'Add' ) }
 				</Button>
 			</Card>
-			<Card className="agency-site-tags__tag-list">
+			<Card className="agency-site-tags__list">
 				{ tags.map( ( tag ) => (
 					<AgencySiteTag key={ tag } tag={ tag } onRemoveTag={ onRemoveTag } />
 				) ) }

--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import AgencySiteTag from 'calypso/a8c-for-agencies/components/agency-site-tag';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import './style.scss';
 
 interface Props {
 	tags: string[];

--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -35,7 +35,7 @@ export default function AgencySiteTags( { tags, onAddTags, onRemoveTag }: Props 
 					{ translate( 'Add' ) }
 				</Button>
 			</Card>
-			<Card className="agency-site-tags__list">
+			<Card tagName="ul" className="agency-site-tags__list">
 				{ tags.map( ( tag ) => (
 					<AgencySiteTag key={ tag } tag={ tag } onRemoveTag={ onRemoveTag } />
 				) ) }

--- a/client/a8c-for-agencies/components/agency-site-tags/style.scss
+++ b/client/a8c-for-agencies/components/agency-site-tags/style.scss
@@ -1,0 +1,23 @@
+.agency-site-tags__controls {
+	display: flex;
+	padding: 8px;
+	margin-bottom: 0;
+}
+
+.agency-site-tags__input {
+	width: 100%;
+	border: 0 !important;
+}
+
+.agency-site-tags__input:focus {
+	outline: none !important;
+}
+
+.agency-site-tags__button {
+	width: auto;
+	min-width: 50px;
+	max-height: 2rem;
+	position: relative;
+	top: 3px;
+	right: 10px;
+}

--- a/client/a8c-for-agencies/components/agency-site-tags/style.scss
+++ b/client/a8c-for-agencies/components/agency-site-tags/style.scss
@@ -7,6 +7,7 @@
 .agency-site-tags__input {
 	width: 100%;
 	border: 0 !important;
+	box-shadow: none !important;
 }
 
 .agency-site-tags__input:focus {
@@ -20,4 +21,9 @@
 	position: relative;
 	top: 3px;
 	right: 10px;
+}
+
+.agency-site-tags__list {
+	padding: 0.875rem 0 0 0.875rem;
+	margin-bottom: 0;
 }

--- a/client/a8c-for-agencies/components/agency-site-tags/style.scss
+++ b/client/a8c-for-agencies/components/agency-site-tags/style.scss
@@ -26,4 +26,6 @@
 .agency-site-tags__list {
 	padding: 0.875rem 0 0 0.875rem;
 	margin-bottom: 0;
+	display: flex;
+	flex-direction: row;
 }

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import AgencySiteTags from 'calypso/a8c-for-agencies/components/agency-site-tags';
 import SiteTagType from 'calypso/a8c-for-agencies/types/site-tag';
+import './style.scss';
 
 export default function SiteDetails( { site }: any ) {
 	/* eslint-disable-next-line */

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import AgencySiteTags from 'calypso/a8c-for-agencies/components/agency-site-tags';
 import SiteTagType from 'calypso/a8c-for-agencies/types/site-tag';
@@ -27,6 +28,7 @@ export default function SiteDetails( { site }: any ) {
 
 	return (
 		<div className="site-details">
+			<h3 className="site-details__section-header">{ translate( 'Tags' ) }</h3>
 			<AgencySiteTags
 				{ ...{
 					tags,

--- a/client/a8c-for-agencies/sections/sites/features/a4a/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/style.scss
@@ -1,0 +1,7 @@
+.site-details {
+	padding: 1rem 3rem;
+}
+
+.site-details__section-header {
+	margin: 1rem 0;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add styling for site tags

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run a8c-for-agencies environment locally
- Connect at least one site to your user, so they appear on the dashboard
- Click the sites to have the flyout pane opened
- There should be a "Details" tab in the flyout, click it
- Should be able to add tags following the instructions on the screen

![image](https://github.com/Automattic/wp-calypso/assets/5550190/d6c77192-392e-455c-9e49-e63fa516f6d5)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?