### PR TITLE
Stats: Exempt VIP sites from paywall enforcement

### DIFF
--- a/client/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check.ts
@@ -1,16 +1,25 @@
 import { useSelector } from 'calypso/state';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import usePlanUsageQuery from './use-plan-usage-query';
 
 const MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL = 1000;
 
-export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: number | null ) {
+export default function useSiteCompulsoryPlanSelectionQualifiedCheck( siteId: number | null ) {
 	const siteCreatedTimeStamp = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'created_at' )
 	) as string;
+
+	// `is_vip` option is not set in Odyssey, so we need to check `options.is_vip` as well.
+	const isVip = useSelector(
+		( state ) =>
+			!! isVipSite( state as object, siteId as number ) ||
+			!! getSiteOption( state, siteId, 'is_vip' )
+	);
+
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
 	// `recent_usages` is an array of the most recent 3 months usage data, and `current_usage` is the current month usage data.
-	// Note: two of the highest days every month in the last 3 months are excluded before calculating the monthly views.
+	// Note: two of the highest days every month in the last 3 months are excluded before calculating views in `current_usage`.
 	const recentMonthlyViews = Math.max(
 		usageInfo?.recent_usages[ 0 ]?.views_count ?? 0,
 		usageInfo?.recent_usages[ 1 ]?.views_count ?? 0,
@@ -19,12 +28,15 @@ export default function useSiteComplusoryPlanSelectionQualifiedCheck( siteId: nu
 	);
 	const isNewSite =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
-	const isExistingSampleSite = recentMonthlyViews > MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL; // Targeting all existing sites with views higher than 1000/mth.
+	const isExceedingTrafficThreshold = recentMonthlyViews > MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL; // Targeting all existing sites with views higher than 1000/mth.
+
+	// Show paywall if the site exceeds the traffic threshold. Exempt VIP sites.
+	const shouldShowPaywall = ! isVip && ! isPending && ( isNewSite || isExceedingTrafficThreshold );
 
 	return {
 		isNewSite,
-		isExistingSampleSite,
-		isQualified: ! isPending && ( isNewSite || isExistingSampleSite ),
+		isExceedingTrafficThreshold,
+		shouldShowPaywall,
 		isPending,
 	};
 }

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -18,6 +18,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSiteSlug, getSiteOption } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -160,8 +161,18 @@ const StatsPurchasePage = ( {
 	const noPlanOwned = ! supportCommercialUse && ! isFreeOwned && ! isPWYWOwned;
 	const allowCommercialTierUpgrade =
 		isTierUpgradeSliderEnabled && isCommercialOwned && ! isLegacyCommercialLicense;
+
+	// `is_vip` option is not set in Odyssey, so we need to check `options.is_vip` as well.
+	const isVip = useSelector(
+		( state ) =>
+			!! isVipSite( state as object, siteId as number ) ||
+			!! getSiteOption( state, siteId, 'is_vip' )
+	);
+
 	// We show purchase page if there is no plan owned or if we are forcing a product redirect
-	const showPurchasePage = noPlanOwned || isForceProductRedirect || allowCommercialTierUpgrade;
+	// VIP sites are exempt from being shown this page.
+	const showPurchasePage =
+		! isVip && ( noPlanOwned || isForceProductRedirect || allowCommercialTierUpgrade );
 
 	const variant = useMemo( () => {
 		let pageVariant = 'personal';

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -20,7 +20,6 @@ import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSiteSlug, getSiteOption } from 'calypso/state/sites/selectors';
-import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useStatsPurchases from '../../hooks/use-stats-purchases';
 import PageViewTracker from '../../stats-page-view-tracker';
@@ -51,9 +50,6 @@ const StatsPurchasePage = ( {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
-		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
-	);
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	// `is_vip` option is not set in Odyssey, so we need to check `options.is_vip` as well.
 	const isVip = useSelector(
@@ -80,14 +76,10 @@ const StatsPurchasePage = ( {
 		if ( ! siteSlug ) {
 			return;
 		}
-		const trafficPageUrl = `/stats/day/${ siteSlug }`;
-		// Redirect to Calypso Stats if:
-		// - the site is not Jetpack.
-		// TODO: remove this check once we have Stats in Calypso for all sites.
-		if ( ! isSiteJetpackNotAtomic || isVip ) {
-			page.redirect( trafficPageUrl );
+		if ( isVip ) {
+			page.redirect( `/stats/day/${ siteSlug }` ); // Redirect to the stats page for VIP sites
 		}
-	}, [ siteSlug, isSiteJetpackNotAtomic, isVip ] );
+	}, [ siteSlug, isVip ] );
 
 	useEffect( () => {
 		// Scroll to top on page load

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -55,6 +55,12 @@ const StatsPurchasePage = ( {
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
+	// `is_vip` option is not set in Odyssey, so we need to check `options.is_vip` as well.
+	const isVip = useSelector(
+		( state ) =>
+			!! isVipSite( state as object, siteId as number ) ||
+			!! getSiteOption( state, siteId, 'is_vip' )
+	);
 
 	const isCommercial = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'is_commercial' )
@@ -78,10 +84,10 @@ const StatsPurchasePage = ( {
 		// Redirect to Calypso Stats if:
 		// - the site is not Jetpack.
 		// TODO: remove this check once we have Stats in Calypso for all sites.
-		if ( ! isSiteJetpackNotAtomic && ! config.isEnabled( 'stats/paid-wpcom-stats' ) ) {
+		if ( ! isSiteJetpackNotAtomic || isVip ) {
 			page.redirect( trafficPageUrl );
 		}
-	}, [ siteSlug, isSiteJetpackNotAtomic ] );
+	}, [ siteSlug, isSiteJetpackNotAtomic, isVip ] );
 
 	useEffect( () => {
 		// Scroll to top on page load
@@ -162,17 +168,9 @@ const StatsPurchasePage = ( {
 	const allowCommercialTierUpgrade =
 		isTierUpgradeSliderEnabled && isCommercialOwned && ! isLegacyCommercialLicense;
 
-	// `is_vip` option is not set in Odyssey, so we need to check `options.is_vip` as well.
-	const isVip = useSelector(
-		( state ) =>
-			!! isVipSite( state as object, siteId as number ) ||
-			!! getSiteOption( state, siteId, 'is_vip' )
-	);
-
 	// We show purchase page if there is no plan owned or if we are forcing a product redirect
 	// VIP sites are exempt from being shown this page.
-	const showPurchasePage =
-		! isVip && ( noPlanOwned || isForceProductRedirect || allowCommercialTierUpgrade );
+	const showPurchasePage = noPlanOwned || isForceProductRedirect || allowCommercialTierUpgrade;
 
 	const variant = useMemo( () => {
 		let pageVariant = 'personal';

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -45,11 +45,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		}: StatsNoticeProps ) => {
 			// Gate notices for WPCOM sites behind a flag.
 			const showUpgradeNoticeForWpcomSites =
-				config.isEnabled( 'stats/paid-wpcom-stats' ) &&
-				isWpcom &&
-				! isVip &&
-				! isP2 &&
-				! isOwnedByTeam51;
+				config.isEnabled( 'stats/paid-wpcom-stats' ) && isWpcom && ! isP2 && ! isOwnedByTeam51;
 
 			// Show the notice if the site is Jetpack or it is Odyssey Stats.
 			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
@@ -63,7 +59,8 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				// Show the notice if the site has not purchased the paid stats product.
 				! hasPaidStats &&
 				// Show the notice only if the site is commercial.
-				isCommercial
+				isCommercial &&
+				! isVip
 			);
 		},
 		disabled: ! config.isEnabled( 'stats/type-detection' ),
@@ -83,11 +80,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		}: StatsNoticeProps ) => {
 			// Gate notices for WPCOM sites behind a flag.
 			const showUpgradeNoticeForWpcomSites =
-				config.isEnabled( 'stats/paid-wpcom-stats' ) &&
-				isWpcom &&
-				! isVip &&
-				! isP2 &&
-				! isOwnedByTeam51;
+				config.isEnabled( 'stats/paid-wpcom-stats' ) && isWpcom && ! isP2 && ! isOwnedByTeam51;
 
 			// Show the notice if the site is Jetpack or it is Odyssey Stats.
 			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
@@ -101,7 +94,8 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				// Show the notice if the site has not purchased the paid stats product.
 				! hasPaidStats &&
 				// Show the notice if the site is not commercial.
-				( ! config.isEnabled( 'stats/type-detection' ) || ! isCommercial )
+				( ! config.isEnabled( 'stats/type-detection' ) || ! isCommercial ) &&
+				! isVip
 			);
 		},
 		disabled: false,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -10,7 +10,7 @@ import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import useOnDemandCommercialClassificationMutation from '../hooks/use-on-demand-site-identification-mutation';
-import useSiteComplusoryPlanSelectionQualifiedCheck from '../hooks/use-site-complusory-plan-selection-qualified-check';
+import useSiteCompulsoryPlanSelectionQualifiedCheck from '../hooks/use-site-compulsory-plan-selection-qualified-check';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import { StatsCommercialUpgradeSlider, getTierQuentity } from './stats-commercial-upgrade-slider';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
@@ -297,7 +297,7 @@ const StatsSingleItemPagePurchase = ( {
 }: StatsSingleItemPagePurchaseProps ) => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const { supportCommercialUse } = useStatsPurchases( siteId );
-	const { isNewSite } = useSiteComplusoryPlanSelectionQualifiedCheck( siteId );
+	const { isNewSite } = useSiteCompulsoryPlanSelectionQualifiedCheck( siteId );
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -12,7 +12,7 @@ import {
 	requestStatNoticeSettings,
 } from 'calypso/state/stats/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import useSiteComplusoryPlanSelectionQualifiedCheck from '../hooks/use-site-complusory-plan-selection-qualified-check';
+import useSiteCompulsoryPlanSelectionQualifiedCheck from '../hooks/use-site-compulsory-plan-selection-qualified-check';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import StatsLoader from './stats-loader';
 
@@ -53,7 +53,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 
 	const isLoading = ! hasLoadedSitePurchases || isRequestingSitePurchases || isLoadingNotices;
 	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned || supportCommercialUse;
-	const { isNewSite, isQualified } = useSiteComplusoryPlanSelectionQualifiedCheck( siteId );
+	const { isNewSite, isQualified } = useSiteCompulsoryPlanSelectionQualifiedCheck( siteId );
 	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
 	const redirectToPurchase =
 		config.isEnabled( 'stats/checkout-flows-v2' ) &&

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -53,14 +53,14 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 
 	const isLoading = ! hasLoadedSitePurchases || isRequestingSitePurchases || isLoadingNotices;
 	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned || supportCommercialUse;
-	const { isNewSite, isQualified } = useSiteCompulsoryPlanSelectionQualifiedCheck( siteId );
+	const { isNewSite, shouldShowPaywall } = useSiteCompulsoryPlanSelectionQualifiedCheck( siteId );
 	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
 	const redirectToPurchase =
 		config.isEnabled( 'stats/checkout-flows-v2' ) &&
 		isSiteJetpackNotAtomic &&
 		! hasPlan &&
 		purchaseNotPostponed &&
-		isQualified;
+		shouldShowPaywall;
 
 	// TODO: If notices are not used by class components, we don't have any reasons to launch any of those actions anymore. If we do need them, we should consider refactoring them to another component.
 	const dispatch = useDispatch();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Exempts VIP sites from paywall enforcement
* Redirect VIP sites from purchase page to Traffic page
* Refactored compulsory check hook

## Testing Instructions

* Build Jetpack and Odyssey Stats locally
  * `jetpack build plugins/jetpack`
  * `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Tweak this is_vip to `true`: https://github.com/Automattic/jetpack/blob/1dfa4bead12f14d34a79904b12a67bb8c6d587a9/projects/packages/stats-admin/src/class-odyssey-config-data.php#L95
* Open `/wp-admin/admin.php?page=stats#!/stats/day/:site`
* Ensure you see Stats (not redirected to paywall)
* Open `/wp-admin/admin.php?page=stats#!/stats/purchase/:site`
* Ensure you are redirected to the Traffic page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?