### PR TITLE
Scheduled Updates: WIP for the scheduled updates notification form

### DIFF
--- a/client/blocks/plugins-update-manager/forms.scss
+++ b/client/blocks/plugins-update-manager/forms.scss
@@ -1,4 +1,5 @@
-.schedule-form, .notification-form {
+.schedule-form,
+.notification-form {
 	& > div {
 		width: 100%;
 	}

--- a/client/blocks/plugins-update-manager/forms.scss
+++ b/client/blocks/plugins-update-manager/forms.scss
@@ -1,4 +1,4 @@
-.schedule-form {
+.schedule-form, .notification-form {
 	& > div {
 		width: 100%;
 	}

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -20,6 +20,7 @@ import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleEdit } from './schedule-edit';
 import { ScheduleList } from './schedule-list';
+import { ScheduleNotifications } from './schedule-notifications';
 import './styles.scss';
 
 interface Props {
@@ -83,6 +84,10 @@ export const PluginsUpdateManager = ( props: Props ) => {
 		edit: {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
 			title: translate( 'Edit schedule' ),
+		},
+		notifications: {
+			component: <ScheduleNotifications onNavBack={ onNavBack } />,
+			title: translate( 'Scheduled Updates Notifications' ),
 		},
 	}[ context ];
 

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -16,7 +16,7 @@ import { useSiteSlug } from './hooks/use-site-slug';
 import { validatePlugins, validateTimeSlot } from './schedule-form.helper';
 import type { SyncSuccessParams } from './types';
 
-import './schedule-form.scss';
+import './forms.scss';
 
 interface Props {
 	scheduleForEdit?: ScheduleUpdates;

--- a/client/blocks/plugins-update-manager/schedule-notifications-users.tsx
+++ b/client/blocks/plugins-update-manager/schedule-notifications-users.tsx
@@ -25,7 +25,7 @@ export const ScheduleNotificationsUsers = ( { initUsers = [], onChange }: Props 
 		data: userPages,
 		isLoading: isUsersLoading,
 		isFetched: isUsersFetched,
-	} = useUsersQuery( siteSlug, { role: 'administrator' } );
+	} = useUsersQuery( siteSlug, { capabilities: [ 'update_plugins' ] } );
 	const users = userPages?.pages
 		?.reduce( ( acc, page ) => [ ...acc, ...page.users ], [] )
 		.sort( ( a: User, b: User ) => a.name.localeCompare( b.name ) );

--- a/client/blocks/plugins-update-manager/schedule-notifications-users.tsx
+++ b/client/blocks/plugins-update-manager/schedule-notifications-users.tsx
@@ -25,7 +25,7 @@ export const ScheduleNotificationsUsers = ( { initUsers = [], onChange }: Props 
 		data: userPages,
 		isLoading: isUsersLoading,
 		isFetched: isUsersFetched,
-	} = useUsersQuery( siteSlug, { capabilities: [ 'update_plugins' ] } );
+	} = useUsersQuery( siteSlug, { capability: 'update_plugins' } );
 	const users = userPages?.pages
 		?.reduce( ( acc, page ) => [ ...acc, ...page.users ], [] )
 		.sort( ( a: User, b: User ) => a.name.localeCompare( b.name ) );

--- a/client/blocks/plugins-update-manager/schedule-notifications-users.tsx
+++ b/client/blocks/plugins-update-manager/schedule-notifications-users.tsx
@@ -1,0 +1,91 @@
+import { CheckboxControl, SearchControl, Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import { useSiteSlug } from 'calypso/blocks/plugins-update-manager/hooks/use-site-slug';
+import useUsersQuery from 'calypso/data/users/use-users-query';
+
+type Props = {
+	initUsers?: number[];
+	onChange?: ( userIds: number[] ) => void;
+};
+
+type User = {
+	ID: number;
+	name: string;
+};
+
+export const ScheduleNotificationsUsers = ( { initUsers = [], onChange }: Props ) => {
+	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
+
+	const [ userSearchTerm, setUserSearchTerm ] = useState( '' );
+	const [ selectedUsers, setSelectedUsers ] = useState< number[] >( initUsers );
+
+	const {
+		data: userPages,
+		isLoading: isUsersLoading,
+		isFetched: isUsersFetched,
+	} = useUsersQuery( siteSlug, { role: 'administrator' } );
+	const users = userPages?.pages
+		?.reduce( ( acc, page ) => [ ...acc, ...page.users ], [] )
+		.sort( ( a: User, b: User ) => a.name.localeCompare( b.name ) );
+
+	const onUsersSelectAllChange = useCallback(
+		( isChecked: boolean ) => {
+			isChecked
+				? setSelectedUsers( users?.map( ( user: User ) => user.ID ) ?? [] )
+				: setSelectedUsers( [] );
+		},
+		[ users ]
+	);
+
+	const onUsersSelectionChange = useCallback(
+		( user: User, isChecked: boolean ) => {
+			if ( isChecked ) {
+				const _users: number[] = [ ...selectedUsers ];
+				_users.push( user.ID );
+				setSelectedUsers( _users );
+			} else {
+				setSelectedUsers( selectedUsers.filter( ( id ) => id !== user.ID ) );
+			}
+		},
+		[ selectedUsers ]
+	);
+
+	useEffect( () => onChange?.( selectedUsers ), [ selectedUsers, onChange ] );
+
+	return (
+		<div className="form-field">
+			<label htmlFor="users">{ translate( 'Select users' ) }</label>
+
+			<div className="checkbox-options">
+				<SearchControl id="users" onChange={ setUserSearchTerm } value={ userSearchTerm } />
+				<div className="checkbox-options-container">
+					{ isUsersLoading && <Spinner /> }
+					{ isUsersFetched && (
+						<CheckboxControl
+							label={ translate( 'Select all' ) }
+							indeterminate={ selectedUsers.length > 0 && selectedUsers.length < users?.length }
+							checked={ selectedUsers.length === users?.length }
+							onChange={ onUsersSelectAllChange }
+						/>
+					) }
+					{ isUsersFetched &&
+						users.map( ( user: User ) => (
+							<Fragment key={ user.ID }>
+								{ user.name?.toLowerCase().includes( userSearchTerm?.toLowerCase() ) && (
+									<CheckboxControl
+										label={ user.name }
+										checked={ selectedUsers.includes( user.ID ) }
+										onChange={ ( isChecked ) => {
+											onUsersSelectionChange( user, isChecked );
+										} }
+									/>
+								) }
+							</Fragment>
+						) ) }
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/client/blocks/plugins-update-manager/schedule-notifications.tsx
+++ b/client/blocks/plugins-update-manager/schedule-notifications.tsx
@@ -1,0 +1,63 @@
+import {
+	__experimentalText as Text,
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	Flex,
+	FlexItem,
+} from '@wordpress/components';
+import { arrowLeft } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { ScheduleNotificationsUsers } from './schedule-notifications-users';
+
+import './forms.scss';
+
+type Props = {
+	onNavBack?: () => void;
+};
+
+export const ScheduleNotifications = ( { onNavBack }: Props ) => {
+	const translate = useTranslate();
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const onUsersChange = useCallback( ( userIds: number[] ) => {}, [] );
+
+	return (
+		<Card className="plugins-update-manager">
+			<CardHeader size="extraSmall">
+				<div className="ch-placeholder">
+					{ onNavBack && (
+						<Button icon={ arrowLeft } onClick={ onNavBack }>
+							{ translate( 'Back' ) }
+						</Button>
+					) }
+				</div>
+				<Text>{ translate( 'Manage notifications' ) }</Text>
+				<div className="ch-placeholder"></div>
+			</CardHeader>
+			<CardBody>
+				<form
+					id="notifications"
+					className="notification-form"
+					onSubmit={ ( e ) => {
+						e.preventDefault();
+					} }
+				>
+					<Flex
+						className="schedule-form"
+						direction={ [ 'column', 'row' ] }
+						expanded={ true }
+						align="start"
+						gap={ 12 }
+					>
+						<FlexItem>
+							<ScheduleNotificationsUsers onChange={ onUsersChange } />
+						</FlexItem>
+					</Flex>
+				</form>
+			</CardBody>
+		</Card>
+	);
+};

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -126,7 +126,6 @@ export function updatesManager( context, next ) {
 		goToScheduledUpdatesList();
 		return;
 	}
-
 	switch ( context.params.action ) {
 		case 'logs':
 			context.primary = createElement( PluginsUpdateManager, {
@@ -153,7 +152,14 @@ export function updatesManager( context, next ) {
 				onNavBack: goToScheduledUpdatesList,
 			} );
 			break;
-
+		case 'notifications':
+			context.primary = createElement( PluginsUpdateManager, {
+				siteSlug,
+				scheduleId,
+				context: 'notifications',
+				onNavBack: goToScheduledUpdatesList,
+			} );
+			break;
 		case 'list':
 		default:
 			context.primary = createElement( PluginsUpdateManager, {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89439

## Proposed Changes

- Adds a new route: `plugins/scheduled-updates/notifications/<siteid>`
- Currently shows a list of admins on the selected site

This PR is just to get the user selection component in, please look through all design/UX/copy.

Next steps: decide whether:
- Notification settings are site-wide or schedule-based
- Work out other details

Since this PR is quite isolated, and the route isn't linked anywhere I think this could already be merged as a first step.

## Testing Instructions

1. Apply this PR
2. Visit the route: `plugins/scheduled-updates/notifications/<siteid>`

![CleanShot 2024-04-11 at 13 38 31@2x](https://github.com/Automattic/wp-calypso/assets/528287/41a87bde-4c44-465b-abde-7b6196e5ad1d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?