### PR TITLE
Stats: Exclude WordAds & Subscriber stats from paywall

### DIFF
--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -41,16 +41,19 @@ type NavItem = {
 	label: string;
 	path: string;
 	showIntervals: boolean;
+	paywall?: boolean;
 };
 const traffic = {
 	label: translate( 'Traffic' ),
 	path: '/stats',
 	showIntervals: true,
+	paywall: true,
 } as NavItem;
 const insights = {
 	label: translate( 'Insights' ),
 	path: '/stats/insights',
 	showIntervals: false,
+	paywall: true,
 } as NavItem;
 // TODO: Consider adding subscriber counts into this nav item in the future.
 // See client/blocks/subscribers-count/index.jsx.

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -61,6 +61,8 @@ class StatsNavigation extends Component {
 		slug: PropTypes.string,
 		isLegacy: PropTypes.bool,
 		adminUrl: PropTypes.string,
+		showLock: PropTypes.bool,
+		hideModuleSettings: PropTypes.bool,
 	};
 
 	state = {
@@ -138,8 +140,16 @@ class StatsNavigation extends Component {
 	}
 
 	render() {
-		const { slug, selectedItem, interval, isLegacy, showSettingsTooltip, statsAdminVersion } =
-			this.props;
+		const {
+			slug,
+			selectedItem,
+			interval,
+			isLegacy,
+			showSettingsTooltip,
+			statsAdminVersion,
+			showLock,
+			hideModuleSettings,
+		} = this.props;
 		const { pageModules, isPageSettingsTooltipDismissed } = this.state;
 		const { label, showIntervals, path } = navItems[ selectedItem ];
 		const slugPath = slug ? `/${ slug }` : '';
@@ -189,6 +199,7 @@ class StatsNavigation extends Component {
 										selected={ selectedItem === item }
 									>
 										{ navItem.label }
+										{ navItem.paywall && showLock && ' 🔒' }
 									</NavItem>
 								);
 							} ) }
