### PR TITLE
Checkout: Replace unified cost overrides list with per-item overrides

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -14,8 +14,11 @@ import {
 	useShoppingCart,
 } from '@automattic/shopping-cart';
 import {
+	LineItemPrice,
 	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
 	doesIntroductoryOfferHavePriceIncrease,
+	filterCostOverridesForLineItem,
+	getLabel,
 	hasCheckoutVersion,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
@@ -356,5 +359,46 @@ export function LineItemCostOverrides( {
 				/>
 			) ) }
 		</CostOverridesListStyle>
+	);
+}
+
+const ProductTitleAreaForCostOverridesList = styled.div`
+	word-break: break-word;
+	font-size: 14px;
+	display: flex;
+	justify-content: space-between;
+	gap: 0.5em;
+`;
+
+function ProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
+	const translate = useTranslate();
+	const costOverridesList = filterCostOverridesForLineItem( product, translate );
+	const label = getLabel( product );
+	const actualAmountDisplay = formatCurrency(
+		product.item_original_subtotal_integer,
+		product.currency,
+		{
+			isSmallestUnit: true,
+			stripZeros: true,
+		}
+	);
+	return (
+		<div>
+			<ProductTitleAreaForCostOverridesList>
+				<span>{ label }</span>
+				<LineItemPrice actualAmount={ actualAmountDisplay } />
+			</ProductTitleAreaForCostOverridesList>
+			<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
+		</div>
+	);
+}
+
+export function ProductsAndCostOverridesList( { responseCart }: { responseCart: ResponseCart } ) {
+	return (
+		<div>
+			{ responseCart.products.map( ( product ) => (
+				<ProductAndCostOverridesList product={ product } key={ product.uuid } />
+			) ) }
+		</div>
 	);
 }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -371,6 +371,25 @@ const ProductsAndCostOverridesListWrapper = styled.div`
 const SingleProductAndCostOverridesListWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
+	justify-content: space-between;
+	font-size: 12px;
+	font-weight: 400;
+
+	& .cost-overrides-list-item {
+		display: grid;
+		justify-content: space-between;
+		grid-template-columns: auto auto;
+		margin-top: 4px;
+		gap: 0 16px;
+	}
+
+	& .cost-overrides-list-item__reason--is-discount {
+		color: #008a20;
+	}
+
+	& .cost-overrides-list-item__discount {
+		white-space: nowrap;
+	}
 `;
 
 const ProductTitleAreaForCostOverridesList = styled.div`
@@ -404,12 +423,38 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	);
 }
 
+function CouponCostOverride( { responseCart }: { responseCart: ResponseCart } ) {
+	const translate = useTranslate();
+	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
+		return null;
+	}
+	// translators: The label of the coupon line item in checkout, including the coupon code
+	const label = translate( 'Coupon: %(couponCode)s', {
+		args: { couponCode: responseCart.coupon },
+	} );
+	return (
+		<SingleProductAndCostOverridesListWrapper>
+			<div className="cost-overrides-list-item">
+				<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
+					{ label }
+				</span>
+				<span className="cost-overrides-list-item__discount">
+					{ formatCurrency( -responseCart.coupon_savings_total_integer, responseCart.currency, {
+						isSmallestUnit: true,
+					} ) }
+				</span>
+			</div>
+		</SingleProductAndCostOverridesListWrapper>
+	);
+}
+
 export function ProductsAndCostOverridesList( { responseCart }: { responseCart: ResponseCart } ) {
 	return (
 		<ProductsAndCostOverridesListWrapper>
 			{ responseCart.products.map( ( product ) => (
 				<SingleProductAndCostOverridesList product={ product } key={ product.uuid } />
 			) ) }
+			<CouponCostOverride responseCart={ responseCart } />
 		</ProductsAndCostOverridesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -284,7 +284,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	return (
 		<SingleProductAndCostOverridesListWrapper>
 			<ProductTitleAreaForCostOverridesList>
-				<span>{ label }</span>
+				<span className="cost-overrides-list-product__title">{ label }</span>
 				<LineItemPrice actualAmount={ actualAmountDisplay } />
 			</ProductTitleAreaForCostOverridesList>
 			<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -37,21 +37,17 @@ const CostOverridesListStyle = styled.div`
 	justify-content: space-between;
 	font-size: 12px;
 	font-weight: 400;
