### PR TITLE
(try)(chore)(e2e) Setup docker logging for the gutenbergCoreE2eBuildType bash scripts (take 3) 

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -144,7 +144,7 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 			}
 
 			step(ScriptBuildStep {
-				name = "Copy Docker Logs"
+				name = "Copy Docker Container Logs and Capture Script Output"
 				scriptContent = """
 					#!/bin/bash
 					exec &> %system.teamcity.build.checkoutDir%/logs/script-run.log  # Redirect all output to script-run.log
@@ -160,18 +160,18 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 						echo "No Docker containers found. No logs to copy."
 					else
 						while read id; do
-							echo "Checking logs for container $id"
-							src_log_file="/var/lib/docker/containers/$id/$id-json.log"
-							dest_log_file="%system.teamcity.build.checkoutDir%/logs/$id-json.log"
+							echo "Checking logs for container ${'$'}id"
+							src_log_file="/var/lib/docker/containers/${'$'}id/${'$'}id-json.log"
+							dest_log_file="%system.teamcity.build.checkoutDir%/logs/${'$'}id-json.log"
 
-							if [ -f "$src_log_file" ]; then
-								cp "$src_log_file" "$dest_log_file"
-								echo "Logs copied from $src_log_file to $dest_log_file"
+							if [ -f "${'$'}src_log_file" ]; then
+								cp "${'$'}src_log_file" "${'$'}dest_log_file"
+								echo "Logs copied from ${'$'}src_log_file to ${'$'}dest_log_file"
 							else
-								echo "Log file $src_log_file does not exist"
+								echo "Log file ${'$'}src_log_file does not exist"
 							fi
 						done < container_ids.txt
-                    fi
+					fi
 
 					echo "Appending 'foobar' to a log file to ensure file system is writable."
 					echo "foobar" >> %system.teamcity.build.checkoutDir%/logs/test-foobar-log.txt

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -146,36 +146,36 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 			step(ScriptBuildStep {
 				name = "Copy Docker Logs"
 				scriptContent = """
-                    #!/bin/bash
-                    exec &> %system.teamcity.build.checkoutDir%/logs/script-run.log  # Redirect all output to script-run.log
-                    set -x  # Enable debugging
+					#!/bin/bash
+					exec &> %system.teamcity.build.checkoutDir%/logs/script-run.log  # Redirect all output to script-run.log
+					set -x  # Enable debugging
 
-                    echo "Checkout Directory: %system.teamcity.build.checkoutDir%"
-                    mkdir -p %system.teamcity.build.checkoutDir%/logs
+					echo "Checkout Directory: %system.teamcity.build.checkoutDir%"
+					mkdir -p %system.teamcity.build.checkoutDir%/logs
 
-                    echo "Attempting to copy logs for all known containers, regardless of state:"
-                    docker ps -a --no-trunc | awk '{print ${'$'}1}' | tail -n +2 > container_ids.txt
+					echo "Attempting to copy logs for all known containers, regardless of state:"
+					docker ps -a --no-trunc | awk '{print ${'$'}1}' | tail -n +2 > container_ids.txt
 
-                    if [ ! -s container_ids.txt ]; then
-                        echo "No Docker containers found. No logs to copy."
-                    else
-                        while read id; do
-                            echo "Checking logs for container $id"
-                            src_log_file="/var/lib/docker/containers/$id/$id-json.log"
-                            dest_log_file="%system.teamcity.build.checkoutDir%/logs/$id-json.log"
+					if [ ! -s container_ids.txt ]; then
+						echo "No Docker containers found. No logs to copy."
+					else
+						while read id; do
+							echo "Checking logs for container $id"
+							src_log_file="/var/lib/docker/containers/$id/$id-json.log"
+							dest_log_file="%system.teamcity.build.checkoutDir%/logs/$id-json.log"
 
-                            if [ -f "$src_log_file" ]; then
-                                cp "$src_log_file" "$dest_log_file"
-                                echo "Logs copied from $src_log_file to $dest_log_file"
-                            else
-                                echo "Log file $src_log_file does not exist"
-                            fi
-                        done < container_ids.txt
+							if [ -f "$src_log_file" ]; then
+								cp "$src_log_file" "$dest_log_file"
+								echo "Logs copied from $src_log_file to $dest_log_file"
+							else
+								echo "Log file $src_log_file does not exist"
+							fi
+						done < container_ids.txt
                     fi
 
-                    echo "Appending 'foobar' to a log file to ensure file system is writable."
-                    echo "foobar" >> %system.teamcity.build.checkoutDir%/logs/test-foobar-log.txt
-                    echo "End of Script"
+					echo "Appending 'foobar' to a log file to ensure file system is writable."
+					echo "foobar" >> %system.teamcity.build.checkoutDir%/logs/test-foobar-log.txt
+					echo "End of Script"
 				"""
 				executionMode = BuildStep.ExecutionMode.ALWAYS
 			})

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -80,7 +80,7 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 
 		artifactRules = """
 			gutenberg/artifacts => artifacts
-			logs/docker-logs.log => logs
+			logs/*.log => logs
 		""".trimIndent()
 
 		vcs {
@@ -146,12 +146,36 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 			step(ScriptBuildStep {
 				name = "Copy Docker Logs"
 				scriptContent = """
-					#!/bin/bash
-					echo "Checkout Directory: %system.teamcity.build.checkoutDir%"
-					mkdir -p %system.teamcity.build.checkoutDir%/logs
-					docker logs $(docker ps -ql --no-trunc) > %system.teamcity.build.checkoutDir%/logs/docker-logs.log
-					# Append 'foobar' to the log file to test file writing
-					echo "foobar" >> %system.teamcity.build.checkoutDir%/logs/docker-logs.log
+                    #!/bin/bash
+                    exec &> %system.teamcity.build.checkoutDir%/logs/script-run.log  # Redirect all output to script-run.log
+                    set -x  # Enable debugging
+
+                    echo "Checkout Directory: %system.teamcity.build.checkoutDir%"
+                    mkdir -p %system.teamcity.build.checkoutDir%/logs
+
+                    echo "Attempting to copy logs for all known containers, regardless of state:"
+                    docker ps -a --no-trunc | awk '{print ${'$'}1}' | tail -n +2 > container_ids.txt
+
+                    if [ ! -s container_ids.txt ]; then
+                        echo "No Docker containers found. No logs to copy."
+                    else
+                        while read id; do
+                            echo "Checking logs for container $id"
+                            src_log_file="/var/lib/docker/containers/$id/$id-json.log"
+                            dest_log_file="%system.teamcity.build.checkoutDir%/logs/$id-json.log"
+
+                            if [ -f "$src_log_file" ]; then
+                                cp "$src_log_file" "$dest_log_file"
+                                echo "Logs copied from $src_log_file to $dest_log_file"
+                            else
+                                echo "Log file $src_log_file does not exist"
+                            fi
+                        done < container_ids.txt
+                    fi
+
+                    echo "Appending 'foobar' to a log file to ensure file system is writable."
+                    echo "foobar" >> %system.teamcity.build.checkoutDir%/logs/test-foobar-log.txt
+                    echo "End of Script"
 				"""
 				executionMode = BuildStep.ExecutionMode.ALWAYS
 			})


### PR DESCRIPTION
Follow-up to: https://github.com/Automattic/wp-calypso/pull/89502.

## Proposed Changes

Make the script in the step more verbose and try to capture logs from all containers regardless of state (i.e exited).

## Testing Instructions

* Checks should pass (make sure the syntax is OK);
* Merge and test (the only way to test the new build in TC).
