### PR TITLE
Site Migration: Fix height when displaying trial message

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -163,7 +163,9 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 				</div>
 			) }
 
-			<UpgradePlanDetails>{ renderCTAs() }</UpgradePlanDetails>
+			<UpgradePlanDetails isEligibleForTrialPlan={ isEligibleForTrialPlan }>
+				{ renderCTAs() }
+			</UpgradePlanDetails>
 		</div>
 	);
 };

--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -40,6 +40,32 @@ $business-plan-color: #7f54b3;
 				}
 			}
 		}
+
+		&.is-not-eligible-for-trial-plan {
+			.import__upgrade-plan-features-container {
+				@include break-medium {
+					height: initial;
+				}
+			}
+
+			.import__upgrade-plan-hosting-details {
+				@include break-medium {
+					margin-top: 12px;
+				}
+			}
+		}
+
+		&.is-not-eligible-for-trial-plan:not(.feature-list-expanded) {
+			.import__upgrade-plan-hosting-details {
+				@include break-medium {
+					margin-top: 27px;
+					height: 392px;
+					margin-bottom: 27px;
+					padding-top: 32px;
+					padding-bottom: 32px;
+				}
+			}
+		}
 	}
 
 	.import__upgrade-plan-features-container {

--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -62,7 +62,7 @@ $business-plan-color: #7f54b3;
 			margin-right: 0;
 			margin-left: 0;
 			width: 324px;
-			height: 400px;
+			min-height: 400px;
 		}
 	}
 

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -17,6 +17,7 @@ import { UpgradePlanHostingDetails } from './upgrade-plan-hosting-details';
 
 interface Props {
 	children: React.ReactNode;
+	isEligibleForTrialPlan: boolean;
 }
 
 export const UpgradePlanDetails = ( props: Props ) => {
@@ -24,7 +25,7 @@ export const UpgradePlanDetails = ( props: Props ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const [ showFeatures, setShowFeatures ] = useState( false );
 
-	const { children } = props;
+	const { children, isEligibleForTrialPlan } = props;
 	const [ selectedPlan, setSelectedPlan ] = useState<
 		typeof PLAN_BUSINESS | typeof PLAN_BUSINESS_MONTHLY
 	>( PLAN_BUSINESS );
@@ -70,6 +71,7 @@ export const UpgradePlanDetails = ( props: Props ) => {
 			<div
 				className={ classnames( 'import__upgrade-plan-container', {
 					'feature-list-expanded': showFeatures,
+					'is-not-eligible-for-trial-plan': ! isEligibleForTrialPlan,
 				} ) }
 			>
 				<div className={ classnames( 'import__upgrade-plan-features-container' ) }>

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-feature-list.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-feature-list.tsx
@@ -57,20 +57,6 @@ export const UpgradePlanFeatureList = ( props: Props ) => {
 							>
 								{ i === 0 && <strong>{ feature?.getTitle() }</strong> }
 								{ i > 0 && <span>{ feature?.getTitle() }</span> }
-								{ i === 2 && (
-									<>
-										<li className={ classnames( 'import__upgrade-plan-feature logo' ) }>
-											<strong>{ __( 'Storage' ) }</strong>
-										</li>
-										<li className={ classnames( 'import__upgrade-plan-feature' ) }>
-											{ storageOptions?.map( ( storage, i ) => (
-												<Badge type="info" key={ i }>
-													{ storage?.getTitle() }
-												</Badge>
-											) ) }
-										</li>
-									</>
-								) }
 							</Plans2023Tooltip>
 						</li>
 					) ) }
@@ -90,6 +76,16 @@ export const UpgradePlanFeatureList = ( props: Props ) => {
 							</Plans2023Tooltip>
 						</li>
 					) ) }
+					<li className={ classnames( 'import__upgrade-plan-feature logo' ) }>
+						<strong>{ __( 'Storage' ) }</strong>
+					</li>
+					<li className={ classnames( 'import__upgrade-plan-feature' ) }>
+						{ storageOptions?.map( ( storage, i ) => (
+							<Badge type="info" key={ i }>
+								{ storage?.getTitle() }
+							</Badge>
+						) ) }
+					</li>
 				</>
 			) }
 		</ul>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix site migration upgrade plan trial migration message overflow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Create new account, add a new site, and select import goal. Go through import flow until you reach the upgrade plan step.
* Verify the upgrade plan card does not overflow when trial text is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?