### PR TITLE
A4A: Redirect user to the Sites page by default when onboarding is completed.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -1,3 +1,4 @@
+export const A4A_LANDING_LINK = '/landing';
 export const A4A_OVERVIEW_LINK = '/overview';
 export const A4A_SITES_LINK = '/sites';
 export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -2,11 +2,13 @@ import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { A4A_LANDING_LINK } from './components/sidebar-menu/lib/constants';
 
-export const redirectToOverviewContext: Callback = () => {
+export const redirectToLandingContext: Callback = () => {
 	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+
 	if ( isA4AEnabled ) {
-		page( '/overview' );
+		page.redirect( A4A_LANDING_LINK );
 		return;
 	}
 	window.location.href = 'https://automattic.com/for/agencies';
@@ -28,7 +30,7 @@ export const requireAccessContext: Callback = ( context, next ) => {
 			{
 				return: pathname + hash + search,
 			},
-			'/landing'
+			A4A_LANDING_LINK
 		)
 	);
 };

--- a/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
+++ b/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
@@ -1,0 +1,98 @@
+import { Task } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
+import {
+	A4A_MARKETPLACE_LINK,
+	A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
+	A4A_SITES_LINK_WALKTHROUGH_TOUR,
+} from '../components/sidebar-menu/lib/constants';
+import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from '../sections/onboarding-tours/constants';
+import useNoActiveSite from './use-no-active-site';
+
+const checkTourCompletion = ( preferences: object, prefSlug: string ): boolean => {
+	if ( preferences && A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] ) {
+		return A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] in preferences;
+	}
+	return false;
+};
+
+export default function useOnboardingTours() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const noActiveSite = useNoActiveSite();
+
+	const preferences = useSelector( getAllRemotePreferences );
+
+	const resetTour = useCallback(
+		( prefSlugs: string[] ): void => {
+			prefSlugs.forEach( ( slug ) => {
+				if ( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ] ) {
+					dispatch(
+						savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ], { dismiss: false } )
+					);
+				}
+			} );
+		},
+		[ dispatch ]
+	);
+
+	return useMemo( () => {
+		const addNewSiteTask: Task = {
+			calypso_path: A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
+			completed: checkTourCompletion( preferences, 'addSiteStep1' ),
+			disabled: false,
+			actionDispatch: () => {
+				dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_add_sites_click' ) );
+				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
+			},
+			id: 'add_sites',
+			title: translate( 'Learn how to add new sites' ),
+			useCalypsoPath: true,
+		};
+
+		const tasks: Task[] = [
+			{
+				calypso_path: A4A_SITES_LINK_WALKTHROUGH_TOUR,
+				completed: checkTourCompletion( preferences, 'sitesWalkthrough' ),
+				disabled: false,
+				actionDispatch: () => {
+					dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_get_familiar_click' ) );
+					resetTour( [ 'sitesWalkthrough' ] );
+				},
+				id: 'get_familiar',
+				title: translate( 'Get familiar with the sites management dashboard' ),
+				useCalypsoPath: true,
+			},
+			{
+				calypso_path: A4A_MARKETPLACE_LINK,
+				completed: checkTourCompletion( preferences, 'exploreMarketplace' ),
+				disabled: false,
+				actionDispatch: () => {
+					dispatch(
+						recordTracksEvent( 'calypso_a4a_overview_next_steps_explore_marketplace_click' )
+					);
+					dispatch(
+						savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'exploreMarketplace' ], true )
+					);
+				},
+				id: 'explore_marketplace',
+				title: translate( 'Explore the marketplace' ),
+				useCalypsoPath: true,
+			},
+		];
+
+		if ( noActiveSite ) {
+			// When the user has no active site, the "Add new site" task should be the first step.
+			tasks.unshift( addNewSiteTask );
+		} else {
+			// Otherwise, it should be the last step.
+			tasks.push( addNewSiteTask );
+		}
+
+		return tasks;
+	}, [ dispatch, noActiveSite, preferences, resetTour, translate ] );
+}

