### PR TITLE
Stats: Reverification lock should be per site

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -364,9 +364,11 @@ function StatsCommercialFlowOptOutForm( {
 
 	useEffect( () => {
 		setComemercialClassificationRunAt(
-			parseInt( localStorage.getItem( 'commercial_classification__button_clicked' ) ?? '0' )
+			parseInt(
+				localStorage?.getItem( `commercial_classification__button_clicked_${ siteId }` ) ?? '0'
+			)
 		);
-	}, [] );
+	}, [ siteId ] );
 
 	const handleSwitchToPersonalClick = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
@@ -392,16 +394,19 @@ function StatsCommercialFlowOptOutForm( {
 		useOnDemandCommercialClassificationMutation( siteId );
 	const handleCommercialClassification = async () => {
 		const now = Date.now();
-		localStorage?.setItem( 'commercial_classification__button_clicked', `${ now }` );
+		localStorage?.setItem( `commercial_classification__button_clicked_${ siteId }`, `${ now }` );
 		setComemercialClassificationRunAt( now );
 		runCommercialClassificationAsync().catch( ( e ) => {
 			setErrorMessage( e.message );
 		} );
 	};
 	const commercialClassificationLastRunAt = useMemo(
-		() => parseInt( localStorage.getItem( 'commercial_classification__button_clicked' ) ?? '0' ),
+		() =>
+			parseInt(
+				localStorage?.getItem( `commercial_classification__button_clicked_${ siteId }` ) ?? '0'
+			),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ comemercialClassificationRunAt ]
+		[ comemercialClassificationRunAt, siteId ]
 	);
 	const hasRunLessThan3DAgo =
 		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 1; // 1 day


### PR DESCRIPTION
## Proposed Changes

* Lock reverify per site; otherwise if users have multiple sites, the verification process will affect one another

## Testing Instructions

* Prepare two commercial sites
* Open Calypso Live `/stats/purchase/:siteSlug`
* Ensure you could reverify one site along with the other one

<img width="764" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/59b60249-4ede-4e14-8401-6057e72f0895">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?