### PR TITLE
Segmentation Survey: Create query to retrieve survey answers

### DIFF
--- a/client/data/segmentaton-survey/mutations/use-save-answers-mutation.ts
+++ b/client/data/segmentaton-survey/mutations/use-save-answers-mutation.ts
@@ -1,21 +1,21 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-type SaveAnswersMutationParams = {
+type SaveAnswersMutationArgs = {
 	surveyKey: string;
 	blogId?: number;
 };
 
-type SaveAnswersMutationFnParams = {
+type SaveAnswersMutationFnArgs = {
 	questionKey: string;
 	answerKeys: string[];
 };
 
-const useSaveAnswersMutation = ( { surveyKey, blogId }: SaveAnswersMutationParams ) => {
+const useSaveAnswersMutation = ( { surveyKey, blogId }: SaveAnswersMutationArgs ) => {
 	const queryClient = useQueryClient();
 
 	return useMutation( {
-		mutationFn: async ( { answerKeys, questionKey }: SaveAnswersMutationFnParams ) => {
+		mutationFn: async ( { answerKeys, questionKey }: SaveAnswersMutationFnArgs ) => {
 			return wpcom.req.post( {
 				path: `/segmentation-survey/answers`,
 				apiNamespace: 'wpcom/v2',

--- a/client/data/segmentaton-survey/mutations/use-save-answers-mutation.ts
+++ b/client/data/segmentaton-survey/mutations/use-save-answers-mutation.ts
@@ -1,19 +1,21 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-type SaveAnswersHookArgs = {
+type SaveAnswersMutationParams = {
 	surveyKey: string;
 	blogId?: number;
 };
 
-type SaveAnswersMutationArgs = {
+type SaveAnswersMutationFnParams = {
 	questionKey: string;
 	answerKeys: string[];
 };
 
-const useSaveAnswersMutation = ( { surveyKey, blogId }: SaveAnswersHookArgs ) => {
+const useSaveAnswersMutation = ( { surveyKey, blogId }: SaveAnswersMutationParams ) => {
+	const queryClient = useQueryClient();
+
 	return useMutation( {
-		mutationFn: async ( { answerKeys, questionKey }: SaveAnswersMutationArgs ) => {
+		mutationFn: async ( { answerKeys, questionKey }: SaveAnswersMutationFnParams ) => {
 			return wpcom.req.post( {
 				path: `/segmentation-survey/answers`,
 				apiNamespace: 'wpcom/v2',
@@ -24,6 +26,9 @@ const useSaveAnswersMutation = ( { surveyKey, blogId }: SaveAnswersHookArgs ) =>
 					answers: answerKeys,
 				},
 			} );
+		},
+		onSettled: () => {
+			void queryClient.invalidateQueries( { queryKey: [ 'survey-answers', surveyKey ] } );
 		},
 	} );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/test/use-survey-answers-query.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/test/use-survey-answers-query.test.tsx
@@ -61,7 +61,7 @@ describe( 'useSurveyAnswersQuery', () => {
 
 		expect( wpcom.req.get ).toHaveBeenCalledWith( {
 			apiNamespace: 'wpcom/v2',
-			path: '/segmentation-survey/answer?survey_key=test_key',
+			path: '/segmentation-survey/answers?survey_key=test_key',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/test/use-survey-answers-query.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/test/use-survey-answers-query.test.tsx
@@ -10,15 +10,11 @@ import useSurveyAnswersQuery from '../use-survey-answers-query';
 const mockResponse = [
 	{
 		question_key: 'question_key_1',
-		answer_key: 'answer_key_1',
-	},
-	{
-		question_key: 'question_key_1',
-		answer_key: 'answer_key_2',
+		answer_keys: [ 'answer_key_1', 'answer_key_2' ],
 	},
 	{
 		question_key: 'question_key_2',
-		answer_key: 'answer_key_3',
+		answer_keys: [ 'answer_key_3' ],
 	},
 ];
 
@@ -65,7 +61,7 @@ describe( 'useSurveyAnswersQuery', () => {
 
 		expect( wpcom.req.get ).toHaveBeenCalledWith( {
 			apiNamespace: 'wpcom/v2',
-			path: '/segmentation-survey/answers?survey_key=test_key',
+			path: '/segmentation-survey/answer?survey_key=test_key',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/test/use-survey-answers-query.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/test/use-survey-answers-query.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import wpcom from 'calypso/lib/wp';
+import useSurveyAnswersQuery from '../use-survey-answers-query';
+
+const mockResponse = [
+	{
+		question_key: 'question_key_1',
+		answer_key: 'answer_key_1',
+	},
+	{
+		question_key: 'question_key_1',
+		answer_key: 'answer_key_2',
+	},
+	{
+		question_key: 'question_key_2',
+		answer_key: 'answer_key_3',
+	},
+];
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: jest.fn(),
+	},
+} ) );
+
+describe( 'useSurveyAnswersQuery', () => {
+	let queryClient: QueryClient;
+	let wrapper: React.FC< React.PropsWithChildren< any > >;
+
+	beforeEach( () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+
+		queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
+
+		wrapper = ( { children }: React.PropsWithChildren< any > ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should call wpcom.req.get with the right parameters', async () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
+			mockResponse
+		);
+
+		const { result } = renderHook( () => useSurveyAnswersQuery( { surveyKey: 'test_key' } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( wpcom.req.get ).toHaveBeenCalledWith( {
+			apiNamespace: 'wpcom/v2',
+			path: '/segmentation-survey/answers?survey_key=test_key',
+		} );
+	} );
+
+	it( 'should return expected data when successful', async () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
+			mockResponse
+		);
+
+		const { result } = renderHook( () => useSurveyAnswersQuery( { surveyKey: 'test_key' } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( {
+			question_key_1: [ 'answer_key_1', 'answer_key_2' ],
+			question_key_2: [ 'answer_key_3' ],
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/use-survey-answers-query.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/use-survey-answers-query.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { Answers } from 'calypso/components/survey-container/types';
+import wpcom from 'calypso/lib/wp';
+
+type SurveyAnswersQueryParams = {
+	surveyKey: string;
+};
+
+type SurveyAnswersResponse = {
+	question_key: string;
+	answer_key: string;
+}[];
+
+const mapSurveyAnswers = ( response: SurveyAnswersResponse ): Answers => {
+	return response.reduce( ( acc: Record< string, string[] >, { question_key, answer_key } ) => {
+		acc[ question_key ] = [ ...( acc[ question_key ] || [] ), answer_key ];
+		return acc;
+	}, {} );
+};
+
+const useSurveyAnswersQuery = ( { surveyKey }: SurveyAnswersQueryParams ) => {
+	return useQuery( {
+		queryKey: [ 'survey-answers', surveyKey ],
+		queryFn: () => {
+			return wpcom.req.get( {
+				path: `/segmentation-survey/answers?survey_key=${ surveyKey }`,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+		enabled: !! surveyKey,
+		select: mapSurveyAnswers,
+	} );
+};
+
+export default useSurveyAnswersQuery;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/use-survey-answers-query.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/use-survey-answers-query.ts
@@ -21,7 +21,7 @@ const useSurveyAnswersQuery = ( { surveyKey }: SurveyAnswersQueryParams ) => {
 		queryKey: [ 'survey-answers', surveyKey ],
 		queryFn: () => {
 			return wpcom.req.get( {
-				path: `/segmentation-survey/answer?survey_key=${ surveyKey }`,
+				path: `/segmentation-survey/answers?survey_key=${ surveyKey }`,
 				apiNamespace: 'wpcom/v2',
 			} );
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/use-survey-answers-query.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/use-survey-answers-query.ts
@@ -8,22 +8,20 @@ type SurveyAnswersQueryParams = {
 
 type SurveyAnswersResponse = {
 	question_key: string;
-	answer_key: string;
+	answer_keys: string[];
 }[];
 
-const mapSurveyAnswers = ( response: SurveyAnswersResponse ): Answers => {
-	return response.reduce( ( acc: Record< string, string[] >, { question_key, answer_key } ) => {
-		acc[ question_key ] = [ ...( acc[ question_key ] || [] ), answer_key ];
-		return acc;
+const mapSurveyAnswers = ( response: SurveyAnswersResponse ): Answers =>
+	response.reduce( ( acc, { question_key, answer_keys } ) => {
+		return { ...acc, [ question_key ]: answer_keys };
 	}, {} );
-};
 
 const useSurveyAnswersQuery = ( { surveyKey }: SurveyAnswersQueryParams ) => {
 	return useQuery( {
 		queryKey: [ 'survey-answers', surveyKey ],
 		queryFn: () => {
 			return wpcom.req.get( {
-				path: `/segmentation-survey/answers?survey_key=${ surveyKey }`,
+				path: `/segmentation-survey/answer?survey_key=${ surveyKey }`,
 				apiNamespace: 'wpcom/v2',
 			} );
 		},


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89333

## Proposed Changes

* Create useSurveyAnswersQuery. It was implemented to make it easier to reuse the endpoint. For now it's not used on the segmentation survey UI.
* Should be merged after D145776-code
## Testing Instructions

* Apply this PR to your local
* Run tests with the following command: `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/queries/test/use-survey-answers-query.test.tsx`
* Should be tested together with D145776-code
* You can apply this hook to any page and verify if the returned answers match previously submitted answers
```
const { data } = useSurveyAnswersQuery( { surveyKey: 'key' } );
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?