### PR TITLE
Fix Blaze View documentation for Simple Classic

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -30,6 +30,7 @@ import {
 	getCampaignDurationFormatted,
 } from 'calypso/my-sites/promote-post-i2/utils';
 import { useSelector } from 'calypso/state';
+import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	formatCents,
@@ -88,6 +89,10 @@ const getExternalTabletIcon = ( fillColor = '#A7AAAD' ) => (
 
 export default function CampaignItemDetails( props: Props ) {
 	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isRunningInClassicSimple = useSelector( ( state ) =>
+		getSiteOption( state, props.siteId, 'is_wpcom_simple' )
+	);
+	const isRunningJetpackOrClassicSimple = isRunningInJetpack || isRunningInClassicSimple;
 	const translate = useTranslate();
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const [ showErrorDialog, setShowErrorDialog ] = useState( false );
@@ -935,7 +940,7 @@ export default function CampaignItemDetails( props: Props ) {
 									className="is-link components-button campaign-item-details__support-link"
 									supportContext="advertising"
 									showIcon={ false }
-									showSupportModal={ ! isRunningInJetpack }
+									showSupportModal={ ! isRunningJetpackOrClassicSimple }
 								>
 									{ translate( 'View documentation' ) }
 									{ getExternalLinkIcon() }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6558

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| In Simple Classic wp-admin, click on doc link, nothing happens  | Doc link opens |

![doc link](https://github.com/Automattic/wp-calypso/assets/6586048/113ffa40-e2a0-4749-9ceb-a85d21baec39)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisite 1: Simple Classic
To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```

### Prerequisite 2: public site

* Run `install-plugin.sh blaze-dashboard fix/blaze-view-doc` in your sandbox and sandbox widgets.wp.com for testing, alternatively, locally you can checkout to this branch and cd to `apps/blaze-dashboard` and run `yarn dev --sync`
* Go to /wp-admin/tools.php?page=advertising and click on the Campaigns tab and go to the Details (instructions on how to create a campaign: https://github.com/Automattic/wp-calypso/pull/89484#issuecomment-2051848954)
![campaigns](https://github.com/Automattic/wp-calypso/assets/6586048/9cb098fd-b6a0-45ab-8f5a-64ec1c43e19a)
* Click on View documentation, should open the support docs in a new tab


Test on Self-hosted/Atomic/Simple Calypso to make sure we didn't break anything. In Calypso, instead of opening a link, it will open support docs in help center.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?