### PR TITLE
Site Migration: Add test for site-migration-add-trial-plan step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
@@ -13,7 +13,7 @@ const SiteMigrationAssignTrialPlanStep: Step = ( { navigation } ) => {
 	const site = useSite();
 
 	const dispatch = useDispatch();
-	const { addHostingTrial, isError } = useAddHostingTrialMutation( {
+	const { addHostingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
 			// After the trial is added, we need to request the site again to get the updated plan
 			site && dispatch( requestSite( site.ID ) );
@@ -21,7 +21,7 @@ const SiteMigrationAssignTrialPlanStep: Step = ( { navigation } ) => {
 		},
 		onError: () => {
 			// If adding the trial fails, submit with error dependency.
-			submit?.( { error: isError } );
+			submit?.( { error: true } );
 		},
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/test/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import SiteMigrationAssignTrialPlanStep from '..';
+import { StepProps } from '../../../types';
+import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
+
+const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
+
+const render = ( props?: Partial< StepProps >, renderOptions?: RenderStepOptions ) => {
+	const combinedProps = { ...mockStepProps( props ) };
+	return renderStep( <SiteMigrationAssignTrialPlanStep { ...combinedProps } />, renderOptions );
+};
+
+const planSlug = PLAN_MIGRATION_TRIAL_MONTHLY;
+
+describe( 'SiteMigrationAssignTrialPlanStep', () => {
+	beforeAll( () => nock.disableNetConnect() );
+
+	it( 'shows the error step when the api returns an error', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		mockApi()
+			.post( `/wpcom/v2/sites/123456789/hosting/trial/add/${ planSlug }` )
+			.reply( 500, new Error( 'Internal Server Error' ) );
+
+		await waitFor( () =>
+			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { error: true } ) )
+		);
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/test/index.tsx
@@ -5,9 +5,20 @@ import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { waitFor } from '@testing-library/react';
 import nock from 'nock';
 import React from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import SiteMigrationAssignTrialPlanStep from '..';
 import { StepProps } from '../../../types';
 import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site' );
+
+const siteId = 123456789;
+const planSlug = PLAN_MIGRATION_TRIAL_MONTHLY;
+
+( useSite as jest.Mock ).mockReturnValue( {
+	ID: siteId,
+	URL: 'https://site-url.wordpress.com',
+} );
 
 const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
 
@@ -16,18 +27,36 @@ const render = ( props?: Partial< StepProps >, renderOptions?: RenderStepOptions
 	return renderStep( <SiteMigrationAssignTrialPlanStep { ...combinedProps } />, renderOptions );
 };
 
-const planSlug = PLAN_MIGRATION_TRIAL_MONTHLY;
-
 describe( 'SiteMigrationAssignTrialPlanStep', () => {
 	beforeAll( () => nock.disableNetConnect() );
 
-	it( 'shows the error step when the api returns an error', async () => {
+	it( 'submits the step when the api returns a response', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 
 		mockApi()
-			.post( `/wpcom/v2/sites/123456789/hosting/trial/add/${ planSlug }` )
-			.reply( 500, new Error( 'Internal Server Error' ) );
+			.post( `/wpcom/v2/sites/${ siteId }/hosting/trial/add/${ planSlug }`, {
+				hosting_intent: 'migrate',
+			} )
+			.reply( 200 );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalled() );
+	} );
+
+	it( 'submits the step with an error object when the api returns an error', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		mockApi()
+			.post( `/wpcom/v2/sites/${ siteId }/hosting/trial/add/${ planSlug }`, {
+				hosting_intent: 'migrate',
+			} )
+			.reply(
+				400,
+				new Error(
+					'You cannot add WordPress.com Migration Trial when you already have paid upgrades'
+				)
+			);
 
 		await waitFor( () =>
 			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { error: true } ) )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/test/index.tsx
@@ -51,12 +51,7 @@ describe( 'SiteMigrationAssignTrialPlanStep', () => {
 			.post( `/wpcom/v2/sites/${ siteId }/hosting/trial/add/${ planSlug }`, {
 				hosting_intent: 'migrate',
 			} )
-			.reply(
-				400,
-				new Error(
-					'You cannot add WordPress.com Migration Trial when you already have paid upgrades'
-				)
-			);
+			.reply( 500, new Error( 'Internal Server Error' ) );
 
 		await waitFor( () =>
 			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { error: true } ) )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89417

## Proposed Changes

* Add tests for the new site migration add trial plan step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From the root calypso folder on your local machine, run `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/test/index.tsx` on this branch. Two tests should run and both should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?