### PR TITLE
Site migration: Styling and design update

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -19,6 +19,27 @@ $business-plan-color: #7f54b3;
 		@include break-medium {
 			flex-direction: row;
 		}
+
+		&.feature-list-expanded {
+			.import__upgrade-plan-features-container,
+			.import__upgrade-plan-hosting-details {
+				@include break-medium {
+					height: initial;
+				}
+			}
+
+			.import__upgrade-plan-features-container {
+				@include break-medium {
+					margin-bottom: 8.5rem;
+				}
+			}
+
+			.import__upgrade-plan-hosting-details {
+				@include break-medium {
+					margin-bottom: 9.25rem;
+				}
+			}
+		}
 	}
 
 	.import__upgrade-plan-features-container {
@@ -28,7 +49,7 @@ $business-plan-color: #7f54b3;
 		box-sizing: border-box;
 		display: flex;
 		flex-direction: column;
-		gap: 1.5rem;
+		gap: 1rem;
 		margin-bottom: -3px;
 		max-width: 100%;
 		padding: 1.5em;
@@ -37,22 +58,26 @@ $business-plan-color: #7f54b3;
 
 		@include break-medium {
 			flex-direction: column;
-			margin-bottom: 2em;
+			margin-bottom: 1rem;
 			margin-right: 0;
 			margin-left: 0;
 			width: 324px;
+			height: 400px;
 		}
 	}
 
 	.import__upgrade-plan-header {
 		.plan-title {
-			font-size: 2.25rem;
+			font-size: 2rem;
 			line-height: 1;
-			margin: 0;
+			margin: 0.5rem 0;
 		}
 
-		small {
-			line-height: 1.4;
+		p {
+			line-height: 16px;
+			font-size: 0.75rem;
+			margin-bottom: 0;
+			color: #2c3338;
 		}
 	}
 
@@ -138,6 +163,7 @@ $business-plan-color: #7f54b3;
 				background-color: $business-plan-color !important;
 				border: $business-plan-color;
 				color: var(--studio-purple-0);
+				height: 40px;
 			}
 
 			&.is-busy {
@@ -194,6 +220,7 @@ $business-plan-color: #7f54b3;
 			color: var(--studio-gray-80);
 			flex-basis: 100%;
 			padding: 0;
+			font-size: 0.75rem;
 
 			button {
 				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
@@ -217,11 +244,17 @@ $business-plan-color: #7f54b3;
 			}
 		}
 
