### PR TITLE
A4A: Indicate ownership of the Pressable plan

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -1,20 +1,24 @@
-import { Button } from '@automattic/components';
+import { Badge, Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
+import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getHostingLogo, getHostingPageUrl } from '../../lib/hosting';
 import useHostingDescription from '../hooks/use-hosting-description';
-
 import './style.scss';
 type Props = {
 	plan: APIProductFamilyProduct;
+	pressableOwnership?: boolean;
 };
 
-export default function HostingCard( { plan }: Props ) {
+export default function HostingCard( { plan, pressableOwnership }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	//FIXME: We want to unify and refactor this logic, once we decide
+	//on how the UX should look in the end
+	const pressableUrl = 'https://my.pressable.com/agency/auth';
 
 	const { name, description } = useHostingDescription( plan.family_slug );
 
@@ -28,7 +32,10 @@ export default function HostingCard( { plan }: Props ) {
 
 	return (
 		<div className="hosting-card">
-			<div className="hosting-card__header">{ getHostingLogo( plan.family_slug ) }</div>
+			<div className="hosting-card__header">
+				{ getHostingLogo( plan.family_slug ) }
+				{ pressableOwnership && <Badge type="success">{ translate( 'You own this' ) }</Badge> }
+			</div>
 
 			<div className="hosting-card__price">
 				<b className="hosting-card__price-value">
@@ -44,19 +51,31 @@ export default function HostingCard( { plan }: Props ) {
 
 			<p className="hosting-card__description">{ description }</p>
 
-			<Button
-				className="hosting-card__explore-button"
-				href={ getHostingPageUrl( plan.family_slug ) }
-				onClick={ onExploreClick }
-				primary
-			>
-				{ translate( 'Explore %(hosting)s plans', {
-					args: {
-						hosting: name,
-					},
-					comment: '%(hosting)s is the name of the hosting provider.',
-				} ) }
-			</Button>
+			{ ! pressableOwnership ? (
+				<Button
+					className="hosting-card__explore-button"
+					href={ getHostingPageUrl( plan.family_slug ) }
+					onClick={ onExploreClick }
+					primary
+				>
+					{ translate( 'Explore %(hosting)s plans', {
+						args: {
+							hosting: name,
+						},
+						comment: '%(hosting)s is the name of the hosting provider.',
+					} ) }
+				</Button>
+			) : (
+				<Button
+					className="hosting-card__pressable-dashboard-button"
+					target="_blank"
+					rel="norefferer nooppener"
+					href={ pressableUrl }
+				>
+					{ translate( 'Go to Pressable Dashboard' ) }
+					<Icon icon={ external } size={ 18 } />
+				</Button>
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -28,3 +28,23 @@
 	font-weight: 400;
 	margin: 0;
 }
+
+.hosting-card__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+
+	.badge {
+		display: flex;
+		background-color: #b8e6bf;
+		color: #00450c;
+
+	}
+}
+
+.hosting-card__pressable-dashboard-button {
+	svg {
+		margin-inline-start: 6px;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -59,3 +59,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 export default function getPressablePlan( slug: string ) {
 	return PLAN_DATA[ slug ];
 }
+
+export function getAllPressablePlans() {
+	return Object.keys( PLAN_DATA );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/159

## Proposed Changes
We need to indicate if the user already has licenses of pressable, as purchasing new one would count as upgrade/downgrade. This is MVP and further solution would be discussed.

Note: as it's MVP I haven't tried to make code flexible, as we don't yet know what UX would look like at the end.

| Without plan | With Plan |
| ---- | ---- |
| <img width="630" alt="Screenshot 2024-04-12 at 12 29 28 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/65d34ddf-4ee2-4d54-b522-92686fc08a35"> | <img width="695" alt="Screenshot 2024-04-12 at 12 30 01 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/706c09e3-cb2c-47f5-bdee-da695ed3a050"> |

## Testing Instructions
- Without purchasing Pressable plan, navigate to `marketplace/hosting` and check that it looks and acts as before
- Pruchase new Pressable plan and observe the changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?