### PR TITLE
Move is_wpcom_simple to the correct object path under options

### DIFF
--- a/client/state/sites/selectors/is-jetpack-site-pred.ts
+++ b/client/state/sites/selectors/is-jetpack-site-pred.ts
@@ -37,7 +37,7 @@ export default function isJetpackSitePred( options?: IsJetpackSitePredOptions ) 
 		// Merge default options with options.
 		const mergedOptions = options ? { ...DEFAULT_OPTIONS, ...options } : DEFAULT_OPTIONS;
 
-		if ( site.is_wpcom_simple ) {
+		if ( site.options?.is_wpcom_simple ) {
 			return false;
 		}
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -129,7 +129,6 @@ export interface SiteDetails {
 	is_deleted?: boolean;
 	is_vip?: boolean;
 	is_wpcom_atomic?: boolean;
-	is_wpcom_simple?: boolean;
 	is_wpcom_staging_site?: boolean;
 	jetpack: boolean;
 	lang?: string;
@@ -253,6 +252,7 @@ export interface SiteDetailsOptions {
 	is_pending_plan?: boolean;
 	is_redirect?: boolean;
 	is_wpcom_atomic?: boolean;
+	is_wpcom_simple?: boolean;
 	is_wpcom_store?: boolean;
 	is_wpforteams_site?: boolean;
 	jetpack_connection_active_plugins?: string[];


### PR DESCRIPTION
## Proposed Changes

`is_wpcom_simple` should be under site options and not the root site object

This should not affect the logic as `site.jetpack` value should be `false` for simple sites. And this value didn't exist for all sites before.

Ref:
* https://github.com/Automattic/jetpack/blob/f3b9cebf1118c8f364b7aa58c1c3921b65635291/projects/packages/blaze/src/class-dashboard-config-data.php#L81
* https://github.com/Automattic/jetpack/blob/f3b9cebf1118c8f364b7aa58c1c3921b65635291/projects/packages/stats-admin/src/class-odyssey-config-data.php#L94

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check /wp-admin stats page for self-hosted, atomic, simple to make sure nothing breaks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?