### PR TITLE
Pattern Library: Fix issue with client-side router and onboarding links

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -31,6 +31,7 @@ import {
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { addQueryArgs } from 'calypso/lib/route';
+import { getOnboardingUrl as getPatternLibraryOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
@@ -201,6 +202,9 @@ const LayoutLoggedOut = ( {
 				isLoggedIn={ isLoggedIn }
 				sectionName={ sectionName }
 				{ ...( sectionName === 'subscriptions' && { variant: 'minimal' } ) }
+				{ ...( sectionName === 'patterns' && {
+					startUrl: getPatternLibraryOnboardingUrl( locale, isLoggedIn ),
+				} ) }
 			/>
 		);
 	} else if ( isWooCoreProfilerFlow ) {

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -31,7 +31,6 @@ export function PatternsGetStarted() {
 				<Button
 					className="patterns-get-started__start-button"
 					href={ getOnboardingUrl( locale, isLoggedIn ) }
-					rel="external"
 				>
 					{ translate( 'Build a site' ) }
 				</Button>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -31,7 +31,7 @@ import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 import { filterPatternsByTerm } from 'calypso/my-sites/patterns/lib/filter-patterns-by-term';
 import { getPatternPermalink } from 'calypso/my-sites/patterns/lib/get-pattern-permalink';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
-import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
+import { getCategoryUrlPath, getOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import {
 	PatternTypeFilter,
 	PatternView,
@@ -211,6 +211,28 @@ export const PatternLibrary = ( {
 			window.removeEventListener( 'scroll', handleScroll );
 		};
 	}, [] );
+
+	// `calypso-router` has trouble with the onboarding URL we use. This code prevents click
+	// events on onboarding links from propagating to the `calypso-router` event listener,
+	// which fixes the problem.
+	useEffect( () => {
+		const onboardingUrl = getOnboardingUrl( locale, isLoggedIn );
+
+		function stopPropagationOnClick( event: MouseEvent ) {
+			if (
+				event.target instanceof HTMLAnchorElement &&
+				event.target.getAttribute( 'href' ) === onboardingUrl
+			) {
+				event.stopPropagation();
+			}
+		}
+
+		document.addEventListener( 'click', stopPropagationOnClick, { capture: true } );
+
+		return () => {
+			document.removeEventListener( 'click', stopPropagationOnClick );
+		};
+	}, [ locale, isLoggedIn ] );
 
 	const categoryObject = categories?.find( ( { name } ) => name === category );
 	const shouldDisplayPatternTypeToggle =

--- a/client/my-sites/patterns/wrapper.tsx
+++ b/client/my-sites/patterns/wrapper.tsx
@@ -1,5 +1,7 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
 import Main from 'calypso/components/main';
+import { getOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
@@ -9,10 +11,13 @@ type PatternsWrapperProps = React.PropsWithChildren< unknown >;
 
 export const PatternsWrapper = ( { children }: PatternsWrapperProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const locale = useLocale();
 
 	return (
 		<>
-			{ isLoggedIn && <UniversalNavbarHeader isLoggedIn /> }
+			{ isLoggedIn && (
+				<UniversalNavbarHeader isLoggedIn startUrl={ getOnboardingUrl( locale, isLoggedIn ) } />
+			) }
 
 			<Main fullWidthLayout>{ children }</Main>
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to #89329 and #89327

## Proposed Changes

`calypso-router` has trouble with links that lead to `/setup/assembler-first` (or at least it does in production). This PR implements a new approach to circumvent `Page.prototype.clickHandler`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the following diff

```diff
diff --git a/client/my-sites/patterns/paths.ts b/client/my-sites/patterns/paths.ts
index 32e63b9268..5664c2c381 100644
--- a/client/my-sites/patterns/paths.ts
+++ b/client/my-sites/patterns/paths.ts
@@ -20,7 +20,7 @@ export function getCategoryUrlPath(
 
 export function getOnboardingUrl( locale: Locale, isLoggedIn: boolean ) {
        return localizeUrl(
-               `https://wordpress.com/setup/assembler-first?${ buildQueryString( {
+               `/setup/assembler-first?${ buildQueryString( {
                        ref: URL_REFERRER_PARAM,
                } ) }`,
                locale,
diff --git a/packages/calypso-router/src/index.js b/packages/calypso-router/src/index.js
index ed765ab5d0..53c2d6f5e2 100644
--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -828,6 +828,8 @@ Page.prototype.clickHandler = function ( e ) {
                return;
        }
 
+       alert( 'Hello' );
+
        e.preventDefault();
        this.show( orig );
 };
```

2. Navigate to `/patterns`
3. Click the `Get started` link in the header
4. Ensure that you don't see an alert popup
5. Comment out `event.stopPropagation()` in `stopPropagationOnClick`
6. Navigate back to `/patterns`
7. Click the `Get started` link in the header again
8. Ensure that you see the alert popup