### PR TITLE
Assembler: Unset white background (try 2)

### DIFF
--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -56,7 +56,7 @@ const ScaledBlockRendererContainer = ( {
 	const { settings } = useContext( BlockRendererContext );
 	const { styles, assets, duotone } = useMemo(
 		() => ( {
-			styles: settings.styles.map( ( styles ) => {
+			styles: settings.styles.map( ( styles: RenderedStyle ) => {
 				if ( ! isSafari || ! styles.css || ! styles.css.includes( 'body' ) ) {
 					return styles;
 				}

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -22,6 +22,12 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 
 const { getDuotoneFilter } = unlock( blockEditorPrivateApis );
 
+const isSafari =
+	window?.navigator.userAgent &&
+	window.navigator.userAgent.includes( 'Safari' ) &&
+	! window.navigator.userAgent.includes( 'Chrome' ) &&
+	! window.navigator.userAgent.includes( 'Chromium' );
+
 interface BlockRendererContainerProps {
 	children: ReactNode;
 	styles?: RenderedStyle[];
@@ -50,11 +56,31 @@ const ScaledBlockRendererContainer = ( {
 	const { settings } = useContext( BlockRendererContext );
 	const { styles, assets, duotone } = useMemo(
 		() => ( {
-			styles: settings.styles,
+			styles: settings.styles.map( ( styles ) => {
+				if ( ! isSafari || ! styles.css || ! styles.css.includes( 'body' ) ) {
+					return styles;
+				}
+
+				// The Iframe component injects the CSS rule body{ background: white } to <head>.
+				// In Safari, this creates a specificity issue that prevents other background colors
+				// to be applied to the body.
+				// As a solution, we use regex to add !important to these background colors.
+				//
+				// TODO: Remove this workaround when https://github.com/WordPress/gutenberg/pull/60106
+				// lands in Calypso's @wordpress/block-editor, which should be 12.23.0.
+				const regex = /(body\s*{[\s\S]*?\bbackground-color\s*:\s*([^;}]+)\s*;[\s\S]*?})/g;
+				styles.css = styles.css.replace( regex, ( match, cssRule, bgColor ) => {
+					return ! bgColor.includes( '!important' )
+						? cssRule.replace( bgColor, bgColor + ' !important' )
+						: cssRule;
+				} );
+
+				return styles;
+			} ),
 			assets: settings.__unstableResolvedAssets,
 			duotone: settings.__experimentalFeatures?.color?.duotone,
 		} ),
-		[ settings ]
+		[ settings, isSafari ]
 	);
 
 	const styleAssets = useParsedAssets( assets?.styles ) as HTMLLinkElement[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/89324

## Proposed Changes

This PR fixes the issue where the background colors from global styles are not applied in the block renderer in the Assembler. This is caused by https://github.com/WordPress/gutenberg/pull/59377/files, where the background is explicitly set to white.

I don't feel great about this approach due to the performance penalties and that we are imposing CSS specificity, but since it's a short-term solution, I think it's okay we'll just remove it at a later date.

Note that the issue only affects Safari.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using Safari, head to the Assembler.
- Select some patterns, then styles.
- Ensure that the background color from the global styles is applied correctly to the pattern in the large preview.
- Ensure that Chrome and Safari also works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?