### PR TITLE
Refactor translate calls by providing full context

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/staging-site-sync-loading-bar-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-site-sync-loading-bar-card-content.tsx
@@ -23,13 +23,25 @@ export const StagingSiteSyncLoadingBarCardContent = ( {
 	const currentUserId = useSelector( getCurrentUserId );
 	const isOwner = siteOwnerId === currentUserId;
 
-	const message = isOwner
-		? translate( 'We are updating your %s site. We’ll email you once it is ready.', {
-				args: [ siteToSync ?? '' ],
-		  } )
-		: translate( 'We are updating the %s site. We’ll email the site owner once it is ready.', {
-				args: [ siteToSync ?? '' ],
-		  } );
+	let message;
+	if ( siteToSync === 'production' ) {
+		message = isOwner
+			? translate( 'We are updating your production site. We’ll email you once it is ready.' )
+			: translate(
+					'We are updating the production site. We’ll email the site owner once it is ready.'
+			  );
+	} else if ( siteToSync === 'staging' ) {
+		message = isOwner
+			? translate( 'We are updating your staging site. We’ll email you once it is ready.' )
+			: translate(
+					'We are updating the staging site. We’ll email the site owner once it is ready.'
+			  );
+	} else {
+		message = isOwner
+			? translate( 'We are updating your site. We’ll email you once it is ready.' )
+			: translate( 'We are updating the site. We’ll email the site owner once it is ready.' );
+	}
+
 	return (
 		<div data-testid="syncing-site-content">
 			<StyledLoadingBar progress={ progress } />


### PR DESCRIPTION
Related to https://github.com/Automattic/i18n-issues/issues/779 

## Proposed Changes

In line with the recommendations shared in PCYsg-3hI-p2, this commit resolves an issue where the strings 'staging' and 'production' were not translated at all, potentially causing confusion for non-English speaking users.

With this commit, we translate the entire sentences including the 'staging' and 'production' words based on different conditions. This not only provides the translators with full context but also allows for the appropriate translation of 'staging' and 'production', improving the overall user experience for various language users.

# Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?