### PR TITLE
Pattern Library: Use a different onboarding URL on mobile

### DIFF
--- a/client/my-sites/patterns/components/get-access-modal/index.tsx
+++ b/client/my-sites/patterns/components/get-access-modal/index.tsx
@@ -1,7 +1,6 @@
 import { Button, Dialog } from '@automattic/components';
 import { useLocalizeUrl, useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { Icon, close as iconClose } from '@wordpress/icons';
-import { buildQueryString } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
@@ -35,7 +34,7 @@ export const PatternsGetAccessModal = ( {
 	const redirectUrl = getPatternPermalink( pattern, category, patternTypeFilter, categories );
 
 	const signupUrl = localizeUrl(
-		`//wordpress.com/start/account/user?${ buildQueryString( {
+		`//wordpress.com/start/account/user?${ new URLSearchParams( {
 			redirect_to: redirectUrl,
 			ref: URL_REFERRER_PARAM,
 		} ) }`,
@@ -44,7 +43,7 @@ export const PatternsGetAccessModal = ( {
 	);
 
 	const loginUrl = localizeUrl(
-		`//wordpress.com/log-in?${ buildQueryString( { redirect_to: redirectUrl } ) }`,
+		`//wordpress.com/log-in?${ new URLSearchParams( { redirect_to: redirectUrl } ) }`,
 		locale,
 		isLoggedIn
 	);

--- a/client/my-sites/patterns/paths.ts
+++ b/client/my-sites/patterns/paths.ts
@@ -19,18 +19,18 @@ export function getCategoryUrlPath(
 }
 
 export function getOnboardingUrl( locale: Locale, isLoggedIn: boolean ) {
-	const refQueryString = new URLSearchParams( {
+	const refQuery = new URLSearchParams( {
 		ref: URL_REFERRER_PARAM,
 	} );
 
 	// The Assembler only works on larger viewports
 	if ( isAssemblerSupported() ) {
 		return localizeUrl(
-			`https://wordpress.com/setup/assembler-first?${ refQueryString }`,
+			`https://wordpress.com/setup/assembler-first?${ refQuery }`,
 			locale,
 			isLoggedIn
 		);
 	}
 
-	return localizeUrl( `https://wordpress.com/start?${ refQueryString }`, locale, isLoggedIn );
+	return localizeUrl( `https://wordpress.com/start?${ refQuery }`, locale, isLoggedIn );
 }

--- a/client/my-sites/patterns/paths.ts
+++ b/client/my-sites/patterns/paths.ts
@@ -1,5 +1,5 @@
+import { isAssemblerSupported } from '@automattic/design-picker';
 import { addLocaleToPathLocaleInFront, localizeUrl } from '@automattic/i18n-utils';
-import { buildQueryString } from '@wordpress/url';
 import { PatternTypeFilter } from 'calypso/my-sites/patterns/types';
 import type { Locale } from '@automattic/i18n-utils';
 
@@ -19,11 +19,18 @@ export function getCategoryUrlPath(
 }
 
 export function getOnboardingUrl( locale: Locale, isLoggedIn: boolean ) {
-	return localizeUrl(
-		`https://wordpress.com/setup/assembler-first?${ buildQueryString( {
-			ref: URL_REFERRER_PARAM,
-		} ) }`,
-		locale,
-		isLoggedIn
-	);
+	const refQueryString = new URLSearchParams( {
+		ref: URL_REFERRER_PARAM,
+	} );
+
+	// The Assembler only works on larger viewports
+	if ( isAssemblerSupported() ) {
+		return localizeUrl(
+			`https://wordpress.com/setup/assembler-first?${ refQueryString }`,
+			locale,
+			isLoggedIn
+		);
+	}
+
+	return localizeUrl( `https://wordpress.com/start?${ refQueryString }`, locale, isLoggedIn );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6534

## Proposed Changes

As reported here p1712824081983569-slack-C06ELHR6L9J, the `/setup/assembler-first` onboarding flow doesn't work on mobile. This PR makes it so `getOnboardingUrl` returns `/start` instead on mobile.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Simulate a mobile viewport
2. Navigate to `/patterns`
3. Scroll down to the `Build a site` CTA
4. Ensure that it leads to `wordpress.com/start`
5. Switch to a large viewport and reload the page
6. Ensure that the `Build a site` CTA leads to `wordpress.com/setup/assembler-first`
7. Navigate to a category
8. Scroll down to a `Get access` button and click it
9. Ensure that the Sign up and Log in links in the modal have proper query strings