### PR TITLE
A8C For Agencies: Add feature flag to site details on staging and development

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -137,14 +137,18 @@ export function OverviewPreviewPane( {
 						),
 				  ]
 				: [] ),
-			createFeaturePreview(
-				A4A_SITE_DETAILS_ID,
-				translate( 'Details' ),
-				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
-				<SiteDetails site={ site } />
-			),
+			...( isEnabled( 'a4a/site-details-pane' )
+				? [
+						createFeaturePreview(
+							A4A_SITE_DETAILS_ID,
+							translate( 'Details' ),
+							true,
+							selectedSiteFeature,
+							setSelectedSiteFeature,
+							<SiteDetails site={ site } />
+						),
+				  ]
+				: [] ),
 		],
 		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent, hasError, translate ]
 	);

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -30,7 +30,8 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"oauth": true,
-		"a4a/hosting-preview-pane": true
+		"a4a/hosting-preview-pane": true,
+		"a4a/site-details-pane": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -24,7 +24,8 @@
 	"features": {
 		"a8c-for-agencies": true,
 		"oauth": false,
-		"a4a/hosting-preview-pane": true
+		"a4a/hosting-preview-pane": true,
+		"a4a/site-details-pane": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -25,7 +25,8 @@
 	"oauth_client_id": 95931,
 	"features": {
 		"a8c-for-agencies": true,
-		"oauth": true
+		"oauth": true,
+		"a4a/site-details-pane": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
theinked issue.
-->

## Proposed Changes

* Add a feature flag to only show site details on Staging and Development environments

## Testing Instructions

- Run a8c-for-agencies environment locally or via the calyspo live link
- Connect at least one site to your user, so they appear on the dashboard
- Click the site to have the flyout pane opened
- There should be a "Details" tab in the flyout
- The flyout pane should not show for production environments

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?