### PR TITLE
SSSR: Update the design of the Site Delete page - P1

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -51,6 +51,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/dashboard/',
 		post_id: 137,
 	},
+	delete_site: {
+		link: 'https://wordpress.com/support/delete-site/',
+		post_id: 14411,
+	},
 	discussion: {
 		link: 'https://wordpress.com/support/settings/discussion-settings/',
 		post_id: 1504,

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -158,7 +158,7 @@ class DeleteSite extends Component {
 			getLocaleSlug() === 'en' ||
 			getLocaleSlug() === 'en-gb' ||
 			i18n.hasTranslation(
-				'Deletion is {{strong}}irreversible and will permanently remove all site content{{/strong}} - posts, pages, media, users, authors, domains, purchased upgrades, and previum themes.'
+				'Deletion is {{strong}}irreversible and will permanently remove all site content{{/strong}} — posts, pages, media, users, authors, domains, purchased upgrades, and previum themes.'
 			)
 		) {
 			return (
@@ -166,7 +166,7 @@ class DeleteSite extends Component {
 					<div>
 						<p>
 							{ translate(
-								'Deletion is {{strong}}irreversible and will permanently remove all site content{{/strong}} - posts, pages, media, users, authors, domains, purchased upgrades, and previum themes.',
+								'Deletion is {{strong}}irreversible and will permanently remove all site content{{/strong}} — posts, pages, media, users, authors, domains, purchased upgrades, and previum themes.',
 								{
 									components: {
 										strong: <strong />,

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -45,6 +45,7 @@ class DeleteSite extends Component {
 	state = {
 		confirmDomain: '',
 		showWarningDialog: false,
+		isDeletingSite: false,
 	};
 
 	renderNotice() {
@@ -138,6 +139,7 @@ class DeleteSite extends Component {
 					<Button
 						primary
 						scary
+						busy={ this.state.isDeletingSite }
 						disabled={
 							deleteDisabled ||
 							! this.props.siteId ||
@@ -241,7 +243,7 @@ class DeleteSite extends Component {
 		);
 	}
 
-	handleDeleteSiteClick = ( event ) => {
+	handleDeleteSiteClick = async ( event ) => {
 		event.preventDefault();
 
 		if ( ! this.props.hasLoadedSitePurchasesFromServer ) {
@@ -252,7 +254,13 @@ class DeleteSite extends Component {
 			this.setState( { showWarningDialog: true } );
 		} else {
 			const { siteId } = this.props;
-			this.props.deleteSite( siteId );
+
+			try {
+				this.setState( { isDeletingSite: true } );
+				await this.props.deleteSite( siteId );
+			} finally {
+				this.setState( { isDeletingSite: false } );
+			}
 		}
 	};
 

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -3,41 +3,65 @@
  * - panels specific to the delete site process
  */
 
-.delete-site__content-list-header {
-	margin-bottom: 8px;
-	font-size: $font-body-extra-small;
-	line-height: 16px;
-	text-transform: uppercase;
-	text-align: left;
-	color: var(--color-text-subtle);
-}
-
-.delete-site__content-list {
-	margin: 0 0 20px;
-	border: solid 1px var(--color-neutral-10);
-	border-radius: 2px;
-	list-style: none;
-	text-align: left;
-}
-
-.delete-site__content-list-item {
-	box-sizing: border-box;
-	width: 100%;
-	padding: 12px 16px;
-	border-top: solid 1px var(--color-neutral-10);
-	font-size: $font-body-small;
-	line-height: 18px;
-	color: var(--color-neutral-70);
-
-	&:first-child {
-		border-top: none;
+.delete-site {
+	&__content-list-header {
+		margin-bottom: 8px;
+		font-size: $font-body-extra-small;
+		line-height: 16px;
+		text-transform: uppercase;
+		text-align: left;
+		color: var(--color-text-subtle);
 	}
-}
 
-// Confirm Dialog
-.delete-site__confirm-dialog {
-	max-width: 424px;
-	padding-bottom: 16px;
+	&__content-list {
+		margin: 0 0 20px;
+		border: solid 1px var(--color-neutral-10);
+		border-radius: 2px;
+		list-style: none;
+		text-align: left;
+	}
+
+	&__content-list-item {
+		box-sizing: border-box;
+		width: 100%;
+		padding: 12px 16px;
+		border-top: solid 1px var(--color-neutral-10);
+		font-size: $font-body-small;
+		line-height: 18px;
+		color: var(--color-neutral-70);
+
+		&:first-child {
+			border-top: none;
+		}
+	}
+
+	// Confirm Dialog
+	&__confirm-dialog {
+		max-width: 424px;
+		padding-bottom: 16px;
+	}
+
+	&__target-domain {
+		color: var(--color-error);
+	}
+
+	&__cannot-delete-message {
+		font-size: $font-body-small;
+		color: var(--color-error);
+	}
+
+	&__header-cake {
+		margin-bottom: 0;
+	}
+
+	.notice__text {
+		a,
+		a:visited {
+			float: right;
+			text-decoration: none;
+			color: #ccc;
+		}
+	}
 }
 
 h1.delete-site__confirm-header {
@@ -55,11 +79,3 @@ h1.delete-site__confirm-header {
 	font-weight: normal;
 }
 
-.delete-site__target-domain {
-	color: var(--color-error);
-}
-
-.delete-site__cannot-delete-message {
-	font-size: $font-body-small;
-	color: var(--color-error);
-}

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -54,28 +54,14 @@
 		margin-bottom: 0;
 	}
 
-	.notice__text {
-		a,
-		a:visited {
-			float: right;
-			text-decoration: none;
-			color: #ccc;
-		}
+	&__deletion-block {
+		display: flex;
+	}
+
+	.card .delete-site__confirm-input {
+		width: auto;
+		flex-grow: 1;
+		margin-left: 2px;
+		margin-right: 10px;
 	}
 }
-
-h1.delete-site__confirm-header {
-	height: auto;
-	margin-bottom: 16px;
-	font-size: $font-title-small;
-	line-height: 24px;
-	color: var(--color-neutral-70);
-}
-
-.form-label.delete-site__confirm-label {
-	margin-bottom: 8px;
-	line-height: 24px;
-	color: var(--color-text-subtle);
-	font-weight: normal;
-}
-


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6296

## Proposed Changes

* Implemented the main screen changes. 
* We're not implementing "Manage purchases" or "removing your previous plan" screens here.

![image](https://github.com/Automattic/wp-calypso/assets/1044309/0c3c4d96-ef29-4cb5-8323-f8f44dca023e)


* Non-EN language will show the old screen copy while waiting for translation:

<img width="844" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/bc248283-0e39-44f3-bc10-be0a49e9fb8a">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure "learn more" loads the correct content
* Ensure `Export content` CTA works as expected on sites with and without purchases
* Ensure with EN new interface is shown and with non-EN language, old copy is shown
* Ensure it will show the `Free Trial Active` warning for sites with Trial enabled
* Ensure it won't allow deleting sites with plan subscription enabled
* Ensure everything work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?