### PR TITLE
A4A: Update Sites Dashboard with some code improvements and style tweaks

### DIFF
--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -1,5 +1,4 @@
 import { Context, type Callback } from '@automattic/calypso-router';
-import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import SitesSidebar from '../../components/sidebar-menu/sites';
 import {
 	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
@@ -53,9 +52,6 @@ function configureSitesContext( context: Context ) {
 	);
 
 	context.secondary = <SitesSidebar path={ context.path } />;
-
-	// By definition, Sites Management does not select any one specific site
-	context.store.dispatch( setAllSitesSelected() );
 }
 
 export const sitesContext: Callback = ( context: Context, next ) => {

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/activity/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/activity/index.tsx
@@ -1,24 +1,18 @@
+import { JetpackFeaturePreview } from 'calypso/a8c-for-agencies/sections/sites/features/jetpack/jetpack-feature';
+import { Site } from 'calypso/a8c-for-agencies/sections/sites/types';
 import ActivityLogV2 from 'calypso/my-sites/activity/activity-log-v2';
-import { useDispatch } from 'calypso/state';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import SitePreviewPaneContent from '../../../site-preview-pane/site-preview-pane-content';
 
 import 'calypso/my-sites/activity/activity-log-v2/style.scss';
 import './style.scss';
 
 type Props = {
-	siteId: number;
+	site: Site;
 };
 
-export function JetpackActivityPreview( { siteId }: Props ) {
-	const dispatch = useDispatch();
-
-	if ( siteId ) {
-		dispatch( setSelectedSiteId( siteId ) );
-	}
+export function JetpackActivityPreview( { site }: Props ) {
 	return (
-		<SitePreviewPaneContent>
+		<JetpackFeaturePreview site={ site }>
 			<ActivityLogV2 />
-		</SitePreviewPaneContent>
+		</JetpackFeaturePreview>
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/activity/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/activity/style.scss
@@ -1,7 +1,6 @@
-.activity-log-v2 {
+main.main.activity-log-v2 {
 	text-align: left;
-}
-
-main.activity-log-v2:not(.wordpressdotcom) .activity-log-v2__header {
-	margin: 0;
+	.activity-log-v2__header {
+		margin: 0;
+	}
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/activity/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/activity/style.scss
@@ -1,3 +1,7 @@
 .activity-log-v2 {
 	text-align: left;
 }
+
+main.activity-log-v2:not(.wordpressdotcom) .activity-log-v2__header {
+	margin: 0;
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/backup/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/backup/index.tsx
@@ -1,26 +1,12 @@
-import { useContext } from 'react';
-import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
-import { useDispatch } from 'calypso/state';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import SitePreviewPaneContent from '../../../site-preview-pane/site-preview-pane-content';
+import { JetpackFeaturePreview } from 'calypso/a8c-for-agencies/sections/sites/features/jetpack/jetpack-feature';
+import { Site } from '../../../types';
+
+import './style.scss';
 
 type Props = {
-	siteId: number;
+	site: Site;
 };
 
-export function JetpackBackupPreview( { siteId }: Props ) {
-	const { featurePreview } = useContext( SitesDashboardContext );
-	const dispatch = useDispatch();
-
-	if ( siteId ) {
-		dispatch( setSelectedSiteId( siteId ) );
-	}
-
-	return (
-		<>
-			<SitePreviewPaneContent>
-				<SitePreviewPaneContent>{ siteId && featurePreview }</SitePreviewPaneContent>
-			</SitePreviewPaneContent>
-		</>
-	);
+export function JetpackBackupPreview( { site }: Props ) {
+	return <JetpackFeaturePreview site={ site } />;
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/backup/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/backup/style.scss
@@ -1,0 +1,3 @@
+.backup__page {
+	text-align: left;
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/backup/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/backup/style.scss
@@ -1,3 +1,3 @@
-.backup__page {
+main {
 	text-align: left;
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-feature.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-feature.tsx
@@ -1,0 +1,26 @@
+import { useContext, useEffect, ReactNode } from 'react';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import SitePreviewPaneContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content';
+import { useDispatch, useSelector } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { Site } from '../../types';
+
+type Props = {
+	site: Site;
+	children?: ReactNode;
+};
+
+export function JetpackFeaturePreview( { site, children }: Props ) {
+	const { featurePreview } = useContext( SitesDashboardContext );
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+
+	useEffect( () => {
+		if ( siteId === null ) {
+			dispatch( setSelectedSiteId( site.blog_id ) );
+		}
+	}, [ siteId ] );
+
+	return siteId && <SitePreviewPaneContent>{ children || featurePreview }</SitePreviewPaneContent>;
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import SiteDetails from 'calypso/a8c-for-agencies/sections/sites/features/a4a/site-details';
@@ -71,7 +72,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<JetpackBackupPreview siteId={ site.blog_id } />
+				<JetpackBackupPreview site={ site } />
 			),
 			createFeaturePreview(
 				JETPACK_SCAN_ID,
@@ -120,16 +121,20 @@ export function JetpackPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<JetpackActivityPreview siteId={ site.blog_id } />
+				<JetpackActivityPreview site={ site } />
 			),
-			createFeaturePreview(
-				A4A_SITE_DETAILS_ID,
-				translate( 'Details' ),
-				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
-				<SiteDetails site={ site } />
-			),
+			...( isEnabled( 'a4a/site-details-pane' )
+				? [
+						createFeaturePreview(
+							A4A_SITE_DETAILS_ID,
+							translate( 'Details' ),
+							true,
+							selectedSiteFeature,
+							setSelectedSiteFeature,
+							<SiteDetails site={ site } />
+						),
+				  ]
+				: [] ),
 		],
 		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ]
 	);

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-preview-pane.tsx
@@ -13,7 +13,6 @@ import {
 } from 'calypso/a8c-for-agencies/sections/sites/features/features';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { useJetpackAgencyDashboardRecordTrackEvent } from 'calypso/jetpack-cloud/sections/agency-dashboard/hooks';
-import { A4A_SITES_DASHBOARD_DEFAULT_FEATURE } from '../../constants';
 import SitePreviewPane, { createFeaturePreview } from '../../site-preview-pane';
 import { PreviewPaneProps } from '../../site-preview-pane/types';
 import { JetpackActivityPreview } from './activity';
@@ -47,8 +46,9 @@ export function JetpackPreviewPane( {
 
 	useEffect( () => {
 		if ( selectedSiteFeature === undefined ) {
-			setSelectedSiteFeature( A4A_SITES_DASHBOARD_DEFAULT_FEATURE );
+			setSelectedSiteFeature( JETPACK_BOOST_ID );
 		}
+
 		return () => {
 			setSelectedSiteFeature( undefined );
 		};

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/scan/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/scan/index.tsx
@@ -1,27 +1,13 @@
-import { useContext } from 'react';
-import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
-import SitePreviewPaneContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content';
-import { useDispatch } from 'calypso/state';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { JetpackFeaturePreview } from 'calypso/a8c-for-agencies/sections/sites/features/jetpack/jetpack-feature';
 import { Site } from '../../../types';
 
 import 'calypso/my-sites/scan/style.scss';
+import './style.scss';
 
 type Props = {
 	site: Site;
 };
 
 export function JetpackScanPreview( { site }: Props ) {
-	const { featurePreview } = useContext( SitesDashboardContext );
-	const dispatch = useDispatch();
-
-	if ( site ) {
-		dispatch( setSelectedSiteId( site.blog_id ) );
-	}
-
-	return (
-		<>
-			<SitePreviewPaneContent>{ site && featurePreview }</SitePreviewPaneContent>
-		</>
-	);
+	return <JetpackFeaturePreview site={ site } />;
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/scan/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/scan/style.scss
@@ -1,3 +1,3 @@
-main.scan {
+main {
 	text-align: left;
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/scan/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/scan/style.scss
@@ -1,0 +1,3 @@
+main.scan {
+	text-align: left;
+}

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/index.tsx
@@ -45,7 +45,7 @@ export default function SitePreviewPane( {
 	useEffect( () => {
 		setTimeout( () => {
 			setCanDisplayNavTabs( true );
-		}, 150 );
+		}, 200 );
 	}, [] );
 
 	// Ensure we have features

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -35,14 +35,14 @@
 		padding-block-start: 24px;
 	}
 
-	.dataviews-view-table thead {
-		position: sticky;
-		top: 0;
-		z-index: 2;
-	}
-
 	@media (min-width: $break-large) {
 		background: inherit;
+
+		.dataviews-view-table thead {
+			position: sticky;
+			top: 0;
+			z-index: 2;
+		}
 
 		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-title {
 			font-size: 1.25rem;
@@ -233,7 +233,7 @@
 		}
 	}
 
-	@media (min-width: $break-wide) {
+	@media (min-width: $break-large) {
 		&.sites-dashboard__layout {
 			.dataviews-view-table-wrapper {
 				overflow-y: auto;


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/265

## Proposed Changes

**Note:** This PR is part of the work of this parent issue: https://github.com/Automattic/automattic-for-agencies-dev/issues/227 that requires to break-down into multiple PRs.

This is quick PR to improve the code (duplicated, extracting and moving to a component component). Also it has some style tweaks (align to left) for Jetpack features:

Trunk:
<img width="869" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/4d80e05a-4143-4b4b-bd45-7b1b6af58a82">

<img width="756" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/5f776176-f28a-42c2-a566-3484b36e023f">

<img width="776" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/3e38af46-dfbe-462e-9882-852a523bcbdf">


This branch:
![image](https://github.com/Automattic/wp-calypso/assets/9832440/965f22ed-6b6c-4dd4-8776-155b1389c9de)

![image](https://github.com/Automattic/wp-calypso/assets/9832440/2d95e92b-ba57-4840-a815-8af4f68dd597)

![image](https://github.com/Automattic/wp-calypso/assets/9832440/4b06d893-cbad-4d00-b276-33ca5489aa9a)

## Testing Instructions

- Check the code
- Everything should work as before.
- In Scan tab, elements should be aligned to left, like in Jetpack Cloud.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
