### PR TITLE
A4A: Change order of hosting & products on overview page and marketplace

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -293,6 +293,18 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 				) }
 			</div>
 
+			{ wooExtensions.length > 0 && (
+				<ListingSection
+					icon={ <WooLogo width={ 45 } height={ 28 } /> }
+					title={ translate( 'WooCommerce Extensions' ) }
+					description={ translate(
+						'You must have WooCommerce installed to utilize these paid extensions.'
+					) }
+				>
+					{ getProductCards( wooExtensions ) }
+				</ListingSection>
+			) }
+
 			{ plans.length > 0 && (
 				<ListingSection
 					icon={ <JetpackLogo size={ 26 } /> }
@@ -315,18 +327,6 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 					) }
 				>
 					{ getProductCards( products ) }
-				</ListingSection>
-			) }
-
-			{ wooExtensions.length > 0 && (
-				<ListingSection
-					icon={ <WooLogo width={ 45 } height={ 28 } /> }
-					title={ translate( 'WooCommerce Extensions' ) }
-					description={ translate(
-						'You must have WooCommerce installed to utilize these paid extensions.'
-					) }
-				>
-					{ getProductCards( wooExtensions ) }
 				</ListingSection>
 			) }
 

--- a/client/a8c-for-agencies/sections/overview/body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/index.tsx
@@ -8,8 +8,8 @@ const OverviewBody = () => {
 		<div className="overview-body">
 			<OverviewBodyIntroCards />
 			<OverviewBodyNextSteps />
-			<OverviewBodyProducts />
 			<OverviewBodyHosting />
+			<OverviewBodyProducts />
 		</div>
 	);
 };

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -45,7 +45,7 @@ const OverviewBodyProducts = () => {
 		],
 		// translators: Button navigating to A4A Marketplace
 		buttonTitle: translate( 'View all Jetpack products' ),
-		expanded: true,
+		expanded: false,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'jetpack' );
 			page( A4A_PRODUCTS_MARKETPLACE_LINK );
@@ -73,7 +73,7 @@ const OverviewBodyProducts = () => {
 		],
 		// translators: Button navigating to A4A Marketplace
 		buttonTitle: translate( 'View all WooCommerce products' ),
-		expanded: false,
+		expanded: true,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'woocommerce' );
 			page( A4A_PRODUCTS_MARKETPLACE_LINK );
@@ -86,7 +86,7 @@ const OverviewBodyProducts = () => {
 			description={ translate(
 				'Add services to create sites, increase security and performance, and provide excellent shopping experiences for your clients’ sites.'
 			) }
-			items={ [ jetpack, woo ] }
+			items={ [ woo, jetpack ] }
 		/>
 	);
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/254

## Proposed Changes

* This PR:
  * Overview page: Moves 'Hosting' above 'Products' , and 'Jetpack' below 'WooCommerce' in the Products section.
  * MarketPlace - Products: Move Woo Extensions to the top of the page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start A4A ( `yarn start-a8c-for-agencies` )
* Open up the **Overview** page (`/overview`)
  * The order of the sections should be:
     * Welcome to the Automattic for Agencies beta
     * Next Steps
     * Hosting
        * Pressable
        * WordPress.com
     * Products
        * WooCommerce
        * Jetpack
* Open up the **Marketplace - Products** page (`/marketplace/products`)
  * The order of the sections should be:
     * WooCommerce Extensions
     * Jetpack Plans
     * Jetpack Products
     * Jetpack VaultPress Backup Add-ons


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?