### PR TITLE
Customize user experience on Free trial page to the Entrepreneur plan.

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -11,12 +11,14 @@ import './style.scss';
 interface ECommerceTrialPlansPageProps {
 	interval?: 'monthly' | 'yearly';
 	site: Site;
+	isWooExpressTrial: boolean;
 }
 
 const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const interval = props.interval ?? 'monthly';
 	const siteSlug = props.site?.slug;
 	const siteId = props.site?.ID;
+	const { isWooExpressTrial } = props;
 
 	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
 		recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', {
@@ -32,7 +34,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 			<BodySectionCssClass bodyClass={ [ 'is-ecommerce-trial-plan' ] } />
 
 			<div className="e-commerce-trial-plans__banner-wrapper">
-				<TrialBanner isEcommerceTrial={ true } />
+				<TrialBanner isWooExpressTrial={ isWooExpressTrial } />
 			</div>
 
 			<WooExpressPlans

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -300,7 +300,7 @@ class Plans extends Component {
 	}
 
 	renderEcommerceTrialPage() {
-		const { selectedSite } = this.props;
+		const { selectedSite, purchase } = this.props;
 
 		if ( ! selectedSite ) {
 			return this.renderPlaceholder();
@@ -308,7 +308,13 @@ class Plans extends Component {
 
 		const interval = this.getIntervalForWooExpressPlans();
 
-		return <ECommerceTrialPlansPage interval={ interval } site={ selectedSite } />;
+		return (
+			<ECommerceTrialPlansPage
+				isWooExpressTrial={ !! purchase?.isWooExpressTrial }
+				interval={ interval }
+				site={ selectedSite }
+			/>
+		);
 	}
 
 	renderBusinessTrialPage() {

--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -15,11 +15,11 @@ import './style.scss';
 
 interface TrialBannerProps {
 	callToAction?: JSX.Element | null;
-	isEcommerceTrial?: boolean;
+	isWooExpressTrial?: boolean;
 }
 
 const TrialBanner = ( props: TrialBannerProps ) => {
-	const { callToAction, isEcommerceTrial } = props;
+	const { callToAction, isWooExpressTrial } = props;
 	const selectedSiteId = useSelector( getSelectedSiteId ) || -1;
 
 	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );
@@ -48,7 +48,7 @@ const TrialBanner = ( props: TrialBannerProps ) => {
 		trialDaysLeftToDisplay,
 		trialExpiration,
 		selectedSiteId,
-		isEcommerceTrial
+		isWooExpressTrial
 	);
 
 	return (

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -110,6 +110,7 @@ describe( 'selectors', () => {
 				isRefundable: false,
 				isRenewable: false,
 				isRenewal: false,
+				isWooExpressTrial: false,
 				meta: undefined,
 				mostRecentRenewDate: undefined,
 				ownershipId: NaN,

--- a/client/state/sites/plans/selectors/get-current-plan.js
+++ b/client/state/sites/plans/selectors/get-current-plan.js
@@ -2,7 +2,7 @@ import debugFactory from 'debug';
 import { find } from 'lodash';
 import { createSitePlanObject } from 'calypso/state/sites/plans/assembler';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
-import { getSite } from 'calypso/state/sites/selectors';
+import { default as getSite } from 'calypso/state/sites/selectors/get-site';
 
 const debug = debugFactory( 'calypso:state:sites:plans:selectors' );
 

--- a/client/state/ui/selectors/get-selected-purchase.ts
+++ b/client/state/ui/selectors/get-selected-purchase.ts
@@ -1,11 +1,11 @@
 import { Purchase } from 'calypso/lib/purchases/types';
-import { getByPurchaseId } from 'calypso/state/purchases/selectors';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors/get-by-purchase-id';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors/get-current-plan';
 import getSelectedSiteId from './get-selected-site-id';
 import type { AppState } from 'calypso/types';
 
 /**
- * Returns the site object for the currently selected site.
+ * Returns the purchase object for the currently selected site.
  */
 export default function getSelectedPurchase( state: AppState ): Purchase | null | undefined {
 	const selectedSiteId = getSelectedSiteId( state );

--- a/client/state/ui/selectors/get-selected-purchase.ts
+++ b/client/state/ui/selectors/get-selected-purchase.ts
@@ -1,0 +1,17 @@
+import { Purchase } from 'calypso/lib/purchases/types';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import getSelectedSiteId from './get-selected-site-id';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns the site object for the currently selected site.
+ */
+export default function getSelectedPurchase( state: AppState ): Purchase | null | undefined {
+	const selectedSiteId = getSelectedSiteId( state );
+	const currentPlan = getCurrentPlan( state, selectedSiteId );
+	if ( ! currentPlan?.id ) {
+		return null;
+	}
+	return getByPurchaseId( state, currentPlan.id );
+}

--- a/client/state/ui/selectors/index.js
+++ b/client/state/ui/selectors/index.js
@@ -1,3 +1,4 @@
+export { default as getSelectedPurchase } from './get-selected-purchase';
 export { default as getSelectedSite } from './get-selected-site';
 export { default as getSelectedSiteId } from './get-selected-site-id';
 export { default as getSelectedSiteSlug } from './get-selected-site-slug';

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -64,6 +64,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		isRefundable: Boolean( purchase.is_refundable ),
 		isRenewable: Boolean( purchase.is_renewable ),
 		isRenewal: Boolean( purchase.is_renewal ),
+		isWooExpressTrial: Boolean( purchase.is_woo_express_trial ),
 		meta: purchase.meta,
 		ownershipId: Number( purchase.ownership_id ),
 		priceText: purchase.price_text,

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -35,6 +35,7 @@ export interface Purchase {
 	isRefundable: boolean;
 	isRenewable: boolean;
 	isRenewal: boolean;
+	isWooExpressTrial: boolean;
 	meta?: string;
 	mostRecentRenewDate?: string;
 	ownershipId?: number;
@@ -208,6 +209,7 @@ export interface RawPurchase {
 	is_refundable: boolean;
 	is_renewable: boolean;
 	is_renewal: boolean;
+	is_woo_express_trial: boolean;
 	meta: string | undefined;
 	ownership_id: number | undefined;
 	partner_name: string | undefined;


### PR DESCRIPTION
Related to pdDOJh-3j6-p2

## Proposed Changes
### Woo Express trial
![image](https://github.com/Automattic/wp-calypso/assets/33497086/c51c6910-b364-462a-9f7e-27d29d7cd45a)

### Entrepreneur trial
![image](https://github.com/Automattic/wp-calypso/assets/33497086/5651d3df-bdd0-4123-95e3-75b3b7678b2a)

We are introducing the new Entrepreneur trial plan, which share some similarities with Woo Express trial, but requires customized experience on Plans page. 
The plans page itself have 2 tabs and this PR focus specifically on the first tab `Free trial`.

The first change is on the trial banner. Because Entrepreneur trial will not have the 1U$ offer, we need to replace the copy.
Luckily, Calypso already had translated copies for that.

The call to action button `Upgrade now`, on Entrepreneur trial, should direct you to the checkout page targeting `Entrepreneur` plan and not `Woo Express: Performance`.

The entire `Ready to start selling?` should not be present on Entrepreneur trial.

![image](https://github.com/Automattic/wp-calypso/assets/33497086/0ecc5aca-3a9b-4ab9-98a1-da6367db64b3)

## Testing Instructions
For testing this you will need an Entrepreneur trial account:
p1712672819187649-slack-C02TCEHP3HA

You will also need a Woo Express trial to check that we didn't break the original experience
https://woocommerce.com/start/

Access `http://calypso.localhost:3000/plans/my-plan/{your-site-here}`
- Check that the `Ready to start selling?` section is not there.
- Check that the trial banner does not refer to the 1U$ offer.
- Click on Upgrade now.
- You should be redirected to checkout page targeting the Entrepreneur plan and the 1U$ offer should **not** be offered.

Do. a regression test with Woo Express trial account and check that:
- `Ready to start selling?` section still exists
- The 1U$ offer is presented on the banner and checkout page.
- Checkout page should target `Woo Express: Performance` plan.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?