### PR TITLE
Display the survey to English locales

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -6,7 +6,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { Icon, image, verse, layout } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { useScreen } from './hooks';
@@ -37,6 +37,7 @@ const ScreenConfirmation = ( {
 
 	const currentThemeId = useSelector( ( state: IAppState ) => getActiveTheme( state, siteId ) );
 	const willThemeChange = currentThemeId !== selectedDesign?.slug;
+	const isEnglishLocale = getLocaleSlug()?.startsWith( 'en' );
 
 	const description =
 		currentThemeId && willThemeChange && ! isNewSite
@@ -89,7 +90,7 @@ const ScreenConfirmation = ( {
 						</HStack>
 					) ) }
 				</VStack>
-				{ ! surveyDismissed && (
+				{ ! surveyDismissed && isEnglishLocale && (
 					<Survey
 						eventName="assembler-january-2024"
 						eventUrl="https://automattic.survey.fm/assembler-simple-survey"


### PR DESCRIPTION
Related to https://github.com/Automattic/i18n-issues/issues/774

## Proposed Changes

* Display the survey only to users whose locale is English.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/start` when your locale is English
2. Set up a website using the Pattern Assembler
3. Verify that the survey is shown
4. Switch your locale to a non-English locale
5. Set up the website using the Pattern Assembler
6. Verify that the survey is not shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?