### PR TITLE
Patterns: fix footer size

### DIFF
--- a/client/my-sites/patterns/components/header/style.scss
+++ b/client/my-sites/patterns/components/header/style.scss
@@ -56,7 +56,8 @@
 
 	@media ( max-width: $break-wide ) {
 		.patterns-header__inner {
-			padding: 90px 24px 24px;
+			padding-top: 90px;
+			padding-bottom: 24px;
 			background: none;
 
 			h1 {

--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -30,7 +30,8 @@
 
 	@media ( max-width: $break-wide ) {
 		.pattern-library__filters-inner {
-			padding: 24px;
+			padding-top: 24px;
+			padding-bottom: 24px;
 		}
 	}
 
@@ -118,7 +119,8 @@
 	padding-bottom: 96px;
 
 	@media ( max-width: $break-wide ) {
-		padding: 24px;
+		padding-top: 24px;
+		padding-bottom: 24px;
 	}
 }
 

--- a/client/my-sites/patterns/components/section/style.scss
+++ b/client/my-sites/patterns/components/section/style.scss
@@ -58,10 +58,6 @@
 	}
 
 	.patterns-section__header {
-		padding: 0 24px 32px;
-	}
-
-	.patterns-section__body {
-		padding: 0 24px;
+		padding-bottom: 32px;
 	}
 }

--- a/client/my-sites/patterns/mixins.scss
+++ b/client/my-sites/patterns/mixins.scss
@@ -5,4 +5,9 @@
 	padding-left: 110px;
 	padding-right: 110px;
 	box-sizing: border-box;
+
+	@media ( max-width: $break-wide ) {
+		padding-left: 24px;
+		padding-right: 24px;
+	}
 }

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -38,7 +38,8 @@
 		}
 
 		.lpc-footer-nav-wrapper,
-		.lpc-footer-automattic-nav-wrapper {
+		.lpc-footer-automattic-nav-wrapper,
+		.lp-link-work-m {
 			@include patterns-page-width;
 		}
 	}

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "calypso/my-sites/patterns/mixins";
 
 .is-section-patterns {
 	.layout__content {
@@ -28,6 +29,17 @@
 
 		.lp-footer-language {
 			display: none;
+		}
+
+		.lpc-footer-nav,
+		.lpc-footer-automattic-nav {
+			padding-left: 0;
+			padding-right: 0;
+		}
+
+		.lpc-footer-nav-wrapper,
+		.lpc-footer-automattic-nav-wrapper {
+			@include patterns-page-width;
 		}
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6541

## Proposed Changes
Footer on patterns pages is not aligned vertically with header and content. With this PR we are aligning it.

## Testing Instructions
1) Open `/patterns`
2) Assert that WP and A8C footers are aligned with other page content <br /><img width="955" alt="Screenshot 2024-04-11 at 15 21 11" src="https://github.com/Automattic/wp-calypso/assets/5598437/76e197e1-95f0-42d5-ac1e-0837a0c6f3b7">
3) Open `/patterns/header`
4) Assert that content, header and footer are aligned the same way

