### PR TITLE
Segmentation Survey: Create mutation to link survey answers

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/mutations/test/use-link-answers-mutation.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/mutations/test/use-link-answers-mutation.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import wpcom from 'calypso/lib/wp';
+import useLinkAnswersMutation from '../use-link-answers-mutation';
+
+const MockedComponent = () => {
+	const { mutate } = useLinkAnswersMutation();
+	return (
+		<div>
+			<button
+				onClick={ () => mutate( { blogId: 123, surveyKey: 'test_key' } ) }
+				data-testid="button-mutate"
+			>
+				Click me
+			</button>
+		</div>
+	);
+};
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		post: jest.fn(),
+	},
+} ) );
+
+describe( 'useLinkAnswersMutation', () => {
+	let queryClient: QueryClient;
+	let wrapper: React.FC< React.PropsWithChildren< any > >;
+
+	beforeEach( () => {
+		( wpcom.req.post as jest.MockedFunction< typeof wpcom.req.post > ).mockReset();
+
+		queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
+
+		wrapper = ( { children }: React.PropsWithChildren< any > ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should call wpcom.req.post with the right parameters', async () => {
+		render( <MockedComponent />, { wrapper } );
+		const button = document.querySelector( '[data-testid="button-mutate"]' ) as HTMLButtonElement;
+		button && button.click();
+
+		waitFor( () =>
+			expect( wpcom.req.post ).toHaveBeenCalledWith( {
+				apiNamespace: 'wpcom/v2',
+				path: '/segmentation-survey/answers/link',
+				body: {
+					blog_id: 123,
+					survey_key: 'test_key',
+				},
+			} )
+		);
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/mutations/use-link-answers-mutation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/mutations/use-link-answers-mutation.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+type LinkAnswersMutationArgs = {
+	blogId: number;
+	surveyKey: string;
+};
+
+const useLinkAnswersMutation = () => {
+	return useMutation( {
+		mutationFn: async ( { blogId, surveyKey }: LinkAnswersMutationArgs ) => {
+			return wpcom.req.post( {
+				path: `/segmentation-survey/answers/link`,
+				apiNamespace: 'wpcom/v2',
+				body: {
+					blog_id: blogId,
+					survey_key: surveyKey,
+				},
+			} );
+		},
+	} );
+};
+
+export default useLinkAnswersMutation;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89418

## Proposed Changes

* Create useLinkAnswersMutation. This mutation will be used as part of the Ecommerce Signup Segmentation Survey flow.

## Testing Instructions

* Should be tested together with D144818-code
* Apply this PR to your local
* Run tests with the following command: `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/ecommerce-segmentation-survey/mutations/test/use-link-answers-mutation.test.tsx`
* You can apply the component on any page and verify if the link endpoint is properly called
```
const { mutate } = useLinkAnswersMutation();
...
mutate( { blogId: 123, surveyKey: 'test_key' } )
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?