### PR TITLE
A4A: user long name handling in sidebar

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -106,7 +106,10 @@ const ProfileDropdown = ( { compact, dropdownPosition = 'down' }: ProfileDropdow
 
 				{ ! compact && (
 					<div className="a4a-sidebar__profile-dropdown-button-label">
-						{ user?.display_name } <Icon icon={ chevronDown } />
+						<span className="a4a-sidebar__profile-dropdown-button-label-text">
+							{ user?.display_name }
+						</span>
+						<Icon icon={ chevronDown } />
 					</div>
 				) }
 			</Button>

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -31,7 +31,14 @@
 	align-items: flex-start;
 	gap: 4px;
 	color: var(--color-sidebar-text);
+}
 
+.a4a-sidebar__profile-dropdown-button-label-text {
+	max-width: 160px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	position: relative;
 }
 
 html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/170

## Proposed Changes

Set max-width for the text element, so it doesn't push gravatar out of boundaries


<img width="258" alt="Screenshot 2024-04-10 at 1 42 16 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/f431a64f-72b3-4f51-9c23-4c86404575b6">


<img width="259" alt="Screenshot 2024-04-10 at 1 42 40 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/bc13b612-ff9f-40dd-82d6-3f47c3c1d11f">

## Testing Instructions

- Navigate to A4A from this branch
- Using developer tools, change the wording of your name in left side corner to be lengthly.
- Check that UI represented correctly.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?