### PR TITLE
A4A: Add HubSpot tracking code in the Signup form.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
+import { loadScript } from '@automattic/load-script';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import AgencyDetailsForm from 'calypso/a8c-for-agencies/sections/signup/agency-details-form';
 import useCreateAgencyMutation from 'calypso/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation';
 import AutomatticLogo from 'calypso/components/automattic-logo';
@@ -55,6 +56,11 @@ export default function SignupForm() {
 		},
 		[ notificationId, createAgency, dispatch ]
 	);
+
+	useEffect( () => {
+		// We need to include HubSpot tracking code on the signup form.
+		loadScript( '//js.hs-scripts.com/45522507.js' );
+	}, [] );
 
 	return (
 		<Card className="agency-signup-form">


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/314

## Proposed Changes

* Load the `//js.hs-scripts.com/45522507.js` script everytime SignUpForm component is rendered.

## Testing Instructions

* Create a new WPCOM account.
* Spin up this branch locally and go to http://agencies.localhost:3000/signup.
* Connect your WPCOM account to A4A.
* Once you end up on the SIgnup page. Inspect in your browser's network tab the the script 45522507.js is loaded.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?