### PR TITLE
A4A: Move the User profile dropdown at the sidebar's footer.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/marketplace.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/marketplace.tsx
@@ -60,7 +60,7 @@ export default function ( { path }: Props ) {
 				},
 			} }
 			menuItems={ menuItems }
-			withGetHelpLink
+			withUserProfileFooter
 		/>
 	);
 }

--- a/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
@@ -86,7 +86,7 @@ export default function ( { path }: Props ) {
 				},
 			} }
 			menuItems={ menuItems }
-			withGetHelpLink
+			withUserProfileFooter
 		/>
 	);
 }

--- a/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
@@ -95,7 +95,7 @@ export default function ( { path }: Props ) {
 				},
 			} }
 			menuItems={ menuItems }
-			withGetHelpLink
+			withUserProfileFooter
 		/>
 	);
 }


### PR DESCRIPTION
This PR standardizes where the User profile dropdown should be positioned in the sidebar.

| Before | After |
| :---:   | :---: |
| <img width="268" alt="Screenshot 2024-04-12 at 9 09 16 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/cf86cdfd-b5fe-4bdb-8b25-af942e97ce8a">  | <img width="270" alt="Screenshot 2024-04-12 at 9 03 57 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f8de2695-eb6c-4e85-812a-a927abb5cf7f">   |





Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/278

## Proposed Changes

* Update the Sites, Purchases, and Marketplace sections to render the User profile dropdown at the sidebar's footer.

## Testing Instructions

* Use the A4A live link below and go to `/`.
* Navigate all Sidebar sections and confirm the User profile dropdown is always rendered at the bottom.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?