### PR TITLE
Untangling: fix some CSS in unified masterbar to match Core's

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1028,9 +1028,9 @@ a.masterbar__quick-language-switcher {
 }
 
 .masterbar__unified {
-	.masterbar__item-wordpress {
-		padding-left: 7px;
-		padding-right: 1px;
+	.masterbar__item-wordpress,
+	.masterbar__item-current-site {
+		padding: 0 7px;
 	}
 
 	.masterbar__item-all-sites {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -64,6 +64,10 @@ $brand-text: "SF Pro Text", $sans;
 	.is-unified-site-sidebar-visible {
 		--sidebar-width-max: 160px;
 		--sidebar-width-min: 160px;
+
+		.my-sites__navigation {
+			margin-top: 12px;
+		}
 	}
 
 	.is-global-sidebar-visible,


### PR DESCRIPTION
I have some free time before I leave for my hometown for my one-week AFK... please review and take care of this PR 🙈 

## Proposed Changes

This PR fixes some CSS issues of the unified masterbar first introduced via https://github.com/Automattic/wp-calypso/pull/89201:

- distance between the masterbar and the Dashboard menu
- gaps between masterbar items

|Before|After|wp-admin (reference)|
|-|-|-|
|<img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/27c3a347-1e28-414e-94d1-dbb55f4a3d0d">|<img width="250" alt="320529873-6dd20e2f-37e2-4c72-8982-2b0d1e088d8f" src="https://github.com/Automattic/wp-calypso/assets/1525580/c7b3d4fe-4b6e-49ef-b6c9-a3bbc37b400a">|<img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/683ceb67-6e54-4712-ad03-3430046e8fff">|


## Testing Instructions

1. Apply https://github.com/Automattic/jetpack/pull/36632 to your site, and go to `/wp-admin`.
2. Use Calypso live URL, and go to one of the Hosting menus (such as `/plans/:site`).
3. Move back and forth between (1) and (2) and verify that the masterbar looks consistent.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?