### PR TITLE
Entrepreneur Trial: Add entrepreneur trial signup flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -1,0 +1,161 @@
+import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useFlowLocale } from '../hooks/use-flow-locale';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import { getLoginUrl } from '../utils/path';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
+import { AssignTrialResult } from './internals/steps-repository/assign-trial-plan/constants';
+import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
+import type { Flow, ProvidedDependencies } from './internals/types';
+import type { SiteSelect, UserSelect } from '@automattic/data-stores';
+
+const entrepreneurFlow: Flow = {
+	name: ENTREPRENEUR_FLOW,
+
+	isSignupFlow: true,
+
+	useSteps() {
+		return [
+			// Replacing the `segmentation-survey` slug with `start` as having the
+			// word `survey` in the address bar might discourage users from continuing.
+			{ ...STEPS.SEGMENTATION_SURVEY, ...{ slug: 'start' } },
+			STEPS.SITE_CREATION_STEP,
+			STEPS.PROCESSING,
+			STEPS.ASSIGN_TRIAL_PLAN, // TODO: See if this can be combined with addHostingTrial
+			STEPS.WAIT_FOR_ATOMIC,
+			STEPS.WAIT_FOR_PLUGIN_INSTALL,
+			STEPS.ERROR,
+		];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+
+		const siteSlugParam = useSiteSlugParam();
+
+		const { setPluginsToVerify } = useDispatch( ONBOARD_STORE );
+		setPluginsToVerify( [ 'woocommerce' ] );
+
+		const { getSiteIdBySlug, getSiteOption } = useSelect(
+			( select ) => select( SITE_STORE ) as SiteSelect,
+			[]
+		);
+
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+
+		const locale = useFlowLocale();
+
+		const getEntrepreneurLoginUrl = () => {
+			let hasFlowParams = false;
+			const flowParams = new URLSearchParams();
+
+			if ( locale && locale !== 'en' ) {
+				flowParams.set( 'locale', locale );
+				hasFlowParams = true;
+			}
+
+			const redirectTarget =
+				`/setup/entrepreneur/create-site` +
+				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+
+			const loginUrl = getLoginUrl( {
+				variationName: flowName,
+				redirectTo: redirectTarget,
+				locale,
+			} );
+
+			const flags = new URLSearchParams( window.location.search ).get( 'flags' );
+			return loginUrl + ( flags ? `&flags=${ flags }` : '' );
+		};
+
+		const exitFlow = ( to: string ) => {
+			window.location.assign( to );
+		};
+
+		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+			recordSubmitStep( providedDependencies, '' /* intent */, flowName, currentStep );
+
+			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
+			const siteId = getSiteIdBySlug( siteSlug );
+			const adminUrl = siteId && getSiteOption( siteId, 'admin_url' );
+
+			switch ( currentStep ) {
+				case 'start': {
+					if ( userIsLoggedIn ) {
+						return navigate( 'create-site' );
+					}
+
+					// Redirect user to the sign-in/sign-up page before site creation.
+					const entrepreneurLoginUrl = getEntrepreneurLoginUrl();
+					return window.location.replace( entrepreneurLoginUrl );
+				}
+
+				case 'create-site': {
+					return navigate( 'processing', {
+						currentStep,
+					} );
+				}
+
+				case 'processing': {
+					const processingResult = params[ 0 ] as ProcessingResult;
+
+					if ( processingResult === ProcessingResult.FAILURE ) {
+						return navigate( 'error' );
+					}
+
+					if ( providedDependencies?.finishedWaitingForAtomic ) {
+						return navigate( 'waitForPluginInstall', { siteId, siteSlug } );
+					}
+
+					if ( providedDependencies?.pluginsInstalled ) {
+						// Redirect users to the login page with the 'action=jetpack-sso' parameter to initiate Jetpack SSO login and redirect them to Woo CYS's Design With AI after.
+
+						// TODO: This is currently not working. Need to investigate in further PR.
+						const redirectTo = encodeURIComponent(
+							`${
+								adminUrl as string
+							}admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai&ref=wpcom-entrepreneur-signup`
+						);
+
+						return exitFlow(
+							`//${ siteSlug }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`
+						);
+					}
+
+					return navigate( 'assignTrialPlan', { siteSlug } );
+				}
+
+				// TODO: See if this can be combined with addHostingTrial
+				case 'assignTrialPlan': {
+					const assignTrialResult = params[ 0 ] as AssignTrialResult;
+
+					if ( assignTrialResult === AssignTrialResult.FAILURE ) {
+						return navigate( 'error' );
+					}
+
+					return navigate( 'waitForAtomic', { siteId, siteSlug } );
+				}
+
+				case 'waitForAtomic': {
+					return navigate( 'processing', {
+						currentStep,
+					} );
+				}
+
+				case 'waitForPluginInstall': {
+					return navigate( 'processing' );
+				}
+			}
+			return providedDependencies;
+		}
+
+		return { submit };
+	},
+};
+
+export default entrepreneurFlow;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -1,4 +1,4 @@
-import { isWooExpressFlow, StepContainer } from '@automattic/onboarding';
+import { isWooExpressFlow, isEntrepreneurFlow, StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
@@ -25,6 +25,19 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getProfilerData(), [] ) ||
 		{};
 
