### PR TITLE
A4A: update license handling for Pressable

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -59,5 +59,5 @@ export function getHostingLogo( slug: string ) {
  * @returns boolean True if Pressable hosting product, false if not
  */
 export function isPressableHostingProduct( keyOrSlug: string ) {
-	return keyOrSlug.startsWith( 'pressable-hosting' );
+	return keyOrSlug.startsWith( 'pressable-hosting' ) || keyOrSlug.startsWith( 'jetpack-pressable' );
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect, useMemo } from 'react';
 import {
 	LicenseRole,
 	LicenseState,
@@ -36,6 +36,9 @@ export default function LicenseDetailsActions( {
 	const translate = useTranslate();
 
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
+	// FIXME: ideally we want endpoint also sending us some slug so we could check with precission
+	const isPressableLicense = useMemo( () => product.indexOf( 'Pressable' ) !== -1, [ product ] );
+	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
 
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
@@ -79,15 +82,27 @@ export default function LicenseDetailsActions( {
 					</Button>
 				) }
 
-			{ licenseState === LicenseState.Attached && siteUrl && (
+			{ ! isPressableLicense && licenseState === LicenseState.Attached && siteUrl && (
 				<Button compact href={ siteUrl } target="_blank" rel="noopener noreferrer">
 					{ translate( 'View site' ) }
 				</Button>
 			) }
 
-			{ licenseState === LicenseState.Attached && debugUrl && (
+			{ ! isPressableLicense && licenseState === LicenseState.Attached && debugUrl && (
 				<Button compact href={ debugUrl } target="_blank" rel="noopener noreferrer">
 					{ translate( 'Debug site' ) }
+				</Button>
+			) }
+
+			{ isPressableLicense && licenseState === LicenseState.Attached && (
+				<Button
+					primary
+					compact
+					href={ pressableManageUrl }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ translate( 'Manage in Pressable' ) }
 				</Button>
 			) }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState, useEffect, useMemo } from 'react';
+import { useCallback, useState, useEffect } from 'react';
+import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import {
 	LicenseRole,
 	LicenseState,
@@ -36,8 +37,7 @@ export default function LicenseDetailsActions( {
 	const translate = useTranslate();
 
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
-	// FIXME: ideally we want endpoint also sending us some slug so we could check with precission
-	const isPressableLicense = useMemo( () => product.indexOf( 'Pressable' ) !== -1, [ product ] );
+	const isPressableLicense = isPressableHostingProduct( licenseKey );
 	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
 
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -1,7 +1,7 @@
 import { Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
@@ -42,8 +42,7 @@ export default function LicenseDetails( {
 }: Props ) {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
-	// FIXME: ideally we want endpoint also sending us some slug so we could check with precission
-	const isPressableLicense = useMemo( () => product.indexOf( 'Pressable' ) !== -1, [ product ] );
+	const isPressableLicense = isPressableHostingProduct( licenseKey );
 
 	return (
 		<Card

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -1,6 +1,7 @@
 import { Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
@@ -41,6 +42,8 @@ export default function LicenseDetails( {
 }: Props ) {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
+	// FIXME: ideally we want endpoint also sending us some slug so we could check with precission
+	const isPressableLicense = useMemo( () => product.indexOf( 'Pressable' ) !== -1, [ product ] );
 
 	return (
 		<Card
@@ -49,23 +52,31 @@ export default function LicenseDetails( {
 			} ) }
 		>
 			<ul className="license-details__list">
-				<li className="license-details__list-item">
-					<h4 className="license-details__label">{ translate( 'License code' ) }</h4>
+				{ /* FIXME: This of a better handling without conditions */ }
+				{ ! isPressableLicense && (
+					<li className="license-details__list-item">
+						<h4 className="license-details__label">{ translate( 'License code' ) }</h4>
 
-					<div className="license-details__license-key-row">
-						<code className="license-details__license-key">{ licenseKey }</code>
+						<div className="license-details__license-key-row">
+							<code className="license-details__license-key">{ licenseKey }</code>
 
-						<ClipboardButton
-							text={ licenseKey }
-							className="license-details__clipboard-button"
-							borderless
-							compact
-							onCopy={ onCopyLicense }
-						>
-							<Gridicon icon="clipboard" />
-						</ClipboardButton>
-					</div>
-				</li>
+							<ClipboardButton
+								text={ licenseKey }
+								className="license-details__clipboard-button"
+								borderless
+								compact
+								onCopy={ onCopyLicense }
+							>
+								<Gridicon icon="clipboard" />
+							</ClipboardButton>
+						</div>
+					</li>
+				) }
+				{ isPressableLicense && licenseState !== LicenseState.Revoked && (
+					<h4 className="license-details__label">
+						{ translate( 'Manage your Pressable licenses' ) }
+					</h4>
+				) }
 
 				<li className="license-details__list-item-small">
 					<h4 className="license-details__label">{ translate( 'Issued on' ) }</h4>
@@ -79,7 +90,7 @@ export default function LicenseDetails( {
 					</li>
 				) }
 
-				{ licenseState === LicenseState.Attached && (
+				{ ! isPressableLicense && licenseState === LicenseState.Attached && (
 					<li className="license-details__list-item">
 						<h4 className="license-details__label">{ translate( 'Site ID' ) }</h4>
 						{ blogId ? <span>{ blogId }</span> : <Gridicon icon="minus" /> }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -4,7 +4,7 @@ import { Badge, Button, Gridicon } from '@automattic/components';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState, useContext } from 'react';
+import { useCallback, useEffect, useState, useContext, useMemo } from 'react';
 import FormattedDate from 'calypso/components/formatted-date';
 import getLicenseState from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-license-state';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
@@ -60,6 +60,8 @@ export default function LicensePreview( {
 	const dispatch = useDispatch();
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
+	// FIXME: ideally we want endpoint also sending us some slug so we could check with precission
+	const isPressableLicense = useMemo( () => product.indexOf( 'Pressable' ) !== -1, [ product ] );
 
 	const { filter } = useContext( LicensesOverviewContext );
 
@@ -79,7 +81,7 @@ export default function LicensePreview( {
 
 	const { paymentMethodRequired } = usePaymentMethod();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
-	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
+	const domain = siteUrl && ! isPressableLicense ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
 	const assign = useCallback( () => {
 		const redirectUrl = addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -4,7 +4,8 @@ import { Badge, Button, Gridicon } from '@automattic/components';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState, useContext, useMemo } from 'react';
+import { useCallback, useEffect, useState, useContext } from 'react';
+import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import FormattedDate from 'calypso/components/formatted-date';
 import getLicenseState from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-license-state';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
@@ -60,8 +61,7 @@ export default function LicensePreview( {
 	const dispatch = useDispatch();
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
-	// FIXME: ideally we want endpoint also sending us some slug so we could check with precission
-	const isPressableLicense = useMemo( () => product.indexOf( 'Pressable' ) !== -1, [ product ] );
+	const isPressableLicense = isPressableHostingProduct( licenseKey );
 
 	const { filter } = useContext( LicensesOverviewContext );
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -62,6 +62,7 @@ export default function LicensePreview( {
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
+	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
 
 	const { filter } = useContext( LicensesOverviewContext );
 
@@ -163,6 +164,16 @@ export default function LicensePreview( {
 						<>
 							<div className="license-preview__product-small">{ product }</div>
 							{ domain }
+							{ isPressableLicense && (
+								<a
+									className="license-preview__product-pressable-link"
+									target="_blank"
+									rel="norefferer noopener noreferrer"
+									href={ pressableManageUrl }
+								>
+									{ translate( 'Manage in Pressable' ) }
+								</a>
+							) }
 							{ ! domain && licenseState === LicenseState.Detached && (
 								<span>
 									<Badge type="warning">{ translate( 'Unassigned' ) }</Badge>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -37,6 +37,10 @@
 	inset-block-start: 3px;
 }
 
+.license-preview__product-pressable-link {
+	text-decoration: underline;
+}
+
 .license-preview__domain {
 	padding: 0;
 	margin: 0 0 4px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/272

## Proposed Changes
Don't show unrelated license information in billing section for Pressable licenses.

As it's an urgent issue the code maybe not the best, but we could iterate on it in the future.

**General**
Added some text to fulfill the emptiness. And more syled buttons.
<img width="837" alt="Screenshot 2024-04-11 at 11 39 12 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/b628fb70-d698-493f-9abe-86af11a026b6">

**Revoke Dialog**
I wonder if we should make the same update here as well. @rcanepa what do you think?
<img width="717" alt="Screenshot 2024-04-11 at 11 43 13 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/ac2a30eb-6425-4715-a2cc-480632e58205">

**After revoking**
<img width="823" alt="Screenshot 2024-04-11 at 11 44 44 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/42686175-9e4c-45a0-9e39-5adcf9816bda">

## Testing Instructions
- With current branch purchase Pressable plan
- Navigate to `/purchases/licenses`
- Check that everything looks good and works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?