### PR TITLE
Experiment: Change Starter plan name to Beginner

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { setPlansListExperiment } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import {
 	getLanguage,
@@ -7,6 +8,7 @@ import {
 } from '@automattic/i18n-utils';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import EmptyContent from 'calypso/components/empty-content';
@@ -14,6 +16,7 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { useExperiment } from 'calypso/lib/explat';
 import { login, createAccountUrl } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -46,6 +49,19 @@ export const ProviderWrappedLayout = ( {
 } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
+
+	const [ isLoading, experimentAssignment ] = useExperiment(
+		'wpcom_plan_name_change_starter_to_beginner'
+	);
+
+	useEffect( () => {
+		if ( ! isLoading ) {
+			setPlansListExperiment(
+				'wpcom_plan_name_change_starter_to_beginner',
+				experimentAssignment?.variationName
+			);
+		}
+	}, [ isLoading ] );
 
 	const layout = userLoggedIn ? (
 		<Layout primary={ primary } secondary={ secondary } />

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -725,7 +725,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	type: TYPE_PERSONAL,
 	getTitle: () =>
 		getPlansListExperiment( 'wpcom_plan_name_change_starter_to_beginner' ) === 'treatment'
-			? // translators: Starter is a plan name
+			? // translators: Beginner is a plan name
 			  i18n.translate( 'Beginner' )
 			: // translators: Starter is a plan name
 			  i18n.translate( 'Starter' ),

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -445,6 +445,7 @@ import {
 	FEATURE_SECURITY_VULNERABILITY_NOTIFICATIONS,
 	FEATURE_WOOCOMMERCE_HOSTING,
 } from './constants';
+import { getPlansListExperiment } from './experiments';
 import type {
 	BillingTerm,
 	Plan,
@@ -723,8 +724,11 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_PERSONAL,
 	getTitle: () =>
-		// translators: Starter is a plan name
-		i18n.translate( 'Starter' ),
+		getPlansListExperiment( 'wpcom_plan_name_change_starter_to_beginner' ) === 'treatment'
+			? // translators: Starter is a plan name
+			  i18n.translate( 'Beginner' )
+			: // translators: Starter is a plan name
+			  i18n.translate( 'Starter' ),
 	getAudience: () => i18n.translate( 'Best for personal use' ),
 	getBlogAudience: () => i18n.translate( 'Best for personal use' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for personal use' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Implements the Calypso changes required for the experiment changing the "Starter' plan name to "Beginner".


<img width="797" alt="Screenshot 2024-04-18 at 4 49 18 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/7cdb98fb-cb04-4ae2-8eff-63afeca7890d">
<img width="1211" alt="Screenshot 2024-04-18 at 4 49 04 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/6e2a9b3c-9624-4ac0-8886-58fc25534c46">
<img width="1597" alt="Screenshot 2024-04-18 at 4 48 57 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/c2371da9-3a7a-40e3-b3b5-c52b58215d51">
<img width="1728" alt="Screenshot 2024-04-18 at 4 48 41 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/65441e77-a387-47fe-939f-a5fed927d449">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions in D145312-code. `/start/plans` should show the new plan name.

