### PR TITLE
Create valid checkout links for theme related plan upgrades

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -136,6 +136,16 @@ export const useCanPreviewButNeedUpgrade = (
 	const [ checkoutTab, setCheckoutTab ] = useState< Window | null >();
 	const [ checkoutStatus, setCheckoutStatus ] = useState< CheckoutStatus >( '' );
 
+	let requiredPlanSlug = '';
+	switch ( previewingTheme.type ) {
+		case WOOCOMMERCE_THEME:
+			requiredPlanSlug = PLAN_BUSINESS;
+		case PREMIUM_THEME:
+			requiredPlanSlug = PLAN_PREMIUM;
+		case PERSONAL_THEME:
+			requiredPlanSlug = PLAN_PERSONAL;
+	}
+
 	const handleCanPreviewButNeedUpgrade = useCallback(
 		( previewingTheme: ReturnType< typeof usePreviewingTheme > ) => {
 			// Currently, Live Preview only supports upgrades for these themes
@@ -207,30 +217,14 @@ export const useCanPreviewButNeedUpgrade = (
 			}/${ plan }?checkoutBackUrl=${ encodeURIComponent( url ) }`;
 		};
 
-		let link = '';
-		switch ( previewingTheme.type ) {
-			/**
-			 * For a WooCommerce theme, the users should have the Business plan or higher,
-			 * AND the WooCommerce plugin has to be installed.
-			 */
-			case WOOCOMMERCE_THEME:
-				link = generateCheckoutUrl( PLAN_BUSINESS );
-				break;
-			// For a Premium theme, the users should have the Premium plan or higher.
-			case PREMIUM_THEME:
-				link = generateCheckoutUrl( PLAN_PREMIUM );
-				break;
-			case PERSONAL_THEME:
-				link = generateCheckoutUrl( PLAN_PERSONAL );
-				break;
-		}
+		const link = generateCheckoutUrl( requiredPlanSlug );
 		// Open the checkout in a new tab.
 		if ( checkoutTab && ! checkoutTab.closed ) {
 			checkoutTab.focus();
 		} else {
 			setCheckoutTab( window.open( link, 'wpcom-live-preview-upgrade-plan-window' ) );
 		}
-	}, [ checkoutTab, previewingTheme.id, previewingTheme.type, siteSlug ] );
+	}, [ checkoutTab, previewingTheme.id, previewingTheme.type, siteSlug, requiredPlanSlug ] );
 
 	useDisplayCheckoutNotice( checkoutStatus );
 
@@ -280,5 +274,6 @@ export const useCanPreviewButNeedUpgrade = (
 	return {
 		canPreviewButNeedUpgrade,
 		upgradePlan,
+		requiredPlanSlug,
 	};
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -137,6 +137,8 @@ export const useCanPreviewButNeedUpgrade = (
 	const [ checkoutStatus, setCheckoutStatus ] = useState< CheckoutStatus >( '' );
 
 	const getRequiredPlanSlug = (): string => {
+		// TODO: This doesn't work on sites with longer length plans, the plan should be the
+		// biannual plan if the site is on a biannual plan.
 		switch ( previewingTheme.type ) {
 			case WOOCOMMERCE_THEME:
 				return PLAN_BUSINESS;

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -138,11 +138,9 @@ export const useCanPreviewButNeedUpgrade = (
 
 	const handleCanPreviewButNeedUpgrade = useCallback(
 		( previewingTheme: ReturnType< typeof usePreviewingTheme > ) => {
+			// Currently, Live Preview only supports upgrades for these themes
 			const livePreviewUpgradeTypes = [ WOOCOMMERCE_THEME, PREMIUM_THEME, PERSONAL_THEME ];
 
-			/**
-			 * Currently, Live Preview only supports upgrades for WooCommerce and Premium themes.
-			 */
 			if ( ! previewingTheme?.type || ! livePreviewUpgradeTypes.includes( previewingTheme.type ) ) {
 				setCanPreviewButNeedUpgrade( false );
 				return;

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -136,6 +136,8 @@ export const useCanPreviewButNeedUpgrade = (
 	const [ checkoutTab, setCheckoutTab ] = useState< Window | null >();
 	const [ checkoutStatus, setCheckoutStatus ] = useState< CheckoutStatus >( '' );
 
+	// TODO: This doesn't work on sites with longer length plans, the plan should be the
+	// biannual / trieenial plan.
 	let requiredPlanSlug = '';
 	switch ( previewingTheme.type ) {
 		case WOOCOMMERCE_THEME:

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -136,17 +136,20 @@ export const useCanPreviewButNeedUpgrade = (
 	const [ checkoutTab, setCheckoutTab ] = useState< Window | null >();
 	const [ checkoutStatus, setCheckoutStatus ] = useState< CheckoutStatus >( '' );
 
-	// TODO: This doesn't work on sites with longer length plans, the plan should be the
-	// biannual / trieenial plan.
-	let requiredPlanSlug = '';
-	switch ( previewingTheme.type ) {
-		case WOOCOMMERCE_THEME:
-			requiredPlanSlug = PLAN_BUSINESS;
-		case PREMIUM_THEME:
-			requiredPlanSlug = PLAN_PREMIUM;
-		case PERSONAL_THEME:
-			requiredPlanSlug = PLAN_PERSONAL;
-	}
+	const getRequiredPlanSlug = (): string => {
+		switch ( previewingTheme.type ) {
+			case WOOCOMMERCE_THEME:
+				return PLAN_BUSINESS;
+			case PREMIUM_THEME:
+				return PLAN_PREMIUM;
+			case PERSONAL_THEME:
+				return PLAN_PERSONAL;
+			default:
+				return '';
+		}
+	};
+
+	const requiredPlanSlug = getRequiredPlanSlug();
 
 	const handleCanPreviewButNeedUpgrade = useCallback(
 		( previewingTheme: ReturnType< typeof usePreviewingTheme > ) => {

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
@@ -55,7 +55,8 @@ const LivePreviewNotice: FC< {
 const LivePreviewNoticePlugin = () => {
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
 	const previewingTheme = usePreviewingTheme();
-	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( previewingTheme );
+	const { canPreviewButNeedUpgrade, upgradePlan, requiredPlanSlug } =
+		useCanPreviewButNeedUpgrade( previewingTheme );
 	const dashboardLink = useSelect(
 		( select ) =>
 			unlock &&
@@ -72,7 +73,7 @@ const LivePreviewNoticePlugin = () => {
 	if ( canPreviewButNeedUpgrade ) {
 		return (
 			<>
-				<LivePreviewUpgradeModal { ...{ previewingTheme, upgradePlan } } />
+				<LivePreviewUpgradeModal { ...{ previewingTheme, upgradePlan, requiredPlanSlug } } />
 				<LivePreviewUpgradeNotice { ...{ previewingTheme, dashboardLink } } />
 			</>
 		);

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
@@ -10,7 +10,8 @@ import './upgrade-modal.scss';
 export const LivePreviewUpgradeModal: FC< {
 	previewingTheme: ReturnType< typeof usePreviewingTheme >;
 	upgradePlan: () => void;
-} > = ( { previewingTheme, upgradePlan } ) => {
+	requiredPlanSlug: string;
+} > = ( { previewingTheme, upgradePlan, requiredPlanSlug } ) => {
 	const [ isThemeUpgradeModalOpen, setIsThemeUpgradeModalOpen ] = useState( false );
 
 	useOverrideSaveButton( { setIsThemeUpgradeModalOpen, previewingTheme } );
@@ -38,6 +39,7 @@ export const LivePreviewUpgradeModal: FC< {
 				isOpen={ isThemeUpgradeModalOpen }
 				closeModal={ closeModal }
 				checkout={ upgradePlan }
+				requiredPlan={ requiredPlanSlug }
 			/>
 		</QueryClientProvider>
 	);

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -214,9 +214,9 @@ export const ThemeUpgradeModal = ( {
 		const planPrice = requiredPlanProduct?.combined_cost_display;
 
 		const planText = getPlanText(
-			premiumPlanName,
+			premiumPlanName as string,
 			requiredPlanProduct?.product_term || '',
-			planPrice
+			planPrice || ''
 		);
 
 		return {
@@ -308,9 +308,9 @@ export const ThemeUpgradeModal = ( {
 		const color = bundleSettings.color;
 		const Icon = bundleSettings.iconComponent;
 		const planText = getPlanText(
-			businessPlanName,
+			businessPlanName as string,
 			requiredPlanProduct?.product_term || '',
-			businessPlanPrice
+			businessPlanPrice || ''
 		);
 
 		return {

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -109,20 +109,6 @@ export const ThemeUpgradeModal = ( {
 	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() || '';
 	const ecommercePlanName = getPlan( PLAN_ECOMMERCE )?.getTitle() || '';
 
-	const getPlanTextByTerm = ( term: string, cost: string ) => {
-		switch ( term ) {
-			case 'three years':
-				return translate( '%(cost)s per three years', { args: { cost } } );
-			case 'two years':
-				return translate( '%(cost)s per two years', { args: { cost } } );
-			case 'month':
-				return translate( '%(cost)s per month', { args: { cost } } );
-			case 'year':
-			default:
-				return translate( '%(cost)s per year', { args: { cost } } );
-		}
-	};
-
 	const getPersonalPlanModalData = (): UpgradeModalContent => {
 		const planPrice = requiredPlanProduct?.combined_cost_display;
 
@@ -168,28 +154,76 @@ export const ThemeUpgradeModal = ( {
 	};
 
 	const getStandardPurchaseModalData = (): UpgradeModalContent => {
-		const planPrice = requiredPlanProduct?.combined_cost_display;
-
-		return {
-			header: (
-				<h1 className="theme-upgrade-modal__heading">{ translate( 'Unlock this theme' ) }</h1>
-			),
-			text: (
-				<p>
-					{ translate(
-						'Get access to this theme, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+		const getPlanText = ( planName: string, term: string, planPrice: string ) => {
+			switch ( term ) {
+				case 'three years':
+					return translate(
+						'Get access to this theme, and a ton of other features, with a subscription to the %(planName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} per three years, risk-free with a 14-day money-back guarantee.',
 						{
 							components: {
 								strong: <strong />,
 							},
 							args: {
 								planPrice: planPrice || '',
-								premiumPlanName: premiumPlanName,
+								planName: planName,
 							},
 						}
-					) }
-				</p>
+					);
+				case 'two years':
+					return translate(
+						'Get access to this theme, and a ton of other features, with a subscription to the %(planName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} per two years, risk-free with a 14-day money-back guarantee.',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: {
+								planPrice: planPrice || '',
+								planName: planName,
+							},
+						}
+					);
+				case 'month':
+					return translate(
+						'Get access to this theme, and a ton of other features, with a subscription to the %(planName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} per month, risk-free with a 7-day money-back guarantee.',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: {
+								planPrice: planPrice || '',
+								planName: planName,
+							},
+						}
+					);
+				case 'year':
+				default:
+					return translate(
+						'Get access to this theme, and a ton of other features, with a subscription to the %(planName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} anually, risk-free with a 14-day money-back guarantee.',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: {
+								planPrice: planPrice || '',
+								planName: planName,
+							},
+						}
+					);
+			}
+		};
+		const planPrice = requiredPlanProduct?.combined_cost_display;
+
+		const planText = getPlanText(
+			premiumPlanName,
+			requiredPlanProduct?.product_term || '',
+			planPrice
+		);
+
+		return {
+			header: (
+				<h1 className="theme-upgrade-modal__heading">{ translate( 'Unlock this theme' ) }</h1>
 			),
+			text: <p>{ planText }</p>,
 			price: null,
 			action: (
 				<div className="theme-upgrade-modal__actions bundle">
@@ -212,6 +246,52 @@ export const ThemeUpgradeModal = ( {
 	};
 
 	const getBundledFirstPartyPurchaseModalData = (): UpgradeModalContent => {
+		const getPlanText = ( planName: string, term: string, planPrice: string ) => {
+			switch ( term ) {
+				case 'three years':
+					return translate(
+						'Upgrade to a %(planName)s plan to select this theme and unlock all its features. It’s %(planPrice)s per three years with a 14-day money-back guarantee',
+						{
+							args: {
+								planPrice: planPrice || '',
+								planName: planName,
+							},
+						}
+					);
+				case 'two years':
+					return translate(
+						'Upgrade to a %(planName)s plan to select this theme and unlock all its features. It’s %(planPrice)s per two years with a 14-day money-back guarantee',
+						{
+							args: {
+								planPrice: planPrice || '',
+								planName: planName,
+							},
+						}
+					);
+
+				case 'month':
+					return translate(
+						'Upgrade to a %(planName)s plan to select this theme and unlock all its features. It’s %(planPrice)s per month with a 7-day money-back guarantee',
+						{
+							args: {
+								planPrice: planPrice || '',
+								planName: planName,
+							},
+						}
+					);
+				case 'year':
+				default:
+					return translate(
+						'Upgrade to a %(planName)s plan to select this theme and unlock all its features. It’s %(planPrice)s per year with a 14-day money-back guarantee',
+						{
+							args: {
+								planPrice: planPrice || '',
+								planName: planName,
+							},
+						}
+					);
+			}
+		};
 		const businessPlanPrice = requiredPlanProduct?.combined_cost_display;
 
 		if ( ! bundleSettings ) {
@@ -227,6 +307,11 @@ export const ThemeUpgradeModal = ( {
 		const bundledPluginMessage = bundleSettings.bundledPluginMessage;
 		const color = bundleSettings.color;
 		const Icon = bundleSettings.iconComponent;
+		const planText = getPlanText(
+			businessPlanName,
+			requiredPlanProduct?.product_term || '',
+			businessPlanPrice
+		);
 
 		return {
 			header: (
@@ -244,17 +329,7 @@ export const ThemeUpgradeModal = ( {
 			),
 			text: (
 				<p>
-					{ bundledPluginMessage }{ ' ' }
-					{ translate(
-						// translators: %s is the business plan price.
-						'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.',
-						{
-							args: {
-								businessPlanPrice: businessPlanPrice || '',
-								businessPlanName: businessPlanName,
-							},
-						}
-					) }
+					{ bundledPluginMessage } { planText }
 				</p>
 			),
 			price: null,
@@ -279,8 +354,22 @@ export const ThemeUpgradeModal = ( {
 	};
 
 	const getExternallyManagedPurchaseModalData = (): UpgradeModalContent => {
+		const getMarketplacePlanTextByTerm = ( term: string, cost: string ) => {
+			switch ( term ) {
+				case 'three years':
+					return translate( '%(cost)s per three years', { args: { cost } } );
+				case 'two years':
+					return translate( '%(cost)s per two years', { args: { cost } } );
+				case 'month':
+					return translate( '%(cost)s per month', { args: { cost } } );
+				case 'year':
+				default:
+					return translate( '%(cost)s per year', { args: { cost } } );
+			}
+		};
+
 		const productPrice = marketplaceProduct?.cost_display;
-		const businessPlanPriceText = getPlanTextByTerm(
+		const businessPlanPriceText = getMarketplacePlanTextByTerm(
 			requiredPlanProduct?.product_term || '',
 			requiredPlanProduct?.combined_cost_display || ''
 		);

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -198,7 +198,7 @@ export const ThemeUpgradeModal = ( {
 				case 'year':
 				default:
 					return translate(
-						'Get access to this theme, and a ton of other features, with a subscription to the %(planName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} anually, risk-free with a 14-day money-back guarantee.',
+						'Get access to this theme, and a ton of other features, with a subscription to the %(planName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} annually, risk-free with a 14-day money-back guarantee.',
 						{
 							components: {
 								strong: <strong />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -964,7 +964,7 @@ function getRequiredPlan( selectedDesign: Design | undefined, currentPlanSlug: s
 		// Marketplace themes require upgrading to a monthly business plan or higher, everything else requires an annual plan.
 		requiredTerm = selectedDesign?.is_externally_managed ? TERM_MONTHLY : TERM_ANNUALLY;
 	} else {
-		requiredTerm = getPlan( currentPlanSlug )?.term || '';
+		requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
 	}
 
 	return getPlanByTerm( tierMinimumUpsellPlan, requiredTerm );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -4,7 +4,7 @@ import {
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	getPlan,
 	isFreePlan,
-	findSimilarPlansKeys,
+	findFirstSimilarPlanKey,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
@@ -940,7 +940,7 @@ function getRequiredPlan( selectedDesign: Design | undefined, currentPlanSlug: s
 		requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
 	}
 
-	return findSimilarPlansKeys( tierMinimumUpsellPlan, { term: requiredTerm } );
+	return findFirstSimilarPlanKey( tierMinimumUpsellPlan, { term: requiredTerm } );
 }
 
 export default UnifiedDesignPickerStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -949,7 +949,7 @@ function getBusinessPlanByTerm( term: string ) {
 }
 
 function getRequiredPlan( selectedDesign: Design | undefined, currentPlanSlug: string ) {
-	if ( ! selectedDesign || ! selectedDesign?.design_tier ) {
+	if ( ! selectedDesign?.design_tier ) {
 		return;
 	}
 	// Different designs require different plans to unlock them, additionally the terms required can vary.
@@ -962,11 +962,7 @@ function getRequiredPlan( selectedDesign: Design | undefined, currentPlanSlug: s
 	let requiredTerm;
 	if ( ! currentPlanSlug || isFreePlan( currentPlanSlug ) ) {
 		// Marketplace themes require upgrading to a monthly business plan or higher, everything else requires an annual plan.
-		if ( selectedDesign?.is_externally_managed ) {
-			requiredTerm = TERM_MONTHLY;
-		} else {
-			requiredTerm = TERM_ANNUALLY;
-		}
+		requiredTerm = selectedDesign?.is_externally_managed ? TERM_MONTHLY : TERM_ANNUALLY;
 	} else {
 		requiredTerm = getPlan( currentPlanSlug )?.term || '';
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -1,23 +1,10 @@
 import {
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_MONTHLY,
-	PLAN_BUSINESS_2_YEARS,
-	PLAN_BUSINESS_3_YEARS,
-	PLAN_PERSONAL,
 	TERM_ANNUALLY,
-	TERM_BIENNIALLY,
 	TERM_MONTHLY,
-	TERM_TRIENNIALLY,
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	getPlan,
 	isFreePlan,
-	PLAN_PREMIUM,
-	PLAN_PERSONAL_3_YEARS,
-	PLAN_PERSONAL_2_YEARS,
-	PLAN_PREMIUM_3_YEARS,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PREMIUM_MONTHLY,
-	PLAN_PERSONAL_MONTHLY,
+	findSimilarPlansKeys,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
@@ -934,20 +921,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 };
 
-function getBusinessPlanByTerm( term: string ) {
-	switch ( term ) {
-		case TERM_TRIENNIALLY:
-			return PLAN_BUSINESS_3_YEARS;
-		case TERM_BIENNIALLY:
-			return PLAN_BUSINESS_2_YEARS;
-		case TERM_ANNUALLY:
-			return PLAN_BUSINESS;
-		case TERM_MONTHLY:
-		default:
-			return PLAN_BUSINESS_MONTHLY;
-	}
-}
-
 function getRequiredPlan( selectedDesign: Design | undefined, currentPlanSlug: string ) {
 	if ( ! selectedDesign?.design_tier ) {
 		return;
@@ -967,41 +940,7 @@ function getRequiredPlan( selectedDesign: Design | undefined, currentPlanSlug: s
 		requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
 	}
 
-	return getPlanByTerm( tierMinimumUpsellPlan, requiredTerm );
-}
-
-function getPlanByTerm( plan: string, term: string ) {
-	// This is icky, replace later with less hard-coding.
-	switch ( plan ) {
-		case PLAN_PERSONAL:
-			switch ( term ) {
-				case TERM_TRIENNIALLY:
-					return PLAN_PERSONAL_3_YEARS;
-				case TERM_BIENNIALLY:
-					return PLAN_PERSONAL_2_YEARS;
-				case TERM_MONTHLY:
-					return PLAN_PERSONAL_MONTHLY;
-				case TERM_ANNUALLY:
-				default:
-					return PLAN_PERSONAL;
-			}
-		case PLAN_PREMIUM:
-			switch ( term ) {
-				case TERM_TRIENNIALLY:
-					return PLAN_PREMIUM_3_YEARS;
-				case TERM_BIENNIALLY:
-					return PLAN_PREMIUM_2_YEARS;
-				case TERM_MONTHLY:
-					return PLAN_PREMIUM_MONTHLY;
-				case TERM_ANNUALLY:
-				default:
-					return PLAN_PREMIUM;
-			}
-		case PLAN_BUSINESS:
-			return getBusinessPlanByTerm( term );
-		default:
-			return plan;
-	}
+	return findSimilarPlansKeys( tierMinimumUpsellPlan, { term: requiredTerm } );
 }
 
 export default UnifiedDesignPickerStep;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88378

## Proposed Changes

When a user needs to upgrade their site plan to get access to a theme, checkout to a plan with a valid term. A valid term is one that is longer, or as long as the current plans term. I.e you can go from two year starter to two year explorer but not to one year explorer - the checkout would display an error.

Previously this had been solved specifically for marketplace themes requiring an upgrade but not for other theme tiers.

The ThemeUpgradeModal now has a `requiredPlan` prop so that it can display information about that plan. Previously it was just given the plan length (term) and had to calculate the plan type itself. The parents needed to calculate the plan type anyway in order to provide the `checkout` prop, so this saves duplicating the logic.

**This does not completely fix #88378** - it does not fix the problem occurring from /themes and it does not fix the problem occurring from block theme live previews.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Design picker

1. Use the calypso live link
2. Go to /start
3. Create a site, purchasing a two year starter plan
4. When you get to the design picker choose an Explorer theme
5. Notice the theme detail page has an "Unlock" button, press it
6. You should see a modal telling you that you need to upgrade and how much that would be for a two year plan
7. Press the Continue / purchase / whateveritscalled button on the modal
8. You should land in the checkout which has a two year Explorer theme.

You should repeat with Explorer, Marketplace and Woo themes. 

You could also repeat with different plan lengths on the initial purchase, both the modal and the checkout should give you a plan of the same length as the plan you initially purchased. The free plan should always upgrade to an annual plan except for marketplace themes where it upgrades to monthly.

### Live preview

This hasn't been fully addressed yet, but should continue to work as it does in production - i.e. it works if you're on a monthly or annual plan and the checkout fails for the rest.

 1. Follow the instructions in the generated comment below to install wpcom-block-editor on your sandbox
 2. Create a site, purchasing a one year starter plan
 3. Go to /themes, choose a {Explorer, Marketplace, Woo} theme
 4. Choose to do a live preview
 5. The button in the bottom left corner should say 'Upgrade now', press it.
 6. You should see a dialog telling you you need to upgrade your plan. The dialog should have the annual price on it
 7. Press Upgrade to activate, you should go to the checkout with the appropriate plan with an annual length in your basket.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?