### PR TITLE
Stats: use new upsell card definition for Jetpack

### DIFF
--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -40,6 +40,7 @@ export const STAT_TYPE_VISITS = 'statsVisits';
 export const STAT_TYPE_TAGS_LIST = 'tagsList';
 export const STAT_TYPE_USERS_LIST = 'usersList';
 export const STAT_TYPE_WPCOM_PLUGINS_LIST = 'wpcomPluginsList';
+export const STATS_TYPE_DEVICE_STATS = 'statsDeviceStats';
 
 // stats feature are for more granular control, string value is based on component name
 export const STATS_FEATURE_DATE_CONTROL = 'StatsDateControl';

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -9,7 +9,11 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { STATS_FEATURE_DATE_CONTROL, STATS_FEATURE_UTM_STATS } from '../constants';
+import {
+	STATS_FEATURE_DATE_CONTROL,
+	STATS_FEATURE_UTM_STATS,
+	STATS_TYPE_DEVICE_STATS,
+} from '../constants';
 import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
 import { Props } from './';
 
@@ -21,6 +25,15 @@ const useUpsellCopy = ( statType: string ) => {
 		case STATS_FEATURE_UTM_STATS:
 			return translate(
 				'Track your campaign performance data with UTM codes. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
+					},
+				}
+			);
+		case STATS_TYPE_DEVICE_STATS:
+			return translate(
+				'Look at what devices your users are on. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 				{
 					components: {
 						learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,

--- a/client/my-sites/stats/stats-module-devices/stats-module-upgrade-overlay.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-upgrade-overlay.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
-import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { STATS_TYPE_DEVICE_STATS } from '../constants';
 import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
 import StatsListCard from '../stats-list/stats-list-card';
 
@@ -16,8 +15,6 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 	siteId,
 	className,
 } ) => {
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) || '' );
-
 	const fakeData = [
 		{
 			label: 'Windows',
@@ -66,8 +63,8 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 			overlay={
 				<StatsCardUpsellJetpack
 					className="stats-module__upsell"
-					siteSlug={ siteSlug }
-					tracksEvent="stats_devices_upgrade_clicked"
+					siteId={ siteId }
+					statType={ STATS_TYPE_DEVICE_STATS }
 				/>
 			}
 		></StatsListCard>


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/89380 unified the interface of Jetpack and WPCOM upsell cards, and https://github.com/Automattic/wp-calypso/pull/89387 is still using the old one, which caused build failure.

## Testing Instructions

* Ensure builds succeed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?