### PR TITLE
Automattic for Agencies: Update pressable plan translation text

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -82,13 +82,20 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 
 				<IncludedList
 					items={ [
-						translate( '{{b}}%(count)s{{/b}} WordPress installs', {
-							args: {
-								count: info?.install ?? customString,
-							},
-							components: { b: <b /> },
-							comment: '%(count)s is the number of WordPress installs.',
-						} ),
+						info?.install
+							? translate(
+									'{{b}}%(count)d{{/b}} WordPress install',
+									'{{b}}%(count)d{{/b}} WordPress installs',
+									{
+										args: {
+											count: info.install,
+										},
+										count: info.install,
+										components: { b: <b /> },
+										comment: '%(count)s is the number of WordPress installs.',
+									}
+							  )
+							: translate( 'Custom WordPress installs' ),
 						translate( '{{b}}%(count)s{{/b}} visits per month', {
 							args: {
 								count: info ? formatNumber( info.visits ) : customString,


### PR DESCRIPTION
## Proposed Changes

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/251

This PR adds singular form to the pressable plan translation text

## Testing Instructions

- Open the Calyso live link for A4A.
- Visit /marketplace/hosting/pressable > Select a Personal plan > Verify that the text is a singular form:

<img width="843" alt="Screenshot 2024-04-10 at 11 26 41 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9b60cf69-80f4-474e-a247-f460337d4508">

- Select any other plan and verify the text is a plural form:

<img width="843" alt="Screenshot 2024-04-10 at 11 26 45 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/101f01d9-6c36-4b8b-9313-c87ecce9abd5">

- Select the last plan & verify the text says "Custom WordPress install"

<img width="843" alt="Screenshot 2024-04-10 at 11 26 49 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3016e72d-0a2a-42a8-b92e-c466e35ea63c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?