### PR TITLE
Remove the “My Sites” copy from the top left of the masterbar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -84,7 +84,6 @@ class MasterbarLoggedIn extends Component {
 		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
 		isEcommerce: PropTypes.bool,
-		hasMoreThanOneSite: PropTypes.bool,
 		isCheckout: PropTypes.bool,
 		isCheckoutPending: PropTypes.bool,
 		isCheckoutFailed: PropTypes.bool,
@@ -312,15 +311,7 @@ class MasterbarLoggedIn extends Component {
 
 	// will render as back button on mobile and in editor
 	renderMySites() {
-		const {
-			domainOnlySite,
-			hasNoSites,
-			hasMoreThanOneSite,
-			siteSlug,
-			translate,
-			section,
-			currentRoute,
-		} = this.props;
+		const { domainOnlySite, siteSlug, translate, section, currentRoute } = this.props;
 		const { isMenuOpen, isResponsiveMenu } = this.state;
 
 		const homeUrl = this.getHomeUrl();
@@ -349,11 +340,7 @@ class MasterbarLoggedIn extends Component {
 				isActive={ this.isActive( 'sites' ) && ! isMenuOpen }
 				tooltip={ translate( 'Manage your sites' ) }
 				preloadSection={ this.preloadMySites }
-			>
-				{ hasNoSites || hasMoreThanOneSite
-					? translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
-					: translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
-			</Item>
+			/>
 		);
 	}
 
@@ -833,7 +820,6 @@ export default connect(
 			sectionGroup,
 			domainOnlySite: isDomainOnlySite( state, siteId ),
 			hasNoSites: siteCount === 0,
-			hasMoreThanOneSite: siteCount > 1,
 			user: getCurrentUser( state ),
 			isSupportSession: isSupportSession( state ),
 			isInEditor: getSectionName( state ) === 'gutenberg-editor',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

This PR removes the “My Sites” copy from the top left of the masterbar.

| before | after |
|--------|--------|
| <img width="1438" alt="Screenshot 2024-04-12 at 17 00 09" src="https://github.com/Automattic/wp-calypso/assets/5287479/975f3486-a705-4307-9150-a876d488ed1e"> | <img width="1438" alt="Screenshot 2024-04-12 at 16 58 26" src="https://github.com/Automattic/wp-calypso/assets/5287479/5fdcd200-40d9-4a9d-b3e0-003684a7586c"> | 

Since we've made a change to the site switcher in https://github.com/Automattic/wp-calypso/pull/87585, the “My Sites” label on the masterbar (see the before image above) may lead to confusion, as it actually redirects users to `Home` instead of `/sites`. This PR proposes to remove the copy and retain only the logo, which is already the case on the classic interface and would be consistent with Core.

p1712898028178789/1712871943.690009-slack-C06DN6QQVAQ

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare a site with Default interface
* Go to any Calypso page (e.g., `/home/<site>`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?