### PR TITLE
Automattic for Agencies: Add initial layout for Referrals

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -1,8 +1,9 @@
 import { type Callback } from '@automattic/calypso-router';
 import MainSidebar from '../../components/sidebar-menu/main';
+import ReferralsOverview from './primary/referrals-overview';
 
 export const referralsContext: Callback = ( context, next ) => {
-	context.primary = 'Referrals!';
+	context.primary = <ReferralsOverview />;
 	context.secondary = <MainSidebar path={ context.path } />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,0 +1,29 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+export default function ReferralsOverview() {
+	const translate = useTranslate();
+
+	const title = translate( 'Referrals' );
+
+	return (
+		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<PageViewTracker title="Referrals" path="/referrals" />
+
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title } </Title>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>Content goes here</LayoutBody>
+		</Layout>
+	);
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/316

## Proposed Changes

This PR adds an initial layout for Referrals.

## Testing Instructions

- Open the A4A live link
- Verify that you can see the `Referrals` sidebar menu item
- Click the `Referrals` sidebar menu item and verify that you can see the page & header as shown below

<img width="1582" alt="Screenshot 2024-04-11 at 12 14 38 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a9e33e6b-3a87-4d98-a711-917e2b7e780e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?