### PR TITLE
Automattic for Agencies: Show atomic site actions & issue license action for non-atomic sites

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -17,7 +18,7 @@ export default function useSiteActions(
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );
-	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses ) || isA8CForAgencies();
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const siteValue = site?.value;
 
@@ -27,6 +28,14 @@ export default function useSiteActions(
 		}
 
 		const { url, url_with_scheme, blog_id, has_backup, is_atomic } = siteValue;
+
+		let issueLicenseURL = undefined;
+
+		if ( isA8CForAgencies() ) {
+			issueLicenseURL = A4A_MARKETPLACE_LINK;
+		} else if ( partnerCanIssueLicense ) {
+			issueLicenseURL = `/partner-portal/issue-license/?site_id=${ blog_id }&source=dashboard`;
+		}
 
 		const siteSlug = urlToSlug( url );
 
@@ -65,12 +74,14 @@ export default function useSiteActions(
 			},
 			{
 				name: translate( 'Issue new license' ),
-				href: partnerCanIssueLicense
-					? `/partner-portal/issue-license/?site_id=${ blog_id }&source=dashboard`
-					: undefined,
+				href: issueLicenseURL,
 				onClick: () => handleClickMenuItem( 'issue_license' ),
 				isExternalLink: false,
-				isEnabled: partnerCanIssueLicense && ! siteError && ! is_atomic && ! isUrlOnly,
+				isEnabled:
+					( partnerCanIssueLicense || isA8CForAgencies() ) &&
+					! siteError &&
+					! is_atomic &&
+					! isUrlOnly,
 			},
 			{
 				name: translate( 'View activity' ),

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -16,7 +17,7 @@ export default function useSiteActions(
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );
-	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses ) || isA8CForAgencies();
 
 	const siteValue = site?.value;
 
@@ -35,7 +36,8 @@ export default function useSiteActions(
 		};
 
 		const isWPCOMAtomicSiteCreationEnabled =
-			isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && is_atomic;
+			( isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) || isA8CForAgencies() ) &&
+			is_atomic;
 
 		const isUrlOnly = site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
 
@@ -112,5 +114,13 @@ export default function useSiteActions(
 				isEnabled: true && ! isUrlOnly,
 			},
 		];
-	}, [ dispatch, isLargeScreen, partnerCanIssueLicense, siteError, siteValue, translate ] );
+	}, [
+		dispatch,
+		isLargeScreen,
+		partnerCanIssueLicense,
+		site?.value?.sticker,
+		siteError,
+		siteValue,
+		translate,
+	] );
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/234

## Proposed Changes

This PR:

- Shows atomic site actions like: `Set up site`, `Change domain`, `Hosting configuration`
- Shows non-atomic site action: `Issue new license`

## Testing Instructions

- Open the A4A live link
- Go to Sites view
- Click the actions menu and verify that you can see the actions as shown below for atomic & non-atomic sites.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td colSpan=2 align="center">
Atomic Sites
</td>
</tr>
<tr>
<td>
<img width="317" alt="Screenshot 2024-04-15 at 2 09 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/19373c7b-5dd4-4fb3-bbe2-1f0c754f38f3">
</td>
<td>
<img width="317" alt="Screenshot 2024-04-15 at 2 09 36 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/502031c0-4db8-4701-af8b-28c1e2f5f979">
</td>
</tr>
<tr>
<td colSpan=2 align="center">
Non-Atomic Sites
</td>
</tr>
<tr>
<td>
<img width="317" alt="Screenshot 2024-04-15 at 2 10 44 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fec2df65-3c9a-4db1-ab77-b232a8f89176">
</td>
<td>
<img width="317" alt="Screenshot 2024-04-15 at 2 10 53 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b8c96b20-b864-4826-b1f4-01c9823722b4">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?