### PR TITLE
Patterns: fix patterns titles alignment

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -47,8 +47,8 @@
 	}
 
 	.pattern-preview__header {
-		align-items: start;
 		display: flex;
+		align-items: flex-start;
 		font-family: $font-sf-pro-display;
 		gap: 16px;
 		justify-content: space-between;
@@ -61,8 +61,7 @@
 	.pattern-preview__title {
 		font-size: inherit;
 		line-height: inherit;
-		padding-bottom: 0;
-		padding-top: 4px;
+		padding: 0;
 		text-align: left;
 
 		&:hover {
@@ -121,12 +120,11 @@
 	flex-direction: column-reverse;
 
 	.pattern-preview__header {
+		align-items: center;
 		min-height: auto;
 	}
 
 	.pattern-preview__title {
-		padding-top: 8px;
-
 		@include break-huge {
 			font-size: rem(20px);
 		}

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -47,8 +47,8 @@
 	}
 
 	.pattern-preview__header {
+		align-items: start;
 		display: flex;
-		align-items: flex-start;
 		font-family: $font-sf-pro-display;
 		gap: 16px;
 		justify-content: space-between;
@@ -61,7 +61,8 @@
 	.pattern-preview__title {
 		font-size: inherit;
 		line-height: inherit;
-		padding: 0;
+		padding-bottom: 0;
+		padding-top: 4px;
 		text-align: left;
 
 		&:hover {
@@ -125,6 +126,7 @@
 	}
 
 	.pattern-preview__title {
+		padding-top: 0;
 		@include break-huge {
 			font-size: rem(20px);
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6464

## Proposed Changes
When a preview is resized to mobile width where the pattern name wraps to the second line - the name is not aligned properly with the button:
<img width="288" alt="Screenshot 2024-04-09 at 16 23 45" src="https://github.com/Automattic/wp-calypso/assets/5598437/61692d41-7f5d-4c5e-8d4c-115f352d4b8d">


## Testing Instructions
1) Open `/patterns/header`
2) Assert then pattern name is aligned with button <br /><img width="1264" alt="Screenshot 2024-04-09 at 16 25 17" src="https://github.com/Automattic/wp-calypso/assets/5598437/516d2253-e2a5-4333-824d-3658f82325e2">
3) Check mobile version
4) Assert that it's aligned and looks good <br /> <img width="304" alt="Screenshot 2024-04-09 at 16 26 08" src="https://github.com/Automattic/wp-calypso/assets/5598437/13f6a207-83e0-4e6e-a5e7-12c3f210786a">
5) Let's test grid view (I decided that here is better to align top top) <br /> <img width="1271" alt="Screenshot 2024-04-09 at 16 26 59" src="https://github.com/Automattic/wp-calypso/assets/5598437/bde35945-4c3d-4bcd-9d60-bc19f96f0d37">

