### PR TITLE
Site Migration: Add CTA to skip the site identification

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -74,7 +74,10 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 						onComplete={ ( { platform, url } ) =>
 							navigation?.submit?.( { action: 'continue', platform: platform, from: url } )
 						}
-						onSkip={ () => navigation?.submit?.( { action: 'skip' } ) }
+						onSkip={ () => {
+							recordTracksEvent( 'calypso_site_migration_identify_skip' );
+							navigation?.submit?.( { action: 'skip' } );
+						} }
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,6 +1,6 @@
 import { StepContainer, Title } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
 import ScanningStep from 'calypso/blocks/import/scanning';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -56,7 +56,16 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip } ) => {
 	);
 };
 
+export type SiteMigrationIdentifyAction = 'continue' | 'skip_platform_identification';
+
 const SiteMigrationIdentify: Step = function ( { navigation } ) {
+	const handleSubmit = useCallback(
+		( action: SiteMigrationIdentifyAction, data?: { platform: string; from: string } ) => {
+			navigation?.submit?.( { action: action, ...data } );
+		},
+		[ navigation ]
+	);
+
 	return (
 		<>
 			<DocumentHead title="Site migration instructions" />
@@ -72,11 +81,10 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 				stepContent={
 					<Analyzer
 						onComplete={ ( { platform, url } ) =>
-							navigation?.submit?.( { action: 'continue', platform: platform, from: url } )
+							handleSubmit( 'continue', { platform, from: url } )
 						}
 						onSkip={ () => {
-							recordTracksEvent( 'calypso_site_migration_identify_skip' );
-							navigation?.submit?.( { action: 'skip' } );
+							handleSubmit( 'skip_platform_identification' );
 						} }
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -14,11 +14,11 @@ import './style.scss';
 interface Props {
 	hasError?: boolean;
 	onComplete: ( siteInfo: UrlData ) => void;
+	onSkip: () => void;
 }
 
-export const Analyzer: FC< Props > = ( props ) => {
+export const Analyzer: FC< Props > = ( { onComplete, onSkip } ) => {
 	const translate = useTranslate();
-	const { onComplete } = props;
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 
 	const {
@@ -49,6 +49,7 @@ export const Analyzer: FC< Props > = ( props ) => {
 					onInputChange={ () => setSiteURL( '' ) }
 					hasError={ hasError }
 					skipInitialChecking
+					onDontHaveSiteAddressClick={ onSkip }
 				/>
 			</div>
 		</div>
@@ -71,8 +72,9 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 				stepContent={
 					<Analyzer
 						onComplete={ ( { platform, url } ) =>
-							navigation?.submit?.( { platform: platform, from: url } )
+							navigation?.submit?.( { action: 'continue', platform: platform, from: url } )
 						}
+						onSkip={ () => navigation?.submit?.( { action: 'skip' } ) }
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -80,7 +80,7 @@ describe( 'SiteMigrationIdentify', () => {
 		);
 	} );
 
-	it( 'skips the flow when the user clicks on "choose a content platform"', async () => {
+	it( 'calls submit with the "skip" action when the user clicks on "choose a content platform"', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -87,7 +87,9 @@ describe( 'SiteMigrationIdentify', () => {
 		await userEvent.click( screen.getByRole( 'button', { name: /choose a content platform/ } ) );
 
 		await waitFor( () =>
-			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { action: 'skip' } ) )
+			expect( submit ).toHaveBeenCalledWith(
+				expect.objectContaining( { action: 'skip_platform_identification' } )
+			)
 		);
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -80,6 +80,17 @@ describe( 'SiteMigrationIdentify', () => {
 		);
 	} );
 
+	it( 'skips the flow when the user clicks on "choose a content platform"', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /choose a content platform/ } ) );
+
+		await waitFor( () =>
+			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { action: 'skip' } ) )
+		);
+	} );
+
 	it( 'shows an error when the api analyzer returns error', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -153,21 +153,25 @@ const siteMigration: Flow = {
 
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
-					const { from, platform } = providedDependencies as { from: string; platform: string };
+					const { from, platform, action } = providedDependencies as {
+						from: string;
+						platform: string;
+						action: string;
+					};
 
-					if ( platform === 'wordpress' ) {
-						return navigate(
+					if ( action === 'skip' || platform !== 'wordpress' ) {
+						return exitFlow(
 							addQueryArgs(
-								{ from: from, siteSlug, siteId },
-								STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
+								{ siteId, siteSlug, from, origin: STEPS.SITE_MIGRATION_IDENTIFY.slug },
+								'/setup/site-setup/importList'
 							)
 						);
 					}
 
-					return exitFlow(
+					return navigate(
 						addQueryArgs(
-							{ siteId, siteSlug, from, origin: STEPS.SITE_MIGRATION_IDENTIFY.slug },
-							'/setup/site-setup/importList'
+							{ from: from, siteSlug, siteId },
+							STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
 						)
 					);
 				}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -11,6 +11,7 @@ import { goToCheckout } from '../utils/checkout';
 import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
+import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
@@ -156,10 +157,10 @@ const siteMigration: Flow = {
 					const { from, platform, action } = providedDependencies as {
 						from: string;
 						platform: string;
-						action: string;
+						action: SiteMigrationIdentifyAction;
 					};
 
-					if ( action === 'skip' || platform !== 'wordpress' ) {
+					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
 						return exitFlow(
 							addQueryArgs(
 								{ siteId, siteSlug, from, origin: STEPS.SITE_MIGRATION_IDENTIFY.slug },

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -20,12 +20,17 @@ describe( 'Site Migration Flow', () => {
 		Object.defineProperty( window, 'location', originalLocation );
 	} );
 
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
 	describe( 'navigation', () => {
 		it( 'redirects the user to the migrate or import page when the platform is wordpress', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
 				dependencies: {
+					action: 'continue',
 					platform: 'wordpress',
 					from: 'https://site-to-be-migrated.com',
 				},
@@ -42,6 +47,7 @@ describe( 'Site Migration Flow', () => {
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
 				dependencies: {
+					action: 'continue',
 					platform: 'unknown',
 					from: 'https://example-to-be-migrated.com',
 				},
@@ -49,6 +55,20 @@ describe( 'Site Migration Flow', () => {
 
 			expect( window.location.assign ).toHaveBeenCalledWith(
 				'/setup/site-setup/importList?siteSlug=example.wordpress.com&from=https%3A%2F%2Fexample-to-be-migrated.com&origin=site-migration-identify'
+			);
+		} );
+
+		it( 'redirects the user to the import content flow when the skip the flow', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+				dependencies: {
+					action: 'skip',
+				},
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'/setup/site-setup/importList?siteSlug=example.wordpress.com&origin=site-migration-identify'
 			);
 		} );
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -63,7 +63,7 @@ describe( 'Site Migration Flow', () => {
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
 				dependencies: {
-					action: 'skip',
+					action: 'skip_platform_identification',
 				},
 			} );
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -58,7 +58,7 @@ describe( 'Site Migration Flow', () => {
 			);
 		} );
 
-		it( 'redirects the user to the import content flow when the skip the flow', () => {
+		it( 'redirects the user to the import content flow when the user skip the site identification', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -58,7 +58,7 @@ describe( 'Site Migration Flow', () => {
 			);
 		} );
 
-		it( 'redirects the user to the import content flow when the user skip the site identification', () => {
+		it( 'redirects the user to the import content flow when the user skip the plaform identification', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,


### PR DESCRIPTION
Related to #89397 

## Proposed Changes
* Add the "choose your platform" CTA 
<img width="922" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/61028fab-d825-4a68-8eea-b8d94086b596">

NOTE: No translations were necessary because the CTA was already on the existent capture form component. 


## Testing Instructions
* Go to setup/site-migration/site-migration-identify?siteSlug=[YOU_WPCOMSITE]
* Click on "choose a content platform" CTA
* Check if you were redirected to `/setup/site-setup/importList` page.



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?