### PR TITLE
Automattic for Agencies: Fix page break for atomic site plugin updates being undefined

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -156,7 +156,7 @@ const useFormatPluginData = () => {
 	return useCallback(
 		( site: Site ): PluginNode => {
 			const pluginUpdates = site.is_atomic
-				? site.awaiting_plugin_updates.filter(
+				? site.awaiting_plugin_updates?.filter(
 						( plugin ) =>
 							! PREINSTALLED_PLUGINS.includes( plugin ) &&
 							! AUTOMOMANAGED_PLUGINS.includes( plugin ) &&
@@ -165,6 +165,14 @@ const useFormatPluginData = () => {
 				  )
 				: site.awaiting_plugin_updates;
 
+			if ( ! pluginUpdates ) {
+				return {
+					value: '',
+					status: 'disabled',
+					type: 'plugin',
+					updates: 0,
+				};
+			}
 			return {
 				value: `${ pluginUpdates?.length } ${ translate( 'Available' ) }`,
 				status: pluginUpdates?.length > 0 ? 'warning' : 'success',


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/249

## Proposed Changes

This PR fixes the page break issue that happens when the `awaiting_plugin_updates` for an atomic site is undefined. 

Even though it is not possible to get this state in A4A since we don't support WP.com site creation yet, it is easy to miss it later as we have the same code being used in both places.

## Testing Instructions

- Open https://cloud.jetpack.com/ > Create a new WP.com site > Return to the dashboard > Refresh the page and notice the page breaks.
- Open the A4A or Jetpack Cloud live link
- Visit the Dashboard and verify that the page doesn't break, and we show `-` for Plugins column for the newly created site:

<img width="1590" alt="Screenshot 2024-04-09 at 12 26 47 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/14a8ee92-ccc4-48f0-8f57-9496c0616920">

![Screenshot 2024-04-09 at 12 28 26 PM](https://github.com/Automattic/wp-calypso/assets/10586875/38021931-1472-472f-a24b-423baa711f12)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?