### PR TITLE
Fix Promote buttons in Blaze for Simple Classic

### DIFF
--- a/apps/blaze-dashboard/src/styles/promote-widget.scss
+++ b/apps/blaze-dashboard/src/styles/promote-widget.scss
@@ -14,6 +14,14 @@ html.has-blank-canvas {
 		overflow: hidden;
 	}
 }
+
+// Lower the z-index to match WordPress core.
+// This is a fix for simple sites due to #wpadminbar being modified to have a really higher z-index.
+// We only want to override the CSS for the promote post widget to not break anything else.
+.is-section-promote-post-i2 #wpadminbar {
+	z-index: 99999 !important;
+}
+
 .blazepress-widget {
 	z-index: 99999;
 

--- a/client/my-sites/promote-post-i2/hooks/use-open-promote-widget.ts
+++ b/client/my-sites/promote-post-i2/hooks/use-open-promote-widget.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { recordDSPEntryPoint, useDspOriginProps } from 'calypso/lib/promote-post';
 import { useRouteModal } from 'calypso/lib/route-modal';
-import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getAdvertisingDashboardPath } from '../utils';
 
@@ -17,6 +17,11 @@ export interface Props {
 const useOpenPromoteWidget = ( { keyValue, entrypoint, external }: Props ) => {
 	const { openModal } = useRouteModal( 'blazepress-widget', keyValue );
 	const siteId = useSelector( getSelectedSiteId );
+	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isRunningInClassicSimple = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'is_wpcom_simple' )
+	);
+	const isRunningJetpackOrClassicSimple = isRunningInJetpack || isRunningInClassicSimple;
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const dspOriginProps = useDspOriginProps();
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
@@ -24,7 +29,7 @@ const useOpenPromoteWidget = ( { keyValue, entrypoint, external }: Props ) => {
 
 	const onOpenPromoteWidget = useCallback( () => {
 		dispatch( recordDSPEntryPoint( entrypoint, dspOriginProps ) );
-		if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+		if ( isRunningJetpackOrClassicSimple ) {
 			const blazeURL = getAdvertisingDashboardPath( `/posts/promote/${ keyValue }/${ siteSlug }` );
 
 			if ( external ) {
@@ -46,6 +51,7 @@ const useOpenPromoteWidget = ( { keyValue, entrypoint, external }: Props ) => {
 		dspOriginProps,
 		external,
 		siteAdminUrl,
+		isRunningJetpackOrClassicSimple,
 		openModal,
 		dispatch,
 	] );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6529 and fixes https://github.com/Automattic/dotcom-forge/issues/6539

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| In Simple Classic wp-admin, clicking on Promote doesn't trigger anything  | Opens the promote campaign creation process |

### Entry points

#### Tools > Advertising

![ad](https://github.com/Automattic/wp-calypso/assets/6586048/dae43cc5-0bbc-4f15-87c4-a448897477b8)

#### Tools > Advertising > Campaigns > Details

![again](https://github.com/Automattic/wp-calypso/assets/6586048/052160bc-f840-4322-9150-e67a386511c6)

#### Posts & Pages
![image](https://github.com/Automattic/wp-calypso/assets/6586048/48b23063-d930-4642-819f-4ea9f7697377)
![image](https://github.com/Automattic/wp-calypso/assets/6586048/ce40e326-c491-46fd-a195-97437ccaf0c2)

## Testing Instructions

### Prerequisite 1: Simple Classic
To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```

### Prerequisite 2: Public site

* Run `install-plugin.sh blaze-dashboard fix/blaze-promote` in your sandbox and sandbox widgets.wp.com for testing, alternatively, locally you can checkout to this branch and cd to `apps/blaze-dashboard` and run `yarn dev --sync`
* Go to `/wp-admin/tools.php?page=advertising` and try all entry points to Promote (see screenshots above)

* See the campaign creation page

Other notes: Instructions on how to create a campaign: https://github.com/Automattic/wp-calypso/pull/89484#issuecomment-2051848954

Test on Self-hosted/Atomic/Simple Calypso to make sure we didn't break anything. In Calypso, instead of opening a link, it will open support docs in help center.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?