### PR TITLE
E2E: Fix click location in FullSiteEditorDataViewsComponent

### DIFF
--- a/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
@@ -3,7 +3,7 @@ import { EditorComponent } from './editor-component';
 
 const selectors = {
 	primaryFieldByText: ( primaryFieldText: string ) =>
-		`.dataviews-view-table__primary-field:has-text("${ primaryFieldText }")`,
+		`.dataviews-view-table__primary-field:has-text("${ primaryFieldText }") a`,
 };
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Prior to WordPress/gutenberg#59803, the `a` inside the `.dataviews-view-table__primary-field` div occupied the full width of the div, so when Playwright clicked in the center of the div it would hit the link.

![before](https://github.com/Automattic/wp-calypso/assets/1030580/e32a01e7-b5d4-4ca9-af8e-3094e9820a86)

That PR changed things up a bit, now the `a` is not expanded to fill the entire div and a click in the middle of the div misses the link, meaning the test never navigates to the next page as expected.

![after](https://github.com/Automattic/wp-calypso/assets/1030580/d1f7c0b9-d789-40e2-8b37-a049b85e28a5)

This updates the logic to click the actual `a` instead of the div.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the test, see if it works again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?