### PR TITLE
Patterns: add alt text to images

### DIFF
--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -47,7 +47,7 @@ export function PatternsGetStarted() {
 					<img
 						className="patterns-get-started__item-image"
 						src={ imageBlockPatterns }
-						alt={ translate( "A support page with the title 'Use block patterns'", {
+						alt={ translate( "Support page with the title 'Use block patterns'", {
 							comment:
 								'This string is the ALT text for an image depicting the Block Patterns support page',
 							textOnly: true,
@@ -74,7 +74,7 @@ export function PatternsGetStarted() {
 					<img
 						className="patterns-get-started__item-image"
 						src={ imagePageLayouts }
-						alt={ translate( "A support page with the title 'Understand Page Layouts'", {
+						alt={ translate( "Support page with the title 'Understand page layouts'", {
 							comment:
 								'This string is the ALT text for an image depicting the Page Layouts support page',
 							textOnly: true,
@@ -102,7 +102,7 @@ export function PatternsGetStarted() {
 						className="patterns-get-started__item-image"
 						src={ imagePreviewPublish }
 						alt={ translate(
-							"A row of buttons from the WordPress editor, with a cursor hovering over the 'Publish' button",
+							"Row of buttons from the WordPress editor, with a cursor hovering over the 'Publish' button",
 							{
 								comment:
 									'This string is the ALT text for an image depicting the a user clicking on a button labeled "Publish"',

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -47,7 +47,11 @@ export function PatternsGetStarted() {
 					<img
 						className="patterns-get-started__item-image"
 						src={ imageBlockPatterns }
-						alt=""
+						alt={ translate( "A support page with the title 'Use block patterns'", {
+							comment:
+								'This string is the ALT text for an image depicting the Block Patterns support page',
+							textOnly: true,
+						} ) }
 						width="1200"
 						height="675"
 						loading="lazy"
@@ -70,7 +74,11 @@ export function PatternsGetStarted() {
 					<img
 						className="patterns-get-started__item-image"
 						src={ imagePageLayouts }
-						alt=""
+						alt={ translate( "A support page with the title 'Understand Page Layouts'", {
+							comment:
+								'This string is the ALT text for an image depicting the Page Layouts support page',
+							textOnly: true,
+						} ) }
 						width="1200"
 						height="675"
 						loading="lazy"
@@ -93,7 +101,14 @@ export function PatternsGetStarted() {
 					<img
 						className="patterns-get-started__item-image"
 						src={ imagePreviewPublish }
-						alt=""
+						alt={ translate(
+							"A row of buttons from the WordPress editor, with a cursor hovering over the 'Publish' button",
+							{
+								comment:
+									'This string is the ALT text for an image depicting the a user clicking on a button labeled "Publish"',
+								textOnly: true,
+							}
+						) }
 						width="1137"
 						height="639"
 						loading="lazy"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6446-gh-Automattic/dotcom-forge

## Proposed Changes

Adds ALT text to all three images in the Pattern Library's "Get Started" section

I'm running the ALT tags through a `translate` call, but let me know if that feels like overkill!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Load the `/patterns` and inspect each of the images in the Get Started section
- Confirm each one has a proper ALT tag