### PR TITLE
Update continue as screen copy for woo.com passwordless login flow

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -458,7 +458,9 @@ class Login extends Component {
 					);
 					postHeader = (
 						<p className="login__header-subtitle">
-							{ translate( 'First, select the account you’d like to use.' ) }
+							{ wccomFrom === 'nux'
+								? translate( 'First, select the account you’d like to use.' )
+								: translate( 'Select the account you’d like to use.' ) }
 						</p>
 					);
 				} else if ( this.props.isWooPasswordless ) {


### PR DESCRIPTION
Tweak the copy. Remove `First`, as this isn’t part of a flow.

![image](https://github.com/Automattic/wp-calypso/assets/4344253/6358c662-18b1-46fa-a550-67e0c329a936)
