### PR TITLE
Site Migration: Enable the `ImportList`'s  back button redirect the user to previous flows

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -16,8 +16,10 @@ import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 
+const FLOW_NAME = 'site-migration';
+
 const siteMigration: Flow = {
-	name: 'site-migration',
+	name: FLOW_NAME,
 	isSignupFlow: false,
 
 	useSteps() {
@@ -89,7 +91,7 @@ const siteMigration: Flow = {
 			}
 
 			const redirectTarget =
-				`/setup/site-migration` +
+				`/setup/${ FLOW_NAME }` +
 				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
 
 			let queryString = `redirect_to=${ redirectTarget }`;
@@ -163,8 +165,14 @@ const siteMigration: Flow = {
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
 						return exitFlow(
 							addQueryArgs(
-								{ siteId, siteSlug, from, origin: STEPS.SITE_MIGRATION_IDENTIFY.slug },
-								`/setup/site-setup/${ STEPS.IMPORT_LIST.slug }`
+								{
+									siteId,
+									siteSlug,
+									from,
+									origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+									backToFlow: `/${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+								},
+								'/setup/site-setup/importList'
 							)
 						);
 					}
@@ -180,7 +188,14 @@ const siteMigration: Flow = {
 					// Switch to the normal Import flow.
 					if ( providedDependencies?.destination === 'import' ) {
 						return exitFlow(
-							`/setup/site-setup/${ STEPS.IMPORT_LIST.slug }?siteSlug=${ siteSlug }&siteId=${ siteId }`
+							addQueryArgs(
+								{
+									siteSlug,
+									siteId,
+									backToFlow: `/${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }`,
+								},
+								'/setup/site-setup/importList'
+							)
 						);
 					}
 
@@ -238,11 +253,11 @@ const siteMigration: Flow = {
 								siteSlug,
 								from: fromQueryParam,
 							},
-							`/setup/site-migration/${ STEPS.BUNDLE_TRANSFER.slug }`
+							`/setup/${ FLOW_NAME }/${ STEPS.BUNDLE_TRANSFER.slug }`
 						);
 						goToCheckout( {
-							flowName: 'site-migration',
-							stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+							flowName: FLOW_NAME,
+							stepName: 'site-migration-upgrade-plan',
 							siteSlug: siteSlug,
 							destination: destination,
 							plan: providedDependencies.plan as string,

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -128,6 +128,8 @@ const siteSetupFlow: Flow = {
 
 		const origin = urlQueryParams.get( 'origin' );
 		const from = urlQueryParams.get( 'from' );
+		const backToStep = urlQueryParams.get( 'backToStep' );
+		const backToFlow = urlQueryParams.get( 'backToFlow' );
 
 		const adminUrl = useSelect(
 			( select ) =>
@@ -146,6 +148,14 @@ const siteSetupFlow: Flow = {
 			useDispatch( ONBOARD_STORE );
 		const { setDesignOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
+
+		const goToFlow = ( fullStepPath: string ) => {
+			const path = `/setup/${ fullStepPath }`.replace( /([^:])(\/\/+)/g, '$1/' );
+
+			return window.location.assign(
+				addQueryArgs( { siteSlug, from, origin: `site-setup/${ currentStep }` }, path )
+			);
+		};
 
 		const exitFlow = ( to: string, options: ExitFlowOptions = {} ) => {
 			setPendingAction( () => {
@@ -501,11 +511,12 @@ const siteSetupFlow: Flow = {
 				}
 
 				case 'importList':
-					// eslint-disable-next-line no-case-declarations
-					const backToStep = urlQueryParams.get( 'backToStep' );
-
 					if ( backToStep ) {
 						return navigate( `${ backToStep }?siteSlug=${ siteSlug }` );
+					}
+
+					if ( backToFlow ) {
+						return goToFlow( backToFlow );
 					}
 
 					return navigate( `import?siteSlug=${ siteSlug }` );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { addQueryArgs } from '../../../../lib/url';
 import { goToCheckout } from '../../utils/checkout';
 import { STEPS } from '../internals/steps';
 import siteMigrationFlow from '../site-migration-flow';
@@ -27,6 +28,7 @@ describe( 'Site Migration Flow', () => {
 	describe( 'navigation', () => {
 		it( 'redirects the user to the migrate or import page when the platform is wordpress', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
 				dependencies: {
@@ -54,7 +56,15 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				`/setup/site-setup/${ STEPS.IMPORT_LIST.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fexample-to-be-migrated.com&origin=site-migration-identify`
+				addQueryArgs(
+					{
+						siteSlug: 'example.wordpress.com',
+						from: 'https://example-to-be-migrated.com',
+						origin: 'site-migration-identify',
+						backToFlow: '/site-migration/site-migration-identify',
+					},
+					'/setup/site-setup/importList'
+				)
 			);
 		} );
 
@@ -68,7 +78,14 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				`/setup/site-setup/${ STEPS.IMPORT_LIST.slug }?siteSlug=example.wordpress.com&origin=site-migration-identify`
+				addQueryArgs(
+					{
+						siteSlug: 'example.wordpress.com',
+						origin: 'site-migration-identify',
+						backToFlow: '/site-migration/site-migration-identify',
+					},
+					'/setup/site-setup/importList'
+				)
 			);
 		} );
 

--- a/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
@@ -3,7 +3,7 @@
  */
 import { STEPS } from '../internals/steps';
 import siteSetupFlow from '../site-setup-flow';
-import { renderFlow } from './helpers';
+import { getFlowLocation, renderFlow } from './helpers';
 // we need to save the original object for later to not affect tests from other files
 const originalLocation = window.location;
 
@@ -72,6 +72,34 @@ describe( 'Site Setup Flow', () => {
 
 			expect( window.location.assign ).not.toHaveBeenCalledWith(
 				expect.stringContaining( '/setup/site-migration/' )
+			);
+		} );
+	} );
+
+	describe( 'goBack', () => {
+		it( 'redirects the user to preview STEP using the regular flow', () => {
+			const { runUseStepNavigationGoBack } = renderFlow( siteSetupFlow );
+
+			runUseStepNavigationGoBack( {
+				currentStep: STEPS.IMPORT_LIST.slug,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: '/import?siteSlug=example.wordpress.com',
+				state: null,
+			} );
+		} );
+
+		it( 'redirects the users to previous FLOW when backToFlow is defined', () => {
+			const { runUseStepNavigationGoBack } = renderFlow( siteSetupFlow );
+
+			runUseStepNavigationGoBack( {
+				currentURL: '/some-path?backToFlow=some-flow/some-step',
+				currentStep: STEPS.IMPORT_LIST.slug,
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				expect.stringContaining( '/setup/some-flow/some-step' )
 			);
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #89407

## Proposed Changes
* Introduce the `backToFlow` param as similar to the already existent `backToStep` query param to indicate the back button should return the user to the previous flow instead of the previous step.

### More context
The new site migration identify screen lands the user on the 'site-setup/importList' page when the user enters one of our supported platform (E.g. tumblr.com) or when the user clicks on the  'choose a content platform'

## Testing Instructions
**Scenario 1:** `Import content from another platform` 
* Go to the site migration identify page
* Select the `choose a content platform'` button
* Click on the back button on the `Import content from another platform`
* Check if you were redirected to the `setup/site-migration/site-migration-identify` page. 

**Scenario 2:**  `Enter a supported content platform` 
* Go to the site migration identify page
* Set `tumblr.com` as site URL
* Click on the back button on the `Import content from another platform`
* Check if you were redirected to the `setup/site-migration/site-migration-identify` page. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?