### PR TITLE
Stats: Introduce the donut chart to the Stats Devices module

### DIFF
--- a/apps/odyssey-stats/.size-limit.js
+++ b/apps/odyssey-stats/.size-limit.js
@@ -3,7 +3,7 @@ const path = require( 'path' );
 module.exports = [
 	{
 		path: path.join( __dirname, 'dist/build.min.js' ),
-		limit: '385 KiB',
+		limit: '400 KiB',
 	},
 	{
 		path: path.join( __dirname, 'dist/widget-loader.min.js' ),

--- a/client/components/legend-item/index.js
+++ b/client/components/legend-item/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { Component, cloneElement } from 'react';
 
 import './style.scss';
 
@@ -18,6 +18,7 @@ class LegendItem extends Component {
 		percent: PropTypes.string,
 		seriesIndex: PropTypes.number,
 		value: PropTypes.string,
+		svgElement: PropTypes.element,
 	};
 
 	static defaultProps = {
@@ -51,7 +52,7 @@ class LegendItem extends Component {
 	}
 
 	render() {
-		const { circleClassName, description, name } = this.props;
+		const { circleClassName, description, name, svgElement } = this.props;
 
 		return (
 			<div
@@ -62,17 +63,21 @@ class LegendItem extends Component {
 				/* eslint-enable jsx-a11y/mouse-events-have-key-events */
 			>
 				<div className="legend-item__title">
-					<svg
-						className="legend-item__title-sample-drawing"
-						viewBox={ `0 0 ${ SVG_SIZE } ${ SVG_SIZE }` }
-					>
-						<circle
-							className={ circleClassName }
-							cx={ SVG_SIZE / 2 }
-							cy={ SVG_SIZE / 2 }
-							r={ SVG_SIZE / 2 }
-						/>
-					</svg>
+					{ svgElement ? (
+						cloneElement( svgElement, { className: circleClassName } )
+					) : (
+						<svg
+							className="legend-item__title-sample-drawing"
+							viewBox={ `0 0 ${ SVG_SIZE } ${ SVG_SIZE }` }
+						>
+							<circle
+								className={ circleClassName }
+								cx={ SVG_SIZE / 2 }
+								cy={ SVG_SIZE / 2 }
+								r={ SVG_SIZE / 2 }
+							/>
+						</svg>
+					) }
 
 					<div className="legend-item__title-name">{ name }</div>
 				</div>

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -10,6 +10,8 @@ import './style.scss';
 
 const SVG_SIZE = 300;
 const NUM_COLOR_SECTIONS = 3;
+const TOOLTIP_OFFSET_X = -205;
+const TOOLTIP_OFFSET_Y = 14;
 
 function transformData( data, { donut = false, startAngle = -Math.PI } ) {
 	const sortedData = sortBy( data, ( datum ) => datum.value )
@@ -62,8 +64,8 @@ class PieChart extends Component {
 				const percent =
 					dataTotal > 0 ? Math.round( ( current.value / dataTotal ) * 100 ).toString() : '0';
 
-				tooltip.style( 'left', coordinates[ 0 ] + 150 - 205 + 'px' );
-				tooltip.style( 'top', coordinates[ 1 ] + 150 + 10 + 'px' );
+				tooltip.style( 'left', coordinates[ 0 ] + SVG_SIZE / 2 + TOOLTIP_OFFSET_X + 'px' );
+				tooltip.style( 'top', coordinates[ 1 ] + SVG_SIZE / 2 + TOOLTIP_OFFSET_Y + 'px' );
 				tooltip.style( 'visibility', 'visible' );
 				tooltip.html(
 					`${ current.icon }<div class="pie-chart__tooltip-content"><div>${ current.name }</div><div>${ percent }%</div></div>`

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -10,8 +10,8 @@ import './style.scss';
 
 const SVG_SIZE = 300;
 const NUM_COLOR_SECTIONS = 3;
-const TOOLTIP_OFFSET_X = -205;
-const TOOLTIP_OFFSET_Y = 14;
+const TOOLTIP_OFFSET_X = -207;
+const TOOLTIP_OFFSET_Y = 0;
 
 function transformData( data, { donut = false, startAngle = -Math.PI } ) {
 	const sortedData = sortBy( data, ( datum ) => datum.value )
@@ -71,7 +71,7 @@ class PieChart extends Component {
 					`${ current.icon }<div class="pie-chart__tooltip-content"><div>${ current.name }</div><div>${ percent }%</div></div>`
 				);
 			},
-			50,
+			30,
 			{
 				leading: true,
 				trailing: false,

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -20,6 +20,7 @@ class PieChartLegend extends Component {
 		data: PropTypes.arrayOf( DataType ).isRequired,
 		onlyPercent: PropTypes.bool,
 		fixedOrder: PropTypes.bool,
+		svgElement: PropTypes.element,
 	};
 
 	state = {
@@ -58,6 +59,7 @@ class PieChartLegend extends Component {
 							circleClassName={ `pie-chart__legend-sample-${ datum.sectionNum } pie-chart__legend-sample-${ datum.className }` }
 							percent={ percent }
 							description={ datum.description }
+							svgElement={ this.props.svgElement }
 						/>
 					);
 				} ) }

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -1,3 +1,52 @@
+/**
+ * Pie Chart Tooltip styles section
+ */
+.pie-chart__chart-container {
+	position: relative;
+
+	& > svg {
+		width: 100%;
+		height: auto;
+	}
+
+	.pie-chart__chart-drawing {
+		max-width: unset;
+	}
+}
+
+.pie-chart__tooltip {
+	display: flex;
+	align-items: center;
+
+	visibility: hidden;
+	position: absolute;
+	width: 244px;
+	box-sizing: border-box;
+	background-color: var(--studio-gray-100);
+	color: var(--studio-white);
+	padding: 16px 24px;
+	border-radius: 4px;
+	pointer-events: none;
+
+	& > svg {
+		margin-right: 8px;
+	}
+
+	.pie-chart__tooltip-content {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-family: Inter, $sans;
+		font-size: $font-body-small;
+		font-weight: 500;
+		line-height: 20px;
+	}
+}
+/**
+ * Pie Chart Tooltip styles section
+ */
+
 .pie-chart__placeholder,
 .pie-chart {
 	display: flex;

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -17,11 +17,10 @@
 .pie-chart__tooltip {
 	display: flex;
 	align-items: center;
-
 	visibility: hidden;
+	box-sizing: border-box;
 	position: absolute;
 	width: 244px;
-	box-sizing: border-box;
 	background-color: var(--studio-gray-100);
 	color: var(--studio-white);
 	padding: 16px 24px;
@@ -31,13 +30,12 @@
 	&::after {
 		content: "";
 		position: absolute;
-		transition: all 0.2s ease-in;
-		top: -20px;
+		top: -12px;
 		right: 30px;
-		border-top: 10px solid transparent;
-		border-bottom: 10px solid var(--studio-gray-100);
-		border-left: 10px solid transparent;
-		border-right: 10px solid transparent;
+		border-top: 7px solid transparent;
+		border-bottom: 7px solid var(--studio-gray-100);
+		border-left: 7px solid transparent;
+		border-right: 7px solid transparent;
 	}
 
 	& > svg {

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -28,6 +28,18 @@
 	border-radius: 4px;
 	pointer-events: none;
 
+	&::after {
+		content: "";
+		position: absolute;
+		transition: all 0.2s ease-in;
+		top: -20px;
+		right: 30px;
+		border-top: 10px solid transparent;
+		border-bottom: 10px solid var(--studio-gray-100);
+		border-left: 10px solid transparent;
+		border-right: 10px solid transparent;
+	}
+
 	& > svg {
 		margin-right: 8px;
 	}

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.scss
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.scss
@@ -2,6 +2,66 @@
 
 .stats-module-devices {
 	@include segmented-controls;
+
+	// Set layout for chart inside the StatsCard.
+	.stats-card--body__chart {
+		padding: 0 24px;
+	}
+
+	.pie-chart {
+		padding: 32px 0;
+	}
+
+	// Override the default legend styles.
+	.pie-chart__legend {
+		flex-direction: row;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 20px;
+
+		.legend-item {
+			flex-direction: row;
+
+			&:not(:first-child) {
+				margin-left: 20px;
+				margin-top: 0;
+			}
+		}
+
+		.legend-item__title {
+			&::after {
+				content: ":";
+			}
+
+			& > svg {
+				width: 14px;
+				height: 14px;
+				margin-right: 4px;
+			}
+		}
+
+		.legend-item__detail {
+			margin-left: 4px;
+		}
+	}
+
+	// TODO: Update corresponding colors based on color schemes.
+	.pie-chart__chart-section-donut-desktop,
+	.pie-chart__legend-sample-donut-desktop {
+		fill: var(--studio-jetpack-green-60);
+	}
+	.pie-chart__chart-section-donut-mobile,
+	.pie-chart__legend-sample-donut-mobile {
+		fill: #069e08;
+	}
+	.pie-chart__chart-section-donut-tablet,
+	.pie-chart__legend-sample-donut-tablet {
+		fill: #64ca43;
+	}
+	.pie-chart__chart-section-donut-others,
+	.pie-chart__legend-sample-donut-others {
+		fill: #d0e6b8;
+	}
 }
 
 .stats-module-upgrade-overlay {

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
@@ -1,8 +1,10 @@
-import { SimplifiedSegmentedControl } from '@automattic/components';
+import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import PieChart from 'calypso/components/pie-chart';
+import PieChartLegend from 'calypso/components/pie-chart/legend';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { JETPACK_SUPPORT_URL } from '../const';
@@ -15,7 +17,7 @@ import StatsModulePlaceholder from '../stats-module/placeholder';
 import './stats-module-devices.scss';
 
 const OPTION_KEYS = {
-	SIZE: 'size',
+	SIZE: 'screen-size',
 	BROWSER: 'browser',
 	OS: 'os',
 };
@@ -80,13 +82,97 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 		setSelectedOption( filter );
 	};
 
+	// TODO: Format real data from the API.
+	const chartData = [
+		{
+			id: 'desktop',
+			icon: '<svg width="20" height="12" viewBox="0 0 20 12" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M18.5 10H17.8V2C17.8 0.9 16.9 0 15.8 0H4.2C3.1 0 2.2 0.9 2.2 2V10H1.5C0.7 10 0 10.7 0 11.5H20C20 10.7 19.3 10 18.5 10ZM3.7 2C3.7 1.7 3.9 1.5 4.2 1.5H15.8C16.1 1.5 16.3 1.7 16.3 2V9.6H3.7V2Z" fill="white"/> </svg>',
+			value: 58,
+			name: 'Desktop',
+			descrtipion: 'Desktop',
+			className: 'donut-desktop',
+		},
+		{
+			id: 'mobile',
+			icon: '<svg width="10" height="16" viewBox="0 0 10 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M8 0H2C0.9 0 0 0.9 0 2V14C0 15.1 0.9 16 2 16H8C9.1 16 10 15.1 10 14V2C10 0.9 9.1 0 8 0ZM8.5 14C8.5 14.3 8.3 14.5 8 14.5H2C1.7 14.5 1.5 14.3 1.5 14V2C1.5 1.7 1.7 1.5 2 1.5H8C8.3 1.5 8.5 1.7 8.5 2V14ZM4 13.5H6V12H4V13.5Z" fill="white"/> </svg>',
+			value: 31,
+			name: 'Mobile',
+			descrtipion: 'Mobile',
+			className: 'donut-mobile',
+		},
+		{
+			id: 'tablet',
+			icon: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M17 4H7C5.9 4 5 4.9 5 6V18C5 19.1 5.9 20 7 20H17C18.1 20 19 19.1 19 18V6C19 4.9 18.1 4 17 4ZM17.5 18C17.5 18.3 17.3 18.5 17 18.5H7C6.7 18.5 6.5 18.3 6.5 18V6C6.5 5.7 6.7 5.5 7 5.5H17C17.3 5.5 17.5 5.7 17.5 6V18ZM10 17.5H14V16H10V17.5Z" fill="white"/> </svg>',
+			value: 8,
+			name: 'Tablet',
+			descrtipion: 'Tablet',
+			className: 'donut-table',
+		},
+		{
+			id: 'not-set',
+			icon: '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"> <path fill-rule="evenodd" clip-rule="evenodd" d="M19 10C19 14.9706 14.9706 19 10 19C7.62008 19 5.45591 18.0762 3.8465 16.5677L16.5677 3.8465C18.0762 5.45591 19 7.62008 19 10ZM3.15559 15.8444L15.8444 3.15559C14.2719 1.81158 12.2307 1 10 1C5.02944 1 1 5.02944 1 10C1 12.2307 1.81158 14.2719 3.15559 15.8444ZM20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10Z" fill="white"/> </svg>',
+			value: 3,
+			name: 'Not set',
+			descrtipion: 'Not set',
+			className: 'donut-others',
+		},
+	];
+
+	const toggleControlComponent = (
+		<SimplifiedSegmentedControl
+			options={ Object.entries( optionLabels ).map( ( entry ) => ( {
+				value: entry[ 0 ], // optionLabels key
+				label: entry[ 1 ].selectLabel, // optionLabels object value
+			} ) ) }
+			initialSelected={ selectedOption }
+			// @ts-expect-error TODO: missing TS type
+			onSelect={ changeViewButton }
+		/>
+	);
+
+	const title = translate( 'Devices', { context: 'Stats: title of module', textOnly: true } );
+
+	// Use dedicated StatsCard for the screen size chart section.
+	if ( 'screen-size' === selectedOption ) {
+		return (
+			<StatsCard
+				className={ classNames( className, 'stats-module__card', path ) }
+				title={ title }
+				titleURL=""
+				metricLabel=""
+				splitHeader
+				mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
+				toggleControl={ toggleControlComponent }
+			>
+				<div className="stats-card--body__chart">
+					<PieChart data={ chartData } donut hasTooltip />
+					<PieChartLegend
+						data={ chartData }
+						onlyPercent
+						svgElement={
+							<svg
+								width="15"
+								height="14"
+								viewBox="0 0 15 14"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<rect x="0.5" width="14" height="14" rx="3" />
+							</svg>
+						}
+					/>
+				</div>
+			</StatsCard>
+		);
+	}
+
 	return (
 		// @ts-expect-error TODO: Refactor StatsListCard with TypeScript.
 		<StatsListCard
 			className={ classNames( className, 'stats-module__card', path ) }
 			moduleType={ path }
 			data={ data }
-			title={ translate( 'Devices', { context: 'Stats: title of module', textOnly: true } ) }
+			title={ title }
 			emptyMessage={ translate(
 				'If you use UTM codes, your {{link}}campaign performance data{{/link}} will show here.',
 				{
@@ -102,17 +188,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 			splitHeader
 			useShortNumber
 			mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
-			toggleControl={
-				<SimplifiedSegmentedControl
-					options={ Object.entries( optionLabels ).map( ( entry ) => ( {
-						value: entry[ 0 ], // optionLabels key
-						label: entry[ 1 ].selectLabel, // optionLabels object value
-					} ) ) }
-					initialSelected={ OPTION_KEYS.BROWSER } // until pie chart is added
-					// @ts-expect-error TODO: missing TS type
-					onSelect={ changeViewButton }
-				/>
-			}
+			toggleControl={ toggleControlComponent }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89302 

## Proposed Changes

* Add customized label icon support to the `PieChartLegend` component.
* Introduce the tooltip to the `PieChart` component.
* Apply the donut chart to the screen size option of the Stats `Devices` module.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > `Traffic` page for a **_Jetpack site_** with a purchased Stats commercial license.
* Scroll down to the `Devices` module.
* Click on the `Size` option.
* Ensure the donut chart works in line with the design.
* Ensure the tooltip shows when hovering on the donut chart.

<img width="661" alt="截圖 2024-04-11 下午11 58 12" src="https://github.com/Automattic/wp-calypso/assets/6869813/e4c43f63-de96-4660-a15f-727dacbcf998">

<img width="659" alt="截圖 2024-04-11 下午11 58 16" src="https://github.com/Automattic/wp-calypso/assets/6869813/8b579c20-6013-4ad3-b0e8-ad8f4ed1ce4e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?