### PR TITLE
A4A: Make the Overview page always the default page.

### DIFF
--- a/client/a8c-for-agencies/sections/landing/landing.tsx
+++ b/client/a8c-for-agencies/sections/landing/landing.tsx
@@ -11,9 +11,7 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import {
 	A4A_OVERVIEW_LINK,
 	A4A_SIGNUP_LINK,
-	A4A_SITES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useOnboardingTours from 'calypso/a8c-for-agencies/hooks/use-onboarding-tours';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency, hasFetchedAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
@@ -25,8 +23,6 @@ export default function Landing() {
 
 	const hasFetched = useSelector( hasFetchedAgency );
 	const agency = useSelector( getActiveAgency );
-
-	const tasks = useOnboardingTours();
 
 	useEffect( () => {
 		if ( ! hasFetched ) {
@@ -41,16 +37,11 @@ export default function Landing() {
 				return;
 			}
 
-			// If we have completed all onboarding list. We redirect user to the Sites page as the default page.
-			if ( tasks.every( ( task ) => task.completed ) ) {
-				return page.redirect( A4A_SITES_LINK );
-			}
-
 			return page.redirect( A4A_OVERVIEW_LINK );
 		}
 
 		page.redirect( A4A_SIGNUP_LINK );
-	}, [ agency, hasFetched, tasks ] );
+	}, [ agency, hasFetched ] );
 
 	return (
 		<Layout className="a4a-landing" title={ title } wide>


### PR DESCRIPTION
After some time, it was determined that redirecting users to the Sites page was not the best choice for navigation. See the Discussion below for full context:

p1712650826107459-slack-C06JY8QL0TU

Follow up https://github.com/Automattic/wp-calypso/pull/89301

## Proposed Changes

* Remove logic that redirects users to the Sites page by default.

## Testing Instructions

* Complete the onboarding steps on the overview page
* Use the A4A live link below and go to root path `/`.
* Confirm that you are redirected to the Overview page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?