### PR TITLE
Stats: fix disabled status for the continue button on the purchase page

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -496,7 +496,7 @@ function StatsCommercialFlowOptOutForm( {
 					( ! isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
 					<Button
 						variant="secondary"
-						disabled={ ! supportsOnDemandCommercialClassification && isFormSubmissionDisabled() }
+						disabled={ ! supportsOnDemandCommercialClassification || isFormSubmissionDisabled() }
 						onClick={ formHandler }
 					>
 						{ formButton }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -409,9 +409,8 @@ function StatsCommercialFlowOptOutForm( {
 		commercialClassificationLastRunAt > 0 &&
 		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60; // 1 hour
 
-	const isFormSubmissionDisabled = () => {
-		return ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked;
-	};
+	const isFormSubmissionDisabled =
+		! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked;
 
 	// Message, button text, and handler differ based on isCommercial flag.
 	const formMessage = isCommercial
@@ -485,7 +484,7 @@ function StatsCommercialFlowOptOutForm( {
 				{ supportsOnDemandCommercialClassification && isCommercial && (
 					<Button
 						variant="secondary"
-						disabled={ hasRunLessThan3DAgo || isFormSubmissionDisabled() }
+						disabled={ hasRunLessThan3DAgo || isFormSubmissionDisabled }
 						onClick={ handleCommercialClassification }
 					>
 						{ translate( 'Reverify' ) }
@@ -494,11 +493,7 @@ function StatsCommercialFlowOptOutForm( {
 				{ ( ! supportsOnDemandCommercialClassification ||
 					! isCommercial ||
 					( ! isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
-					<Button
-						variant="secondary"
-						disabled={ isFormSubmissionDisabled() }
-						onClick={ formHandler }
-					>
+					<Button variant="secondary" disabled={ isFormSubmissionDisabled } onClick={ formHandler }>
 						{ formButton }
 					</Button>
 				) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -496,7 +496,7 @@ function StatsCommercialFlowOptOutForm( {
 					( ! isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
 					<Button
 						variant="secondary"
-						disabled={ ! supportsOnDemandCommercialClassification || isFormSubmissionDisabled() }
+						disabled={ isFormSubmissionDisabled() }
 						onClick={ formHandler }
 					>
 						{ formButton }


### PR DESCRIPTION
## Proposed Changes

* Fix a broken condition to disable the `Continue` button

## Testing Instructions

* Open Calypso Live on a personal site `http://calypso.localhost:3000/stats/purchase/:siteSlug?productType=commercial`
* Ensure the Continue button is disabled before all the boxes are checked

<img width="738" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/87424274-ac0b-4585-98ea-960ba2504186">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?