### PR TITLE
A4A: Update the Color Studio package to import Automattic Blue.

### DIFF
--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -29,7 +29,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/typography": "workspace:^",

--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -4,14 +4,14 @@
 // This file is meant to house style rules that all implementations of the base
 // sidebar will implement by default.
 .a4a-sidebar {
-	--color-sidebar-background: #021a23;
-	--color-sidebar-menu-hover-background: #02395c;
-	--color-sidebar-menu-hover-text: #fff;
-	--color-sidebar-menu-selected-background: #02395c;
-	--color-sidebar-menu-selected-text: #fff;
-	--color-sidebar-text: #fff;
-	--color-sidebar-text-alternative: #bbe0fa;
-	--color-sidebar-gridicon-fill: #bbe0fa;
+	--color-sidebar-background: var(--color-primary-100);
+	--color-sidebar-menu-hover-background: var(--color-primary-80);
+	--color-sidebar-menu-hover-text: var(--color-text-inverted);
+	--color-sidebar-menu-selected-background: var(--color-primary-80);
+	--color-sidebar-menu-selected-text: var(--color-text-inverted);
+	--color-sidebar-text: var(--color-text-inverted);
+	--color-sidebar-text-alternative: var(--color-primary-5);
+	--color-sidebar-gridicon-fill: var(--color-primary-5);
 
 	.a4a-sidebar__site-selector {
 		background-color: var(--color-sidebar-background);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button } from '@automattic/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -127,7 +127,7 @@ export default function PressableOverview() {
 						href={ PRESSABLE_LINK }
 						onClick={ onclickMoreInfo }
 						target="_blank"
-						variant="primary"
+						primary
 					>
 						{ translate( 'Learn more about Pressable' ) } <Icon icon={ external } size={ 18 } />
 					</Button>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,6 +1,6 @@
+import { Button } from '@automattic/components';
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
-import { Button } from '@wordpress/components';
 import { Icon, check, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useCallback } from 'react';
@@ -110,7 +110,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 					<Button
 						className="pressable-overview-plan-selection__details-card-cta-button"
 						onClick={ onSelectPlan }
-						variant="primary"
+						primary
 					>
 						{ translate( 'Select %(planName)s plan', {
 							args: {
@@ -127,7 +127,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 						onClick={ onChatWithUs }
 						href={ PRESSABLE_CONTACT_LINK }
 						target="_blank"
-						variant="primary"
+						primary
 					>
 						{ translate( 'Chat with us' ) } <Icon icon={ external } size={ 16 } />
 					</Button>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button } from '@automattic/components';
 import { Icon, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -196,7 +196,7 @@ export default function MultiProductCard( props: Props ) {
 
 							<Button
 								className="product-card__select-button"
-								variant={ isSelected ? 'secondary' : 'primary' }
+								primary={ ! isSelected }
 								tabIndex={ -1 }
 							>
 								{ isSelected && <Icon icon={ check } /> }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button } from '@automattic/components';
 import { Icon, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -142,7 +142,7 @@ export default function ProductCard( props: Props ) {
 
 							<Button
 								className="product-card__select-button"
-								variant={ isSelected ? 'secondary' : 'primary' }
+								primary={ ! isSelected }
 								tabIndex={ -1 }
 							>
 								{ isSelected && <Icon icon={ check } /> }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
@@ -48,6 +48,8 @@ button.product-card__select-button {
 	font-weight: 600;
 	line-height: 1.1;
 	max-height: 36px;
+	min-width: 82px;
+	max-width: 82px;
 }
 
 @mixin product-card-block__details {

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Badge } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { Badge, Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useState } from 'react';
@@ -56,7 +55,7 @@ export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props
 
 	return (
 		<div className="shopping-cart">
-			<Button className="shopping-cart__button" onClick={ toggleShoppingCart }>
+			<Button className="shopping-cart__button" onClick={ toggleShoppingCart } borderless>
 				<Icon className="shopping-cart__button-icon" icon={ <ShoppingCartIcon /> } />
 
 				<Badge

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -1,5 +1,6 @@
+import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
-import { Button, Popover } from '@wordpress/components';
+import { Popover } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { getTotalInvoiceValue } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
@@ -35,7 +36,11 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 				<div className="shopping-cart__menu-header">
 					<h2 className="shopping-cart__menu-header-title">{ translate( 'Your cart' ) }</h2>
 
-					<Button className="shopping-cart__menu-header-close-button" onClick={ onClose }>
+					<Button
+						className="shopping-cart__menu-header-close-button"
+						onClick={ onClose }
+						borderless
+					>
 						<Icon icon={ close } size={ 24 } />
 					</Button>
 				</div>
@@ -64,7 +69,7 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 						className="shopping-cart__menu-checkout-button"
 						onClick={ onCheckout }
 						disabled={ ! items.length }
-						variant="primary"
+						primary
 					>
 						{ translate( 'Checkout' ) }
 					</Button>

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
@@ -23,7 +23,14 @@
 
 .a4a-intro-cards__wrapper {
 	border-radius: 4px;
+
 	.button {
+		border-radius: 4px;
+	}
+
+	.dot-pager__control-prev:focus-visible,
+	.dot-pager__control-next:focus-visible,
+	.dot-pager__control-choose-page:focus-visible {
 		border-radius: 4px;
 	}
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -4,21 +4,6 @@
 	--a4a-corners-sharp: 0;
 	--a4a-corners-soft: 4px;
 
-	// FIXME: Remove this when we have a proper color scheme
-	--studio-automattic-0: #ebf4fa;
-	--studio-automattic-5: #c4e2f5;
-	--studio-automattic-10: #88ccf2;
-	--studio-automattic-20: #5ab7e8;
-	--studio-automattic-30: #24a3e0;
-	--studio-automattic-40: #1490c7;
-	--studio-automattic-50: #0277a8;
-	--studio-automattic-60: #036085;
-	--studio-automattic-70: #02506e;
-	--studio-automattic-80: #02384d;
-	--studio-automattic-90: #022836;
-	--studio-automattic-100: #021b24;
-	--studio-automattic: #24a3e0;
-
 	--color-surface-backdrop: #021a23;
 
 	--color-text-gray: "#333";
@@ -31,15 +16,41 @@
 	--color-scary-60: var(--studio-red-60);
 	--color-scary-70: var(--studio-red-70);
 
-	--color-primary: var(--studio-automattic-60);
-	--color-primary-40: var(--studio-automattic-40);
-	--color-accent: var(--studio-automattic-40);
-	--color-accent-60: var(--studio-automattic-60);
-	--color-accent-70: var(--studio-automattic-70);
+	--color-primary: var(--studio-automattic-blue-50);
+	--color-primary-rgb: var(--studio-automattic-blue-50-rgb);
+	--color-primary-dark: var(--studio-automattic-blue-70);
+	--color-primary-dark-rgb: var(--studio-automattic-blue-70-rgb);
+	--color-primary-light: var(--studio-automattic-blue-30);
+	--color-primary-light-rgb: var(--studio-automattic-blue-30-rgb);
+	--color-primary-0: var(--studio-automattic-blue-0);
+	--color-primary-0-rgb: var(--studio-automattic-blue-0-rgb);
+	--color-primary-5: var(--studio-automattic-blue-5);
+	--color-primary-5-rgb: var(--studio-automattic-blue-5-rgb);
+	--color-primary-10: var(--studio-automattic-blue-10);
+	--color-primary-10-rgb: var(--studio-automattic-blue-10-rgb);
+	--color-primary-20: var(--studio-automattic-blue-20);
+	--color-primary-20-rgb: var(--studio-automattic-blue-20-rgb);
+	--color-primary-30: var(--studio-automattic-blue-30);
+	--color-primary-30-rgb: var(--studio-automattic-blue-30-rgb);
+	--color-primary-40: var(--studio-automattic-blue-40);
+	--color-primary-40-rgb: var(--studio-automattic-blue-40-rgb);
+	--color-primary-50: var(--studio-automattic-blue-50);
+	--color-primary-50-rgb: var(--studio-automattic-blue-50-rgb);
+	--color-primary-60: var(--studio-automattic-blue-60);
+	--color-primary-60-rgb: var(--studio-automattic-blue-60-rgb);
+	--color-primary-70: var(--studio-automattic-blue-70);
+	--color-primary-70-rgb: var(--studio-automattic-blue-70-rgb);
+	--color-primary-80: var(--studio-automattic-blue-80);
+	--color-primary-80-rgb: var(--studio-automattic-blue-80-rgb);
+	--color-primary-90: var(--studio-automattic-blue-90);
+	--color-primary-90-rgb: var(--studio-automattic-blue-90-rgb);
+	--color-primary-100: var(--studio-automattic-blue-100);
+	--color-primary-100-rgb: var(--studio-automattic-blue-100-rgb);
 }
 
 .theme-a8c-for-agencies {
 	.button {
+		box-sizing: border-box;
 		border-radius: 4px;
 	}
 
@@ -52,8 +63,14 @@
 	}
 
 	.button.is-primary {
-		background-color: var(--studio-automattic-40);
-		border-color: var(--studio-automattic-40);
+		background-color: var(--studio-automattic-blue-40);
+		border-color: var(--studio-automattic-blue-40);
+
+		&:focus,
+		&:focus-visible {
+			box-shadow: none;
+			border: 1px solid;
+		}
 	}
 
 	.button.is-borderless:focus,
@@ -63,25 +80,25 @@
 	}
 
 	.components-form-toggle.is-checked .components-form-toggle__track {
-		background-color: var(--studio-automattic-60);
-		border-color: var(--studio-automattic-60);
+		background-color: var(--studio-automattic-blue-60);
+		border-color: var(--studio-automattic-blue-60);
 	}
 
 	.components-checkbox-control__input[type="checkbox"]:checked,
 	.components-checkbox-control__input[type="checkbox"]:indeterminate {
-		background: var(--studio-automattic-60);
-		border-color: var(--studio-automattic-60);
+		background: var(--studio-automattic-blue-60);
+		border-color: var(--studio-automattic-blue-60);
 	}
 
 	.components-button.is-tertiary {
-		color: var(--studio-automattic-60);
+		color: var(--studio-automattic-blue-60);
 	}
 
 	.button.is-borderless.is-primary.is-active,
 	.button.is-borderless.is-primary:active,
 	.button.is-borderless.is-primary:focus,
 	.button.is-borderless.is-primary:hover {
-		color: var(--studio-automattic-60);
+		color: var(--studio-automattic-blue-60);
 	}
 
 	// Masterbar
@@ -213,7 +230,7 @@ html {
 
 .button.is-primary:hover,
 .button.is-primary:focus {
-	background-color: var(--studio-automattic-70);
-	border-color: var(--studio-automattic-70);
+	background-color: var(--studio-automattic-blue-70);
+	border-color: var(--studio-automattic-blue-70);
 	color: var(--color-text-inverted);
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -9,6 +9,7 @@
 	--color-text-gray: "#333";
 	--color-sidebar-text-alternative: #bbe0fa;
 
+	// FIXME: Need to move this colors to a color scheme file
 	--color-scary-0: var(--studio-red-0);
 	--color-scary-5: var(--studio-red-5);
 	--color-scary-40: var(--studio-red-40);
@@ -46,10 +47,46 @@
 	--color-primary-90-rgb: var(--studio-automattic-blue-90-rgb);
 	--color-primary-100: var(--studio-automattic-blue-100);
 	--color-primary-100-rgb: var(--studio-automattic-blue-100-rgb);
+
+	--color-accent: var(--studio-gray-50);
+	--color-accent-rgb: var(--studio-gray-50-rgb);
+	--color-accent-dark: var(--studio-gray-70);
+	--color-accent-dark-rgb: var(--studio-gray-70-rgb);
+	--color-accent-light: var(--studio-gray-30);
+	--color-accent-light-rgb: var(--studio-gray-30-rgb);
+	--color-accent-0: var(--studio-gray-0);
+	--color-accent-0-rgb: var(--studio-gray-0-rgb);
+	--color-accent-5: var(--studio-gray-5);
+	--color-accent-5-rgb: var(--studio-gray-5-rgb);
+	--color-accent-10: var(--studio-gray-10);
+	--color-accent-10-rgb: var(--studio-gray-10-rgb);
+	--color-accent-20: var(--studio-gray-20);
+	--color-accent-20-rgb: var(--studio-gray-20-rgb);
+	--color-accent-30: var(--studio-gray-30);
+	--color-accent-30-rgb: var(--studio-gray-30-rgb);
+	--color-accent-40: var(--studio-gray-40);
+	--color-accent-40-rgb: var(--studio-gray-40-rgb);
+	--color-accent-50: var(--studio-gray-50);
+	--color-accent-50-rgb: var(--studio-gray-50-rgb);
+	--color-accent-60: var(--studio-gray-60);
+	--color-accent-60-rgb: var(--studio-gray-60-rgb);
+	--color-accent-70: var(--studio-gray-70);
+	--color-accent-70-rgb: var(--studio-gray-70-rgb);
+	--color-accent-80: var(--studio-gray-80);
+	--color-accent-80-rgb: var(--studio-gray-80-rgb);
+	--color-accent-90: var(--studio-gray-90);
+	--color-accent-90-rgb: var(--studio-gray-90-rgb);
+	--color-accent-100: var(--studio-gray-100);
+	--color-accent-100-rgb: var(--studio-gray-100-rgb);
 }
 
 .theme-a8c-for-agencies {
 	.button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		white-space: nowrap;
+
 		box-sizing: border-box;
 		border-radius: 4px;
 	}
@@ -63,11 +100,16 @@
 	}
 
 	.button.is-primary {
-		background-color: var(--studio-automattic-blue-40);
-		border-color: var(--studio-automattic-blue-40);
+		background-color: var(--color-primary-50);
+		border-color: var(--color-primary-50);
+		fill: var(--color-text-inverted);
 
+		&:hover,
 		&:focus,
 		&:focus-visible {
+			background-color: var(--color-primary-70);
+			border-color: var(--color-primary-70);
+			color: var(--color-text-inverted);
 			box-shadow: none;
 			border: 1px solid;
 		}
@@ -80,25 +122,25 @@
 	}
 
 	.components-form-toggle.is-checked .components-form-toggle__track {
-		background-color: var(--studio-automattic-blue-60);
-		border-color: var(--studio-automattic-blue-60);
+		background-color: var(--color-primary-60);
+		border-color: var(--color-primary-60);
 	}
 
 	.components-checkbox-control__input[type="checkbox"]:checked,
 	.components-checkbox-control__input[type="checkbox"]:indeterminate {
-		background: var(--studio-automattic-blue-60);
-		border-color: var(--studio-automattic-blue-60);
+		background: var(--color-primary-60);
+		border-color: var(--color-primary-60);
 	}
 
 	.components-button.is-tertiary {
-		color: var(--studio-automattic-blue-60);
+		color: var(--color-primary-60);
 	}
 
 	.button.is-borderless.is-primary.is-active,
 	.button.is-borderless.is-primary:active,
 	.button.is-borderless.is-primary:focus,
 	.button.is-borderless.is-primary:hover {
-		color: var(--studio-automattic-blue-60);
+		color: var(--color-primary-60);
 	}
 
 	// Masterbar
@@ -226,11 +268,4 @@ html {
 
 .site-selector .site-selector__actions {
 	padding: 16px;
-}
-
-.button.is-primary:hover,
-.button.is-primary:focus {
-	background-color: var(--studio-automattic-blue-70);
-	border-color: var(--studio-automattic-blue-70);
-	color: var(--color-text-inverted);
 }

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
 		"@automattic/calypso-sentry": "workspace:^",
 		"@automattic/calypso-stripe": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -28,7 +28,7 @@
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"postcss": "^8.4.5",
 		"postcss-custom-properties": "^11.0.0",
 		"sass": "^1.37.5"

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -46,7 +46,7 @@
 	"devDependencies": {
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@storybook/cli": "^7.6.17",
 		"@storybook/react": "^7.6.17",
 		"@testing-library/dom": "^9.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,7 +313,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/color-studio": "npm:2.5.0"
+    "@automattic/color-studio": "npm:2.6.0"
     postcss: "npm:^8.4.5"
     postcss-custom-properties: "npm:^11.0.0"
     sass: "npm:^1.37.5"
@@ -536,10 +536,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/color-studio@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@automattic/color-studio@npm:2.5.0"
-  checksum: 94516458713382306299da06dc0661d8abf9a9f7d1c9cd36cf679c4c5f86e259bddd15f5ed6f137c6d9f8d4c2a3f8cb4eff0773d62f8013dea3923f6a836264d
+"@automattic/color-studio@npm:2.6.0":
+  version: 2.6.0
+  resolution: "@automattic/color-studio@npm:2.6.0"
+  checksum: 1171df1d9b92b2734950239eb82250fe53f45d09485fd18b2aa62a40aaabbaa1c127898da97319f871e137254aae9ed7141e2aae30ec09f0151f515af8516510
   languageName: node
   linkType: hard
 
@@ -662,7 +662,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/color-studio": "npm:2.5.0"
+    "@automattic/color-studio": "npm:2.6.0"
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@storybook/cli": "npm:^7.6.17"
@@ -12250,7 +12250,7 @@ __metadata:
     "@automattic/calypso-sentry": "workspace:^"
     "@automattic/calypso-stripe": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
-    "@automattic/color-studio": "npm:2.5.0"
+    "@automattic/color-studio": "npm:2.6.0"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
@@ -18527,7 +18527,7 @@ __metadata:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
-    "@automattic/color-studio": "npm:2.5.0"
+    "@automattic/color-studio": "npm:2.6.0"
     "@automattic/components": "workspace:^"
     "@automattic/format-currency": "workspace:^"
     "@automattic/typography": "workspace:^"
@@ -32556,7 +32556,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/color-studio": "npm:2.5.0"
+    "@automattic/color-studio": "npm:2.6.0"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"


### PR DESCRIPTION
This pull request updates the Color Studio package to version 2.6.0, which now includes the Automattic blue color palette. This is the main theme color used in the A4A portal. Currently, we have hardcoded some of the colors, which will now be removed in favor of the Color Studio.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/214

## Proposed Changes

* Update `@automattic/color-studio` package to version **2.6.0** which includes Automattic blue color palette.
* Update A4A global style to remove hardcoded theme colors to use Automattic blue from Color studio.
* **Additional**: Replace **WordPress** button components with the **Automattic** button components to make all A4A button behavior and styling consistent.

## Testing Instructions

* Use the live link below to test the following pages for broken colors. (Pay more attention to the buttons)
   
| Page | Link    | 
| :---:   | :---: | 
| Overview | `/overview`   | 
| Sites | `/sites` |
| Marketplace - Products | `/marketplace/products` |
| Marketplace - Hosting  | `/marketplace/hosting` |
| Marketplace - Hosting - Pressable | `/marketplace/hosting/pressable` |
| Marketplace - Checkout | `/marketplace/checkout` |
| Marketplace - Assign Licenses | `/marketplace/assign-licenses |
| Purchases - Licenses | `/purchases/licenses` |
| Purchases - Billing | `/purchases/billing` |
| Purchases - Payment Methods | `/purchases/payment-methods` |
| Purchases - Payment Methods - Add | `/purchases/payment-methods/add` |
| Purchases - Invoices | `/purchases/invoices` |


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?