### PR TITLE
A4A: update link to plugin button on sites page

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { Icon, external } from '@wordpress/icons';
+// import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -18,8 +18,8 @@ export default function EmptyState() {
 
 	const title = translate( 'Sites' );
 
-	const pluginDownloadLink = ''; // FIXME: Provide correct download link.
-	const resourceLink = ''; // FIXME: Provide correct resource link.
+	const pluginDownloadLink = 'https://wordpress.org/plugins/jetpack/'; // FIXME: Provide correct download link.
+	// const resourceLink = ''; // FIXME: Provide correct resource link.
 
 	return (
 		<Layout title={ title } wide withBorder sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -50,6 +50,19 @@ export default function EmptyState() {
 								)
 							}
 						>
+							{ translate( 'Connect sites with Jetpack (Temporary)' ) }
+						</Button>
+						{ /* TODO: replace this after A4A plugin and docs are ready */ }
+						{ /* <Button
+							href={ pluginDownloadLink }
+							target="_blank"
+							primary
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_sites_dashboard_download_a4a_plugin_click' )
+								)
+							}
+						>
 							{ translate( 'Download A4A Plugin' ) }
 						</Button>
 						<Button
@@ -60,7 +73,7 @@ export default function EmptyState() {
 							}
 						>
 							{ translate( 'Learn more' ) } <Icon icon={ external } size={ 18 } />
-						</Button>
+						</Button> */ }
 					</div>
 				</div>
 			</LayoutBody>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/275

## Proposed Changes
Update button to point to jetpack plugin on Sites page for users with no sites.
<img width="743" alt="Screenshot 2024-04-11 at 8 28 18 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/c32b90a0-8ed4-4edb-b6ff-d241ea9a4a51">

Note: I just commented out previous code as we will be returning it shortly.

## Testing Instructions
- Create a new User or use User without sites
- On the local branch, navigate to `/sites` page
- Observe the button. Clicking on it should redirect us to Jetpack plugin page: https://wordpress.org/plugins/jetpack/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?