### PR TITLE
A8C For Agencies: Add keyboard event capture for entering tags by pressing Enter

### DIFF
--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { KeyboardEvent, useState } from 'react';
 import AgencySiteTag from 'calypso/a8c-for-agencies/components/agency-site-tag';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import './style.scss';
@@ -17,8 +17,16 @@ export default function AgencySiteTags( { tags, isLoading, onAddTags, onRemoveTa
 	const [ tagsInput, setTagsInput ] = useState( '' );
 
 	const handleAddTags = () => {
-		setTagsInput( '' );
 		onAddTags( tagsInput.split( ',' ).map( ( s ) => s.trim() ) );
+		setTagsInput( '' );
+	};
+
+	const handleEnterKeyPress = ( event: KeyboardEvent ) => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			onAddTags( tagsInput.split( ',' ).map( ( s ) => s.trim() ) );
+			setTagsInput( '' );
+		}
 	};
 
 	return (
@@ -30,6 +38,7 @@ export default function AgencySiteTags( { tags, isLoading, onAddTags, onRemoveTa
 					onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
 						setTagsInput( e.target.value )
 					}
+					onKeyDown={ handleEnterKeyPress }
 					value={ tagsInput }
 					placeholder={ translate( 'Add tags here (separate by commas)' ) }
 				/>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import SiteDetails from 'calypso/a8c-for-agencies/sections/sites/features/a4a/site-details';
@@ -56,8 +55,8 @@ export function JetpackPreviewPane( {
 	}, [] );
 
 	// Jetpack features: Boost, Backup, Monitor, Stats
-	const features = useMemo( () => {
-		const f = [
+	const features = useMemo(
+		() => [
 			createFeaturePreview(
 				JETPACK_BOOST_ID,
 				'Boost',
@@ -123,23 +122,17 @@ export function JetpackPreviewPane( {
 				setSelectedSiteFeature,
 				<JetpackActivityPreview siteId={ site.blog_id } />
 			),
-		];
-
-		if ( isEnabled( 'a4a/site-details-pane' ) ) {
-			f.push(
-				createFeaturePreview(
-					A4A_SITE_DETAILS_ID,
-					translate( 'Details' ),
-					true,
-					selectedSiteFeature,
-					setSelectedSiteFeature,
-					<SiteDetails site={ site } />
-				)
-			);
-		}
-
-		return f;
-	}, [ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ] );
+			createFeaturePreview(
+				A4A_SITE_DETAILS_ID,
+				translate( 'Details' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<SiteDetails site={ site } />
+			),
+		],
+		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ]
+	);
 
 	return (
 		<SitePreviewPane

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -30,8 +30,7 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"oauth": true,
-		"a4a/mock-api-data": true,
-		"a4a/site-details-pane": true
+		"a4a/mock-api-data": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* When adding site tags, should be able to submit by pressing Enter

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run a8c-for-agencies environment locally
- Connect at least one site to your user, so they appear on the dashboard
- Click the sites to have the flyout pane opened
- There should be a "Details" tab in the flyout, click on it
- There's a form for adding tags, individual tags are comma separated
- Write tags, hit Enter on your keyboard
- The tags should be updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?