-		.import__upgrade-plan-feature-more button {
-			width: 100%;
-			font-weight: 600;
-			color: $business-plan-color;
-			text-align: start;
+		.import__upgrade-plan-feature-more {
+			margin-top: 0.5rem;
+			margin-bottom: 0;
+
+			button {
+				width: 100%;
+				font-weight: 600;
+				color: $business-plan-color;
+				text-align: start;
+				font-size: 0.75rem;
+			}
 		}
 
 		.import__upgrade-plan-feature-more svg {
@@ -244,11 +277,11 @@ $business-plan-color: #7f54b3;
 		box-sizing: border-box;
 		display: flex;
 		flex-direction: column;
-		gap: 2rem;
-		margin-bottom: 2.75rem;
+		gap: 1.5rem;
 		margin-top: 0;
 		max-width: 100%;
 		padding: 1.5rem;
+		margin-bottom: 60px;
 
 		@include break-medium {
 			margin-right: 0;
@@ -258,9 +291,15 @@ $business-plan-color: #7f54b3;
 			border-top-right-radius: 4px;
 			border-bottom-right-radius: 4px;
 			border-bottom-left-radius: 0;
+			border-bottom: 1px solid #e0e0e0;
 			border-left: 0;
 			width: 324px;
-			padding: 2.75rem 1.5rem;
+			height: 376px;
+			margin-bottom: 60px;
+		}
+
+		@include break-small {
+			margin-bottom: 0;
 		}
 
 		.import__upgrade-plan-hosting-details-header {
@@ -313,7 +352,15 @@ $business-plan-color: #7f54b3;
 				line-height: 1.4;
 				justify-content: space-around;
 
-				span {
+				.import__upgrade-plan-hosting-details-list-stats-title {
+					font-size: 0.875rem;
+					font-weight: 500;
+					color: var(--studio-gray-100, #101517);
+					line-height: 20px;
+					margin-bottom: 0;
+				}
+
+				.import__upgrade-plan-hosting-details-list-stats-description {
 					font-size: 0.75rem;
 					color: var(--studio-gray-50, #646970);
 				}
@@ -399,6 +446,10 @@ $business-plan-color: #7f54b3;
 		overflow-wrap: break-word;
 		top: -8px;
 
+		@media (max-width: 355px) {
+			width: auto;
+		}
+
 		.import__upgrade-plan-hosting-details-tooltip-user-text {
 			color: #2c3338;
 			margin-bottom: 1rem;
@@ -411,5 +462,20 @@ $business-plan-color: #7f54b3;
 		.import__upgrade-plan-hosting-details-tooltip-user-info {
 			color: var(--studio-gray-50, #646970);
 		}
+	}
+}
+
+.importer-step {
+	.import__upgrade-plan-container {
+		@media ( min-width: 782px ) and (max-width: 830px) {
+			.import__upgrade-plan-features-container {
+				height: 431px;
+			}
+
+			.import__upgrade-plan-hosting-details {
+				height: 407px;
+			}
+		}
+
 	}
 }

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -22,6 +22,7 @@ interface Props {
 export const UpgradePlanDetails = ( props: Props ) => {
 	const { __ } = useI18n();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
+	const [ showFeatures, setShowFeatures ] = useState( false );
 
 	const { children } = props;
 	const [ selectedPlan, setSelectedPlan ] = useState<
@@ -66,7 +67,11 @@ export const UpgradePlanDetails = ( props: Props ) => {
 				</ButtonGroup>
 			</div>
 
-			<div className={ classnames( 'import__upgrade-plan-container' ) }>
+			<div
+				className={ classnames( 'import__upgrade-plan-container', {
+					'feature-list-expanded': showFeatures,
+				} ) }
+			>
 				<div className={ classnames( 'import__upgrade-plan-features-container' ) }>
 					<div className={ classnames( 'import__upgrade-plan-header' ) }>
 						<Plans2023Tooltip
@@ -82,7 +87,7 @@ export const UpgradePlanDetails = ( props: Props ) => {
 						<Title className="plan-title" tagName="h2">
 							{ plan?.getTitle() }
 						</Title>
-						<small>{ __( 'Unlock the power of WordPress with plugins and cloud tools.' ) }</small>
+						<p>{ __( 'Unlock the power of WordPress with plugins and cloud tools.' ) }</p>
 					</div>
 
 					<div className={ classnames( 'import__upgrade-plan-price' ) }>
@@ -96,7 +101,11 @@ export const UpgradePlanDetails = ( props: Props ) => {
 					<div className={ classnames( 'import__upgrade-plan-cta' ) }>{ children }</div>
 
 					<div className={ classnames( 'import__upgrade-plan-features-list' ) }>
-						<UpgradePlanFeatureList plan={ plan } />
+						<UpgradePlanFeatureList
+							plan={ plan }
+							showFeatures={ showFeatures }
+							setShowFeatures={ setShowFeatures }
+						/>
 					</div>
 				</div>
 				<UpgradePlanHostingDetails />

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-feature-list.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-feature-list.tsx
@@ -9,12 +9,13 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 
 interface Props {
 	plan: Plan | JetpackPlan | WPComPlan | undefined;
+	showFeatures: boolean;
+	setShowFeatures: ( showFeatures: boolean ) => void;
 }
 
 export const UpgradePlanFeatureList = ( props: Props ) => {
 	const { __ } = useI18n();
-	const { plan } = props;
-	const [ showFeatures, setShowFeatures ] = useState( false );
+	const { plan, showFeatures, setShowFeatures } = props;
 	const [ activeTooltipId, setActiveTooltipId ] = useState( '' );
 
 	const wpcomFeatures = plan
@@ -39,7 +40,7 @@ export const UpgradePlanFeatureList = ( props: Props ) => {
 				<li className={ classnames( 'import__upgrade-plan-feature-more' ) }>
 					<button onClick={ () => setShowFeatures( true ) }>
 						{ __( 'Show all features' ) }
-						<Icon icon={ chevronDown } />
+						<Icon size={ 18 } icon={ chevronDown } />
 					</button>
 				</li>
 			) }
@@ -56,6 +57,20 @@ export const UpgradePlanFeatureList = ( props: Props ) => {
 							>
 								{ i === 0 && <strong>{ feature?.getTitle() }</strong> }
 								{ i > 0 && <span>{ feature?.getTitle() }</span> }
+								{ i === 2 && (
+									<>
+										<li className={ classnames( 'import__upgrade-plan-feature logo' ) }>
+											<strong>{ __( 'Storage' ) }</strong>
+										</li>
+										<li className={ classnames( 'import__upgrade-plan-feature' ) }>
+											{ storageOptions?.map( ( storage, i ) => (
+												<Badge type="info" key={ i }>
+													{ storage?.getTitle() }
+												</Badge>
+											) ) }
+										</li>
+									</>
+								) }
 							</Plans2023Tooltip>
 						</li>
 					) ) }
@@ -75,17 +90,6 @@ export const UpgradePlanFeatureList = ( props: Props ) => {
 							</Plans2023Tooltip>
 						</li>
 					) ) }
-
-					<li className={ classnames( 'import__upgrade-plan-feature logo' ) }>
-						<strong>{ __( 'Storage' ) }</strong>
-					</li>
-					<li className={ classnames( 'import__upgrade-plan-feature' ) }>
-						{ storageOptions?.map( ( storage, i ) => (
-							<Badge type="info" key={ i }>
-								{ storage?.getTitle() }
-							</Badge>
-						) ) }
-					</li>
 				</>
 			) }
 		</ul>

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details-tooltip.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details-tooltip.tsx
@@ -51,7 +51,7 @@ export const UpgradePlanHostingDetailsTooltip = ( {
 				hideArrow={ props.hideArrow }
 				showOnMobile={ showOnMobile }
 			>
-				<div className="import__upgrade-plan-hosting-details-tooltipz">
+				<div>
 					<div className="import__upgrade-plan-hosting-details-tooltip-user-text">
 						{ props.customerTestimonial }
 					</div>

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
@@ -1,5 +1,6 @@
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useState } from '@wordpress/element';
+import { hasTranslation } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { UpgradePlanHostingDetailsList, UpgradePlanHostingTestimonials } from './constants';
@@ -10,12 +11,15 @@ export const UpgradePlanHostingDetails = () => {
 	const isEnglishLocale = useIsEnglishLocale();
 	const [ activeTooltipId, setActiveTooltipId ] = useState( '' );
 
+	const headerMainText =
+		hasTranslation( 'Why should you host with us?' ) || isEnglishLocale
+			? __( 'Why should you host with us?' )
+			: __( 'Why you should host with us?' );
+
 	return (
 		<div className="import__upgrade-plan-hosting-details">
 			<div className="import__upgrade-plan-hosting-details-header">
-				<p className="import__upgrade-plan-hosting-details-header-main">
-					{ __( 'Why you should host with us?' ) }
-				</p>
+				<p className="import__upgrade-plan-hosting-details-header-main">{ headerMainText }</p>
 				<p className="import__upgrade-plan-hosting-details-header-subtext">
 					{ __( 'Check our performance, compared to the average WordPress host' ) }
 				</p>
@@ -30,8 +34,10 @@ export const UpgradePlanHostingDetails = () => {
 								size={ 24 }
 							/>
 							<div className="import__upgrade-plan-hosting-details-list-stats">
-								<strong>{ title }</strong>
-								<span>{ description }</span>
+								<p className="import__upgrade-plan-hosting-details-list-stats-title">{ title }</p>
+								<span className="import__upgrade-plan-hosting-details-list-stats-description">
+									{ description }
+								</span>
 							</div>
 						</li>
 					) ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88970

## Proposed Changes

Design: 5yhaC6umexdQLlLpCrCyEe-fi-2304%3A4454

* Update styling in mobile & desktop view ( spacing, alignment, height)
* Update location of feature lists "storage" details
* Update features list icon size
* Removed unncessary class for tooltip
* Updated hosting details header text

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/setup/import-hosted-site` , add site to import, select a free site, and inspect plan upgrade page based on updates above.
* Navigate to `/setup/site-migration/site-migration-upgrade-plan?from={IMPORT_SITE_URL}&siteSlug={FREE_SITE_SLUG}` and inspect plan upgrade page based on updates above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?