### PR TITLE
Theme Showcase: Fix Broken Layout

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -7,15 +7,22 @@
 	flex-wrap: wrap;
 	font-size: $font-body-small;
 	line-height: 20px;
+	overflow: hidden;
 	white-space: nowrap;
 
 	.theme-tier-badge__content {
 		margin: 0 8px 4px 0;
+		max-width: 100%;
 		vertical-align: middle;
 
 		&.is-third-party {
 			background-color: var(--color-neutral-5);
 			color: var(--color-neutral-70);
+		}
+
+		.premium-badge__label {
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 	}
 }

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -4,11 +4,13 @@
 	color: var(--color-neutral-60);
 	display: flex;
 	flex-basis: 100%;
+	flex-wrap: wrap;
 	font-size: $font-body-small;
 	line-height: 20px;
+	white-space: nowrap;
 
 	.theme-tier-badge__content {
-		margin: 0 8px 0 0;
+		margin: 0 8px 4px 0;
 		vertical-align: middle;
 
 		&.is-third-party {

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -2,14 +2,19 @@
 @import "@wordpress/base-styles/mixins";
 
 .themes-list {
-	$theme-item-min-width: 320px;
-	$theme-item-horizontal-margin: 32px; // Keep using margin as there might be an empty row
-
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax($theme-item-min-width + $theme-item-horizontal-margin, 1fr));
+	grid-template-columns: 100%;
 	list-style: none;
 	padding: 0;
 	margin: 0 -10px; // items flush against list edge
+
+	@include break-small {
+		$theme-item-min-width: 320px;
+		$theme-item-horizontal-margin: 32px; // Keep using margin as there might be an empty row
+
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax($theme-item-min-width + $theme-item-horizontal-margin, 1fr));
+	}
 
 	.feature-example & {
 		max-width: 1000px;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -75,7 +75,10 @@ body.command-palette-modal-open {
 
 	// Themes sets it own padding/margin
 	.is-section-theme &,
-	.is-section-themes.has-no-sidebar & {
+	.is-section-themes.has-no-sidebar &,
+	.theme-default .layout.is-section-theme &,
+	.theme-default .layout.is-section-themes.has-no-sidebar &,
+	.theme-default .layout.is-section-themes:not(.is-logged-in) & {
 		padding: 0;
 		margin: 0;
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -27,13 +27,14 @@
 	}
 
 	.themes__header-logged-out {
-		padding: 24px 16px;
+		padding: 88px 16px 8px;
 		border: none;
 		margin: 0;
 		position: relative;
 
 		@include breakpoint-deprecated( ">660px" ) {
-			padding: 88px 32px 8px;
+			padding-left: 32px;
+			padding-right: 32px;
 		}
 
 		h1 {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #89309

## Proposed Changes

* Fix the `.theme-list` grid template breaking the layout on small screens.
* Ensure the Logged-out Theme Showcase header is (reasonably[^1]) correctly padded.

| | Before | After |
|--------|--------|--------|
| `/themes` (600px) | <img width="700" alt="Screenshot 2024-04-09 at 15 35 18" src="https://github.com/Automattic/wp-calypso/assets/2070010/da404282-3d60-4af1-8741-b9f74a42e3ea"> | <img width="700" alt="Screenshot 2024-04-09 at 15 34 19" src="https://github.com/Automattic/wp-calypso/assets/2070010/a8b9f76a-3bdb-41dd-a05d-1181e6288bc8"> |
| `/theme` (600px) | <img width="700" alt="Screenshot 2024-04-09 at 15 35 25" src="https://github.com/Automattic/wp-calypso/assets/2070010/87cfe8ba-ff51-49c6-911f-55a7d0c37b84"> | <img width="700" alt="Screenshot 2024-04-09 at 15 34 14" src="https://github.com/Automattic/wp-calypso/assets/2070010/a4efc6a7-3778-4191-8cd7-dc7e669b742a"> |
| `/themes` (350px) | <img width="700" alt="Screenshot 2024-04-09 at 15 44 19" src="https://github.com/Automattic/wp-calypso/assets/2070010/0f8b47d2-5b00-4955-9d82-5eb0eb6a4596"> | <img width="700" alt="Screenshot 2024-04-09 at 15 44 17" src="https://github.com/Automattic/wp-calypso/assets/2070010/06bac9e7-8f2d-4301-86c6-ceb06b7d5010"> |

[^1]: The logged-out layout is massively customized on every section and responsive breakpoint. I've attempted to follow the same sizes of the Plugins section, but there are a lot of differences and tiny details that would bloat this change to no end.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/themes` **logged out**.
* Ensure the header is correctly padded, without white space around and between light blue backgrounds (roughly compare with `/plugins`).
* Also check the details of a theme, and ensure there are no awkward margins above the back navigation.
* Navigate back to the Showcase.
* Resize the window to around ~300px.
* Ensure the theme cards don't overflow the layout anymore.

⚠️  Also **check for regressions** in the logged-in Theme Showcase and Onboarding Design Picker.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?