### PR TITLE
Plugin update manager: show when there are no plugins to update 

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-logs.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-logs.helper.ts
@@ -18,6 +18,11 @@ export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[] ) => {
 		case 'PLUGIN_UPDATES_START':
 			return translate( 'Plugins update started' );
 		case 'PLUGIN_UPDATES_SUCCESS':
+			if ( log.message === 'no_plugins_to_update' ) {
+				return (
+					translate( 'Plugins update completed' ) + ' — ' + translate( 'no plugins to update' )
+				);
+			}
 			return translate( 'Plugins update completed' );
 		case 'PLUGIN_UPDATES_FAILURE':
 			return translate( 'Plugins update failed' );

--- a/client/blocks/plugins-update-manager/schedule-logs.helper.ts
+++ b/client/blocks/plugins-update-manager/schedule-logs.helper.ts
@@ -19,9 +19,7 @@ export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[] ) => {
 			return translate( 'Plugins update started' );
 		case 'PLUGIN_UPDATES_SUCCESS':
 			if ( log.message === 'no_plugins_to_update' ) {
-				return (
-					translate( 'Plugins update completed' ) + ' — ' + translate( 'no plugins to update' )
-				);
+				return translate( 'Plugins update completed — no plugins to update' );
 			}
 			return translate( 'Plugins update completed' );
 		case 'PLUGIN_UPDATES_FAILURE':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/89347 

## Proposed Changes

![CleanShot 2024-04-10 at 11 24 55@2x](https://github.com/Automattic/wp-calypso/assets/528287/0fc884eb-3d92-475b-9e2f-60fc8aa61120)

Discussion: should we show the started event? 

## Testing Instructions

- Make sure you have https://github.com/Automattic/jetpack/pull/36817 applied using Jetpack Beta Tester
- Schedule a log for a plugin that needs no updates
- Wait for it to run


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?