### PR TITLE
Monetize: Enable on Jetpack Cloud Production

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -95,6 +95,7 @@
 		"jetpack-search": true,
 		"jetpack-social": true,
 		"jetpack-subscribers": true,
+		"jetpack-monetize": true,
 		"scan": true,
 		"site-purchases": true
 	},


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/88778

## Proposed Changes

As part of the release Monetize on Jetpack Cloud, this PR enable it on Production environment.

## Testing Instructions

This only enables the section on production environment and will be seen when it is deployed