### PR TITLE
A4A: Sites Dashboard, small fix in the sites table/list padding

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -51,6 +51,11 @@
 		.dataviews-view-table tr td:first-child {
 			padding-left: 64px;
 		}
+		.dataviews-view-table tr th:last-child,
+		.dataviews-view-table tr td:last-child {
+			padding-right: 64px;
+			width: 20px;
+		}
 	}
 
 	@media (max-width: 660px) {
@@ -113,7 +118,11 @@
 
 		.dataviews-view-table tr th:first-child,
 		.dataviews-view-table tr td:first-child {
-			padding-left: 16px;
+			padding: 8px 24px 8px 8px;
+		}
+		.dataviews-view-table tr td:last-child {
+			padding: 0;
+			padding-inline-end: 8px;
 		}
 
 		.components-button.is-compact.has-icon:not(.has-text).dataviews-filters-button {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -157,7 +157,7 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	justify-content: center;
+	justify-content: end;
 	flex-wrap: nowrap;
 
 	@media (min-width: 1080px) {


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/245

## Proposed Changes

This PR fixes an issue with the padding:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/b222be3c-c455-4c12-91c7-23f5f3b50d8e)

![image](https://github.com/Automattic/wp-calypso/assets/9832440/bf624d17-c861-4cf6-9ee5-8a7205c79df7)


## Testing Instructions

- Check the styles in large and small/mobile screens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
