### PR TITLE
Patterns: Hide language switcher for logged-in users on Patterns pages

### DIFF
--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -25,6 +25,10 @@
 				padding-top: 46px;
 			}
 		}
+
+		.lp-footer-language {
+			display: none;
+		}
 	}
 
 	.has-no-sidebar {


### PR DESCRIPTION
This pull request temporarily addresses https://github.com/Automattic/dotcom-forge/issues/6193 by hiding the language switcher usually shown at the bottom of the page (in the universal footer navigation) on all `Patterns` pages:

![image](https://github.com/Automattic/wp-calypso/assets/594356/57d3858d-da5b-4283-aed6-0a6c24bbf435)

#### Testing instructions

1. Run `git checkout update/language-switcher-for-patterns` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/89354#issuecomment-2044542650)
2. Log into WordPress.com
3. Open the [`Patterns` page](http://calypso.localhost:3000/patterns)
4. Assert that no language switcher is shown