### PR TITLE
Scheduled updates: Logs: Update status icon styles

### DIFF
--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -205,12 +205,13 @@
 		}
 
 		.timeline-event__icon {
-			width: 24px !important;
-			height: 24px !important;
+			width: 40px !important;
+			height: 20px !important;
+			border-radius: 4px !important;
 
 			svg {
-				width: 16px;
-				height: 16px;
+				width: 14px;
+				height: 14px;
 			}
 
 			&.success {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89036

## Proposed Changes

* Update status icon styles

## Testing Instructions

* Go to scheduled updates logs
* Check if the badge styles are updated

| Before | After |
|--------|--------|
| <img width="458" alt="Screenshot 2024-04-08 at 14 16 11" src="https://github.com/Automattic/wp-calypso/assets/1241413/7eba62b9-b3ad-4d71-b620-2855207b6425"> | <img width="464" alt="Screenshot 2024-04-08 at 14 16 22" src="https://github.com/Automattic/wp-calypso/assets/1241413/48bd1f05-a3a0-4f51-b0ab-0a8bb3712b75"> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?