### PR TITLE
Stats: Revise feature list for stats products

### DIFF
--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -14,6 +14,7 @@ import {
 	isJetpackAISlug,
 	isJetpackCreatorSlug,
 	PRODUCT_JETPACK_CREATOR_MONTHLY,
+	isJetpackStatsPaidTieredProductSlug,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { createElement } from 'react';
@@ -35,7 +36,8 @@ type featureString =
 	| 'videopress'
 	| 'creator'
 	| 'creator-promo'
-	| 'complete';
+	| 'complete'
+	| 'support-if-eligible';
 
 function getFeatureStrings(
 	feature: featureString,
@@ -118,12 +120,11 @@ function getFeatureStrings(
 				translate( 'View weekly and yearly trends' ),
 			];
 		case 'stats':
-			return [
-				translate( 'Instant access to upcoming features' ),
-				translate( 'Ad-free experience' ),
-			];
+			return [ translate( 'Instant access to upcoming features' ), translate( 'UTM Tracking' ) ];
 		case 'support':
 			return [ translate( 'Priority support' ) ];
+		case 'support-if-eligible':
+			return [ translate( 'Priority support if eligible' ) ];
 		case 'videopress':
 			return [
 				translate( '1TB of cloud-hosted video' ),
@@ -244,7 +245,18 @@ export default function getJetpackProductFeatures(
 		return [ ...getFeatureStrings( 'stats-free', translate ) ];
 	}
 
-	if ( isJetpackStatsPaidProductSlug( product.product_slug ) ) {
+	/** Stats PWYW has the same feature set with Stats Free, only with support when paying above certain amount */
+	if (
+		isJetpackStatsPaidProductSlug( product.product_slug ) &&
+		! isJetpackStatsPaidTieredProductSlug( product.product_slug )
+	) {
+		return [
+			...getFeatureStrings( 'stats-free', translate ),
+			...getFeatureStrings( 'support-if-eligible', translate ),
+		];
+	}
+
+	if ( isJetpackStatsPaidTieredProductSlug( product.product_slug ) ) {
 		return [
 			...getFeatureStrings( 'stats-free', translate ),
 			...getFeatureStrings( 'stats', translate ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1055,6 +1055,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Access to upcoming advanced features' ),
 		translate( 'Priority support' ),
 		translate( 'Commercial use' ),
+		translate( 'UTM tracking' ),
 	];
 	const aiAssistantIncludesInfo = [
 		translate( '100 monthly requests (upgradeable)' ),
@@ -1303,6 +1304,10 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 			'Find who is creating the most popular content on your team with our author metrics'
 		),
 		translate( 'View weekly and yearly trends with 7-day Highlights and Year in Review' ),
+		translate( 'UTM tracking' ),
+		translate( 'Traffic spike forgiveness' ),
+		translate( 'Overage forgiveness' ),
+		translate( 'Commercial use' ),
 	];
 
 	const aiAssistantBenefits = [


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/89188

## Proposed Changes

* Remove upcoming features and priority support from PWYW feature list
* Add UTM tracking to feature list
* Add overage, commercial use to statsCommercialBenefits - available at https://cloud.jetpack.com/pricing/:siteSlug#jetpack_stats_yearly

## Testing Instructions

* Add Stats Free, PWYW and Commercial to checkout
* Ensure the feature list look like the following
* Run `yarn start-jetpack-cloud` to verify the pricing page

Stats Free

<img width="1100" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/a6f9b26e-46ff-4eb9-b1ea-3143006d489a">

Stats PWYW

<img width="1124" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/4cfe3e7c-92ab-458a-a248-f9de0ead0b0e">


Stats Commercial

<img width="1158" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/c75c7686-74ee-4d7e-83d4-cf1392f35dea">


Pricing in Jetpack Green:

<img width="1136" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/61013e13-8c33-4714-a896-bf07bdc654ab">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?