### PR TITLE
A8C For Agencies: Invalidate queries for the sites dashboard after updating tags

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import AgencySiteTags from 'calypso/a8c-for-agencies/components/agency-site-tags';
@@ -17,8 +18,8 @@ export default function SiteDetails( { site }: any ) {
 		initialTags ? initialTags.map( ( tag: SiteTagType ) => tag.label ) : []
 	);
 	const [ isLoading, setIsLoading ] = useState( false );
-
 	const { mutate } = useUpdateSiteTagsMutation();
+	const queryClient = useQueryClient();
 
 	const onAddTags = ( siteTags: string[] ) => {
 		setIsLoading( true );
@@ -31,6 +32,9 @@ export default function SiteDetails( { site }: any ) {
 				onSuccess: ( data ) => {
 					setTags( data.map( ( tag: SiteTagType ) => tag.label ) );
 					setIsLoading( false );
+					queryClient.invalidateQueries( {
+						queryKey: [ 'jetpack-agency-dashboard-sites' ],
+					} );
 				},
 				onError: ( error ) => {
 					setIsLoading( false );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Update the dashboard sites state after updating tags, as the dashboard sites are the mains source of truth

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run a8c-for-agencies environment locally
- Connect at least one site to your user, so they appear on the dashboard
- Click the sites to have the flyout pane opened
- There should be a "Details" tab in the flyout, click on it
- There's a form for adding tags, individual tags are comma separated
- Add tags
- Close the side panel & open again
- The tags should be updated
- Remove tags
- Close the side panel & open again
- The tags should be updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?