### PR TITLE
Updates fix-path function for the blaze dashboard app

### DIFF
--- a/apps/blaze-dashboard/src/lib/fix-path.js
+++ b/apps/blaze-dashboard/src/lib/fix-path.js
@@ -1,6 +1,18 @@
+import config from '@automattic/calypso-config';
+
 // Page library adds the query string at the end of the initial path on the hash.
 // We don't want that, so we clean the query and show the correct path when the app starts
 export default ( path = '' ) => {
 	const index = path.indexOf( '?' );
-	return index >= 0 ? path.substring( 0, index ) : path;
+	path = index >= 0 ? path.substring( 0, index ) : path;
+
+	// Fix the blaze path prefix if its not correct
+	if ( path && ! path.startsWith( config( 'advertising_dashboard_path_prefix' ) ) ) {
+		const segments = path.split( '/' );
+		if ( segments.length > 1 ) {
+			path = path.replace( `/${ segments[ 1 ] }`, config( 'advertising_dashboard_path_prefix' ) );
+		}
+	}
+
+	return path;
 };


### PR DESCRIPTION
We are working on making the Blaze dashboard more compatible with multiple plugins. For this reason, we want to be more friendly when initializing the app and fixing the path we get in the hash.

This change will fix the path prefix of the blaze if we detect that it is not the default configured for the running version of the dashboard. This will allow us to redirect the dashboard in the backend and fix the prefix in the front end.

## Proposed Changes

* Fix the dashboard's initial path if we detect that start with a different path prefix than the one is configured

## Testing Instructions

 * In your sandbox execute `bin/install-plugin.sh blaze update/blaze-dashboard-fix-path-function`
 * Then you need to move the traffic from `widgets.wp.com` to your sandbox.
 * Open any site that has Jetpack Blaze (any self-hosted site will work)
 * Click on Tools->Advertising and verify that the dashboard is loaded correctly
 * Smoke test the dashboard by refreshing the page in different sections and validating that you landed in the correct page after the refresh
 * Now go to the campaigns page and copy the URL
 * Change the path prefix in the URL's hash to any other prefix. (e.g. `wp-admin/tools.php?page=advertising#!/any-other-prefix/campaigns/{SITE_NAME}`
 * In another tab, open that URL and verify that you actually landed on the campaign page (the invalid path prefix should be replaced with the valid `advertising` prefix).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?