### PR TITLE
Stats: Adjust the layout distribution of the purchase upgrade page

### DIFF
--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -9,7 +9,10 @@ $button-padding: 8px 32px;
 	--jp-white: #fff;
 	--jp-green-50: #008710;
 	--gray-gray-50: #646970;
+	--stats-purchase-width: 1124px;
+	// The following variables are layout distribution related to the `--stats-purchase-width`.
 	--stats-purchase-right-width: 456px;
+	--stats-purchase-left-max-width: calc(var(--stats-purchase-width) - var(--stats-purchase-right-width));
 
 	// Apply Jetpack dedicated styling upon the Calypso theme base.
 	&:not(.stats-purchase-page--is-wpcom) {
@@ -162,7 +165,7 @@ $button-padding: 8px 32px;
 
 	.stats-purchase-wizard__card-parent {
 		border-radius: 4px;
-		width: 1124px;
+		width: var(--stats-purchase-width);
 		max-width: 100%;
 	}
 
@@ -183,7 +186,7 @@ $button-padding: 8px 32px;
 		padding: 64px;
 		box-sizing: border-box;
 		flex: 2 2 auto;
-		max-width: 668px;
+		max-width: var(--stats-purchase-left-max-width);
 
 		@media (max-width: $break-medium) {
 			padding: 32px 24px;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -182,7 +182,8 @@ $button-padding: 8px 32px;
 	.stats-purchase-wizard__card-inner--left {
 		padding: 64px;
 		box-sizing: border-box;
-		flex: 2 1 auto;
+		flex: 2 2 auto;
+		max-width: 668px;
 
 		@media (max-width: $break-medium) {
 			padding: 32px 24px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84885 

## Proposed Changes

* Make the layout of columns reasonable for the upgrade purchase page on a narrower viewport.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to the Stats purchase page with a site with a purchased Stats commercial license: `/stats/purchase/{site-slug}`.
* Ensure the page layout is reasonable for a `full-width` browser window.
* Narrow the window to a narrower width of about `1063px`.
* Ensure the page layout is reasonable as well.

#### Full-width
|Before|After|
|-|-|
|<img width="920" alt="u_wide_old" src="https://github.com/Automattic/wp-calypso/assets/6869813/86b5c687-c318-46f4-966b-50febc75194c">|<img width="937" alt="u_wide_new" src="https://github.com/Automattic/wp-calypso/assets/6869813/0bd1b31d-f40e-4ea2-b191-4719e6a2d2fc">|

#### <= 1063px
|Before|After|
|-|-|
|<img width="642" alt="u_narrow_old" src="https://github.com/Automattic/wp-calypso/assets/6869813/4654f50a-d841-4c05-9440-427d97bfc122">|<img width="605" alt="u_narrow_new" src="https://github.com/Automattic/wp-calypso/assets/6869813/32d4ec4d-4fcf-4947-982d-af7b485b2b6b">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?