### PR TITLE
Plans: Update plan upsell modals to use pricing from `data-stores` package

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
@@ -1,28 +1,29 @@
 import { PlanButton } from '@automattic/plans-grid-next';
 import { useTranslate } from 'i18n-calypso';
-import type { PlanUpsellInfo } from '../hooks/use-plan-upsell-info';
+import { usePlanUpsellInfo } from '../hooks/use-plan-upsell-info';
 import type { PlanSlug } from '@automattic/calypso-products';
 
 function PlanUpsellButton( {
-	planUpsellInfo,
+	planSlug,
 	onPlanSelected,
 	disabled = false,
 	isBusy = false,
 }: {
-	planUpsellInfo: PlanUpsellInfo;
+	planSlug: PlanSlug;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;
 	disabled?: boolean;
 	isBusy?: boolean;
 } ) {
 	const translate = useTranslate();
+	const planUpsellInfo = usePlanUpsellInfo( { planSlug } );
 
 	return (
 		<PlanButton
-			planSlug={ planUpsellInfo.planSlug }
+			planSlug={ planSlug }
 			disabled={ disabled }
 			busy={ isBusy }
 			onClick={ () => {
-				onPlanSelected( planUpsellInfo.planSlug );
+				onPlanSelected( planSlug );
 			} }
 		>
 			{ translate( 'Get %(planTitle)s - %(planPrice)s/month', {

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -1,9 +1,6 @@
 import { type PlanSlug, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { usePlanUpsellInfo } from '../hooks/use-plan-upsell-info';
 import PlanUpsellButton from './plan-upsell-button';
 import { DomainName } from '.';
 
@@ -25,9 +22,6 @@ export default function SuggestedPlanSection( {
 	isBusy: boolean;
 } ) {
 	const translate = useTranslate();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? 'USD';
-	const basicPlanUpsellInfo = usePlanUpsellInfo( PLAN_PERSONAL, currencyCode );
-	const advancePlanUpsellInfo = usePlanUpsellInfo( PLAN_PREMIUM, currencyCode );
 
 	return (
 		<>
@@ -38,7 +32,7 @@ export default function SuggestedPlanSection( {
 				</DomainName>
 			) }
 			<PlanUpsellButton
-				planUpsellInfo={ basicPlanUpsellInfo }
+				planSlug={ PLAN_PERSONAL }
 				onPlanSelected={ onPlanSelected }
 				isBusy={ isBusy }
 			/>
@@ -51,7 +45,7 @@ export default function SuggestedPlanSection( {
 				</DomainName>
 			) }
 			<PlanUpsellButton
-				planUpsellInfo={ advancePlanUpsellInfo }
+				planSlug={ PLAN_PREMIUM }
 				onPlanSelected={ onPlanSelected }
 				isBusy={ isBusy }
 			/>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -6,8 +6,6 @@ import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSelector } from 'calypso/state';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { DialogContainer, Heading } from './components';
 import PlanUpsellButton from './components/plan-upsell-button';
 import { usePlanUpsellInfo } from './hooks/use-plan-upsell-info';
@@ -96,9 +94,8 @@ export function FreePlanFreeDomainDialog( {
 	onPlanSelected,
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? 'USD';
-	const basicPlanUpsellInfo = usePlanUpsellInfo( PLAN_PERSONAL, currencyCode );
-	const advancePlanUpsellInfo = usePlanUpsellInfo( PLAN_PREMIUM, currencyCode );
+	const basicPlanUpsellInfo = usePlanUpsellInfo( { planSlug: PLAN_PERSONAL } );
+	const advancePlanUpsellInfo = usePlanUpsellInfo( { planSlug: PLAN_PREMIUM } );
 	const buttonDisabled = generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result;
 
 	useEffect( () => {
@@ -173,12 +170,12 @@ export function FreePlanFreeDomainDialog( {
 
 			<ButtonRow>
 				<PlanUpsellButton
-					planUpsellInfo={ basicPlanUpsellInfo }
+					planSlug={ PLAN_PERSONAL }
 					disabled={ buttonDisabled }
 					onPlanSelected={ onPlanSelected }
 				/>
 				<PlanUpsellButton
-					planUpsellInfo={ advancePlanUpsellInfo }
+					planSlug={ PLAN_PREMIUM }
 					disabled={ buttonDisabled }
 					onPlanSelected={ onPlanSelected }
 				/>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-plan-upsell-info.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-plan-upsell-info.tsx
@@ -1,42 +1,38 @@
 import { getPlan, type PlanSlug } from '@automattic/calypso-products';
+import { Plans } from '@automattic/data-stores';
 import formatCurrency from '@automattic/format-currency';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { useSelector } from 'calypso/state';
-import { getPlanPrices } from 'calypso/state/plans/selectors/get-plan-prices';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import type { TranslateResult } from 'i18n-calypso';
 
-export type PlanUpsellInfo = {
-	planSlug: PlanSlug;
+type PlanUpsellInfo = {
 	title: TranslateResult;
 	formattedPriceMonthly: string;
 	formattedPriceFull: string;
 };
 
-// TODO:
-// Replace `getPlanPrices` with the selectors from the Plans datastore.
-export const usePlanUpsellInfo = ( planSlug: PlanSlug, currencyCode: string ): PlanUpsellInfo => {
+export const usePlanUpsellInfo = ( { planSlug }: { planSlug: PlanSlug } ): PlanUpsellInfo => {
 	const title = getPlan( planSlug )?.getTitle() || '';
-	const priceMonthly = useSelector( ( state ) => {
-		const siteId = getSelectedSiteId( state ) ?? null;
-		const rawPlanPrices = getPlanPrices( state, {
-			planSlug,
-			siteId,
-			returnMonthly: true,
-		} );
-		return ( rawPlanPrices.discountedRawPrice || rawPlanPrices.rawPrice ) ?? 0;
+	const siteId = useSelector( getSelectedSiteId );
+	const pricingMeta = Plans.usePricingMetaForGridPlans( {
+		planSlugs: [ planSlug ],
+		selectedSiteId: siteId,
+		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
 	} );
-	const priceFull = useSelector( ( state ) => {
-		const siteId = getSelectedSiteId( state ) ?? null;
-		const rawPlanPrices = getPlanPrices( state, {
-			planSlug,
-			siteId,
-			returnMonthly: false,
-		} );
-		return ( rawPlanPrices.discountedRawPrice || rawPlanPrices.rawPrice ) ?? 0;
-	} );
+	const currencyCode = pricingMeta?.[ planSlug ].currencyCode ?? 'USD';
+	const priceMonthly =
+		( pricingMeta?.[ planSlug ].discountedPrice.monthly ||
+			pricingMeta?.[ planSlug ].originalPrice.monthly ) ??
+		0;
+	const priceFull =
+		( pricingMeta?.[ planSlug ].discountedPrice.full ||
+			pricingMeta?.[ planSlug ].originalPrice.full ) ??
+		0;
 
 	return {
-		planSlug,
 		title,
 		formattedPriceMonthly: formatCurrency( priceMonthly, currencyCode, { stripZeros: true } ),
 		formattedPriceFull: formatCurrency( priceFull, currencyCode, { stripZeros: true } ),

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-plan-upsell-info.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-plan-upsell-info.tsx
@@ -34,7 +34,13 @@ export const usePlanUpsellInfo = ( { planSlug }: { planSlug: PlanSlug } ): PlanU
 
 	return {
 		title,
-		formattedPriceMonthly: formatCurrency( priceMonthly, currencyCode, { stripZeros: true } ),
-		formattedPriceFull: formatCurrency( priceFull, currencyCode, { stripZeros: true } ),
+		formattedPriceMonthly: formatCurrency( priceMonthly, currencyCode, {
+			stripZeros: true,
+			isSmallestUnit: true,
+		} ),
+		formattedPriceFull: formatCurrency( priceFull, currencyCode, {
+			stripZeros: true,
+			isSmallestUnit: true,
+		} ),
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

- Updates the upsell modals to use pricing info from data-store hooks - `Plans.usePricingMetaForGridPlans`.
- Minor other refactors/cleanup that felt essential

## Media

| USD | INR (discounted) |
|--------|--------|
| <img width="350" alt="Screenshot 2024-04-10 at 1 21 42 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/eee603b3-8517-4cc3-b963-c73a1d262222"> | <img width="350" alt="Screenshot 2024-04-10 at 1 21 17 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/f89d2f05-0b89-4791-b6af-de420558d8ed"> | 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure pricing is displayed correctly in the various plan upsell modals
    * go to `/start` and select a paid domain
    * then a free plan on `/start/plans`
    * ensure modal opens with buttons showing correct plan pricing (for personal/starter and premium/explorer)
    * repeat with a currency that results in discounted price e.g. INR. Ensure the discounted price is shown, not the original (Tip: just keep the modal open and switch currency in SA - changes will be reflected directly in the modal)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?