--- a/client/a8c-for-agencies/index.tsx
+++ b/client/a8c-for-agencies/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { redirectToOverviewContext } from './controller';
+import { redirectToLandingContext } from './controller';
 
 export default function () {
-	page( '/', redirectToOverviewContext, makeLayout, clientRender );
+	page( '/', redirectToLandingContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/landing/landing.tsx
+++ b/client/a8c-for-agencies/sections/landing/landing.tsx
@@ -11,7 +11,9 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import {
 	A4A_OVERVIEW_LINK,
 	A4A_SIGNUP_LINK,
+	A4A_SITES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useOnboardingTours from 'calypso/a8c-for-agencies/hooks/use-onboarding-tours';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency, hasFetchedAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
@@ -23,6 +25,8 @@ export default function Landing() {
 
 	const hasFetched = useSelector( hasFetchedAgency );
 	const agency = useSelector( getActiveAgency );
+
+	const tasks = useOnboardingTours();
 
 	useEffect( () => {
 		if ( ! hasFetched ) {
@@ -37,11 +41,16 @@ export default function Landing() {
 				return;
 			}
 
-			page.redirect( A4A_OVERVIEW_LINK );
+			// If we have completed all onboarding list. We redirect user to the Sites page as the default page.
+			if ( tasks.every( ( task ) => task.completed ) ) {
+				return page.redirect( A4A_SITES_LINK );
+			}
+
+			return page.redirect( A4A_OVERVIEW_LINK );
 		}
 
 		page.redirect( A4A_SIGNUP_LINK );
-	}, [ agency, hasFetched ] );
+	}, [ agency, hasFetched, tasks ] );
 
 	return (
 		<Layout className="a4a-landing" title={ title } wide>

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
@@ -1,94 +1,14 @@
 import { Card, CircularProgressBar } from '@automattic/components';
-import { Checklist, ChecklistItem, type Task } from '@automattic/launchpad';
+import { Checklist, ChecklistItem } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
-import {
-	A4A_MARKETPLACE_LINK,
-	A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
-	A4A_SITES_LINK_WALKTHROUGH_TOUR,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
-import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
-import { useDispatch, useSelector } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
+import useOnboardingTours from 'calypso/a8c-for-agencies/hooks/use-onboarding-tours';
 
 import './style.scss';
 
 export default function OverviewBodyNextSteps() {
-	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const noActiveSite = useNoActiveSite();
-	const preferences = useSelector( getAllRemotePreferences );
-
-	const checkTourCompletion = ( prefSlug: string ): boolean => {
-		if ( preferences && A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] ) {
-			return A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] in preferences;
-		}
-		return false;
-	};
-
-	const resetTour = ( prefSlugs: string[] ): void => {
-		prefSlugs.forEach( ( slug ) => {
-			if ( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ] ) {
-				dispatch(
-					savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ], { dismiss: false } )
-				);
-			}
-		} );
-	};
-
-	const addNewSiteTask: Task = {
-		calypso_path: A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
-		completed: checkTourCompletion( 'addSiteStep1' ),
-		disabled: false,
-		actionDispatch: () => {
-			dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_add_sites_click' ) );
-			resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
-		},
-		id: 'add_sites',
-		title: translate( 'Learn how to add new sites' ),
-		useCalypsoPath: true,
-	};
-
-	const tasks: Task[] = [
-		{
-			calypso_path: A4A_SITES_LINK_WALKTHROUGH_TOUR,
-			completed: checkTourCompletion( 'sitesWalkthrough' ),
-			disabled: false,
-			actionDispatch: () => {
-				dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_get_familiar_click' ) );
-				resetTour( [ 'sitesWalkthrough' ] );
-			},
-			id: 'get_familiar',
-			title: translate( 'Get familiar with the sites management dashboard' ),
-			useCalypsoPath: true,
-		},
-		{
-			calypso_path: A4A_MARKETPLACE_LINK,
-			completed: checkTourCompletion( 'exploreMarketplace' ),
-			disabled: false,
-			actionDispatch: () => {
-				dispatch(
-					recordTracksEvent( 'calypso_a4a_overview_next_steps_explore_marketplace_click' )
-				);
-				dispatch(
-					savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'exploreMarketplace' ], true )
-				);
-			},
-			id: 'explore_marketplace',
-			title: translate( 'Explore the marketplace' ),
-			useCalypsoPath: true,
-		},
-	];
-	if ( noActiveSite ) {
-		// When the user has no active site, the "Add new site" task should be the first step.
-		tasks.unshift( addNewSiteTask );
-	} else {
-		// Otherwise, it should be the last step.
-		tasks.push( addNewSiteTask );
-	}
+	const tasks = useOnboardingTours();
 
 	const numberOfTasks = tasks.length;
 	const completedTasks = tasks.filter( ( task ) => task.completed ).length;


### PR DESCRIPTION
This pull request updates the default page based on the user's onboarding status. If the user has completed the onboarding process, they will be directed to the Sites page by default. Otherwise, they will be redirected to the Overview page.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/209

## Proposed Changes

* To make the onboarding tours logic shareable in the route middleware, we need to move it within a reusable hook. This will ensure that the information can be easily accessed and utilized by other parts of the UI.
* Update routing to set the Landing page as the default path, which will determine the correct redirect (Overview or Sites page) based on the onboarding status context.

## Testing Instructions

* Create a new Agency account on the Signup page.
* Once, you have created the account, use the A4A live link below and go to the root route `/`.
* Confirm that you are redirected to the Overview page.
* Complete the Onboarding by clicking the Onboarding steps on the Overview page.
   <img width="1023" alt="Screenshot 2024-04-08 at 2 06 19 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/873d5537-cc8c-4309-a112-5fcce044867c">
* Once you have completed the onboarding, use the A4A live link below and go to the root route '/'.
* Confirm that you are now redirected to the Sites page.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
