### PR TITLE
Continue with Google: Update error handling on `GoogleIdentityServicesApi` initialization failure

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -63,6 +63,12 @@ class GoogleSocialButton extends Component {
 		const googleSignIn = await this.loadGoogleIdentityServicesAPI();
 
 		if ( ! googleSignIn ) {
+			this.props.recordTracksEvent( 'calypso_social_button_failure', {
+				social_account_type: 'google',
+				starting_point: this.props.startingPoint,
+				error_code: 'google_identity_services_api_not_loaded',
+			} );
+
 			this.props.showErrorNotice(
 				this.props.translate( 'Something went wrong while trying to load Google sign-in.' )
 			);

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -70,9 +70,9 @@ class GoogleSocialButton extends Component {
 		const googleSignIn = await this.loadGoogleIdentityServicesAPI();
 
 		if ( ! googleSignIn ) {
-			this.setState( {
-				error: this.props.translate( 'Something went wrong while trying to load Google sign-in.' ),
-			} );
+			this.props.showErrorNotice(
+				this.props.translate( 'Something went wrong while trying to load Google sign-in.' )
+			);
 
 			return;
 		}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -38,10 +38,6 @@ class GoogleSocialButton extends Component {
 		onClick: noop,
 	};
 
-	state = {
-		eventTimeStamp: null,
-	};
-
 	constructor( props ) {
 		super( props );
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -57,7 +57,7 @@ class GoogleSocialButton extends Component {
 	async initializeGoogleSignIn( state ) {
 		const googleSignIn = await this.loadGoogleIdentityServicesAPI();
 
-		if ( googleSignIn ) {
+		if ( ! googleSignIn ) {
 			this.props.recordTracksEvent( 'calypso_social_button_failure', {
 				social_account_type: 'google',
 				starting_point: this.props.startingPoint,

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { Popover } from '@automattic/components';
 import { loadScript } from '@automattic/load-script';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -8,7 +7,6 @@ import { cloneElement, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import wpcomRequest from 'wpcom-proxy-request';
 import GoogleIcon from 'calypso/components/social-icons/google';
-import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/utils';
@@ -41,9 +39,6 @@ class GoogleSocialButton extends Component {
 	};
 
 	state = {
-		error: '',
-		showError: false,
-		errorRef: null,
 		eventTimeStamp: null,
 		isDisabled: false,
 	};
@@ -52,8 +47,6 @@ class GoogleSocialButton extends Component {
 		super( props );
 
 		this.handleClick = this.handleClick.bind( this );
-		this.showError = this.showError.bind( this );
-		this.hideError = this.hideError.bind( this );
 	}
 
 	componentDidMount() {
@@ -97,8 +90,6 @@ class GoogleSocialButton extends Component {
 				this.handleAuthorizationCode( { auth_code: response.code, state: response.state } );
 			},
 		} );
-
-		this.setState( { isDisabled: false } );
 	}
 
 	async loadGoogleIdentityServicesAPI() {
@@ -186,35 +177,11 @@ class GoogleSocialButton extends Component {
 		await this.fetchNonceAndInitializeGoogleSignIn();
 		this.props.onClick( event );
 
-		if ( this.state.error ) {
-			return;
-		}
-
 		this.client?.requestCode();
 	}
 
-	showError( event ) {
-		if ( ! this.state.error ) {
-			return;
-		}
-
-		event.stopPropagation();
-
-		this.setState( {
-			showError: true,
-			errorRef: event.currentTarget,
-			eventTimeStamp: event.timeStamp,
-		} );
-	}
-
-	hideError() {
-		this.setState( { showError: false } );
-	}
-
 	render() {
-		const isDisabled = Boolean(
-			this.state.isDisabled || this.props.isFormDisabled || this.state.error
-		);
+		const isDisabled = Boolean( this.state.isDisabled || this.props.isFormDisabled );
 
 		const { children } = this.props;
 		let customButton = null;
@@ -223,10 +190,6 @@ class GoogleSocialButton extends Component {
 			const childProps = {
 				className: classNames( { disabled: isDisabled } ),
 				onClick: this.handleClick,
-				onMouseOver: this.showError,
-				onFocus: this.showError,
-				onMouseOut: this.hideError,
-				onBlur: this.hideError,
 			};
 
 			customButton = cloneElement( children, childProps );
@@ -240,8 +203,6 @@ class GoogleSocialButton extends Component {
 					<button
 						className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
 						onClick={ this.handleClick }
-						onMouseEnter={ this.showError }
-						onMouseLeave={ this.hideError }
 						disabled={ isDisabled }
 					>
 						<GoogleIcon
@@ -259,16 +220,6 @@ class GoogleSocialButton extends Component {
 						</span>
 					</button>
 				) }
-				<Popover
-					id="social-buttons__error"
-					className="social-buttons__error"
-					isVisible={ this.state.showError }
-					onClose={ this.hideError }
-					position="top"
-					context={ this.state.errorRef }
-				>
-					{ preventWidows( this.state.error ) }
-				</Popover>
 			</Fragment>
 		);
 	}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -40,7 +40,6 @@ class GoogleSocialButton extends Component {
 
 	state = {
 		eventTimeStamp: null,
-		isDisabled: false,
 	};
 
 	constructor( props ) {
@@ -62,7 +61,7 @@ class GoogleSocialButton extends Component {
 	async initializeGoogleSignIn( state ) {
 		const googleSignIn = await this.loadGoogleIdentityServicesAPI();
 
-		if ( ! googleSignIn ) {
+		if ( googleSignIn ) {
 			this.props.recordTracksEvent( 'calypso_social_button_failure', {
 				social_account_type: 'google',
 				starting_point: this.props.startingPoint,
@@ -176,10 +175,6 @@ class GoogleSocialButton extends Component {
 		event.preventDefault();
 		event.stopPropagation();
 
-		if ( this.state.isDisabled ) {
-			return;
-		}
-
 		await this.fetchNonceAndInitializeGoogleSignIn();
 		this.props.onClick( event );
 
@@ -187,7 +182,7 @@ class GoogleSocialButton extends Component {
 	}
 
 	render() {
-		const isDisabled = Boolean( this.state.isDisabled || this.props.isFormDisabled );
+		const isDisabled = Boolean( this.props.isFormDisabled );
 
 		const { children } = this.props;
 		let customButton = null;


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/89393.

With the current production code, if the Google `client` isn’t initilized correctly, the button gets disabled after it is clicked (with error message displayed on button hover). This is a leftover from the old logic when the `client` used to be initilized on page load instead of `onClick` event.

## Proposed Changes

With proposed changes, in case the `client` doesn’t get initilized correctly, the button won’t get disabled and the error message will display prominently as an Error Notice on the side. This way, the user will know right away what’s going on and can try to click the button again.

* display the error message in an Error Notice instead of Popover
* do not disable the `Connect` button on failure
* add error tracking using Tracks

| Before | After |
|--------|--------|
| ![Markup on 2024-04-10 at 11:01:43](https://github.com/Automattic/wp-calypso/assets/25105483/f97b5700-6a97-477e-93b7-8247531b353e) | ![Markup on 2024-04-10 at 10:57:58](https://github.com/Automattic/wp-calypso/assets/25105483/4bec6f97-1a83-4388-8ea9-b8579cc68f85) | 


TODO:
- [ ] mark related sentry issue as resolved

## Testing Instructions

1. Check out the branch.
2. Temporarily simulate `GoogleIdentityServicesApi` initialization failure, e.g. by making the following change:

```diff
diff --git a/client/components/social-buttons/google.js b/client/components/social-buttons/google.js
index 7e8ef28723..7a98777493 100644
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -62,7 +62,7 @@ class GoogleSocialButton extends Component {
        async initializeGoogleSignIn( state ) {
                const googleSignIn = await this.loadGoogleIdentitySericesAPI();

-               if ( ! googleSignIn ) {
+               if ( googleSignIn ) {
                        this.props.recordTracksEvent( 'calypso_socialbutton_failure', {
button_failure', {
ial_account_type: 'google',
nt,
```

3. Navigate to the https://wordpress.com/me/security/social-login page where the _Continue with Google_ button is used.
4. Click on the Google `Connect` button. The error should display in an Error Notice (as can be seen in the _After_ screenshot above). 

Due to testing limitations, the login/sign-up flows will be fully tested in staging when the PR is merged (before deploying the changes to production).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?