### PR TITLE
Untangling: fix All Sites CSS in unified masterbar to match Core's

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1028,17 +1028,17 @@ a.masterbar__quick-language-switcher {
 }
 
 .masterbar__unified {
-	.masterbar__item-wordpress,
-	.masterbar__item-current-site {
+	.masterbar__item {
+		gap: 6px;
 		padding: 0 7px;
 	}
 
 	.masterbar__item-all-sites {
-		gap: 4px;
-	}
+		gap: 2px;
 
-	.masterbar__item-current-site {
-		gap: 6px;
+		@media only screen and ( min-width: 783px ) {
+			padding: 0 8px 0 4px;
+		}
 	}
 
 	.masterbar__item-notifications {


### PR DESCRIPTION
## Proposed Changes

This is a continuation of https://github.com/Automattic/wp-calypso/pull/89321, where things have changed since we implemented the wp-admin changes in https://github.com/Automattic/jetpack/pull/36632 last week. This PR fixes some alignment issues of the new All Sites menu in the top bar.


Before (top: Calypso, bottom: wp-admin for reference)

<img width="420" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9a3f424a-17a6-4a6d-bf31-7097f89f5992">
<img width="420" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9a21c57d-052d-42a5-bce5-b5a1150bfcf4">

<br><br>

After (top: Calypso, bottom: wp-admin for reference)

<img width="420" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/3d19f9c5-638e-4edf-aba4-96e9c1522f05">
<img width="420" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9a21c57d-052d-42a5-bce5-b5a1150bfcf4">


## Testing Instructions

* See: https://github.com/Automattic/wp-calypso/pull/89321

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?