### PR TITLE
Earn: Retrieve the GET param subscriber using context query instead of window.location.search

### DIFF
--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -33,12 +33,17 @@ import {
 import { Subscriber } from '../types';
 import CancelDialog from './cancel-dialog';
 import Customer from './customer/index';
+import { Query } from './types';
 
-function CustomerSection() {
+type CustomerSectionProps = {
+	query?: Query;
+};
+
+const CustomerSection = ( { query }: CustomerSectionProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
-	const subscriberId = new URLSearchParams( window.location.search ).get( 'subscriber' );
+	const subscriberId = query?.subscriber;
 	const [ subscriberToCancel, setSubscriberToCancel ] = useState< Subscriber | null >( null );
 	const site = useSelector( getSelectedSite );
 
@@ -245,6 +250,6 @@ function CustomerSection() {
 			<div>{ renderSubscriberList() }</div>
 		</div>
 	);
-}
+};
 
 export default CustomerSection;

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -30,10 +30,9 @@ import {
 	PLAN_MONTHLY_FREQUENCY,
 	PLAN_ONE_TIME_FREQUENCY,
 } from '../memberships/constants';
-import { Subscriber } from '../types';
+import { Query, Subscriber } from '../types';
 import CancelDialog from './cancel-dialog';
 import Customer from './customer/index';
-import { Query } from './types';
 
 type CustomerSectionProps = {
 	query?: Query;

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -45,7 +45,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const canAccessAds = useSelector( ( state ) => canAccessWordAds( state, site?.ID ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const adsProgramName = isJetpack ? 'Ads' : 'WordAds';
-	const subscriberId = new URLSearchParams( window.location.search ).get( 'subscriber' );
+	const subscriberId = query?.subscriber;
 	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, site?.ID ) );
 	const isJetpackNotAtomic = isJetpack && ! isAtomicSite;
 
@@ -158,7 +158,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				return <MembershipsSection query={ query } />;
 
 			case 'supporters':
-				return <CustomersSection />;
+				return <CustomersSection query={ query } />;
 
 			case 'refer-a-friend':
 				return <ReferAFriendSection />;


### PR DESCRIPTION
## Proposed Changes

Depends on https://github.com/Automattic/wp-calypso/pull/89375

This PR fixes an issue in Jetpack Cloud where navigating from `/monetize/supporters/:site` to `/monetize/supporters/:site?subscriber=:user` doesn't update window.location.search unless retried again. Interestingly enough, this doesn't happen with Calypso's `/earn/supporters/:site` to `/earn/supporters/:site?subscriber=:user`.

As this seems to be a router issue, this PR updates the code to retrieve the GET param `subscriber` from the router context rather than looking at window.location.search.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions in https://github.com/Automattic/wp-calypso/pull/89375#issue-2234077762 to see how to add subscribers.
* Ensure that navigating from `/monetize/supporters/:site` to `/monetize/supporters/:site?subscriber=:user` and vice versa only needs clicking once.
* Ensure that navigation from `/earn/supporters/:site` to `/earn/supporters/:site?subscriber=:user` and vice versa only needs clicking once.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?