### PR TITLE
Localize the Learn More url

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/components/pricing-plans-header.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/pricing-plans-header.tsx
@@ -1,3 +1,4 @@
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
@@ -10,7 +11,8 @@ interface Props {
 }
 
 const PricingPlansHeader: FunctionComponent< Props > = ( { currentPlan, attributes } ) => {
-	let learnMoreLink = 'https://wordpress.com/pricing/';
+	const localizeUrl = useLocalizeUrl();
+	let learnMoreLink = localizeUrl( 'https://wordpress.com/pricing/' );
 
 	if ( attributes.domain ) {
 		learnMoreLink = `https://wordpress.com/plans/${ attributes.domain }`;

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -154,6 +154,9 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 		}
 		return prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},
+	'wordpress.com/pricing/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
+		return isLoggedIn ? url : prefixLocalizedUrlPath( localesForPricePlans )( url, localeSlug );
+	},
 	'wordpress.com/theme/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -125,6 +125,7 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 		}
 		return prefixLocalizedUrlPath( localesWithGoBlog )( url, localeSlug );
 	},
+	'wordpress.com/pricing/': prefixLocalizedUrlPath( localesForPricePlans ),
 	'wordpress.com/tos/': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'wordpress.com/wp-admin/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
@@ -153,9 +154,6 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 			return url;
 		}
 		return prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
-	},
-	'wordpress.com/pricing/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
-		return isLoggedIn ? url : prefixLocalizedUrlPath( localesForPricePlans )( url, localeSlug );
 	},
 	'wordpress.com/theme/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -448,6 +448,24 @@ describe( '#localizeUrl', () => {
 		);
 	} );
 
+	test( 'pricing', () => {
+		expect( localizeUrl( 'https://wordpress.com/pricing/', 'en' ) ).toEqual(
+			'https://wordpress.com/pricing/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/pricing/', 'fr' ) ).toEqual(
+			'https://wordpress.com/fr/pricing/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/pricing/', 'pt-br' ) ).toEqual(
+			'https://wordpress.com/pt-br/pricing/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/pricing/', 'zh-tw' ) ).toEqual(
+			'https://wordpress.com/zh-tw/pricing/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/pricing/', 'xx' ) ).toEqual(
+			'https://wordpress.com/pricing/'
+		);
+	} );
+
 	test( 'jetpack', () => {
 		expect( localizeUrl( 'https://jetpack.com/features/comparison/', 'en' ) ).toEqual(
 			'https://jetpack.com/features/comparison/'


### PR DESCRIPTION
Related to Automattic/i18n-issues#777

## Proposed Changes

* Localize the `Learn More` url

## Testing Instructions

* Execute `yarn test-packages -- test/localize-url.js`
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?