### PR TITLE
Automattic for Agencies: Add Referrals sidebar & section

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -15,6 +15,7 @@ export const A4A_MARKETPLACE_HOSTING_WPCOM_LINK = `${ A4A_MARKETPLACE_HOSTING_LI
 export const A4A_MARKETPLACE_CHECKOUT_LINK = `${ A4A_MARKETPLACE_LINK }/checkout`;
 export const A4A_MARKETPLACE_ASSIGN_LICENSE_LINK = `${ A4A_MARKETPLACE_LINK }/assign-license`;
 export const A4A_PURCHASES_LINK = '/purchases';
+export const A4A_REFERRALS_LINK = '/referrals';
 export const A4A_LICENSES_LINK = `${ A4A_PURCHASES_LINK }/licenses`;
 export const A4A_UNASSIGNED_LICENSES_LINK = `${ A4A_LICENSES_LINK }/unassigned`;
 export const A4A_BILLING_LINK = `${ A4A_PURCHASES_LINK }/billing`;

--- a/client/a8c-for-agencies/components/sidebar-menu/main.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/main.tsx
@@ -1,4 +1,4 @@
-import { category, home, tag, currencyDollar } from '@wordpress/icons';
+import { category, home, tag, currencyDollar, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import Sidebar from '../sidebar';
@@ -9,6 +9,7 @@ import {
 	A4A_PURCHASES_LINK,
 	A4A_LICENSES_LINK,
 	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_REFERRALS_LINK,
 } from './lib/constants';
 import { createItem } from './lib/utils';
 
@@ -70,6 +71,15 @@ export default function ( { path }: Props ) {
 					menu_item: 'Automattic for Agencies / Purchases',
 				},
 				withChevron: true,
+			},
+			{
+				icon: reusableBlock,
+				path: '/',
+				link: A4A_REFERRALS_LINK,
+				title: translate( 'Referrals' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Referrals',
+				},
 			},
 		].map( ( item ) => createItem( item, path ) );
 	}, [ path, translate ] );

--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -1,0 +1,8 @@
+import { type Callback } from '@automattic/calypso-router';
+import MainSidebar from '../../components/sidebar-menu/main';
+
+export const referralsContext: Callback = ( context, next ) => {
+	context.primary = 'Referrals!';
+	context.secondary = <MainSidebar path={ context.path } />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/referrals/index.ts
+++ b/client/a8c-for-agencies/sections/referrals/index.ts
@@ -1,0 +1,8 @@
+import page from '@automattic/calypso-router';
+import { A4A_REFERRALS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import * as controller from './controller';
+
+export default function () {
+	page( A4A_REFERRALS_LINK, controller.referralsContext, makeLayout, clientRender );
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -776,6 +776,12 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
+		name: 'a8c-for-agencies-referrals',
+		paths: [ '/referrals' ],
+		module: 'calypso/a8c-for-agencies/sections/referrals',
+		group: 'a8c-for-agencies',
+	},
+	{
 		name: 'a8c-for-agencies-signup',
 		paths: [ '/signup' ],
 		module: 'calypso/a8c-for-agencies/sections/signup',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -165,6 +165,7 @@
 		"a8c-for-agencies-marketplace": false,
 		"a8c-for-agencies-purchases": false,
 		"a8c-for-agencies-signup": false,
+		"a8c-for-agencies-referrals": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -42,7 +42,8 @@
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,
-		"a8c-for-agencies-signup": true
+		"a8c-for-agencies-signup": true,
+		"a8c-for-agencies-referrals": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -36,7 +36,8 @@
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,
-		"a8c-for-agencies-signup": true
+		"a8c-for-agencies-signup": true,
+		"a8c-for-agencies-referrals": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/315

## Proposed Changes

This PR:

- Adds a new sidebar menu item for Referrals.
- Adds referrals section.
- Enable the referrals section in dev & horizon env.

NOTE: The page background color will be automatically fixed when we have the Layout. So, please ignore it for now.

## Testing Instructions

- Open the A4A live link
- Verify that you can see the `Referrals` sidebar menu item
- Click the menu item and verify you are navigated to the `referrals` page.
- Visit the Calypso Blue & Jetpack Cloud live links > Append the URL with /referrals & verify that you can not see this page.

<img width="720" alt="Screenshot 2024-04-11 at 11 54 50 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/666f2ff3-5768-44ea-85c1-c07e675b8dc4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?