### PR TITLE
Fix moment longDateFormat for en locale

### DIFF
--- a/apps/odyssey-stats/.size-limit.js
+++ b/apps/odyssey-stats/.size-limit.js
@@ -3,7 +3,7 @@ const path = require( 'path' );
 module.exports = [
 	{
 		path: path.join( __dirname, 'dist/build.min.js' ),
-		limit: '350 KiB',
+		limit: '385 KiB',
 	},
 	{
 		path: path.join( __dirname, 'dist/widget-loader.min.js' ),

--- a/apps/odyssey-stats/src/lib/set-locale.ts
+++ b/apps/odyssey-stats/src/lib/set-locale.ts
@@ -1,21 +1,75 @@
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
-import moment from 'moment';
-
+import moment, { LongDateFormatKey } from 'moment';
+import { phpToMomentMapping } from 'calypso/my-sites/site-settings/date-time-format/utils';
 const debug = debugFactory( 'apps:odyssey' );
 
 const DEFAULT_LANGUAGE = 'en';
 const DEFAULT_MOMENT_LOCALE = 'en';
+// Only Simple Site has the default locale as 'en'. For atomic/jetpack sites the default locale is 'en-us'.
+const SIMPLE_SITE_DEFAULT_LOCALE = 'en';
 const ALWAYS_LOAD_WITH_LOCALE = [ 'zh' ];
 
 const getLanguageCodeFromLocale = ( localeSlug: string ) => {
+	debug( localeSlug );
 	if ( localeSlug.indexOf( '-' ) > -1 ) {
 		return localeSlug.split( '-' )[ 0 ];
 	}
 	return localeSlug;
 };
 
-const loadMomentLocale = ( localeSlug: string, languageCode: string ) => {
+const convertPhpToMomentFormat = ( phpFormat: string ): string => {
+	const phpToMomentMap = phpToMomentMapping as {
+		[ key: string ]: string;
+	};
+
+	let momentFormat = '';
+
+	for ( let i = 0; i < phpFormat.length; i++ ) {
+		const char = phpFormat.charAt( i );
+		if ( phpToMomentMap[ char ] ) {
+			momentFormat += phpToMomentMap[ char ];
+		} else {
+			momentFormat += char;
+		}
+	}
+
+	return momentFormat;
+};
+
+/**
+ * WordPress core replaces the longDateFormat with the PHP date format.
+ * https://github.com/WordPress/wordpress-develop/blob/1393dc25b54479314acd2162fc39befd84dc46eb/src/wp-includes/script-loader.php#L155
+ * This function will convert it back to the moment format.
+ *
+ * So for Simple sites, the longDateFormat for en is changed to a PHP date format.
+ */
+const fixLongDateFormatForEn = ( localeSlug: string ) => {
+	if ( localeSlug === SIMPLE_SITE_DEFAULT_LOCALE ) {
+		const keysReplacedByWordPressCore: LongDateFormatKey[] = [
+			'LTS',
+			'LT',
+			'L',
+			'LL',
+			'LLL',
+			'LLLL',
+		];
+		const currentLocaleData = moment.localeData();
+		const momentLongDateFormat: Partial< { [ key in LongDateFormatKey ]: string } > = {};
+		keysReplacedByWordPressCore.forEach( ( key ) => {
+			if ( currentLocaleData.longDateFormat( key ) ) {
+				momentLongDateFormat[ key ] = convertPhpToMomentFormat(
+					currentLocaleData.longDateFormat( key )
+				);
+			}
+		} );
+		moment.updateLocale( localeSlug, {
+			longDateFormat: momentLongDateFormat as { [ key in LongDateFormatKey ]: string },
+		} );
+	}
+};
+
+const loadMomentLocale = async ( localeSlug: string, languageCode: string ) => {
 	return import( `moment/locale/${ localeSlug }` )
 		.catch( ( error: Error ) => {
 			debug(
@@ -37,6 +91,7 @@ const loadMomentLocale = ( localeSlug: string, languageCode: string ) => {
 			);
 			// Fallback 2 to the default US date time format.
 			// Interestingly `en` here represents `en-us` locale.
+			fixLongDateFormatForEn( localeSlug );
 			localeSlug = DEFAULT_MOMENT_LOCALE;
 		} )
 		.then( () => moment.locale( localeSlug ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6334

## Proposed Changes

On Simple Site Classic, WordPress core replaces the `longDateFormat` with PHP date formats, hence we're seeing the issue.
In this PR, we will convert the PHP date formats back to moment Date formats.

More details on why it only breaks in Simple Classic:
* https://github.com/Automattic/wp-calypso/pull/89158#issuecomment-2044313813
* https://github.com/Automattic/wp-calypso/pull/89158#issuecomment-2044410617


| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/effa6f35-96f6-4700-ab79-c666284e3fa3">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/5799bf9e-773f-495e-85fc-95975ddd7840">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To get a Simple Site Classic, please run this in your sandbox's wpsh:

```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID,'wpcom_classic_early_release', 1 );
```

* Go to `/apps/odyssey-stats`
* Run NODE_ENV=production yarn dev --sync to sync the changes to your sandbox
* Sandbox `widgets.wp.com`
* Go to `/wp-admin/admin.php?page=stats`
* Make sure the locale formats are correct

Note: Make sure when changing the site to other locales in Users > Profile (`/wp-admin/profile.php`), the locales are still respected.

Test for Atomic and Jetpack sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?