### PR TITLE
Pattern Library: Update link to quick launch course

### DIFF
--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -1,6 +1,5 @@
-import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation, useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import imagePreviewPublish from 'calypso/my-sites/patterns/components/get-started/images/preview-publish.png';
 import imagePageLayouts from 'calypso/my-sites/patterns/components/get-started/images/understand-page-layouts.png';
@@ -17,9 +16,7 @@ export function PatternsGetStarted() {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const localizeUrl = useLocalizeUrl();
 	const locale = useLocale();
-	const { hasTranslation } = useI18n();
-
-	const isTitleTranslated = hasTranslation( 'Launch your site faster' ) || locale === 'en';
+	const hasTranslation = useHasEnTranslation();
 
 	return (
 		<PatternsSection
@@ -103,12 +100,12 @@ export function PatternsGetStarted() {
 					/>
 					<div className="patterns-get-started__item-name">{ translate( 'Free course' ) }</div>
 					<div className="patterns-get-started__item-description">
-						{ isTitleTranslated &&
+						{ hasTranslation( 'Launch your site faster' ) &&
 							translate( 'Launch Your Site Faster', {
 								comment:
 									'This string is taken from the first line of the page content from https://wordpress.com/learn/courses/quick-launch/',
 							} ) }
-						{ ! isTitleTranslated &&
+						{ ! hasTranslation( 'Launch your site faster' ) &&
 							translate( 'Design Your Homepage', {
 								comment:
 									'This string is a copy of the page title from wordpress.com/learn/webinars/compelling-homepages/',

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -85,7 +85,7 @@ export function PatternsGetStarted() {
 
 				<a
 					className="patterns-get-started__item"
-					href="https://wordpress.com/learn/webinars/compelling-homepages/"
+					href="https://wordpress.com/learn/courses/quick-launch/design-your-homepage/"
 					rel="noreferrer"
 					target="_blank"
 				>

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -1,5 +1,6 @@
 import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import imagePreviewPublish from 'calypso/my-sites/patterns/components/get-started/images/preview-publish.png';
 import imagePageLayouts from 'calypso/my-sites/patterns/components/get-started/images/understand-page-layouts.png';
@@ -16,6 +17,9 @@ export function PatternsGetStarted() {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const localizeUrl = useLocalizeUrl();
 	const locale = useLocale();
+	const { hasTranslation } = useI18n();
+
+	const isTitleTranslated = hasTranslation( 'Launch your site faster' ) || locale === 'en';
 
 	return (
 		<PatternsSection
@@ -85,7 +89,7 @@ export function PatternsGetStarted() {
 
 				<a
 					className="patterns-get-started__item"
-					href="https://wordpress.com/learn/courses/quick-launch/design-your-homepage/"
+					href="https://wordpress.com/learn/courses/quick-launch/"
 					rel="noreferrer"
 					target="_blank"
 				>
@@ -99,10 +103,16 @@ export function PatternsGetStarted() {
 					/>
 					<div className="patterns-get-started__item-name">{ translate( 'Free course' ) }</div>
 					<div className="patterns-get-started__item-description">
-						{ translate( 'Design Your Homepage', {
-							comment:
-								'This string is a copy of the page title from wordpress.com/learn/webinars/compelling-homepages/',
-						} ) }
+						{ isTitleTranslated &&
+							translate( 'Launch Your Site Faster', {
+								comment:
+									'This string is taken from the first line of the page content from https://wordpress.com/learn/courses/quick-launch/',
+							} ) }
+						{ ! isTitleTranslated &&
+							translate( 'Design Your Homepage', {
+								comment:
+									'This string is a copy of the page title from wordpress.com/learn/webinars/compelling-homepages/',
+							} ) }
 					</div>
 				</a>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

HE suggested that it's more appropriate to link users to the lesson "Quick Launch" lesson instead of previously recorded webinars. We'll update the tile title to "Launch Your Site Faster" and link users to the "Quick Launch" lesson https://wordpress.com/learn/courses/quick-launch/

<img width="1220" alt="Screen Shot 2024-04-10 at 9 07 28 AM" src="https://github.com/Automattic/wp-calypso/assets/104910361/e5ce39dd-9a69-4b3e-b600-2709a2f234ed">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/patterns`
* Scroll down to the "All about patterns" section
* Have EN as your language setting. Assert the third tile says "Launch Your Site Faster" and that the tile links to https://wordpress.com/learn/courses/quick-launch/
* Set your language setting to non-EN. Assert the third tile is translated (based on the original title) and that the tile links to https://wordpress.com/learn/courses/quick-launch/

<img width="1219" alt="Screen Shot 2024-04-10 at 9 07 44 AM" src="https://github.com/Automattic/wp-calypso/assets/104910361/e6cc93b9-ef14-4bdb-a3f1-0cd7969d4d42">
