### PR TITLE
A4A: Make the Hosting Preview Pane tab available in production

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -125,18 +125,14 @@ export function OverviewPreviewPane( {
 				setSelectedSiteFeature,
 				<JetpackActivityPreview site={ site } />
 			),
-			...( isEnabled( 'a4a/hosting-preview-pane' )
-				? [
-						createFeaturePreview(
-							HOSTING_OVERVIEW_ID,
-							translate( 'Hosting' ),
-							true,
-							selectedSiteFeature,
-							setSelectedSiteFeature,
-							<HostingOverviewPreview site={ site } />
-						),
-				  ]
-				: [] ),
+			createFeaturePreview(
+				HOSTING_OVERVIEW_ID,
+				translate( 'Hosting' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				<HostingOverviewPreview site={ site } />
+			),
 			...( isEnabled( 'a4a/site-details-pane' )
 				? [
 						createFeaturePreview(

--- a/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
@@ -56,12 +56,6 @@ const HostingOverviewPreview = ( { site }: Props ) => {
 					</div>
 					<div className="hosting__content">
 						<div className="hosting__content-row">
-							<div className="hosting__content-label">Status</div>
-							<div className="hosting__content-value">
-								<div className="hosting__content-live-text">{ translate( 'Live' ) }</div>
-							</div>
-						</div>
-						<div className="hosting__content-row">
 							<div className="hosting__content-label">Host</div>
 							<div className="hosting__content-value">
 								{ formatHostingProviderName( site.hosting_provider_guess ) }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -30,7 +30,6 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"oauth": true,
-		"a4a/hosting-preview-pane": true,
 		"a4a/site-details-pane": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -24,7 +24,6 @@
 	"features": {
 		"a8c-for-agencies": true,
 		"oauth": false,
-		"a4a/hosting-preview-pane": true,
 		"a4a/site-details-pane": true
 	},
 	"enable_all_sections": false,


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/273

## Proposed Changes

This PR opens the Hosting Preview Pane tab to production. We have removed the `Status` row because of technical issues to get an accurate and a reliable value.

This task [Add to the Site Profiles index the site status](https://github.com/Automattic/automattic-for-agencies-dev/issues/264) will be moved and addressed as a maintenance task once we get some input/feedback from Jetpack Data.

<img width="981" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/dca0004f-ada4-4b89-832f-5ab2a31e2b31">


## Testing Instructions

- Check the code, especially the code that removes the feature flag.
- Everything should work as before.
- The Hosting Preview Pane tab should show the rows except the Status value.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
