### PR TITLE
A4A: Fix issue with Sites table showing two scrollbars.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -6,7 +6,6 @@ import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState } from 'react';
 import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
-import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
@@ -254,18 +253,16 @@ export default function SitesDashboard() {
 							isLargeScreen: isLargeScreen || false,
 						} }
 					>
-						<LayoutBody>
-							<SitesDataViews
-								className={ classNames( 'sites-overview__content', {
-									'is-hiding-navigation': navItems.length <= 1,
-								} ) }
-								data={ data }
-								isLoading={ isLoading }
-								isLargeScreen={ isLargeScreen || false }
-								onSitesViewChange={ onSitesViewChange }
-								sitesViewState={ sitesViewState }
-							/>
-						</LayoutBody>
+						<SitesDataViews
+							className={ classNames( 'sites-overview__content', {
+								'is-hiding-navigation': navItems.length <= 1,
+							} ) }
+							data={ data }
+							isLoading={ isLoading }
+							isLargeScreen={ isLargeScreen || false }
+							onSitesViewChange={ onSitesViewChange }
+							sitesViewState={ sitesViewState }
+						/>
 					</DashboardDataContext.Provider>
 				</LayoutColumn>
 			) }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -6,6 +6,7 @@ import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState } from 'react';
 import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
@@ -253,16 +254,18 @@ export default function SitesDashboard() {
 							isLargeScreen: isLargeScreen || false,
 						} }
 					>
-						<SitesDataViews
-							className={ classNames( 'sites-overview__content', {
-								'is-hiding-navigation': navItems.length <= 1,
-							} ) }
-							data={ data }
-							isLoading={ isLoading }
-							isLargeScreen={ isLargeScreen || false }
-							onSitesViewChange={ onSitesViewChange }
-							sitesViewState={ sitesViewState }
-						/>
+						<LayoutBody>
+							<SitesDataViews
+								className={ classNames( 'sites-overview__content', {
+									'is-hiding-navigation': navItems.length <= 1,
+								} ) }
+								data={ data }
+								isLoading={ isLoading }
+								isLargeScreen={ isLargeScreen || false }
+								onSitesViewChange={ onSitesViewChange }
+								sitesViewState={ sitesViewState }
+							/>
+						</LayoutBody>
 					</DashboardDataContext.Provider>
 				</LayoutColumn>
 			) }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -19,10 +19,6 @@
 		}
 	}
 
-	.a4a-layout__body-wrapper {
-		padding: 0;
-	}
-
 	.site-actions__actions-large-screen {
 		display: block;
 		margin-left: 10px;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -19,6 +19,10 @@
 		}
 	}
 
+	.a4a-layout__body-wrapper {
+		padding: 0;
+	}
+
 	.site-actions__actions-large-screen {
 		display: block;
 		margin-left: 10px;
@@ -33,6 +37,12 @@
 
 	.a4a-layout__top-wrapper:not(.preview-hidden) {
 		padding-block-start: 24px;
+	}
+
+	.dataviews-view-table thead {
+		position: sticky;
+		top: 0;
+		z-index: 2;
 	}
 
 	@media (min-width: $break-large) {
@@ -517,8 +527,6 @@
 			@media only screen and (min-width: $break-large) {
 				.sites-overview {
 					padding: 0;
-					overflow-x: auto;
-					overflow-y: auto;
 
 					.dataviews-filters__view-actions {
 						& > :first-child {


### PR DESCRIPTION
This PR fixes an issue with the Sites table showing two scrollbars when the items do not fit on the page.

**Before**

https://github.com/Automattic/wp-calypso/assets/56598660/77e60281-de77-4063-ad18-d76ddf95dd72

**After**

https://github.com/Automattic/wp-calypso/assets/56598660/5d9fdb65-9906-40f7-8ae6-ccbcd151e8f8



Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/248

## Proposed Changes

* Remove overflow in the sites-overview element, on wider screens.

## Testing Instructions

* Connect multiple sites to your A4A account (enough that it fills the entire site's page).
* Use the A4A live link below and go to `/sites`.
* Confirm that the Sites table no longer shows two scrollbars.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?