### PR TITLE
Stats: Paywall for date picker

### DIFF
--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -3,7 +3,7 @@
 @import "./styles/wp-admin.scss";
 @import "./styles/typography.scss";
 
-.jp-stats-dashboard {
+.wp-admin {
 	.card {
 		border: 0;
 		max-width: initial;

--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -60,6 +60,8 @@ export const STATS_FEATURE_SUMMARY_LINKS_30_DAYS = 'StatsModuleSummaryLinks/30_d
 export const STATS_FEATURE_SUMMARY_LINKS_QUARTER = 'StatsModuleSummaryLinks/quarter';
 export const STATS_FEATURE_SUMMARY_LINKS_YEAR = 'StatsModuleSummaryLinks/year';
 export const STATS_FEATURE_SUMMARY_LINKS_ALL = 'StatsModuleSummaryLinks/all';
+// UTM Stats which is already in use, so didn't align with the naming convertion.
+export const STATS_FEATURE_UTM_STATS = 'stats_utm';
 
 // other
 export const STATS_DO_YOU_LOVE_JETPACK_STATS_NOTICE = 'DoYouLoveJetpackStatsNotice';

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -7,7 +7,7 @@ import {
 	PRODUCT_JETPACK_STATS_YEARLY,
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
-import { useMemo } from 'react';
+import { ComponentClass, useMemo } from 'react';
 import { useSelector } from 'calypso/state';
 import {
 	isFetchingSitePurchases,
@@ -93,3 +93,9 @@ export default function useStatsPurchases( siteId: number | null ) {
 		isLoading: ! hasLoadedSitePurchases || isRequestingSitePurchases,
 	};
 }
+
+export const withStatsPurchases =
+	( WrappedComponent: ComponentClass ) => ( props: { siteId: number | null } ) => {
+		const statsPurchases = useStatsPurchases( props.siteId );
+		return <WrappedComponent { ...props } { ...statsPurchases } />;
+	};

--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -16,10 +15,9 @@ const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, butt
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	let UpsellComponent = StatsCardUpsellWPCOM;
-	if ( isSiteJetpackNotAtomic || isOdysseyStats ) {
+	if ( isSiteJetpackNotAtomic ) {
 		UpsellComponent = StatsCardUpsellJetpack;
 	}
 

--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -1,60 +1,32 @@
 import { translate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
-import { preventWidows } from 'calypso/lib/formatting';
-import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
-import {
-	STATS_FEATURE_DATE_CONTROL,
-	STAT_TYPE_CLICKS,
-	STAT_TYPE_REFERRERS,
-	STAT_TYPE_SEARCH_TERMS,
-	STAT_TYPE_TOP_AUTHORS,
-} from '../constants';
-import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
+import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import StatsCardUpsellJetpack from './stats-card-upsell-jetpack';
+import StatsCardUpsellWPCOM from './stats-card-upsell-wpcom';
 
-import './style.scss';
-
-interface Props {
+export interface Props {
 	className: string;
 	statType: string;
 	siteId: number;
 	buttonLabel?: string;
 }
 
-const getUpsellCopy = ( statType: string ) => {
-	switch ( statType ) {
-		case STAT_TYPE_REFERRERS:
-			return translate(
-				'Find out where your visitors come from to optimize your content strategy.'
-			);
-		case STAT_TYPE_CLICKS:
-			return translate(
-				'Learn what external links your visitors click on your site to reveal their areas of interest.'
-			);
-		case STAT_TYPE_SEARCH_TERMS:
-			return translate( 'Discover the terms and phrases your visitors use to find your site.' );
-		case STAT_TYPE_TOP_AUTHORS:
-			return translate( 'Identify your audience’s favorite writers and perspectives.' );
-		case STATS_FEATURE_DATE_CONTROL:
-			return translate( 'Compare different time periods to analyze your site’s growth.' );
-		default:
-			return translate( 'Upgrade your plan to unlock Jetpack Stats.' );
-	}
-};
-
 const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, buttonLabel } ) => {
-	const dispatch = useDispatch();
+	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
 
-	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
-		event.preventDefault();
-		dispatch( toggleUpsellModal( siteId, statType ) );
-	};
+	let UpsellComponent = StatsCardUpsellWPCOM;
+	if ( isSiteJetpackNotAtomic ) {
+		UpsellComponent = StatsCardUpsellJetpack;
+	}
 
 	return (
-		<StatsCardUpsellOverlay
+		<UpsellComponent
 			className={ className }
-			onClick={ onClick }
-			copyText={ preventWidows( getUpsellCopy( statType ) ) }
-			buttonLabel={ buttonLabel }
+			statType={ statType }
+			siteId={ siteId }
+			buttonLabel={ buttonLabel ?? translate( 'Upgrade plan' ) }
 		/>
 	);
 };

--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -15,9 +16,10 @@ const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, butt
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	let UpsellComponent = StatsCardUpsellWPCOM;
-	if ( isSiteJetpackNotAtomic ) {
+	if ( isSiteJetpackNotAtomic || isOdysseyStats ) {
 		UpsellComponent = StatsCardUpsellJetpack;
 	}
 

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -65,7 +65,7 @@ const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteId, statTyp
 
 	return (
 		<StatsCardUpsellOverlay
-			className={ classNames( className, 'stats-card-upsell-jetpack' ) }
+			className={ className }
 			onClick={ onClick }
 			copyText={ copyText }
 			buttonComponent={

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -57,10 +57,7 @@ const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteId, statTyp
 		recordTracksEvent( `${ event_from }_${ tracksEvent }` );
 
 		// redirect to the Purchase page
-		setTimeout(
-			() => page.redirect( `/stats/purchase/${ siteSlug }?${ queryParams.toString() }` ),
-			250
-		);
+		setTimeout( () => page( `/stats/purchase/${ siteSlug }?${ queryParams.toString() }` ), 250 );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -8,29 +8,38 @@ import React from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { STATS_FEATURE_DATE_CONTROL, STATS_FEATURE_UTM_STATS } from '../constants';
 import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
+import { Props } from './';
 
-interface Props {
-	className: string;
-	siteSlug: string;
-	tracksEvent?: string;
-}
+const useUpsellCopy = ( statType: string ) => {
+	const translate = useTranslate();
+	switch ( statType ) {
+		case STATS_FEATURE_DATE_CONTROL:
+			return translate( 'Compare different time periods to analyze your site’s growth.' );
+		case STATS_FEATURE_UTM_STATS:
+			return translate(
+				'Track your campaign performance data with UTM codes. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
+					},
+				}
+			);
+		default:
+			return translate( 'Upgrade to unlock the feature' );
+	}
+};
 
-const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteSlug, tracksEvent } ) => {
+const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteId, statType } ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const copyText = translate(
-		'Track your campaign performance data with UTM codes. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
-		{
-			components: {
-				learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
-			},
-		}
-	);
+	const copyText = useUpsellCopy( statType );
 
-	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
+	const tracksEvent = `${ statType }_upgrade_clicked`;
 
 	const onClick = () => {
 		// We need to ensure we pass the irclick id for impact affiliate tracking if its set.
@@ -56,7 +65,7 @@ const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteSlug, track
 
 	return (
 		<StatsCardUpsellOverlay
-			className={ className }
+			className={ classNames( className, 'stats-card-upsell-jetpack' ) }
 			onClick={ onClick }
 			copyText={ copyText }
 			buttonComponent={

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
@@ -1,0 +1,56 @@
+import { translate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import { preventWidows } from 'calypso/lib/formatting';
+import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
+import {
+	STATS_FEATURE_DATE_CONTROL,
+	STAT_TYPE_CLICKS,
+	STAT_TYPE_REFERRERS,
+	STAT_TYPE_SEARCH_TERMS,
+	STAT_TYPE_TOP_AUTHORS,
+} from '../constants';
+import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
+import { Props } from '.';
+
+import './style.scss';
+
+const getUpsellCopy = ( statType: string ) => {
+	switch ( statType ) {
+		case STAT_TYPE_REFERRERS:
+			return translate(
+				'Find out where your visitors come from to optimize your content strategy.'
+			);
+		case STAT_TYPE_CLICKS:
+			return translate(
+				'Learn what external links your visitors click on your site to reveal their areas of interest.'
+			);
+		case STAT_TYPE_SEARCH_TERMS:
+			return translate( 'Discover the terms and phrases your visitors use to find your site.' );
+		case STAT_TYPE_TOP_AUTHORS:
+			return translate( 'Identify your audience’s favorite writers and perspectives.' );
+		case STATS_FEATURE_DATE_CONTROL:
+			return translate( 'Compare different time periods to analyze your site’s growth.' );
+		default:
+			return translate( 'Upgrade your plan to unlock Jetpack Stats.' );
+	}
+};
+
+const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, buttonLabel } ) => {
+	const dispatch = useDispatch();
+
+	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
+		event.preventDefault();
+		dispatch( toggleUpsellModal( siteId, statType ) );
+	};
+
+	return (
+		<StatsCardUpsellOverlay
+			className={ className }
+			onClick={ onClick }
+			copyText={ preventWidows( getUpsellCopy( statType ) ) }
+			buttonLabel={ buttonLabel }
+		/>
+	);
+};
+
+export default StatsCardUpsell;

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-overlay.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
-import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { STATS_FEATURE_UTM_STATS } from '../constants';
 import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
 import StatsListCard from '../stats-list/stats-list-card';
 
@@ -13,8 +12,6 @@ type StatsModuleUTMOverlayProps = {
 };
 
 const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( { siteId, className } ) => {
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) || '' );
-
 	const fakeData = [
 		{
 			label: 'google / cpc',
@@ -61,8 +58,8 @@ const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( { siteId
 			overlay={
 				<StatsCardUpsellJetpack
 					className="stats-module__upsell"
-					siteSlug={ siteSlug }
-					tracksEvent="stats_utm_upgrade_clicked"
+					siteId={ siteId }
+					statType={ STATS_FEATURE_UTM_STATS }
 				/>
 			}
 		></StatsListCard>

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -25,6 +25,7 @@ import {
 	STATS_PERIOD,
 } from 'calypso/my-sites/stats/constants';
 import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
@@ -190,6 +191,7 @@ class StatsPeriodNavigation extends PureComponent {
 			intervals,
 			siteId,
 			supportCommercialUse,
+			isSiteJetpackNotAtomic,
 		} = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
@@ -211,7 +213,7 @@ class StatsPeriodNavigation extends PureComponent {
 							onGatedHandler={ this.onGatedHandler }
 							overlay={
 								// TODO: getDateControl is only used by WPCOM at the moment, and we should refactor to reuse it rather than having a separate supportCommercialUse here.
-								( gateDateControl || ! supportCommercialUse ) && (
+								( gateDateControl || ( ! supportCommercialUse && isSiteJetpackNotAtomic ) ) && (
 									<StatsCardUpsell
 										className="stats-module__upsell"
 										statType={ STATS_FEATURE_DATE_CONTROL }
@@ -273,6 +275,9 @@ const connectComponent = connect(
 			siteId,
 			`${ STATS_FEATURE_INTERVAL_DROPDOWN }/${ period }`
 		);
+		const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {
+			treatAtomicAsJetpackSite: false,
+		} );
 		const shortcutList = [
 			{
 				id: 'last_7_days',
@@ -338,7 +343,14 @@ const connectComponent = connect(
 			},
 		};
 
-		return { shortcutList, gateDateControl, gatePeriodInterval, intervals, siteId };
+		return {
+			shortcutList,
+			gateDateControl,
+			gatePeriodInterval,
+			intervals,
+			siteId,
+			isSiteJetpackNotAtomic,
+		};
 	},
 	{ recordGoogleEvent: recordGoogleEventAction, toggleUpsellModal }
 );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -210,6 +210,7 @@ class StatsPeriodNavigation extends PureComponent {
 							shortcutList={ shortcutList }
 							onGatedHandler={ this.onGatedHandler }
 							overlay={
+								// TODO: getDateControl is only used by WPCOM at the moment, and we should refactor to reuse it rather than having a separate supportCommercialUse here.
 								( gateDateControl || ! supportCommercialUse ) && (
 									<StatsCardUpsell
 										className="stats-module__upsell"

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -28,7 +28,7 @@ import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/anal
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
-import useStatsPurchases from '../hooks/use-stats-purchases';
+import { withStatsPurchases } from '../hooks/use-stats-purchases';
 import NavigationArrows from '../navigation-arrows';
 import StatsCardUpsell from '../stats-card-upsell';
 
@@ -342,14 +342,10 @@ const connectComponent = connect(
 	{ recordGoogleEvent: recordGoogleEventAction, toggleUpsellModal }
 );
 
-const StatsPeriodNavigationLinked = flowRight(
+export default flowRight(
 	connectComponent,
 	localize,
 	withRtl,
-	withLocalizedMoment
+	withLocalizedMoment,
+	withStatsPurchases
 )( StatsPeriodNavigation );
-
-export default function ( props ) {
-	const statsPurchases = useStatsPurchases( props.siteId );
-	return <StatsPeriodNavigationLinked { ...props } { ...statsPurchases } />;
-}

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -28,6 +28,7 @@ import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/anal
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
+import useStatsPurchases from '../hooks/use-stats-purchases';
 import NavigationArrows from '../navigation-arrows';
 import StatsCardUpsell from '../stats-card-upsell';
 
@@ -188,6 +189,7 @@ class StatsPeriodNavigation extends PureComponent {
 			gateDateControl,
 			intervals,
 			siteId,
+			supportCommercialUse,
 		} = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
@@ -208,7 +210,7 @@ class StatsPeriodNavigation extends PureComponent {
 							shortcutList={ shortcutList }
 							onGatedHandler={ this.onGatedHandler }
 							overlay={
-								gateDateControl && (
+								( gateDateControl || ! supportCommercialUse ) && (
 									<StatsCardUpsell
 										className="stats-module__upsell"
 										statType={ STATS_FEATURE_DATE_CONTROL }
@@ -340,9 +342,14 @@ const connectComponent = connect(
 	{ recordGoogleEvent: recordGoogleEventAction, toggleUpsellModal }
 );
 
-export default flowRight(
+const StatsPeriodNavigationLinked = flowRight(
 	connectComponent,
 	localize,
 	withRtl,
 	withLocalizedMoment
 )( StatsPeriodNavigation );
+
+export default function ( props ) {
+	const statsPurchases = useStatsPurchases( props.siteId );
+	return <StatsPeriodNavigationLinked { ...props } { ...statsPurchases } />;
+}


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/issues/89185

## Proposed Changes

* Refactored the Jetpack and WPCOM upsell overlay to have the same interface. We probably want to look at it again, as it seems we don't have compelling reason to have two separate components.
* Put the date range selector behind the paywall. If user doesn't have commercial, then they'll only be able to choose the intervals rather than selecting an arbitrary range.

Note: it seems we could easily enable UTM for WPCOM sites following the approach.

## Testing Instructions

* Open Calypso Live for a Jetpack site without any subscription
* Ensure the date picker is behind paywall
* Ensure you could purchase Stats products clicking the button

<img width="790" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/363d67c6-a55f-43fa-a6d7-aee86884b491">

* Test on Odyssey
* Ensure the date picker is behind paywall
* Ensure you could purchase Stats products clicking the button

<img width="1309" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/457061b9-905e-4359-af0f-3523bfe2417f">

* Open Calypso Live for a new free simple site
* Ensure the upsells still work well
* Ensure the paywall only applies to Jetpack self hosted sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?