### PR TITLE
Deemphasize the Free plan on the onboarding flow if a paid domain is selected with the relevant feature flag enabled.

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
@@ -1,0 +1,25 @@
+import config from '@automattic/calypso-config';
+import type { DataResponse } from '@automattic/plans-grid-next';
+
+function useDeemphasizeFreePlan(
+	flowName?: string | null,
+	paidDomainName?: string
+): DataResponse< boolean > {
+	if (
+		config.isEnabled( 'onboarding/deemphasize-free-plan' ) &&
+		flowName === 'onboarding' &&
+		paidDomainName != null
+	) {
+		return {
+			isLoading: false,
+			result: true,
+		};
+	}
+
+	return {
+		isLoading: false,
+		result: false,
+	};
+}
+
+export default useDeemphasizeFreePlan;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -73,6 +73,7 @@ import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
+import useDeemphasizeFreePlan from './hooks/use-deemphasize-free-plan';
 import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-intervals';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
@@ -251,7 +252,7 @@ const PlansFeaturesMain = ( {
 	isStepperUpgradeFlow = false,
 	isLaunchPage = false,
 	showLegacyStorageFeature = false,
-	deemphasizeFreePlan = false,
+	deemphasizeFreePlan: deemphasizeFreePlanFromProps,
 	isSpotlightOnCurrentPlan,
 	renderSiblingWhenLoaded,
 	showPlanTypeSelectorDropdown = false,
@@ -430,6 +431,9 @@ const PlansFeaturesMain = ( {
 		hideEcommercePlan,
 		hideEnterprisePlan,
 	};
+
+	const resolvedDeemphasizeFreePlan = useDeemphasizeFreePlan( flowName, paidDomainName );
+	const deemphasizeFreePlan = deemphasizeFreePlanFromProps || resolvedDeemphasizeFreePlan.result;
 
 	// we need all the plans that are available to pick for comparison grid (these should extend into plans-ui data store selectors)
 	const gridPlansForComparisonGrid = useGridPlansForComparisonGrid( {
@@ -733,7 +737,10 @@ const PlansFeaturesMain = ( {
 	const isLoadingGridPlans = Boolean(
 		! intent || ! gridPlansForFeaturesGrid || ! gridPlansForComparisonGrid
 	);
-	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
+	const isPlansGridReady =
+		! isLoadingGridPlans &&
+		! resolvedSubdomainName.isLoading &&
+		! resolvedDeemphasizeFreePlan.isLoading;
 	const isMobile = useMobileBreakpoint();
 	const enablePlanTypeSelectorStickyBehavior = isMobile && showPlanTypeSelectorDropdown;
 	const stickyPlanTypeSelectorHeight = isMobile ? 62 : 48;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -432,6 +432,9 @@ const PlansFeaturesMain = ( {
 		hideEnterprisePlan,
 	};
 
+	// The hook is introduced temporarily to alter the value dynamically according to the ExPlat variant loaded.
+	// Once the experiment concludes, we will clean it up and simply use the prop value.
+	// For more details, please refer to peP6yB-23n-p2
 	const resolvedDeemphasizeFreePlan = useDeemphasizeFreePlan( flowName, paidDomainName );
 	const deemphasizeFreePlan = deemphasizeFreePlanFromProps || resolvedDeemphasizeFreePlan.result;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2791; based on https://github.com/Automattic/wp-calypso/pull/89395. 

## Proposed Changes

This PR implements the functionality of deemphasizing the Free plan on the onboarding flow when a paid domain is selected. It's a dynamic behavior which will then be further integrated with ExPlat. Thus, the PR introduces a new hook, `useDeemphasizeFreePlan()` to control the free plan presentation. To begin with, it reads the feature flag, `onboarding/deemphasize-free-plan` instead of actually doing any async request.  

At /start/plans, when a paid domain is picked:
<img width="1258" alt="CleanShot 2024-04-11 at 10 09 06@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/290e8b06-4458-4229-8d21-58638931b749">

At /start/plans, when a free domain is picked or domain selection is skipped:
<img width="1260" alt="CleanShot 2024-04-11 at 10 07 56@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/796f7480-b1ae-42c5-a0ab-fbec40e6ec09">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the feature by either starting your local calypso instance by prepending `ENABLE_FEATURES=onboarding/deemphasize-free-plan` or by appending a query string `?flags=onboarding/deemphasizing-free-plan`
* At `/start/domains`, pick a paid domain. Proceeding to the plans step, confirm that the Free plan is shown as a "start with the Free plan" anchor instead of a plan card.
* Pick the free domain or skip domain selection. Proceeding to the plans step, the Free plan should be shown as a plan card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
