### PR TITLE
A4A: Add missing signup fields.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -8,10 +8,13 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 		apiNamespace: 'wpcom/v2',
 		path: '/agency',
 		body: {
+			first_name: details.firstName,
+			last_name: details.lastName,
 			agency_name: details.agencyName,
 			agency_url: details.agencyUrl,
 			number_sites: details.managedSites,
 			services_offered: details.servicesOffered,
+			products_offered: details.productsOffered,
 			address_line1: details.line1,
 			address_line2: details.line2,
 			address_city: details.city,

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -173,30 +173,32 @@ export default function AgencyDetailsForm( {
 	return (
 		<div className="agency-details-form">
 			<form onSubmit={ handleSubmit }>
-				<FormFieldset>
-					<FormLabel htmlFor="firstName">{ translate( 'First name' ) }</FormLabel>
-					<FormTextInput
-						id="firstName"
-						name="firstName"
-						value={ firstName }
-						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
-							setFirstName( event.target.value )
-						}
-						disabled={ isLoading }
-					/>
-				</FormFieldset>
-				<FormFieldset>
-					<FormLabel htmlFor="lastName">{ translate( 'Last name' ) }</FormLabel>
-					<FormTextInput
-						id="lastName"
-						name="lastName"
-						value={ lastName }
-						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
-							setLastName( event.target.value )
-						}
-						disabled={ isLoading }
-					/>
-				</FormFieldset>
+				<div className="agency-details-form__fullname-container">
+					<FormFieldset>
+						<FormLabel htmlFor="firstName">{ translate( 'First name' ) }</FormLabel>
+						<FormTextInput
+							id="firstName"
+							name="firstName"
+							value={ firstName }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+								setFirstName( event.target.value )
+							}
+							disabled={ isLoading }
+						/>
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="lastName">{ translate( 'Last name' ) }</FormLabel>
+						<FormTextInput
+							id="lastName"
+							name="lastName"
+							value={ lastName }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+								setLastName( event.target.value )
+							}
+							disabled={ isLoading }
+						/>
+					</FormFieldset>
+				</div>
 				<FormFieldset>
 					<FormLabel htmlFor="agencyName">{ translate( 'Agency name' ) }</FormLabel>
 					<FormTextInput

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -33,10 +33,13 @@ interface Props {
 	onSubmit: ( payload: AgencyDetailsPayload ) => void;
 	referer?: string | null;
 	initialValues?: {
+		firstName?: string;
+		lastName?: string;
 		agencyName?: string;
 		agencyUrl?: string;
 		managedSites?: string;
 		servicesOffered?: string[];
+		productsOffered?: string[];
 		city?: string;
 		line1?: string;
 		line2?: string;
@@ -66,9 +69,12 @@ export default function AgencyDetailsForm( {
 	const [ postalCode, setPostalCode ] = useState( initialValues.postalCode ?? '' );
 	const [ addressState, setAddressState ] = useState( initialValues.state ?? '' );
 	const [ agencyName, setAgencyName ] = useState( initialValues.agencyName ?? '' );
+	const [ firstName, setFirstName ] = useState( initialValues.firstName ?? '' );
+	const [ lastName, setLastName ] = useState( initialValues.lastName ?? '' );
 	const [ agencyUrl, setAgencyUrl ] = useState( initialValues.agencyUrl ?? '' );
 	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '1-5' );
 	const [ servicesOffered, setServicesOffered ] = useState( initialValues.servicesOffered ?? [] );
+	const [ productsOffered, setProductsOffered ] = useState( initialValues.productsOffered ?? [] );
 
 	const country = getCountry( countryValue, countryOptions );
 	const stateOptions = stateOptionsMap[ country ];
@@ -80,10 +86,13 @@ export default function AgencyDetailsForm( {
 
 	const payload: AgencyDetailsPayload = useMemo(
 		() => ( {
+			firstName,
+			lastName,
 			agencyName,
 			agencyUrl,
 			managedSites,
 			servicesOffered,
+			productsOffered,
 			city,
 			line1,
 			line2,
@@ -94,10 +103,13 @@ export default function AgencyDetailsForm( {
 			...( includeTermsOfService ? { tos: 'consented' } : {} ),
 		} ),
 		[
+			firstName,
+			lastName,
 			agencyName,
 			agencyUrl,
 			managedSites,
 			servicesOffered,
+			productsOffered,
 			city,
 			line1,
 			line2,
@@ -132,6 +144,16 @@ export default function AgencyDetailsForm( {
 		];
 	};
 
+	const getProductsOfferedOptions = () => {
+		return [
+			{ value: 'WordPress.com', label: translate( 'WordPress.com' ) },
+			{ value: 'WooCommerce', label: translate( 'WooCommerce' ) },
+			{ value: 'Jetpack', label: translate( 'Jetpack' ) },
+			{ value: 'Pressable', label: translate( 'Pressable' ) },
+			{ value: 'WordPress VIP', label: translate( 'WordPress VIP' ) },
+		];
+	};
+
 	// <FormSelect> complains if we "just" pass "setManagedSites" because it expects
 	// React.FormEventHandler, so this wrapper function is made to satisfy everything
 	// in an easily readable way.
@@ -144,9 +166,37 @@ export default function AgencyDetailsForm( {
 		setServicesOffered( services.value );
 	};
 
+	const handleSetProductsOffered = ( products: ChangeList< string > ) => {
+		setProductsOffered( products.value );
+	};
+
 	return (
 		<div className="agency-details-form">
 			<form onSubmit={ handleSubmit }>
+				<FormFieldset>
+					<FormLabel htmlFor="firstName">{ translate( 'First name' ) }</FormLabel>
+					<FormTextInput
+						id="firstName"
+						name="firstName"
+						value={ firstName }
+						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+							setFirstName( event.target.value )
+						}
+						disabled={ isLoading }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="lastName">{ translate( 'Last name' ) }</FormLabel>
+					<FormTextInput
+						id="lastName"
+						name="lastName"
+						value={ lastName }
+						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+							setLastName( event.target.value )
+						}
+						disabled={ isLoading }
+					/>
+				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="agencyName">{ translate( 'Agency name' ) }</FormLabel>
 					<FormTextInput
@@ -182,8 +232,8 @@ export default function AgencyDetailsForm( {
 						onChange={ handleSetManagedSites }
 					>
 						<option value="1-5">{ translate( '1-5' ) }</option>
-						<option value="6-25">{ translate( '6-25' ) }</option>
-						<option value="26-50">{ translate( '26-50' ) }</option>
+						<option value="6-20">{ translate( '6-20' ) }</option>
+						<option value="21-50">{ translate( '21-50' ) }</option>
 						<option value="51-100">{ translate( '51-100' ) }</option>
 						<option value="101-500">{ translate( '101-500' ) }</option>
 						<option value="501+">{ translate( '501+' ) }</option>
@@ -204,6 +254,20 @@ export default function AgencyDetailsForm( {
 						// // Using 'as any' to bypass TypeScript type checks due to a known and intentional type mismatch between
 						// the expected custom event type for `onChange` and the standard event types.
 						onChange={ handleSetServicesOffered as any }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="products_offered">
+						{ translate( 'What Automattic products do you currently offer your customers?' ) }
+					</FormLabel>
+					<MultiCheckbox
+						id="products_offered"
+						name="products_offered"
+						checked={ productsOffered }
+						options={ getProductsOfferedOptions() }
+						// // Using 'as any' to bypass TypeScript type checks due to a known and intentional type mismatch between
+						// the expected custom event type for `onChange` and the standard event types.
+						onChange={ handleSetProductsOffered as any }
 					/>
 				</FormFieldset>
 				<FormFieldset>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -238,7 +238,7 @@ export default function AgencyDetailsForm( {
 						<option value="21-50">{ translate( '21-50' ) }</option>
 						<option value="51-100">{ translate( '51-100' ) }</option>
 						<option value="101-500">{ translate( '101-500' ) }</option>
-						<option value="501+">{ translate( '501+' ) }</option>
+						<option value="500+">{ translate( '500+' ) }</option>
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .agency-details-form {
 
 	.agency-details-form__controls {
@@ -21,4 +24,17 @@
 	select {
 		width: 100%;
 	}
+
+	.agency-details-form__fullname-container {
+		@include break-small {
+			display: flex;
+			flex-direction: row;
+			gap: 16px;
+
+			> * {
+				flex-grow: 1;
+			}
+		}
+	}
+
 }

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -1,8 +1,11 @@
 export interface AgencyDetailsPayload {
+	firstName: string;
+	lastName: string;
 	agencyName: string;
 	agencyUrl: string;
 	managedSites?: string;
 	servicesOffered: string[];
+	productsOffered: string[];
 	city: string;
 	line1: string;
 	line2: string;

--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -39,10 +39,13 @@ export default function SignupForm() {
 
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_create_agency_submit', {
+					first_name: payload.firstName,
+					last_name: payload.lastName,
 					name: payload.agencyName,
 					business_url: payload.agencyUrl,
 					managed_sites: payload.managedSites,
 					services_offered: ( payload.servicesOffered || [] ).join( ',' ),
+					products_offered: ( payload.productsOffered || [] ).join( ',' ),
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,


### PR DESCRIPTION
This PR adds missing fields for us to track in the A4A HubSpot app.

Closes https://github.com/Automattic/jetpack-genesis/issues/313

## Proposed Changes

* Add First and Last name fields.
  <img width="657" alt="Screenshot 2024-04-11 at 3 50 51 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/eb558bc3-3e55-495c-8bae-3bf316d6c113">

* Add missing Number of site options.
   <img width="640" alt="Screenshot 2024-04-11 at 3 50 58 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/1f552d29-df35-4f63-aa3d-0aa6f5f3aa63">

* Add Products offered to customer field.
   <img width="498" alt="Screenshot 2024-04-11 at 3 51 04 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8aee6b2e-780b-4d87-9033-65b19de4d480">


## Testing Instructions
This PR needs to be tested together with D144911-code patch.

* Apply the D144911-code patch in your sandbox and redirect public-api.wordpress.com to your sandbox.
* Create a new WPCOM account.
* Checkout this branch: `git checkout add/a4a/missing-signup-fields`
* Spin up A4A locally: `yarn start-a8c-for-agencies`
* Go to http://agencies.localhost:3000/signup
* Confirm that you can see the new fields in the Signup form.
* Fill in the information and confirm the signup form works.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?