+	gap: 2px;
 
 	& .cost-overrides-list-item {
 		display: grid;
 		justify-content: space-between;
 		grid-template-columns: auto auto;
-		margin-top: 4px;
 		gap: 0 16px;
 	}
 
 	& .cost-overrides-list-item--coupon {
 		margin-top: 16px;
-	}
-
-	& .cost-overrides-list-item:nth-of-type( 1 ) {
-		margin-top: 0;
 	}
 
 	& .cost-overrides-list-item__actions {
@@ -374,22 +370,7 @@ const SingleProductAndCostOverridesListWrapper = styled.div`
 	justify-content: space-between;
 	font-size: 12px;
 	font-weight: 400;
-
-	& .cost-overrides-list-item {
-		display: grid;
-		justify-content: space-between;
-		grid-template-columns: auto auto;
-		margin-top: 4px;
-		gap: 0 16px;
-	}
-
-	& .cost-overrides-list-item__reason--is-discount {
-		color: #008a20;
-	}
-
-	& .cost-overrides-list-item__discount {
-		white-space: nowrap;
-	}
+	gap: 2px;
 `;
 
 const ProductTitleAreaForCostOverridesList = styled.div`
@@ -433,7 +414,7 @@ function CouponCostOverride( { responseCart }: { responseCart: ResponseCart } ) 
 		args: { couponCode: responseCart.coupon },
 	} );
 	return (
-		<SingleProductAndCostOverridesListWrapper>
+		<CostOverridesListStyle>
 			<div className="cost-overrides-list-item">
 				<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 					{ label }
@@ -444,7 +425,7 @@ function CouponCostOverride( { responseCart }: { responseCart: ResponseCart } ) 
 					} ) }
 				</span>
 			</div>
-		</SingleProductAndCostOverridesListWrapper>
+		</CostOverridesListStyle>
 	);
 }
 

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -362,6 +362,12 @@ export function LineItemCostOverrides( {
 	);
 }
 
+const ProductsAndCostOverridesListWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 1em;
+`;
+
 const ProductTitleAreaForCostOverridesList = styled.div`
 	word-break: break-word;
 	font-size: 14px;
@@ -383,13 +389,13 @@ function ProductAndCostOverridesList( { product }: { product: ResponseCartProduc
 		}
 	);
 	return (
-		<div>
+		<ProductsAndCostOverridesListWrapper>
 			<ProductTitleAreaForCostOverridesList>
 				<span>{ label }</span>
 				<LineItemPrice actualAmount={ actualAmountDisplay } />
 			</ProductTitleAreaForCostOverridesList>
 			<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
-		</div>
+		</ProductsAndCostOverridesListWrapper>
 	);
 }
 

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -368,6 +368,11 @@ const ProductsAndCostOverridesListWrapper = styled.div`
 	gap: 1em;
 `;
 
+const SingleProductAndCostOverridesListWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
+
 const ProductTitleAreaForCostOverridesList = styled.div`
 	word-break: break-word;
 	font-size: 14px;
@@ -376,7 +381,7 @@ const ProductTitleAreaForCostOverridesList = styled.div`
 	gap: 0.5em;
 `;
 
-function ProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
+function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const costOverridesList = filterCostOverridesForLineItem( product, translate );
 	const label = getLabel( product );
@@ -389,22 +394,22 @@ function ProductAndCostOverridesList( { product }: { product: ResponseCartProduc
 		}
 	);
 	return (
-		<ProductsAndCostOverridesListWrapper>
+		<SingleProductAndCostOverridesListWrapper>
 			<ProductTitleAreaForCostOverridesList>
 				<span>{ label }</span>
 				<LineItemPrice actualAmount={ actualAmountDisplay } />
 			</ProductTitleAreaForCostOverridesList>
 			<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
-		</ProductsAndCostOverridesListWrapper>
+		</SingleProductAndCostOverridesListWrapper>
 	);
 }
 
 export function ProductsAndCostOverridesList( { responseCart }: { responseCart: ResponseCart } ) {
 	return (
-		<div>
+		<ProductsAndCostOverridesListWrapper>
 			{ responseCart.products.map( ( product ) => (
-				<ProductAndCostOverridesList product={ product } key={ product.uuid } />
+				<SingleProductAndCostOverridesList product={ product } key={ product.uuid } />
 			) ) }
-		</div>
+		</ProductsAndCostOverridesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -36,8 +36,6 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
-	getSubtotalWithoutDiscounts,
-	filterAndGroupCostOverridesForDisplay,
 	getCreditsLineItemFromCart,
 	hasCheckoutVersion,
 } from '@automattic/wpcom-checkout';
@@ -59,7 +57,7 @@ import getFlowPlanFeatures from '../lib/get-flow-plan-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
 import { CheckIcon } from './check-icon';
-import { CostOverridesList, ProductsAndCostOverridesList } from './cost-overrides-list';
+import { ProductsAndCostOverridesList } from './cost-overrides-list';
 import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
@@ -182,35 +180,12 @@ function CheckoutSummaryPriceList() {
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
-	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
 
-	const subtotalBeforeDiscounts = getSubtotalWithoutDiscounts( responseCart );
 	const shouldUseCheckoutV2 = hasCheckoutVersion( '2' );
 
 	return (
 		<>
-			{ ! shouldUseCheckoutV2 && costOverridesList.length > 0 && (
-				<CheckoutFirstSubtotalLineItem key="checkout-summary-line-item-subtotal-one">
-					<span>{ translate( 'Subtotal before discounts' ) }</span>
-					<span>
-						{ formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ) }
-					</span>
-				</CheckoutFirstSubtotalLineItem>
-			) }
-			{ ! shouldUseCheckoutV2 && costOverridesList.length > 0 && (
-				<>
-					<ProductsAndCostOverridesList responseCart={ responseCart } />
-					<hr />
-					<CostOverridesList
-						costOverridesList={ costOverridesList }
-						currency={ responseCart.currency }
-						couponCode={ responseCart.coupon }
-					/>
-				</>
-			) }
+			{ ! shouldUseCheckoutV2 && <ProductsAndCostOverridesList responseCart={ responseCart } /> }
 			<CheckoutSummaryAmountWrapper>
 				<CheckoutSubtotalSection>
 					<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
@@ -965,19 +940,6 @@ const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	padding: 20px 0;
 	margin-top: 20px;
-`;
-
-const CheckoutFirstSubtotalLineItem = styled.div`
-	display: flex;
-	flex-wrap: wrap;
-	font-size: 14px;
-	justify-content: space-between;
-	line-height: 20px;
-	margin-bottom: 16px;
-
-	.is-loading & {
-		animation: ${ pulse } 1.5s ease-in-out infinite;
-	}
 `;
 
 const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -59,7 +59,7 @@ import getFlowPlanFeatures from '../lib/get-flow-plan-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
 import { CheckIcon } from './check-icon';
-import { CostOverridesList } from './cost-overrides-list';
+import { CostOverridesList, ProductsAndCostOverridesList } from './cost-overrides-list';
 import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
@@ -201,11 +201,15 @@ function CheckoutSummaryPriceList() {
 				</CheckoutFirstSubtotalLineItem>
 			) }
 			{ ! shouldUseCheckoutV2 && costOverridesList.length > 0 && (
-				<CostOverridesList
-					costOverridesList={ costOverridesList }
-					currency={ responseCart.currency }
-					couponCode={ responseCart.coupon }
-				/>
+				<>
+					<ProductsAndCostOverridesList responseCart={ responseCart } />
+					<hr />
+					<CostOverridesList
+						costOverridesList={ costOverridesList }
+						currency={ responseCart.currency }
+						couponCode={ responseCart.coupon }
+					/>
+				</>
 			) }
 			<CheckoutSummaryAmountWrapper>
 				<CheckoutSubtotalSection>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -30,7 +30,7 @@ import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
-import { CostOverridesList, LineItemCostOverrides } from './cost-overrides-list';
+import { CouponCostOverride, LineItemCostOverrides } from './cost-overrides-list';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -225,12 +225,9 @@ export function WPOrderReviewLineItems( {
 				/>
 			) }
 			{ shouldUseCheckoutV2 && costOverridesList.length > 0 && (
-				<CostOverridesList
-					costOverridesList={ costOverridesList }
-					currency={ responseCart.currency }
+				<CouponCostOverride
+					responseCart={ responseCart }
 					removeCoupon={ couponLineItem?.hasDeleteButton ? removeCoupon : undefined }
-					couponCode={ responseCart.coupon }
-					showOnlyCoupons
 				/>
 			) }
 		</WPOrderReviewList>

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -523,7 +523,7 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'foo.cash' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'foo.cash' ) ).toHaveLength( 3 );
 		} );
 	} );
 
@@ -540,7 +540,7 @@ describe( 'CheckoutMain', () => {
 		);
 		await waitFor( async () => {
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 3 );
 		} );
 	} );
 
@@ -561,7 +561,7 @@ describe( 'CheckoutMain', () => {
 		await waitFor( () => {
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
 			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 4 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 6 );
 		} );
 	} );
 
@@ -631,7 +631,11 @@ describe( 'CheckoutMain', () => {
 		await waitFor( async () => {
 			expect( navigate ).not.toHaveBeenCalled();
 		} );
-		expect( await screen.findByText( /WordPress.com Personal/ ) ).toBeInTheDocument();
+		expect(
+			await screen.findByText( /WordPress.com Personal/, {
+				ignore: '.cost-overrides-list-product__title',
+			} )
+		).toBeInTheDocument();
 		// There are two versions of the "Gift" label: one shown at small width and one at wide width.
 		expect( ( await screen.findAllByText( 'Gift' ) ).length ).toBeGreaterThan( 0 );
 		expect( errorNotice ).not.toHaveBeenCalled();

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -262,7 +262,7 @@ const DeleteButton = styled( Button )< { theme?: Theme; shouldUseCheckoutV2?: bo
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 
-function LineItemPrice( {
+export function LineItemPrice( {
 	actualAmount,
 	crossedOutAmount,
 	shouldUseCheckoutV2,

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -281,7 +281,7 @@ export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 ): boolean {
 	if (
 		costOverrides?.some( ( costOverride ) => {
-			costOverride.override_code !== 'introductory-offer';
+			! isOverrideCodeIntroductoryOffer( costOverride.override_code );
 		} )
 	) {
 		return false;
@@ -301,7 +301,7 @@ export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 function doesIntroductoryOfferCostOverrideHavePriceIncrease(
 	costOverride: ResponseCartCostOverride
 ): boolean {
-	if ( costOverride.override_code !== 'introductory-offer' ) {
+	if ( ! isOverrideCodeIntroductoryOffer( costOverride.override_code ) ) {
 		return false;
 	}
 	if ( costOverride.old_subtotal_integer >= costOverride.new_subtotal_integer ) {
@@ -355,6 +355,7 @@ export function filterCostOverridesForLineItem(
 				// discount is only temporary and the user will still be charged
 				// the remainder before the next renewal.
 				if (
+					isOverrideCodeIntroductoryOffer( costOverride.override_code ) &&
 					doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 						product.cost_overrides,
 						product.introductory_offer_terms,
@@ -635,4 +636,16 @@ export function doesPurchaseHaveFullCredits( cart: ResponseCart ): boolean {
 	const taxes = cart.total_tax_integer;
 	const totalBeforeCredits = subtotal + taxes;
 	return credits > 0 && totalBeforeCredits > 0 && credits >= totalBeforeCredits;
+}
+
+export function isOverrideCodeIntroductoryOffer( overrideCode: string ): boolean {
+	switch ( overrideCode ) {
+		case 'introductory-offer':
+			return true;
+		case 'prorated-introductory-offer':
+			return true;
+		case 'quantity-upgrade-introductory-offer':
+			return true;
+	}
+	return false;
 }


### PR DESCRIPTION
Since https://github.com/Automattic/wp-calypso/pull/86360, we display a list of cost overrides in the checkout sidebar. This is in addition to the list of line items in the main checkout column which includes basic information about discounts like the original price and the current price, but the cost override list is more detailed. These discounts are grouped by their human-readable reason, so if two cart items have the same discount (with some exceptions), their discount amounts will be merged together and only one discount item will be shown.

As part of the checkout v2 design, the list of products was moved entirely from the main column to the sidebar and the list of cost overrides was altered in https://github.com/Automattic/wp-calypso/pull/87732 to be per cart item instead of grouped together to help clarify certain types of confusing discounts (eg: for Professional Email).

The checkout v2 design project did not perform well in our testing so it has been put on hold, but this prevents any users from having the clarity of the per-item overrides.

## Proposed Changes

This PR replaces the grouped cost overrides list in the checkout v1 sidebar with a per-item list. This gives v1 checkout the benefits of the changes introduced for the per-item cost overrides list for v2 checkout in https://github.com/Automattic/wp-calypso/pull/88480 and https://github.com/Automattic/wp-calypso/pull/87732 without needing to completely switch to v2 checkout.

Since v1 checkout still has the line items in the main column with all their subtext and variant pickers, etc, the list of items in the sidebar can be significantly simplified compared to the details needed for the list in v2.

Before (v1)             |  After (v1) | v2 (unchanged; just for comparison)
:-------------------------:|:--:|:-------------------------:
<img width="328" alt="Screenshot 2024-04-12 at 4 53 50 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/0a8d15f3-fb8f-434e-b34d-dcc1f5b8e39f"> | <img width="309" alt="Screenshot 2024-04-29 at 5 51 08 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/ef9ca3ef-f45d-404d-92ee-be15896b435c"> | <img width="330" alt="Screenshot 2024-04-12 at 4 53 07 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/291b618c-d128-4d1f-9d8b-c89b9d757a27">

## Testing Instructions

- Add various products to your cart that have discounts. You should try different combinations of discounts to see how they behave (introductory offers, domain credits, coupon codes, sale coupons, etc.)
- Visit checkout and verify that the discounts shown in the sidebar look ok.