### PR TITLE
Stats: Extend paywall to 100% of sites with min view limit 1k

### DIFF
--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -10,7 +10,7 @@ export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: nu
 	) as string;
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
 	// `recent_usages` is an array of the most recent 3 months usage data, and `current_usage` is the current month usage data.
-	// Note: two of the highest days in the last 3 months are excluded before calculating the monthly views.
+	// Note: two of the highest days every month in the last 3 months are excluded before calculating the monthly views.
 	const recentMonthlyViews = Math.max(
 		usageInfo?.recent_usages[ 0 ]?.views_count ?? 0,
 		usageInfo?.recent_usages[ 1 ]?.views_count ?? 0,

--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -17,8 +17,7 @@ export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: nu
 	);
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
-	const isExistingSampleSite =
-		siteId && siteId % 100 < 50 && recentMonthlyViews > MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL; // Targeting 50% of existing sites with views higher than 1000/mth.
+	const isExistingSampleSite = recentMonthlyViews > MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL; // Targeting all existing sites with views higher than 1000/mth.
 
 	return {
 		isNewSite,

--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -2,21 +2,23 @@ import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import usePlanUsageQuery from './use-plan-usage-query';
 
-const MIN_VIEWS_TO_APPLY_PAYWALL = 1000;
+const MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL = 1000;
 
 export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: number | null ) {
 	const siteCreatedTimeStamp = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'created_at' )
 	) as string;
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
-	const recentViews = Math.max(
+	const recentMonthlyViews = Math.max(
 		usageInfo?.recent_usages[ 0 ]?.views_count ?? 0,
+		usageInfo?.recent_usages[ 1 ]?.views_count ?? 0,
+		usageInfo?.recent_usages[ 2 ]?.views_count ?? 0,
 		usageInfo?.current_usage?.views_count ?? 0
 	);
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
 	const isExistingSampleSite =
-		siteId && siteId % 100 < 50 && recentViews > MIN_VIEWS_TO_APPLY_PAYWALL; // Targeting 50% of existing sites with views higher than 1000/mth.
+		siteId && siteId % 100 < 50 && recentMonthlyViews > MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL; // Targeting 50% of existing sites with views higher than 1000/mth.
 
 	return {
 		isNewSite,

--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -1,17 +1,27 @@
 import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
+import usePlanUsageQuery from './use-plan-usage-query';
+
+const MIN_VIEWS_TO_APPLY_PAYWALL = 1000;
 
 export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: number | null ) {
 	const siteCreatedTimeStamp = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'created_at' )
 	) as string;
+	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
+	const recentViews = Math.max(
+		usageInfo?.recent_usages[ 0 ]?.views_count ?? 0,
+		usageInfo?.current_usage?.views_count ?? 0
+	);
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
-	const isExistingSampleSite = siteId && siteId % 100 < 10; // Targeting 10% of existing sites
+	const isExistingSampleSite =
+		siteId && siteId % 100 < 50 && recentViews > MIN_VIEWS_TO_APPLY_PAYWALL; // Targeting 50% of existing sites with views higher than 1000/mth.
 
 	return {
 		isNewSite,
 		isExistingSampleSite,
-		isQualified: isNewSite || isExistingSampleSite,
+		isQualified: ! isPending && ( isNewSite || isExistingSampleSite ),
+		isPending,
 	};
 }

--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -9,6 +9,7 @@ export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: nu
 		getSiteOption( state, siteId, 'created_at' )
 	) as string;
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
+	// `recent_usages` is an array of the most recent 3 months usage data, and `current_usage` is the current month usage data.
 	const recentMonthlyViews = Math.max(
 		usageInfo?.recent_usages[ 0 ]?.views_count ?? 0,
 		usageInfo?.recent_usages[ 1 ]?.views_count ?? 0,

--- a/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-complusory-plan-selection-qualified-check.ts
@@ -10,6 +10,7 @@ export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: nu
 	) as string;
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
 	// `recent_usages` is an array of the most recent 3 months usage data, and `current_usage` is the current month usage data.
+	// Note: two of the highest days in the last 3 months are excluded before calculating the monthly views.
 	const recentMonthlyViews = Math.max(
 		usageInfo?.recent_usages[ 0 ]?.views_count ?? 0,
 		usageInfo?.recent_usages[ 1 ]?.views_count ?? 0,


### PR DESCRIPTION
## Proposed Changes

* Extend paywall to all existing sites
* Only sites with 1k+ monthly views are paywalled
    * We reused the views data in recent / current usage API, which skips the highest views

## Testing Instructions

* Open Calypso Live `https://wordpress.com/stats/day/:siteSlug` for any site with views greater than 1k/mth (you can sandbox /sites/:siteId/jetpack-stats/usage and tweak the number there)
* Ensure you see the paywall

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?