### PR TITLE
Automattic for Agencies: Add singular pressable plan description in the checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -25,6 +25,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 		productIcon = pressableIcon;
 		productTitle = product.name;
 		productDescription = translate(
+			'Plan with %(install)d WordPress install, %(visits)s visits per month, and %(storage)dGB of storage per month.',
 			'Plan with %(install)d WordPress installs, %(visits)s visits per month, and %(storage)dGB of storage per month.',
 			{
 				args: {
@@ -32,6 +33,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 					visits: formatNumber( presablePlan.visits ),
 					storage: presablePlan.storage,
 				},
+				count: presablePlan.install,
 				comment:
 					'The `install`, `visits` & `storage` are the count of WordPress installs, visits per month, and storage per month in the plan description.',
 			}


### PR DESCRIPTION
## Proposed Changes

This PR adds the singular translation text to the pressable plan description in the checkout as suggested here: https://github.com/Automattic/wp-calypso/pull/89076#discussion_r1555308964

## Testing Instructions

NOTE: The text on the hosting page still says `1 WordPress installs`. I have created an issue here: https://github.com/Automattic/automattic-for-agencies-dev/issues/251

- Open the Calyso live link for A4A.
- Visit /marketplace/hosting/pressable > Select a Personal plan > Go to Checkout & verify that the text is a singular form:

<img width="948" alt="Screenshot 2024-04-09 at 1 14 43 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3199fc98-1834-41c1-8bbe-0e8971a954e7">

- Repeat the same for any other place and verify the text is a plural form:

<img width="947" alt="Screenshot 2024-04-09 at 1 15 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/10d102e9-409b-4251-beb6-b3277346c5fa">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?