### PR TITLE
Evergreen campaigns - date fixes

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -788,9 +788,13 @@ export default function CampaignItemDetails( props: Props ) {
 														const originalDate = moment( createdAt );
 
 														// We only have the "created at" date stored, so we need to subtract a week to match the billing cycle
-														const weekBefore = originalDate.clone().subtract( 7, 'days' );
+														let periodStart = originalDate.clone().subtract( 7, 'days' );
 
-														return `${ weekBefore.format( 'MMM, D' ) } - ${ originalDate.format(
+														if ( periodStart.isBefore( moment( start_date ) ) ) {
+															periodStart = moment( start_date );
+														}
+
+														return `${ periodStart.format( 'MMM, D' ) } - ${ originalDate.format(
 															'MMM, D'
 														) }`;
 													};

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -5,9 +5,8 @@ import { Badge } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
-import { Moment } from 'moment';
+import moment from 'moment';
 import { Fragment, useMemo } from 'react';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { Campaign } from 'calypso/data/promote-post/types';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { useSelector } from 'calypso/state';
@@ -27,19 +26,15 @@ interface Props {
 	campaign: Campaign;
 }
 
-const getCampaignEndText = ( end_date: Moment, status: string, is_evergreen = 0 ) => {
-	if (
-		[ campaignStatus.SCHEDULED, campaignStatus.CREATED, campaignStatus.REJECTED ].includes( status )
-	) {
-		return '-';
-	} else if (
-		is_evergreen &&
-		[ campaignStatus.APPROVED, campaignStatus.ACTIVE ].includes( status )
-	) {
+const getCampaignEndText = ( end_date: string, status: string, is_evergreen = 0 ) => {
+	if ( is_evergreen && [ campaignStatus.APPROVED, campaignStatus.ACTIVE ].includes( status ) ) {
 		return __( 'Until stopped' );
+	} else if ( ! end_date ) {
+		return '-';
 	}
+
 	// return moment in format similar to 27 June
-	return end_date.format( 'D MMMM' );
+	return moment( end_date ).format( 'D MMMM' );
 };
 
 export default function CampaignItem( props: Props ) {
@@ -66,7 +61,6 @@ export default function CampaignItem( props: Props ) {
 		? `${ conversion_rate_percentage.toFixed( 2 ) }%`
 		: '-';
 
-	const moment = useLocalizedMoment();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
 	const safeUrl = safeImageUrl( content_config.imageUrl );
@@ -203,11 +197,7 @@ export default function CampaignItem( props: Props ) {
 			</td>
 			<td className="campaign-item__ends">
 				<div>
-					{ getCampaignEndText(
-						moment( campaign.end_date ),
-						campaign.status,
-						campaign?.is_evergreen
-					) }
+					{ getCampaignEndText( campaign.end_date, campaign.status, campaign?.is_evergreen ) }
 				</div>
 			</td>
 			<td className="campaign-item__budget">

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -26,18 +26,20 @@ import './style.scss';
 interface Props {
 	campaign: Campaign;
 }
+
 const getCampaignEndText = ( end_date: Moment, status: string, is_evergreen = 0 ) => {
 	if (
 		[ campaignStatus.SCHEDULED, campaignStatus.CREATED, campaignStatus.REJECTED ].includes( status )
 	) {
 		return '-';
-	} else if ( [ campaignStatus.APPROVED, campaignStatus.ACTIVE ].includes( status ) ) {
-		return is_evergreen ? __( 'Until stopped' ) : __( 'Ongoing' );
-	} else if ( [ campaignStatus.CANCELED, campaignStatus.FINISHED ].includes( status ) ) {
-		// return moment in format similar to 27 June
-		return end_date.format( 'D MMMM' );
+	} else if (
+		is_evergreen &&
+		[ campaignStatus.APPROVED, campaignStatus.ACTIVE ].includes( status )
+	) {
+		return __( 'Until stopped' );
 	}
-	return '-';
+	// return moment in format similar to 27 June
+	return end_date.format( 'D MMMM' );
 };
 
 export default function CampaignItem( props: Props ) {
@@ -201,13 +203,11 @@ export default function CampaignItem( props: Props ) {
 			</td>
 			<td className="campaign-item__ends">
 				<div>
-					{ campaign.end_date
-						? getCampaignEndText(
-								moment( campaign.end_date ),
-								campaign.status,
-								campaign?.is_evergreen
-						  )
-						: '-' }
+					{ getCampaignEndText(
+						moment( campaign.end_date ),
+						campaign.status,
+						campaign?.is_evergreen
+					) }
 				</div>
 			</td>
 			<td className="campaign-item__budget">


### PR DESCRIPTION
Related to #

## Proposed Changes

- Fixes an issue where scheduled campaigns would show the end date as "ongoing"
    - I tweaked this to show the end date for all campaigns unless unless evergreen
- Fixes a bug where the billing period would show before the campaign start date on reused subscriptions  

## Testing Instructions

- Red: A scheduled campaign (not evergreen) should now show the end date (not "ongoing") 
- Blue: An Evergeen cmapign will say "until stopped"
- Green: An active evergreen campaign will also say "until stopped"
![Screenshot 2024-04-10 at 18 14 21](https://github.com/Automattic/wp-calypso/assets/6440498/20dbcf92-3f3d-4bdc-8d13-a97a7bce3915)


This will require a campaign that is on a reusable subscription, created mid billing cycle.   I think a code review is adequate as it could be a pain to set up the data if you don't have it already.  I'm happy to send a db dump if necessary.

![Screenshot 2024-04-10 at 18 17 19](https://github.com/Automattic/wp-calypso/assets/6440498/66d079c0-47cc-4396-9aba-5ec7beaa25f8)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?