### PR TITLE
Show full Jetpack product names on purchases page

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -249,7 +249,7 @@ export function getName( purchase: Purchase ): string {
 export function getDisplayName( purchase: Purchase ): TranslateResult {
 	const { productName, productSlug, purchaseRenewalQuantity } = purchase;
 
-	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
+	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames( 'full' );
 	if ( jetpackProductsDisplayNames[ productSlug ] ) {
 		return jetpackProductsDisplayNames[ productSlug ];
 	}

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -88,7 +88,7 @@ import {
 import type { FAQ, SelectorProductFeaturesItem } from './types';
 import type { TranslateResult } from 'i18n-calypso';
 
-export const getJetpackProductsShortNames = (): Record< string, TranslateResult > => {
+export const getJetpackProductsShortNames = (): Record< string, React.ReactElement | string > => {
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: (
 			<>
@@ -175,8 +175,61 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 	};
 };
 
-export const getJetpackProductsDisplayNames = (): Record< string, TranslateResult > => {
-	const vaultPressBackupName = getJetpackProductsShortNames()[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ];
+export const getJetpackProductsFullNames = (): Record< string, React.ReactElement | string > => {
+	const jetpackFullNames = getJetpackProductsShortNames();
+
+	jetpackFullNames[ PRODUCT_JETPACK_BACKUP_DAILY ] = (
+		<>
+			Jetpack VaultPress Backup <span>Daily</span>
+		</>
+	);
+
+	jetpackFullNames[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ] = (
+		<>
+			Jetpack VaultPress Backup <span>Daily</span>
+		</>
+	);
+
+	jetpackFullNames[ PRODUCT_JETPACK_BACKUP_REALTIME ] = (
+		<>
+			Jetpack VaultPress Backup <span style={ { whiteSpace: 'nowrap' } }>Real-time</span>
+		</>
+	);
+
+	jetpackFullNames[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ] = (
+		<>
+			Jetpack VaultPress Backup <span style={ { whiteSpace: 'nowrap' } }>Real-time</span>
+		</>
+	);
+
+	jetpackFullNames[ PRODUCT_JETPACK_SCAN_REALTIME ] = (
+		<>
+			Jetpack Scan <span style={ { whiteSpace: 'nowrap' } }>Real-time</span>
+		</>
+	);
+
+	jetpackFullNames[ PRODUCT_JETPACK_SCAN_REALTIME_MONTHLY ] = (
+		<>
+			Jetpack Scan <span style={ { whiteSpace: 'nowrap' } }>Real-time</span>
+		</>
+	);
+
+	Object.entries( jetpackFullNames ).forEach( ( [ key, shortName ] ) => {
+		if ( typeof shortName === 'string' && ! shortName.includes( 'Akismet' ) ) {
+			jetpackFullNames[ key ] = `Jetpack ${ shortName }`;
+		}
+	} );
+
+	return jetpackFullNames;
+};
+
+export const getJetpackProductsDisplayNames = (
+	type: 'short' | 'full' = 'short'
+): Record< string, TranslateResult > => {
+	const vaultPressBackupName =
+		type === 'short'
+			? getJetpackProductsShortNames()[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]
+			: getJetpackProductsFullNames()[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ];
 	const text10gb = translate( '%(numberOfGigabytes)dGB', '%(numberOfGigabytes)dGB', {
 		comment:
 			'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
@@ -227,8 +280,11 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		args: { storageAmount: text5tb, pluginName: vaultPressBackupName },
 	} );
 
+	const jetpackProductNames =
+		type === 'short' ? getJetpackProductsShortNames() : getJetpackProductsFullNames();
+
 	return {
-		...getJetpackProductsShortNames(),
+		...jetpackProductNames,
 		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_MONTHLY ]: backupAddon10gb,
 		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_100GB_MONTHLY ]: backupAddon100gb,
 		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_MONTHLY ]: backupAddon1tb,


### PR DESCRIPTION
## Proposed Changes

* Add an option to the getJetpackProductsDisplayNames function to show the full Jetpack product name
* Show the full Jetpack product names on the purchases page

## Testing Instructions

1. Make sure you have some Jetpack products associated with your user account
2. Checkout this branch or use the calypso live link and go to `/me/purchases`
3. Make sure all the Jetpack products start with the word "Jetpack"
![image](https://github.com/Automattic/wp-calypso/assets/65001528/0d8d8099-2e93-48e0-9a3d-07a0d9e1660a)
4. If you are running this locally, you can go to `client/lib/purchases/index.ts` and log `jetpackProductsDisplayNames` in the `getDisplayNames` function on line 252 to the console to make sure all of the product names have been updated to show the full name
![image](https://github.com/Automattic/wp-calypso/assets/65001528/f4b98529-25e6-422f-9adb-92cda0792c97)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?