### PR TITLE
Stats: Revert a change that breeks all time stats

### DIFF
--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useSelector } from 'calypso/state';
-import { getSiteStatsViewSummaryMemoized } from 'calypso/state/stats/lists/selectors';
+import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
 import StatsHeatMapLegend from '../stats-heap-map/legend';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import Months from '../stats-views/months';
@@ -21,7 +21,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 	const query = { quantity: -1, stat_fields: 'views' };
 	const translate = useTranslate();
 	const [ chartOption, setChartOption ] = useState( 'total' );
-	const viewData = useSelector( ( state ) => getSiteStatsViewSummaryMemoized( state, siteId ) );
+	const viewData = useSelector( ( state ) => getSiteStatsViewSummary( state, siteId ) );
 	const monthViewOptions = useMemo( () => {
 		return [
 			{ value: 'total', label: translate( 'Months and years' ) },


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/89477

## Proposed Changes

* Revert a change to resolve the issue

## Testing Instructions

* Build Odyssey Stats and Jetpack locally
* Open `/wp-admin/admin.php?page=stats#!/stats/insights/:site`
* Ensure all time stats is loading

<img width="1252" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/1ce73faf-9293-49ca-9674-345b40c37757">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?