@@ -205,7 +216,8 @@ class StatsNavigation extends Component {
 
 				{ ! isLegacy &&
 					isModuleSettingsSupported &&
-					AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] && (
+					AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] &&
+					! hideModuleSettings && (
 						<PageModuleToggler
 							availableModules={ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] }
 							pageModules={ pageModules }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -440,19 +440,7 @@ export function wordAds( context, next ) {
 
 	bumpStat( 'calypso_wordads_stats_site_period', activeFilter.period + numPeriodAgo );
 
-	context.primary = isPurchaseFlowEnabled ? (
-		<LoadStatsPage>
-			<AsyncLoad
-				require="calypso/my-sites/stats/wordads"
-				placeholder={ PageLoading }
-				path={ context.pathname }
-				date={ date }
-				chartTab={ queryOptions.tab || 'impressions' }
-				context={ context }
-				period={ rangeOfPeriod( activeFilter.period, date ) }
-			/>
-		</LoadStatsPage>
-	) : (
+	context.primary = (
 		<AsyncLoad
 			require="calypso/my-sites/stats/wordads"
 			placeholder={ PageLoading }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -487,21 +487,7 @@ export function emailStats( context, next ) {
 	const validTabs = statType === 'opens' ? [ 'opens_count' ] : [ 'clicks_count' ];
 	const chartTab = validTabs.includes( queryOptions.tab ) ? queryOptions.tab : validTabs[ 0 ];
 
-	context.primary = isPurchaseFlowEnabled ? (
-		<LoadStatsPage>
-			<StatsEmailDetail
-				path={ context.path }
-				postId={ postId }
-				statType={ statType }
-				chartTab={ chartTab }
-				context={ context }
-				givenSiteId={ givenSiteId }
-				period={ rangeOfPeriod( activeFilter.period, date ) }
-				date={ date }
-				isValidStartDate={ isValidStartDate }
-			/>
-		</LoadStatsPage>
-	) : (
+	context.primary = (
 		<StatsEmailDetail
 			path={ context.path }
 			postId={ postId }
@@ -539,13 +525,7 @@ export function emailSummary( context, next ) {
 
 	const date = moment().locale( 'en' );
 
-	context.primary = isPurchaseFlowEnabled ? (
-		<LoadStatsPage>
-			<StatsEmailSummary period={ rangeOfPeriod( activeFilter.period, date ) } />
-		</LoadStatsPage>
-	) : (
-		<StatsEmailSummary period={ rangeOfPeriod( activeFilter.period, date ) } />
-	);
+	context.primary = <StatsEmailSummary period={ rangeOfPeriod( activeFilter.period, date ) } />;
 
 	next();
 }

--- a/client/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check.ts
@@ -3,7 +3,7 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import usePlanUsageQuery from './use-plan-usage-query';
 
-const MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL = 1;
+const MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL = 1000;
 
 export default function useSiteCompulsoryPlanSelectionQualifiedCheck( siteId: number | null ) {
 	const siteCreatedTimeStamp = useSelector( ( state ) =>

--- a/client/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check.ts
@@ -3,7 +3,7 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import usePlanUsageQuery from './use-plan-usage-query';
 
-const MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL = 1000;
+const MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL = 1;
 
 export default function useSiteCompulsoryPlanSelectionQualifiedCheck( siteId: number | null ) {
 	const siteCreatedTimeStamp = useSelector( ( state ) =>

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -90,6 +90,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 		supportCommercialUse,
 		isLegacyCommercialLicense,
 		hasLoadedSitePurchases,
+		hasAnyPlan: isFreeOwned || isCommercialOwned || isPWYWOwned || supportCommercialUse,
 		isLoading: ! hasLoadedSitePurchases || isRequestingSitePurchases,
 	};
 }

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -192,22 +192,21 @@ const StatsPurchasePage = ( {
 	return (
 		<Main fullWidthLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
-
+			{ ! isLoading && (
+				<PageViewTracker
+					path="/stats/purchase/:site"
+					title="Stats > Purchase"
+					from={ query.from ?? '' }
+					variant={ variant }
+					is_upgrade={ +supportCommercialUse }
+					is_site_commercial={ isCommercial === null ? '' : +isCommercial }
+				/>
+			) }
 			<div
 				className={ classNames( 'stats', 'stats-purchase-page', {
 					'stats-purchase-page--is-wpcom': isTypeDetectionEnabled && isWPCOMSite,
 				} ) }
 			>
-				{ ! isLoading && (
-					<PageViewTracker
-						path="/stats/purchase/:site"
-						title="Stats > Purchase"
-						from={ query.from ?? '' }
-						variant={ variant }
-						is_upgrade={ +supportCommercialUse }
-						is_site_commercial={ isCommercial === null ? '' : +isCommercial }
-					/>
-				) }
 				{ /** Only show the navigation header on force redirections and site has no plans */ }
 				{ ! isLoading && ! hasAnyPlan && query.from?.startsWith( 'cmp-red' ) && (
 					<>

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -198,7 +198,8 @@ const StatsPurchasePage = ( {
 					'stats-purchase-page--is-wpcom': isTypeDetectionEnabled && isWPCOMSite,
 				} ) }
 			>
-				{ ! hasAnyPlan && (
+				{ /** Only show the navigation header on force redirections and site has no plans */ }
+				{ ! hasAnyPlan && query.from?.startsWith( 'cmp-red' ) && (
 					<>
 						<NavigationHeader
 							className="stats__section-header modernized-header"
@@ -218,8 +219,7 @@ const StatsPurchasePage = ( {
 							interval="day"
 							siteId={ siteId }
 							slug={ siteSlug }
-							/** Force redirected */
-							showLock={ query.from?.startsWith( 'cmp-red' ) }
+							showLock={ true }
 							hideModuleSettings
 						/>
 					</>

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -74,6 +74,7 @@ const StatsPurchasePage = ( {
 		supportCommercialUse,
 		isLegacyCommercialLicense,
 		hasLoadedSitePurchases,
+		hasAnyPlan,
 	} = useStatsPurchases( siteId );
 
 	useEffect( () => {
@@ -215,7 +216,7 @@ const StatsPurchasePage = ( {
 					interval="day"
 					siteId={ siteId }
 					slug={ siteSlug }
-					showLock
+					showLock={ ! hasAnyPlan && ! isWPCOMSite && ! isVip }
 					hideModuleSettings
 				/>
 				{ ! isLoading && (

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -209,7 +209,7 @@ const StatsPurchasePage = ( {
 					/>
 				) }
 				{ /** Only show the navigation header on force redirections and site has no plans */ }
-				{ ! hasAnyPlan && query.from?.startsWith( 'cmp-red' ) && (
+				{ ! isLoading && ! hasAnyPlan && query.from?.startsWith( 'cmp-red' ) && (
 					<>
 						<NavigationHeader
 							className="stats__section-header modernized-header"

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -198,27 +198,32 @@ const StatsPurchasePage = ( {
 					'stats-purchase-page--is-wpcom': isTypeDetectionEnabled && isWPCOMSite,
 				} ) }
 			>
-				<NavigationHeader
-					className="stats__section-header modernized-header"
-					title={ translate( 'Jetpack Stats' ) }
-					subtitle={ translate(
-						"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
-							},
-						}
-					) }
-					navigationItems={ [] }
-				></NavigationHeader>
-				<StatsNavigation
-					selectedItem="traffic"
-					interval="day"
-					siteId={ siteId }
-					slug={ siteSlug }
-					showLock={ ! hasAnyPlan && ! isWPCOMSite && ! isVip }
-					hideModuleSettings
-				/>
+				{ ! hasAnyPlan && (
+					<>
+						<NavigationHeader
+							className="stats__section-header modernized-header"
+							title={ translate( 'Jetpack Stats' ) }
+							subtitle={ translate(
+								"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
+								{
+									components: {
+										learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
+									},
+								}
+							) }
+							navigationItems={ [] }
+						></NavigationHeader>
+						<StatsNavigation
+							selectedItem="traffic"
+							interval="day"
+							siteId={ siteId }
+							slug={ siteSlug }
+							/** Force redirected */
+							showLock={ query.from?.startsWith( 'cmp-red' ) }
+							hideModuleSettings
+						/>
+					</>
+				) }
 				{ ! isLoading && (
 					<PageViewTracker
 						path="/stats/purchase/:site"

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -9,11 +9,14 @@ import { ProductsList } from '@automattic/data-stores';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
+import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
@@ -38,6 +41,7 @@ import StatsPurchaseWizard, {
 	TYPE_PERSONAL,
 } from '../../stats-purchase/stats-purchase-wizard';
 import StatsLoader from '../../stats-redirect/stats-loader';
+import './style.scss';
 
 const StatsPurchasePage = ( {
 	query,
@@ -187,21 +191,44 @@ const StatsPurchasePage = ( {
 	return (
 		<Main fullWidthLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
-			{ ! isLoading && (
-				<PageViewTracker
-					path="/stats/purchase/:site"
-					title="Stats > Purchase"
-					from={ query.from ?? '' }
-					variant={ variant }
-					is_upgrade={ +supportCommercialUse }
-					is_site_commercial={ isCommercial === null ? '' : +isCommercial }
-				/>
-			) }
+
 			<div
 				className={ classNames( 'stats', 'stats-purchase-page', {
 					'stats-purchase-page--is-wpcom': isTypeDetectionEnabled && isWPCOMSite,
 				} ) }
 			>
+				<NavigationHeader
+					className="stats__section-header modernized-header"
+					title={ translate( 'Jetpack Stats' ) }
+					subtitle={ translate(
+						"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
+							},
+						}
+					) }
+					navigationItems={ [] }
+				></NavigationHeader>
+				<StatsNavigation
+					selectedItem="traffic"
+					interval="day"
+					siteId={ siteId }
+					slug={ siteSlug }
+					showLock
+					hideModuleSettings
+				/>
+				{ ! isLoading && (
+					<PageViewTracker
+						path="/stats/purchase/:site"
+						title="Stats > Purchase"
+						from={ query.from ?? '' }
+						variant={ variant }
+						is_upgrade={ +supportCommercialUse }
+						is_site_commercial={ isCommercial === null ? '' : +isCommercial }
+					/>
+				) }
+
 				{ /* Only query site purchases on Calypso via existing data component */ }
 				<QuerySitePurchases siteId={ siteId } />
 				<QueryProductsList type="jetpack" />

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -198,6 +198,16 @@ const StatsPurchasePage = ( {
 					'stats-purchase-page--is-wpcom': isTypeDetectionEnabled && isWPCOMSite,
 				} ) }
 			>
+				{ ! isLoading && (
+					<PageViewTracker
+						path="/stats/purchase/:site"
+						title="Stats > Purchase"
+						from={ query.from ?? '' }
+						variant={ variant }
+						is_upgrade={ +supportCommercialUse }
+						is_site_commercial={ isCommercial === null ? '' : +isCommercial }
+					/>
+				) }
 				{ /** Only show the navigation header on force redirections and site has no plans */ }
 				{ ! hasAnyPlan && query.from?.startsWith( 'cmp-red' ) && (
 					<>
@@ -223,16 +233,6 @@ const StatsPurchasePage = ( {
 							hideModuleSettings
 						/>
 					</>
-				) }
-				{ ! isLoading && (
-					<PageViewTracker
-						path="/stats/purchase/:site"
-						title="Stats > Purchase"
-						from={ query.from ?? '' }
-						variant={ variant }
-						is_upgrade={ +supportCommercialUse }
-						is_site_commercial={ isCommercial === null ? '' : +isCommercial }
-					/>
 				) }
 
 				{ /* Only query site purchases on Calypso via existing data component */ }

--- a/client/my-sites/stats/pages/purchase/style.scss
+++ b/client/my-sites/stats/pages/purchase/style.scss
@@ -1,3 +1,3 @@
 .stats-purchase-wizard {
-	margin-top: 32px;
+	margin-top: 24px;
 }

--- a/client/my-sites/stats/pages/purchase/style.scss
+++ b/client/my-sites/stats/pages/purchase/style.scss
@@ -1,3 +1,3 @@
-.stats-purchase-page__notice {
+.stats-purchase-wizard {
 	margin-top: 32px;
 }

--- a/client/my-sites/stats/pages/purchase/style.scss
+++ b/client/my-sites/stats/pages/purchase/style.scss
@@ -1,0 +1,3 @@
+.stats-purchase-page__notice {
+	margin-top: 32px;
+}

--- a/client/my-sites/stats/pages/subscribers/controller.tsx
+++ b/client/my-sites/stats/pages/subscribers/controller.tsx
@@ -1,13 +1,9 @@
-import config from '@automattic/calypso-config';
 import { find } from 'lodash';
 import moment from 'moment';
 import AsyncLoad from 'calypso/components/async-load';
-import LoadStatsPage from '../../stats-redirect/load-stats-page';
 import { getSiteFilters, rangeOfPeriod, type SiteFilterType } from '../shared/helpers';
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
-
-const isPurchaseFlowEnabled = config.isEnabled( 'stats/checkout-flows-v2' );
 
 function subscribers( context: Context, next: () => void ) {
 	const givenSiteId = context.params.site;
@@ -22,15 +18,7 @@ function subscribers( context: Context, next: () => void ) {
 	// moment and rangeOfPeriod format needed for summary page link for email mdule
 	const date = moment().locale( 'en' );
 
-	context.primary = isPurchaseFlowEnabled ? (
-		<LoadStatsPage>
-			<AsyncLoad
-				require="calypso/my-sites/stats/pages/subscribers"
-				placeholder={ PageLoading }
-				period={ rangeOfPeriod( activeFilter?.period || 'day', date ) }
-			/>
-		</LoadStatsPage>
-	) : (
+	context.primary = (
 		<AsyncLoad
 			require="calypso/my-sites/stats/pages/subscribers"
 			placeholder={ PageLoading }

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -25,14 +25,8 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
-	const {
-		isFreeOwned,
-		isPWYWOwned,
-		isCommercialOwned,
-		supportCommercialUse,
-		hasLoadedSitePurchases,
-		isRequestingSitePurchases,
-	} = useStatsPurchases( siteId );
+	const { hasLoadedSitePurchases, isRequestingSitePurchases, hasAnyPlan } =
+		useStatsPurchases( siteId );
 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -52,13 +46,12 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 	);
 
 	const isLoading = ! hasLoadedSitePurchases || isRequestingSitePurchases || isLoadingNotices;
-	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned || supportCommercialUse;
 	const { isNewSite, shouldShowPaywall } = useSiteCompulsoryPlanSelectionQualifiedCheck( siteId );
 	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
 	const redirectToPurchase =
 		config.isEnabled( 'stats/checkout-flows-v2' ) &&
 		isSiteJetpackNotAtomic &&
-		! hasPlan &&
+		! hasAnyPlan &&
 		purchaseNotPostponed &&
 		shouldShowPaywall;
 


### PR DESCRIPTION
Related to pejTkB-1i8-p2

## Proposed Changes

* Excluded WordAds, Subscriber and Email stats from paywall
* Added navigation header for users to find the stats above

Known issue: the selected navigation item is always shown as Traffic for the purchase page.

## Testing Instructions

* Open Calypso Live for a self hosted Jetpack site with Commercial subscription
* All stats pages work like before
* Open Calypso Live `/stats/purchase/:siteSlug` for a self hosted Jetpack site with NO Commercial subscription
* Ensure the navigation header on the purchase page works okay
* Ensure WordAds (You need a Complete subscription), Subscribers, Store and Email stats work as expected, including tabs and details page

<img width="1385" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/1569ad93-2e02-4092-ae52-3ef52ff9d5fe">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?