### PR TITLE
Stats: Release paywall for 10% of existing sites

### DIFF
--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -7,7 +7,7 @@ export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: nu
 	) as string;
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
-	const isExistingSampleSite = siteId && siteId % 100 < 1; // Targeting 1% of existing sites
+	const isExistingSampleSite = siteId && siteId % 100 < 10; // Targeting 10% of existing sites
 
 	return {
 		isNewSite,


### PR DESCRIPTION
Related: p1712334548324229-slack-C82FZ5T4G p1712340518252609-slack-C0438NHCLSY

## Proposed Changes

Release paywall for 10% of existing users - blog ID ending with `00`~`09` will be gated if no plan selected.

## Testing Instructions

* Find a Jetpack blog with blog ID ending with `00`~`09`
* Ensure Jetpack Stats is gated if no Stats plan selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?