### PR TITLE
Automattic for Agencies: Implement "Get set up" section on referrals page

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@automattic/components';
+import { Icon } from '@wordpress/icons';
+import React from 'react';
+
+import './style.scss';
+
+const ICON_SIZE = 24;
+
+interface StepSectionItemProps {
+	icon: JSX.Element;
+	heading: string;
+	description: string;
+	buttonProps: React.ComponentProps< typeof Button >;
+}
+
+export default function StepSectionItem( {
+	icon,
+	heading,
+	description,
+	buttonProps,
+}: StepSectionItemProps ) {
+	return (
+		<div className="step-section-item">
+			<div className="step-section-item__icon">
+				<Icon
+					className="sidebar__menu-icon"
+					style={ { fill: 'currentcolor' } }
+					icon={ icon }
+					size={ ICON_SIZE }
+				/>
+			</div>
+			<div className="step-section-item__content">
+				<div className="step-section-item__heading">{ heading }</div>
+				<div className="step-section-item__description">{ description }</div>
+			</div>
+			<div className="step-section-item__button">
+				<Button { ...buttonProps } />
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -1,11 +1,24 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .step-section-item {
-	display: flex;
 	margin-block-end: 16px;
 	border-radius: 4px;
 	border: 1px solid var(--color-accent-5);
 	padding: 16px 24px;
-	gap: 16px;
-	position: relative;
+
+	@include break-large {
+		display: flex;
+		gap: 16px;
+	}
+
+	.step-section-item__icon {
+		display: none;
+
+		@include break-large {
+			display: block;
+		}
+	}
 
 	.step-section-item__heading {
 		font-size: rem(16px);
@@ -18,6 +31,17 @@
 	}
 
 	.step-section-item__button {
-		margin-block: auto;
+		margin-block-start: 16px;
+		margin-inline-start: auto;
+
+		button {
+			width: 100%;
+		}
+
+		@include break-large {
+			margin-block: auto;
+			display: flex;
+			gap: 16px;
+		}
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -19,7 +19,5 @@
 
 	.step-section-item__button {
 		margin-block: auto;
-		position: absolute;
-		right: 14px;
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -1,0 +1,25 @@
+.step-section-item {
+	display: flex;
+	margin-block-end: 16px;
+	border-radius: 4px;
+	border: 1px solid var(--color-accent-5);
+	padding: 16px 24px;
+	gap: 16px;
+	position: relative;
+
+	.step-section-item__heading {
+		font-size: rem(16px);
+		font-weight: 500;
+	}
+
+	.step-section-item__description {
+		font-size: rem(13px);
+		color: var(--color-accent);
+	}
+
+	.step-section-item__button {
+		margin-block: auto;
+		position: absolute;
+		right: 14px;
+	}
+}

--- a/client/a8c-for-agencies/sections/referrals/common/step-section/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import './style.scss';
+
+interface StepSectionProps {
+	heading: string;
+	stepCount: number;
+	children: React.ReactNode;
+}
+
+export default function StepSection( { stepCount, heading, children }: StepSectionProps ) {
+	return (
+		<div className="step-section">
+			<div className="step-section__header">
+				<div className="step-section__step-count">{ stepCount }</div>
+				<div className="step-section__step-heading">{ heading }</div>
+			</div>
+			<div className="step-section__content">{ children }</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/common/step-section/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section/style.scss
@@ -1,0 +1,25 @@
+.step-section {
+	.step-section__header {
+		display: flex;
+		align-items: center;
+		margin-block-end: 16px;
+		gap: 8px;
+
+		.step-section__step-count {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			border: 2px solid var(--color-primary-60);
+			font-size: rem(12px);
+			font-weight: 600;
+			color: var(--color-primary-60);
+			width: 24px;
+			border-radius: 50%;
+			height: 24px;
+		}
+
+		.step-section__step-heading {
+			font-size: rem(20px);
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,3 +1,4 @@
+import { pages, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
@@ -7,6 +8,10 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import StepSection from '../../common/step-section';
+import StepSectionItem from '../../common/step-section-item';
+
+import './style.scss';
 
 export default function ReferralsOverview() {
 	const translate = useTranslate();
@@ -23,7 +28,26 @@ export default function ReferralsOverview() {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>Content goes here</LayoutBody>
+			<LayoutBody className="referrals-overview">
+				<StepSection heading={ translate( 'Get set up' ) } stepCount={ 1 }>
+					<StepSectionItem
+						icon={ pages }
+						heading={ translate( 'Add your bank details and upload tax forms' ) }
+						description={ translate(
+							'Once confirmed, we’ll be able to send you a commission payment at the end of each month.'
+						) }
+						buttonProps={ { children: translate( 'Add bank details' ), primary: true } }
+					/>
+					<StepSectionItem
+						icon={ plugins }
+						heading={ translate( 'Install the A4A plugin on your clients’ sites' ) }
+						description={ translate(
+							'Our plugin can confirm that your agency is connected to the Automattic products your clients buy.'
+						) }
+						buttonProps={ { children: translate( 'Download plugin' ) } }
+					/>
+				</StepSection>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -1,0 +1,3 @@
+.referrals-overview {
+	margin-block-start: 48px;
+}


### PR DESCRIPTION

Resolves https://github.com/Automattic/jetpack-genesis/issues/318
Resolves https://github.com/Automattic/jetpack-genesis/issues/319
Resolves https://github.com/Automattic/jetpack-genesis/issues/321

<img width="1427" alt="Screenshot 2024-04-11 at 3 21 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e3018b67-ff2a-4f6a-a34c-557be881eec6">


## Proposed Changes

This PR:

- Adds `StepSection` component
- Adds `StepSectionItem` component
- Updates the referrals' LayoutBody to use these reusable components to display `Get set up` step

## NOTE:

- The buttons don't work as of now. This will be implemented in another PR.
- @madebynoam: I have hidden the icons on the mobile view. Let me know if this is ok.
- @madebynoam: I have also taken the whole page width to be consistent with all the other pages on A4A. Let me know if this is ok.

## Testing Instructions

- Open A4A live link
- Visit /referrals 
- Verify that the UI looks well on all the devices

<img width="1427" alt="Screenshot 2024-04-11 at 3 21 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8de12581-be73-49ca-a621-7a33d7cde103">

<img width="313" alt="Screenshot 2024-04-11 at 7 11 16 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8ae2a1a8-779a-44df-b280-8322ad61fa02">

<img width="763" alt="Screenshot 2024-04-11 at 7 11 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/af104cb1-5a42-4b16-88b1-9162ed9307fe">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?