### PR TITLE
Assembler: Unset white background

### DIFF
--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -64,7 +64,15 @@ const ScaledBlockRendererContainer = ( {
 			// Ignore svgs since the current version of EditorStyles doesn't support it
 			.filter( ( style: RenderedStyle ) => style.__unstableType !== 'svgs' );
 
-		return mergedStyles;
+		return [
+			...mergedStyles,
+			{
+				// Override the white background set by Gutenberg.
+				// See: https://github.com/WordPress/gutenberg/pull/59377/files
+				css: 'body{background:unset!important;}',
+				isGlobalStyles: true,
+			},
+		];
 	}, [ styles, customStyles ] );
 
 	const scripts = useMemo( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/89324

## Proposed Changes

This PR fixes the issue where the background colors from global styles are not applied in the block renderer in the Assembler. This is caused by https://github.com/WordPress/gutenberg/pull/59377/files, where the background is explicitly set to white.

Note that the issue only affects Safari.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Using Safari, head to the Assembler.
2. Select some patterns, then styles.
3. Ensure that the background color from the global styles is applied correctly to the pattern in the large preview.
4. Ensure that Chrome and Safari also works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?