### PR TITLE
Pattern Library: Fix category filter tracking

### DIFF
--- a/client/blocks/category-pill-navigation/README.md
+++ b/client/blocks/category-pill-navigation/README.md
@@ -19,11 +19,13 @@ function render() {
 			selectedCategory="category-2"
 			buttons={ [
 				{
+					id: 'discover',
 					icon: <Icon icon={ iconStar } size={ 30 } />,
 					label: 'Discover',
 					link: '/',
 				},
 				{
+					id: 'all',
 					icon: <Icon icon={ iconCategory } size={ 26 } />,
 					label: 'All categories',
 					link: '/',

--- a/client/blocks/category-pill-navigation/README.md
+++ b/client/blocks/category-pill-navigation/README.md
@@ -62,6 +62,7 @@ This property should match the `id` of one of the items in the `categories` arra
 An optional array of additional link objects to prepend to the main list of links:
 ```
 {
+	id: string; // The identifier of the button, typically used for click tracking
 	icon: string; // The icon displayed before the label
 	label: string; // The text displayed on the link
 	link: string; // The URL that the link points to

--- a/client/blocks/category-pill-navigation/docs/example.tsx
+++ b/client/blocks/category-pill-navigation/docs/example.tsx
@@ -21,11 +21,13 @@ export const CategoryPillNavigationExample: FunctionComponent = () => {
 					selectedCategoryId="category-2"
 					buttons={ [
 						{
+							id: 'discover',
 							icon: <Icon icon={ iconStar } size={ 30 } />,
 							label: 'Discover',
 							link: '/',
 						},
 						{
+							id: 'all',
 							icon: <Icon icon={ iconCategory } size={ 26 } />,
 							label: 'All categories',
 							link: '/',

--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -24,7 +24,7 @@ type CategoryPillNavigationProps = {
 		link: string;
 	}[];
 	selectedCategoryId: string;
-	onSelect?: ( selectedId: string ) => null;
+	onSelect?: ( selectedId: string ) => void;
 };
 
 export const CategoryPillNavigation = ( {

--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -7,6 +7,7 @@ import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useRtl } from 'i18n-calypso';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
+import { useRecordPatternsEvent } from 'calypso/my-sites/patterns/hooks/use-record-patterns-event';
 
 import './style.scss';
 
@@ -14,6 +15,7 @@ type CategoryPillNavigationProps = {
 	buttons?: {
 		icon: React.ReactElement< typeof Icon >;
 		label: string;
+		id: string;
 		link: string;
 		isActive?: boolean;
 	}[];
@@ -36,6 +38,7 @@ export const CategoryPillNavigation = ( {
 	const [ showRightArrow, setShowRightArrow ] = useState( false );
 	const listInnerRef = useRef< HTMLDivElement | null >( null );
 	const isRtl = useRtl();
+	const { recordPatternsEvent } = useRecordPatternsEvent();
 
 	const checkScrollArrows = () => {
 		if ( ! listInnerRef.current ) {
@@ -101,6 +104,9 @@ export const CategoryPillNavigation = ( {
 					{ buttons?.map( ( button ) => (
 						<SelectDropdown.Item
 							key={ button.label }
+							onClick={ () =>
+								recordPatternsEvent( 'calypso_pattern_library_filter', { category: button.id } )
+							}
 							path={ addLocaleToPathLocaleInFront( button.link, locale ) }
 							selected={ button.isActive }
 						>
@@ -110,6 +116,9 @@ export const CategoryPillNavigation = ( {
 					{ categories?.map( ( category ) => (
 						<SelectDropdown.Item
 							key={ category.id }
+							onClick={ () =>
+								recordPatternsEvent( 'calypso_pattern_library_filter', { category: category.id } )
+							}
 							path={ addLocaleToPathLocaleInFront( category.link, locale ) }
 							selected={ category.id === selectedCategoryId }
 						>
@@ -129,6 +138,9 @@ export const CategoryPillNavigation = ( {
 						<LocalizedLink
 							key={ button.label }
 							href={ button.link }
+							onClick={ () =>
+								recordPatternsEvent( 'calypso_pattern_library_filter', { category: button.id } )
+							}
 							className={ classnames( 'category-pill-navigation__button', {
 								'is-active': button.isActive,
 							} ) }
@@ -169,6 +181,9 @@ export const CategoryPillNavigation = ( {
 						<LocalizedLink
 							key={ category.id }
 							href={ category.link }
+							onClick={ () =>
+								recordPatternsEvent( 'calypso_pattern_library_filter', { category: category.id } )
+							}
 							className={ classnames( 'category-pill-navigation__button', {
 								'is-active': category.id === selectedCategoryId,
 							} ) }

--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -31,7 +31,7 @@ export const CategoryPillNavigation = ( {
 	buttons,
 	categories,
 	selectedCategoryId,
-	onSelect,
+	onSelect = () => {},
 }: CategoryPillNavigationProps ) => {
 	const locale = useLocale();
 	const isMobile = useMobileBreakpoint();

--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -7,7 +7,6 @@ import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useRtl } from 'i18n-calypso';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
-import { useRecordPatternsEvent } from 'calypso/my-sites/patterns/hooks/use-record-patterns-event';
 
 import './style.scss';
 
@@ -25,12 +24,14 @@ type CategoryPillNavigationProps = {
 		link: string;
 	}[];
 	selectedCategoryId: string;
+	onSelect?: ( selectedId: string ) => null;
 };
 
 export const CategoryPillNavigation = ( {
 	buttons,
 	categories,
 	selectedCategoryId,
+	onSelect,
 }: CategoryPillNavigationProps ) => {
 	const locale = useLocale();
 	const isMobile = useMobileBreakpoint();
@@ -38,7 +39,6 @@ export const CategoryPillNavigation = ( {
 	const [ showRightArrow, setShowRightArrow ] = useState( false );
 	const listInnerRef = useRef< HTMLDivElement | null >( null );
 	const isRtl = useRtl();
-	const { recordPatternsEvent } = useRecordPatternsEvent();
 
 	const checkScrollArrows = () => {
 		if ( ! listInnerRef.current ) {
@@ -104,9 +104,7 @@ export const CategoryPillNavigation = ( {
 					{ buttons?.map( ( button ) => (
 						<SelectDropdown.Item
 							key={ button.label }
-							onClick={ () =>
-								recordPatternsEvent( 'calypso_pattern_library_filter', { category: button.id } )
-							}
+							onClick={ () => onSelect( button.id ) }
 							path={ addLocaleToPathLocaleInFront( button.link, locale ) }
 							selected={ button.isActive }
 						>
@@ -116,9 +114,7 @@ export const CategoryPillNavigation = ( {
 					{ categories?.map( ( category ) => (
 						<SelectDropdown.Item
 							key={ category.id }
-							onClick={ () =>
-								recordPatternsEvent( 'calypso_pattern_library_filter', { category: category.id } )
-							}
+							onClick={ () => onSelect( category.id ) }
 							path={ addLocaleToPathLocaleInFront( category.link, locale ) }
 							selected={ category.id === selectedCategoryId }
 						>
@@ -138,9 +134,7 @@ export const CategoryPillNavigation = ( {
 						<LocalizedLink
 							key={ button.label }
 							href={ button.link }
-							onClick={ () =>
-								recordPatternsEvent( 'calypso_pattern_library_filter', { category: button.id } )
-							}
+							onClick={ () => onSelect( button.id ) }
 							className={ classnames( 'category-pill-navigation__button', {
 								'is-active': button.isActive,
 							} ) }
@@ -181,9 +175,7 @@ export const CategoryPillNavigation = ( {
 						<LocalizedLink
 							key={ category.id }
 							href={ category.link }
-							onClick={ () =>
-								recordPatternsEvent( 'calypso_pattern_library_filter', { category: category.id } )
-							}
+							onClick={ () => onSelect( category.id ) }
 							className={ classnames( 'category-pill-navigation__button', {
 								'is-active': category.id === selectedCategoryId,
 							} ) }

--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -2,7 +2,12 @@ import { addLocaleToPathLocaleInFront, useLocale } from '@automattic/i18n-utils'
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
-export function LocalizedLink( { children, href = '', ...props }: JSX.IntrinsicElements[ 'a' ] ) {
+export function LocalizedLink( {
+	children,
+	href = '',
+	onClick = () => null,
+	...props
+}: JSX.IntrinsicElements[ 'a' ] ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	// `addLocaleToPathLocaleInFront` retrieves the active locale differently from `useLocale`.
@@ -11,7 +16,7 @@ export function LocalizedLink( { children, href = '', ...props }: JSX.IntrinsicE
 	const localizedHref = isLoggedIn ? href : addLocaleToPathLocaleInFront( href, locale );
 
 	return (
-		<a { ...props } href={ localizedHref }>
+		<a { ...props } href={ localizedHref } onClick={ onClick }>
 			{ children }
 		</a>
 	);

--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -5,7 +5,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 export function LocalizedLink( {
 	children,
 	href = '',
-	onClick = () => null,
+	onClick = () => {},
 	...props
 }: JSX.IntrinsicElements[ 'a' ] ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -46,17 +46,6 @@ export function PatternsPageViewTracker( {
 	} );
 
 	useEffect( () => {
-		if ( category && isDevAccount !== undefined ) {
-			recordTracksEvent( 'calypso_pattern_library_filter', {
-				category,
-				is_logged_in: isLoggedIn,
-				user_is_dev_account: isDevAccount ? '1' : '0',
-				type: getTracksPatternType( patternTypeFilter ),
-			} );
-		}
-	}, [ category, isDevAccount, isLoggedIn, patternTypeFilter ] );
-
-	useEffect( () => {
 		if ( isDevAccount !== undefined && patternsCount !== undefined ) {
 			recordTracksEvent( 'calypso_pattern_library_view', {
 				name: patternPermalinkName,

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -290,6 +290,7 @@ export const PatternLibrary = ( {
 							buttons={ [
 								{
 									icon: <Icon icon={ iconCategory } size={ 26 } />,
+									id: 'all',
 									label: translate( 'All Categories' ),
 									link: addLocaleToPathLocaleInFront( '/patterns' ),
 									isActive: ! category,

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -28,6 +28,7 @@ import { CATEGORY_PAGE } from 'calypso/my-sites/patterns/constants';
 import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
+import { useRecordPatternsEvent } from 'calypso/my-sites/patterns/hooks/use-record-patterns-event';
 import { filterPatternsByTerm } from 'calypso/my-sites/patterns/lib/filter-patterns-by-term';
 import { getPatternPermalink } from 'calypso/my-sites/patterns/lib/get-pattern-permalink';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
@@ -117,6 +118,7 @@ export const PatternLibrary = ( {
 	const locale = useLocale();
 	const translate = useTranslate();
 	const navRef = useRef< HTMLDivElement >( null );
+	const { recordPatternsEvent } = useRecordPatternsEvent();
 	const { category, searchTerm, isGridView, patternTypeFilter, referrer, patternPermalinkId } =
 		usePatternsContext();
 
@@ -297,6 +299,9 @@ export const PatternLibrary = ( {
 								},
 							] }
 							categories={ categoryNavList }
+							onSelect={ ( selectedId ) =>
+								recordPatternsEvent( 'calypso_pattern_library_filter', { category: selectedId } )
+							}
 						/>
 
 						<div className="pattern-library__body-search">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6559

## Proposed Changes

Currently, `calypso_pattern_library_filter` is tracked whenever users land the pattern category page, via direct URL or selecting a category from the nav. We should only track the event when user interacts with the category nav / dropdown. And when "All Categories" is selected, the event is fired with `category: all`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/patterns/about` without clicking on the category nav.
* Assert that `calypso_pattern_library_filter` is **not** fired.

### Desktop

* Click on any category.
* Assert that `calypso_pattern_library_filter` is fired and the correct `category` id is reported.
* Click on "All Categories".
* Assert that `calypso_pattern_library_filter` is fired and `category: all` is reported.

### Mobile

* Enable mobile view using the browser simulator.
* Select a category from the dropdown.
* Assert that `calypso_pattern_library_filter` is fired and the correct `category` id is reported.
* Select "All Categories" from the dropdown.
* Assert that `calypso_pattern_library_filter` is fired and `category: all` is reported.
