### PR TITLE
A4A: Sites Dashboard - Fix button styles bleeding into product UI

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-content/style.scss
@@ -43,13 +43,6 @@
 		fill: #fff;
 		padding-left: 8px;
 	}
-
-	.button {
-		font-weight: 500;
-		border-color: unset;
-		border: 1px solid var(--color-accent);
-	}
-
 }
 
 .site-preview-pane__stats-content,


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/280

## Proposed Changes

* This PR removes a `.button` style, which is bleeding into the product components inside the Preview Pane.

## Testing Instructions

* Run yarn start-a8c-for-agencies
* Go to http://agencies.localhost:3000/sites
* Click over a site to open the preview pane
* Check our product pages, blue borders bleeding into them should be gone

Before:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/9a76f855-1956-48da-941d-64cabed52670)


After:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/b06763d0-4287-4d88-9225-b6c49f3b4d81)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?