### PR TITLE
A4A: Change the overview checklist items to hover in color.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -60,12 +60,12 @@
 		&.completed.enabled > a:focus,
 		&.pending > a:focus {
 			.checklist-item__text {
-				color: var(--color-jetpack);
+				color: var(--color-primary);
 			}
 
 			.checklist-item__chevron,
 			.checklist-item__checkmark {
-				fill: var(--color-jetpack);
+				fill: var(--color-primary);
 			}
 		}
 	}


### PR DESCRIPTION
Change Overview checklist items hover color.

**Before**
<img width="438" alt="Screenshot 2024-04-12 at 11 10 09 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a356c843-2843-4f3a-82c7-8ef5b4eb84ba">

**After**
<img width="483" alt="Screenshot 2024-04-12 at 11 09 56 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/539c0a18-679e-4252-bf09-9bbab87ae987">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/279 

## Proposed Changes

* Changed the **text** and **fill** hover color to Primary for Checklist items.

## Testing Instructions

* Use the A4A live link below and go to `\overview`
* Hover over the Overview Checklist and confirm it uses the primary color for the text and icons.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?