### PR TITLE
Scheduled updates: Remove site context dependency from the form "plugins" control

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form-plugins.tsx
@@ -8,11 +8,13 @@ import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useEffect, useState } from 'react';
-import { type CorePlugin, useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import { MAX_SELECTABLE_PLUGINS } from './config';
-import { useSiteSlug } from './hooks/use-site-slug';
+import type { CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
 
 interface Props {
+	plugins: CorePlugin[];
+	isPluginsFetching: boolean;
+	isPluginsFetched: boolean;
 	initPlugins?: string[];
 	touched?: boolean;
 	error?: string;
@@ -21,19 +23,21 @@ interface Props {
 	onChange?: ( value: string[] ) => void;
 }
 export function ScheduleFormPlugins( props: Props ) {
-	const { initPlugins = [], error, showError, onChange, onTouch } = props;
-	const siteSlug = useSiteSlug();
+	const {
+		plugins,
+		isPluginsFetching,
+		isPluginsFetched,
+		initPlugins = [],
+		error,
+		showError,
+		onChange,
+		onTouch,
+	} = props;
 	const translate = useTranslate();
 
 	const [ pluginSearchTerm, setPluginSearchTerm ] = useState( '' );
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( initPlugins );
 	const [ fieldTouched, setFieldTouched ] = useState( false );
-
-	const {
-		data: plugins = [],
-		isLoading: isPluginsFetching,
-		isFetched: isPluginsFetched,
-	} = useCorePluginsQuery( siteSlug, true, true );
 
 	useEffect( () => onTouch?.( fieldTouched ), [ fieldTouched ] );
 	useEffect( () => onChange?.( selectedPlugins ), [ selectedPlugins ] );

--- a/client/blocks/plugins-update-manager/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form-plugins.tsx
@@ -15,7 +15,7 @@ interface Props {
 	plugins: CorePlugin[];
 	isPluginsFetching: boolean;
 	isPluginsFetched: boolean;
-	initPlugins?: string[];
+	selectedPlugins?: string[];
 	touched?: boolean;
 	error?: string;
 	showError?: boolean;
@@ -25,9 +25,9 @@ interface Props {
 export function ScheduleFormPlugins( props: Props ) {
 	const {
 		plugins,
+		selectedPlugins: initPlugins = [],
 		isPluginsFetching,
 		isPluginsFetched,
-		initPlugins = [],
 		error,
 		showError,
 		onChange,

--- a/client/blocks/plugins-update-manager/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form-plugins.tsx
@@ -91,7 +91,7 @@ export function ScheduleFormPlugins( props: Props ) {
 					{ translate( 'Plugins not listed below are automatically updated by WordPress.com.' ) }
 				</Text>
 			) }
-			<div className="checkbox-options">
+			<div className="form-control-container">
 				<SearchControl id="plugins" onChange={ setPluginSearchTerm } value={ pluginSearchTerm } />
 				<div className="checkbox-options-container">
 					{ isPluginsFetching && <Spinner /> }

--- a/client/blocks/plugins-update-manager/schedule-form.scss
+++ b/client/blocks/plugins-update-manager/schedule-form.scss
@@ -3,6 +3,12 @@
 		width: 100%;
 	}
 
+	.form-control-container {
+		padding: 1.5rem;
+		border: solid 1px var(--studio-gray-10);
+		border-radius: 2px;
+	}
+
 	.components-text-control__input {
 		border-color: var(--studio-gray-10);
 	}
@@ -47,12 +53,6 @@
 			border: solid 1px var(--studio-gray-10);
 			background-color: var(--studio-white);
 		}
-	}
-
-	.checkbox-options {
-		padding: 1.5rem;
-		border: solid 1px var(--studio-gray-10);
-		border-radius: 2px;
 	}
 
 	.checkbox-options-container {

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -2,6 +2,7 @@ import { Flex, FlexItem } from '@wordpress/components';
 import { useState, useEffect } from 'react';
 import { ScheduleFormFrequency } from 'calypso/blocks/plugins-update-manager/schedule-form-frequency';
 import { ScheduleFormPlugins } from 'calypso/blocks/plugins-update-manager/schedule-form-plugins';
+import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import {
 	useCreateUpdateScheduleMutation,
 	useEditUpdateScheduleMutation,
@@ -64,6 +65,11 @@ export const ScheduleForm = ( props: Props ) => {
 	};
 	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, serverSyncCallbacks );
 	const { editUpdateSchedule } = useEditUpdateScheduleMutation( siteSlug, serverSyncCallbacks );
+	const {
+		data: plugins = [],
+		isLoading: isPluginsFetching,
+		isFetched: isPluginsFetched,
+	} = useCorePluginsQuery( siteSlug, true, true );
 
 	const onFormSubmit = () => {
 		const formValid = ! Object.values( validationErrors ).filter( ( e ) => !! e ).length;
@@ -139,6 +145,9 @@ export const ScheduleForm = ( props: Props ) => {
 				</FlexItem>
 				<FlexItem>
 					<ScheduleFormPlugins
+						plugins={ plugins }
+						isPluginsFetching={ isPluginsFetching }
+						isPluginsFetched={ isPluginsFetched }
 						initPlugins={ selectedPlugins }
 						error={ validationErrors?.plugins }
 						showError={ fieldTouched?.plugins }

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -146,9 +146,9 @@ export const ScheduleForm = ( props: Props ) => {
 				<FlexItem>
 					<ScheduleFormPlugins
 						plugins={ plugins }
+						selectedPlugins={ selectedPlugins }
 						isPluginsFetching={ isPluginsFetching }
 						isPluginsFetched={ isPluginsFetched }
-						initPlugins={ selectedPlugins }
 						error={ validationErrors?.plugins }
 						showError={ fieldTouched?.plugins }
 						onChange={ setSelectedPlugins }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/89473

## Proposed Changes

* Get rid of the site context from the "Select Plugins" control

I'm preparing the control to be reusable in different contexts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/{site_slug}`
* Check if schedule creation and editing works as before the change

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?