### PR TITLE
Congrats: placeholder

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/placeholder/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/placeholder/index.tsx
@@ -1,0 +1,32 @@
+import './style.scss';
+
+export const PlaceholderThankYou = () => {
+	return (
+		<div className="congrats-placeholder">
+			<div className="congrats-placeholder__title" />
+			<div className="congrats-placeholder__description" />
+			<div className="congrats-placeholder__items">
+				{ Array.from( { length: 2 } ).map( ( _, index ) => (
+					<div key={ index } className="congrats-placeholder__item">
+						<div className="congrats-placeholder__item-body">
+							<div className="congrats-placeholder__item-title" />
+							<div className="congrats-placeholder__item-description" />
+						</div>
+						<div className="congrats-placeholder__item-buttons" />
+					</div>
+				) ) }
+			</div>
+			<div className="congrats-placeholder__footer">
+				{ Array.from( { length: 2 } ).map( ( _, index ) => (
+					<div key={ index } className="congrats-placeholder__footer-item">
+						<div className="congrats-placeholder__footer-item-title" />
+						<div className="congrats-placeholder__footer-item-description congrats-placeholder__footer-item-description--m" />
+						<div className="congrats-placeholder__footer-item-description congrats-placeholder__footer-item-description--l" />
+						<div className="congrats-placeholder__footer-item-description congrats-placeholder__footer-item-description--s" />
+						<div className="congrats-placeholder__footer-item-description congrats-placeholder__footer-item-description--s" />
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/placeholder/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/placeholder/style.scss
@@ -1,0 +1,127 @@
+@import "@wordpress/base-styles/breakpoints";
+
+@mixin congrats-placeholder-title {
+	@include placeholder(--color-neutral-20);
+	height: 17px;
+	border-radius: 20px; /* stylelint-disable-line scales/radii */
+}
+
+@mixin congrats-placeholder-text {
+	@include placeholder(--color-neutral-5);
+	height: 14px;
+	border-radius: 20px; /* stylelint-disable-line scales/radii */
+}
+
+.congrats-placeholder {
+	max-width: 650px;
+	margin: 0 auto;
+	padding: 40px 24px;
+}
+
+.congrats-placeholder__title {
+	@include congrats-placeholder-title;
+	width: 70%;
+	margin: 0 auto;
+	margin-bottom: 20px;
+}
+
+.congrats-placeholder__description {
+	@include congrats-placeholder-text;
+	width: 47%;
+	margin: 0 auto;
+	margin-bottom: 40px;
+	height: 17px;
+}
+
+.congrats-placeholder__items {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding-bottom: 40px;
+}
+
+.congrats-placeholder__item {
+	border: 1px solid var(--color-neutral-5);
+	border-radius: 2px;
+	padding: 20px 25px;
+	display: flex;
+	align-items: flex-start;
+	gap: 20px;
+}
+
+.congrats-placeholder__item-body {
+	margin-right: auto;
+}
+
+.congrats-placeholder__item-title {
+	@include congrats-placeholder-title;
+	margin-bottom: 12px;
+	width: 200px;
+}
+
+.congrats-placeholder__item-description {
+	@include congrats-placeholder-text;
+	width: 154px;
+}
+
+.congrats-placeholder__item-buttons {
+	border: 1px solid var(--color-neutral-10);
+	border-radius: 4px;
+	padding: 10.5px 23px;
+	flex: none;
+}
+
+.congrats-placeholder__item-buttons::after {
+	content: "";
+	display: block;
+	@include placeholder(--color-neutral-5);
+	width: 68px;
+	height: 17px;
+	border-radius: 20px; /* stylelint-disable-line scales/radii */
+}
+
+.congrats-placeholder__footer {
+	display: flex;
+	gap: 40px;
+	padding: 0 25px;
+}
+
+.congrats-placeholder__footer-item {
+	flex: 1;
+}
+
+.congrats-placeholder__footer-item-title {
+	@include congrats-placeholder-title;
+	width: 200px;
+	margin-bottom: 12px;
+}
+
+.congrats-placeholder__footer-item-description {
+	@include congrats-placeholder-text;
+	width: 154px;
+	margin-bottom: 12px;
+}
+
+.congrats-placeholder__footer-item-description:last-child {
+	margin-top: 12px;
+	margin-bottom: 0;
+}
+
+.congrats-placeholder__footer-item-description--s {
+	width: 120px;
+}
+
+.congrats-placeholder__footer-item-description--m {
+	width: 154px;
+}
+
+.congrats-placeholder__footer-item-description--l {
+	width: 200px;
+}
+
+@media ( max-width: $break-medium ) {
+	.congrats-placeholder__footer,
+	.congrats-placeholder__item {
+		flex-direction: column;
+	}
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6500

## Proposed Changes
With this PR, we are introducing a new placeholder (when the congrats page is being loaded) according to the new congrats page designs - VLoPHWqcewxNKZYjjkDu3O-fi-3444_434

## Testing Instructions
1) To simplify testing - let's freeze the placeholder (loading state) by:
``` JS
diff --git a/client/my-sites/checkout/checkout-thank-you/index.tsx b/client/my-sites/checkout/checkout-thank-you/index.tsx
index e3726549b4..a0f6026db1 100644
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -536,7 +536,7 @@ export class CheckoutThankYou extends Component<
                let wasDomainOnly = false;
                let wasBulkDomainTransfer = false;

-               if ( ! this.isDataLoaded() ) {
+               if ( true ) {
                        return <PlaceholderThankYou />;
                }
```
2) Buy, for example, a domain
3) At the end of a day - assert that you see the next page <br /><img width="825" alt="Screenshot 2024-04-12 at 14 14 36" src="https://github.com/Automattic/wp-calypso/assets/5598437/659288a2-b52e-4b44-838b-366b8a1843bb">
4) Also assert that mobile version also looks good <br /> <img width="284" alt="Screenshot 2024-04-12 at 14 15 19" src="https://github.com/Automattic/wp-calypso/assets/5598437/a73f8755-61a3-4592-8cc6-955a86ba514e">