### PR TITLE
WIP use agency dashboard code for a sites dashboard flyout panel

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -123,11 +123,11 @@ const useFormatMonitorData = () => {
 				status: '',
 				type: 'monitor',
 				error: false,
-				settings: site.monitor_settings,
+				settings: site.monitor_settings || {},
 			};
 
 			const { monitor_active: monitorActive, monitor_site_status: monitorStatus } =
-				site.monitor_settings;
+				site.monitor_settings || {};
 
 			if ( ! monitorActive ) {
 				monitor.status = 'disabled';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -19,7 +19,7 @@ const getTrendIcon = ( viewsTrend: 'up' | 'down' | 'same' ) => {
 };
 
 export default function SiteStatsColumn( { stats }: Props ) {
-	const { total: totalViews, trend: viewsTrend } = stats.views;
+	const { total: totalViews, trend: viewsTrend } = stats?.views || {};
 	const trendIcon = getTrendIcon( viewsTrend );
 	return (
 		<span

--- a/client/sites-dashboard/components/a4a-components/guided-tour/index.tsx
+++ b/client/sites-dashboard/components/a4a-components/guided-tour/index.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useContext } from 'react';
+import { GuidedTourContext } from 'calypso/a8c-for-agencies/data/guided-tours/guided-tour-context';
+import { TourId } from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
+
+const GuidedTour = ( { defaultTourId }: { defaultTourId: TourId } ) => {
+	const { currentTourId, currentStep, startTour } = useContext( GuidedTourContext );
+
+	useEffect( () => {
+		if ( ! currentTourId && defaultTourId ) {
+			startTour( defaultTourId );
+		}
+	}, [ currentTourId, defaultTourId, startTour ] );
+
+	if ( ! currentTourId || ! currentStep ) {
+		return null;
+	}
+
+	return null;
+};
+
+export default GuidedTour;

--- a/client/sites-dashboard/components/a4a-components/layout/body.tsx
+++ b/client/sites-dashboard/components/a4a-components/layout/body.tsx
@@ -1,0 +1,17 @@
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+	className?: string;
+};
+
+export default function LayoutBody( { children, className }: Props ) {
+	const wrapperClass = classNames( className, 'a4a-layout__body' );
+
+	return (
+		<div className={ wrapperClass }>
+			<div className="a4a-layout__body-wrapper">{ children }</div>
+		</div>
+	);
+}

--- a/client/sites-dashboard/components/a4a-components/layout/column.tsx
+++ b/client/sites-dashboard/components/a4a-components/layout/column.tsx
@@ -1,0 +1,28 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import Main from 'calypso/components/main';
+
+import './style.scss';
+
+type Props = {
+	children: ReactNode;
+	className?: string;
+	wide?: boolean;
+	withBorder?: boolean;
+	compact?: boolean;
+};
+
+export default function LayoutColumn( { children, className, wide, withBorder, compact }: Props ) {
+	return (
+		<Main
+			className={ classNames( 'a4a-layout-column', className, {
+				'is-with-border': withBorder,
+				'is-compact': compact,
+			} ) }
+			fullWidthLayout={ wide }
+			wideLayout={ ! wide } // When we set to full width, we want to set this to false.
+		>
+			<div className="a4a-layout-column__container">{ children }</div>
+		</Main>
+	);
+}

--- a/client/sites-dashboard/components/a4a-components/layout/header.tsx
+++ b/client/sites-dashboard/components/a4a-components/layout/header.tsx
@@ -1,0 +1,110 @@
+import classNames from 'classnames';
+import { Children, ReactNode, useLayoutEffect, useState } from 'react';
+import Breadcrumb, { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
+import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
+
+type Props = {
+	showStickyContent?: boolean;
+	children: ReactNode;
+	className?: string;
+};
+
+export function LayoutHeaderTitle( { children }: Props ) {
+	return <h1 className="a4a-layout__header-title">{ children }</h1>;
+}
+
+export function LayoutHeaderSubtitle( { children }: Props ) {
+	return <h2 className="a4a-layout__header-subtitle">{ children }</h2>;
+}
+
+export function LayoutHeaderActions( { children, className }: Props ) {
+	const wrapperClass = classNames( className, 'a4a-layout__header-actions' );
+	return <div className={ wrapperClass }>{ children }</div>;
+}
+
+export function LayoutHeaderBreadcrumb( { items }: { items: BreadcrumbItem[] } ) {
+	return (
+		<div className="a4a-layout__header-breadcrumb">
+			<Breadcrumb items={ items } />
+		</div>
+	);
+}
+
+export default function LayoutHeader( { showStickyContent, children, className }: Props ) {
+	const headerBreadcrumb = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderBreadcrumb
+	);
+
+	const headerTitle = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderTitle
+	);
+
+	const headerSubtitle = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderSubtitle
+	);
+
+	const headerActions = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderActions
+	);
+
+	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
+
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+	const wrapperClass = classNames( className, 'a4a-layout__viewport' );
+
+	const [ minHeaderHeight, setMinHeaderHeight ] = useState( 0 );
+
+	// To avoid shifting the layout when displaying sticky content,  we will need to
+	// keep track of our Header height and set it as the minimum viewport height.
+	useLayoutEffect(
+		() => {
+			const headerRef = outerDivProps?.ref?.current;
+
+			const updateMinHeaderHeight = () => {
+				setMinHeaderHeight( headerRef?.clientHeight ?? 0 );
+			};
+
+			window.addEventListener( 'resize', updateMinHeaderHeight );
+
+			updateMinHeaderHeight();
+
+			return () => {
+				window.removeEventListener( 'resize', updateMinHeaderHeight );
+			};
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	);
+
+	return (
+		<div
+			className={ wrapperClass }
+			{ ...outerDivProps }
+			style={ showStickyContent ? { minHeight: `${ minHeaderHeight }px` } : {} }
+		>
+			<div
+				className={ classNames( {
+					'a4a-layout__sticky-header': showStickyContent && hasCrossed,
+				} ) }
+			>
+				<div
+					className={ classNames( 'a4a-layout__header', {
+						'has-actions': !! headerActions,
+					} ) }
+				>
+					<div className="a4a-layout__header-main">
+						{ headerBreadcrumb }
+						{ headerTitle }
+						{ headerSubtitle }
+					</div>
+
+					{ headerActions }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/sites-dashboard/components/a4a-components/layout/index.tsx
+++ b/client/sites-dashboard/components/a4a-components/layout/index.tsx
@@ -1,0 +1,53 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import { GuidedTourContextProvider } from 'calypso/a8c-for-agencies/data/guided-tours/guided-tour-context';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import LayoutColumn from './column';
+
+import './style.scss';
+
+type Props = {
+	children: ReactNode;
+	sidebarNavigation?: ReactNode;
+	className?: string;
+	title: ReactNode;
+	wide?: boolean;
+	withBorder?: boolean;
+	compact?: boolean;
+};
+
+export default function Layout( {
+	children,
+	className,
+	title,
+	wide,
+	withBorder,
+	compact,
+	sidebarNavigation,
+}: Props ) {
+	const hasLayoutColumns = React.Children.toArray( children ).some(
+		( child ) => React.isValidElement( child ) && child.type === LayoutColumn
+	);
+	const layoutContainerClassname = hasLayoutColumns
+		? 'a4a-layout-with-columns__container'
+		: 'a4a-layout__container';
+
+	return (
+		<GuidedTourContextProvider>
+			<Main
+				className={ classNames( 'a4a-layout', className, {
+					'is-with-border': withBorder,
+					'is-compact': compact,
+				} ) }
+				fullWidthLayout={ wide }
+				wideLayout={ ! wide } // When we set to full width, we want to set this to false.
+			>
+				<DocumentHead title={ title } />
+				{ sidebarNavigation }
+
+				<div className={ layoutContainerClassname }>{ children }</div>
+			</Main>
+		</GuidedTourContextProvider>
+	);
+}

--- a/client/sites-dashboard/components/a4a-components/layout/nav.tsx
+++ b/client/sites-dashboard/components/a4a-components/layout/nav.tsx
@@ -1,0 +1,76 @@
+import { Count } from '@automattic/components';
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+
+type LayoutNavigationProps = {
+	className?: string;
+	children: ReactNode;
+	selectedText: string;
+	selectedCount?: number;
+};
+
+type LayoutNavigationItemProps = {
+	label: string;
+	compactCount?: boolean;
+	onClick?: () => void;
+	path?: string;
+	count?: number;
+	selected?: boolean;
+};
+
+type LayoutNavigationTabsProps = {
+	selectedText: string;
+	selectedCount?: number;
+	items: LayoutNavigationItemProps[];
+};
+
+export function LayoutNavigationTabs( {
+	selectedText,
+	selectedCount,
+	items,
+}: LayoutNavigationTabsProps ) {
+	return (
+		<NavTabs selectedText={ selectedText } selectedCount={ selectedCount }>
+			{ items.map( ( { label, onClick, selected, count, path, compactCount = true } ) => (
+				<NavItem
+					key={ label.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
+					compactCount={ compactCount }
+					count={ count }
+					path={ path }
+					onClick={ onClick }
+					selected={ selected }
+				>
+					{ label }
+				</NavItem>
+			) ) }
+		</NavTabs>
+	);
+}
+
+export default function LayoutNavigation( {
+	className,
+	selectedText,
+	selectedCount,
+	children,
+}: LayoutNavigationProps ) {
+	return (
+		<div className="a4a-layout__navigation-wrapper">
+			<SectionNav
+				className={ classNames( 'a4a-layout__navigation', className ) }
+				applyUpdatedStyles
+				selectedText={
+					<span>
+						{ selectedText }
+						{ Number.isInteger( selectedCount ) && <Count count={ selectedCount } compact /> }
+					</span>
+				}
+				selectedCount={ selectedCount }
+			>
+				{ children }
+			</SectionNav>
+		</div>
+	);
+}

--- a/client/sites-dashboard/components/a4a-components/layout/stepper.tsx
+++ b/client/sites-dashboard/components/a4a-components/layout/stepper.tsx
@@ -1,0 +1,49 @@
+import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { Fragment } from 'react';
+
+type Props = {
+	steps: string[];
+	current: number;
+};
+
+function getStepClassName( currentStep: number, step: number ): string {
+	return classnames( {
+		'is-current': currentStep === step,
+		'is-next': currentStep < step,
+		'is-complete': currentStep > step,
+	} );
+}
+
+function Marker( { currentStep, step }: { currentStep: number; step: number } ) {
+	if ( currentStep > step ) {
+		return (
+			<span className="a4a-layout__stepper-step-circle">
+				<Gridicon icon="checkmark" size={ 16 } />
+			</span>
+		);
+	}
+
+	return (
+		<span className="a4a-layout__stepper-step-circle">
+			<span>{ step }</span>
+		</span>
+	);
+}
+
+export default function LayoutStepper( { steps, current }: Props ) {
+	return (
+		<div className="a4a-layout__stepper">
+			{ steps.map( ( label, index ) => (
+				<Fragment key={ `step-${ index }` }>
+					<div className={ `a4a-layout__stepper-step ${ getStepClassName( current, index ) }` }>
+						<Marker currentStep={ current + 1 } step={ index + 1 } />
+						<span className="a4a-layout__stepper-step-name">{ label }</span>
+					</div>
+
+					{ index < steps.length - 1 && <div className="a4a-layout__stepper-step-separator" /> }
+				</Fragment>
+			) ) }
+		</div>
+	);
+}

--- a/client/sites-dashboard/components/a4a-components/layout/style.scss
+++ b/client/sites-dashboard/components/a4a-components/layout/style.scss
@@ -1,0 +1,378 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+html,
+.theme-a8c-for-agencies {
+	overflow: auto;
+}
+
+.main.a4a-layout-column,
+.main.a4a-layout {
+	background: var(--color-surface);
+	margin: 0;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	overflow: hidden;
+	height: calc(100vh - 32px);
+
+	header.current-section {
+		margin: 0;
+		padding: 0;
+
+		button {
+			padding: 20px 0;
+		}
+	}
+}
+
+.a4a-layout-with-columns__container,
+.a4a-layout__container {
+	max-width: 100%;
+	max-height: 100%;
+	display: flex;
+	margin: auto;
+	padding: 0;
+}
+
+.a4a-layout__container {
+	flex-direction: column;
+}
+
+.a4a-layout-with-columns__container {
+	flex-direction: row;
+	flex-wrap: nowrap;
+	gap: 16px;
+}
+
+.a4a-layout-column {
+	flex: 1;
+}
+
+.a4a-layout__body {
+	width: 100%;
+	overflow-y: auto;
+	padding-block-start: 16px;
+	padding-block-end: 32px;
+}
+
+.a4a-layout__top-wrapper,
+.a4a-layout__body {
+	margin-inline: 0;
+	max-height: 100%;
+
+	> * {
+		padding-inline: 16px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			max-width: 1500px;
+			margin-inline: auto !important;
+			padding-inline: 64px;
+		}
+	}
+}
+
+.a4a-layout__top-wrapper {
+	padding-block-start: 48px;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		padding: 0;
+		border-block-end: 1px solid var(--color-neutral-5);
+	}
+}
+
+.main.a4a-layout.is-compact .a4a-layout__top-wrapper {
+	padding-block-start: 28px;
+	@include breakpoint-deprecated( "<660px" ) {
+		padding: 0;
+	}
+}
+
+.main.a4a-layout.is-with-border {
+	@include breakpoint-deprecated( ">660px" ) {
+		.a4a-layout__top-wrapper {
+			border-block-end: 1px solid var(--color-neutral-5);
+			// If we don't have a navigation, we will require some spacing on the borders.
+			&:not(.has-navigation) {
+				padding-block-end: 48px;
+			}
+		}
+	}
+}
+
+.main.a4a-layout.is-with-border.is-compact {
+	@include breakpoint-deprecated( ">660px" ) {
+		.a4a-layout__top-wrapper {
+
+			&:not(.has-navigation) {
+				padding-block-end: 28px;
+			}
+		}
+	}
+}
+
+
+.a4a-layout__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin: auto;
+	height: 100%;
+
+	> * + * {
+		margin-inline-start: 24px;
+	}
+
+	@include breakpoint-deprecated( "<1280px" ) {
+		flex-wrap: wrap;
+
+		> * + * {
+			margin-inline-start: 0;
+		}
+	}
+}
+
+.a4a-layout__header.has-actions > .a4a-layout__header-main {
+	@include breakpoint-deprecated( "<1280px" ) {
+		margin-block-end: 16px;
+	}
+}
+
+.a4a-layout__header-actions {
+	width: 100%;
+	display: flex;
+
+	> * {
+		flex-grow: 1;
+	}
+
+	@include break-medium {
+		width: auto;
+		> * {
+			flex-grow: 0;
+		}
+	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		align-items: center;
+		justify-content: space-between;
+		> * {
+			flex-grow: 0;
+		}
+		.current-section button {
+			border: none;
+		}
+
+		.current-section .gridicons-menu {
+			margin: 0;
+		}
+	}
+}
+
+.a4a-layout__sticky-header {
+	position: fixed;
+	width: calc(100%);
+	left: 0;
+	top: var(--masterbar-height);
+	background-color: rgba(246, 247, 247, 0.95);
+	box-shadow: 2px 2px 2px 0 rgb(0 0 0 / 8%);
+	z-index: 1001;
+	height: 74px;
+
+	.a4a-layout__header {
+		flex-wrap: nowrap;
+		max-width: 1500px;
+		padding-inline: 48px;
+
+		> * {
+			width: auto;
+		}
+	}
+
+	.a4a-layout__header-main,
+	.a4a-layout__header-actions {
+		margin: 0;
+	}
+
+	.a4a-layout__header-subtitle {
+		display: none;
+	}
+
+	.a4a-layout__header-title {
+		font-size: rem(24px);
+		margin-block-end: 0;
+		display: none;
+
+		@include break-large {
+			display: block;
+		}
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		width: calc(100% - var(--sidebar-width-min));
+		left: var(--sidebar-width-min);
+	}
+
+	@include breakpoint-deprecated( ">960px" ) {
+		width: calc(100% - var(--sidebar-width-max));
+		left: var(--sidebar-width-max);
+	}
+}
+
+.a4a-layout__header-breadcrumb {
+	margin-block-end: 4px;
+}
+
+.a4a-layout__header-title {
+	font-size: 2.25rem;
+	font-weight: 600;
+	line-height: 1.2;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		display: none;
+	}
+}
+
+.a4a-layout__header-subtitle {
+	font-size: 1rem;
+	color: var(--color-neutral-60);
+	margin: 8px 0 0 0;
+	font-weight: 400;
+	line-height: 1.2;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		display: none;
+	}
+}
+
+.section-nav.a4a-layout__navigation {
+	margin-block-start: 16px;
+
+	.section-nav__mobile-header-text .count {
+		margin-inline-start: 8px;
+	}
+
+	.select-dropdown__item.is-selected .count {
+		color: var(--color-text);
+	}
+
+	.select-dropdown__header {
+		border-width: 0;
+
+		.count {
+			top: 12.5px;
+		}
+
+		@include breakpoint-deprecated( ">660px" ) {
+			border-width: 1px;
+		}
+	}
+
+	.section-nav-tabs.is-dropdown {
+		width: 100%;
+		margin: 0 0 1px 0;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			margin-block-end: 12px;
+		}
+	}
+
+	.select-dropdown__options {
+		margin-inline: -1px;
+	}
+
+	.section-nav-tabs__dropdown .select-dropdown__container {
+		max-width: unset;
+		width: 100%;
+	}
+
+	.section-nav-tabs__dropdown {
+		// Since the search below the dropdown has z-index: 22,
+		// we need to make sure the dropdown is above it
+		z-index: 23;
+	}
+
+	@include breakpoint-deprecated( ">1040px" ) {
+		margin-block-start: 32px;
+		margin-inline: -16px;
+	}
+}
+
+
+.a4a-layout__stepper {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+	margin-block: 16px 32px;
+}
+
+.a4a-layout__stepper-step {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	.a4a-layout__stepper-step-circle {
+		width: 20px;
+		height: 20px;
+		display: flex;
+		border-radius: 50%;
+		justify-content: center;
+		align-content: center;
+		align-items: center;
+		font-size: 0.75rem;
+	}
+
+	.a4a-layout__stepper-step-name {
+		margin-left: 0.5rem;
+		white-space: nowrap;
+	}
+
+	.a4a-layout__viewport {
+		margin-inline-start: 0;
+	}
+
+	&.is-current > .a4a-layout__stepper-step-circle {
+		background-color: var(--color-neutral-60);
+		border: 2px solid var(--color-neutral-60);
+		color: var(--color-text-inverted);
+	}
+
+	&.is-next > .a4a-layout__stepper-step-circle {
+		border: 2px solid var(--color-neutral-60);
+		color: var(--color-neutral-80);
+	}
+
+	&.is-complete > .a4a-layout__stepper-step-circle {
+		background-color: var(--color-primary-50);
+		border: 2px solid var(--color-primary-50);
+		color: var(--color-text-inverted);
+	}
+
+	&.is-next > .a4a-layout__stepper-step-name {
+		display: none;
+
+		@include break-medium {
+			display: flex;
+		}
+	}
+
+	&.is-complete > .a4a-layout__stepper-step-name,
+	&.is-complete > .a4a-layout__stepper-step-circle,
+	&.is-complete + .a4a-layout__stepper-step-separator {
+		display: none;
+
+		@include break-medium {
+			display: flex;
+		}
+	}
+}
+
+.a4a-layout__stepper-step-separator {
+	border: 1px solid var(--color-neutral-80);
+	width: 20px;
+	height: 0;
+	margin: 0 0.75rem;
+
+	@include break-medium {
+		width: 40px;
+		margin: 0 1.25rem;
+	}
+}

--- a/client/sites-dashboard/components/a4a-components/layout/top.tsx
+++ b/client/sites-dashboard/components/a4a-components/layout/top.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import { Children, ReactNode } from 'react';
+import LayoutNavigation from './nav';
+
+type Props = {
+	children: ReactNode;
+	withNavigation?: boolean;
+};
+
+export default function LayoutTop( { children, withNavigation }: Props ) {
+	const navigation = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutNavigation
+	);
+
+	return (
+		<div
+			className={ classNames( 'a4a-layout__top-wrapper', {
+				'has-navigation': withNavigation || !! navigation,
+			} ) }
+		>
+			{ children }
+		</div>
+	);
+}

--- a/client/sites-dashboard/components/a4a-components/sidebar/mobile-sidebar-navigation/index.tsx
+++ b/client/sites-dashboard/components/a4a-components/sidebar/mobile-sidebar-navigation/index.tsx
@@ -1,0 +1,9 @@
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import { useSelector } from 'calypso/state';
+import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
+
+export default function MobileSidebarNavigation() {
+	const headerTitle = useSelector( getDocumentHeadTitle );
+
+	return <SidebarNavigation sectionTitle={ headerTitle } />;
+}

--- a/client/sites-dashboard/data/guided-tours/guided-tour-context.tsx
+++ b/client/sites-dashboard/data/guided-tours/guided-tour-context.tsx
@@ -1,0 +1,102 @@
+import { ReactNode, createContext, useCallback, useMemo, useState } from 'react';
+import useGuidedTour, { type TourId } from './use-guided-tours';
+
+type TourStep = {
+	id: string;
+	popoverPosition: string;
+	title: string;
+	description: JSX.Element | string;
+	nextStepOnTargetClick?: boolean;
+	forceShowSkipButton?: boolean;
+};
+
+type GuidedTourContextType = {
+	currentTourId: TourId | null;
+	startTour: ( id: TourId ) => void;
+	currentStep: TourStep | null;
+	currentStepCount: number;
+	stepsCount: number;
+	nextStep: () => void;
+};
+
+const defaultGuidedTourContextValue = {
+	currentTourId: null,
+	startTour: () => {},
+	currentStep: null,
+	currentStepCount: 0,
+	stepsCount: 0,
+	nextStep: () => {},
+};
+
+export const GuidedTourContext = createContext< GuidedTourContextType >(
+	defaultGuidedTourContextValue
+);
+
+/**
+ * Guided Tour Context Provider
+ * Provides access to interact with the contextually relevant guided tour.
+ */
+export const GuidedTourContextProvider = ( { children }: { children?: ReactNode } ) => {
+	const [ currentTourId, setCurrentTourId ] = useState< TourId | null >( null );
+	const [ completedSteps, setCompletedSteps ] = useState< string[] >( [] );
+
+	const currentTour: TourStep[] = useGuidedTour( currentTourId );
+
+	/**
+	 * Derive current tour state from the available vs completed steps.
+	 */
+	type DerivedTourState = {
+		currentStep: TourStep | null;
+		currentStepCount: number;
+		stepsCount: number;
+	};
+	const { currentStep, currentStepCount, stepsCount } = useMemo< DerivedTourState >( () => {
+		return currentTour.reduce(
+			( carry: DerivedTourState, step: TourStep ) => {
+				carry.stepsCount++;
+				if ( ! carry.currentStep && ! completedSteps.includes( step.id ) ) {
+					carry.currentStep = step;
+					carry.currentStepCount = carry.stepsCount;
+				}
+				return carry;
+			},
+			{
+				currentStep: null,
+				currentStepCount: 0,
+				stepsCount: 0,
+			} as DerivedTourState
+		);
+	}, [ currentTour, completedSteps ] );
+
+	/**
+	 * Set the active guided tour.
+	 */
+	const startTour = useCallback( ( id: TourId ) => {
+		setCurrentTourId( id );
+	}, [] );
+
+	/**
+	 * Proceed to the next available step in the active tour.
+	 */
+	const nextStep = useCallback( () => {
+		if ( currentStep ) {
+			setCompletedSteps( ( currentSteps ) => [ ...currentSteps, currentStep.id ] );
+		}
+	}, [ currentStep ] );
+
+	const contextValue = useMemo(
+		() => ( {
+			startTour,
+			nextStep,
+			currentTourId,
+			stepsCount,
+			currentStep,
+			currentStepCount,
+		} ),
+		[ startTour, nextStep, currentTourId, stepsCount, currentStep, currentStepCount ]
+	);
+
+	return (
+		<GuidedTourContext.Provider value={ contextValue }>{ children }</GuidedTourContext.Provider>
+	);
+};

