### PR TITLE
A4A: Fix secondary button global style.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/overview/header-actions/style.scss
@@ -15,20 +15,10 @@
 		border-right: none;
 		font-size: 1rem;
 		height: 40px;
-
-		&:hover {
-			background: #fff;
-			border-color: var(--color-neutral-20);
-		}
 	}
 
 	.button.split-button__toggle {
 		border-radius: 0 4px 4 0;
-
-		&:hover {
-			background: #fff;
-			border-color: var(--color-neutral-20);
-		}
 
 		svg {
 			fill: #000;

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -115,16 +115,10 @@
 }
 
 .license-details__actions .button.is-compact {
-	border: 1px solid var(--color-accent);
 	padding: 8px 14px;
 	font-size: 1rem;
 	font-weight: 500;
 	line-height: 1.375;
-
-	&:hover {
-		background-color: var(--color-accent-90);
-
-	}
 
 	@include break-large {
 		padding: 7px;

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/style.scss
@@ -31,7 +31,6 @@
 
 	.button {
 		margin-block: 1.75rem;
-		color: var(--color-neutral);
 	}
 }
 

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
@@ -13,20 +13,10 @@
 	.button.split-button__main {
 		border-radius: 4px 0 0 4px;
 		border-right: none;
-
-		&:hover {
-			background: #fff;
-			border-color: var(--color-neutral-20);
-		}
 	}
 
 	.button.split-button__toggle {
 		border-radius: 0 4px 4 0;
-
-		&:hover {
-			background: #fff;
-			border-color: var(--color-neutral-20);
-		}
 
 		svg {
 			fill: #000;

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -89,6 +89,16 @@
 
 		box-sizing: border-box;
 		border-radius: 4px;
+
+		background-color: var(--color-surface);
+		border-color: var(--color-accent-5);
+		fill: var(--color-accent-100);
+		color: var(--color-accent-100);
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-accent-0);
+		}
 	}
 
 	.button.split-button__toggle {
@@ -103,12 +113,14 @@
 		background-color: var(--color-primary-50);
 		border-color: var(--color-primary-50);
 		fill: var(--color-text-inverted);
+		color: var(--color-text-inverted);
 
 		&:hover,
 		&:focus,
 		&:focus-visible {
 			background-color: var(--color-primary-70);
 			border-color: var(--color-primary-70);
+			fill: var(--color-text-inverted);
 			color: var(--color-text-inverted);
 			box-shadow: none;
 			border: 1px solid;

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -116,7 +116,6 @@
 		color: var(--color-text-inverted);
 
 		&:hover,
-		&:focus,
 		&:focus-visible {
 			background-color: var(--color-primary-70);
 			border-color: var(--color-primary-70);


### PR DESCRIPTION
This PR standardizes the Secondary button style. A couple of conflicting styles were also removed to ensure we have consistent button behavior.

**Before (normal )**
<img width="430" alt="Screenshot 2024-04-12 at 9 50 00 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c840c4ef-c2be-42c7-89e0-c4c3b3ee2f10">

**After ( normal | hovered/focused )**
<img width="432" alt="Screenshot 2024-04-12 at 9 50 29 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/373a2db1-6893-4988-8590-44bbadea2389">
<img width="430" alt="Screenshot 2024-04-12 at 9 55 13 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/588a9773-5c98-4ec0-a6ba-8e74a6794be6">


Closes  https://github.com/Automattic/automattic-for-agencies-dev/issues/276

## Proposed Changes

* Add global style for the Secondary button.
* Remove conflicting styles that were defined for some of the components.

## Testing Instructions

* Use the live link below and navigate all pages that contain the Secondary button. Confirm that it all follows the global style.
   * Overview page - Split button / Contact button `/overview`
   * Sites page - Split button `/sites`
   * Marketplace - Product card `/marketplace/products`
   * Marketplace - Checkout button `marketplace/checkout`
   * Licenses page  - Action buttons | empty list button `/purchases/licenses`
   * Payment method form page `/purchases/payment-methods/add`
   * Invoices page - `/purchases/invoices`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?