### PR TITLE
A4A: update number of sites on signup

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -67,7 +67,7 @@ export default function AgencyDetailsForm( {
 	const [ addressState, setAddressState ] = useState( initialValues.state ?? '' );
 	const [ agencyName, setAgencyName ] = useState( initialValues.agencyName ?? '' );
 	const [ agencyUrl, setAgencyUrl ] = useState( initialValues.agencyUrl ?? '' );
-	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '1-20' );
+	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '1-5' );
 	const [ servicesOffered, setServicesOffered ] = useState( initialValues.servicesOffered ?? [] );
 
 	const country = getCountry( countryValue, countryOptions );

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -181,9 +181,12 @@ export default function AgencyDetailsForm( {
 						value={ managedSites }
 						onChange={ handleSetManagedSites }
 					>
-						<option value="1-20">{ translate( '1-20' ) }</option>
-						<option value="21-100">{ translate( '21–100' ) }</option>
-						<option value="101+">{ translate( '101+' ) }</option>
+						<option value="1-5">{ translate( '1-5' ) }</option>
+						<option value="6-25">{ translate( '6-25' ) }</option>
+						<option value="26-50">{ translate( '26-50' ) }</option>
+						<option value="51-100">{ translate( '51-100' ) }</option>
+						<option value="101-500">{ translate( '101-500' ) }</option>
+						<option value="501+">{ translate( '501+' ) }</option>
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/255

## Proposed Changes

Update the number of sites on signup form
<img width="633" alt="Screenshot 2024-04-09 at 9 26 11 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/11cf14d8-ffe1-4eda-89b4-66f748b122d0">

## Testing Instructions

- Create new WPCOM user
- Spin up this branch or use live link and navigate to `/signup`
- Observe the number of sites values.
- Patch wpcom diff: D144812-code
- Make hosts file point to your sandbox
- Finish registration, should be successfull
- Follow instructions to check values here: D142696-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?