### PR TITLE
A4A: Fix login page colors to match A4A brand instead of Jetpack

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -483,11 +483,6 @@
 		margin-top: 24px;
 	}
 
-	input:focus:hover[type],
-	input:focus[type] {
-		box-shadow: 0 0 0 2px var(--studio-jetpack-green-10);
-	}
-
 	.login__form-header-wrapper,
 	.signup-form__wrapper {
 		padding: 32px 0 0;
@@ -639,6 +634,13 @@
 		border: none;
 		box-shadow: none;
 	}
+}
+
+.jetpack-cloud {
+	input:focus:hover[type],
+	input:focus[type] {
+		box-shadow: 0 0 0 2px var(--studio-jetpack-green-10);
+	}
 
 	.button:not(.social-buttons__button) {
 		color: var(--studio-jetpack-green-60);
@@ -702,6 +704,78 @@
 		&:hover,
 		&:focus {
 			color: var(--studio-jetpack-green-60);
+		}
+	}
+}
+
+.a8c-for-agencies {
+	input:focus:hover[type],
+	input:focus[type] {
+		box-shadow: 0 0 0 2px var(--studio-automattic-blue-10);
+	}
+
+	.button:not(.social-buttons__button) {
+		color: var(--studio-automattic-blue-60);
+		background: var(--studio-white);
+		border: 1px solid var(--studio-automattic-blue-40);
+		border-radius: 2px;
+
+		&:hover,
+		&:focus {
+			background: var(--studio-automattic-blue-0);
+		}
+
+		&:active {
+			background: var(--studio-automattic-blue-5);
+			border-color: var(--studio-automattic-blue-40);
+			border-width: 1px;
+		}
+
+		&[disabled]:active {
+			border-width: 1px;
+		}
+
+		&[disabled],
+		&:disabled {
+			color: var(--studio-gray-10);
+			border-color: var(--color-gray-10);
+			background: var(--studio-white);
+		}
+	}
+
+	.button.is-primary {
+		color: var(--studio-white);
+		background: var(--studio-automattic-blue-40);
+		border-color: var(--studio-automattic-blue-40);
+
+		&:hover,
+		&:focus {
+			background: var(--studio-automattic-blue-30);
+			border-color: var(--studio-automattic-blue-30);
+		}
+
+		&:active {
+			background: var(--studio-automattic-blue-50);
+			border-color: var(--studio-automattic-blue-50);
+		}
+
+		&[disabled],
+		&:disabled {
+			color: var(--studio-white);
+			background: var(--studio-gray-10);
+			border-color: var(--studio-gray-10);
+		}
+	}
+
+	a,
+	a:visited,
+	.login__form-change-username,
+	.wp-login__links button {
+		color: var(--studio-automattic-blue-40);
+
+		&:hover,
+		&:focus {
+			color: var(--studio-automattic-blue-60);
 		}
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -711,23 +711,23 @@
 .a8c-for-agencies {
 	input:focus:hover[type],
 	input:focus[type] {
-		box-shadow: 0 0 0 2px var(--studio-automattic-blue-10);
+		box-shadow: 0 0 0 2px var(--color-primary-10);
 	}
 
 	.button:not(.social-buttons__button) {
-		color: var(--studio-automattic-blue-60);
+		color: var(--color-primary-60);
 		background: var(--studio-white);
-		border: 1px solid var(--studio-automattic-blue-40);
+		border: 1px solid var(--color-primary-40);
 		border-radius: 2px;
 
 		&:hover,
 		&:focus {
-			background: var(--studio-automattic-blue-0);
+			background: var(--color-primary-0);
 		}
 
 		&:active {
-			background: var(--studio-automattic-blue-5);
-			border-color: var(--studio-automattic-blue-40);
+			background: var(--color-primary-5);
+			border-color: var(--color-primary-40);
 			border-width: 1px;
 		}
 
@@ -745,18 +745,18 @@
 
 	.button.is-primary {
 		color: var(--studio-white);
-		background: var(--studio-automattic-blue-40);
-		border-color: var(--studio-automattic-blue-40);
+		background: var(--color-primary-40);
+		border-color: var(--color-primary-40);
 
 		&:hover,
 		&:focus {
-			background: var(--studio-automattic-blue-30);
-			border-color: var(--studio-automattic-blue-30);
+			background: var(--color-primary-30);
+			border-color: var(--color-primary-30);
 		}
 
 		&:active {
-			background: var(--studio-automattic-blue-50);
-			border-color: var(--studio-automattic-blue-50);
+			background: var(--color-primary-50);
+			border-color: var(--color-primary-50);
 		}
 
 		&[disabled],
@@ -771,11 +771,11 @@
 	a:visited,
 	.login__form-change-username,
 	.wp-login__links button {
-		color: var(--studio-automattic-blue-40);
+		color: var(--color-primary-40);
 
 		&:hover,
 		&:focus {
-			color: var(--studio-automattic-blue-60);
+			color: var(--color-primary-60);
 		}
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -639,7 +639,7 @@
 .jetpack-cloud {
 	input:focus:hover[type],
 	input:focus[type] {
-		box-shadow: 0 0 0 2px var(--studio-jetpack-green-10);
+		box-shadow: 0 0 0 2px var(--color-primary-10);
 	}
 
 	.button:not(.social-buttons__button) {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/134

## Proposed Changes

* This PR changes the login page colors to match A4A brand instead of Jetpack

## Testing Instructions

1) Open the Calypso live link
2) Append the URL with `/log-in?client_id=95928&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95928%26redirect_uri%3Dhttps%253A%252F%252Fagencies.localhost%253A3000%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1`. `95928` is the dev OAuth client ID.

3) Verify that the colors match the A4A brand (and not our Jetpack green colors)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?