### PR TITLE
Checkout/Purchase: Remove hasTranslation for pre-translated strings

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { CompactCard, Card } from '@automattic/components';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -40,10 +40,7 @@ function BillingHistory() {
 	const genericTaxName =
 		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
 		translate( 'tax (VAT/GST/CT)' );
-	const fallbackTaxName =
-		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
-			? genericTaxName
-			: translate( 'VAT', { textOnly: true } );
+	const fallbackTaxName = genericTaxName;
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 	const editVatText = translate( 'Edit %s details', {
 		textOnly: true,

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import i18n, { getLocaleSlug, localize, useTranslate } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
@@ -145,10 +145,7 @@ export function vatDetails( context, next ) {
 		const genericTaxName =
 			/* translators: This is a generic name for taxes to use when we do not know the user's country. */
 			translate( 'tax (VAT/GST/CT)' );
-		const fallbackTaxName =
-			getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
-				? genericTaxName
-				: translate( 'VAT', { textOnly: true } );
+		const fallbackTaxName = genericTaxName;
 		/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 		const title = translate( 'Add %s details', {
 			textOnly: true,

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -6,9 +6,8 @@ import {
 	isJetpackProduct,
 	JETPACK_LEGACY_PLANS,
 } from '@automattic/calypso-products';
-import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -52,9 +51,7 @@ function PurchaseMetaExpiration( {
 	renderRenewsOrExpiresOnLabel,
 }: ExpirationProps ) {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
 	const moment = useLocalizedMoment();
-	const locale = getLocaleSlug();
 	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
 	const isJetpackPurchase = isJetpackPlan( purchase ) || isJetpackProduct( purchase );
 	const isCancellableSitelessPurchase = isAkismetTemporarySitePurchase( purchase );
@@ -154,11 +151,6 @@ function PurchaseMetaExpiration( {
 			return false;
 		};
 
-		// TODO - remove this once the translation is available in all languages - see https://translate.wordpress.com/deliverables/overview/9768580/
-		const hasToolTipTextBeenTranslated = hasTranslation(
-			'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date. {{inlineSupportLink}}Learn more{{/inlineSupportLink}}'
-		);
-
 		return (
 			<li className="manage-purchase__meta-expiration">
 				<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
@@ -175,7 +167,7 @@ function PurchaseMetaExpiration( {
 					} ) }
 				>
 					{ subsBillingText }
-					{ shouldShowTooltip() && ( locale === 'en' || hasToolTipTextBeenTranslated ) && (
+					{ shouldShowTooltip() && (
 						<InfoPopover position="bottom right">
 							{ translate(
 								'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date. {{inlineSupportLink}}Learn more{{/inlineSupportLink}}',

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -7,7 +7,7 @@ import {
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from '@automattic/urls';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -77,10 +77,7 @@ export default function PurchaseMeta( {
 	const showJetpackUserLicense = isJetpackProduct( purchase ) || isJetpackPlan( purchase );
 	const isAkismetPurchase = isAkismetTemporarySitePurchase( purchase );
 
-	const renewalPriceHeader =
-		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Renewal Price' )
-			? translate( 'Renewal Price' )
-			: translate( 'Price' );
+	const renewalPriceHeader = translate( 'Renewal Price' );
 
 	const hideRenewalPriceSection = isOneTimePurchase( purchase );
 	const hideTaxString = isIncludedWithPlan( purchase );
@@ -89,10 +86,9 @@ export default function PurchaseMeta( {
 	// The country is not included in the purchase information envelope
 	// We should add this information so we can utilize useTaxName to retrieve the correct taxName
 	// For now, we are using a fallback tax name
-	const taxName =
-		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax' )
-			? translate( 'tax' )
-			: translate( 'tax (VAT/GST/CT)' );
+	const taxName = translate( 'tax', {
+		context: "Shortened form of 'Sales Tax', not a country-specific tax name",
+	} );
 
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 	const excludeTaxStringAbbreviation = translate( 'excludes %s', {

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,7 +1,7 @@
 import { CompactCard, Button, Card, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CALYPSO_CONTACT } from '@automattic/urls';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef, useMemo } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -69,10 +69,7 @@ export default function VatInfoPage() {
 	const genericTaxName =
 		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
 		translate( 'tax (VAT/GST/CT)' );
-	const fallbackTaxName =
-		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
-			? genericTaxName
-			: translate( 'VAT', { textOnly: true } );
+	const fallbackTaxName = genericTaxName;
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 	const title = translate( 'Add %s details', {
 		textOnly: true,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'calypso/state';
@@ -43,19 +42,10 @@ export function useThankYouFoooter(
 function usePluginSteps(): FooterStep[] {
 	const localizeUrl = useLocalizeUrl();
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
-	const locale = useLocale();
-	const newText =
-		'Check out our support documentation for step-by-step instructions and expert guidance on your plugin setup.';
 
-	const descriptionText =
-		locale.startsWith( 'en' ) || hasTranslation?.( newText )
-			? translate(
-					'Check out our support documentation for step-by-step instructions and expert guidance on your plugin setup.'
-			  )
-			: translate(
-					'Check out our support documentation for step-by-step instructions and expert guidance on your plugin set up.'
-			  );
+	const descriptionText = translate(
+		'Check out our support documentation for step-by-step instructions and expert guidance on your plugin setup.'
+	);
 
 	return [
 		{

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -23,13 +23,12 @@ import {
 	usePaymentMethod,
 } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/format-currency';
-import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses, hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import {
@@ -346,7 +345,6 @@ export default function CheckoutMainContent( {
 	customizedPreviousPath?: string;
 	loadingHeader?: ReactNode;
 } ) {
-	const locale = useLocale();
 	const cartKey = useCartKey();
 	const {
 		responseCart,
@@ -518,10 +516,7 @@ export default function CheckoutMainContent( {
 		);
 	}
 
-	const nextStepButtonText =
-		locale.startsWith( 'en' ) || i18n.hasTranslation( 'Continue to payment' )
-			? translate( 'Continue to payment', { textOnly: true } )
-			: translate( 'Continue', { textOnly: true } );
+	const nextStepButtonText = translate( 'Continue to payment', { textOnly: true } );
 
 	return (
 		<WPCheckoutWrapper>

--- a/client/my-sites/checkout/src/components/coupon.tsx
+++ b/client/my-sites/checkout/src/components/coupon.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/composite-checkout';
 import { Field, styled, joinClasses, hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { CouponStatus } from '@automattic/shopping-cart';
@@ -133,10 +133,10 @@ const CouponWrapper = styled.form< { shouldUseCheckoutV2: boolean } >`
 	${ ( props ) =>
 		props.shouldUseCheckoutV2
 			? `display: grid;
-		align-items: center; 
-		justify-content: space-between; 
-		grid-template-columns: 1fr max-content; 
-		grid-template-areas: 
+		align-items: center;
+		justify-content: space-between;
+		grid-template-columns: 1fr max-content;
+		grid-template-areas:
 		'label     .  '
 		'field  button';
 		gap: .5em;`
@@ -178,16 +178,7 @@ function getCouponErrorMessageFromStatus(
 	isFreshOrEdited: boolean
 ): string | undefined {
 	if ( status === 'rejected' && ! isFreshOrEdited ) {
-		if (
-			getLocaleSlug() === 'en' ||
-			getLocaleSlug() === 'en-gb' ||
-			i18n.hasTranslation( 'There was a problem applying this coupon.' )
-		) {
-			return translate( 'There was a problem applying this coupon.', { textOnly: true } );
-		}
-		return String(
-			translate( "We couldn't find your coupon. Please check your coupon code and try again." )
-		);
+		return translate( 'There was a problem applying this coupon.', { textOnly: true } );
 	}
 	return undefined;
 }

--- a/client/my-sites/checkout/src/components/google-transfers-copy.tsx
+++ b/client/my-sites/checkout/src/components/google-transfers-copy.tsx
@@ -1,5 +1,4 @@
 import { isDomainTransfer } from '@automattic/calypso-products';
-import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import type { ResponseCart } from '@automattic/shopping-cart';
@@ -11,8 +10,7 @@ const GoogleDomainsCopyStyle = styled.p`
 `;
 
 export function GoogleDomainsCopy( { responseCart }: { responseCart: ResponseCart } ) {
-	const { __, hasTranslation } = useI18n();
-	const locale = useLocale();
+	const { __ } = useI18n();
 
 	const hasFreeCouponTransfersOnly = responseCart.products?.every( ( item ) => {
 		return (
@@ -24,19 +22,9 @@ export function GoogleDomainsCopy( { responseCart }: { responseCart: ResponseCar
 	} );
 
 	if ( hasFreeCouponTransfersOnly ) {
-		let couponText = __(
-			"We're paying the first year of your domain transfer. We'll use the payment information below to renew your domain transfer starting next year."
+		const couponText = __(
+			'We’re paying to extend your registration for an additional year. We’ll use the payment information below to renew your domain before it expires.'
 		);
-		if (
-			englishLocales.includes( locale ) ||
-			hasTranslation(
-				'We’re paying to extend your registration for an additional year. We’ll use the payment information below to renew your domain before it expires.'
-			)
-		) {
-			couponText = __(
-				'We’re paying to extend your registration for an additional year. We’ll use the payment information below to renew your domain before it expires.'
-			);
-		}
 
 		return <GoogleDomainsCopyStyle>{ couponText }</GoogleDomainsCopyStyle>;
 	}

--- a/client/my-sites/checkout/src/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/src/components/vat-form/index.tsx
@@ -2,7 +2,7 @@ import { CALYPSO_CONTACT } from '@automattic/urls';
 import { Field } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
@@ -161,10 +161,7 @@ export function VatForm( {
 	const genericTaxName =
 		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
 		translate( 'tax (VAT/GST/CT)' );
-	const fallbackTaxName =
-		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax (VAT/GST/CT)' )
-			? genericTaxName
-			: translate( 'VAT', { textOnly: true } );
+	const fallbackTaxName = genericTaxName;
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 	const addVatText = translate( 'Add %s details', {
 		textOnly: true,

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -145,9 +145,7 @@ const ProfessionalEmailUpsell = ( {
 							} ) }
 						</h1>
 						<h3 className="professional-email-upsell__small-subtitle">
-							{ i18n.hasTranslation( 'No setup required. Easy to manage.' )
-								? translate( 'No setup required. Easy to manage.' )
-								: null }
+							{ translate( 'No setup required. Easy to manage.' ) }
 						</h3>
 						<BillingIntervalToggle
 							intervalLength={ selectedIntervalLength }


### PR DESCRIPTION
## Proposed Changes

When new translations are added to code, we often use `hasTranslation` to provide a fallback so the code can be merged before the translations are available. However, we rarely go back and remove those calls which can lead to bugs like the one fixed in https://github.com/Automattic/wp-calypso/pull/89538.

In this diff, we remove `hasTranslation` in all checkout and purchase management related code for translations which have already completed.

## Testing Instructions

A visual syntax check should be sufficient.