### PR TITLE
A4A: Update html title when switching to site details pane

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import AgencySiteTags from 'calypso/a8c-for-agencies/components/agency-site-tags';
 import SiteTagType from 'calypso/a8c-for-agencies/types/site-tag';
+import DocumentHead from 'calypso/components/data/document-head';
 
 export default function SiteDetails( { site }: any ) {
 	/* eslint-disable-next-line */
@@ -26,6 +27,7 @@ export default function SiteDetails( { site }: any ) {
 
 	return (
 		<div className="site-details">
+			<DocumentHead title="Site Details" />
 			<AgencySiteTags
 				{ ...{
 					tags,


### PR DESCRIPTION
## Proposed Changes

* Fixes unchanging document title when switching between feature panes and back to "Details".

## Testing Instructions

* Check to ensure that the doc title changes to "Site Details" when switching to that tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
