### PR TITLE
Implement the deemphasizing Free plan test

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
@@ -1,24 +1,20 @@
-import config from '@automattic/calypso-config';
+import { useExperiment } from 'calypso/lib/explat';
 import type { DataResponse } from '@automattic/plans-grid-next';
 
 function useDeemphasizeFreePlan(
 	flowName?: string | null,
 	paidDomainName?: string
 ): DataResponse< boolean > {
-	if (
-		config.isEnabled( 'onboarding/deemphasize-free-plan' ) &&
-		flowName === 'onboarding' &&
-		paidDomainName != null
-	) {
-		return {
-			isLoading: false,
-			result: true,
-		};
-	}
+	const [ isLoading, experimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_deemphasize_free_plan',
+		{
+			isEligible: flowName === 'onboarding',
+		}
+	);
 
 	return {
-		isLoading: false,
-		result: false,
+		isLoading,
+		result: experimentAssignment?.variationName === 'treatment' && paidDomainName != null,
 	};
 }
 

--- a/client/signup/flow-actions.ts
+++ b/client/signup/flow-actions.ts
@@ -1,3 +1,8 @@
-// Remove this eslint disabling line once there are things to be preloaded
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const onEnterOnboarding = ( flowName: string ) => {};
+import { loadExperimentAssignment } from 'calypso/lib/explat';
+
+export const onEnterOnboarding = ( flowName: string ) => {
+	// just to be extra safe since `loadExperimentAssignment` doesn't have the same eligibility check like `useExperiment` does
+	if ( flowName === 'onboarding' ) {
+		loadExperimentAssignment( 'calypso_signup_onboarding_deemphasize_free_plan' );
+	}
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2791; based on https://github.com/Automattic/wp-calypso/pull/89400.

## Proposed Changes

This PR implements the deemphasizing Free plan test by integrating ExPlat in the `useDeemphasizeFreePlan` hook.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The following requires you to use EXPLAT to assign your test account to different variants and sandbox the public API.

1. Assign a test account to the treatment group.
    1. Access the main onboarding flow, `/start`
    2. At the domain step, choose a paid domain. Proceeding to the plans step, confirm that the Free plan is shown as a "start with the Free plan" anchor rather than a plan card.
    3. At the domain step, choose the free domain or click on "check paid plans" to skip domain selection. Proceeding to the plans step, confirm that the Free plan is shown as a plan card.
1. Assign a test account to the control group. The Free plan should always be shown as a plan card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
