### PR TITLE
Stats: Simplify highlights data setup on Ads page

### DIFF
--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -24,6 +24,7 @@ function useHighlights( earnings ) {
 			{
 				heading: translate( 'Earnings', { comment: 'Total WordAds earnings to date' } ),
 				icon: <Icon icon={ payment } />,
+				svg: payment,
 				value: getAmountAsFormattedString( total ),
 			},
 			{
@@ -31,6 +32,7 @@ function useHighlights( earnings ) {
 					comment: 'Total WordAds earnings that have been paid out',
 				} ),
 				icon: <Icon icon={ receipt } />,
+				svg: receipt,
 				value: getAmountAsFormattedString( paid ),
 			},
 			{
@@ -38,6 +40,7 @@ function useHighlights( earnings ) {
 					comment: 'Total WordAds earnings currently unpaid',
 				} ),
 				icon: <Icon icon={ tip } />,
+				svg: tip,
 				value: getAmountAsFormattedString( owed ),
 			},
 		];
@@ -142,27 +145,16 @@ function HighlightsListing( { highlights } ) {
 function HighlightsListingMobile( { highlights } ) {
 	// Convert the highlights data for the MobileHighlightCardListing component.
 	// Use preformattedValue property as an override to the count.
-	// Send the raw SVG icon (not the provided Icon comp) and zero out the count.
-	const mobileHighlights = [
-		{
-			...highlights[ 0 ],
-			preformattedValue: highlights[ 0 ].value,
-			icon: payment,
+	// Send the SVG data (and not the Icon comp) and zero out the count.
+	const mobileHighlights = highlights.map( ( highlight ) => {
+		return {
 			count: 0,
-		},
-		{
-			...highlights[ 1 ],
-			preformattedValue: highlights[ 1 ].value,
-			icon: receipt,
-			count: 0,
-		},
-		{
-			...highlights[ 2 ],
-			preformattedValue: highlights[ 2 ].value,
-			icon: tip,
-			count: 0,
-		},
-	];
+			heading: highlight.heading,
+			icon: highlight.svg,
+			preformattedValue: highlight.value,
+		};
+	} );
+
 	return <MobileHighlightCardListing highlights={ mobileHighlights } />;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87375

## Proposed Changes

Adds SVG property to initial setup so we can simplify things in the mobile highlights code path. No UI updates. Should still look like this:

<img width="439" alt="SCR-20240405-pckv" src="https://github.com/Automattic/wp-calypso/assets/40267301/b2c8c8c0-18c4-4e71-bd96-5f6e0818f5ea">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live branch.
* Navigate to the **Stats → Ads** page.
* Use the browser tools to test at different screen sizes. iPad mini and larger should get the standard Desktop UI with horizontal scrolling while smaller screens should get the vertically stacked cards.
* Confirm **Traffic**, **Insights**, & **Subscriber** pages all continue to behave correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?