### PR TITLE
Simple Classic: Hide performance settings in /sites view.

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -38,6 +38,7 @@ import {
 	getSiteMonitoringUrl,
 	isCustomDomain,
 	isNotAtomicJetpack,
+	isSimpleSite,
 	isP2Site,
 } from '../utils';
 import type { SiteExcerptData } from '@automattic/sites';
@@ -448,6 +449,7 @@ export const SitesEllipsisMenu = ( {
 	const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( site );
 	const hasCustomDomain = isCustomDomain( site.slug );
 	const isLaunched = site.launch_status !== 'unlaunched';
+	const isClassicSimple = isWpAdminInterface && isSimpleSite( site );
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, site.ID ) );
 
 	return (
@@ -468,18 +470,20 @@ export const SitesEllipsisMenu = ( {
 					{ ! isWpcomStagingSite && shouldShowSiteCopyItem && (
 						<CopySiteItem { ...props } onClick={ startSiteCopy } />
 					) }
-					<MenuItemLink
-						href={
-							isWpAdminInterface
-								? `${ wpAdminUrl }options-general.php?page=page-optimize`
-								: `/settings/performance/${ site.slug }`
-						}
-						onClick={ () =>
-							recordTracks( 'calypso_sites_dashboard_site_action_performance_settings_click' )
-						}
-					>
-						{ __( 'Performance settings' ) }
-					</MenuItemLink>
+					{ ! isClassicSimple && (
+						<MenuItemLink
+							href={
+								isWpAdminInterface
+									? `${ wpAdminUrl }options-general.php?page=page-optimize`
+									: `/settings/performance/${ site.slug }`
+							}
+							onClick={ () =>
+								recordTracks( 'calypso_sites_dashboard_site_action_performance_settings_click' )
+							}
+						>
+							{ __( 'Performance settings' ) }
+						</MenuItemLink>
+					) }
 					{ isLaunched && (
 						<MenuItemLink
 							href={ `/settings/general/${ site.slug }#site-privacy-settings` }

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -50,6 +50,10 @@ export const isNotAtomicJetpack = ( site: SiteExcerptNetworkData ) => {
 	return site.jetpack && ! site?.is_wpcom_atomic;
 };
 
+export const isSimpleSite = ( site: SiteExcerptNetworkData ) => {
+	return ! site?.jetpack && ! site?.is_wpcom_atomic;
+};
+
 export const isP2Site = ( site: SiteExcerptNetworkData ) => {
 	return site.options?.is_wpforteams_site;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6196

## Proposed Changes

* Hide the "Performance settings" menu item in the /sites ellipsis Actions menu, for Simple Classic sites.

Before | After
------- | ------
<img width="218" alt="Screen Shot 2024-04-15 at 5 28 05 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/a5736b76-1903-4b2b-bfb5-b13661fd5206"> | <img width="214" alt="Screen Shot 2024-04-15 at 5 27 50 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/7c293eb4-f067-4c78-89af-f822eb82d04e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* For a Simple Classic site, check that Performance Settings is not visible.
* For an Atomic Classic site, check that Performance Settings is still visible.
* For an Atomic Default site, check that Performance Settings is still visible.
* For a Simple Default site, check that Performance Settings is still visible.
* For a Jetpack site, check that Performance Settings is still visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?