### PR TITLE
Site restore: Show appropriate empty state for deleted sites

### DIFF
--- a/client/components/empty-content/no-sites-message/index.tsx
+++ b/client/components/empty-content/no-sites-message/index.tsx
@@ -14,6 +14,7 @@ interface NoSitesMessageProps {
 	actionURL?: string;
 	actionCallback?: () => void;
 	illustration?: false;
+	hideAction?: boolean;
 }
 
 const NoSitesMessage = ( {
@@ -23,6 +24,7 @@ const NoSitesMessage = ( {
 	actionURL,
 	actionCallback,
 	illustration,
+	hideAction = false,
 }: NoSitesMessageProps ) => {
 	const { __ } = useI18n();
 
@@ -44,9 +46,9 @@ const NoSitesMessage = ( {
 						) }
 				</p>
 			}
-			action={ action ?? __( 'Create a site' ) }
-			actionURL={ actionURL ?? onboardingUrl() + '?ref=calypso-nosites' }
-			actionCallback={ actionCallback }
+			action={ hideAction ? undefined : action ?? __( 'Create a site' ) }
+			actionURL={ hideAction ? undefined : actionURL ?? onboardingUrl() + '?ref=calypso-nosites' }
+			actionCallback={ hideAction ? undefined : actionCallback }
 			illustration={ illustration === false ? null : noSitesIllustration }
 			illustrationWidth={ 124 }
 			illustrationHeight={ 101 }

--- a/client/sites-dashboard/components/no-sites-message.tsx
+++ b/client/sites-dashboard/components/no-sites-message.tsx
@@ -86,6 +86,32 @@ export const NoSitesMessage = ( { status, statusSiteCount }: SitesContainerProps
 		);
 	}
 
+	if ( status === 'deleted' ) {
+		return (
+			<NoSitesMessageLayout
+				title={ __( 'You have no deleted sites' ) }
+				line={ createInterpolateElement(
+					__(
+						'Sites that are deleted can be restored within the first 30 days of deletion. Read more about restoring your site <a>here</a>.'
+					),
+					{
+						a: (
+							<a
+								href={ localizeUrl(
+									'https://wordpress.com/support/delete-site/#restore-a-deleted-site'
+								) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					}
+				) }
+				illustration={ false }
+				hideAction={ true }
+			/>
+		);
+	}
+
 	if ( status === 'redirect' ) {
 		return (
 			<NoSitesMessageLayout


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Show appropriate empty state for deleted sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/sites?status=deleted`
* You should see empty states if there are no deleted sites

**Before**
![image](https://github.com/Automattic/wp-calypso/assets/47489215/c1dc8b26-d848-4796-83ad-ecb5cfa44aae)

**After**
![image](https://github.com/Automattic/wp-calypso/assets/47489215/8b289085-fb60-4d2d-a241-ab43b7349c32)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?