### PR TITLE
Patterns: Fix Support and Learn links

### DIFF
--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -40,6 +40,8 @@ export function PatternsGetStarted() {
 				<a
 					className="patterns-get-started__item"
 					href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/block-pattern/' ) }
+					rel="noreferrer"
+					target="_blank"
 				>
 					<img
 						className="patterns-get-started__item-image"
@@ -61,6 +63,8 @@ export function PatternsGetStarted() {
 				<a
 					className="patterns-get-started__item"
 					href={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/page-layouts/' ) }
+					rel="noreferrer"
+					target="_blank"
 				>
 					<img
 						className="patterns-get-started__item-image"
@@ -81,7 +85,9 @@ export function PatternsGetStarted() {
 
 				<a
 					className="patterns-get-started__item"
-					href={ localizeUrl( 'https://wordpress.com/learn/webinars/compelling-homepages/' ) }
+					href="https://wordpress.com/learn/webinars/compelling-homepages/"
+					rel="noreferrer"
+					target="_blank"
 				>
 					<img
 						className="patterns-get-started__item-image"


### PR DESCRIPTION
This pull request seeks to fix a navigation issue on the `Patterns` page with the links shown in the `All about patterns` section:

![image](https://github.com/Automattic/wp-calypso/assets/594356/d018e128-0a79-4075-b5a8-c6e001e3a697)

In production, clicking the last thumbnail would do nothing. Clicking the first two thumbnails would load the Support pages but navigating back would not update the url (or would update it but the content of the page would not change). Forcing each link to open in a new tab should address that.

Finally, this pull request fixes a link that shouldn't be localized as that Learn page is only available in English for now.

#### Testing instructions

This issue is only visible in production but you can still test that nothing broke like so:

1. Run `git checkout fix/patterns` and start your server, or access a [live branch](https://calypso.live/?image=registry.a8c.com/calypso/app:commit-a22cf3aae4b5ca16535284ea298a167f6030439f)
2. Open the [`Emails` page](http://calypso.localhost:3000/patterns)
3. Check that clicking each link of the `All about patterns` section opens the right page