### PR TITLE
SSSR: Update the design of the Site Delete page - P2

### DIFF
--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -1,50 +1,52 @@
-import { Dialog, Button } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import ActionPanel from 'calypso/components/action-panel';
+import ActionPanelBody from 'calypso/components/action-panel/body';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 
-import './style.scss';
-
-function DeleteSiteWarningDialog( { isVisible, p2HubP2Count, onClose, isTrialSite = false } ) {
+function DeleteSiteWarningDialog( {
+	isVisible,
+	p2HubP2Count,
+	onClose,
+	isAtomicRemovalInProgress,
+	isTrialSite = false,
+} ) {
 	const translate = useTranslate();
 
 	const getButtons = () => {
-		const buttons = [ { action: 'dismiss', label: translate( 'Dismiss' ) } ];
+		if ( isAtomicRemovalInProgress ) {
+			return null;
+		}
+
 		if ( p2HubP2Count ) {
-			buttons.push(
+			return (
 				<Button primary href="/settings/general">
 					{ translate( 'Go to your site listing' ) }
 				</Button>
 			);
 		} else if ( isTrialSite ) {
-			buttons.push(
+			return (
 				<Button primary href={ purchasesRoot }>
 					{ translate( 'Cancel trial', { context: 'button label' } ) }
 				</Button>
 			);
-		} else {
-			buttons.push(
-				<Button primary href={ purchasesRoot }>
-					{ translate( 'Manage purchases', { context: 'button label' } ) }
-				</Button>
-			);
-		}
-		return buttons;
-	};
-
-	const renderWarningHeader = () => {
-		if ( p2HubP2Count ) {
-			return translate( 'P2 workspace' );
 		}
 
-		if ( isTrialSite ) {
-			return translate( 'Free Trial Active' );
-		}
-
-		return translate( 'Paid Upgrades' );
+		return (
+			<Button primary href={ purchasesRoot }>
+				{ translate( 'Manage purchases', { context: 'button label' } ) }
+			</Button>
+		);
 	};
 
 	const renderWarningContent = () => {
+		if ( isAtomicRemovalInProgress ) {
+			return translate(
+				"We are still in the process of removing your previous plan. Please check back in a few minutes and you'll be able to delete your site."
+			);
+		}
+
 		if ( p2HubP2Count ) {
 			return translate(
 				'There is %(numP2s)d P2 in your workspace. Please delete it prior to deleting your workspace.',
@@ -70,15 +72,16 @@ function DeleteSiteWarningDialog( { isVisible, p2HubP2Count, onClose, isTrialSit
 	};
 
 	return (
-		<Dialog
-			isVisible={ isVisible }
-			buttons={ getButtons() }
-			onClose={ onClose }
-			className="delete-site-warning-dialog"
-		>
-			<h1>{ renderWarningHeader() }</h1>
-			<p>{ renderWarningContent() }</p>
-		</Dialog>
+		<ActionPanel>
+			<ActionPanelBody
+				isVisible={ isVisible }
+				onClose={ onClose }
+				className="delete-site-warning-dialog"
+			>
+				<p>{ renderWarningContent() }</p>
+				{ getButtons() }
+			</ActionPanelBody>
+		</ActionPanel>
 	);
 }
 

--- a/client/my-sites/site-settings/delete-site-warning-dialog/style.scss
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/style.scss
@@ -1,3 +1,0 @@
-.delete-site-warning-dialog {
-	max-width: 472px;
-}

--- a/client/my-sites/site-settings/delete-site-warnings/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warnings/index.jsx
@@ -5,13 +5,7 @@ import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 
-function DeleteSiteWarningDialog( {
-	isVisible,
-	p2HubP2Count,
-	onClose,
-	isAtomicRemovalInProgress,
-	isTrialSite = false,
-} ) {
+function DeleteSiteWarnings( { p2HubP2Count, isAtomicRemovalInProgress, isTrialSite = false } ) {
 	const translate = useTranslate();
 
 	const getButtons = () => {
@@ -73,11 +67,7 @@ function DeleteSiteWarningDialog( {
 
 	return (
 		<ActionPanel>
-			<ActionPanelBody
-				isVisible={ isVisible }
-				onClose={ onClose }
-				className="delete-site-warning-dialog"
-			>
+			<ActionPanelBody>
 				<p>{ renderWarningContent() }</p>
 				{ getButtons() }
 			</ActionPanelBody>
@@ -85,11 +75,10 @@ function DeleteSiteWarningDialog( {
 	);
 }
 
-DeleteSiteWarningDialog.propTypes = {
+DeleteSiteWarnings.propTypes = {
 	isVisible: PropTypes.bool.isRequired,
 	p2HubP2Count: PropTypes.number,
-	onClose: PropTypes.func.isRequired,
 	isTrialSite: PropTypes.bool,
 };
 
-export default DeleteSiteWarningDialog;
+export default DeleteSiteWarnings;

--- a/client/my-sites/site-settings/delete-site-warnings/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warnings/index.jsx
@@ -76,8 +76,8 @@ function DeleteSiteWarnings( { p2HubP2Count, isAtomicRemovalInProgress, isTrialS
 }
 
 DeleteSiteWarnings.propTypes = {
-	isVisible: PropTypes.bool.isRequired,
 	p2HubP2Count: PropTypes.number,
+	isAtomicRemovalInProgress: PropTypes.bool,
 	isTrialSite: PropTypes.bool,
 };
 

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -135,7 +135,6 @@ class DeleteSite extends Component {
 						onChange={ this.onConfirmDomainChange }
 						value={ this.state.confirmDomain }
 						aria-required="true"
-						data-testid="confirmDomainChangeInput"
 					/>
 					<Button
 						primary
@@ -147,7 +146,6 @@ class DeleteSite extends Component {
 							! this.props.hasLoadedSitePurchasesFromServer ||
 							isAtomicRemovalInProgress
 						}
-						data-testid="deleteSite"
 						onClick={ this.handleDeleteSiteClick }
 					>
 						{ translate( 'Delete site' ) }

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -135,7 +135,7 @@ class DeleteSite extends Component {
 						onChange={ this.onConfirmDomainChange }
 						value={ this.state.confirmDomain }
 						aria-required="true"
-						id="confirmDomainChangeInput"
+						data-testid="confirmDomainChangeInput"
 					/>
 					<Button
 						primary
@@ -147,6 +147,7 @@ class DeleteSite extends Component {
 							! this.props.hasLoadedSitePurchasesFromServer ||
 							isAtomicRemovalInProgress
 						}
+						data-testid="deleteSite"
 						onClick={ this.handleDeleteSiteClick }
 					>
 						{ translate( 'Delete site' ) }

--- a/client/my-sites/site-settings/delete-site/test/index.js
+++ b/client/my-sites/site-settings/delete-site/test/index.js
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import DeleteSite from '../index';
+
+const initialState = {
+	sites: {
+		items: [
+			{},
+			{
+				URL: 'test.com',
+			},
+		],
+		requesting: {},
+		plans: {},
+	},
+	ui: {
+		selectedSiteId: 1,
+	},
+	currentUser: {
+		id: 12,
+		user: {
+			email_verified: true,
+		},
+	},
+	notices: {
+		items: [],
+	},
+	purchases: {
+		hasLoadedSitePurchasesFromServer: true,
+		data: [],
+	},
+};
+
+const mockDeleteSite = jest.fn();
+
+jest.mock( 'calypso/components/data/query-site-purchases', () => {
+	return () => {};
+} );
+jest.mock( 'calypso/components/inline-support-link', () => {
+	return () => {
+		<>InlineSupportLink</>;
+	};
+} );
+
+describe( 'index', () => {
+	jest.mock( 'calypso/state/sites/actions', () => {
+		return {
+			deleteSite: mockDeleteSite,
+		};
+	} );
+
+	test( 'Check DeleteSite renders as expected', async () => {
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+		const queryClient = new QueryClient();
+
+		render(
+			<Provider store={ store }>
+				<QueryClientProvider client={ queryClient }>
+					<DeleteSite context="profile" siteCount={ 1 } />
+				</QueryClientProvider>
+			</Provider>
+		);
+
+		expect(
+			screen.getByText( 'irreversible and will permanently remove all site content' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'Check will delete a site if the typed domain it the current one', async () => {
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+		const queryClient = new QueryClient();
+
+		render(
+			<Provider store={ store }>
+				<QueryClientProvider client={ queryClient }>
+					<DeleteSite context="profile" siteCount={ 1 } />
+				</QueryClientProvider>
+			</Provider>
+		);
+
+		fireEvent.change( screen.getByTestId( 'confirmDomainChangeInput' ), {
+			target: { value: 'test.com' },
+		} );
+
+		const deleteButton = await screen.getByTestId( 'deleteSite' );
+		expect( deleteButton ).not.toBeDisabled();
+		expect( mockDeleteSite ).not.toHaveBeenCalled();
+	} );
+
+	test( 'Check will show purchases message', async () => {
+		const mockStore = configureStore();
+		const storeData = initialState;
+		storeData.purchases.data = [
+			{
+				blog_id: 1,
+				active: true,
+				is_refundable: true,
+			},
+		];
+		const store = mockStore( storeData );
+		const queryClient = new QueryClient();
+
+		const { container } = render(
+			<Provider store={ store }>
+				<QueryClientProvider client={ queryClient }>
+					<DeleteSite context="profile" siteCount={ 1 } />
+				</QueryClientProvider>
+			</Provider>
+		);
+
+		expect( container.innerHTML ).toContain( 'You have active paid upgrades on your site' );
+	} );
+} );

--- a/client/my-sites/site-settings/delete-site/test/index.js
+++ b/client/my-sites/site-settings/delete-site/test/index.js
@@ -87,11 +87,11 @@ describe( 'index', () => {
 			</Provider>
 		);
 
-		fireEvent.change( screen.getByTestId( 'confirmDomainChangeInput' ), {
+		fireEvent.change( screen.getByRole( 'textbox' ), {
 			target: { value: 'test.com' },
 		} );
 
-		const deleteButton = await screen.getByTestId( 'deleteSite' );
+		const deleteButton = await screen.getByRole( 'button', { name: /Delete site/ } );
 		expect( deleteButton ).not.toBeDisabled();
 		expect( mockDeleteSite ).not.toHaveBeenCalled();
 	} );

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -4,10 +4,8 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
-import withP2HubP2Count from 'calypso/data/p2/with-p2-hub-p2-count';
 import { withSiteCopy } from 'calypso/landing/stepper/hooks/use-site-copy';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import DeleteSiteWarningDialog from 'calypso/my-sites/site-settings/delete-site-warning-dialog';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { errorNotice } from 'calypso/state/notices/actions';
 import {
@@ -34,10 +32,6 @@ const trackDeleteSiteOption = ( option ) => {
 };
 
 class SiteTools extends Component {
-	state = {
-		showDialog: false,
-	};
-
 	componentDidUpdate( prevProps ) {
 		if ( ! prevProps.purchasesError && this.props.purchasesError ) {
 			this.props.errorNotice( this.props.purchasesError );
@@ -151,11 +145,6 @@ class SiteTools extends Component {
 						description={ manageConnectionText }
 					/>
 				) }
-				<DeleteSiteWarningDialog
-					isVisible={ this.state.showDialog }
-					p2HubP2Count={ this.props?.p2HubP2Count }
-					onClose={ this.closeDialog }
-				/>
 			</div>
 		);
 	}
@@ -167,23 +156,6 @@ class SiteTools extends Component {
 	trackStartOver() {
 		trackDeleteSiteOption( 'start-over' );
 	}
-
-	checkForSubscriptions = ( event ) => {
-		trackDeleteSiteOption( 'delete-site' );
-		const { isAtomic, hasCancelablePurchases, p2HubP2Count } = this.props;
-
-		if ( isAtomic || ( ! hasCancelablePurchases && ! p2HubP2Count ) ) {
-			return true;
-		}
-
-		event.preventDefault();
-
-		this.setState( { showDialog: true } );
-	};
-
-	closeDialog = () => {
-		this.setState( { showDialog: false } );
-	};
 }
 
 export default compose( [
@@ -229,4 +201,4 @@ export default compose( [
 			errorNotice,
 		}
 	),
-] )( localize( withSiteCopy( withP2HubP2Count( SiteTools ) ) ) );
+] )( localize( withSiteCopy( SiteTools ) ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6296

## Proposed Changes

* Removed deletion site managing logic from the `/settings/general` page
* Migrated Dialog to ActionPanel messages format
* Showing error messages right after clicking on "Delete your site permanently"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Ensure we show the Trial warning and CTA on**:

*  Deleting Trial sites:

	<img width="815" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/fe4d96d9-ea96-495a-9153-0beb5f82df0c">

* Sites with active plans:

	<img width="804" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/b167c7fe-8fc1-4f6e-b5a6-8ec00bd8ce12">

* Sites with recent Atomic cancelation (removing plan process):

	<img width="806" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/990b9349-3052-44b9-a450-1859904aec52">


* Sites with P2

	**Note**: To simulate these sites, replace `data?.totalItems || 0` for `2` [here at p2HubP2Count attribute](https://github.com/Automattic/wp-calypso/blob/trunk/client/data/p2/with-p2-hub-p2-count.js#L8).

	<img width="806" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/13c4c252-4ec1-45a9-996e-a1f40ecfcba1">



* Normal deletable sites:

	<img width="806" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/f74aac8f-e58f-40ae-b5d8-11414b06a1eb">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?