### PR TITLE
 (try)(chore)(e2e) Log the `Prepare environment` step in `gutenbergCoreE2eBuildType` to troubleshoot it (take 5)

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -105,19 +105,27 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 			bashNodeScript {
 				name = "Prepare environment"
 				scriptContent = """
-					# Clone Gutenberg
-					mkdir gutenberg
+					# Set up the logs directory and define log file path
+					logs_dir="%system.teamcity.build.checkoutDir%/logs"
+					mkdir -p "${'$'}logs_dir"
+					exec &> "${'$'}logs_dir/prepare-environment.log"
+					set -x  # Enable debugging
+
+					echo "Starting environment preparation"
+					mkdir -p gutenberg
 					cd gutenberg
 					git init
 					git remote add origin https://github.com/WordPress/gutenberg.git
 					git fetch --depth=1 origin try/run-e2e-tests-against-wpcom
 					git checkout try/run-e2e-tests-against-wpcom
 
-					# Install deps
+					echo "Installing dependencies"
 					npm ci
 
-					# Build packages
+					echo "Building packages"
 					npm run build:packages
+
+					echo "Environment preparation complete"
 				""".trimIndent()
 				dockerImage = "%docker_image_ci_e2e_gb_core_on_dotcom%"
 				dockerRunParameters = "-u %env.UID% --log-driver=json-file --log-opt max-size=10m --log-opt max-file=3"
@@ -179,7 +187,7 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 					echo "Appending 'foobar' to a log file to ensure file system is writable."
 					echo "foobar" >> "${'$'}logs_dir/test-foobar-log.log"
 					echo "End of Script"
-				"""
+				"""..trimIndent()
 				executionMode = BuildStep.ExecutionMode.ALWAYS
 			})
 		}

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -187,7 +187,7 @@ fun gutenbergCoreE2eBuildType(): BuildType {
 					echo "Appending 'foobar' to a log file to ensure file system is writable."
 					echo "foobar" >> "${'$'}logs_dir/test-foobar-log.log"
 					echo "End of Script"
-				"""..trimIndent()
+				""".trimIndent()
 				executionMode = BuildStep.ExecutionMode.ALWAYS
 			})
 		}


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/89509.

## Proposed Changes

General docker logging didn't work well (see the chain of related PRs for more details). Let's take a step back and try log from the script that runs in the step that fails. Hopefully, the fact it runs from a custom docker instance doesn't hinder the process. I might need to mount a custom volume if so. 

## Testing Instructions

* Checks should pass (make sure the syntax is OK);
* Merge and test (the only way to test the new build in TC).
