### PR TITLE
Pattern Library: Remove customized onboarding flow for universal get started link

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -31,7 +31,6 @@ import {
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { addQueryArgs } from 'calypso/lib/route';
-import { getOnboardingUrl as getPatternLibraryOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
@@ -202,9 +201,6 @@ const LayoutLoggedOut = ( {
 				isLoggedIn={ isLoggedIn }
 				sectionName={ sectionName }
 				{ ...( sectionName === 'subscriptions' && { variant: 'minimal' } ) }
-				{ ...( sectionName === 'patterns' && {
-					startUrl: getPatternLibraryOnboardingUrl( locale, isLoggedIn ),
-				} ) }
 			/>
 		);
 	} else if ( isWooCoreProfilerFlow ) {

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -86,12 +86,6 @@ function checkCategorySlug( context: RouterContext, next: RouterNext ) {
 }
 
 export default function ( router: typeof clientRouter ) {
-	setTimeout( () => {
-		document
-			.querySelector( '.masterbar [href^="https://wordpress.com/setup/assembler-first/"]' )
-			?.setAttribute( 'rel', 'external' );
-	}, 3000 );
-
 	const langParam = getLanguageRouteParam();
 	const middleware = [ checkCategorySlug, renderPatterns, makeLayout, clientRender ];
 

--- a/client/my-sites/patterns/wrapper.tsx
+++ b/client/my-sites/patterns/wrapper.tsx
@@ -1,7 +1,5 @@
-import { useLocale } from '@automattic/i18n-utils';
 import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
 import Main from 'calypso/components/main';
-import { getOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
@@ -11,13 +9,10 @@ type PatternsWrapperProps = React.PropsWithChildren< unknown >;
 
 export const PatternsWrapper = ( { children }: PatternsWrapperProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const locale = useLocale();
 
 	return (
 		<>
-			{ isLoggedIn && (
-				<UniversalNavbarHeader isLoggedIn startUrl={ getOnboardingUrl( locale, isLoggedIn ) } />
-			) }
+			{ isLoggedIn && <UniversalNavbarHeader isLoggedIn /> }
 
 			<Main fullWidthLayout>{ children }</Main>
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to
* https://github.com/Automattic/wp-calypso/pull/89327
* https://github.com/Automattic/wp-calypso/pull/88965

## Proposed Changes

Given that `page.js` isn't configured to support `/setup`, The "Get Started" link in the universal header stopped working when we customized its link to the Assembler-first flow `/setup/assembler-first`. While setting `ref=external` addresses the issue, the hot fix https://github.com/Automattic/wp-calypso/pull/89327 where we set the attribute on a timeout isn't ideal when "Get Started" is easily accessible by the user on page load. Users may well click on it before we're able to apply `ref=external`.

This PR removed the customized `startUrl` so that "Get Started" takes users to the regular onboarding flow. Once we sort out the configuration for supporting `/setup`, we'll revisit reverting the onboarding flow customization.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/patterns` as a logged-in user.
* Click on "Get Started", assert that you're taken to the generic onboarding flow.
* Navigate to `/patterns` as a logged-out user.
* Click on "Get Started", assert that you're taken to the generic onboarding flow.