--- a/client/sites-dashboard/data/guided-tours/tours/use-add-new-site-tour.tsx
+++ b/client/sites-dashboard/data/guided-tours/tours/use-add-new-site-tour.tsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function useAddNewSiteTour() {
+	const translate = useTranslate();
+
+	return [
+		{
+			id: 'add-new-site',
+			popoverPosition: 'bottom left',
+			title: translate( 'Click the arrow button' ),
+			description: (
+				<>
+					{ translate( 'Click the arrow button and select "Connect a site to Jetpack".' ) }
+					<br />
+					<br />
+					{ translate(
+						'Sites with Jetpack installed will automatically appear in the site management view.'
+					) }
+				</>
+			),
+			nextStepOnTargetClick: true,
+			forceShowSkipButton: true,
+		},
+	];
+}

--- a/client/sites-dashboard/data/guided-tours/tours/use-sites-walkthrough-tour.tsx
+++ b/client/sites-dashboard/data/guided-tours/tours/use-sites-walkthrough-tour.tsx
@@ -1,0 +1,104 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function useSitesWalkthroughTour() {
+	const translate = useTranslate();
+
+	return [
+		{
+			id: 'sites-walkthrough-intro',
+			popoverPosition: 'bottom right',
+			title: translate( 'Manage all your sites' ),
+			description: translate( 'Here you can find your sites and detailed overview about each.' ),
+		},
+		{
+			id: 'sites-walkthrough-stats',
+			popoverPosition: 'bottom right',
+			title: translate( '📊 Stats' ),
+			description: translate(
+				'Here you can see page view metrics and how they evolved over the last 7 days.'
+			),
+		},
+		{
+			id: 'sites-walkthrough-boost',
+			popoverPosition: 'bottom right',
+			title: translate( '🚀 Boost score rating' ),
+			description: translate(
+				"Here's a score reflecting your website's load speed. Click 'Get Score' to know your site's speed rating – it's free!"
+			),
+		},
+		{
+			id: 'sites-walkthrough-backup',
+			popoverPosition: 'bottom right',
+			title: translate( '🛡️ Backups' ),
+			description: translate(
+				'We automatically back up your site and safeguard your data. Restoring is as simple as a single click.'
+			),
+		},
+		{
+			id: 'sites-walkthrough-monitor',
+			popoverPosition: 'bottom left',
+			title: translate( '⏲️ Uptime Monitor' ),
+			description: (
+				<>
+					{ translate(
+						"We keep tabs on your site's uptime. Simply toggle this on, and we'll alert you if your site goes down."
+					) }
+					<br />
+					<br />
+					{ translate(
+						'🟢 With the premium plan, you can tweak notification settings to alert multiple recipients simultaneously.'
+					) }
+				</>
+			),
+		},
+		{
+			id: 'sites-walkthrough-scan',
+			popoverPosition: 'bottom right',
+			title: translate( '🔍 Scan' ),
+			description: translate(
+				'We scan your site and flag any detected issues using a traffic light warning system – 🔴 for severe or 🟡 for a warning.'
+			),
+		},
+		{
+			id: 'sites-walkthrough-plugins',
+			popoverPosition: 'bottom right',
+			title: translate( '🔌 Plugin updates' ),
+			description: (
+				<>
+					{ translate(
+						"We keep an eye on the status of your plugins for every site. If any plugins require updates, we'll let you know."
+					) }
+					<br />
+					<br />
+					{ translate(
+						"From here, you can update individually, enable auto-updates, or update all plugins simultaneously. Oh, and it's all free."
+					) }
+				</>
+			),
+		},
+		{
+			id: 'sites-walkthrough-site-preview',
+			nextStepOnTargetClick: true,
+			popoverPosition: 'bottom right',
+			title: translate( '🔍 Detailed views' ),
+			description: translate(
+				'Click the arrow for detailed insights on stats, site speed performance, recent backups, and monitoring activity trends. Handy, right?'
+			),
+		},
+		{
+			id: 'sites-walkthrough-site-preview-tabs',
+			popoverPosition: 'bottom right',
+			title: translate( '🔍 Detailed site view' ),
+			description: (
+				<>
+					{ translate( "Great! You're now viewing detailed insights." ) }
+					<br />
+					<br />
+					{ translate(
+						'Use the tabs to navigate between site speed, backups, uptime monitor, activity trends, and plugins.'
+					) }
+				</>
+			),
+		},
+	];
+}

--- a/client/sites-dashboard/data/guided-tours/use-guided-tours.tsx
+++ b/client/sites-dashboard/data/guided-tours/use-guided-tours.tsx
@@ -1,0 +1,16 @@
+import useAddNewSiteTour from './tours/use-add-new-site-tour';
+import useSitesWalkthroughTour from './tours/use-sites-walkthrough-tour';
+
+export type TourId = 'sitesWalkthrough' | 'addSiteStep1';
+
+export default function useGuidedTour( id: TourId | null ) {
+	const sitesWalkthrough = useSitesWalkthroughTour();
+	const addNewSite = useAddNewSiteTour();
+
+	const tours = {
+		sitesWalkthrough: sitesWalkthrough,
+		addSiteStep1: addNewSite,
+	};
+
+	return id ? tours[ id ] : [];
+}

--- a/client/sites-dashboard/hooks/use-no-active-site.ts
+++ b/client/sites-dashboard/hooks/use-no-active-site.ts
@@ -1,0 +1,24 @@
+import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function useNoActiveSite() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const { data, isFetched } = useFetchDashboardSites( {
+		isPartnerOAuthTokenLoaded: false,
+		searchQuery: '',
+		currentPage: 1,
+		filter: {
+			issueTypes: [],
+			showOnlyFavorites: false,
+		},
+		sort: {
+			field: '',
+			direction: '',
+		},
+		agencyId,
+	} );
+
+	return isFetched && ! data?.sites?.length;
+}

--- a/client/sites-dashboard/index.ts
+++ b/client/sites-dashboard/index.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { getSiteBySlug, getSiteHomeUrl } from 'calypso/state/sites/selectors';
@@ -6,23 +7,29 @@ import {
 	sanitizeQueryParameters,
 	sitesDashboard,
 } from './controller';
+import { sitesContext } from './sections/sites/controller';
 
 export default function () {
-	// Maintain old `/sites/:id` URLs by redirecting them to My Home
-	page( '/sites/:site', ( context ) => {
-		const state = context.store.getState();
-		const site = getSiteBySlug( state, context.params.site );
-		// The site may not be loaded into state yet.
-		const siteId = site?.ID;
-		page.redirect( getSiteHomeUrl( state, siteId ) );
-	} );
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		page( '/sites', sitesContext, makeLayout, clientRender );
+	} else {
+		console.log( 'This is the OLD sites dashboard...' );
+		// Maintain old `/sites/:id` URLs by redirecting them to My Home
+		page( '/sites/:site', ( context ) => {
+			const state = context.store.getState();
+			const site = getSiteBySlug( state, context.params.site );
+			// The site may not be loaded into state yet.
+			const siteId = site?.ID;
+			page.redirect( getSiteHomeUrl( state, siteId ) );
+		} );
 
-	page(
-		'/sites',
-		maybeRemoveCheckoutSuccessNotice,
-		sanitizeQueryParameters,
-		sitesDashboard,
-		makeLayout,
-		clientRender
-	);
+		page(
+			'/sites',
+			maybeRemoveCheckoutSuccessNotice,
+			sanitizeQueryParameters,
+			sitesDashboard,
+			makeLayout,
+			clientRender
+		);
+	}
 }

--- a/client/sites-dashboard/sections/sites-overview/dashboard-data-context.ts
+++ b/client/sites-dashboard/sections/sites-overview/dashboard-data-context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import type { DashboardDataContextInterface } from './types';
+
+const DashboardDataContext = createContext< DashboardDataContextInterface >( {
+	verifiedContacts: {
+		emails: [],
+		phoneNumbers: [],
+		refetchIfFailed: () => {
+			return undefined;
+		},
+	},
+	products: [],
+	isLargeScreen: true,
+} );
+
+export default DashboardDataContext;

--- a/client/sites-dashboard/sections/sites-overview/types.ts
+++ b/client/sites-dashboard/sections/sites-overview/types.ts
@@ -1,0 +1,422 @@
+import { TranslateResult } from 'i18n-calypso';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+// All types based on which the data is populated on the agency dashboard table rows
+export type AllowedTypes = 'site' | 'stats' | 'boost' | 'backup' | 'scan' | 'monitor' | 'plugin';
+
+// Site column object which holds key and title of each column
+export type SiteColumns = Array< {
+	key: AllowedTypes;
+	title: string;
+	className?: string;
+	isExpandable?: boolean;
+	isSortable?: boolean;
+	showInfo?: boolean;
+} >;
+
+export type AllowedStatusTypes =
+	| 'active'
+	| 'inactive'
+	| 'progress'
+	| 'failed'
+	| 'warning'
+	| 'success'
+	| 'disabled'
+	| 'critical';
+
+interface MonitorContactEmail {
+	name: string;
+	email_address: string;
+	verified: boolean;
+}
+interface MonitorContactSMS {
+	name: string;
+	sms_number: string;
+	number: string;
+	country_code: string;
+	country_numeric_code: string;
+	verified: boolean;
+}
+interface MonitorContacts {
+	emails?: Array< MonitorContactEmail >;
+	sms_numbers?: Array< MonitorContactSMS >;
+}
+
+export interface MonitorSettings {
+	monitor_active: boolean;
+	monitor_site_status: boolean;
+	last_down_time: string;
+	check_interval: number;
+	monitor_user_emails: Array< string >;
+	monitor_user_email_notifications: boolean;
+	monitor_user_sms_notifications: boolean;
+	monitor_user_wp_note_notifications: boolean;
+	monitor_notify_additional_user_emails: Array< MonitorContactEmail >;
+	monitor_notify_additional_user_sms: Array< MonitorContactSMS >;
+	is_over_limit: boolean;
+	sms_sent_count: number;
+	sms_monthly_limit: number;
+}
+
+interface StatsObject {
+	total: number;
+	trend: 'up' | 'down' | 'same';
+	trend_change: number;
+}
+export interface SiteStats {
+	views: StatsObject;
+	visitors: StatsObject;
+}
+
+export interface BoostData {
+	overall: number;
+	mobile: number;
+	desktop: number;
+}
+
+export interface Site {
+	sticker: string[];
+	blog_id: number;
+	blogname: string;
+	url: string;
+	url_with_scheme: string;
+	monitor_active: boolean;
+	monitor_site_status: boolean;
+	has_scan: boolean;
+	has_backup: boolean;
+	has_boost: boolean;
+	latest_scan_threats_found: Array< string >;
+	latest_backup_status: string;
+	is_connection_healthy: boolean;
+	awaiting_plugin_updates: Array< string >;
+	is_favorite: boolean;
+	monitor_settings: MonitorSettings;
+	monitor_last_status_change: string;
+	isSelected?: boolean;
+	site_stats: SiteStats;
+	onSelect?: () => void;
+	jetpack_boost_scores: BoostData;
+	php_version_num: number;
+	has_paid_agency_monitor: boolean;
+	is_atomic: boolean;
+	has_pending_boost_one_time_score: boolean;
+	has_vulnerable_plugins: boolean;
+	latest_scan_has_threats_found: boolean;
+	active_paid_subscription_slugs: Array< string >;
+	site_color?: string;
+}
+export interface SiteNode {
+	value: Site;
+	error: boolean;
+	type: AllowedTypes;
+	status: AllowedStatusTypes;
+}
+
+export interface StatsNode {
+	type: AllowedTypes;
+	status: AllowedStatusTypes;
+	value: SiteStats;
+}
+
+export interface BoostNode {
+	type: AllowedTypes;
+	status: AllowedStatusTypes;
+	value: BoostData;
+}
+export interface BackupNode {
+	type: AllowedTypes;
+	status: AllowedStatusTypes;
+	value: string;
+}
+
+export interface ScanNode {
+	type: AllowedTypes;
+	status: AllowedStatusTypes;
+	value: string;
+	threats: number;
+}
+
+export interface PluginNode {
+	type: AllowedTypes;
+	status: AllowedStatusTypes;
+	value: string;
+	updates: number;
+}
+export interface MonitorNode {
+	type: AllowedTypes;
+	status: AllowedStatusTypes;
+	value: string;
+	error?: boolean;
+	settings?: MonitorSettings;
+}
+export interface SiteData {
+	site: SiteNode;
+	stats: StatsNode;
+	boost: BoostNode;
+	backup: BackupNode;
+	scan: ScanNode;
+	plugin: PluginNode;
+	monitor: MonitorNode;
+	isFavorite?: boolean;
+	isSelected?: boolean;
+	onSelect?: () => void;
+}
+
+export interface RowMetaData {
+	row: {
+		value: Site | SiteStats | BoostData | string;
+		status: AllowedStatusTypes;
+	};
+	link: string;
+	isExternalLink: boolean;
+	tooltip?: TranslateResult;
+	tooltipId: string;
+	siteDown?: boolean;
+	isSupported: boolean;
+	eventName: string | undefined;
+}
+
+export type PreferenceType = 'dismiss' | 'view' | 'view_date';
+
+export type Preference = {
+	dismiss?: boolean;
+	view?: boolean;
+	view_date?: string;
+};
+
+export type StatusEventNames = {
+	[ key in AllowedStatusTypes ]?: { small_screen: string; large_screen: string };
+};
+
+export type StatusTooltip = {
+	[ key in AllowedStatusTypes ]?: string;
+};
+
+export type AllowedActionTypes =
+	| 'issue_license'
+	| 'view_activity'
+	| 'view_site'
+	| 'visit_wp_admin'
+	| 'clone_site'
+	| 'site_settings'
+	| 'set_up_site'
+	| 'change_domain'
+	| 'hosting_configuration';
+
+export type ActionEventNames = {
+	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };
+};
+
+export interface DashboardSortInterface {
+	field: string;
+	direction: 'asc' | 'desc' | '';
+}
+export interface DashboardOverviewContextInterface {
+	path: string;
+	search: string;
+	currentPage: number;
+	filter: { issueTypes: Array< AgencyDashboardFilterOption >; showOnlyFavorites: boolean };
+	sort: DashboardSortInterface;
+	showSitesDashboardV2: boolean;
+}
+
+export interface SitesOverviewContextInterface extends DashboardOverviewContextInterface {
+	isBulkManagementActive: boolean;
+	setIsBulkManagementActive: ( value: boolean ) => void;
+	selectedSites: Array< Site >;
+	setSelectedSites: ( value: Array< Site > ) => void;
+	currentLicenseInfo: string | null;
+	showLicenseInfo: ( license: string ) => void;
+	hideLicenseInfo: () => void;
+	mostRecentConnectedSite: string | null;
+	setMostRecentConnectedSite: ( mostRecentConnectedSite: string ) => void;
+	isPopoverOpen: boolean;
+	setIsPopoverOpen: React.Dispatch< React.SetStateAction< boolean > >;
+}
+
+export interface DashboardDataContextInterface {
+	verifiedContacts: {
+		emails: Array< string >;
+		phoneNumbers: Array< string >;
+		refetchIfFailed: () => void;
+	};
+	products: APIProductFamilyProduct[];
+	isLargeScreen: boolean;
+}
+
+export type AgencyDashboardFilterOption =
+	| 'all_issues'
+	| 'backup_failed'
+	| 'backup_warning'
+	| 'threats_found'
+	| 'site_disconnected'
+	| 'site_down'
+	| 'plugin_updates';
+
+export interface AgencyDashboardFilterMap {
+	filterType: AgencyDashboardFilterOption;
+	ref: number;
+}
+
+export type AgencyDashboardFilter = {
+	issueTypes: Array< AgencyDashboardFilterOption >;
+	showOnlyFavorites: boolean;
+};
+
+export type ProductInfo = { name: string; key: string; status: 'rejected' | 'fulfilled' };
+
+export type PurchasedProductsInfo = {
+	selectedSite: string;
+	selectedProducts: Array< ProductInfo >;
+	type?: string;
+};
+
+export interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+	data?: any;
+}
+
+export interface APIToggleFavorite {
+	[ key: string ]: any;
+}
+
+export interface ToggleFavoriteOptions {
+	siteId: number;
+	isFavorite: boolean;
+	agencyId?: number;
+}
+
+interface MonitorURLS {
+	monitor_url: string;
+	options: Array< string >;
+	check_interval: number;
+}
+
+export interface UpdateMonitorSettingsAPIResponse {
+	success: boolean;
+	settings: {
+		email_notifications: boolean;
+		sms_notifications: boolean;
+		wp_note_notifications: boolean;
+		contacts?: MonitorContacts;
+		urls?: MonitorURLS[];
+	};
+}
+
+export interface UpdateMonitorSettingsParams {
+	wp_note_notifications?: boolean;
+	email_notifications?: boolean;
+	sms_notifications?: boolean;
+	contacts?: MonitorContacts;
+	urls?: MonitorURLS[];
+}
+export interface UpdateMonitorSettingsArgs {
+	siteId: number;
+	params: UpdateMonitorSettingsParams;
+}
+
+export interface SubmitProductFeedbackParams {
+	rating: number;
+	feedback: string;
+	source_url: string;
+}
+
+export type SiteMonitorStatus = {
+	[ siteId: number ]: 'loading' | 'completed';
+};
+
+export interface ToggleActivaateMonitorAPIResponse {
+	code: 'success' | 'error';
+	message: string;
+}
+export interface ToggleActivateMonitorArgs {
+	siteId: number;
+	params: { monitor_active: boolean };
+}
+
+export interface Backup {
+	activityTitle: string;
+	activityDescription: { children: { text: string }[] }[];
+	activityName: string;
+	activityTs: number;
+}
+
+export type AllowedMonitorPeriods = 'day' | 'week' | '30 days' | '90 days';
+
+export interface MonitorUptimeAPIResponse {
+	[ key: string ]: { status: string; downtime_in_minutes?: number };
+}
+
+export interface MonitorSettingsEmail {
+	email: string;
+	name: string;
+	verified: boolean;
+}
+
+export interface StateMonitorSettingsSMS {
+	name: string;
+	countryCode: string;
+	countryNumericCode: string;
+	phoneNumber: string;
+	phoneNumberFull: string;
+	verified: boolean;
+}
+
+export interface StateMonitorSettingsEmail extends MonitorSettingsEmail {
+	isDefault?: boolean;
+}
+
+export interface StateMonitorSettingsSMS {
+	name: string;
+	countryCode: string;
+	phoneNumber: string;
+	phoneNumberFull: string;
+	verified: boolean;
+}
+
+export type MonitorSettingsContact = Partial< MonitorSettingsEmail > &
+	Partial< StateMonitorSettingsSMS >;
+
+export type AllowedMonitorContactActions = 'add' | 'verify' | 'edit' | 'remove';
+
+export type AllowedMonitorContactTypes = 'email' | 'sms';
+
+export type StateMonitoringSettingsContact = StateMonitorSettingsEmail | StateMonitorSettingsSMS;
+
+export interface RequestVerificationCodeParams {
+	type: AllowedMonitorContactTypes;
+	value: string;
+	site_ids: Array< number >;
+	// For SMS contacts
+	number?: string;
+	country_code?: string;
+	country_numeric_code?: string;
+}
+
+export interface ValidateVerificationCodeParams {
+	type: AllowedMonitorContactTypes;
+	value: string;
+	verification_code: number;
+}
+
+export interface MonitorContactsResponse {
+	emails: [ { verified: boolean; email_address: string } ];
+	sms_numbers: [ { verified: boolean; sms_number: string; country_numeric_code: string } ];
+}
+
+export type MonitorDuration = { label: string; time: number };
+
+export interface InitialMonitorSettings {
+	enableSMSNotification: boolean;
+	enableEmailNotification: boolean;
+	enableMobileNotification: boolean;
+	selectedDuration: MonitorDuration | undefined;
+	emailContacts?: MonitorSettingsEmail[] | [];
+	phoneContacts?: StateMonitorSettingsSMS[] | [];
+}
+export interface ResendVerificationCodeParams {
+	type: 'email' | 'sms';
+	value: string;
+}

--- a/client/sites-dashboard/sections/sites/constants.ts
+++ b/client/sites-dashboard/sections/sites/constants.ts
@@ -1,4 +1,4 @@
-import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import { SitesViewState } from './sites-dataviews/interfaces';
 import { AgencyDashboardFilterMap } from './types';
 
 export const A4A_SITES_DASHBOARD_DEFAULT_CATEGORY = 'overview';

--- a/client/sites-dashboard/sections/sites/constants.ts
+++ b/client/sites-dashboard/sections/sites/constants.ts
@@ -1,0 +1,33 @@
+import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import { AgencyDashboardFilterMap } from './types';
+
+export const A4A_SITES_DASHBOARD_DEFAULT_CATEGORY = 'overview';
+export const A4A_SITES_DASHBOARD_DEFAULT_FEATURE = 'jetpack-boost';
+
+export const DEFAULT_SORT_FIELD = 'url';
+export const DEFAULT_SORT_DIRECTION = 'asc';
+
+export const filtersMap: AgencyDashboardFilterMap[] = [
+	{ filterType: 'all_issues', ref: 1 },
+	{ filterType: 'backup_failed', ref: 2 },
+	{ filterType: 'backup_warning', ref: 3 },
+	{ filterType: 'threats_found', ref: 4 },
+	{ filterType: 'site_disconnected', ref: 5 },
+	{ filterType: 'site_down', ref: 6 },
+	{ filterType: 'plugin_updates', ref: 7 },
+];
+
+export const initialSitesViewState: SitesViewState = {
+	type: 'table',
+	perPage: 50,
+	page: 1,
+	sort: {
+		field: DEFAULT_SORT_FIELD,
+		direction: DEFAULT_SORT_DIRECTION,
+	},
+	search: '',
+	filters: [],
+	hiddenFields: [ 'status' ],
+	layout: {},
+	selectedSite: undefined,
+};

--- a/client/sites-dashboard/sections/sites/controller.tsx
+++ b/client/sites-dashboard/sections/sites/controller.tsx
@@ -1,0 +1,64 @@
+import { Context, type Callback } from '@automattic/calypso-router';
+import MySitesNavigation from 'calypso/my-sites/navigation';
+import { setAllSitesSelected } from 'calypso/state/ui/actions';
+import {
+	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
+	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
+	DEFAULT_SORT_DIRECTION,
+	DEFAULT_SORT_FIELD,
+} from './constants';
+import SitesDashboard from './sites-dashboard';
+import { SitesDashboardProvider } from './sites-dashboard-provider';
+import type { DashboardSortInterface } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+function configureSitesContext( context: Context ) {
+	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;
+	const siteUrl = context.params.siteUrl;
+	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
+	const hideListingInitialState = !! siteUrl;
+
+	const {
+		s: search,
+		page: contextPage,
+		issue_types,
+		sort_field,
+		sort_direction,
+		is_favorite,
+	} = context.query;
+
+	const sort: DashboardSortInterface = {
+		field: sort_field || DEFAULT_SORT_FIELD,
+		direction: sort_direction || DEFAULT_SORT_DIRECTION,
+	};
+	const currentPage = parseInt( contextPage ) || 1;
+
+	context.primary = (
+		<SitesDashboardProvider
+			categoryInitialState={ category }
+			siteUrlInitialState={ siteUrl }
+			siteFeatureInitialState={ siteFeature }
+			hideListingInitialState={ hideListingInitialState }
+			showOnlyFavoritesInitialState={
+				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
+			}
+			path={ context.path }
+			searchQuery={ search }
+			currentPage={ currentPage }
+			issueTypes={ issue_types }
+			sort={ sort }
+			{ ...( context.featurePreview ? { featurePreview: context.featurePreview } : {} ) }
+		>
+			<SitesDashboard />
+		</SitesDashboardProvider>
+	);
+
+	context.secondary = <MySitesNavigation path={ context.path } />;
+
+	// By definition, Sites Management does not select any one specific site
+	context.store.dispatch( setAllSitesSelected() );
+}
+
+export const sitesContext: Callback = ( context: Context, next ) => {
+	configureSitesContext( context );
+	next();
+};

