### PR TITLE
Congrats: remove legacy thank you code

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -26,7 +26,6 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HappinessSupport from 'calypso/components/happiness-support';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
-import PurchaseDetail from 'calypso/components/purchase-detail';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { debug, TRACKING_IDS } from 'calypso/lib/analytics/ad-tracking/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -712,33 +711,6 @@ export class CheckoutThankYou extends Component<
 		const hasFailedPurchases = failedPurchases.length > 0;
 		const componentAndPrimaryPurchaseAndDomain = this.getComponentAndPrimaryPurchaseAndDomain();
 		const [ component, primaryPurchase ] = componentAndPrimaryPurchaseAndDomain;
-
-		if ( ! this.isDataLoaded() ) {
-			return (
-				<div>
-					<CheckoutThankYouHeader
-						isDataLoaded={ false }
-						isSimplified={ isSimplified }
-						selectedSite={ selectedSite }
-						upgradeIntent={ upgradeIntent }
-						siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
-						displayMode={ displayMode }
-					/>
-
-					{ ! isSimplified && (
-						<>
-							<CheckoutThankYouFeaturesHeader isDataLoaded={ false } />
-
-							<div className="checkout-thank-you__purchase-details-list">
-								<PurchaseDetail isPlaceholder />
-								<PurchaseDetail isPlaceholder />
-								<PurchaseDetail isPlaceholder />
-							</div>
-						</>
-					) }
-				</div>
-			);
-		}
 
 		return (
 			<div>

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -26,6 +26,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HappinessSupport from 'calypso/components/happiness-support';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { debug, TRACKING_IDS } from 'calypso/lib/analytics/ad-tracking/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -711,6 +712,33 @@ export class CheckoutThankYou extends Component<
 		const hasFailedPurchases = failedPurchases.length > 0;
 		const componentAndPrimaryPurchaseAndDomain = this.getComponentAndPrimaryPurchaseAndDomain();
 		const [ component, primaryPurchase ] = componentAndPrimaryPurchaseAndDomain;
+
+		if ( ! this.isDataLoaded() ) {
+			return (
+				<div>
+					<CheckoutThankYouHeader
+						isDataLoaded={ false }
+						isSimplified={ isSimplified }
+						selectedSite={ selectedSite }
+						upgradeIntent={ upgradeIntent }
+						siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
+						displayMode={ displayMode }
+					/>
+
+					{ ! isSimplified && (
+						<>
+							<CheckoutThankYouFeaturesHeader isDataLoaded={ false } />
+
+							<div className="checkout-thank-you__purchase-details-list">
+								<PurchaseDetail isPlaceholder />
+								<PurchaseDetail isPlaceholder />
+								<PurchaseDetail isPlaceholder />
+							</div>
+						</>
+					) }
+				</div>
+			);
+		}
 
 		return (
 			<div>

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -44,7 +44,10 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
-import { isRequesting as isRequestingSitePlugins } from 'calypso/state/plugins/installed/selectors';
+import {
+	isRequesting as isRequestingSitePlugins,
+	getPlugins as getInstalledPlugins,
+} from 'calypso/state/plugins/installed/selectors';
 import { isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
@@ -642,10 +645,15 @@ export class CheckoutThankYou extends Component<
 	};
 }
 
+function isWooCommercePluginInstalled( sitePlugins: { slug: string }[] ) {
+	return sitePlugins.length > 0 && sitePlugins.some( ( item ) => item.slug === 'woocommerce' );
+}
+
 export default connect(
 	( state: IAppState, props: CheckoutThankYouProps ) => {
 		let siteId = getSelectedSiteId( state );
 		const activeTheme = getActiveTheme( state, siteId ?? 0 );
+		const sitePlugins = getInstalledPlugins( state, [ siteId ] );
 		const receipt = getReceiptById( state, props.receiptId );
 
 		if ( props.domainOnlySiteFlow && receipt.hasLoadedFromServer ) {
@@ -664,6 +672,7 @@ export default connect(
 			gsuiteReceipt: props.gsuiteReceiptId ? getReceiptById( state, props.gsuiteReceiptId ) : null,
 			sitePlans: getPlansBySite( state, props.selectedSite ),
 			isFetchingSitePlugins: isRequestingSitePlugins( state, siteId ),
+			isWooCommerceInstalled: isWooCommercePluginInstalled( sitePlugins ),
 			upgradeIntent: props.upgradeIntent || getCheckoutUpgradeIntent( state ),
 			isSimplified:
 				[ 'install_theme', 'install_plugin', 'browse_plugins' ].indexOf( props.upgradeIntent ) !==

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
@@ -8,6 +8,7 @@ import { DefaultMasterbarContact } from './default-contact';
 const MasterbarStyledBlock = styled( Masterbar )`
 	--color-masterbar-background: var( --studio-white );
 	--color-masterbar-text: var( --studio-gray-60 );
+	padding-right: 24px;
 	border-bottom: 0;
 `;
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -28,7 +28,7 @@
 
 		&.main {
 			max-width: 750px;
-			padding: 0 24px 0;
+			padding: 0;
 			display: flex;
 			flex-direction: column;
 			text-align: initial;
@@ -660,6 +660,15 @@
 	100% {
 		transform: translateY(-80px);
 		opacity: 1;
+	}
+}
+
+.is-section-checkout-thank-you {
+	background: var(--studio-white);
+
+	.layout__content {
+		padding-right: 0;
+		padding-left: 0;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6015-gh-Automattic/dotcom-forge

## Proposed Changes

Remove legacy unused/unreachable thank you code from [client/my-sites/checkout/checkout-thank-you/index.tsx](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/checkout/checkout-thank-you/index.tsx)

There is additional code to remove in other files that will be split up/batched into followup(s).

## Testing Instructions

Confirm that these purchase flows continue to match behavior on `trunk`:

- Domain only
- Dlan only
- Ecomm plan only
- Plan with domain 
- Add-ons (e.g. Jetpack AI)
- Delayed domain transfer (i.e. select a domain transfer during signup)
- Titan email
- Google Workspace email
- Bulk domain transfer (e.g. https://wordpress.com/transfer-google-domains/)

All but Delayed domain transfers should render the new Congrats pages.