### PR TITLE
Scheduled updates: Scaffold form for the multisite context

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,0 +1,7 @@
+import { ScheduleCreate } from './schedule-create';
+
+import './styles.scss';
+
+export const PluginsScheduledUpdatesMultisite = () => {
+	return <ScheduleCreate />;
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
@@ -1,0 +1,11 @@
+import { ScheduleForm } from './schedule-form';
+
+export const ScheduleCreate = () => {
+	return (
+		<div className="plugins-update-manager plugins-update-manager-multisite">
+			<h1 className="wp-brand-font">Weekly on Monday at 10AM</h1>
+
+			<ScheduleForm />
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,0 +1,25 @@
+import { Flex, FlexItem } from '@wordpress/components';
+import { ScheduleFormFrequency } from '../plugins-scheduled-updates/schedule-form-frequency';
+import { ScheduleFormPlugins } from '../plugins-scheduled-updates/schedule-form-plugins';
+
+export const ScheduleForm = () => {
+	return (
+		<div className="schedule-form">
+			<div className="form-control-container">
+				<Flex direction={ [ 'column', 'row' ] } expanded={ true } align="start">
+					<FlexItem>Site selection</FlexItem>
+					<FlexItem>
+						<ScheduleFormPlugins
+							plugins={ [] }
+							isPluginsFetching={ false }
+							isPluginsFetched={ true }
+						/>
+					</FlexItem>
+				</Flex>
+			</div>
+			<div className="form-control-container">
+				<ScheduleFormFrequency initFrequency="daily" optionsDirection={ [ 'column', 'row' ] } />
+			</div>
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -1,0 +1,41 @@
+.plugins-update-manager-multisite {
+	h1 {
+		font-size: 2rem;
+		margin-bottom: 1rem;
+	}
+
+	.schedule-form {
+		& > .form-control-container {
+			margin-bottom: 1.25rem;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+
+			& > .components-flex {
+				gap: 2rem;
+
+				& > .components-flex-item {
+					flex-basis: 100%;
+				}
+			}
+		}
+
+		div.radio-option {
+			flex-basis: 100%;
+			min-height: 85px;
+		}
+	}
+
+	.form-field--frequency {
+		& > .components-flex {
+			gap: 2rem;
+
+			& > .components-flex-item {
+				margin-bottom: 0;
+				border: solid 1px var(--studio-gray-10);
+				border-radius: 2px;
+			}
+		}
+	}
+}

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -17,6 +17,7 @@
 
 				& > .components-flex-item {
 					flex-basis: 100%;
+					width: 100%;
 				}
 			}
 		}

--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -18,10 +18,13 @@ import { DAILY_OPTION, DAY_OPTIONS, DEFAULT_HOUR, WEEKLY_OPTION } from './schedu
 import { prepareTimestamp } from './schedule-form.helper';
 
 type Frequency = 'daily' | 'weekly';
+type FlexDirection = 'column' | 'row';
 
 interface Props {
+	className?: string;
 	initTimestamp?: number;
 	initFrequency: Frequency;
+	optionsDirection?: FlexDirection[];
 	error?: string;
 	showError?: boolean;
 	onTouch?: ( touched: boolean ) => void;
@@ -31,7 +34,16 @@ export function ScheduleFormFrequency( props: Props ) {
 	const siteSlug = useSiteSlug();
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
-	const { initTimestamp, initFrequency = 'daily', error, showError, onChange, onTouch } = props;
+	const {
+		className = '',
+		initTimestamp,
+		initFrequency = 'daily',
+		optionsDirection = [ 'column' ],
+		error,
+		showError,
+		onChange,
+		onTouch,
+	} = props;
 	const { isAmPmPhpTimeFormat } = useSiteDateTimeFormat( siteSlug );
 	const isAmPmFormat = isAmPmPhpTimeFormat();
 
@@ -55,67 +67,69 @@ export function ScheduleFormFrequency( props: Props ) {
 	useEffect( () => onChange?.( frequency, timestamp ), [ frequency, timestamp ] );
 
 	return (
-		<div className="form-field">
+		<div className={ `form-field form-field--frequency ${ className }` }>
 			<label htmlFor="frequency">{ translate( 'Update every' ) }</label>
-			<div className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
-				<RadioControl
-					name="frequency"
-					options={ [ DAILY_OPTION ] }
-					selected={ frequency }
-					onChange={ ( f ) => setFrequency( f as 'daily' ) }
-					onBlur={ () => setFieldTouched( true ) }
-				></RadioControl>
-				{ frequency === 'daily' && (
-					<Flex gap={ 6 }>
-						<FlexBlock>
-							<ScheduleFormTime
-								initHour={ hour }
-								initPeriod={ period }
-								isAmPmFormat={ isAmPmFormat }
-								onChange={ ( hour, period ) => {
-									setHour( hour );
-									setPeriod( period );
-								} }
-							/>
-						</FlexBlock>
-					</Flex>
-				) }
-			</div>
-			<div className={ classnames( 'radio-option', { selected: frequency === 'weekly' } ) }>
-				<RadioControl
-					name="frequency"
-					options={ [ WEEKLY_OPTION ] }
-					selected={ frequency }
-					onChange={ ( f ) => setFrequency( f as 'weekly' ) }
-					onBlur={ () => setFieldTouched( true ) }
-				></RadioControl>
-				{ frequency === 'weekly' && (
-					<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>
-						<FlexItem>
-							<div className="form-field">
-								<SelectControl
-									__next40pxDefaultSize
-									name="day"
-									value={ day }
-									options={ DAY_OPTIONS }
-									onChange={ setDay }
+			<Flex direction={ optionsDirection }>
+				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
+					<RadioControl
+						name="frequency"
+						options={ [ DAILY_OPTION ] }
+						selected={ frequency }
+						onChange={ ( f ) => setFrequency( f as 'daily' ) }
+						onBlur={ () => setFieldTouched( true ) }
+					></RadioControl>
+					{ frequency === 'daily' && (
+						<Flex gap={ 6 }>
+							<FlexBlock>
+								<ScheduleFormTime
+									initHour={ hour }
+									initPeriod={ period }
+									isAmPmFormat={ isAmPmFormat }
+									onChange={ ( hour, period ) => {
+										setHour( hour );
+										setPeriod( period );
+									} }
 								/>
-							</div>
-						</FlexItem>
-						<FlexBlock>
-							<ScheduleFormTime
-								initHour={ hour }
-								initPeriod={ period }
-								isAmPmFormat={ isAmPmFormat }
-								onChange={ ( hour, period ) => {
-									setHour( hour );
-									setPeriod( period );
-								} }
-							/>
-						</FlexBlock>
-					</Flex>
-				) }
-			</div>
+							</FlexBlock>
+						</Flex>
+					) }
+				</FlexItem>
+				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'weekly' } ) }>
+					<RadioControl
+						name="frequency"
+						options={ [ WEEKLY_OPTION ] }
+						selected={ frequency }
+						onChange={ ( f ) => setFrequency( f as 'weekly' ) }
+						onBlur={ () => setFieldTouched( true ) }
+					></RadioControl>
+					{ frequency === 'weekly' && (
+						<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>
+							<FlexItem>
+								<div className="form-field">
+									<SelectControl
+										__next40pxDefaultSize
+										name="day"
+										value={ day }
+										options={ DAY_OPTIONS }
+										onChange={ setDay }
+									/>
+								</div>
+							</FlexItem>
+							<FlexBlock>
+								<ScheduleFormTime
+									initHour={ hour }
+									initPeriod={ period }
+									isAmPmFormat={ isAmPmFormat }
+									onChange={ ( hour, period ) => {
+										setHour( hour );
+										setPeriod( period );
+									} }
+								/>
+							</FlexBlock>
+						</Flex>
+					) }
+				</FlexItem>
+			</Flex>
 			{ ( ( showError && error ) || ( fieldTouched && error ) ) && (
 				<Text className="validation-msg">
 					<Icon className="icon-info" icon={ info } size={ 16 } />

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -4,6 +4,7 @@
 	}
 
 	.form-control-container {
+		box-sizing: border-box;
 		padding: 1.5rem;
 		border: solid 1px var(--studio-gray-10);
 		border-radius: 2px;

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { includes, some } from 'lodash';
 import { createElement } from 'react';
 import { PluginsScheduledUpdates } from 'calypso/blocks/plugins-scheduled-updates';
+import { PluginsScheduledUpdatesMultisite } from 'calypso/blocks/plugins-scheduled-updates-multisite';
 import { redirectLoggedOut } from 'calypso/controller';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
@@ -173,7 +174,7 @@ export function scheduledUpdates( context, next ) {
 export function scheduledUpdatesMultisite( context, next ) {
 	switch ( context.params.action ) {
 		case 'create':
-			context.primary = 'Create multisite scheduled updates';
+			context.primary = createElement( PluginsScheduledUpdatesMultisite );
 			break;
 
 		case 'edit':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89473

## Proposed Changes

* Creates module for the multisite context
* Adapts frequency form control for different use cases
* Adjust CSS

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/create` from `dev env` or provide `plugins/multisite-scheduled-updates` flag
* Check the form styles and controls render
* This is an initial version only rendering existing adapted controls

The next PR will bring the site selection control and BE integration

<img width="1406" alt="Screenshot 2024-04-15 at 17 17 06" src="https://github.com/Automattic/wp-calypso/assets/1241413/c46d41ae-b0b5-4281-9a87-04836d7a5bdc">

<img width="568" alt="Screenshot 2024-04-15 at 17 17 24" src="https://github.com/Automattic/wp-calypso/assets/1241413/406c1638-3c1d-416c-a2e4-0de97be5d6d5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?