### PR TITLE
Automattic for Agencies: Enable all the features & sections in the production environment

### DIFF
--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -29,8 +29,7 @@
 		"always_use_logout_url": true,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
-		"oauth": true,
-		"a4a/mock-api-data": true
+		"oauth": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -23,8 +23,7 @@
 	],
 	"features": {
 		"a8c-for-agencies": true,
-		"oauth": false,
-		"a4a/mock-api-data": false
+		"oauth": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -24,12 +24,20 @@
 	],
 	"oauth_client_id": 95932,
 	"features": {
-		"a8c-for-agencies": false,
-		"oauth": false
+		"a8c-for-agencies": true,
+		"oauth": true
 	},
 	"enable_all_sections": false,
 	"sections": {
-		"a8c-for-agencies": true
+		"a8c-for-agencies": true,
+		"a8c-for-agencies-auth": true,
+		"a8c-for-agencies-landing": true,
+		"a8c-for-agencies-overview": true,
+		"a8c-for-agencies-plugins": true,
+		"a8c-for-agencies-sites": true,
+		"a8c-for-agencies-marketplace": true,
+		"a8c-for-agencies-purchases": true,
+		"a8c-for-agencies-signup": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -25,8 +25,7 @@
 	"oauth_client_id": 95931,
 	"features": {
 		"a8c-for-agencies": true,
-		"oauth": true,
-		"a4a/mock-api-data": false
+		"oauth": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/211

## Proposed Changes

This PR:

- Enables all the required features & sections in the production environment for the A4A env to work.
- Removes the `a4a/mock-api-data` feature as it is not used anymore.

## Testing Instructions

- Verify that we have enabled all the required features & sections comparing it to the staging env file.
- Verify `a4a/mock-api-data` is removed from all the env files.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?