### PR TITLE
(try)(chore)(e2e) Setup docker logging for the gutenbergCoreE2eBuildType bash scripts  (take 2)

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -147,8 +147,11 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 				name = "Copy Docker Logs"
 				scriptContent = """
 					#!/bin/bash
+					echo "Checkout Directory: %system.teamcity.build.checkoutDir%"
 					mkdir -p %system.teamcity.build.checkoutDir%/logs
 					docker logs $(docker ps -ql --no-trunc) > %system.teamcity.build.checkoutDir%/logs/docker-logs.log
+					# Append 'foobar' to the log file to test file writing
+					echo "foobar" >> %system.teamcity.build.checkoutDir%/logs/docker-logs.log
 				"""
 				executionMode = BuildStep.ExecutionMode.ALWAYS
 			})


### PR DESCRIPTION
Follow-up to: https://github.com/Automattic/wp-calypso/pull/89278.

## Proposed Changes

The `docker-logs.log` file is coming up empty. Try to append a string to the docker-log to troubleshoot where the issue might be.

## Testing Instructions

* Checks should pass;
* Merge and test build.
