### PR TITLE
Simplifying the type of window.rdt due to failing unit tests

### DIFF
--- a/client/lib/analytics/ad-tracking/ad-track-trial-start.ts
+++ b/client/lib/analytics/ad-tracking/ad-track-trial-start.ts
@@ -6,10 +6,7 @@ import { mayWeTrackByTracker } from '../tracker-buckets';
  */
 declare global {
 	interface Window {
-		rdt: {
-			callQueue: object[];
-			sendEvent: ( ...args: [ string, string?, object? ] ) => void;
-		} & ( ( ...args: [ string, string?, object? ] ) => void );
+		rdt: any[] & { ( ...args: any[] ): void };
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The types from the definition in the trial start tracking and purchase tracking collide.
* This simplifies the type in the trial start tracking to be the same as for the purchase tracking.

## Testing Instructions
* Unit test pass and build is ✅ 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
