### PR TITLE
Scheduled Updates: Show update in progress label

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -55,16 +55,17 @@ export const ScheduleListTable = ( props: Props ) => {
 							</Button>
 						</td>
 						<td>
-							{ schedule.last_run_status && (
-								<Badge type={ schedule.last_run_status } />
-							) }
-							{ schedule.last_run_timestamp && (
+							{ schedule.last_run_status && <Badge type={ schedule.last_run_status } /> }
+							{ ( schedule.last_run_timestamp || schedule.last_run_status === 'in-progress' ) && (
 								<Button
 									className="schedule-last-run"
 									variant="link"
 									onClick={ () => onShowLogs( schedule.id ) }
 								>
-									{ prepareDateTime( schedule.last_run_timestamp ) }
+									{ schedule.last_run_status === 'in-progress'
+										? translate( 'In progress' )
+										: schedule.last_run_timestamp &&
+										  prepareDateTime( schedule.last_run_timestamp ) }
 								</Button>
 							) }
 							{ ! schedule.last_run_status && ! schedule.last_run_timestamp && '-' }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/89287

## Proposed Changes

Shows a label when an update is in progress

![CleanShot 2024-04-10 at 13 43 24@2x](https://github.com/Automattic/wp-calypso/assets/528287/4b5f6490-8341-4a0b-9843-2200cf6aa94b)

(The extra check `schedule.last_run_timestamp && prepareDateTime( schedule.last_run_timestamp )` is because otherwise TS complains that `schedule.last_run_timestamp` could be null 🤷‍♂️) 

## Testing Instructions

- Apply this PR
- Start an update with the script: `wp run-scheduled-update --require=bin/scheduled-updates/run-scheduled-updates.php --blog-id=`
- Hope that the update doesn't run too quick 😀

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?