### PR TITLE
E2E Tests: Fix the Gutenberg atomic E2E tests nightly (mobile)

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { getQueryArg } from '@wordpress/url';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map, pickBy, flowRight } from 'lodash';
 import { Component, Fragment } from 'react';
@@ -218,7 +218,11 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		if ( this.disableRedirects ) {
 			return;
 		}
-		window.location.replace( this.props.iframeUrl );
+
+		// We have to remove the `frame-nonce` after the redirection to prevent it
+		// from being thought to be embedded in an iframe.
+		const redirectUrl = removeQueryArgs( this.props.iframeUrl, 'frame-nonce' );
+		window.location.replace( redirectUrl );
 	};
 
 	onMessage = ( { data, origin }: MessageEvent ) => {

--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -49,6 +49,7 @@ export class EditorTemplateModalComponent {
 	async selectTemplate( label: string, timeout: number ): Promise< void > {
 		const editorParent = await this.editor.parent();
 		await editorParent
+			.getByRole( 'listbox', { name: 'Block patterns' } )
 			.getByRole( 'option', { name: label, exact: true } )
 			.first()
 			.click( { timeout: timeout } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1712625525355939/1712624408.091799-slack-CBTN58FTJ

## Proposed Changes

* This PR is proposing to fix the following test cases on mobile
  * `Select page template` - The reason is the locator gets the “About” category instead of the “About” pattern so it cannot be clicked. Hence, we locate the `listbox` first to avoid it getting the incorrect element.
  * `Return to Calypso dashboard` - This test case should be skipped on the mobile classic view (https://github.com/Automattic/wp-calypso/pull/70982). However, we opened the iframed block editor first (`/post/<your_site>`) and then redirected the page to the `<your_site>/wp-admin/post-new.php?frame-nonce=xxx` so that somewhere misunderstood the editor was still iframed and prevented the masterbar from being rendered. As a result, the `isMobileClassicView` check didn't work and the test couldn't exit the editor successfully. The solution here is to remove the `frame-nonce` query parameter to prevent it from being thought to be embedded in an iframe. 

![image](https://github.com/Automattic/wp-calypso/assets/13596067/91e3c9a4-0056-4307-a2f8-2d53490a67c3)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The Gutenberg atomic E2E tests nightly (mobile) should pass successfully
![image](https://github.com/Automattic/wp-calypso/assets/13596067/8f4a16cc-5935-49b9-8e31-1a22cf51e4cd)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?