### PR TITLE
Tracks: Add `ref` prop to `calypso_page_view` event

### DIFF
--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -295,16 +295,21 @@ export function recordTracksPageView( urlPath: string, params: any ) {
 		eventProperties = Object.assign( eventProperties, params );
 	}
 
-	// Record all `utm` marketing parameters as event properties on the page view event
+	// Record some query parameters as event properties on the page view event
 	// so we can analyze their performance with our analytics tools
 	if ( typeof window !== 'undefined' && window.location ) {
 		const urlParams = new URL( window.location.href ).searchParams;
+
+		// Record all `utm` marketing params.
 		const utmParamEntries =
 			urlParams &&
 			Array.from( urlParams.entries() ).filter( ( [ key ] ) => key.startsWith( 'utm_' ) );
 		const utmParams = utmParamEntries ? Object.fromEntries( utmParamEntries ) : {};
 
-		eventProperties = Object.assign( eventProperties, utmParams );
+		// Record the 'ref' param.
+		const refParam = urlParams && urlParams.get( 'ref' ) ? { ref: urlParams.get( 'ref' ) } : {};
+
+		eventProperties = Object.assign( eventProperties, { ...utmParams, ...refParam } );
 	}
 
 	recordTracksEvent( 'calypso_page_view', eventProperties );


### PR DESCRIPTION
## Proposed Changes

Records the value of the `ref` query param as an additional prop of the `calypso_page_view` events.

The `ref` param can be used to flag what originated the request to see particular Calypso page. For instance, we're using this param in https://github.com/Automattic/jetpack/pull/36801 to indicate which users are landing in the Theme Showcase because of the WP Admin banner.

## Testing Instructions

- Use the Calypso live link below
- Open the Network tab on your browser dev tools
- Observe the `t.gif` requests
- Go to any Calypso page
- Check the `t.gif` request for the `calypso_page_view` event
- Make sure that no `ref` prop is recorded
- Reload the same page with a `?ref=<VALUE>` query param
- Check the `t.gif` request for the `calypso_page_view` event
- Make sure that a `ref` prop is recorded with the correct value