### PR TITLE
A4A: tweak sites dataview styles

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-favicon/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-favicon/style.scss
@@ -2,7 +2,8 @@
 	margin-right: 16px;
 
 	.site-icon {
-		border-radius: 10px; /* stylelint-disable-line scales/radii */
+		border-radius: 4px;
+
 		&.is-blank {
 			background: transparent;
 			.wpcom-favicon {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -471,10 +471,6 @@
 			transition: all 0.2s;
 			background: var(--studio-white);
 
-			.site-set-favorite__favorite-icon {
-				position: relative;
-			}
-
 			.sites-overview__content {
 				margin-top: 24px;
 
@@ -506,6 +502,10 @@
 			background: var(--studio-white);
 			max-height: calc(100vh - 32px);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
+		}
+
+		.site-preview__open {
+			display: block;
 		}
 
 
@@ -996,7 +996,8 @@
 	}
 
 	.sites-dataviews__favorite-btn-wrapper {
-		position: relative;
+		display: flex;
+		align-items: center;
 
 		.site-set-favorite__favorite-icon {
 			visibility: hidden;

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -65,10 +65,11 @@
 		}
 
 		th {
-			padding: 16px 4px 16px 48px;
+			padding: 13px 4px 13px 48px;
 			border-bottom: 1px solid var(--studio-gray-5);
 			font-size: rem(13px);
 			font-weight: 400;
+			vertical-align: middle;
 		}
 
 		td {


### PR DESCRIPTION
This PR tweaks some styles on the  sites dataview (table):

- Set site favicon border-radius to 4px.
- Vertically center table header text.
- Vertically center icons in row

Before | After
--|--
<img width="1650" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/e5de7396-4b49-420b-9512-9667efdf7905"> | <img width="1577" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/ba8a9aee-280a-4670-8104-08f04114eb42">
