### PR TITLE
Purchases: remove status `hasTranslation` conditions

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -269,49 +269,25 @@ class PurchaseItem extends Component {
 				};
 				switch ( purchase.billPeriodDays ) {
 					case PLAN_MONTHLY_PERIOD:
-						if (
-							locale === 'en' ||
-							i18n.hasTranslation( 'Renews monthly at %(amount)s on {{span}}%(date)s{{/span}}' )
-						) {
-							return translate(
-								'Renews monthly at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
-								translateOptions
-							);
-						}
+						return translate(
+							'Renews monthly at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+							translateOptions
+						);
 					case PLAN_ANNUAL_PERIOD:
-						if (
-							locale === 'en' ||
-							i18n.hasTranslation( 'Renews yearly at %(amount)s on {{span}}%(date)s{{/span}}' )
-						) {
-							return translate(
-								'Renews yearly at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
-								translateOptions
-							);
-						}
+						return translate(
+							'Renews yearly at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+							translateOptions
+						);
 					case PLAN_BIENNIAL_PERIOD:
-						if (
-							locale === 'en' ||
-							i18n.hasTranslation(
-								'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
-							)
-						) {
-							return translate(
-								'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
-								translateOptions
-							);
-						}
+						return translate(
+							'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+							translateOptions
+						);
 					case PLAN_TRIENNIAL_PERIOD:
-						if (
-							locale === 'en' ||
-							i18n.hasTranslation(
-								'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
-							)
-						) {
-							return translate(
-								'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
-								translateOptions
-							);
-						}
+						return translate(
+							'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+							translateOptions
+						);
 				}
 			}
 

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -14,7 +14,7 @@ import { CALYPSO_CONTACT } from '@automattic/urls';
 import { ExternalLink } from '@wordpress/components';
 import { Icon, warning as warningIcon } from '@wordpress/icons';
 import classNames from 'classnames';
-import i18n, { localize, getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
@@ -65,16 +65,16 @@ class PurchaseItem extends Component {
 	}
 
 	getStatus() {
-		const { purchase, translate, locale, moment, name, isJetpack, isDisconnectedSite } = this.props;
+		const { purchase, translate, moment, name, isJetpack, isDisconnectedSite } = this.props;
 		const expiry = moment( purchase.expiryDate );
-		// To-do: There isn't currently a way to get the taxName based on the country.
-		// The country is not included in the purchase information envelope
-		// We should add this information so we can utilize useTaxName to retrieve the correct taxName
-		// For now, we are using a fallback tax name
-		const taxName =
-			getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax' )
-				? translate( 'tax' )
-				: translate( 'tax (VAT/GST/CT)' );
+		// @todo: There isn't currently a way to get the taxName based on the
+		// country. The country is not included in the purchase information
+		// envelope. We should add this information so we can utilize useTaxName
+		// to retrieve the correct taxName. For now, we are using a fallback tax
+		// name with context, to prevent mis-translation.
+		const taxName = translate( 'tax', {
+			context: "Shortened form of 'Sales Tax', not a country-specific tax name",
+		} );
 
 		/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 		const excludeTaxStringAbbreviation = translate( '(excludes %s)', {
@@ -170,13 +170,7 @@ class PurchaseItem extends Component {
 		}
 
 		if ( isWithinIntroductoryOfferPeriod( purchase ) && isIntroductoryOfferFreeTrial( purchase ) ) {
-			if (
-				isRenewing( purchase ) &&
-				( locale === 'en' ||
-					i18n.hasTranslation(
-						'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s'
-					) )
-			) {
+			if ( isRenewing( purchase ) ) {
 				return translate(
 					'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}}',
 					{
@@ -196,29 +190,24 @@ class PurchaseItem extends Component {
 				);
 			}
 
-			if (
-				locale === 'en' ||
-				i18n.hasTranslation( 'Free trial ends on {{span}}%(date)s{{/span}}' )
-			) {
-				const expiryClass =
-					expiry < moment().add( 7, 'days' )
-						? 'purchase-item__is-error'
-						: 'purchase-item__is-warning';
+			const expiryClass =
+				expiry < moment().add( 7, 'days' )
+					? 'purchase-item__is-error'
+					: 'purchase-item__is-warning';
 
-				return (
-					<span className={ expiryClass }>
-						{ translate( 'Free trial ends on {{span}}%(date)s{{/span}}', {
-							args: {
-								date: expiry.format( 'LL' ),
-							},
-							components: {
-								span: <span className="purchase-item__date" />,
-							},
-						} ) }
-						{ this.trackImpression( 'purchase-expiring' ) }
-					</span>
-				);
-			}
+			return (
+				<span className={ expiryClass }>
+					{ translate( 'Free trial ends on {{span}}%(date)s{{/span}}', {
+						args: {
+							date: expiry.format( 'LL' ),
+						},
+						components: {
+							span: <span className="purchase-item__date" />,
+						},
+					} ) }
+					{ this.trackImpression( 'purchase-expiring' ) }
+				</span>
+			);
 		}
 
 		if ( isRenewing( purchase ) && purchase.renewDate ) {


### PR DESCRIPTION
In the `getStatus()` [translation logic statement for one-year plans](https://github.com/Automattic/wp-calypso/blob/trunk/client/me/purchases/purchase-item/index.jsx#L274), there's a bug (introduced in https://github.com/Automattic/wp-calypso/pull/86486) where the `hasTranslation()` call is using a string that differs from the string being returned. Since `'Renews yearly at %(amount)s on {{span}}%(date)s{{/span}}'` was removed as a translation string in that same diff, `hasTranslation()` fails, and the switch statement for non-EN yearly plan then falls through to the bi-yearly case. Effectively:

```js
case PLAN_ANNUAL_PERIOD:
case PLAN_BIENNIAL_PERIOD:
	if (
		locale === 'en' ||
		i18n.hasTranslation(
			'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
		)
	) {
		return translate(
			'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
			translateOptions
		);
	}
```

Since all of these translation strings are now fully translated, this diff removes the `hasTranslation()` conditions. It also removes other unnecessary `hasTranslation()` calls, unrelated to the bug here.

Fixes: https://github.com/Automattic/payments-shilling/issues/2664

**To test:**
- Purchase any yearly plan
- Switch your locale to something other than English
- Visit Me > Purchases
- Verify that the correct status string is shown in the purchase list (e.g. `Se renueva anualmente por 180 US$ (impuesto no incluido) el 2 de mayo de 2024`)
- Verify that other strings on the page are properly translated.
- I've already done this, but you can additionally check that the strings have full translations by searching for them on translate.wordpress.com