### PR TITLE
Scheduled Updates: Adds a Scheduled updates setting in Notification Settings

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -106,6 +106,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Promotions' );
 		} else if ( 'reports' === category ) {
 			return this.props.translate( 'Reports' );
+		} else if ( 'scheduled_updates' === category ) {
+			return this.props.translate( 'Scheduled Updates' );
 		} else if ( 'learn' === category ) {
 			return this.props.translate( 'Learn Faster to Grow Faster' );
 		} else if ( 'jetpack_marketing' === category ) {
@@ -157,6 +159,8 @@ class MainComponent extends Component {
 			return this.props.translate(
 				'Complimentary reports and updates regarding site performance and traffic.'
 			);
+		} else if ( 'scheduled_updates' === category ) {
+			return this.props.translate( 'Complimentary reports regarding scheduled plugin updates.' );
 		} else if ( 'learn' === category ) {
 			return this.props.translate(
 				'Take your WordPress.com site to new heights with expert webinars, courses, and community forums.'

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -37,6 +37,7 @@ const options = {
 	news: 'news',
 	digest: 'digest',
 	reports: 'reports',
+	scheduled_updates: 'scheduled_updates',
 	jetpack_marketing: 'jetpack_marketing',
 	jetpack_research: 'jetpack_research',
 	jetpack_promotion: 'jetpack_promotion',
@@ -132,6 +133,13 @@ class WPCOMNotifications extends Component {
 					description={ translate(
 						'Complimentary reports and updates regarding site performance and traffic.'
 					) }
+				/>
+
+				<EmailCategory
+					name={ options.scheduled_updates }
+					isEnabled={ get( settings, options.scheduled_updates ) }
+					title={ translate( 'Scheduled updates' ) }
+					description={ translate( 'Complimentary reports regarding scheduled plugin updates.' ) }
 				/>
 
 				{ this.props.hasJetpackSites ? (


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89533 

## Proposed Changes

* Adds a checkbox to Notification Settings to opt out of Scheduled Updates mails (default = on)

![CleanShot 2024-04-15 at 14 15 53@2x](https://github.com/Automattic/wp-calypso/assets/528287/0593083f-1196-4201-a56e-7b35c477dfbd)

## Testing Instructions

1. Test together with D145303-code 
2. Schedule an update without changing the option: you should receive a mail
3. Unsubscribe from that mail, replace the URL with calypso.localhost:3000
4. Schedule another update: no mail should be sent.
5. Check the checkbox again
6. Schedule another update: you should receive a mail

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?