### PR TITLE
A4A: Remove create a WPCOM site in "Add new site" dropdown

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -1,12 +1,9 @@
-import { Gridicon, WordPressLogo } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
-import {
-	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
-	A4A_SITES_CONNECT_URL_LINK,
-} from '../sidebar-menu/lib/constants';
+import { A4A_SITES_CONNECT_URL_LINK } from '../sidebar-menu/lib/constants';
 import type { MutableRefObject } from 'react';
 
 const JETPACK_CONNECT_URL = 'https://wordpress.com/jetpack/connect?source=a8c-for-agencies';
@@ -17,7 +14,6 @@ type Props = {
 	popoverContext?: MutableRefObject< HTMLElement | null >;
 	onToggleMenu?: ( isOpen: boolean ) => void;
 	onClickAddNewSite?: () => void;
-	onClickWpcomMenuItem?: () => void;
 	onClickJetpackMenuItem?: () => void;
 	onClickUrlMenuItem?: () => void;
 };
@@ -28,7 +24,6 @@ const AddNewSiteButton = ( {
 	popoverContext,
 	onToggleMenu,
 	onClickAddNewSite,
-	onClickWpcomMenuItem,
 	onClickJetpackMenuItem,
 	onClickUrlMenuItem,
 }: Props ): JSX.Element => {
@@ -47,12 +42,6 @@ const AddNewSiteButton = ( {
 			onClick={ onClickAddNewSite }
 			href={ JETPACK_CONNECT_URL }
 		>
-			{ /** @todo The A4A_MARKETPLACE_HOSTING_WPCOM_LINK URL does not exist yet.*/ }
-			<PopoverMenuItem onClick={ onClickWpcomMenuItem } href={ A4A_MARKETPLACE_HOSTING_WPCOM_LINK }>
-				<WordPressLogo className="gridicon" size={ 18 } />
-				<span>{ translate( 'Create a new WordPress.com site' ) }</span>
-			</PopoverMenuItem>
-
 			{ /** @todo Add support for the "a8c-for-agencies" source parameter in JETPACK_CONNECT_URL. */ }
 			<PopoverMenuItem onClick={ onClickJetpackMenuItem } href={ JETPACK_CONNECT_URL }>
 				<JetpackLogo className="gridicon" size={ 18 } />

--- a/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
@@ -20,9 +20,6 @@ export default function OverviewHeaderActions() {
 				onClickAddNewSite={ () =>
 					dispatch( recordTracksEvent( 'calypso_a4a_overview_add_new_site_click' ) )
 				}
-				onClickWpcomMenuItem={ () =>
-					dispatch( recordTracksEvent( 'calypso_a4a_overview_create_wpcom_site_click' ) )
-				}
 				onClickJetpackMenuItem={ () =>
 					dispatch( recordTracksEvent( 'calypso_a4a_overview_connect_jetpack_site_click' ) )
 				}

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -25,9 +25,6 @@ export default function SitesHeaderActions() {
 					onClickAddNewSite={ () =>
 						dispatch( recordTracksEvent( 'calypso_a4a_sites_add_new_site_click' ) )
 					}
-					onClickWpcomMenuItem={ () =>
-						dispatch( recordTracksEvent( 'calypso_a4a_sites_create_wpcom_site_click' ) )
-					}
 					onClickJetpackMenuItem={ () =>
 						dispatch( recordTracksEvent( 'calypso_a4a_sites_connect_jetpack_site_click' ) )
 					}


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/257

## Proposed Changes

* This PR removes the 'Create a new WordPress.com site' option from our  "Add new site" dropdown.

## Testing Instructions

* Start A4A ( `yarn start-a8c-for-agencies` )
* Check the  "Add new site" dropdown on the Overview page (`/overview`), and on the Sites Dashboard (`/sites`)
*  'Create a new WordPress.com site' option should be gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?