### PR TITLE
Deemphasizing free plan as a general functionality

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -431,7 +431,7 @@ const PlansFeaturesMain = ( {
 		hideEnterprisePlan,
 	};
 
-	// we neeed only the visible ones for comparison grid (these should extend into plans-ui data store selectors)
+	// we need all the plans that are available to pick for comparison grid (these should extend into plans-ui data store selectors)
 	const gridPlansForComparisonGrid = useGridPlansForComparisonGrid( {
 		allFeaturesList: getFeaturesList(),
 		coupon,
@@ -450,7 +450,7 @@ const PlansFeaturesMain = ( {
 		useFreeTrialPlanSlugs,
 	} );
 
-	// we neeed only the visible ones for features grid (these should extend into plans-ui data store selectors)
+	// we need only the visible ones for features grid (these should extend into plans-ui data store selectors)
 	const gridPlansForFeaturesGrid = useGridPlansForFeaturesGrid( {
 		allFeaturesList: getFeaturesList(),
 		coupon,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -451,30 +451,31 @@ const PlansFeaturesMain = ( {
 	} );
 
 	// we need only the visible ones for features grid (these should extend into plans-ui data store selectors)
-	const gridPlansForFeaturesGrid = useGridPlansForFeaturesGrid( {
-		allFeaturesList: getFeaturesList(),
-		coupon,
-		eligibleForFreeHostingTrial,
-		hiddenPlans,
-		intent,
-		isDisplayingPlansNeededForFeature,
-		isInSignup,
-		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
-		selectedFeature,
-		selectedPlan,
-		showLegacyStorageFeature,
-		siteId,
-		storageAddOns,
-		term,
-		useCheckPlanAvailabilityForPurchase,
-		useFreeTrialPlanSlugs,
-	} )?.filter( ( { planSlug } ) => {
-		// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.
-		if ( deemphasizeFreePlan ) {
-			return planSlug !== PLAN_FREE;
-		}
-		return true;
-	} );
+	const gridPlansForFeaturesGrid =
+		useGridPlansForFeaturesGrid( {
+			allFeaturesList: getFeaturesList(),
+			coupon,
+			eligibleForFreeHostingTrial,
+			hiddenPlans,
+			intent,
+			isDisplayingPlansNeededForFeature,
+			isInSignup,
+			isSubdomainNotGenerated: ! resolvedSubdomainName.result,
+			selectedFeature,
+			selectedPlan,
+			showLegacyStorageFeature,
+			siteId,
+			storageAddOns,
+			term,
+			useCheckPlanAvailabilityForPurchase,
+			useFreeTrialPlanSlugs,
+		} )?.filter( ( { planSlug } ) => {
+			// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.
+			if ( deemphasizeFreePlan ) {
+				return planSlug !== PLAN_FREE;
+			}
+			return true;
+		} ) ?? null; // optional chaining can result in `undefined`; we don't want to introduce it here.
 
 	let hidePlanSelector = false;
 	// In the "purchase a plan and free domain" flow we do not want to show

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -455,10 +455,7 @@ const PlansFeaturesMain = ( {
 		allFeaturesList: getFeaturesList(),
 		coupon,
 		eligibleForFreeHostingTrial,
-		hiddenPlans: {
-			...hiddenPlans,
-			hideFreePlan: hideFreePlan || deemphasizeFreePlan,
-		},
+		hiddenPlans,
 		intent,
 		isDisplayingPlansNeededForFeature,
 		isInSignup,
@@ -471,6 +468,12 @@ const PlansFeaturesMain = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
+	} )?.filter( ( { planSlug } ) => {
+		// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.
+		if ( deemphasizeFreePlan ) {
+			return planSlug !== PLAN_FREE;
+		}
+		return true;
 	} );
 
 	let hidePlanSelector = false;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -188,6 +188,12 @@ export interface PlansFeaturesMainProps {
 	 */
 	showPlanTypeSelectorDropdown?: boolean;
 	onPlanIntervalUpdate?: ( path: string ) => void;
+
+	/*
+	 * Shows the free plan as a plain text anchor instead of a plan card.
+	 * It's outside of the intent system since it is about the way the Free plan is presented, not the plan mix available to choose.
+	 */
+	deemphasizeFreePlan?: boolean;
 }
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -245,6 +251,7 @@ const PlansFeaturesMain = ( {
 	isStepperUpgradeFlow = false,
 	isLaunchPage = false,
 	showLegacyStorageFeature = false,
+	deemphasizeFreePlan = false,
 	isSpotlightOnCurrentPlan,
 	renderSiblingWhenLoaded,
 	showPlanTypeSelectorDropdown = false,
@@ -448,7 +455,10 @@ const PlansFeaturesMain = ( {
 		allFeaturesList: getFeaturesList(),
 		coupon,
 		eligibleForFreeHostingTrial,
-		hiddenPlans,
+		hiddenPlans: {
+			...hiddenPlans,
+			hideFreePlan: hideFreePlan || deemphasizeFreePlan,
+		},
 		intent,
 		isDisplayingPlansNeededForFeature,
 		isInSignup,
@@ -785,7 +795,7 @@ const PlansFeaturesMain = ( {
 							} ) }
 					/>
 				) }
-				{ intent === 'plans-paid-media' && (
+				{ deemphasizeFreePlan && (
 					<FreePlanSubHeader>
 						{ translate(
 							`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -201,13 +201,8 @@ export function generateFlows( {
 			optionalDependenciesInQuery: [ 'coupon' ],
 			props: {
 				plans: {
-					/**
-					 * This intent is geared towards customizations related to the paid media flow
-					 * Current customizations are as follows
-					 * - Show only Personal, Premium, Business, and eCommerce plans (Hide free, enterprise)
-					 */
-					intent: 'plans-paid-media',
 					isCustomDomainAllowedOnFreePlan: true,
+					deemphasizeFreePlan: true,
 				},
 			},
 		},

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -95,6 +95,7 @@ export class PlansStep extends Component {
 	plansFeaturesList() {
 		const {
 			disableBloggerPlanWithNonBlogDomain,
+			deemphasizeFreePlan,
 			hideFreePlan,
 			isLaunchPage,
 			selectedSite,
@@ -138,6 +139,7 @@ export class PlansStep extends Component {
 					onUpgradeClick={ ( cartItems ) => this.onSelectPlan( cartItems ) }
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain } // TODO clk investigate
+					deemphasizeFreePlan={ deemphasizeFreePlan }
 					plansWithScroll={ this.state.isDesktop }
 					intent={ intent }
 					flowName={ flowName }

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -156,9 +156,6 @@ const usePlanTypesWithIntent = ( {
 		case 'plans-jetpack-app-site-creation':
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
-		case 'plans-paid-media':
-			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
-			break;
 		case 'plans-p2':
 			planTypes = [ TYPE_FREE ];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2791

## Proposed Changes

This PR lifts the behavior of deemphasizing Free plan as a general functionality of `PlansFeaturesMain` that can be controlled by the `deemphasizeFreePlan` prop. It will also make subsequent implementation of the deemphasizing Free plan test easier. See https://github.com/Automattic/wp-calypso/pull/89400 and https://github.com/Automattic/wp-calypso/pull/89427.

Currently, `/start/onboarding-pm` implements this behavior based on the intent system, which presents two issues:

1. From the user point of view, the Free plan is still there; just in a less prominent form. However, since the intent system controls the actual plan mix that a user can pick from, it is incorrect to completely obscure the Free plan. We should at least show it in the comparison grid, since it is available to pick.
2. When we need to bring the same deemphasizing Free plan behavior to another flow, we'd need to extend the boolean expression as `( intent === 'aaa' && intent === 'bbb' && intent === ...) && <FreePlanSubHeader> )`, which is inconvenient and shows that there is a disjoint between "obscuring the Free plan from the features grid" and "showing the Free plan as an anchor".

This PR aims to address the both by lifting it into a separate concept of "how we present the Free plan" at `PlansFeaturesMain` level, controlled by a single prop. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/onboarding-pm`. At the plans stepthe Free plan CTA should work as it is. In the meantime, the Free plan should be available in the comparison grid.
* Cherry-picking a few `/start` flows, e.g. `/start`, the plans step should work as it is.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
