### PR TITLE
Monetize: Fix Launchpad CSS, boxes & ads tabs

### DIFF
--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -160,6 +160,19 @@
 	}
 }
 
+.theme-jetpack-cloud {
+	.ads__activate-header-title {
+		font-size: $font-title-small;
+	}
+	.action-card__heading {
+		font-size: $font-body-large;
+	}
+	.action-card__main {
+		p {
+			font-size: $font-body;
+		}
+	}
+}
 .ads__activate-header-title {
 	font-weight: 600;
 }

--- a/client/my-sites/earn/customers/customer/customer-header.tsx
+++ b/client/my-sites/earn/customers/customer/customer-header.tsx
@@ -3,6 +3,7 @@ import { Item } from 'calypso/components/breadcrumb';
 import Gravatar from 'calypso/components/gravatar';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { decodeEntities } from 'calypso/lib/formatting';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { Subscriber } from '../../types';
@@ -12,6 +13,7 @@ import './style.scss';
 type CustomerHeaderProps = {
 	customer: Subscriber;
 };
+const earnPath = ! isJetpackCloud() ? '/earn' : '/monetize';
 
 const CustomerHeader = ( { customer }: CustomerHeaderProps ) => {
 	const translate = useTranslate();
@@ -20,11 +22,11 @@ const CustomerHeader = ( { customer }: CustomerHeaderProps ) => {
 	const breadcrumbs: Item[] = [
 		{
 			label: translate( 'Monetize' ),
-			href: `/earn/${ siteSlug }`,
+			href: `${ earnPath }/${ siteSlug }`,
 		},
 		{
 			label: translate( 'Supporters' ),
-			href: `/earn/supporters/${ siteSlug }`,
+			href: `${ earnPath }/supporters/${ siteSlug }`,
 		},
 		{
 			label: translate( 'Details' ),

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -167,11 +167,14 @@ const CustomerSection = ( { query }: CustomerSectionProps ) => {
 			} );
 		}
 	}
+	const earnPath = ! isJetpackCloud() ? '/earn' : '/monetize';
 
 	function renderSubscriberActions( subscriber: Subscriber ) {
 		return (
 			<EllipsisMenu position="bottom left" className="memberships__subscriber-actions">
-				<PopoverMenuItem href={ `/earn/supporters/${ site?.slug }?subscriber=${ subscriber.id }` }>
+				<PopoverMenuItem
+					href={ `${ earnPath }/supporters/${ site?.slug }?subscriber=${ subscriber.id }` }
+				>
 					<Gridicon size={ 18 } icon="visible" />
 					{ translate( 'View' ) }
 				</PopoverMenuItem>

--- a/client/my-sites/earn/index.ts
+++ b/client/my-sites/earn/index.ts
@@ -12,7 +12,7 @@ import {
 const earnPath = ! isJetpackCloud() ? '/earn' : '/monetize';
 
 export default function () {
-	page( '/earn', siteSelection, sites, makeLayout, clientRender );
+	page( earnPath, siteSelection, sites, makeLayout, clientRender );
 	page( earnPath + '/supporters', siteSelection, sites, makeLayout, clientRender );
 	page( earnPath + '/payments', siteSelection, sites, makeLayout, clientRender );
 	// This is legacy, we are leaving it here because it may have been public

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -242,6 +242,9 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		);
 	};
 
+	const atomicLearnMoreLink = localizeUrl( 'https://wordpress.com/support/monetize-your-site/' );
+	const jetpackLearnMoreLink = localizeUrl( 'https://jetpack.com/support/monetize-your-site/' );
+
 	return (
 		<Main wideLayout={ true } className="earn">
 			<PageViewTracker
@@ -260,9 +263,9 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 							'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 							{
 								components: {
-									learnMoreLink: isJetpackNotAtomic ? (
+									learnMoreLink: isJetpackCloud() ? (
 										<a
-											href={ localizeUrl( 'https://jetpack.com/support/monetize-your-site/' ) }
+											href={ isJetpackNotAtomic ? jetpackLearnMoreLink : atomicLearnMoreLink }
 											target="_blank"
 											rel="noopener noreferrer"
 										/>

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -28,7 +28,7 @@ body.is-section-earn.theme-default.color-scheme {
 
 .memberships__module-content {
 	max-height: 520px;
-	overflow-y: scroll;
+	overflow-y: auto;
 	margin-top: -24px;
 	border-bottom: 1px solid var(--color-neutral-5);
 }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -36,6 +36,21 @@
 			}
 		}
 	}
+	.highlight-card-tooltip-content {
+		p {
+			font-size: $font-body-small;
+			font-weight: normal;
+		}
+	}
+	.earn__cancel-dialog {
+		h1 {
+			font-size: $font-title-small;
+		}
+		p {
+			font-size: $font-body;
+		}
+	}
+
 }
 
 .earn__launchpad {

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -142,6 +142,7 @@
 		color: var(--color-link);
 		&:hover {
 			background-color: transparent;
+			color: var(--color-link);
 		}
 	}
 }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -25,15 +25,14 @@
 		font-family: "SF Pro Display", $sans;
 	}
 
+	.earn__launchpad-title {
+		font-size: $font-size-header-small;
+	}
+
 	.promo-section {
-		.promo-card {
-			.gridicon {
-				background: none;
-			}
-		}
 		.action-panel__body {
 			p {
-				font-size: 1rem;
+				font-size: $font-body-small;
 			}
 		}
 	}
@@ -47,8 +46,17 @@
 	gap: 30px;
 	background: #fff;
 
+	@media (max-width: $break-xlarge) {
+		flex-direction: column;
+		gap: 10px;
+	}
+
 	.earn__launchpad-header {
 		padding: 20px 0;
+
+		@media (max-width: $break-xlarge) {
+			padding-bottom: 0;
+		}
 		.earn__launchpad-progress-bar-container {
 			margin: 0 0 10px 6px;
 		}

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -113,6 +113,39 @@
 	}
 }
 
+.earn__ads-header {
+	margin: 20px 0;
+
+	h2.formatted-header__title {
+		margin: 0 0 12px;
+		font-size: $font-size-header-small;
+	}
+
+	.section-nav {
+		box-shadow: none;
+		background: none;
+	}
+
+	.section-nav-tab {
+		&:hover:not(.is-selected) {
+			border-bottom-color: transparent;
+		}
+		&.is-selected {
+			border-bottom: none;
+			.section-nav-tab__link {
+				color: var(--color-text);
+			}
+		}
+	}
+	.section-nav-tab__link {
+		padding: 0 20px 10px 0;
+		color: var(--color-link);
+		&:hover {
+			background-color: transparent;
+		}
+	}
+}
+
 @include break-wide {
 	.earn .promo-card.is-primary {
 		padding-left: 72px;


### PR DESCRIPTION
P2: pdtkmj-2y9-p2#comment-4781

## Proposed Changes

- Rollback the background on the Boxes icons.
- Make the font size on boxes a little small.
- Fixed Launchpad on all screen sizes.
- Update Ad's settings CSS.
- Fixed individual subscriber view. 
- Fixed scrollbar showing on earnings.
- Also font sizes mentioned here: pdtkmj-2y9-p2#comment-4803

#### Known Bugs
- [x] When clicking on view subscriber, the URL changed but did not load the subscriber. It works if reloaded. Fixed https://github.com/Automattic/wp-calypso/pull/89390
- [x] Same as before, but in the inverse, viewing a subscriber, clicking on Subscribers at the top won't change the page. Fixed: https://github.com/Automattic/wp-calypso/pull/89390


#### Screenshots
| Before | After |
| --- | --- |
| https://github.com/Automattic/wp-calypso/assets/402286/dac0d954-226a-49c0-9cc7-7da87d475b4f | https://github.com/Automattic/wp-calypso/assets/402286/7d3a513c-2d27-42b3-a8fc-afeca9f155fd |
| ![Before](https://github.com/Automattic/wp-calypso/assets/402286/c0fb6541-9249-4025-93c6-7afdf865ea57 | ![After](https://github.com/Automattic/wp-calypso/assets/402286/34f7c006-2abf-423d-8893-573a0cde46f9) |
| ![Screenshot from 2024-04-09 15-43-34](https://github.com/Automattic/wp-calypso/assets/402286/a9bb6b40-a965-4be8-b06f-ce55f1c7aeef) | ![Screenshot from 2024-04-09 15-43-21](https://github.com/Automattic/wp-calypso/assets/402286/cafcf252-022c-453b-ba49-719b4daa8210) |


## Testing Instructions

* Run `yarn start-jetpack-cloud` or follow JP Cloud Live from the first comment.
* Go to `http://jetpack.cloud.localhost:3000/monetize`
* Should show the site selector.
* Check the Launchpad design in some resolutions/devices
* Check the boxes font size & icon background.
* Check export a supporter (instructions :point_down:)

#### How to be a supporter
Slack discussion: p1712690618985889-slack-CKZHG0QCR
- Sandbox public-api, `dashboard.wordpress.com` & `subscribe.wordpress.com`.
- Sandbox the store on your sandbox adding `define( 'USE_STORE_SANDBOX', true );` to your `0-sandbox.php` file
- In your Atomic site, you need to add `define( 'JETPACK__SANDBOX_DOMAIN', '$SANDBOX_HOSTNAME' );`
- Connect Stripe again (as you are sandboxed, you have to start over) at `/monetize/payments/YOUR_SITE`
- Create a `payment plan` at `/monetize/payments/YOUR_SITE`
- Add a `Paid content` button to a post (choosing your created plan :point_up: )
- Using another user, go to the post and subscribe using a test credit card ( PCYsg-IA-p2 )
- Now you should see a supporter on `/monetize/supporters/YOUR_SITE`