### PR TITLE
Automattic for Agencies: Add heading & Implement "Get paid" section on Referrals page

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
@@ -10,7 +10,7 @@ interface StepSectionItemProps {
 	icon: JSX.Element;
 	heading: string;
 	description: string;
-	buttonProps: React.ComponentProps< typeof Button >;
+	buttonProps?: React.ComponentProps< typeof Button >;
 }
 
 export default function StepSectionItem( {
@@ -33,9 +33,11 @@ export default function StepSectionItem( {
 				<div className="step-section-item__heading">{ heading }</div>
 				<div className="step-section-item__description">{ description }</div>
 			</div>
-			<div className="step-section-item__button">
-				<Button { ...buttonProps } />
-			</div>
+			{ buttonProps && (
+				<div className="step-section-item__button">
+					<Button { ...buttonProps } />
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,4 +1,4 @@
-import { pages, plugins } from '@wordpress/icons';
+import { pages, plugins, payment, percent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
@@ -28,25 +28,46 @@ export default function ReferralsOverview() {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody className="referrals-overview">
-				<StepSection heading={ translate( 'Get set up' ) } stepCount={ 1 }>
-					<StepSectionItem
-						icon={ pages }
-						heading={ translate( 'Add your bank details and upload tax forms' ) }
-						description={ translate(
-							'Once confirmed, we’ll be able to send you a commission payment at the end of each month.'
-						) }
-						buttonProps={ { children: translate( 'Add bank details' ), primary: true } }
-					/>
-					<StepSectionItem
-						icon={ plugins }
-						heading={ translate( 'Install the A4A plugin on your clients’ sites' ) }
-						description={ translate(
-							'Our plugin can confirm that your agency is connected to the Automattic products your clients buy.'
-						) }
-						buttonProps={ { children: translate( 'Download plugin' ) } }
-					/>
-				</StepSection>
+			<LayoutBody>
+				<div className="referrals-overview__section-heading">
+					{ translate( 'Earn a 30% commission for every purchase made by a client' ) }
+				</div>
+				<div className="referrals-overview__section-container">
+					<StepSection heading={ translate( 'Get set up' ) } stepCount={ 1 }>
+						<StepSectionItem
+							icon={ pages }
+							heading={ translate( 'Add your bank details and upload tax forms' ) }
+							description={ translate(
+								'Once confirmed, we’ll be able to send you a commission payment at the end of each month.'
+							) }
+							buttonProps={ { children: translate( 'Add bank details' ), primary: true } }
+						/>
+						<StepSectionItem
+							icon={ plugins }
+							heading={ translate( 'Install the A4A plugin on your clients’ sites' ) }
+							description={ translate(
+								'Our plugin can confirm that your agency is connected to the Automattic products your clients buy.'
+							) }
+							buttonProps={ { children: translate( 'Download plugin' ) } }
+						/>
+					</StepSection>
+					<StepSection heading={ translate( 'Get paid' ) } stepCount={ 2 }>
+						<StepSectionItem
+							icon={ payment }
+							heading={ translate( 'Have your client purchase Automattic Products' ) }
+							description={ translate(
+								'We offer commissions for each purchase of Automattic products by your clients, including Woo, Jetpack, and hosting from either Pressable or WordPress.com.'
+							) }
+						/>
+						<StepSectionItem
+							icon={ percent }
+							heading={ translate( 'Get paid a commission on your referrals' ) }
+							description={ translate(
+								'At the end of each month, we will review your clients’ purchases and pay you a commission based on them.'
+							) }
+						/>
+					</StepSection>
+				</div>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -1,3 +1,11 @@
-.referrals-overview {
-	margin-block-start: 48px;
+.referrals-overview__section-heading {
+	margin-block-start: 24px;
+	font-size: rem(24px);
+	margin-block-end: 48px;
+}
+
+.referrals-overview__section-container {
+	display: flex;
+	flex-direction: column;
+	gap: 48px;
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/317
Resolves https://github.com/Automattic/jetpack-genesis/issues/320

<img width="1555" alt="Screenshot 2024-04-15 at 10 40 39 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b719217a-00f2-4f69-bef5-366dc6b4756a">


## Proposed Changes

This PR:

- Adds the heading to the Referrals page
- Adds `Get Paid` section

## NOTE:

- The buttons don't work as of now. This will be implemented in another PR.

## Testing Instructions

- Open A4A live link
- Visit /referrals 
- Verify that the UI looks well on all the devices


<img width="311" alt="Screenshot 2024-04-15 at 10 39 34 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/eef1f694-5254-4773-a5ea-c37a676e7eff">
<img width="771" alt="Screenshot 2024-04-15 at 10 40 23 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ed7bf2e9-0c5a-4e1d-bfba-f71a9e958e17">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?