--- a/client/sites-dashboard/sections/sites/controller.tsx
+++ b/client/sites-dashboard/sections/sites/controller.tsx
@@ -9,7 +9,7 @@ import {
 } from './constants';
 import SitesDashboard from './sites-dashboard';
 import { SitesDashboardProvider } from './sites-dashboard-provider';
-import type { DashboardSortInterface } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import type { DashboardSortInterface } from '../sites-overview/types';
 
 function configureSitesContext( context: Context ) {
 	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;

--- a/client/sites-dashboard/sections/sites/features/jetpack/activity/index.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/activity/index.tsx
@@ -1,0 +1,24 @@
+import ActivityLogV2 from 'calypso/my-sites/activity/activity-log-v2';
+import { useDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import SitePreviewPaneContent from '../../../site-preview-pane/site-preview-pane-content';
+
+import 'calypso/my-sites/activity/activity-log-v2/style.scss';
+import './style.scss';
+
+type Props = {
+	siteId: number;
+};
+
+export function JetpackActivityPreview( { siteId }: Props ) {
+	const dispatch = useDispatch();
+
+	if ( siteId ) {
+		dispatch( setSelectedSiteId( siteId ) );
+	}
+	return (
+		<SitePreviewPaneContent>
+			<ActivityLogV2 />
+		</SitePreviewPaneContent>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/activity/routes.ts
+++ b/client/sites-dashboard/sections/sites/features/jetpack/activity/routes.ts
@@ -1,0 +1,12 @@
+import page from '@automattic/calypso-router';
+import { JETPACK_ACTIVITY_ID } from 'calypso/a8c-for-agencies/sections/sites/features/features';
+
+export default function () {
+	// Intercept the activity log route and redirect to the activity log feature
+	page( '/activity-log/:site', ( context, next ) => {
+		const { site } = context.params;
+		//todo: get the current selected feature family instead of the hardcoded 'overview'
+		page.replace( `/sites/overview/${ site }/${ JETPACK_ACTIVITY_ID }`, context.state, true, true );
+		next();
+	} );
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/activity/style.scss
+++ b/client/sites-dashboard/sections/sites/features/jetpack/activity/style.scss
@@ -1,0 +1,3 @@
+.activity-log-v2 {
+	text-align: left;
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/backup/controller.js
+++ b/client/sites-dashboard/sections/sites/features/jetpack/backup/controller.js
@@ -1,0 +1,199 @@
+import { isJetpackBackupSlug } from '@automattic/calypso-products';
+import Debug from 'debug';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
+import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
+import IsJetpackDisconnectedSwitch from 'calypso/components/jetpack/is-jetpack-disconnected-switch';
+import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
+import { UpsellProductCardPlaceholder } from 'calypso/components/jetpack/upsell-product-card';
+import UpsellSwitch from 'calypso/components/jetpack/upsell-switch';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import { SiteOffsetProvider } from 'calypso/components/site-offset/context';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import BackupContentsPage from 'calypso/my-sites/backup/backup-contents-page';
+import BackupUpsell from 'calypso/my-sites/backup/backup-upsell';
+import BackupCloneFlow from 'calypso/my-sites/backup/clone-flow';
+import BackupsPage from 'calypso/my-sites/backup/main';
+import MultisiteNoBackupPlanSwitch from 'calypso/my-sites/backup/multisite-no-backup-plan-switch';
+import BackupRewindFlow, { RewindFlowPurpose } from 'calypso/my-sites/backup/rewind-flow';
+import WPCOMBackupUpsell from 'calypso/my-sites/backup/wpcom-backup-upsell';
+import WpcomBackupUpsellPlaceholder from 'calypso/my-sites/backup/wpcom-backup-upsell-placeholder';
+import { setFilter } from 'calypso/state/activity-log/actions';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+
+const debug = new Debug( 'calypso:my-sites:backup:controller' );
+
+export function showUpsellIfNoBackup( context, next ) {
+	debug( 'controller: showUpsellIfNoBackup', context.params );
+
+	const UpsellComponent = isJetpackCloud() ? BackupUpsell : WPCOMBackupUpsell;
+	const UpsellPlaceholder = isJetpackCloud()
+		? UpsellProductCardPlaceholder
+		: WpcomBackupUpsellPlaceholder;
+	context.featurePreview = (
+		<>
+			<UpsellSwitch
+				UpsellComponent={ UpsellComponent }
+				QueryComponent={ QueryRewindState }
+				getStateForSite={ getRewindState }
+				isRequestingForSite={ ( state, siteId ) =>
+					'uninitialized' === getRewindState( state, siteId )?.state
+				}
+				display={ context.featurePreview }
+				productSlugTest={ isJetpackBackupSlug }
+			>
+				{ isJetpackCloud() && <SidebarNavigation /> }
+				<UpsellPlaceholder />
+			</UpsellSwitch>
+		</>
+	);
+	next();
+}
+
+export function showJetpackIsDisconnected( context, next ) {
+	debug( 'controller: showJetpackIsDisconnected', context.params );
+
+	const JetpackConnectionFailed = isJetpackCloud() ? (
+		<BackupUpsell reason="no_connected_jetpack" />
+	) : (
+		<WPCOMBackupUpsell reason="no_connected_jetpack" />
+	);
+	context.featurePreview = (
+		<IsJetpackDisconnectedSwitch
+			trueComponent={ JetpackConnectionFailed }
+			falseComponent={ context.featurePreview }
+		/>
+	);
+	next();
+}
+
+export function showNotAuthorizedForNonAdmins( context, next ) {
+	context.featurePreview = (
+		<IsCurrentUserAdminSwitch
+			trueComponent={ context.featurePreview }
+			falseComponent={ <NotAuthorizedPage /> }
+		/>
+	);
+
+	next();
+}
+
+export function showUnavailableForVaultPressSites( context, next ) {
+	debug( 'controller: showUnavailableForVaultPressSites', context.params );
+
+	const message = isJetpackCloud() ? (
+		<BackupUpsell reason="vp_active_on_site" />
+	) : (
+		<WPCOMBackupUpsell reason="vp_active_on_site" />
+	);
+
+	context.featurePreview = (
+		<HasVaultPressSwitch trueComponent={ message } falseComponent={ context.featurePreview } />
+	);
+
+	next();
+}
+
+export function showUnavailableForMultisites( context, next ) {
+	debug( 'controller: showUnavailableForMultisites', context.params );
+
+	// Only show "Multisite not supported" card if the multisite does not already own a Backup subscription.
+	// https://href.li/?https://wp.me/pbuNQi-1jg
+	const message = isJetpackCloud() ? (
+		<BackupUpsell reason="multisite_not_supported" />
+	) : (
+		<WPCOMBackupUpsell reason="multisite_not_supported" />
+	);
+
+	context.featurePreview = (
+		<MultisiteNoBackupPlanSwitch
+			trueComponent={ message }
+			falseComponent={ context.featurePreview }
+		/>
+	);
+
+	next();
+}
+
+/* handles /backup/:site, see `backupMainPath` */
+export function backups( context, next ) {
+	debug( 'controller: backups', context.params );
+
+	// When a user visits `/backup`, we don't want to carry over any filter
+	// selection that could've happened in the Activity Log, otherwise,
+	// the app will render the `SearchResults` component instead of the
+	// `BackupStatus`.
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	context.store.dispatch( setFilter( siteId, {}, true ) );
+
+	const { date } = context.query;
+
+	context.featurePreview = <BackupsPage queryDate={ date } />;
+	next();
+}
+
+/* handles /backup/:site/download/:rewindId, see `backupDownloadPath` */
+export function backupDownload( context, next ) {
+	debug( 'controller: backupDownload', context.params );
+
+	context.featurePreview = (
+		<BackupRewindFlow rewindId={ context.params.rewindId } purpose={ RewindFlowPurpose.DOWNLOAD } />
+	);
+	next();
+}
+
+/* handles /backup/:site/restore/:rewindId, see `backupRestorePath` */
+export function backupRestore( context, next ) {
+	debug( 'controller: backupRestore', context.params );
+
+	context.featurePreview = (
+		<BackupRewindFlow rewindId={ context.params.rewindId } purpose={ RewindFlowPurpose.RESTORE } />
+	);
+	next();
+}
+
+/* handles /backup/:site/granular-restore/:rewindId, see `backupGranularRestorePath` */
+export function backupGranularRestore( context, next ) {
+	debug( 'controller: backupGranularRestore', context.params );
+
+	context.featurePreview = (
+		<>
+			<BackupRewindFlow
+				rewindId={ context.params.rewindId }
+				purpose={ RewindFlowPurpose.GRANULAR_RESTORE }
+			/>
+		</>
+	);
+	next();
+}
+
+/* handles /backup/:site/clone, see `backupClonePath` */
+export function backupClone( context, next ) {
+	debug( 'controller: backupClone', context.params );
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	context.featurePreview = <BackupCloneFlow siteId={ siteId } />;
+	next();
+}
+
+/* handles /backup/:site/contents/:backupDate, see `backupContentsPath` */
+export function backupContents( context, next ) {
+	debug( 'controller: backupContents', context.params );
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	context.featurePreview = (
+		<BackupContentsPage siteId={ siteId } rewindId={ context.params.rewindId } />
+	);
+	next();
+}
+
+export function wrapInSiteOffsetProvider( context, next ) {
+	context.featurePreview = (
+		<SiteOffsetProvider site={ context.params.site }>{ context.featurePreview }</SiteOffsetProvider>
+	);
+	next();
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/backup/index.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/backup/index.tsx
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import { useDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import SitePreviewPaneContent from '../../../site-preview-pane/site-preview-pane-content';
+
+type Props = {
+	siteId: number;
+};
+
+export function JetpackBackupPreview( { siteId }: Props ) {
+	const { featurePreview } = useContext( SitesDashboardContext );
+	const dispatch = useDispatch();
+
+	if ( siteId ) {
+		dispatch( setSelectedSiteId( siteId ) );
+	}
+
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<SitePreviewPaneContent>{ siteId && featurePreview }</SitePreviewPaneContent>
+			</SitePreviewPaneContent>
+		</>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/backup/routes.ts
+++ b/client/sites-dashboard/sections/sites/features/jetpack/backup/routes.ts
@@ -1,0 +1,176 @@
+import page from '@automattic/calypso-router';
+import { Context, type Callback } from '@automattic/calypso-router';
+import { sitesContext } from 'calypso/a8c-for-agencies/sections/sites/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { JETPACK_BACKUP_ID } from '../../features';
+import {
+	backupClone,
+	backupContents,
+	backupDownload,
+	backupGranularRestore,
+	backupRestore,
+	backups,
+	showUpsellIfNoBackup,
+	showJetpackIsDisconnected,
+	showNotAuthorizedForNonAdmins,
+	showUnavailableForVaultPressSites,
+	showUnavailableForMultisites,
+	wrapInSiteOffsetProvider,
+} from './controller';
+
+/* Todo: This code from Jetpack Cloud is not working properly. Commented.
+const notFoundIfNotEnabled = ( context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const showJetpackSection = isJetpackSectionEnabledForSite( state, siteId );
+
+	if ( ! isJetpackCloud() && ! showJetpackSection ) {
+		return notFound( context, next );
+	}
+
+	next();
+};
+*/
+
+const processBackupContext: Callback = ( context: Context, next ) => {
+	context.params.feature = JETPACK_BACKUP_ID;
+	next();
+};
+
+export default function ( basePath: string ) {
+	basePath += `/${ JETPACK_BACKUP_ID }`;
+
+	/* handles /download/:rewindId */
+	page(
+		`${ basePath }/download/:rewindId?`,
+		processBackupContext,
+		backupDownload,
+		wrapInSiteOffsetProvider,
+		showUnavailableForVaultPressSites,
+		showJetpackIsDisconnected,
+		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
+		sitesContext,
+		//wpcomAtomicTransfer( WPCOMUpsellPage ),
+		//notFoundIfNotEnabled,
+		makeLayout,
+		clientRender
+	);
+
+	/* handles /restore/:rewindId */
+	page(
+		`${ basePath }/restore/:rewindId?`,
+		processBackupContext,
+		backupRestore,
+		wrapInSiteOffsetProvider,
+		showUnavailableForVaultPressSites,
+		showJetpackIsDisconnected,
+		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
+		sitesContext,
+		//wpcomAtomicTransfer( WPCOMUpsellPage ),
+		//notFoundIfNotEnabled,
+		makeLayout,
+		clientRender
+	);
+
+	/* handles /clone */
+	page(
+		`${ basePath }/clone`,
+		processBackupContext,
+		backupClone,
+		wrapInSiteOffsetProvider,
+		showUnavailableForVaultPressSites,
+		showJetpackIsDisconnected,
+		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
+		sitesContext,
+		//wpcomAtomicTransfer( WPCOMUpsellPage ),
+		//notFoundIfNotEnabled,
+		makeLayout,
+		clientRender
+	);
+
+	/* handles /contents/:rewindId, see `backupContentsPath` */
+	page(
+		`${ basePath }/contents/:rewindId?`,
+		processBackupContext,
+		backupContents,
+		wrapInSiteOffsetProvider,
+		showUnavailableForVaultPressSites,
+		showJetpackIsDisconnected,
+		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
+		sitesContext,
+		//wpcomAtomicTransfer( WPCOMUpsellPage ),
+		//notFoundIfNotEnabled,
+		makeLayout,
+		clientRender
+	);
+
+	/* handles /granular-restore/:rewindId, see `backupGranularRestorePath` */
+	page(
+		`${ basePath }/granular-restore/:rewindId?`,
+		processBackupContext,
+		backupGranularRestore,
+		wrapInSiteOffsetProvider,
+		showUnavailableForVaultPressSites,
+		showJetpackIsDisconnected,
+		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
+		sitesContext,
+		//wpcomAtomicTransfer( WPCOMUpsellPage ),
+		//notFoundIfNotEnabled,
+		makeLayout,
+		clientRender
+	);
+
+	/* handles the main page / */
+	page(
+		`${ basePath }`,
+		processBackupContext,
+		backups,
+		wrapInSiteOffsetProvider,
+		showUpsellIfNoBackup,
+		showUnavailableForVaultPressSites,
+		showJetpackIsDisconnected,
+		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
+		sitesContext,
+		//wpcomAtomicTransfer( WPCOMUpsellPage ),
+		//notFoundIfNotEnabled,
+		makeLayout,
+		clientRender
+	);
+
+	handleJetpackCloudRedirections();
+}
+
+function handleJetpackCloudRedirections() {
+	const backupSections = [ 'download', 'restore', 'clone', 'contents', 'granular-restore' ];
+	for ( const section of backupSections ) {
+		backupSectionRedirection( section );
+	}
+
+	//Main Backup page
+	page( `/backup/:site`, ( context, next ) => {
+		const { site } = context.params;
+		//todo: get the current selected feature family instead of the hardcoded 'overview'
+		page.replace( `/sites/overview/${ site }/${ JETPACK_BACKUP_ID }`, context.state, true, true );
+		next();
+	} );
+}
+
+function backupSectionRedirection( sectionName: string ) {
+	page( `/backup/:site/${ sectionName }/:rewindId?`, ( context, next ) => {
+		const { site, rewindId } = context.params;
+		//todo: get the current selected feature family instead of the hardcoded 'overview'
+		page.replace(
+			`/sites/overview/${ site }/${ JETPACK_BACKUP_ID }/${ sectionName }/${ rewindId ?? '' }`,
+			context.state,
+			true,
+			true
+		);
+		next();
+	} );
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/jetpack-boost.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/jetpack-boost.tsx
@@ -1,0 +1,23 @@
+import DocumentHead from 'calypso/components/data/document-head';
+import BoostSitePerformance from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../../types';
+
+type Props = {
+	site: Site;
+	trackEvent: ( eventName: string ) => void;
+	hasError?: boolean;
+};
+
+export function JetpackBoostPreview( { site, trackEvent, hasError = false }: Props ) {
+	return (
+		<>
+			<DocumentHead title="Boost" />
+			<SitePreviewPaneContent className="site-preview-pane__boost-content">
+				<BoostSitePerformance site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -1,0 +1,28 @@
+import DocumentHead from 'calypso/components/data/document-head';
+import MonitorActivity from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../../types';
+
+type Props = {
+	site: Site;
+	trackEvent: ( eventName: string ) => void;
+	hasError?: boolean;
+};
+
+export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: Props ) {
+	return (
+		<>
+			<DocumentHead title="Monitor" />
+			<SitePreviewPaneContent className="site-preview-pane__monitor-content">
+				<MonitorActivity
+					hasMonitor={ site.monitor_settings.monitor_active }
+					site={ site }
+					trackEvent={ trackEvent }
+					hasError={ hasError }
+				/>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/jetpack-plugins.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/jetpack-plugins.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@automattic/components';
+import { external, Icon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
+
+type Props = {
+	featureText: string | React.ReactNode;
+	link: string;
+	linkLabel: string;
+	captionText: string;
+};
+
+export function JetpackPluginsPreview( { featureText, link, linkLabel, captionText }: Props ) {
+	const translate = useTranslate();
+	return (
+		<>
+			<DocumentHead title={ translate( 'Plugins' ) } />
+			<SitePreviewPaneContent>
+				<div className="site-preview-pane__plugins-content">
+					<h3>{ featureText }</h3>
+					<p className="site-preview-pane__plugins-caption">{ captionText }</p>
+					<div style={ { marginTop: '24px' } }>
+						<Button href={ link } primary target="_blank">
+							{ linkLabel }
+							<Icon
+								icon={ external }
+								size={ 16 }
+								className="site-preview-pane__plugins-icon"
+								viewBox="0 0 20 20"
+							/>
+						</Button>
+					</div>
+				</div>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -1,0 +1,152 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
+import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import SiteDetails from 'calypso/a8c-for-agencies/sections/sites/features/a4a/site-details';
+import {
+	JETPACK_ACTIVITY_ID,
+	JETPACK_BACKUP_ID,
+	JETPACK_BOOST_ID,
+	JETPACK_MONITOR_ID,
+	JETPACK_PLUGINS_ID,
+	JETPACK_SCAN_ID,
+	JETPACK_STATS_ID,
+	A4A_SITE_DETAILS_ID,
+} from 'calypso/a8c-for-agencies/sections/sites/features/features';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import { useJetpackAgencyDashboardRecordTrackEvent } from 'calypso/jetpack-cloud/sections/agency-dashboard/hooks';
+import { A4A_SITES_DASHBOARD_DEFAULT_FEATURE } from '../../constants';
+import SitePreviewPane, { createFeaturePreview } from '../../site-preview-pane';
+import { PreviewPaneProps } from '../../site-preview-pane/types';
+import { JetpackActivityPreview } from './activity';
+import { JetpackBackupPreview } from './backup';
+import { JetpackBoostPreview } from './jetpack-boost';
+import { JetpackMonitorPreview } from './jetpack-monitor';
+import { JetpackPluginsPreview } from './jetpack-plugins';
+import { JetpackStatsPreview } from './jetpack-stats';
+import { JetpackScanPreview } from './scan';
+
+import './style.scss';
+
+export function JetpackPreviewPane( {
+	site,
+	closeSitePreviewPane,
+	className,
+	isSmallScreen = false,
+	hasError = false,
+}: PreviewPaneProps ) {
+	const translate = useTranslate();
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
+
+	const trackEvent = useCallback(
+		( eventName: string ) => {
+			recordEvent( eventName );
+		},
+		[ recordEvent ]
+	);
+
+	const { selectedSiteFeature, setSelectedSiteFeature } = useContext( SitesDashboardContext );
+
+	useEffect( () => {
+		if ( selectedSiteFeature === undefined ) {
+			setSelectedSiteFeature( A4A_SITES_DASHBOARD_DEFAULT_FEATURE );
+		}
+		return () => {
+			setSelectedSiteFeature( undefined );
+		};
+	}, [] );
+
+	// Jetpack features: Boost, Backup, Monitor, Stats
+	const features = useMemo( () => {
+		const f = [
+			createFeaturePreview(
+				JETPACK_BOOST_ID,
+				'Boost',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackBoostPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+			),
+			createFeaturePreview(
+				JETPACK_BACKUP_ID,
+				'Backup',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackBackupPreview siteId={ site.blog_id } />
+			),
+			createFeaturePreview(
+				JETPACK_SCAN_ID,
+				'Scan',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackScanPreview site={ site } />
+			),
+			createFeaturePreview(
+				JETPACK_MONITOR_ID,
+				'Monitor',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackMonitorPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+			),
+			createFeaturePreview(
+				JETPACK_PLUGINS_ID,
+				translate( 'Plugins' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackPluginsPreview
+					link={ site.url_with_scheme + '/wp-admin/plugins.php' }
+					linkLabel={ translate( 'Manage Plugins in wp-admin' ) }
+					featureText={ translate( 'Manage all plugins installed on %(siteUrl)s', {
+						args: { siteUrl: site.url },
+					} ) }
+					captionText={ translate(
+						"Note: We are currently working to make this section function from the Automattic for Agencies dashboard. In the meantime, you'll be taken to WP-Admin."
+					) }
+				/>
+			),
+			createFeaturePreview(
+				JETPACK_STATS_ID,
+				'Stats',
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackStatsPreview site={ site } trackEvent={ trackEvent } />
+			),
+			createFeaturePreview(
+				JETPACK_ACTIVITY_ID,
+				translate( 'Activity' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<JetpackActivityPreview siteId={ site.blog_id } />
+			),
+		];
+
+		if ( isEnabled( 'a4a/site-details-pane' ) ) {
+			f.push(
+				createFeaturePreview(
+					A4A_SITE_DETAILS_ID,
+					translate( 'Details' ),
+					true,
+					selectedSiteFeature,
+					setSelectedSiteFeature,
+					<SiteDetails site={ site } />
+				)
+			);
+		}
+
+		return f;
+	}, [ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ] );
+
+	return (
+		<SitePreviewPane
+			site={ site }
+			closeSitePreviewPane={ closeSitePreviewPane }
+			features={ features }
+			className={ className }
+		/>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/jetpack-routes.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/jetpack-routes.tsx
@@ -1,0 +1,9 @@
+import loadActivityRoutes from './activity/routes';
+import loadBackupRoutes from './backup/routes';
+import loadScanRoutes from './scan/routes';
+
+export function JetpackFeatureRoutes( basePath: string ) {
+	loadScanRoutes( basePath );
+	loadBackupRoutes( basePath );
+	loadActivityRoutes();
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/jetpack-stats.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/jetpack-stats.tsx
@@ -1,0 +1,26 @@
+import DocumentHead from 'calypso/components/data/document-head';
+import InsightsStats from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats';
+import SitePreviewPaneContent from '../../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../../types';
+
+type Props = {
+	site: Site;
+	trackEvent: ( eventName: string ) => void;
+};
+
+export function JetpackStatsPreview( { site, trackEvent }: Props ) {
+	return (
+		<>
+			<DocumentHead title="Stats" />
+			<SitePreviewPaneContent className="site-preview-pane__stats-content">
+				<InsightsStats
+					stats={ site.site_stats }
+					siteUrlWithScheme={ site.url_with_scheme }
+					trackEvent={ trackEvent }
+				/>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/scan/controller.js
+++ b/client/sites-dashboard/sections/sites/features/jetpack/scan/controller.js
@@ -1,0 +1,124 @@
+import { isJetpackScanSlug } from '@automattic/calypso-products';
+import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
+import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
+import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
+import IsJetpackDisconnectedSwitch from 'calypso/components/jetpack/is-jetpack-disconnected-switch';
+import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
+import ScanHistoryPlaceholder from 'calypso/components/jetpack/scan-history-placeholder';
+import { UpsellProductCardPlaceholder } from 'calypso/components/jetpack/upsell-product-card/index';
+import UpsellSwitch from 'calypso/components/jetpack/upsell-switch';
+import { SiteOffsetProvider } from 'calypso/components/site-offset/context';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import ScanHistoryPage from 'calypso/my-sites/scan/history';
+import ScanPage from 'calypso/my-sites/scan/main';
+import ScanUpsellPage from 'calypso/my-sites/scan/scan-upsell';
+import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-scan-upsell';
+import WpcomScanUpsellPlaceholder from 'calypso/my-sites/scan/wpcom-scan-upsell-placeholder';
+import getSiteScanRequestStatus from 'calypso/state/selectors/get-site-scan-request-status';
+import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
+import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+
+export const showUpsellIfNoScan = ( context, next ) => {
+	const ScanUpsellPlaceholder = isJetpackCloud()
+		? UpsellProductCardPlaceholder
+		: WpcomScanUpsellPlaceholder;
+	context.featurePreview = scanUpsellSwitcher( <ScanUpsellPlaceholder />, context.featurePreview );
+	next();
+};
+
+export const showUpsellIfNoScanHistory = ( context, next ) => {
+	context.featurePreview = scanUpsellSwitcher( <ScanHistoryPlaceholder />, context.featurePreview );
+	next();
+};
+
+export const showNotAuthorizedForNonAdmins = ( context, next ) => {
+	context.featurePreview = (
+		<IsCurrentUserAdminSwitch
+			trueComponent={ context.featurePreview }
+			falseComponent={ <NotAuthorizedPage /> }
+		/>
+	);
+
+	next();
+};
+
+export const showJetpackIsDisconnected = ( context, next ) => {
+	const JetpackConnectionFailed = isJetpackCloud() ? (
+		<ScanUpsellPage reason="no_connected_jetpack" />
+	) : (
+		<WPCOMScanUpsellPage reason="no_connected_jetpack" />
+	);
+	context.featurePreview = (
+		<IsJetpackDisconnectedSwitch
+			trueComponent={ JetpackConnectionFailed }
+			falseComponent={ context.featurePreview }
+		/>
+	);
+	next();
+};
+
+export const showUnavailableForVaultPressSites = ( context, next ) => {
+	const message = isJetpackCloud() ? (
+		<ScanUpsellPage reason="vp_active_on_site" />
+	) : (
+		<WPCOMScanUpsellPage reason="vp_active_on_site" />
+	);
+
+	context.featurePreview = (
+		<HasVaultPressSwitch trueComponent={ message } falseComponent={ context.featurePreview } />
+	);
+
+	next();
+};
+
+export const showUnavailableForMultisites = ( context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	if ( siteId && isJetpackSiteMultiSite( state, siteId ) ) {
+		context.featurePreview = isJetpackCloud() ? (
+			<ScanUpsellPage reason="multisite_not_supported" />
+		) : (
+			<WPCOMScanUpsellPage reason="multisite_not_supported" />
+		);
+	}
+
+	next();
+};
+
+export const scan = ( context, next ) => {
+	const { filter } = context.params;
+	context.featurePreview = <ScanPage filter={ filter } />;
+	next();
+};
+
+export const scanHistory = ( context, next ) => {
+	const { filter } = context.params;
+	context.featurePreview = <ScanHistoryPage filter={ filter } />;
+	next();
+};
+
+function scanUpsellSwitcher( placeholder, primary ) {
+	const UpsellComponent = isJetpackCloud() ? ScanUpsellPage : WPCOMScanUpsellPage;
+	return (
+		<UpsellSwitch
+			UpsellComponent={ UpsellComponent }
+			QueryComponent={ QueryJetpackScan }
+			getStateForSite={ getSiteScanState }
+			isRequestingForSite={ ( state, siteId ) =>
+				'pending' === getSiteScanRequestStatus( state, siteId )
+			}
+			display={ primary }
+			productSlugTest={ isJetpackScanSlug }
+		>
+			{ placeholder }
+		</UpsellSwitch>
+	);
+}
+
+export function wrapInSiteOffsetProvider( context, next ) {
+	context.featurePreview = (
+		<SiteOffsetProvider site={ context.params.site }>{ context.featurePreview }</SiteOffsetProvider>
+	);
+	next();
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/scan/index.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/scan/index.tsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import SitePreviewPaneContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content';
+import { useDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { Site } from '../../../types';
+
+import 'calypso/my-sites/scan/style.scss';
+
+type Props = {
+	site: Site;
+};
+
+export function JetpackScanPreview( { site }: Props ) {
+	const { featurePreview } = useContext( SitesDashboardContext );
+	const dispatch = useDispatch();
+
+	if ( site ) {
+		dispatch( setSelectedSiteId( site.blog_id ) );
+	}
+
+	return (
+		<>
+			<SitePreviewPaneContent>{ site && featurePreview }</SitePreviewPaneContent>
+		</>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/scan/routes.ts
+++ b/client/sites-dashboard/sections/sites/features/jetpack/scan/routes.ts
@@ -1,0 +1,102 @@
+import page from '@automattic/calypso-router';
+import { Context, type Callback } from '@automattic/calypso-router';
+import { sitesContext } from 'calypso/a8c-for-agencies/sections/sites/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { JETPACK_SCAN_ID } from '../../features';
+import {
+	showJetpackIsDisconnected,
+	showNotAuthorizedForNonAdmins,
+	showUpsellIfNoScan,
+	showUpsellIfNoScanHistory,
+	showUnavailableForVaultPressSites,
+	showUnavailableForMultisites,
+	scan,
+	scanHistory,
+	wrapInSiteOffsetProvider,
+} from './controller';
+
+/* Todo: This code from Jetpack Cloud is not working properly. Commented.
+const notFoundIfNotEnabled: Callback = ( context: Context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const showJetpackSection = isJetpackSectionEnabledForSite( state, siteId );
+	const isWPCOMSite = getIsSiteWPCOM( state, siteId );
+
+	if ( isWPCOMSite || ( ! isJetpackCloud() && ! showJetpackSection ) ) {
+		context.featurePreview = 'Not Connected';
+	}
+
+	next();
+};
+*/
+
+const processScanContext: Callback = ( context: Context, next ) => {
+	context.params.feature = JETPACK_SCAN_ID;
+	next();
+};
+
+export default function ( basePath: string ) {
+	basePath += `/${ JETPACK_SCAN_ID }`;
+
+	// Scan History
+	page(
+		`${ basePath }/history/:filter?`,
+		processScanContext,
+		scanHistory,
+		wrapInSiteOffsetProvider,
+		showUpsellIfNoScanHistory,
+		showUnavailableForVaultPressSites,
+		showJetpackIsDisconnected,
+		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
+		sitesContext,
+		//wpcomAtomicTransfer( WPCOMScanUpsellPage ),
+		//notFoundIfNotEnabled,
+		makeLayout,
+		clientRender
+	);
+
+	// Scan Main Page
+	page(
+		`${ basePath }/:filter?`,
+		processScanContext,
+		scan,
+		wrapInSiteOffsetProvider,
+		showUpsellIfNoScan,
+		showUnavailableForVaultPressSites,
+		showJetpackIsDisconnected,
+		showUnavailableForMultisites,
+		showNotAuthorizedForNonAdmins,
+		sitesContext,
+		//notFoundIfNotEnabled,
+		//wpcomAtomicTransfer( WPCOMScanUpsellPage ),
+		//
+		makeLayout,
+		clientRender
+	);
+
+	handleJetpackCloudRedirections();
+}
+
+function handleJetpackCloudRedirections() {
+	// Manage - Scan History page
+	page( '/scan/history/:site/:filter?', ( context, next ) => {
+		const { site, filter } = context.params;
+		//todo: get the current selected feature family instead of the hardcoded 'overview'
+		page.replace(
+			`/sites/overview/${ site }/${ JETPACK_SCAN_ID }/history/${ filter ?? '' }`,
+			context.state,
+			true,
+			true
+		);
+		next();
+	} );
+
+	// Manage - Scan Summary page
+	page( '/scan/:site/:filter?', ( context, next ) => {
+		const { site, filter } = context.params;
+		//todo: get the current selected feature family instead of the hardcoded 'overview'
+		page.replace( `/sites/overview/${ site }/${ JETPACK_SCAN_ID }/${ filter ?? '' }` );
+		next();
+	} );
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/site-details-pane/index.tsx
+++ b/client/sites-dashboard/sections/sites/features/jetpack/site-details-pane/index.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import AgencySiteTags from 'calypso/a8c-for-agencies/components/agency-site-tags';
+import SiteTagType from 'calypso/a8c-for-agencies/types/site-tag';
+import './style.scss';
+
+interface Props {
+	site: any;
+}
+
+export function SiteDetailsPane( { site }: Props ) {
+	const { a4a_agency_id: agencyId, a4a_site_id: siteId, a4a_site_tags: initialTags } = site;
+
+	const [ tags, setTags ] = useState( initialTags.map( ( tag: SiteTagType ) => tag.label ) );
+
+	const onAddTags = ( newTags: string[] ) => {
+		const newTagList = tags.concat( newTags );
+		setTags( newTagList );
+		/* eslint-disable-next-line */
+		console.log( agencyId, siteId, newTagList );
+	};
+
+	const onRemoveTag = ( removeTag: string ) => {
+		const newTagList = tags.filter( ( tag: string ) => tag !== removeTag );
+		setTags( newTagList );
+		/* eslint-disable-next-line */
+		console.log( agencyId, siteId, newTagList );
+	};
+
+	return (
+		<div className="site-details-pane">
+			<AgencySiteTags { ...{ agencyId, siteId, tags, onAddTags, onRemoveTag } } />
+		</div>
+	);
+}

--- a/client/sites-dashboard/sections/sites/features/jetpack/style.scss
+++ b/client/sites-dashboard/sections/sites/features/jetpack/style.scss
@@ -1,0 +1,11 @@
+.sites-dashboard {
+	.activity-log-v2 .button.toolbar__button {
+		display: none !important;
+	}
+
+	.backup__last-backup-status {
+		padding: initial;
+		background: initial;
+	}
+
+}

--- a/client/sites-dashboard/sections/sites/features/overview/index.tsx
+++ b/client/sites-dashboard/sections/sites/features/overview/index.tsx
@@ -1,0 +1,6 @@
+import { PreviewPaneProps } from 'calypso/a8c-for-agencies/sections/sites/site-preview-pane/types';
+import { JetpackPreviewPane } from '../jetpack/jetpack-preview-pane';
+
+export function OverviewFamily( props: PreviewPaneProps ) {
+	return <JetpackPreviewPane { ...props } />;
+}

--- a/client/sites-dashboard/sections/sites/site-favicon/index.tsx
+++ b/client/sites-dashboard/sections/sites/site-favicon/index.tsx
@@ -1,0 +1,30 @@
+import { WordPressLogo } from '@automattic/components';
+import classNames from 'classnames';
+import SiteIcon from 'calypso/blocks/site-icon';
+import { Site } from '../types';
+
+import './style.scss';
+
+interface SiteFaviconProps {
+	site: Site;
+	size?: number;
+	className?: string;
+}
+
+const SiteFavicon = ( { site, size = 40, className = '' }: SiteFaviconProps ) => {
+	const siteColor = site.site_color ?? 'linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4)';
+
+	const defaultFavicon = site.is_atomic ? (
+		<WordPressLogo className="wpcom-favicon" size={ size * 0.8 } />
+	) : (
+		<div className="no-favicon" style={ { background: siteColor } } />
+	);
+
+	return (
+		<div className={ classNames( 'site-favicon', className ) }>
+			<SiteIcon siteId={ site.blog_id } size={ size } defaultIcon={ defaultFavicon } />
+		</div>
+	);
+};
+
+export default SiteFavicon;

--- a/client/sites-dashboard/sections/sites/site-favicon/style.scss
+++ b/client/sites-dashboard/sections/sites/site-favicon/style.scss
@@ -1,0 +1,19 @@
+.site-favicon {
+	margin-right: 16px;
+
+	.site-icon {
+		border-radius: 10px; /* stylelint-disable-line scales/radii */
+		&.is-blank {
+			background: transparent;
+			.wpcom-favicon {
+				fill: var(--studio-blue-50);
+			}
+
+			.no-favicon {
+				width: 100%;
+				height: 100%;
+				background: linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4);
+			}
+		}
+	}
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/index.tsx
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/index.tsx
@@ -1,0 +1,106 @@
+import classNames from 'classnames';
+import React, { useEffect, useState } from 'react';
+import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import SitePreviewPaneHeader from './site-preview-pane-header';
+import { FeaturePreviewInterface, PreviewPaneProps } from './types';
+
+import './style.scss';
+
+export const createFeaturePreview = (
+	id: string,
+	label: string,
+	enabled: boolean,
+	selectedFeatureId: string | undefined,
+	setSelectedFeatureId: ( id: string ) => void,
+	preview: React.ReactNode
+): FeaturePreviewInterface => {
+	return {
+		id,
+		tab: {
+			label,
+			visible: enabled,
+			selected: enabled && selectedFeatureId === id,
+			onTabClick: () => enabled && setSelectedFeatureId( id ),
+		},
+		enabled,
+		preview: enabled ? preview : null,
+	};
+};
+
+export default function SitePreviewPane( {
+	site,
+	features,
+	closeSitePreviewPane,
+	className,
+}: PreviewPaneProps ) {
+	const [ canDisplayNavTabs, setCanDisplayNavTabs ] = useState( false );
+	const [ navRef, setNavRef ] = useState< HTMLElement | null >( null );
+
+	// For future iterations lets consider something other than SectionNav due to the
+	// manipulation we need to make so that the navigation shows correctly on some smaller
+	// screens within the PreviewPane (hence the timeout).
+	useEffect( () => {
+		setTimeout( () => {
+			setCanDisplayNavTabs( true );
+		}, 150 );
+	}, [] );
+
+	// Ensure we have features
+	if ( ! features || ! features.length ) {
+		return null;
+	}
+
+	// Find the selected feature or default to the first feature
+	const selectedFeature = features.find( ( feature ) => feature.tab.selected ) || features[ 0 ];
+
+	// Ensure we have a valid feature
+	if ( ! selectedFeature ) {
+		return null;
+	}
+
+	// Extract the tabs from the features
+	const featureTabs = features.map( ( feature ) => ( {
+		key: feature.id,
+		label: feature.tab.label,
+		selected: feature.tab.selected,
+		onClick: feature.tab.onTabClick,
+		visible: feature.tab.visible,
+	} ) );
+
+	const navItems = featureTabs.map( ( featureTab ) => {
+		if ( ! featureTab.visible ) {
+			return null;
+		}
+		return (
+			<NavItem
+				key={ featureTab.key }
+				selected={ featureTab.selected }
+				onClick={ featureTab.onClick }
+			>
+				{ featureTab.label }
+			</NavItem>
+		);
+	} );
+
+	return (
+		<div className={ classNames( 'site-preview__pane', className ) }>
+			<SitePreviewPaneHeader site={ site } closeSitePreviewPane={ closeSitePreviewPane } />
+			<div ref={ setNavRef }>
+				<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
+					{ navItems && navItems.length > 0 && canDisplayNavTabs ? (
+						<NavTabs>{ navItems }</NavTabs>
+					) : null }
+				</SectionNav>
+			</div>
+			<GuidedTourStep
+				id="sites-walkthrough-site-preview-tabs"
+				tourId="sitesWalkthrough"
+				context={ navRef }
+			/>
+			{ selectedFeature.preview }
+		</div>
+	);
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-content/index.tsx
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-content/index.tsx
@@ -1,0 +1,13 @@
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+type Props = {
+	children?: ReactNode;
+	className?: string;
+};
+
+export default function SitePreviewPaneContent( { children, className }: Props ) {
+	return <div className={ classNames( 'site-preview__content', className ) }>{ children }</div>;
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -1,0 +1,116 @@
+.site-preview__content {
+	flex-grow: 1;
+	background-color: var(--studio-white);
+	padding: 48px;
+	text-align: center;
+	overflow-y: auto;
+
+	.expanded-card {
+		width: auto;
+		max-width: unset !important;
+
+		.site-expanded-content__card-footer {
+			justify-content: unset !important;
+		}
+
+		.expanded-card__header {
+			font-size: 1.25rem;
+			text-overflow: ellipsis;
+			font-weight: 500;
+			text-align: left;
+		}
+
+		.site-expanded-content__card-content-score {
+			text-align: left;
+		}
+	}
+
+	.site-preview-pane__plugins-content {
+		padding: 16px;
+		box-shadow: 0 0 0 1px #dcdcde;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		border-radius: 0.5rem;
+		text-align: left;
+	}
+
+	.site-preview-pane__plugins-caption {
+		padding-top: 16px;
+		font-size: small;
+	}
+
+	.site-preview-pane__plugins-icon {
+		fill: #fff;
+		padding-left: 8px;
+	}
+
+}
+
+.site-preview-pane__stats-content,
+.site-preview-pane__boost-content {
+	.site-expanded-content__card-content-column {
+		flex: unset;
+		max-width: 285px;
+	}
+}
+
+.site-preview-pane__monitor-content {
+
+	text-align: unset !important;
+
+
+	.site-expanded-content__card-content-column {
+		max-width: unset;
+	}
+
+	.chart__bars {
+		overflow: hidden;
+		gap: 3px;
+		margin-bottom: 4px;
+	}
+
+	.chart__bar,
+	.chart__bars {
+		transform-origin: 0 100%;
+		border-radius: 2px;
+	}
+
+	.chart__bar {
+		gap: 2px;
+	}
+	.chart__bar-section {
+		left: 0;
+		right: 0;
+		text-align: unset;
+	}
+
+
+	.site-expanded-content__chart .chart .chart__bar.site-expanded-content__chart-bar-is-uptime .chart__bar-section {
+		border-radius: 2px;
+	}
+}
+
+.site-preview-pane__stats-content {
+
+	.shortened-number {
+		font-size: 2rem;
+	}
+
+	.site-expanded-content__card-content-column {
+		margin-right: 24px;
+	}
+}
+
+.site-preview-pane__boost-content {
+
+	.expanded-card {
+		padding: 16px 24px !important;
+	}
+
+	.site-expanded-content__card-content-column {
+		margin-right: 32px;
+	}
+
+	.site-expanded-content__card-content-score-title {
+		text-align: left;
+	}
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-footer/index.tsx
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-footer/index.tsx
@@ -1,0 +1,17 @@
+import classNames from 'classnames';
+import './style.scss';
+
+type Props = {
+	children?: React.ReactNode;
+	className?: string;
+};
+
+export default function SitePreviewPaneFooter( { children, className }: Props ) {
+	return (
+		children && (
+			<>
+				<div className={ classNames( 'site-preview__footer', className ) }>{ children }</div>
+			</>
+		)
+	);
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-footer/style.scss
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-footer/style.scss
@@ -1,0 +1,6 @@
+.site-preview__footer {
+	height: 48px;
+	background-color: var(--studio-white);
+	padding: 32px 48px;
+	border-top: 1px solid var(--studio-gray-0);
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-header/index.tsx
@@ -1,0 +1,51 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { useMediaQuery } from '@wordpress/compose';
+import { Icon, external } from '@wordpress/icons';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import SiteFavicon from '../../site-favicon';
+import { Site } from '../../types';
+
+import './style.scss';
+
+const ICON_SIZE = 24;
+
+interface Props {
+	site: Site;
+	closeSitePreviewPane?: () => void;
+	className?: string;
+}
+
+export default function SitePreviewPaneHeader( { site, closeSitePreviewPane, className }: Props ) {
+	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
+	const size = isLargerThan960px ? 64 : 50;
+	return (
+		<div className={ classNames( 'site-preview__header', className ) }>
+			<div className="site-preview__header-content">
+				<SiteFavicon site={ site } className="site-preview__header-favicon" size={ size } />
+				<div className="site-preview__header-title-summary">
+					<div className="site-preview__header-title">{ site.blogname }</div>
+					<div className="site-preview__header-summary">
+						<Button
+							variant="link"
+							className="site-preview__header-summary-link"
+							href={ site.url_with_scheme }
+							target="_blank"
+						>
+							<span>{ site.url }</span>
+							<Icon className="sidebar-v2__external-icon" icon={ external } size={ ICON_SIZE } />
+						</Button>
+					</div>
+				</div>
+				<Button
+					onClick={ closeSitePreviewPane }
+					className="site-preview__close-preview"
+					aria-label={ translate( 'Close Preview' ) }
+				>
+					<Gridicon icon="cross" size={ ICON_SIZE } />
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-header/style.scss
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/site-preview-pane-header/style.scss
@@ -1,0 +1,99 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.site-preview__header {
+
+	@media ( min-width: $break-large ) {
+		.site-preview__header-favicon {
+			margin-right: 24px;
+			position: relative;
+		}
+
+		.site-preview__header-content {
+			padding: 48px 48px 24px 48px;
+			display: flex;
+			align-items: center;
+
+			.site-preview__header-title-summary {
+				flex-grow: 1;
+				display: flex;
+				flex-direction: column;
+
+				.site-preview__header-title {
+					font-style: normal;
+					font-weight: 500;
+					font-size: rem(32px);
+					line-height: 32px;
+					color: var(--studio-black);
+					margin-bottom: 4px;
+				}
+
+				.site-preview__header-summary {
+
+					.site-preview__header-summary-link {
+						display: flex;
+						align-items: center;
+						font-size: rem(18px);
+						font-weight: 400;
+						color: var(--studio-gray-70);
+						line-height: 26px;
+						width: fit-content;
+
+						&:focus {
+							box-shadow: none;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@media ( max-width: $break-large ) {
+		display: flex;
+		padding: 24px 24px 8px;
+
+		.sites-dataviews__site-favicon {
+			border-radius: 2px;
+		}
+
+		.site-preview__header-content {
+			flex-grow: 1;
+			display: flex;
+			justify-content: space-between;
+			.site-preview__header-title-summary {
+				word-wrap: anywhere;
+				flex-grow: 1;
+				display: flex;
+				flex-direction: column;
+
+				.site-preview__header-title {
+					font-style: normal;
+					font-weight: 500;
+					font-size: rem(16px);
+					line-height: 16px;
+					color: var(--studio-black);
+					margin-bottom: 4px;
+				}
+
+				.site-preview__header-summary {
+
+					.site-preview__header-summary-link {
+						display: flex;
+						align-items: center;
+						font-size: rem(13px);
+						font-weight: 400;
+						color: var(--studio-gray-70);
+						line-height: 13px;
+						width: fit-content;
+						text-decoration: none;
+
+						&:focus {
+							box-shadow: none;
+						}
+					}
+				}
+
+			}
+		}
+	}
+
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/style.scss
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/style.scss
@@ -1,0 +1,124 @@
+.site-preview__pane {
+	display: flex;
+	flex-direction: column;
+
+	.preview-pane__navigation {
+		clip-path: inset(0 -1px -1px -1px);
+		box-shadow: 0 0 0 1px var(--studio-gray-0), 0 1px 2px var(--color-neutral-0);
+		margin: 0;
+
+		.section-nav-tab__link {
+			color: #000;
+		}
+
+		.section-nav-tab__link:hover {
+			color: #000;
+			background-color: inherit;
+		}
+
+		.section-nav-tabs__list {
+			padding: 0 32px;
+		}
+
+		.section-nav-tab__text {
+			font-weight: 500;
+		}
+
+		.section-nav-tab:not(.is-selected):hover {
+			border-bottom: none;
+		}
+
+		.section-nav-tab {
+			&.is-selected {
+				border-bottom-color: var(--color-neutral-70);
+			}
+		}
+
+		.section-nav-tabs__dropdown .select-dropdown__container {
+			max-width: revert;
+		}
+
+		.section-nav__panel:has(.is-dropdown) {
+			padding: 16px;
+		}
+
+		.select-dropdown.is-open {
+			height: revert;
+		}
+
+		@media (max-width: 850px) {
+			.section-nav__panel {
+				overflow-x: auto;
+			}
+		}
+
+		@media (min-width: 481px) {
+			.section-nav-group {
+				.is-dropdown {
+					width: 100%;
+				}
+			}
+		}
+
+		@media (max-width: 480px) {
+			.section-nav-group {
+				margin-top: 0;
+			}
+			.section-nav-tabs__list {
+				margin: 0 24px;
+				padding: 0 !important;
+				border: 1px solid var(--color-neutral-10) !important;
+			}
+
+			.section-nav__mobile-header {
+				margin: 16px 24px 0 24px;
+				width: 88%;
+				border: 1px solid var(--color-neutral-10) !important;
+				border-radius: 2px;
+				justify-content: space-between;
+			}
+
+			.section-nav-tab__link {
+				color: var(--color-neutral-70);
+				font-weight: 400;
+			}
+
+			.section-nav-tab {
+				.section-nav-tab__link {
+					&:hover {
+						color: var(--color-accent);
+						background-color: var(--color-neutral-5);
+					}
+				}
+
+				&.is-selected {
+					.section-nav-tab__link {
+						color: #fff;
+
+						&:hover {
+							color: #fff;
+							background-color: var(--studio-automattic-60);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@media (max-width: 480px) {
+	.section-nav {
+		box-shadow: 0 0 0 1px #fff !important;
+	}
+
+	.section-nav.is-open {
+		.section-nav__panel {
+			border-top: none !important;
+			background: none !important;
+		}
+
+		.section-nav__mobile-header {
+			background-color: var(--color-neutral-0);
+		}
+	}
+}

--- a/client/sites-dashboard/sections/sites/site-preview-pane/types.ts
+++ b/client/sites-dashboard/sections/sites/site-preview-pane/types.ts
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Site } from '../types';
+
+export interface FeaturePreviewInterface {
+	id: string;
+	tab: FeatureTabInterface;
+	preview?: React.ReactNode;
+	enabled?: boolean;
+}
+
+export interface FeatureTabInterface {
+	label: string;
+	countValue?: number;
+	countColor?: string;
+	selected?: boolean;
+	visible?: boolean;
+	onTabClick?: () => void;
+}
+
+export interface PreviewPaneProps {
+	site: Site;
+	closeSitePreviewPane?: () => void;
+	selectedFeatureId?: string;
+	features?: FeaturePreviewInterface[];
+	className?: string;
+	isSmallScreen?: boolean;
+	hasError?: boolean;
+}

--- a/client/sites-dashboard/sections/sites/site-set-favorite/index.tsx
+++ b/client/sites-dashboard/sections/sites/site-set-favorite/index.tsx
@@ -1,0 +1,198 @@
+import page from '@automattic/calypso-router';
+import { Button } from '@automattic/components';
+import { useQueryClient } from '@tanstack/react-query';
+import { Icon, starFilled, starEmpty } from '@wordpress/icons';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useContext, useEffect, useState } from 'react';
+import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import useToggleFavoriteSiteMutation from 'calypso/data/agency-dashboard/use-toggle-favourite-site-mutation';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
+import type {
+	APIError,
+	Site,
+	APIToggleFavorite,
+	ToggleFavoriteOptions,
+	AgencyDashboardFilter,
+} from '../types';
+import './style.scss';
+
+interface Props {
+	isFavorite: boolean;
+	siteId: number;
+	siteUrl: string;
+}
+
+export default function A4ASiteSetFavorite( { isFavorite, siteId, siteUrl }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
+	const agency = useSelector( getActiveAgency );
+	const agencyId = agency ? agency.id : undefined;
+	const { sitesViewState, showOnlyFavorites, currentPage } = useContext( SitesDashboardContext );
+	const [ filter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
+		issueTypes: [],
+		showOnlyFavorites: showOnlyFavorites || false,
+	} );
+	useEffect( () => {
+		const selectedFilters = getSelectedFilters( sitesViewState.filters );
+
+		setAgencyDashboardFilter( {
+			issueTypes: selectedFilters,
+			showOnlyFavorites: showOnlyFavorites || false,
+		} );
+	}, [ sitesViewState.filters, showOnlyFavorites ] );
+	const search = sitesViewState.search;
+
+	const queryKey = [
+		'jetpack-agency-dashboard-sites',
+		search,
+		currentPage,
+		filter,
+		sitesViewState.sort,
+		sitesViewState.perPage,
+		...( agencyId ? [ agencyId ] : [] ),
+	];
+
+	const siblingQueryKey = [
+		'jetpack-agency-dashboard-sites',
+		search,
+		currentPage,
+		{ ...filter, ...sitesViewState.sort, showOnlyFavorites: ! showOnlyFavorites },
+		...( agencyId ? [ agencyId ] : [] ),
+	];
+	const successNoticeId = 'success-notice';
+
+	const handleViewFavorites = () => {
+		dispatch( removeNotice( successNoticeId ) );
+		page.redirect( '/dashboard/favorites?highlight=favorite-tab' );
+	};
+
+	const handleOnChangeFavoriteSuccess = ( isFavorite: boolean ) => {
+		const text = (
+			<span>
+				{ ! isFavorite
+					? translate( '%(siteUrl)s has been added to your favorites.', {
+							args: {
+								siteUrl,
+							},
+					  } )
+					: translate( '%(siteUrl)s has been removed from your favorites.', {
+							args: {
+								siteUrl,
+							},
+					  } ) }
+				{ ! showOnlyFavorites && (
+					<Button
+						className="site-set-favorite__view-favorite"
+						borderless
+						compact
+						onClick={ handleViewFavorites }
+					>
+						{ translate( 'View Favorites' ) }
+					</Button>
+				) }
+			</span>
+		);
+		const options = {
+			id: successNoticeId,
+		};
+		dispatch( removeNotice( successNoticeId ) );
+		dispatch( successNotice( text, options ) );
+	};
+
+	const handleMutation = () => {
+		return {
+			onMutate: async ( { siteId, isFavorite }: { siteId: number; isFavorite: boolean } ) => {
+				// Cancel any current refetches, so they don't overwrite our optimistic update
+				await queryClient.cancelQueries( {
+					queryKey,
+				} );
+
+				// Snapshot the previous value
+				const previousSites = queryClient.getQueryData( queryKey );
+				// Optimistically update to the new value
+				queryClient.setQueryData( queryKey, ( oldSites: any ) => {
+					return {
+						...oldSites,
+						sites: oldSites?.sites?.map( ( site: Site ) => {
+							if ( site.blog_id === siteId ) {
+								return {
+									...site,
+									is_favorite: ! isFavorite,
+								};
+							}
+							return site;
+						} ),
+					};
+				} );
+
+				// Optimistically update the favorites count of the current query and the sibling query
+				const updateTotalFavorites = ( oldSites: any ) => {
+					const currentCount = oldSites?.total_favorites || 0;
+					return {
+						...oldSites,
+						// Prevent value being set to negative
+						total_favorites: Math.max( currentCount + ( isFavorite ? -1 : 1 ), 0 ),
+					};
+				};
+				queryClient.setQueryData( queryKey, updateTotalFavorites );
+				queryClient.setQueryData( siblingQueryKey, updateTotalFavorites );
+
+				// Store previous settings in case of failure
+				return { previousSites };
+			},
+			onSuccess: ( _data: APIToggleFavorite, options: ToggleFavoriteOptions ) => {
+				handleOnChangeFavoriteSuccess( options.isFavorite );
+			},
+			onError: ( error: APIError, options: any, context: any ) => {
+				queryClient.setQueryData( queryKey, context?.previousSites );
+				const errorMessage = error.message;
+				dispatch( errorNotice( errorMessage ) );
+			},
+			onSettled: () => {
+				queryClient.invalidateQueries( {
+					queryKey,
+				} );
+			},
+		};
+	};
+
+	const { isPending, mutate } = useToggleFavoriteSiteMutation( handleMutation() );
+
+	const handleFavoriteChange = () => {
+		mutate( {
+			siteId,
+			isFavorite,
+			agencyId: agencyId || 0, // Provide a default value for agencyId
+		} );
+		dispatch(
+			recordTracksEvent(
+				isFavorite
+					? 'calypso_jetpack_agency_dashboard_remove_favorite_site'
+					: 'calypso_jetpack_agency_dashboard_set_favorite_site'
+			)
+		);
+	};
+
+	return (
+		<Button
+			borderless
+			compact
+			disabled={ isPending }
+			onClick={ handleFavoriteChange }
+			className={ classNames(
+				'site-set-favorite__favorite-icon',
+				'disable-card-expand',
+				isFavorite && 'site-set-favorite__favorite-icon-active'
+			) }
+			aria-label={ translate( 'Toggle favorite site' ) }
+		>
+			<Icon size={ 24 } icon={ isFavorite ? starFilled : starEmpty } />
+		</Button>
+	);
+}

--- a/client/sites-dashboard/sections/sites/site-set-favorite/index.tsx
+++ b/client/sites-dashboard/sections/sites/site-set-favorite/index.tsx
@@ -5,13 +5,13 @@ import { Icon, starFilled, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useState } from 'react';
-import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
-import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import useToggleFavoriteSiteMutation from 'calypso/data/agency-dashboard/use-toggle-favourite-site-mutation';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
+import { getSelectedFilters } from '../sites-dashboard/get-selected-filters';
+import SitesDashboardContext from '../sites-dashboard-context';
 import type {
 	APIError,
 	Site,

--- a/client/sites-dashboard/sections/sites/site-set-favorite/style.scss
+++ b/client/sites-dashboard/sections/sites/site-set-favorite/style.scss
@@ -1,0 +1,27 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.site-set-favorite__favorite-icon {
+	position: absolute;
+	top: 6px;
+	color: var(--studio-gray-20) !important;
+}
+
+.site-set-favorite__favorite-icon-active {
+	visibility: visible !important;
+	color: var(--color-primary) !important;
+}
+
+button.button.site-set-favorite__view-favorite {
+	color: var(--studio-white);
+	text-decoration: underline;
+	font-size: inherit;
+	position: relative;
+	top: 4px;
+	left: 4px;
+	padding: 0;
+
+	&:hover {
+		color: var(--studio-white);
+	}
+}

--- a/client/sites-dashboard/sections/sites/sites-dashboard-context.ts
+++ b/client/sites-dashboard/sections/sites/sites-dashboard-context.ts
@@ -1,0 +1,43 @@
+import { createContext } from 'react';
+import { initialSitesViewState } from './constants';
+import type { SitesDashboardContextInterface } from './types';
+
+const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
+	selectedCategory: undefined,
+	setSelectedCategory: () => {},
+
+	selectedSiteFeature: undefined,
+	setSelectedSiteFeature: () => {},
+
+	hideListing: undefined,
+	setHideListing: () => {},
+
+	showOnlyFavorites: undefined,
+	setShowOnlyFavorites: () => {},
+
+	sitesViewState: initialSitesViewState,
+	setSitesViewState: () => {},
+
+	initialSelectedSiteUrl: '',
+	currentPage: 1,
+	path: '',
+	featurePreview: null,
+
+	isBulkManagementActive: false,
+	setIsBulkManagementActive: () => {},
+
+	selectedSites: [],
+	setSelectedSites: () => {},
+
+	currentLicenseInfo: null,
+	showLicenseInfo: () => {},
+	hideLicenseInfo: () => {},
+
+	mostRecentConnectedSite: null,
+	setMostRecentConnectedSite: () => {},
+
+	isPopoverOpen: false,
+	setIsPopoverOpen: () => {},
+} );
+
+export default SitesDashboardContext;

--- a/client/sites-dashboard/sections/sites/sites-dashboard-provider.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard-provider.tsx
@@ -1,0 +1,148 @@
+import { ReactNode, useEffect, useState } from 'react';
+import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import {
+	DashboardSortInterface,
+	Site,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { filtersMap, initialSitesViewState } from './constants';
+import SitesDashboardContext from './sites-dashboard-context';
+
+interface Props {
+	showOnlyFavoritesInitialState?: boolean;
+	hideListingInitialState?: boolean;
+	categoryInitialState?: string;
+	siteUrlInitialState?: string;
+	siteFeatureInitialState?: string;
+	searchQuery: string;
+	children: ReactNode;
+	path: string;
+	issueTypes: string;
+	currentPage: number;
+	sort: DashboardSortInterface;
+	featurePreview?: ReactNode | null;
+}
+
+const buildFilters = ( { issueTypes }: { issueTypes: string } ) => {
+	const issueTypesArray = issueTypes?.split( ',' );
+
+	return (
+		issueTypesArray?.map( ( issueType ) => {
+			return {
+				field: 'status',
+				operator: 'in',
+				value: filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref || 1,
+			};
+		} ) || []
+	);
+};
+
+export const SitesDashboardProvider = ( {
+	hideListingInitialState = false,
+	showOnlyFavoritesInitialState = false,
+	categoryInitialState,
+	siteUrlInitialState,
+	siteFeatureInitialState,
+	children,
+	path,
+	searchQuery,
+	issueTypes,
+	currentPage,
+	sort,
+	featurePreview,
+}: Props ) => {
+	const [ hideListing, setHideListing ] = useState( hideListingInitialState );
+	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
+	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
+	const [ showOnlyFavorites, setShowOnlyFavorites ] = useState( showOnlyFavoritesInitialState );
+	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
+	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
+	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
+	const [ mostRecentConnectedSite, setMostRecentConnectedSite ] = useState< string | null >( null );
+	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
+	const [ initialSelectedSiteUrl, setInitialSelectedSiteUrl ] = useState( siteUrlInitialState );
+
+	const handleSetBulkManagementActive = ( isActive: boolean ) => {
+		setIsBulkManagementActive( isActive );
+		if ( ! isActive ) {
+			setSelectedSites( [] );
+		}
+	};
+
+	const onShowLicenseInfo = ( license: string ) => {
+		setCurrentLicenseInfo( license );
+	};
+
+	const onHideLicenseInfo = () => {
+		setCurrentLicenseInfo( null );
+	};
+
+	const [ sitesViewState, setSitesViewState ] = useState< SitesViewState >( {
+		...initialSitesViewState,
+		page: currentPage,
+		search: searchQuery,
+		sort,
+		filters: buildFilters( { issueTypes } ),
+	} );
+
+	useEffect( () => {
+		setInitialSelectedSiteUrl( siteUrlInitialState );
+		if ( ! siteUrlInitialState ) {
+			setShowOnlyFavorites( showOnlyFavoritesInitialState );
+			setHideListing( false );
+		}
+
+		setSitesViewState( ( previousState ) => ( {
+			...previousState,
+			...( siteUrlInitialState
+				? {}
+				: {
+						filters: buildFilters( { issueTypes } ),
+				  } ),
+			...( siteUrlInitialState ? {} : { search: searchQuery } ),
+			...( siteUrlInitialState ? {} : { sort } ),
+			...( siteUrlInitialState ? {} : { selectedSite: undefined } ),
+			...( siteUrlInitialState ? {} : { type: 'table' } ),
+		} ) );
+	}, [
+		setSitesViewState,
+		showOnlyFavoritesInitialState,
+		searchQuery,
+		sort,
+		issueTypes,
+		siteUrlInitialState,
+		setInitialSelectedSiteUrl,
+	] );
+
+	const sitesDashboardContextValue = {
+		selectedCategory: selectedCategory,
+		setSelectedCategory: setSelectedCategory,
+		selectedSiteFeature: selectedSiteFeature,
+		setSelectedSiteFeature: setSelectedSiteFeature,
+		hideListing: hideListing,
+		setHideListing: setHideListing,
+		showOnlyFavorites: showOnlyFavorites,
+		setShowOnlyFavorites: setShowOnlyFavorites,
+		path,
+		currentPage,
+		isBulkManagementActive,
+		initialSelectedSiteUrl: initialSelectedSiteUrl,
+		setIsBulkManagementActive: handleSetBulkManagementActive,
+		selectedSites,
+		setSelectedSites,
+		currentLicenseInfo,
+		showLicenseInfo: onShowLicenseInfo,
+		hideLicenseInfo: onHideLicenseInfo,
+		mostRecentConnectedSite,
+		setMostRecentConnectedSite,
+		isPopoverOpen,
+		setIsPopoverOpen,
+		sitesViewState,
+		setSitesViewState,
+		featurePreview,
+	};
+	return (
+		<SitesDashboardContext.Provider value={ sitesDashboardContextValue }>
+			{ children }
+		</SitesDashboardContext.Provider>
+	);
+};

--- a/client/sites-dashboard/sections/sites/sites-dashboard-provider.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard-provider.tsx
@@ -1,8 +1,5 @@
 import { ReactNode, useEffect, useState } from 'react';
-import {
-	DashboardSortInterface,
-	Site,
-} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { DashboardSortInterface, Site } from '../sites-overview/types';
 import { filtersMap, initialSitesViewState } from './constants';
 import SitesDashboardContext from './sites-dashboard-context';
 import { SitesViewState } from './sites-dataviews/interfaces';

--- a/client/sites-dashboard/sections/sites/sites-dashboard-provider.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard-provider.tsx
@@ -1,11 +1,11 @@
 import { ReactNode, useEffect, useState } from 'react';
-import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import {
 	DashboardSortInterface,
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { filtersMap, initialSitesViewState } from './constants';
 import SitesDashboardContext from './sites-dashboard-context';
+import { SitesViewState } from './sites-dataviews/interfaces';
 
 interface Props {
 	showOnlyFavoritesInitialState?: boolean;

--- a/client/sites-dashboard/sections/sites/sites-dashboard/empty-state.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/empty-state.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function EmptyState() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const title = translate( 'Sites' );
+
+	const pluginDownloadLink = ''; // FIXME: Provide correct download link.
+	const resourceLink = ''; // FIXME: Provide correct resource link.
+
+	return (
+		<Layout title={ title } wide withBorder sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title } </Title>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<div className="sites-dashboard__empty">
+					<A4ALogo className="sites-dashboard__empty-logo" size={ 64 } />
+
+					<p className="sites-dashboard__empty-message">
+						{ translate(
+							'Add all of your sites to your dashboard by installing the Automattic for Agencies connection plugin. Once connected within wp-admin, your sites will automatically sync here.'
+						) }
+					</p>
+
+					<div className="sites-dashboard__empty-actions">
+						<Button
+							href={ pluginDownloadLink }
+							target="_blank"
+							primary
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_sites_dashboard_download_a4a_plugin_click' )
+								)
+							}
+						>
+							{ translate( 'Download A4A Plugin' ) }
+						</Button>
+						<Button
+							href={ resourceLink }
+							target="_blank"
+							onClick={ () =>
+								dispatch( recordTracksEvent( 'calypso_a4a_sites_dashboard_learn_more_click' ) )
+							}
+						>
+							{ translate( 'Learn more' ) } <Icon icon={ external } size={ 18 } />
+						</Button>
+					</div>
+				</div>
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/sites-dashboard/sections/sites/sites-dashboard/empty-state.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/empty-state.tsx
@@ -2,15 +2,15 @@ import { Button } from '@automattic/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
-import Layout from 'calypso/a8c-for-agencies/components/layout';
-import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
-import LayoutHeader, {
-	LayoutHeaderTitle as Title,
-} from 'calypso/a8c-for-agencies/components/layout/header';
-import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
-import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import Layout from '../../../components/a4a-components/layout';
+import LayoutBody from '../../../components/a4a-components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from '../../../components/a4a-components/layout/header';
+import LayoutTop from '../../../components/a4a-components/layout/top';
+import MobileSidebarNavigation from '../../../components/a4a-components/sidebar/mobile-sidebar-navigation';
 
 export default function EmptyState() {
 	const translate = useTranslate();

--- a/client/sites-dashboard/sections/sites/sites-dashboard/get-selected-filters.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/get-selected-filters.tsx
@@ -1,0 +1,14 @@
+import { Filter } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import { filtersMap } from '../constants';
+
+export function getSelectedFilters( filters: Filter[] ) {
+	return (
+		filters?.map( ( filter ) => {
+			const filterType =
+				filtersMap.find( ( filterMap ) => filterMap.ref === filter.value )?.filterType ||
+				'all_issues';
+
+			return filterType;
+		} ) || []
+	);
+}

--- a/client/sites-dashboard/sections/sites/sites-dashboard/get-selected-filters.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/get-selected-filters.tsx
@@ -1,5 +1,5 @@
-import { Filter } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import { filtersMap } from '../constants';
+import { Filter } from '../sites-dataviews/interfaces';
 
 export function getSelectedFilters( filters: Filter[] ) {
 	return (

--- a/client/sites-dashboard/sections/sites/sites-dashboard/index.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/index.tsx
@@ -1,0 +1,289 @@
+import { isWithinBreakpoint } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { useContext, useEffect, useCallback, useState } from 'react';
+import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutNavigation, {
+	LayoutNavigationTabs as NavigationTabs,
+} from 'calypso/a8c-for-agencies/components/layout/nav';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { type TourId } from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
+import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
+import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features/overview';
+import SitesDataViews from '../sites-dataviews';
+import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
+import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
+import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
+import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import {
+	AgencyDashboardFilter,
+	Site,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import SitesDashboardContext from '../sites-dashboard-context';
+import SitesHeaderActions from '../sites-header-actions';
+import EmptyState from './empty-state';
+import { getSelectedFilters } from './get-selected-filters';
+import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
+import './style.scss';
+
+export default function SitesDashboard() {
+	const { data: liveSites = [], isLoading } = useSiteExcerptsQuery(
+		[],
+		( site ) => ! site.options?.is_domain_only
+	);
+
+	const { data: deletedSites = [] } = useSiteExcerptsQuery(
+		[],
+		( site ) => ! site.options?.is_domain_only,
+		'deleted'
+	);
+	const allSites = liveSites.concat( deletedSites );
+
+	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
+	const dispatch = useDispatch();
+
+	const agency = useSelector( getActiveAgency );
+	const agencyId = agency ? agency.id : undefined;
+
+	const {
+		sitesViewState,
+		setSitesViewState,
+		initialSelectedSiteUrl,
+		selectedSiteFeature,
+		selectedCategory: category,
+		setSelectedCategory: setCategory,
+		showOnlyFavorites,
+		hideListing,
+		setHideListing,
+	} = useContext( SitesDashboardContext );
+
+	const isLargeScreen = isWithinBreakpoint( '>960px' );
+	const isNarrowView = useBreakpoint( '<660px' );
+	// FIXME: We should switch to a new A4A-specific endpoint when it becomes available, instead of using the public-facing endpoint for A4A
+	const { data: products } = useProductsQuery( true );
+
+	const {
+		data: verifiedContacts,
+		refetch: refetchContacts,
+		isError: fetchContactFailed,
+	} = useFetchMonitorVerifiedContacts( false, agencyId );
+
+	const [ agencyDashboardFilter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
+		issueTypes: [],
+		showOnlyFavorites: showOnlyFavorites || false,
+	} );
+
+	useEffect( () => {
+		const selectedFilters = getSelectedFilters( sitesViewState.filters );
+
+		setAgencyDashboardFilter( {
+			issueTypes: selectedFilters,
+			showOnlyFavorites: showOnlyFavorites || false,
+		} );
+	}, [ sitesViewState.filters, setAgencyDashboardFilter, showOnlyFavorites ] );
+
+	const { data, isError, refetch } = useFetchDashboardSites( {
+		isPartnerOAuthTokenLoaded: false,
+		searchQuery: sitesViewState.search,
+		currentPage: sitesViewState.page,
+		filter: agencyDashboardFilter,
+		sort: sitesViewState.sort,
+		perPage: sitesViewState.perPage,
+		agencyId,
+	} );
+
+	const noActiveSite = useNoActiveSite();
+
+	useEffect( () => {
+		if ( sitesViewState.selectedSite && ! initialSelectedSiteUrl ) {
+			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
+			setHideListing( false );
+			return;
+		}
+
+		if ( sitesViewState.selectedSite ) {
+			return;
+		}
+
+		if ( ! isLoading && ! isError && data && initialSelectedSiteUrl ) {
+			const site = data.sites.find( ( site: Site ) => site.url === initialSelectedSiteUrl );
+
+			setSitesViewState( ( prevState ) => ( {
+				...prevState,
+				selectedSite: site,
+				type: 'list',
+			} ) );
+		}
+		// Omitting sitesViewState to prevent infinite loop
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ data, isError, isLoading, initialSelectedSiteUrl, setSitesViewState, setHideListing ] );
+
+	const onSitesViewChange = useCallback(
+		( sitesViewData: SitesViewState ) => {
+			setSitesViewState( sitesViewData );
+		},
+		[ setSitesViewState ]
+	);
+
+	useEffect( () => {
+		// If there isn't a selected site and we are showing only the preview pane we should wait for the selected site to load from the endpoint
+		if ( hideListing && ! sitesViewState.selectedSite ) {
+			return;
+		}
+
+		if ( sitesViewState.selectedSite ) {
+			dispatch( setSelectedSiteId( sitesViewState.selectedSite.blog_id ) );
+		}
+
+		updateSitesDashboardUrl( {
+			category: category,
+			setCategory: setCategory,
+			filters: sitesViewState.filters,
+			selectedSite: sitesViewState.selectedSite,
+			selectedSiteFeature: selectedSiteFeature,
+			search: sitesViewState.search,
+			currentPage: sitesViewState.page,
+			sort: sitesViewState.sort,
+			showOnlyFavorites,
+		} );
+	}, [
+		sitesViewState.selectedSite,
+		selectedSiteFeature,
+		category,
+		setCategory,
+		dispatch,
+		sitesViewState.filters,
+		sitesViewState.search,
+		sitesViewState.page,
+		showOnlyFavorites,
+		sitesViewState.sort,
+		hideListing,
+	] );
+
+	const closeSitePreviewPane = useCallback( () => {
+		if ( sitesViewState.selectedSite ) {
+			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
+			setHideListing( false );
+		}
+	}, [ sitesViewState, setSitesViewState, setHideListing ] );
+
+	useEffect( () => {
+		if ( jetpackSiteDisconnected ) {
+			refetch();
+		}
+	}, [ refetch, jetpackSiteDisconnected ] );
+
+	// This is a basic representation of the feature families for now, with just the Overview tab.
+	const navItems = [
+		{
+			label: translate( 'Overview' ),
+		},
+	].map( ( navItem ) => ( {
+		...navItem,
+		selected: translate( 'Overview' ) === navItem.label,
+		children: navItem.label,
+	} ) );
+
+	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
+	const selectedItemProps = {
+		selectedText: selectedItem.label,
+	};
+
+	const urlParams = new URLSearchParams( window.location.search );
+	let tourId = null;
+	if ( urlParams.get( 'tour' ) === 'sites-walkthrough' ) {
+		tourId = 'sitesWalkthrough';
+	} else if ( urlParams.get( 'tour' ) === 'add-new-site' ) {
+		tourId = 'addSiteStep1';
+	}
+
+	if ( noActiveSite ) {
+		return <EmptyState />;
+	}
+
+	return (
+		<Layout
+			className={ classNames(
+				'sites-dashboard',
+				'sites-dashboard__layout',
+				! sitesViewState.selectedSite && 'preview-hidden'
+			) }
+			wide
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+			title={ sitesViewState.selectedSite ? null : translate( 'Sites' ) }
+		>
+			{ ! hideListing && (
+				<LayoutColumn className="sites-overview" wide>
+					<LayoutTop withNavigation={ navItems.length > 1 }>
+						<LayoutHeader>
+							{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
+							<Actions>
+								<SitesHeaderActions />
+							</Actions>
+						</LayoutHeader>
+						{ navItems.length > 1 && (
+							<LayoutNavigation { ...selectedItemProps }>
+								<NavigationTabs { ...selectedItemProps } items={ navItems } />
+							</LayoutNavigation>
+						) }
+					</LayoutTop>
+
+					{ tourId && <GuidedTour defaultTourId={ tourId as TourId } /> }
+
+					<DashboardDataContext.Provider
+						value={ {
+							verifiedContacts: {
+								emails: verifiedContacts?.emails ?? [],
+								phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+								refetchIfFailed: () => {
+									if ( fetchContactFailed ) {
+										refetchContacts();
+									}
+									return;
+								},
+							},
+							products: products ?? [],
+							isLargeScreen: isLargeScreen || false,
+						} }
+					>
+						<SitesDataViews
+							className={ classNames( 'sites-overview__content', {
+								'is-hiding-navigation': navItems.length <= 1,
+							} ) }
+							data={ allSites }
+							isLoading={ isLoading }
+							isLargeScreen={ isLargeScreen || false }
+							onSitesViewChange={ onSitesViewChange }
+							sitesViewState={ sitesViewState }
+						/>
+					</DashboardDataContext.Provider>
+				</LayoutColumn>
+			) }
+
+			{ sitesViewState.selectedSite && (
+				<LayoutColumn className="site-preview-pane" wide>
+					<OverviewFamily
+						site={ sitesViewState.selectedSite }
+						closeSitePreviewPane={ closeSitePreviewPane }
+						isSmallScreen={ ! isLargeScreen }
+						hasError={ isError }
+					/>
+				</LayoutColumn>
+			) }
+		</Layout>
+	);
+}

--- a/client/sites-dashboard/sections/sites/sites-dashboard/index.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/index.tsx
@@ -3,23 +3,15 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState } from 'react';
-import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
-import { type TourId } from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
-import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
-import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features/overview';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
-import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
-import {
-	AgencyDashboardFilter,
-	Site,
-} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import GuidedTour from '../../../components/a4a-components/guided-tour';
 import Layout from '../../../components/a4a-components/layout';
 import LayoutColumn from '../../../components/a4a-components/layout/column';
 import LayoutHeader, {
@@ -31,6 +23,11 @@ import LayoutNavigation, {
 } from '../../../components/a4a-components/layout/nav';
 import LayoutTop from '../../../components/a4a-components/layout/top';
 import MobileSidebarNavigation from '../../../components/a4a-components/sidebar/mobile-sidebar-navigation';
+import { type TourId } from '../../../data/guided-tours/use-guided-tours';
+import useNoActiveSite from '../../../hooks/use-no-active-site';
+import { OverviewFamily } from '../../sites/features/overview';
+import DashboardDataContext from '../../sites-overview/dashboard-data-context';
+import { AgencyDashboardFilter, Site } from '../../sites-overview/types';
 import SitesDashboardContext from '../sites-dashboard-context';
 import SitesDataViews from '../sites-dataviews';
 import { SitesViewState } from '../sites-dataviews/interfaces';

--- a/client/sites-dashboard/sections/sites/sites-dashboard/index.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/index.tsx
@@ -18,12 +18,10 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import { type TourId } from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
 import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features/overview';
-import SitesDataViews from '../sites-dataviews';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
-import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import {
 	AgencyDashboardFilter,
 	Site,
@@ -34,6 +32,8 @@ import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import SitesDashboardContext from '../sites-dashboard-context';
+import SitesDataViews from '../sites-dataviews';
+import { SitesViewState } from '../sites-dataviews/interfaces';
 import SitesHeaderActions from '../sites-header-actions';
 import EmptyState from './empty-state';
 import { getSelectedFilters } from './get-selected-filters';

--- a/client/sites-dashboard/sections/sites/sites-dashboard/index.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/index.tsx
@@ -4,17 +4,6 @@ import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState } from 'react';
 import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
-import Layout from 'calypso/a8c-for-agencies/components/layout';
-import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
-import LayoutHeader, {
-	LayoutHeaderTitle as Title,
-	LayoutHeaderActions as Actions,
-} from 'calypso/a8c-for-agencies/components/layout/header';
-import LayoutNavigation, {
-	LayoutNavigationTabs as NavigationTabs,
-} from 'calypso/a8c-for-agencies/components/layout/nav';
-import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
-import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { type TourId } from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
 import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import { OverviewFamily } from 'calypso/a8c-for-agencies/sections/sites/features/overview';
@@ -31,6 +20,17 @@ import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors
 import { checkIfJetpackSiteGotDisconnected } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import Layout from '../../../components/a4a-components/layout';
+import LayoutColumn from '../../../components/a4a-components/layout/column';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from '../../../components/a4a-components/layout/header';
+import LayoutNavigation, {
+	LayoutNavigationTabs as NavigationTabs,
+} from '../../../components/a4a-components/layout/nav';
+import LayoutTop from '../../../components/a4a-components/layout/top';
+import MobileSidebarNavigation from '../../../components/a4a-components/sidebar/mobile-sidebar-navigation';
 import SitesDashboardContext from '../sites-dashboard-context';
 import SitesDataViews from '../sites-dataviews';
 import { SitesViewState } from '../sites-dataviews/interfaces';

--- a/client/sites-dashboard/sections/sites/sites-dashboard/style.scss
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/style.scss
@@ -1,0 +1,1059 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+
+.main.a4a-layout.sites-dashboard {
+	padding-block-start: 0;
+
+	.a4a-layout__header-actions {
+		white-space: nowrap;
+	}
+
+	.site-preview-pane .a4a-layout-column__container {
+		display: flex;
+	}
+
+	.a4a-layout-column {
+		@include breakpoint-deprecated( "<660px" ) {
+			border-radius: 0;
+		}
+	}
+
+	.site-actions__actions-large-screen {
+		display: block;
+		margin-left: 10px;
+		margin-right: 10px;
+	}
+
+	.site-actions__actions-small-screen {
+		position: unset;
+		margin-left: 10px;
+		margin-right: 10px;
+	}
+
+	.a4a-layout__top-wrapper:not(.preview-hidden) {
+		padding-block-start: 24px;
+	}
+
+	@media (min-width: $break-large) {
+		background: inherit;
+
+		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-title {
+			font-size: 1.25rem;
+			font-weight: 500;
+		}
+
+		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-subtitle {
+			display: none;
+		}
+
+		.dataviews-view-table tr th:first-child,
+		.dataviews-view-table tr td:first-child {
+			padding-left: 64px;
+		}
+		.dataviews-view-table tr th:last-child,
+		.dataviews-view-table tr td:last-child {
+			padding-right: 64px;
+			width: 20px;
+		}
+	}
+
+	@media (max-width: 660px) {
+		.a4a-layout__header-main {
+			display: none;
+		}
+	}
+
+	@media (max-width: $break-large) {
+		height: calc(100vh - 120px); /* Matches the offset defined in PR #65520 */
+
+		.section-nav__mobile-header {
+			padding: 13px;
+		}
+
+		&.sites-dashboard__layout {
+			.sites-overview {
+				overflow: hidden;
+
+				.sites-overview__page-title-container {
+					display: flex;
+				}
+
+				#sites-overview-add-sites-button {
+					a.button.split-button__main {
+						width: auto;
+						height: auto;
+						font-size: rem(12px);
+						line-height: 24px;
+						padding: 0 12px;
+					}
+				}
+
+				.current-section button {
+					margin-top: 12px;
+					padding: 14px 8px;
+				}
+
+				a.sites-overview__issue-license-button {
+					display: flex;
+					font-size: rem(12px);
+					justify-content: center;
+					align-items: center;
+					height: 28px;
+					flex-grow: 0;
+				}
+
+				.sites-overview__tabs,
+				.dataviews-filters__view-actions {
+					border-bottom: 1px solid var(--studio-gray-5);
+				}
+
+				.sites-overview__content {
+					padding: 0;
+					margin: 0;
+					margin-top: 16px;
+				}
+			}
+		}
+
+		.dataviews-view-table tr th:first-child,
+		.dataviews-view-table tr td:first-child {
+			padding: 8px 24px 8px 8px;
+		}
+		.dataviews-view-table tr td:last-child {
+			padding: 0;
+			padding-inline-end: 8px;
+		}
+
+		.components-button.is-compact.has-icon:not(.has-text).dataviews-filters-button {
+			min-width: 40px;
+		}
+
+		.components-button.is-compact.is-tertiary {
+			margin-right: 8px;
+		}
+
+		.dataviews-filters__view-actions {
+			padding-bottom: 8px;
+
+			& > :first-child {
+				margin-inline-start: 8px;
+			}
+
+			.components-input-control {
+				flex-grow: 1;
+			}
+
+			.components-flex.components-h-stack {
+				flex: 6;
+			}
+
+			.components-button.is-compact.has-icon {
+				flex: 1;
+				margin-left: -12px;
+			}
+		}
+
+		.sites-overview__stats-trend,
+		.sites-overview__column-action-button,
+		.sites-overview__row-status,
+		.toggle-activate-monitoring__toggle-button,
+		.sites-dataviews__favorite-btn-wrapper,
+		.sites-overview__boost-score {
+			display: none;
+		}
+
+		td:nth-child(n+2):nth-child(-n+8) {
+			display: none;
+		}
+
+		tr td:first-child {
+			padding-inline-start: 8px;
+		}
+
+		tr td:last-child {
+			padding-inline-end: 8px;
+		}
+
+		.site-preview__content {
+			padding: 10px 10px 88px; /* 88px matches the padding from PR #39201. */
+
+			.backup__page .main {
+				/* Prevents the backup page from overriding our padding and overflow settings. */
+				padding-bottom: 88px; /* 88px matches the padding from PR #39201. */
+				overflow: hidden;
+			}
+		}
+
+		.dataviews-view-table-wrapper {
+			overflow-y: auto;
+			max-height: calc(100vh - 326px); /* 326px is the size of all the height above and below the dataview, from the edges of the screen, plus 10px offset from the padding. Currently below 9px + 309 above */
+
+			table {
+				width: 100%;
+				max-width: 100vw;
+			}
+
+			th[data-field-id="stats"],
+			th[data-field-id="boost"],
+			th[data-field-id="backup"],
+			th[data-field-id="monitor"],
+			th[data-field-id="scan"],
+			th[data-field-id="plugins"],
+			th[data-field-id="favorite"] {
+				display: none;
+			}
+		}
+	}
+
+	@media (max-width: $break-wide) {
+		&.sites-dashboard__layout:not(.preview-hidden) {
+			flex-direction: column;
+			gap: 0;
+
+			.sites-overview__container {
+				min-height: 0;
+				overflow: hidden;
+			}
+
+			.sites-overview__content {
+				display: none;
+			}
+
+			.sites-overview {
+				width: unset;
+				display: none;
+			}
+		}
+	}
+
+	@media (min-width: $break-wide) {
+		&.sites-dashboard__layout {
+			.dataviews-view-table-wrapper {
+				overflow-y: auto;
+				max-height: calc(100vh - 255px); /* 255px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
+			}
+
+			.is-hiding-navigation .dataviews-view-table-wrapper {
+				overflow-y: auto;
+				max-height: calc(100vh - 182px); /* 182px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
+			}
+		}
+
+		&.sites-dashboard__layout:not(.preview-hidden) {
+			.sites-overview {
+				padding: 0;
+
+				.a4a-layout__viewport {
+					padding-inline: 16px;
+				}
+
+				.a4a-layout__header-title {
+					font-size: rem(20px);
+					font-weight: 500;
+				}
+			}
+
+			.sites-overview__content {
+				padding: 0;
+				padding-inline: 0 !important;
+			}
+
+			.sites-overview__issue-license-button-short-caption {
+				height: 28px;
+				width: auto;
+				line-height: 11px;
+				font-size: rem(12px);
+			}
+
+			.sites-overview__page-subtitle {
+				display: none;
+			}
+
+			.sites-overview__tabs,
+			.dataviews-filters__view-actions {
+				border-bottom: 1px solid var(--studio-gray-5);
+			}
+
+			.dataviews-filters__view-actions {
+				padding: 16px 0;
+				margin: 0;
+				display: flex;
+
+				.components-h-stack {
+					width: unset;
+				}
+
+				.components-h-stack,
+				.components-button {
+					flex-grow: 1;
+				}
+
+			}
+
+			.sites-overview__tabs {
+				padding: 0 24px;
+			}
+
+			.sites-overview__page-title {
+				font-size: rem(20px);
+				font-weight: 500;
+			}
+
+			.sites-overview__issue-license-button {
+				display: flex;
+				font-size: rem(12px);
+				justify-content: center;
+				align-items: center;
+				height: 28px;
+			}
+
+			ul.dataviews-view-list {
+				list-style: none;
+				margin: 0;
+				padding: 0;
+				overflow-y: auto;
+				max-height: calc(100vh - 175px); /* It subtracts the header height to allow scrolling in this block, plus a 10px margin */
+
+				li {
+					padding: 8px 24px;
+					border-bottom: 1px solid var(--studio-gray-5);
+				}
+
+				.dataviews-view-list__fields {
+					display: flex;
+					justify-content: space-between;
+				}
+
+				.components-h-stack,
+				.dataviews-view-list__item {
+					width: 100%;
+				}
+
+				.sites-overview__stats-trend,
+				.sites-overview__column-action-button,
+				.sites-overview__row-status,
+				.toggle-activate-monitoring__toggle-button,
+				.sites-dataviews__favorite-btn-wrapper,
+				.sites-overview__boost-score {
+					display: none;
+				}
+
+				.site-actions__actions-large-screen {
+					display: block;
+				}
+
+			}
+		}
+	}
+
+	thead .dataviews-view-table__row th span {
+		font-size: rem(11px);
+		font-weight: 500;
+		line-height: 20px;
+		color: var(--studio-automattic-80);
+	}
+
+	tr.dataviews-view-table__row th[data-field-id="favorite"] {
+		vertical-align: top;
+	}
+
+	tr.dataviews-view-table__row {
+		&:hover {
+			.site-set-favorite__favorite-icon {
+				visibility: visible;
+			}
+		}
+	}
+
+	.sites-overview__content-wrapper {
+		max-width: none;
+	}
+
+	&.sites-dashboard__layout:not(.preview-hidden) {
+
+
+		.a4a-layout__top-wrapper {
+			padding-block-start: 16px;
+
+			.a4a-layout__header {
+				padding: 0;
+			}
+		}
+
+		.dataviews-filters__view-actions {
+			.components-h-stack {
+				flex-grow: 0;
+				width: 80%;
+				gap: 6px;
+			}
+
+			.components-button {
+				flex-grow: 0;
+			}
+		}
+
+		.components-base-control {
+			width: 86%;
+			margin-right: 6px;
+		}
+
+		.site-preview__open {
+			display: none;
+		}
+	}
+
+	&.sites-dashboard__layout:not(.preview-hidden) .a4a-layout__navigation-wrapper {
+		display: none;
+	}
+
+	&.sites-dashboard__layout {
+
+		.activity-card-list .activity-card .activity-card__time {
+			background: none;
+		}
+
+		.sites-overview__add-site-issue-license-buttons {
+			display: flex;
+			grid-gap: 8px;
+
+			&.is-with-split-button {
+				flex-direction: row;
+
+				> a {
+					flex-grow: 1;
+				}
+
+				.split-button {
+					display: flex;
+				}
+
+				.split-button__main {
+					flex-grow: 1;
+				}
+
+				@media (max-width: $break-small) {
+					> a {
+						flex-grow: 0;
+					}
+				}
+			}
+		}
+
+		.sites-overview__add-new-site {
+			white-space: nowrap;
+		}
+
+		.dataviews-wrapper {
+			.components-button:focus:not(:disabled) {
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+			}
+		}
+
+		.a4a-layout__top-wrapper,
+		.a4a-layout__body {
+			> * {
+				@include breakpoint-deprecated(">660px") {
+					max-width: none;
+				}
+			}
+		}
+
+		.sites-overview {
+			width: 400px;
+			flex: unset;
+			transition: all 0.2s;
+			background: var(--studio-white);
+
+			.site-set-favorite__favorite-icon {
+				position: relative;
+			}
+
+			.sites-overview__content {
+				margin-top: 24px;
+
+				&.is-hiding-navigation {
+					margin-top: 48px; // If there is no navigation bar we need to add a bigger margin.
+				}
+			}
+		}
+
+		@media only screen and (min-width: $break-large) {
+			.sites-overview {
+				padding: 24px 18px;
+			}
+		}
+
+
+		.sites-overview__container {
+			min-height: calc(100vh - 90px);
+		}
+
+		.sites-overview__page-title {
+			font-size: rem(24px);
+		}
+
+		.site-preview__pane {
+			flex-grow: 1;
+			width: auto;
+			transition: flex-grow 0.2s;
+			background: var(--studio-white);
+			max-height: calc(100vh - 32px);
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+		}
+
+
+		&.preview-hidden {
+			.sites-overview {
+				flex-grow: 1;
+				transition: flex-grow 0.2s;
+			}
+
+			.site-preview__pane {
+				max-width: 0;
+				padding: 0;
+			}
+
+			@media only screen and (min-width: $break-large) {
+				.sites-overview {
+					padding: 0;
+					overflow-x: auto;
+					overflow-y: auto;
+
+					.dataviews-filters__view-actions {
+						& > :first-child {
+							margin-inline-start: 64px;
+						}
+
+						& > :last-child {
+							margin-inline-end: 64px;
+						}
+					}
+				}
+			}
+		}
+
+		@media (max-width: 660px) {
+			.sites-overview__page-heading {
+				display: none;
+			}
+		}
+	}
+
+	.sites-overview__add-site-issue-license-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		> a,
+		> button {
+			font-size: 1rem;
+			box-sizing: border-box;
+			max-height: 40px;
+		}
+
+		@include break-large {
+			flex-direction: row;
+		}
+	}
+
+
+	.sites-overview__add-site-issue-license-buttons.is-with-split-button {
+		flex-direction: row;
+
+		> a {
+			flex-grow: 1;
+		}
+
+		.split-button {
+			display: flex;
+		}
+
+		.split-button__main {
+			flex-grow: 1;
+		}
+
+		@include break-small {
+			> a {
+				flex-grow: 0;
+			}
+		}
+	}
+
+	.sites-overview__add-new-site {
+		white-space: nowrap;
+	}
+
+	.sites-overview__column-action-button {
+		max-width: 100%;
+		display: inline-flex;
+		flex-direction: row;
+		justify-content: center;
+		align-items: center;
+		width: fit-content;
+		height: 22px;
+		background: var(--studio-white);
+		box-sizing: border-box;
+		border-radius: 12px; /* stylelint-disable-line scales/radii */
+		font-weight: 500;
+		font-size: 0.75rem;
+		vertical-align: middle;
+		color: var(--studio-gray-80);
+		border: 1px solid var(--studio-gray-5);
+		padding: 2px 11px;
+		cursor: pointer;
+		white-space: nowrap;
+
+		span {
+			margin: 0 0.2em;
+		}
+		svg {
+			margin-inline-start: -0.4em;
+		}
+		&:hover:not(.is-link) {
+			background: var(--studio-gray-80);
+			color: var(--studio-white);
+		}
+
+		&:visited:not(:hover) {
+			color: var(--studio-gray-80);
+		}
+
+		&.is-selected {
+			background: var(--studio-jetpack-green-50);
+			color: var(--studio-white);
+			border: none;
+		}
+
+		&.is-link {
+			border: none;
+			background: none;
+			text-decoration: underline;
+			outline: none;
+			margin: 0;
+			padding: 0;
+
+			&:hover {
+				color: var(--studio-gray-80);
+			}
+		}
+	}
+
+	.sites-overview__grey-icon {
+		vertical-align: middle;
+		color: var(--studio-gray-40);
+	}
+	.sites-overview__icon-active {
+		vertical-align: middle;
+		color: var(--studio-gray-5);
+	}
+	.sites-overview__stats-trend__up,
+	.sites-overview__stats-trend__down {
+		vertical-align: middle;
+		display: inline-flex;
+		margin-inline-start: -5px;
+	}
+	.sites-overview__stats-trend__up {
+		fill: var(--studio-jetpack-green-40);
+	}
+	.sites-overview__stats-trend__down {
+		fill: var(--studio-red-50);
+	}
+	.sites-overview__stats-trend__same .empty-icon {
+		vertical-align: middle;
+		height: 8px;
+		width: 8px;
+		border-radius: 50%;
+		background: var(--studio-gray-5);
+		display: inline-flex;
+		margin-inline-end: 5px;
+		@media screen and (max-width: $break-xlarge) {
+			margin-block-start: 8px;
+		}
+	}
+	.sites-overview__stats .shortened-number,
+	.sites-overview__stats-trend .shortened-number {
+		vertical-align: middle;
+		color: var(--studio-gray-80);
+		font-size: 0.75rem;
+	}
+	.sites-overview__stats-trend svg {
+		position: relative;
+		inset-block-start: 0.3rem;
+		@media screen and (max-width: $break-xlarge) {
+			inset-block-start: 0.27rem;
+		}
+	}
+	.sites-overview__disabled {
+		color: var(--studio-gray-5);
+		cursor: not-allowed;
+		opacity: 0.5;
+		button {
+			pointer-events: none;
+		}
+	}
+	.sites-overview__row-text {
+		display: inline-block;
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: clip;
+		vertical-align: middle;
+		color: var(--studio-gray-100);
+		align-items: center;
+		@include break-zoomed-in {
+			width: calc(100% - 120px);
+			margin-inline-start: 8px;
+			margin-inline-end: 5px;
+			font-size: 1rem !important;
+		}
+	}
+
+	.site-host-info {
+		display: inline-block;
+		margin-inline-end: 10px;
+		min-width: 40px;
+		text-align: center;
+
+		.wordpress-logo {
+			display: inline-block;
+			fill: var(--studio-blue-50);
+			visibility: hidden;
+			margin: auto 0;
+
+			&.is-visible {
+				visibility: visible;
+			}
+		}
+	}
+
+	.sites-overview__error-container {
+		background: #414141;
+		margin: 0 -6px;
+		display: flex;
+		align-items: center;
+		height: 40px;
+		position: relative;
+	}
+	.sites-overview__error-icon {
+		background: #d94f4f;
+		padding: 11px;
+		color: var(--studio-white);
+		width: 5%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	.sites-overview__error-message {
+		font-size: 0.75rem;
+		color: var(--studio-white);
+		padding: 0.5em;
+		margin: auto 0;
+	}
+	.sites-overview__error-message-large-screen {
+		display: none;
+		@include break-wide {
+			display: inline-block;
+		}
+	}
+	.sites-overview__error-message-small-screen {
+		display: inline-block;
+		@include break-wide {
+			display: none;
+		}
+	}
+	.sites-overview__error-message-link {
+		font-size: 0.75rem;
+		color: var(--studio-white) !important;
+		padding: 6px;
+		position: absolute;
+		inset-inline-end: 16px;
+		text-decoration: underline;
+		font-weight: 500;
+	}
+	.sites-overview__badge {
+		font-size: 0.75rem !important;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		vertical-align: middle;
+		@include break-wide {
+			max-width: 70px;
+		}
+		@include break-wide() {
+			max-width: fit-content;
+		}
+	}
+
+	.sites-overview__stats {
+		color: var(--studio-black);
+		display: inline-block;
+		line-height: 17px;
+		height: 18px;
+		padding: 2px 1px;
+	}
+	.sites-overview__tooltip {
+		.popover__arrow {
+			&::before {
+				border-bottom-color: var(--studio-gray-60) !important;
+				inset-block-start: 1px !important;
+			}
+		}
+		.popover__inner {
+			background: var(--studio-gray-60);
+			color: var(--studio-white);
+			padding: 10px 12px;
+			border: none;
+		}
+	}
+	.sites-overview__status-critical {
+		color: var(--studio-red-50);
+		position: absolute;
+		inset-inline-end: 42px;
+		inset-block-start: 50%;
+		transform: translateY(-50%);
+		display: inline-flex;
+	}
+	.sites-overview__status-count {
+		position: absolute;
+		inset-inline-end: 42px;
+		inset-block-start: 50%;
+		transform: translateY(-50%);
+		border-radius: 50%;
+		border-width: 2px;
+		border-style: solid;
+		width: 24px;
+		height: 24px;
+		text-align: center;
+		font-size: 0.75rem;
+		line-height: 20px;
+		box-sizing: border-box;
+	}
+	.sites-overview__status-failed {
+		background-color: var(--studio-red-50);
+		border-color: var(--studio-red-50);
+		color: var(--color-text-inverted);
+	}
+	.sites-overview__status-warning {
+		background-color: var(--studio-yellow-20);
+		border-color: var(--studio-yellow-20);
+		color: var(--color-warning-80);
+	}
+	@keyframes highlight-tab-animation {
+		0% {
+			background: var(--color-neutral-70);
+		}
+		100% {
+			background: unset;
+		}
+	}
+	@keyframes highlight-tab-animation-count {
+		0% {
+			color: var(--color-text-inverted);
+		}
+		100% {
+			color: unset;
+		}
+	}
+	@keyframes highlight-tab-animation-icon {
+		0% {
+			fill: var(--color-text-inverted);
+		}
+		100% {
+			fill: unset;
+		}
+	}
+	.sites-overview__highlight-tab.section-nav {
+		animation: highlight-tab-animation 0.4s linear;
+		.section-nav__mobile-header-text {
+			animation: highlight-tab-animation-count 0.4s linear;
+		}
+		.section-nav__mobile-header .gridicon {
+			animation: highlight-tab-animation-icon 0.4s linear;
+		}
+	}
+	.sites-overview__no-sites {
+		text-align: center;
+		font-size: 1.5rem;
+		margin-top: 16px;
+	}
+
+	.sites-overview__issue-licenses-button-small-screen {
+		position: fixed;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		padding: 1rem;
+		background: var(--studio-white);
+		box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.12);
+		z-index: 20;
+
+		.sites-overview__licenses-buttons-issue-license {
+			width: 70%;
+			max-width: 275px;
+		}
+
+		@include break-mobile {
+			text-align: right;
+		}
+
+		@include breakpoint-deprecated( ">660px" ) {
+			left: var(--sidebar-width-min);
+			padding: 0.5rem;
+		}
+	}
+
+	.sites-overview__column-content {
+		font-size: 0.75rem !important;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		vertical-align: middle;
+	}
+
+	.sites-overview__warning {
+		@extend .sites-overview__column-content;
+		color: var(--color-warning-50);
+	}
+
+	.sites-overview__failed {
+		@extend .sites-overview__column-content;
+		color: var(--studio-red-50);
+	}
+
+	.sites-overview__critical {
+		@extend .sites-overview__column-content;
+		padding: 15px;
+		color: var(--studio-red-50);
+	}
+
+	@mixin boost-score-style($color, $background-color) {
+		@extend .sites-overview__column-content;
+		color: $color;
+		background-color: $background-color;
+
+		&:hover,
+		&:active,
+		&:focus {
+			color: $color;
+			background-color: $background-color;
+		}
+	}
+
+	a.sites-overview__boost-score {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 50%;
+		width: 24px;
+		height: 24px;
+		font-weight: 500;
+		user-select: none;
+
+		&.boost-score-good {
+			@include boost-score-style(var(--studio-green-50), var(--studio-green-0));
+		}
+
+		&.boost-score-okay {
+			@include boost-score-style(var(--studio-yellow-50), var(--studio-yellow-0));
+		}
+
+		&.boost-score-bad {
+			@include boost-score-style(var(--studio-red-50), var(--studio-red-0));
+		}
+	}
+
+	.width-fit-content {
+		width: fit-content !important;
+	}
+
+	.site-content__small-screen-view {
+		.sites-overview__icon-active {
+			position: relative;
+			left: 4px;
+		}
+	}
+
+	.fixed-site-column {
+		max-width: 140px !important;
+		min-width: 140px !important;
+	}
+
+	.cursor-pointer {
+		cursor: pointer;
+	}
+
+	.is-loading {
+		opacity: 0.5;
+	}
+
+	.margin-top-16 {
+		margin-top: 16px;
+	}
+
+	.sites-dataviews__favorite-btn-wrapper {
+		position: relative;
+
+		.site-set-favorite__favorite-icon {
+			visibility: hidden;
+			color: var(--color-primary);
+		}
+
+		button.site-set-favorite__favorite-icon {
+			position: unset;
+		}
+
+		&:hover {
+			.site-set-favorite__favorite-icon {
+				visibility: visible;
+			}
+		}
+	}
+}
+
+/* Once LicenseLightboxJetpackManageLicense is ported to A4A, this can be removed */
+.is-section-a8c-for-agencies-sites {
+	.license-lightbox__jetpack-manage-license-title {
+		display: none;
+	}
+}
+
+.sites-dashboard__empty {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	align-items: center;
+
+	margin: 24px auto;
+	padding: 64px 0;
+	max-width: 700px;
+	text-align: center;
+}
+
+.sites-dashboard__empty-message {
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.5;
+}
+
+.sites-dashboard__empty-actions {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+
+	margin: 0 auto;
+
+	> .button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}
+
+/* See wp-calypso/client/layout/style.scss for the original style - this is removed on sites dashboard to enable pagination to display properly. */
+.layout__primary .preview-hidden {
+	@include breakpoint-deprecated( ">960px" ) {
+		padding-bottom: 0 !important;
+	}
+}
+

--- a/client/sites-dashboard/sections/sites/sites-dashboard/test/set-sites-dashboard-url.jsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/test/set-sites-dashboard-url.jsx
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment jsdom
+ */
+import { mockedSites } from '../../../../data/sites.ts';
+import { A4A_SITES_DASHBOARD_DEFAULT_CATEGORY } from '../../constants';
+import { updateSitesDashboardUrl } from '../update-sites-dashboard-url';
+
+describe( 'updateSitesDashboardUrl returns correct URL', () => {
+	const category = 'overview';
+	const setCategoryMock = jest.fn();
+
+	const defaultSitesParams = {
+		setCategory: setCategoryMock,
+		selectedSiteFeature: 'jetpack-boost',
+		currentPage: 1,
+		sort: { field: 'url', direction: 'asc' },
+	};
+
+	const noAdditionalParams = {
+		filters: null,
+		search: null,
+	};
+
+	const filterSearchParams = {
+		filters: [ { field: 'status', operator: 'in', value: 7 } ],
+		search: 'elegant',
+	};
+
+	const defaultSelectedSiteNoAdditionalParams = {
+		...noAdditionalParams,
+		selectedSite: mockedSites[ 0 ],
+	};
+	const defaultSelectedSitePlusFilterSearch = {
+		...filterSearchParams,
+		selectedSite: mockedSites[ 0 ],
+	};
+
+	const defaultNoSelectedSitePlusFilterSearch = {
+		...filterSearchParams,
+		selectedSite: null,
+	};
+
+	const defaultNoSelectedSiteNoAdditionalParams = {
+		...noAdditionalParams,
+		selectedSite: null,
+	};
+
+	test( 'ensure we set the category when a URL is used with a selected site and no category', () => {
+		updateSitesDashboardUrl( {
+			category: null,
+			showOnlyFavorites: false,
+			...defaultSelectedSiteNoAdditionalParams,
+			...defaultSitesParams,
+		} );
+
+		expect( setCategoryMock ).toHaveBeenCalledWith( A4A_SITES_DASHBOARD_DEFAULT_CATEGORY );
+	} );
+
+	test( 'returns correct URL when a site is selected', () => {
+		const updatedUrl = updateSitesDashboardUrl( {
+			category: category,
+			showOnlyFavorites: false,
+			...defaultSelectedSiteNoAdditionalParams,
+			...defaultSitesParams,
+		} );
+
+		expect( setCategoryMock ).toHaveBeenCalledTimes( 1 );
+		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com' );
+	} );
+
+	test( 'returns correct URL when a site is selected with filters and search', () => {
+		const updatedUrl = updateSitesDashboardUrl( {
+			category: category,
+			showOnlyFavorites: false,
+			...defaultSelectedSitePlusFilterSearch,
+			...defaultSitesParams,
+		} );
+
+		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com' );
+	} );
+
+	test( 'returns correct URL with filters and search applied', () => {
+		const updatedUrl = updateSitesDashboardUrl( {
+			category: category,
+			showOnlyFavorites: false,
+			...defaultNoSelectedSitePlusFilterSearch,
+			...defaultSitesParams,
+		} );
+
+		expect( updatedUrl ).toBe( '/sites?s=elegant&issue_types=plugin_updates' );
+	} );
+
+	test( 'returns correct URL for favorites', () => {
+		const updatedUrl = updateSitesDashboardUrl( {
+			category: category,
+			showOnlyFavorites: true,
+			...defaultNoSelectedSiteNoAdditionalParams,
+			...defaultSitesParams,
+		} );
+
+		expect( updatedUrl ).toBe( '/sites?is_favorite' );
+	} );
+
+	test( 'returns correct URL for favorites, with filters and search added', () => {
+		const updatedUrl = updateSitesDashboardUrl( {
+			category: category,
+			...defaultNoSelectedSitePlusFilterSearch,
+			...defaultSitesParams,
+			showOnlyFavorites: true,
+		} );
+
+		expect( updatedUrl ).toBe( '/sites?s=elegant&issue_types=plugin_updates&is_favorite' );
+	} );
+
+	test( 'returns correct URL for favorites plus filters when a site is selected', () => {
+		const updatedUrl = updateSitesDashboardUrl( {
+			category: category,
+			showOnlyFavorites: true,
+			...defaultSelectedSitePlusFilterSearch,
+			...defaultSitesParams,
+		} );
+
+		expect( updatedUrl ).toBe( '/sites/overview/elegantsuperbly.wpcomstaging.com' );
+	} );
+} );

--- a/client/sites-dashboard/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -1,0 +1,117 @@
+import { Filter } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import {
+	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
+	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
+	DEFAULT_SORT_DIRECTION,
+	DEFAULT_SORT_FIELD,
+} from '../constants';
+import { DashboardSortInterface, Site } from '../types';
+import { getSelectedFilters } from './get-selected-filters';
+
+const buildQueryString = ( {
+	filters,
+	search,
+	currentPage,
+	sort,
+	showOnlyFavorites,
+}: {
+	filters: Filter[];
+	search: string;
+	currentPage: number;
+	sort: DashboardSortInterface;
+	showOnlyFavorites?: boolean;
+} ) => {
+	const urlQuery = new URLSearchParams();
+
+	if ( search ) {
+		urlQuery.set( 's', search );
+	}
+
+	if ( currentPage > 1 ) {
+		urlQuery.set( 'page', currentPage.toString() );
+	}
+
+	// ASC is the default sort direction for the URL
+	if (
+		sort.field !== DEFAULT_SORT_FIELD ||
+		( sort.field === DEFAULT_SORT_FIELD && sort.direction !== DEFAULT_SORT_DIRECTION )
+	) {
+		urlQuery.set( 'sort_field', sort.field );
+		urlQuery.set( 'sort_direction', sort.direction );
+	}
+
+	if ( filters && filters.length > 0 ) {
+		const selectedFilters = getSelectedFilters( filters );
+		urlQuery.set( 'issue_types', selectedFilters.join( ',' ) );
+	}
+
+	if ( showOnlyFavorites ) {
+		urlQuery.set( 'is_favorite', '' );
+	}
+
+	const queryString = urlQuery.toString().replace( 'is_favorite=', 'is_favorite' );
+
+	return queryString ? `?${ queryString }` : '';
+};
+
+export const updateSitesDashboardUrl = ( {
+	category,
+	setCategory,
+	filters,
+	selectedSite,
+	selectedSiteFeature,
+	search,
+	currentPage,
+	sort,
+	showOnlyFavorites,
+}: {
+	category?: string;
+	setCategory: ( category: string ) => void;
+	filters: Filter[];
+	selectedSite?: Site;
+	selectedSiteFeature?: string;
+	search: string;
+	currentPage: number;
+	sort: DashboardSortInterface;
+	showOnlyFavorites?: boolean;
+} ) => {
+	// We need a category in the URL if we have a selected site
+	if ( selectedSite && ! category ) {
+		setCategory( A4A_SITES_DASHBOARD_DEFAULT_CATEGORY );
+		return;
+	}
+
+	const baseUrl = '/sites';
+	let url = baseUrl;
+	let shouldAddQueryArgs = true;
+
+	const queryString = buildQueryString( {
+		filters,
+		search,
+		currentPage,
+		sort,
+		showOnlyFavorites,
+	} );
+
+	if (
+		category &&
+		selectedSite &&
+		selectedSiteFeature &&
+		selectedSiteFeature !== A4A_SITES_DASHBOARD_DEFAULT_FEATURE
+	) {
+		// If the selected feature is the default one, we can leave the url a little cleaner, that's why we are comparing to the default feature in the condition above.
+		url = `${ baseUrl }/${ category }/${ selectedSite.url }/${ selectedSiteFeature }`;
+		shouldAddQueryArgs = false;
+	} else if ( category && selectedSite ) {
+		url = `${ baseUrl }/${ category }/${ selectedSite.url }`;
+		shouldAddQueryArgs = false;
+	} else if ( category && category !== A4A_SITES_DASHBOARD_DEFAULT_CATEGORY ) {
+		// If the selected category is the default one, we can leave the url a little cleaner, that's why we are comparing to the default category in the condition above.
+		url = `${ baseUrl }/${ category }`;
+	}
+
+	if ( shouldAddQueryArgs ) {
+		url += queryString;
+	}
+	return url;
+};

--- a/client/sites-dashboard/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -1,10 +1,10 @@
-import { Filter } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import {
 	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
 	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
 	DEFAULT_SORT_DIRECTION,
 	DEFAULT_SORT_FIELD,
 } from '../constants';
+import { Filter } from '../sites-dataviews/interfaces';
 import { DashboardSortInterface, Site } from '../types';
 import { getSelectedFilters } from './get-selected-filters';
 

--- a/client/sites-dashboard/sections/sites/sites-dataviews/index.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dataviews/index.tsx
@@ -1,0 +1,469 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Button, Gridicon, Spinner } from '@automattic/components';
+import { DataViews } from '@wordpress/dataviews';
+import { Icon, starFilled } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useContext, useMemo, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
+import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
+import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
+import SiteSort from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort';
+import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
+import SiteDataField from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/site-data-field';
+import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import A4ASiteSetFavorite from '../site-set-favorite';
+import SiteSetFavorite from '../site-set-favorite';
+import SitesDashboardContext from '../sites-dashboard-context';
+import { AllowedTypes, Site } from '../types';
+import { SitesDataViewsProps, SiteInfo } from './interfaces';
+import './style.scss';
+
+const SitesDataViews = ( {
+	data,
+	isLoading,
+	isLargeScreen,
+	onSitesViewChange,
+	sitesViewState,
+	forceTourExampleSite = false,
+	className,
+}: SitesDataViewsProps ) => {
+	const translate = useTranslate();
+	const { showOnlyFavorites } = useContext( SitesDashboardContext );
+	const totalSites = showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
+	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
+	const totalPages = Math.ceil( totalSites / sitesPerPage );
+	const sites = useFormattedSites( data || [] );
+	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+
+	const openSitePreviewPane = useCallback(
+		( site: Site ) => {
+			onSitesViewChange( {
+				...sitesViewState,
+				selectedSite: site,
+				type: 'list',
+			} );
+		},
+		[ onSitesViewChange, sitesViewState ]
+	);
+
+	const renderField = useCallback(
+		( column: AllowedTypes, item: SiteInfo ) => {
+			if ( isLoading ) {
+				return <TextPlaceholder />;
+			}
+
+			if ( column ) {
+				return (
+					<SiteStatusContent
+						rows={ item }
+						type={ column }
+						isLargeScreen={ isLargeScreen }
+						isFavorite={ item.isFavorite }
+						siteError={ item.site.error }
+					/>
+				);
+			}
+		},
+		[ isLoading, isLargeScreen ]
+	);
+
+	// Legacy refs for guided tour popovers
+	const [ introRef, setIntroRef ] = useState< HTMLElement | null >();
+	const [ statsRef, setStatsRef ] = useState< HTMLElement | null >();
+	const [ boostRef, setBoostRef ] = useState< HTMLElement | null >();
+	const [ backupRef, setBackupRef ] = useState< HTMLElement | null >();
+	const [ monitorRef, setMonitorRef ] = useState< HTMLElement | null >();
+	const [ scanRef, setScanRef ] = useState< HTMLElement | null >();
+	const [ pluginsRef, setPluginsRef ] = useState< HTMLElement | null >();
+	const [ actionsRef, setActionsRef ] = useState< HTMLElement | null >();
+
+	// todo - refactor: extract fields, along actions, to the upper component
+	const fields = useMemo(
+		() => [
+			{
+				id: 'status',
+				header: translate( 'Status' ),
+				getValue: ( { item }: { item: SiteInfo } ) =>
+					item.site.error || item.scan.status === 'critical',
+				render: () => {},
+				type: 'enumeration',
+				elements: [
+					{ value: 1, label: translate( 'Needs Attention' ) },
+					{ value: 2, label: translate( 'Backup Failed' ) },
+					{ value: 3, label: translate( 'Backup Warning' ) },
+					{ value: 4, label: translate( 'Threat Found' ) },
+					{ value: 5, label: translate( 'Site Disconnected' ) },
+					{ value: 6, label: translate( 'Site Down' ) },
+					{ value: 7, label: translate( 'Plugins Needing Updates' ) },
+				],
+				filterBy: {
+					operators: [ 'in' ],
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'site',
+				header: (
+					<>
+						<SiteSort isSortable={ true } columnKey="site">
+							<span
+								className="sites-dataview__site-header sites-dataview__site-header--sort"
+								ref={ ( ref ) => setIntroRef( ref as HTMLElement | null ) }
+							>
+								{ translate( 'Site' ).toUpperCase() }
+							</span>
+						</SiteSort>
+						<GuidedTourStep
+							id="sites-walkthrough-intro"
+							tourId="sitesWalkthrough"
+							context={ introRef }
+						/>
+					</>
+				),
+				getValue: ( { item }: { item: SiteInfo } ) => item.site.value.url,
+				render: ( { item }: { item: SiteInfo } ) => {
+					if ( isLoading ) {
+						return <TextPlaceholder />;
+					}
+					const site = item.site.value;
+					return (
+						<SiteDataField
+							site={ site }
+							isLoading={ isLoading }
+							onSiteTitleClick={ openSitePreviewPane }
+						/>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'stats',
+				header: (
+					<div>
+						<span
+							className="sites-dataview__stats-header"
+							ref={ ( ref ) => setStatsRef( ref as HTMLElement | null ) }
+						>
+							STATS
+						</span>
+						<GuidedTourStep
+							id="sites-walkthrough-stats"
+							tourId="sitesWalkthrough"
+							context={ statsRef }
+						/>
+					</div>
+				),
+				getValue: () => '-',
+				render: ( { item }: { item: SiteInfo } ) => renderField( 'stats', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'boost',
+				header: (
+					<>
+						<span
+							className="sites-dataview__boost-header"
+							ref={ ( ref ) => setBoostRef( ref as HTMLElement | null ) }
+						>
+							BOOST
+						</span>
+						<GuidedTourStep
+							id="sites-walkthrough-boost"
+							tourId="sitesWalkthrough"
+							context={ boostRef }
+						/>
+					</>
+				),
+				getValue: ( { item }: { item: SiteInfo } ) => item.boost.status,
+				render: ( { item }: { item: SiteInfo } ) => renderField( 'boost', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'backup',
+				header: (
+					<>
+						<span
+							className="sites-dataview__backup-header"
+							ref={ ( ref ) => setBackupRef( ref as HTMLElement | null ) }
+						>
+							BACKUP
+						</span>
+						<GuidedTourStep
+							id="sites-walkthrough-backup"
+							tourId="sitesWalkthrough"
+							context={ backupRef }
+						/>
+					</>
+				),
+				getValue: () => '-',
+				render: ( { item }: { item: SiteInfo } ) => renderField( 'backup', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'monitor',
+				header: (
+					<>
+						<span
+							className="sites-dataview__monitor-header"
+							ref={ ( ref ) => setMonitorRef( ref as HTMLElement | null ) }
+						>
+							MONITOR
+						</span>
+						<GuidedTourStep
+							id="sites-walkthrough-monitor"
+							tourId="sitesWalkthrough"
+							context={ monitorRef }
+						/>
+					</>
+				),
+				getValue: () => '-',
+				render: ( { item }: { item: SiteInfo } ) => renderField( 'monitor', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'scan',
+				header: (
+					<>
+						<span
+							className="sites-dataview__scan-header"
+							ref={ ( ref ) => setScanRef( ref as HTMLElement | null ) }
+						>
+							SCAN
+						</span>
+						<GuidedTourStep
+							id="sites-walkthrough-scan"
+							tourId="sitesWalkthrough"
+							context={ scanRef }
+						/>
+					</>
+				),
+				getValue: () => '-',
+				render: ( { item }: { item: SiteInfo } ) => renderField( 'scan', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'plugins',
+				header: (
+					<>
+						<span
+							className="sites-dataview__plugins-header"
+							ref={ ( ref ) => setPluginsRef( ref as HTMLElement | null ) }
+						>
+							PLUGINS
+						</span>
+						<GuidedTourStep
+							id="sites-walkthrough-plugins"
+							tourId="sitesWalkthrough"
+							context={ pluginsRef }
+						/>
+					</>
+				),
+				getValue: () => '-',
+				render: ( { item }: { item: SiteInfo } ) => renderField( 'plugin', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'favorite',
+				header: (
+					<Icon
+						className="site-table__favorite-icon sites-dataview__favorites-header"
+						size={ 24 }
+						icon={ starFilled }
+					/>
+				),
+				getValue: ( { item }: { item: SiteInfo } ) => item.isFavorite,
+				render: ( { item }: { item: SiteInfo } ) => {
+					if ( isLoading ) {
+						return <TextPlaceholder />;
+					}
+					return (
+						<span className="sites-dataviews__favorite-btn-wrapper">
+							{ isA4AEnabled ? (
+								<A4ASiteSetFavorite
+									isFavorite={ item.isFavorite || false }
+									siteId={ item.site.value.blog_id }
+									siteUrl={ item.site.value.url }
+								/>
+							) : (
+								<SiteSetFavorite
+									isFavorite={ item.isFavorite || false }
+									siteId={ item.site.value.blog_id }
+									siteUrl={ item.site.value.url }
+								/>
+							) }
+						</span>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'actions',
+				getValue: ( { item }: { item: SiteInfo } ) => item.isFavorite,
+				render: ( { item }: { item: SiteInfo } ) => {
+					if ( isLoading ) {
+						return <TextPlaceholder />;
+					}
+					return (
+						<div className="sites-dataviews__actions">
+							<SiteActions
+								isLargeScreen={ isLargeScreen }
+								site={ item.site }
+								siteError={ item.site.error }
+							/>
+							<Button
+								onClick={ () => openSitePreviewPane( item.site.value ) }
+								className="site-preview__open"
+								borderless
+								ref={ ( ref ) => setActionsRef( ( current ) => current || ref ) }
+							>
+								<Gridicon icon="chevron-right" />
+							</Button>
+						</div>
+					);
+				},
+				header: (
+					<GuidedTourStep
+						id="sites-walkthrough-site-preview"
+						tourId="sitesWalkthrough"
+						context={ actionsRef }
+					/>
+				),
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[
+			translate,
+			introRef,
+			statsRef,
+			boostRef,
+			backupRef,
+			monitorRef,
+			scanRef,
+			pluginsRef,
+			actionsRef,
+			isLoading,
+			openSitePreviewPane,
+			renderField,
+			isA4AEnabled,
+			isLargeScreen,
+		]
+	);
+
+	// Actions: Pause Monitor, Resume Monitor, Custom Notification, Reset Notification
+	// todo - refactor: extract actions, along fields, to the upper component
+	// Currently not in use until bulk selections are properly implemented.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const actions = useMemo(
+		() => [
+			{
+				id: 'pause-monitor',
+				label: translate( 'Pause Monitor' ),
+				supportsBulk: true,
+				isEligible( site: SiteInfo ) {
+					return site.monitor.status === 'active';
+				},
+				callback() {
+					// todo: pause monitor. Param: sites: SiteInfo[]
+				},
+			},
+			{
+				id: 'resume-monitor',
+				label: translate( 'Resume Monitor' ),
+				supportsBulk: true,
+				isEligible( site: SiteInfo ) {
+					return site.monitor.status === 'inactive';
+				},
+				callback() {
+					// todo: resume monitor. Param: sites: SiteInfo[]
+				},
+			},
+			{
+				id: 'custom-notification',
+				label: translate( 'Custom Notification' ),
+				supportsBulk: true,
+				isEligible( site: SiteInfo ) {
+					return site.monitor.status === 'active';
+				},
+				callback() {
+					// todo: custom notification. Param: sites: SiteInfo[]
+				},
+			},
+			{
+				id: 'reset-notification',
+				label: translate( 'Reset Notification' ),
+				supportsBulk: true,
+				isEligible( site: SiteInfo ) {
+					return site.monitor.status === 'active';
+				},
+				callback() {
+					// todo: reset notification. Param: sites: SiteInfo[]
+				},
+			},
+		],
+		[ translate ]
+	);
+
+	// Until the DataViews package is updated to support the spinner, we need to manually add the (loading) spinner to the table wrapper for now.
+	const SpinnerWrapper = () => {
+		return (
+			<div className="spinner-wrapper">
+				<Spinner />
+			</div>
+		);
+	};
+
+	const dataviewsWrapper = document.getElementsByClassName( 'dataviews-wrapper' )[ 0 ];
+	if ( dataviewsWrapper ) {
+		// Remove any existing spinner if present
+		const existingSpinner = dataviewsWrapper.querySelector( '.spinner-wrapper' );
+		if ( existingSpinner ) {
+			existingSpinner.remove();
+		}
+
+		const spinnerWrapper = dataviewsWrapper.appendChild( document.createElement( 'div' ) );
+		spinnerWrapper.classList.add( 'spinner-wrapper' );
+		// Render the SpinnerWrapper component inside the spinner wrapper
+		ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
+		//}
+	}
+
+	const urlParams = new URLSearchParams( window.location.search );
+	const isOnboardingTourActive = urlParams.get( 'tour' ) !== null;
+	const useExampleDataForTour =
+		forceTourExampleSite || ( isOnboardingTourActive && ( ! sites || sites.length === 0 ) );
+
+	return (
+		<div className={ className }>
+			<DataViews
+				data={ ! useExampleDataForTour ? sites : JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE }
+				paginationInfo={ { totalItems: totalSites, totalPages: totalPages } }
+				fields={ fields }
+				view={ sitesViewState }
+				search={ true }
+				searchLabel={ translate( 'Search for sites' ) }
+				getItemId={ ( item: SiteInfo ) => {
+					item.id = item.site.value.blog_id; // setting the id because of a issue with the DataViews component
+					return item.id;
+				} }
+				onChangeView={ onSitesViewChange }
+				supportedLayouts={ [ 'table' ] }
+				actions={ [] } // Replace with actions when bulk selections are implemented.
+				isLoading={ isLoading }
+			/>
+		</div>
+	);
+};
+
+export default SitesDataViews;

--- a/client/sites-dashboard/sections/sites/sites-dataviews/index.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dataviews/index.tsx
@@ -13,7 +13,6 @@ import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/s
 import SiteDataField from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/site-data-field';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-import A4ASiteSetFavorite from '../site-set-favorite';
 import SiteSetFavorite from '../site-set-favorite';
 import SitesDashboardContext from '../sites-dashboard-context';
 import { AllowedTypes, Site } from '../types';
@@ -288,19 +287,11 @@ const SitesDataViews = ( {
 					}
 					return (
 						<span className="sites-dataviews__favorite-btn-wrapper">
-							{ isA4AEnabled ? (
-								<A4ASiteSetFavorite
-									isFavorite={ item.isFavorite || false }
-									siteId={ item.site.value.blog_id }
-									siteUrl={ item.site.value.url }
-								/>
-							) : (
-								<SiteSetFavorite
-									isFavorite={ item.isFavorite || false }
-									siteId={ item.site.value.blog_id }
-									siteUrl={ item.site.value.url }
-								/>
-							) }
+							<SiteSetFavorite
+								isFavorite={ item.isFavorite || false }
+								siteId={ item.site.value.blog_id }
+								siteUrl={ item.site.value.url }
+							/>
 						</span>
 					);
 				},

--- a/client/sites-dashboard/sections/sites/sites-dataviews/interfaces.ts
+++ b/client/sites-dashboard/sections/sites/sites-dataviews/interfaces.ts
@@ -1,0 +1,45 @@
+import { Site, SiteData } from '../types';
+
+export interface SitesDataResponse {
+	sites: Array< Site >;
+	total: number;
+	perPage: number;
+	totalFavorites: number;
+}
+
+export interface SitesDataViewsProps {
+	className?: string;
+	data: SitesDataResponse | undefined;
+	forceTourExampleSite?: boolean;
+	isLargeScreen: boolean;
+	isLoading: boolean;
+	onSitesViewChange: ( view: SitesViewState ) => void;
+	sitesViewState: SitesViewState;
+}
+
+export interface Sort {
+	field: string;
+	direction: 'asc' | 'desc' | '';
+}
+
+export interface Filter {
+	field: string;
+	operator: string;
+	value: number;
+}
+
+export interface SitesViewState {
+	type: 'table' | 'list' | 'grid';
+	perPage: number;
+	page: number;
+	sort: Sort;
+	search: string;
+	filters: Filter[];
+	hiddenFields: string[];
+	layout: object;
+	selectedSite?: Site | undefined;
+}
+
+export interface SiteInfo extends SiteData {
+	id: number;
+}

--- a/client/sites-dashboard/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/sites-dashboard/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@automattic/components';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import SiteFavicon from '../site-favicon';
+import { Site } from '../types';
+
+interface SiteDataFieldProps {
+	isLoading: boolean;
+	site: Site;
+	onSiteTitleClick: ( site: Site ) => void;
+}
+
+const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProps ) => {
+	if ( isLoading ) {
+		return <TextPlaceholder />;
+	}
+
+	return (
+		<Button className="sites-dataviews__site" onClick={ () => onSiteTitleClick( site ) } borderless>
+			<SiteFavicon site={ site } />
+			<div className="sites-dataviews__site-name">
+				{ site.blogname }
+				<div className="sites-dataviews__site-url">{ site.url }</div>
+			</div>
+		</Button>
+	);
+};
+
+export default SiteDataField;

--- a/client/sites-dashboard/sections/sites/sites-dataviews/style.scss
+++ b/client/sites-dashboard/sections/sites/sites-dataviews/style.scss
@@ -1,0 +1,264 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.sites-overview__content {
+
+	.components-checkbox-control__input[type="checkbox"]:focus {
+		box-shadow: 0 0 0 var(--studio-jetpack-green-50) #fff, 0 0 0 calc(2* var(--studio-jetpack-green-50)) var(--studio-jetpack-green-50);
+		outline: 2px solid transparent;
+		outline-offset: 2px;
+	}
+	.components-checkbox-control__input[type="checkbox"]:checked,
+	.components-checkbox-control__input[type="checkbox"]:indeterminate {
+		background: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
+		border-color: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
+	}
+
+	.dataviews-bulk-edit-button.components-button.is-tertiary:active:not(:disabled),
+	.dataviews-bulk-edit-button.components-button.is-tertiary:hover:not(:disabled) {
+		box-shadow: none;
+		background-color: transparent;
+		color: var(--studio-jetpack-green-50);
+	}
+
+	.dataviews-view-table__actions-column {
+		display: none;
+	}
+
+	thead {
+		th.sites-dataviews__site {
+			background: var(--studio-white);
+			td {
+				padding: 16px 0;
+				border-bottom: 1px solid var(--studio-gray-5);
+			}
+		}
+	}
+
+	tr.dataviews-view-table__row {
+		background: var(--studio-white);
+
+		.components-checkbox-control__input {
+			opacity: 0;
+		}
+		.components-checkbox-control__input:checked,
+		.components-checkbox-control__input:indeterminate, {
+			opacity: 1;
+		}
+
+		.dataviews-view-table-selection-checkbox {
+			padding-left: 12px;
+			&.is-selected {
+				.components-checkbox-control__input {
+					opacity: 1;
+				}
+			}
+		}
+
+		&:hover {
+			background: var(--studio-gray-0);
+
+			.site-set-favorite__favorite-icon,
+			.components-checkbox-control__input {
+				opacity: 1;
+			}
+		}
+
+		th {
+			padding: 16px 4px 16px 48px;
+			border-bottom: 1px solid var(--studio-gray-5);
+			font-size: rem(13px);
+			font-weight: 400;
+		}
+
+		td {
+			padding: 16px 4px 16px 48px;
+			border-bottom: 1px solid var(--studio-gray-5);
+			vertical-align: middle;
+		}
+
+		td:has(.sites-dataviews__site) {
+			padding: 8px 16px 8px 4px;
+			width: 20%;
+		}
+
+		.site-sort__clickable {
+			cursor: pointer;
+		}
+
+		.dataviews-view-table__checkbox-column,
+		.components-checkbox-control__input {
+			label.components-checkbox-control__label {
+				display: none;
+			}
+			&[type="checkbox"] {
+				border-color: var(--studio-gray-5);
+			}
+		}
+	}
+
+	ul.dataviews-view-list {
+		li:hover {
+			background: var(--studio-gray-0);
+		}
+		.is-selected {
+			background-color: var(--studio-jetpack-green-0);
+		}
+	}
+}
+
+.components-search-control input[type="search"].components-search-control__input {
+	background: var(--studio-white);
+	border: 1px solid var(--studio-gray-5);
+}
+
+.dataviews-filters__view-actions {
+	margin-bottom: 8px;
+}
+
+.sites-dataviews__site {
+	display: flex;
+	flex-direction: row;
+
+	.button {
+		padding: 0;
+	}
+}
+
+.sites-dataviews__site-name {
+	display: inline-block;
+	text-align: left;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	width: 180px;
+	font-weight: 500;
+	font-size: rem(14px);
+}
+
+.sites-dataviews__site-url {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	font-size: rem(12px);
+	color: var(--studio-gray-60);
+	font-weight: 400;
+}
+
+.preview-hidden {
+	@media (min-width: 2040px) {
+		.sites-dataviews__site-name {
+			width: 250px;
+		}
+	}
+}
+
+.sites-dataviews__actions {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: end;
+	flex-wrap: nowrap;
+
+	@media (min-width: 1080px) {
+		.site-actions__actions-large-screen {
+			float: none;
+			margin-inline-end: 20px;
+		}
+	}
+
+	.site-preview__open {
+		.gridicon.gridicons-chevron-right {
+			width: 18px;
+			height: 18px;
+		}
+	}
+}
+
+.sites-overview__content:has(.dataviews-pagination) {
+	padding-bottom: 32px !important;
+}
+
+.main.a4a-layout.sites-dashboard:has(.dataviews-pagination) {
+	height: calc(100vh - 70px) !important;
+}
+
+
+.dataviews-pagination {
+	background: #fff;
+	border-top: 1px solid #f1f1f1;
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
+	bottom: 0;
+	color: var(--Gray-Gray-40, #787c82);
+	font-size: 0.875rem;
+	font-weight: 400;
+	justify-content: space-between !important;
+	margin-bottom: 1rem;
+	padding: 12px 16px 12px 16px;
+	position: fixed;
+	width: calc(100% - 64px);
+
+	.components-input-control__backdrop {
+		border-color: var(--Gray-Gray-5, #dcdcde);
+	}
+
+	.components-input-control__container {
+		padding: 0 5px;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		width: calc(100% - ( var(--sidebar-width-max) + 48px));
+	}
+
+	@include breakpoint-deprecated( ">1400px" ) {
+		bottom: 0;
+	}
+
+}
+
+.sites-dashboard__layout:not(.preview-hidden) {
+
+	.dataviews-pagination {
+		line-height: 1;
+		width: 368px;
+
+		.components-base-control {
+			width: unset !important;
+			margin-right: 0 !important;
+		}
+	}
+}
+
+
+.dataviews-wrapper {
+	.dataviews-no-results,
+	.dataviews-loading {
+		padding-top: 1rem;
+		text-align: center;
+	}
+
+	.spinner-wrapper {
+		display: none;
+	}
+
+}
+
+.dataviews-wrapper:has(.dataviews-loading) {
+	.spinner-wrapper {
+		display: block;
+	}
+	.dataviews-loading p {
+		display: none;
+	}
+
+	.dataviews-view-table-wrapper {
+		height: 0 !important;
+	}
+}
+
+.dataviews-wrapper:has(.dataviews-no-results) {
+	.spinner-wrapper {
+		display: none;
+	}
+}

--- a/client/sites-dashboard/sections/sites/sites-dataviews/types.d.ts
+++ b/client/sites-dashboard/sections/sites/sites-dataviews/types.d.ts
@@ -1,0 +1,1 @@
+declare module '@wordpress/dataviews';

--- a/client/sites-dashboard/sections/sites/sites-header-actions/index.tsx
+++ b/client/sites-dashboard/sections/sites/sites-header-actions/index.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@automattic/components';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
+import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.scss';
+
+export default function SitesHeaderActions() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const isMobile = useMobileBreakpoint();
+
+	const [ tourStepRef, setTourStepRef ] = useState< HTMLElement | null >( null );
+
+	return (
+		<div className="sites-header__actions">
+			<div ref={ ( ref ) => setTourStepRef( ref ) }>
+				<AddNewSiteButton
+					showMainButtonLabel={ ! isMobile }
+					onClickAddNewSite={ () =>
+						dispatch( recordTracksEvent( 'calypso_a4a_sites_add_new_site_click' ) )
+					}
+					onClickWpcomMenuItem={ () =>
+						dispatch( recordTracksEvent( 'calypso_a4a_sites_create_wpcom_site_click' ) )
+					}
+					onClickJetpackMenuItem={ () =>
+						dispatch( recordTracksEvent( 'calypso_a4a_sites_connect_jetpack_site_click' ) )
+					}
+					onClickUrlMenuItem={ () =>
+						dispatch( recordTracksEvent( 'calypso_a4a_sites_connect_url_site_click' ) )
+					}
+				/>
+			</div>
+			<GuidedTourStep id="add-new-site" tourId="addSiteStep1" context={ tourStepRef } />
+			<Button
+				primary
+				href={ A4A_MARKETPLACE_PRODUCTS_LINK }
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_a4a_sites_add_products_click' ) );
+				} }
+			>
+				{ translate( 'Add products' ) }
+			</Button>
+		</div>
+	);
+}

--- a/client/sites-dashboard/sections/sites/sites-header-actions/style.scss
+++ b/client/sites-dashboard/sections/sites/sites-header-actions/style.scss
@@ -1,0 +1,44 @@
+.sites-header__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+
+	.button {
+		border-radius: 4px;
+		border: 1px solid var(--color-neutral-10);
+		font-size: 0.875rem;
+		font-weight: inherit;
+	}
+
+	.button.split-button__main {
+		border-radius: 4px 0 0 4px;
+		border-right: none;
+
+		&:hover {
+			background: #fff;
+			border-color: var(--color-neutral-20);
+		}
+	}
+
+	.button.split-button__toggle {
+		border-radius: 0 4px 4 0;
+
+		&:hover {
+			background: #fff;
+			border-color: var(--color-neutral-20);
+		}
+
+		svg {
+			fill: #000;
+		}
+
+		.gridicon {
+			height: 18px;
+			margin-top: -2px;
+			position: relative;
+			top: 4px;
+			width: 18px;
+		}
+	}
+
+}

--- a/client/sites-dashboard/sections/sites/types.ts
+++ b/client/sites-dashboard/sections/sites/types.ts
@@ -1,0 +1,44 @@
+import { ReactNode, SetStateAction, Dispatch } from 'react';
+import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
+import { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+export * from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+export interface SitesDashboardContextInterface {
+	selectedCategory?: string;
+	setSelectedCategory: ( category: string ) => void;
+
+	selectedSiteFeature?: string;
+	setSelectedSiteFeature: ( siteFeature: string | undefined ) => void;
+
+	sitesViewState: SitesViewState;
+	setSitesViewState: React.Dispatch< React.SetStateAction< SitesViewState > >;
+
+	hideListing?: boolean;
+	setHideListing: ( hideListing: boolean ) => void;
+
+	showOnlyFavorites?: boolean;
+	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
+
+	initialSelectedSiteUrl?: string;
+	path: string;
+	currentPage: number;
+
+	isBulkManagementActive: boolean;
+	setIsBulkManagementActive: ( value: boolean ) => void;
+
+	selectedSites: Array< Site >;
+	setSelectedSites: ( value: Array< Site > ) => void;
+
+	currentLicenseInfo: string | null;
+	showLicenseInfo: ( license: string ) => void;
+	hideLicenseInfo: () => void;
+
+	mostRecentConnectedSite: string | null;
+	setMostRecentConnectedSite: ( mostRecentConnectedSite: string ) => void;
+
+	isPopoverOpen: boolean;
+	setIsPopoverOpen: Dispatch< SetStateAction< boolean > >;
+
+	featurePreview: ReactNode | null;
+}

--- a/client/sites-dashboard/sections/sites/types.ts
+++ b/client/sites-dashboard/sections/sites/types.ts
@@ -1,6 +1,6 @@
 import { ReactNode, SetStateAction, Dispatch } from 'react';
-import { SitesViewState } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { SitesViewState } from './sites-dataviews/interfaces';
 
 export * from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 

--- a/config/development.json
+++ b/config/development.json
@@ -120,7 +120,7 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign-v2": false,
+		"layout/dotcom-nav-redesign-v2": true,
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Based on https://github.com/Automattic/wp-calypso/pull/89318

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?