### PR TITLE
Automattic for Agencies: Hide WordPress.com hosting card from the Overview page

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -54,6 +54,8 @@ const OverviewBodyHosting = () => {
 		},
 	};
 
+	// TODO: Add WordPress.com offering once it's available in the A4A Marketplace
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const wpcom: OfferingItemProps = {
 		//translators: Title for the action card
 		title: translate( 'WordPress.com' ),
@@ -89,7 +91,7 @@ const OverviewBodyHosting = () => {
 			description={ translate(
 				'Choose the hosting that suits your needs from our best-in-class offerings.'
 			) }
-			items={ [ pressable, wpcom ] }
+			items={ [ pressable ] }
 		/>
 	);
 };


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/274

## Proposed Changes

This PR hides the WordPress.com hosting card from the Overview page as we don't support it in A4A yet

## Testing Instructions

- Open the A4A live link
- Verify that you cannot see the WordPress.com hosting card anymore 

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1030" alt="Screenshot 2024-04-15 at 8 54 32 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/881ae903-50ef-465c-8317-77a79b888fe7">
</td>
<td>
<img width="1030" alt="Screenshot 2024-04-15 at 8 54 08 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/37775ade-2caa-4bd9-ba37-9193c4aa6cae">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?