### PR TITLE
A4A: Fix the site selector selected color to the correct gray shade.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -30,7 +30,7 @@
 			background: var(--studio-white);
 			td {
 				padding: 16px 0;
-				border-bottom: 1px solid var(--studio-gray-5);
+				border-bottom: 1px solid var(--color-neutral-5);
 			}
 		}
 	}
@@ -56,7 +56,7 @@
 		}
 
 		&:hover {
-			background: var(--studio-gray-0);
+			background: var(--color-neutral-0);
 
 			.site-set-favorite__favorite-icon,
 			.components-checkbox-control__input {
@@ -66,7 +66,7 @@
 
 		th {
 			padding: 13px 4px 13px 48px;
-			border-bottom: 1px solid var(--studio-gray-5);
+			border-bottom: 1px solid var(--color-neutral-5);
 			font-size: rem(13px);
 			font-weight: 400;
 			vertical-align: middle;
@@ -74,7 +74,7 @@
 
 		td {
 			padding: 16px 4px 16px 48px;
-			border-bottom: 1px solid var(--studio-gray-5);
+			border-bottom: 1px solid var(--color-neutral-5);
 			vertical-align: middle;
 		}
 
@@ -93,24 +93,24 @@
 				display: none;
 			}
 			&[type="checkbox"] {
-				border-color: var(--studio-gray-5);
+				border-color: var(--color-neutral-5);
 			}
 		}
 	}
 
 	ul.dataviews-view-list {
 		li:hover {
-			background: var(--studio-gray-0);
+			background: var(--color-neutral-0);
 		}
 		.is-selected {
-			background-color: var(--studio-jetpack-green-0);
+			background-color: var(--color-neutral-0);
 		}
 	}
 }
 
 .components-search-control input[type="search"].components-search-control__input {
 	background: var(--studio-white);
-	border: 1px solid var(--studio-gray-5);
+	border: 1px solid var(--color-neutral-5);
 }
 
 .dataviews-filters__view-actions {
@@ -142,7 +142,7 @@
 	overflow: hidden;
 	white-space: nowrap;
 	font-size: rem(12px);
-	color: var(--studio-gray-60);
+	color: var(--color-neutral-60);
 	font-weight: 400;
 }
 


### PR DESCRIPTION
This PR fixes the incorrect Site selected color (Jetpack Green 0) to the correct grey shade (Grey 0).

**Before**
<img width="416" alt="Screenshot 2024-04-15 at 7 45 55 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7ccdbf52-69b6-4199-b9f3-25751ac9a594">

**After**
<img width="417" alt="Screenshot 2024-04-15 at 7 46 46 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/66425e00-77b2-46ad-948f-9c1a90d0caab">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/282

## Proposed Changes

* Change Site selector selected color to `--color-grey-0` from `--studio-jetpack-green-0`.
* Additional: Change all `--studio-grey-*` color reference to equivalent theme properties (`--color-netural-*`). No**te that I have skipped other colors that reference `--studio-jetpack-green-*` as I have yet to evaluate which components it is affecting.**

## Testing Instructions


* Use the A4A Live link below and go to /sites
* Select a site and confirm that the Selected Site shows the correct shade of grey.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?