### PR TITLE
Revert "Automattic for Agencies: Add Referrals sidebar & section"

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -15,7 +15,6 @@ export const A4A_MARKETPLACE_HOSTING_WPCOM_LINK = `${ A4A_MARKETPLACE_HOSTING_LI
 export const A4A_MARKETPLACE_CHECKOUT_LINK = `${ A4A_MARKETPLACE_LINK }/checkout`;
 export const A4A_MARKETPLACE_ASSIGN_LICENSE_LINK = `${ A4A_MARKETPLACE_LINK }/assign-license`;
 export const A4A_PURCHASES_LINK = '/purchases';
-export const A4A_REFERRALS_LINK = '/referrals';
 export const A4A_LICENSES_LINK = `${ A4A_PURCHASES_LINK }/licenses`;
 export const A4A_UNASSIGNED_LICENSES_LINK = `${ A4A_LICENSES_LINK }/unassigned`;
 export const A4A_BILLING_LINK = `${ A4A_PURCHASES_LINK }/billing`;

--- a/client/a8c-for-agencies/components/sidebar-menu/main.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/main.tsx
@@ -1,4 +1,4 @@
-import { category, home, tag, currencyDollar, reusableBlock } from '@wordpress/icons';
+import { category, home, tag, currencyDollar } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import Sidebar from '../sidebar';
@@ -9,7 +9,6 @@ import {
 	A4A_PURCHASES_LINK,
 	A4A_LICENSES_LINK,
 	A4A_MARKETPLACE_PRODUCTS_LINK,
-	A4A_REFERRALS_LINK,
 } from './lib/constants';
 import { createItem } from './lib/utils';
 
@@ -71,15 +70,6 @@ export default function ( { path }: Props ) {
 					menu_item: 'Automattic for Agencies / Purchases',
 				},
 				withChevron: true,
-			},
-			{
-				icon: reusableBlock,
-				path: '/',
-				link: A4A_REFERRALS_LINK,
-				title: translate( 'Referrals' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Referrals',
-				},
 			},
 		].map( ( item ) => createItem( item, path ) );
 	}, [ path, translate ] );

--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -1,8 +1,0 @@
-import { type Callback } from '@automattic/calypso-router';
-import MainSidebar from '../../components/sidebar-menu/main';
-
-export const referralsContext: Callback = ( context, next ) => {
-	context.primary = 'Referrals!';
-	context.secondary = <MainSidebar path={ context.path } />;
-	next();
-};

--- a/client/a8c-for-agencies/sections/referrals/index.ts
+++ b/client/a8c-for-agencies/sections/referrals/index.ts
@@ -1,8 +1,0 @@
-import page from '@automattic/calypso-router';
-import { A4A_REFERRALS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { makeLayout, render as clientRender } from 'calypso/controller';
-import * as controller from './controller';
-
-export default function () {
-	page( A4A_REFERRALS_LINK, controller.referralsContext, makeLayout, clientRender );
-}

--- a/client/sections.js
+++ b/client/sections.js
@@ -776,12 +776,6 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
-		name: 'a8c-for-agencies-referrals',
-		paths: [ '/referrals' ],
-		module: 'calypso/a8c-for-agencies/sections/referrals',
-		group: 'a8c-for-agencies',
-	},
-	{
 		name: 'a8c-for-agencies-signup',
 		paths: [ '/signup' ],
 		module: 'calypso/a8c-for-agencies/sections/signup',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -165,7 +165,6 @@
 		"a8c-for-agencies-marketplace": false,
 		"a8c-for-agencies-purchases": false,
 		"a8c-for-agencies-signup": false,
-		"a8c-for-agencies-referrals": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -42,8 +42,7 @@
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,
-		"a8c-for-agencies-signup": true,
-		"a8c-for-agencies-referrals": true
+		"a8c-for-agencies-signup": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -36,8 +36,7 @@
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,
-		"a8c-for-agencies-signup": true,
-		"a8c-for-agencies-referrals": true
+		"a8c-for-agencies-signup": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
Reverting since the Referral tab is visible in Staging and will be visible on production.


Reverts Automattic/wp-calypso#89432