### PR TITLE
Congrats: disable toast notification

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -21,7 +21,6 @@ import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
 import { logStashLoadErrorEvent } from '../../src/lib/analytics';
-import { isRefactoredForThankYouV2 } from '../redesign-v2/utils';
 import type { RedirectInstructions } from 'calypso/my-sites/checkout/src/lib/pending-page';
 import type { ReceiptState } from 'calypso/state/receipts/types';
 import type {
@@ -353,15 +352,6 @@ function triggerPostRedirectNotices( {
 			reduxDispatch,
 		} );
 		return;
-	}
-
-	if ( ! isRefactoredForThankYouV2 ) {
-		reduxDispatch(
-			successNotice( translate( 'Your purchase has been completed!' ), {
-				id: 'checkout-thank-you-success',
-				displayOnNextPage: true,
-			} )
-		);
 	}
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -21,6 +21,7 @@ import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
 import { logStashLoadErrorEvent } from '../../src/lib/analytics';
+import { isRefactoredForThankYouV2 } from '../redesign-v2/utils';
 import type { RedirectInstructions } from 'calypso/my-sites/checkout/src/lib/pending-page';
 import type { ReceiptState } from 'calypso/state/receipts/types';
 import type {
@@ -354,12 +355,14 @@ function triggerPostRedirectNotices( {
 		return;
 	}
 
-	reduxDispatch(
-		successNotice( translate( 'Your purchase has been completed!' ), {
-			id: 'checkout-thank-you-success',
-			displayOnNextPage: true,
-		} )
-	);
+	if ( ! isRefactoredForThankYouV2 ) {
+		reduxDispatch(
+			successNotice( translate( 'Your purchase has been completed!' ), {
+				id: 'checkout-thank-you-success',
+				displayOnNextPage: true,
+			} )
+		);
+	}
 }
 
 function displayRenewalSuccessNotice( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2736-gh-Automattic/dotcom-forge

## Proposed Changes

Disable toast notification for congrats pages. 

## Testing Instructions

Perform test purchases of plans, domains, and add-ons, confirming that none of them display a toast notification upon a successful purchase.