### PR TITLE
Signup: use page.js for checkout redirect (DIFM only)

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -310,7 +310,7 @@ class Signup extends Component {
 				this.props.locale
 			);
 			this.handleLogin( this.props.signupDependencies, stepUrl, false );
-			this.handleDestination( this.props.signupDependencies, stepUrl );
+			this.handleDestination( this.props.signupDependencies, stepUrl, this.props.flowName );
 		}
 	}
 
@@ -409,7 +409,7 @@ class Signup extends Component {
 
 		await this.handlePostFlowCallbacks( dependencies );
 
-		this.handleDestination( dependencies, filteredDestination );
+		this.handleDestination( dependencies, filteredDestination, this.props.flowName );
 	};
 
 	updateShouldShowLoadingScreen = ( progress = this.props.progress ) => {
@@ -559,7 +559,7 @@ class Signup extends Component {
 		}
 	};
 
-	handleDestination( dependencies, destination ) {
+	handleDestination( dependencies, destination, flowName ) {
 		if ( this.props.isLoggedIn ) {
 			// don't use page.js for external URLs (eg redirect to new site after signup)
 			if ( /^https?:\/\//.test( destination ) ) {
@@ -569,6 +569,11 @@ class Signup extends Component {
 			// deferred in case the user is logged in and the redirect triggers a dispatch
 			defer( () => {
 				debug( `Redirecting you to "${ destination }"` );
+				// Experimental: added the flowName check to restrict this functionality only for the 'website-design-services' flow.
+				if ( destination.startsWith( '/checkout/' ) && 'website-design-services' === flowName ) {
+					page( destination );
+					return;
+				}
 				window.location.href = destination;
 			} );
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -570,7 +570,7 @@ class Signup extends Component {
 			defer( () => {
 				debug( `Redirecting you to "${ destination }"` );
 				// Experimental: added the flowName check to restrict this functionality only for the 'website-design-services' flow.
-				if ( destination.startsWith( '/checkout/' ) && 'website-design-services' === flowName ) {
+				if ( destination?.startsWith( '/checkout/' ) && 'website-design-services' === flowName ) {
 					page( destination );
 					return;
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2878

## Proposed Changes

* In this PR, we switch to the page.js when redirecting to checkout from the `website-design-services` signup flow. Since it's a client-side redirect, it does not cause a full-page reload. This decreases the time delay between the page picker step and checkout, and also makes it easier for users to go back from checkout.
* This flow has monitoring in place, and depending on the result, we can roll this out to all flows.

Please see pdh1Xd-2AB-p2#comment-2760 for additional context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/website-design-services/difm-options?siteSlug=<site slug>`.
* Go through the flow steps till you reach the page picker step and click on the Checkout button.
* Confirm that the redirect happens on the client side and does not trigger a page reload.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?