+	let requestBody = {};
+
+	if ( isWooExpressFlow( flow ) ) {
+		requestBody = {
+			wpcom_woocommerce_onboarding: profilerData,
+		};
+	}
+
+	if ( isEntrepreneurFlow( flow ) ) {
+		// TODO: Add WPCOM marker.
+		requestBody = {};
+	}
+
 	useEffect( () => {
 		if ( submit ) {
 			const assignTrialPlan = async () => {
@@ -38,9 +51,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						{
 							apiVersion: '1.1',
 						},
-						{
-							wpcom_woocommerce_onboarding: profilerData,
-						}
+						requestBody
 					);
 
 					submit?.( { siteSlug: data?.siteSlug }, AssignTrialResult.SUCCESS );
@@ -87,7 +98,11 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 							) : (
 								<LoadingEllipsis />
 							) }
-							<p className="processing-step__subtitle">{ getSubTitle() }</p>
+							{ isWooExpressFlow( flow ) ? (
+								<p className="processing-step__subtitle">{ getSubTitle() }</p>
+							) : (
+								<></>
+							) }
 						</div>
 					</>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -3,6 +3,7 @@ import { Site } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
 	ECOMMERCE_FLOW,
+	ENTREPRENEUR_FLOW,
 	StepContainer,
 	WOOEXPRESS_FLOW,
 	addPlanToCart,
@@ -15,6 +16,7 @@ import {
 	isMigrationFlow,
 	isStartWritingFlow,
 	isWooExpressFlow,
+	isEntrepreneurFlow,
 	isNewHostedSiteCreationFlow,
 	isNewsletterFlow,
 	isBlogOnboardingFlow,
@@ -51,6 +53,7 @@ import './styles.scss';
 const DEFAULT_SITE_MIGRATION_THEME = 'pub/zoologist';
 const DEFAULT_LINK_IN_BIO_THEME = 'pub/lynx';
 const DEFAULT_WOOEXPRESS_FLOW = 'pub/twentytwentytwo';
+const DEFAULT_ENTREPRENEUR_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
 const DEFAULT_START_WRITING_THEME = 'pub/hey';
 
@@ -90,6 +93,8 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		theme = DEFAULT_SITE_MIGRATION_THEME;
 	} else if ( isWooExpressFlow( flow ) ) {
 		theme = DEFAULT_WOOEXPRESS_FLOW;
+	} else if ( isEntrepreneurFlow( flow ) ) {
+		theme = DEFAULT_ENTREPRENEUR_FLOW;
 	} else if ( isStartWritingFlow( flow ) ) {
 		theme = DEFAULT_START_WRITING_THEME;
 	} else if ( isLinkInBioFlow( flow ) ) {
@@ -127,7 +132,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 
 	// Default visibility is public
 	let siteVisibility = Site.Visibility.PublicIndexed;
-	const wooFlows = [ ECOMMERCE_FLOW, WOOEXPRESS_FLOW ];
+	const wooFlows = [ ECOMMERCE_FLOW, ENTREPRENEUR_FLOW, WOOEXPRESS_FLOW ];
 
 	// These flows default to "Coming Soon"
 	if (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@wordpress/components';
+import DocumentHead from 'calypso/components/data/document-head';
+import type { Step } from '../../types';
+import './style.scss';
+
+const SegmentationSurveyStep: Step = ( { navigation } ) => {
+	const docTitle = 'Segmentation Survey';
+
+	const handleNext = () => {
+		alert(
+			`Do not use navigation.goNext() here. Instead, update URL params (not route fragments).`
+		);
+	};
+
+	const handleBack = () => {
+		alert(
+			`Do not use navigation.goBack()() here. Instead, update URL params (not route fragments).`
+		);
+	};
+
+	const handleSubmit = () => {
+		navigation.submit();
+	};
+
+	return (
+		<>
+			<DocumentHead title={ docTitle } />
+			<div className="segmentation-survey">
+				<p>Back & Next button can modify URL params, but not the route itself.</p>
+				<Button onClick={ handleBack } variant="secondary">
+					Back
+				</Button>
+				<Button onClick={ handleNext } variant="secondary">
+					Next
+				</Button>
+				<hr />
+				<p>Insert segmentation survey component here.</p>
+				<p>
+					Submit button goes to Login/Signup/SiteCreation step. Call this when segmentation survey
+					is completed (or skipped).
+				</p>
+				<Button onClick={ handleSubmit } variant="primary">
+					Submit
+				</Button>
+			</div>
+		</>
+	);
+};
+
+export default SegmentationSurveyStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -19,7 +19,7 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 	};
 
 	const handleSubmit = () => {
-		navigation.submit();
+		navigation.submit?.();
 	};
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/style.scss
@@ -1,0 +1,9 @@
+.segmentation-survey {
+	width: 50%;
+	margin: 0 auto;
+	padding: 5em;
+
+	button {
+		margin: 1em;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -235,4 +235,9 @@ export const STEPS = {
 		slug: 'site-migration-plugin-install',
 		asyncComponent: () => import( './steps-repository/site-migration-plugin-install' ),
 	},
+
+	SEGMENTATION_SURVEY: {
+		slug: 'segmentation-survey',
+		asyncComponent: () => import( './steps-repository/segmentation-survey' ),
+	},
 };

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -14,6 +14,7 @@ import {
 	GOOGLE_TRANSFER,
 	REBLOGGING_FLOW,
 	SITE_MIGRATION_FLOW,
+	ENTREPRENEUR_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -60,6 +61,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		import(
 			/* webpackChunkName: "tailored-ecommerce-flow" */ '../declarative-flow/tailored-ecommerce-flow'
 		),
+
+	[ ENTREPRENEUR_FLOW ]: () =>
+		import( /* webpackChunkName: "entrepreneur-flow" */ '../declarative-flow/entrepreneur-flow' ),
 
 	wooexpress: () =>
 		import(

--- a/client/landing/stepper/hooks/use-flow-locale.ts
+++ b/client/landing/stepper/hooks/use-flow-locale.ts
@@ -1,0 +1,16 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+
+export function useFlowLocale() {
+	// There is a race condition where useLocale is reporting english,
+	// despite there being a locale in the URL so we need to look it up manually.
+	// We also need to support both query param and path suffix localized urls
+	// depending on where the user is coming from.
+	const localeSlug = useLocale();
+	// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+	const queryLocaleSlug = getLocaleFromQueryParam();
+	const pathLocaleSlug = getLocaleFromPathname();
+	const flowLocale = queryLocaleSlug || pathLocaleSlug || localeSlug;
+
+	return flowLocale;
+}

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -18,6 +18,7 @@ export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const IMPORT_HOSTED_SITE_FLOW = 'import-hosted-site';
 export const SENSEI_FLOW = 'sensei';
 export const ECOMMERCE_FLOW = 'ecommerce';
+export const ENTREPRENEUR_FLOW = 'entrepreneur';
 export const WOOEXPRESS_FLOW = 'wooexpress';
 export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
@@ -113,6 +114,10 @@ export const isMigrationFlow = ( flowName: string | null ) => {
 
 export const isCopySiteFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ COPY_SITE_FLOW ].includes( flowName ) );
+};
+
+export const isEntrepreneurFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ ENTREPRENEUR_FLOW ].includes( flowName ) );
 };
 
 export const isWooExpressFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR adds a new entrepreneur trial signup flow. This barebones flow also includes login/signup and also site creation.

Note: The actual segmentation survey component is to be integrated separately. Click "Submit" on the first step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `calypso.localhost:3000/setup/entrepreneur` to start.
* Try the flow as a logged-in and logged-out user.
  * As logged-out user, you should be redirected to the login/signup step, and then back to site creation step.
  * As logged-in user, you should go straight to the site creation step.
* You should have a trial site created at the end of the flow.

## Known issues

These are issues to be addressed in separate PRs:
* ~When creating the site, it doesn't add the WPCOM marker.~ Not needed anymore as this is based on switching over to new set of plans.
* When a trial plan is being assigned, the loading screen flickers with a "creating your store" text and goes back to the loading screen again. We'll get rid of the trial assignment step and do this directly in the site creation step.
* It doesn't redirect to the Design With AI properly, even though the redirect URL is pointing to it. Likely need to be fixed on Woo's end.
* Race condition in hooks might cause site creation to fail (also happening in existing Woo signup flow), to be fixed separately.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?