### PR TITLE
Stats: Fix stats paywall for non admin users

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -1,6 +1,7 @@
 /**
  * This is a Odyssey implementation of 'calypso/components/data/query-site-purchases'.
  */
+import { APIError } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
 import { isError } from 'lodash';
 import { useEffect } from 'react';
@@ -25,7 +26,7 @@ async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
 			apiNamespace: getApiNamespace(),
 		} )
 		.then( ( res: { data: string } ) => JSON.parse( res.data ) )
-		.catch( ( error: Error ) => error );
+		.catch( ( error: APIError ) => error );
 }
 /**
  * Update site products in the Redux store by fetching purchases via API for Odyssey Stats.
@@ -62,11 +63,26 @@ export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number 
 		}
 
 		if ( isError( purchases ) || hasOtherErrors ) {
-			// Dispatch to the Purchases reducer for error status
-			reduxDispatch( {
-				type: PURCHASES_SITE_FETCH_FAILED,
-				error: 'purchase_fetch_failed',
-			} );
+			if ( ( purchases as APIError ).status !== 403 ) {
+				// Dispatch to the Purchases reducer for error status
+				reduxDispatch( {
+					type: PURCHASES_SITE_FETCH_FAILED,
+					error: 'purchase_fetch_failed',
+				} );
+			} else {
+				// TODO: Remove this after fixing the API permission issue from Jetpack.
+				reduxDispatch( {
+					type: PURCHASES_SITE_FETCH_COMPLETED,
+					siteId,
+					purchases: [
+						{
+							expiry_status: 'active',
+							product_slug: 'jetpack_stats_pwyw_yearly',
+							blog_id: siteId,
+						},
+					],
+				} );
+			}
 		} else {
 			// Dispatch to the Purchases reducer for consistent requesting status
 			reduxDispatch( {

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -101,7 +101,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		);
 
 		return null;
-	} else if ( ! isLoading && canUserViewStats ) {
+	} else if ( ! isLoading && ( canUserViewStats || canUserManageOptions ) ) {
 		return <>{ children }</>;
 	} else if ( isLoading ) {
 		return <StatsLoader />;

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -78,7 +78,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 	}, [ dispatch, siteId, isLoadingNotices, purchaseNotPostponed ] );
 
 	// render purchase flow for Jetpack sites created after February 2024
-	if ( ! isLoading && redirectToPurchase && siteSlug ) {
+	if ( ! isLoading && redirectToPurchase && siteSlug && canUserManageOptions ) {
 		// We need to ensure we pass the irclick id for impact affiliate tracking if its set.
 		const currentParams = new URLSearchParams( window.location.search );
 		const queryParams = new URLSearchParams();
@@ -101,7 +101,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		);
 
 		return null;
-	} else if ( ! isLoading || ( canUserViewStats && ! canUserManageOptions ) ) {
+	} else if ( ! isLoading && canUserViewStats ) {
 		return <>{ children }</>;
 	} else if ( isLoading ) {
 		return <StatsLoader />;


### PR DESCRIPTION
Related: p1712873408053979-slack-C82FZ5T4G

## Proposed Changes

Non-admin users are denied to access `jetpack/v4/purchases`, so we are not temporarily feed these users with a pwyw license as a fix. We'll have to either fix the permission of the API or we could create a dedicated API for stats if for s-e-c-urity reasons, it's not okay to extend the original API to these users.

## Testing Instructions

* Create a non-admin user, and enable their Stats access thru Jetpack settings
* Tweak value of `MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL` to `1`.
* Build Jetpack and Odyssey Stats locally
* Login with the non-admin user
* Open `/wp-admin/admin.php?page=stats#!/stats/day/:site?page=stats`
* Ensure you are not redirected to purchase page
* Ensure admins are still redirected to purchase page
* Ensure after purchase, admins could access Stats

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?