### PR TITLE
Fix text overflow for woo passwordless UI

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1501,6 +1501,7 @@ $breakpoint-mobile: 660px;
 				padding: 0;
 				border: 0;
 				border-radius: 0;
+				width: 100%;
 			}
 
 			.gravatar.continue-as-user__gravatar {


### PR DESCRIPTION
Before:
![Screenshot 2024-04-11 at 16 27 02](https://github.com/Automattic/wp-calypso/assets/4344253/c2ff67af-b230-4802-930f-d1287c4a1c4e)


After:

![Screenshot 2024-04-11 at 16 26 44](https://github.com/Automattic/wp-calypso/assets/4344253/ca62a8de-03d0-4b21-b308-0305c96edd06)
