### PR TITLE
A4A: Use custom company name in connection disclaimer

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -469,6 +469,11 @@ export class JetpackAuthorize extends Component {
 		return startsWith( from, 'wpcom-migration' );
 	}
 
+	isFromAutomatticForAgenciesPlugin( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'automattic-for-agencies-client' );
+	}
+
 	shouldRedirectJetpackStart( props = this.props ) {
 		const { partnerSlug, partnerID } = props;
 
@@ -478,6 +483,10 @@ export class JetpackAuthorize extends Component {
 	isFromMyJetpackConnectAfterCheckout( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'connect-after-checkout' );
+	}
+
+	getCompanyName() {
+		return this.isFromAutomatticForAgenciesPlugin() ? 'Automattic, Inc.' : 'WordPress.com';
 	}
 
 	handleSignIn = async ( e, loginURL ) => {
@@ -1043,7 +1052,10 @@ export class JetpackAuthorize extends Component {
 						<div className="jetpack-connect__logged-in-bottom">
 							{ this.renderStateAction() }
 							<JetpackFeatures col1Features={ col1Features } col2Features={ col2Features } />
-							<Disclaimer siteName={ decodeEntities( authQuery.blogname ) } />
+							<Disclaimer
+								siteName={ decodeEntities( authQuery.blogname ) }
+								companyName={ this.getCompanyName() }
+							/>
 							<div className="jetpack-connect__jetpack-logo-wrapper">
 								<JetpackLogo monochrome size={ 18 } />{ ' ' }
 								<span>{ translate( 'Jetpack powered' ) }</span>
@@ -1197,7 +1209,7 @@ export class JetpackAuthorize extends Component {
 		const { blogname } = this.props.authQuery;
 		return (
 			<LoggedOutFormFooter className="jetpack-connect__action-disclaimer">
-				<Disclaimer siteName={ decodeEntities( blogname ) } />
+				<Disclaimer siteName={ decodeEntities( blogname ) } companyName={ this.getCompanyName() } />
 				<Button
 					primary
 					disabled={ this.isAuthorizing() || this.props.hasXmlrpcError }

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -7,6 +7,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class JetpackConnectDisclaimer extends PureComponent {
 	static propTypes = {
+		companyName: PropTypes.string,
 		siteName: PropTypes.string.isRequired,
 	};
 
@@ -15,7 +16,7 @@ class JetpackConnectDisclaimer extends PureComponent {
 	};
 
 	render() {
-		const { siteName, translate } = this.props;
+		const { companyName = 'WordPress.com', siteName, translate } = this.props;
 
 		const detailsLink = (
 			<a
@@ -28,12 +29,13 @@ class JetpackConnectDisclaimer extends PureComponent {
 		);
 
 		const text = translate(
-			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
+			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between %(companyName)s and %(siteName)s.',
 			{
 				components: {
 					detailsLink,
 				},
 				args: {
+					companyName,
 					siteName,
 				},
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/48

## Proposed Changes

* Updates the `JetpackConnectDisclaimer` component to accept a custom `companyName` prop to override the default "WordPress.com" value.
* Provides "Automattic, Inc." to the disclaimer component when connecting from the A4A client plugin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* While signed in, in Calypso, visit the `/jetpack/connect/authorize` connection screen.
  * This link can't be accessed directly, so you will need to start a new site connection from a test site. You can use Jurassic Ninja with the Automattic For Agenceis Client plugin installed via Jetpack Beta, and get a full connection URL by connecting with the A4A plugin.
  * If you've got the A4A plugin running locally in any other form, that will work just as well.
  * Finally, you could also access the URL from any Jetpack connection flow, just manually add the "from=automattic-for-agencies-client" query string value to the URL.
* Validate that the TOS blurb uses "Automattic, Inc."
* Remove the "from" query string from the URL.
* Validate that the TOS blurb uses "WordPress.com"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="499" alt="Screenshot 2024-04-15 at 2 45 01 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/e24bf59a-1aba-4470-9663-be050d29dcc8">
