### PR TITLE
Fix Stats Subscribers > View Details for Calypso stats and Simple Classic

### DIFF
--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -67,7 +67,6 @@ class StatModuleFollowers extends Component {
 			translate,
 			emailQuery,
 			wpcomQuery,
-			isOdysseyStats,
 			isAtomic,
 			isJetpack,
 			className,
@@ -82,16 +81,10 @@ class StatModuleFollowers extends Component {
 		// email-followers is no longer available, so fallback to the new subscribers URL.
 		// Old, non-functional path: '/people/email-followers/' + summaryPageSlug.
 		// If the site is Atomic or Jetpack self-hosted, it links to Jetpack cloud.
-		let summaryPageLink =
-			isAtomic || isJetpack
-				? `https://cloud.jetpack.com/subscribers/${ summaryPageSlug }`
-				: `/people/subscribers/${ summaryPageSlug }/${ isAtomic }/${ isJetpack }`;
-
-		// Limit scope for Odyssey stats, as the Followers page is not yet available.
-		summaryPageLink =
-			! isOdysseyStats || isAtomic || isJetpack
-				? summaryPageLink
-				: 'https://wordpress.com' + summaryPageLink;
+		// For all other cases, turn to the WP.com URL since Odyssey Stats doesn't have the Followers page.
+		const jetpackCloudLink = `https://cloud.jetpack.com/subscribers/${ summaryPageSlug }`;
+		const wpcomLink = `https://wordpress.com/people/subscribers/${ summaryPageSlug }`;
+		const summaryPageLink = isAtomic || isJetpack ? jetpackCloudLink : wpcomLink;
 
 		// Combine data sets, sort by recency, and limit to 10.
 		const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ]


### PR DESCRIPTION
Related https://github.com/Automattic/dotcom-forge/issues/6466
Followup for: https://github.com/Automattic/wp-calypso/pull/89280

## Proposed Changes

![jetpack stats](https://github.com/Automattic/wp-calypso/assets/6586048/7e1ad34f-832e-4039-b036-7abe779af643)

1. Calypso Stats: Fixes the link in the Subscribers tab "View details" 
2. Simple Classic Odyssey Stats: Fixes the link to point to WordPress.com, still needs discussion on whether that is the correct place, but at least not a broken link for now

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Calypso Stats (wordpress.com)
* Use a site with >0 subscribers
* Go to `/stats/subscribers/:SITE_SLUG`
* Click on VIew details
* Should redirect to WordPress.com subscriber's page (wordpress.com/subscribers/:SITE_SLUG)

### Simple Classic (site.wordpress.com/wp-admin)
* To enable Simple Classic, in`wpsh` run
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID,'wpcom_classic_early_release', 1 );
```
* Go to `/apps/odyssey-stats`
* Run `NODE_ENV=production yarn dev --sync` to sync the changes to your sandbox
* Sandbox `widgets.wp.com`
* On wp-admin, go to `/wp-admin/admin.php?page=stats#!/stats/subscribers/:SITE_SLUG`
* Should redirect to WordPress.com subscriber's page (wordpress.com/subscribers/:SITE_SLUG)

Make sure Atomic/self-hosted still points to Jetpack Cloud.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?