### PR TITLE
A4A: Make the Site listing always visible in Preview mode.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -14,7 +14,6 @@ function configureSitesContext( context: Context ) {
 	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
-	const hideListingInitialState = !! siteUrl;
 
 	const {
 		s: search,
@@ -36,7 +35,6 @@ function configureSitesContext( context: Context ) {
 			categoryInitialState={ category }
 			siteUrlInitialState={ siteUrl }
 			siteFeatureInitialState={ siteFeature }
-			hideListingInitialState={ hideListingInitialState }
 			showOnlyFavoritesInitialState={
 				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
 			}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -9,9 +9,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	selectedSiteFeature: undefined,
 	setSelectedSiteFeature: () => {},
 
-	hideListing: undefined,
-	setHideListing: () => {},
-
 	showOnlyFavorites: undefined,
 	setShowOnlyFavorites: () => {},
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -9,7 +9,6 @@ import SitesDashboardContext from './sites-dashboard-context';
 
 interface Props {
 	showOnlyFavoritesInitialState?: boolean;
-	hideListingInitialState?: boolean;
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
@@ -37,7 +36,6 @@ const buildFilters = ( { issueTypes }: { issueTypes: string } ) => {
 };
 
 export const SitesDashboardProvider = ( {
-	hideListingInitialState = false,
 	showOnlyFavoritesInitialState = false,
 	categoryInitialState,
 	siteUrlInitialState,
@@ -50,7 +48,6 @@ export const SitesDashboardProvider = ( {
 	sort,
 	featurePreview,
 }: Props ) => {
-	const [ hideListing, setHideListing ] = useState( hideListingInitialState );
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
 	const [ showOnlyFavorites, setShowOnlyFavorites ] = useState( showOnlyFavoritesInitialState );
@@ -88,7 +85,6 @@ export const SitesDashboardProvider = ( {
 		setInitialSelectedSiteUrl( siteUrlInitialState );
 		if ( ! siteUrlInitialState ) {
 			setShowOnlyFavorites( showOnlyFavoritesInitialState );
-			setHideListing( false );
 		}
 
 		setSitesViewState( ( previousState ) => ( {
@@ -118,8 +114,6 @@ export const SitesDashboardProvider = ( {
 		setSelectedCategory: setSelectedCategory,
 		selectedSiteFeature: selectedSiteFeature,
 		setSelectedSiteFeature: setSelectedSiteFeature,
-		hideListing: hideListing,
-		setHideListing: setHideListing,
 		showOnlyFavorites: showOnlyFavorites,
 		setShowOnlyFavorites: setShowOnlyFavorites,
 		path,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -56,8 +56,6 @@ export default function SitesDashboard() {
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
 		showOnlyFavorites,
-		hideListing,
-		setHideListing,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
@@ -100,7 +98,6 @@ export default function SitesDashboard() {
 	useEffect( () => {
 		if ( sitesViewState.selectedSite && ! initialSelectedSiteUrl ) {
 			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
-			setHideListing( false );
 			return;
 		}
 
@@ -119,7 +116,7 @@ export default function SitesDashboard() {
 		}
 		// Omitting sitesViewState to prevent infinite loop
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ data, isError, isLoading, initialSelectedSiteUrl, setSitesViewState, setHideListing ] );
+	}, [ data, isError, isLoading, initialSelectedSiteUrl, setSitesViewState ] );
 
 	const onSitesViewChange = useCallback(
 		( sitesViewData: SitesViewState ) => {
@@ -130,7 +127,7 @@ export default function SitesDashboard() {
 
 	useEffect( () => {
 		// If there isn't a selected site and we are showing only the preview pane we should wait for the selected site to load from the endpoint
-		if ( hideListing && ! sitesViewState.selectedSite ) {
+		if ( ! sitesViewState.selectedSite ) {
 			return;
 		}
 
@@ -163,15 +160,13 @@ export default function SitesDashboard() {
 		sitesViewState.page,
 		showOnlyFavorites,
 		sitesViewState.sort,
-		hideListing,
 	] );
 
 	const closeSitePreviewPane = useCallback( () => {
 		if ( sitesViewState.selectedSite ) {
 			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
-			setHideListing( false );
 		}
-	}, [ sitesViewState, setSitesViewState, setHideListing ] );
+	}, [ sitesViewState, setSitesViewState ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {
@@ -218,54 +213,52 @@ export default function SitesDashboard() {
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 			title={ sitesViewState.selectedSite ? null : translate( 'Sites' ) }
 		>
-			{ ! hideListing && (
-				<LayoutColumn className="sites-overview" wide>
-					<LayoutTop withNavigation={ navItems.length > 1 }>
-						<LayoutHeader>
-							{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
-							<Actions>
-								<SitesHeaderActions />
-							</Actions>
-						</LayoutHeader>
-						{ navItems.length > 1 && (
-							<LayoutNavigation { ...selectedItemProps }>
-								<NavigationTabs { ...selectedItemProps } items={ navItems } />
-							</LayoutNavigation>
-						) }
-					</LayoutTop>
+			<LayoutColumn className="sites-overview" wide>
+				<LayoutTop withNavigation={ navItems.length > 1 }>
+					<LayoutHeader>
+						{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
+						<Actions>
+							<SitesHeaderActions />
+						</Actions>
+					</LayoutHeader>
+					{ navItems.length > 1 && (
+						<LayoutNavigation { ...selectedItemProps }>
+							<NavigationTabs { ...selectedItemProps } items={ navItems } />
+						</LayoutNavigation>
+					) }
+				</LayoutTop>
 
-					<SiteNotifications />
-					{ tourId && <GuidedTour defaultTourId={ tourId as TourId } /> }
+				<SiteNotifications />
+				{ tourId && <GuidedTour defaultTourId={ tourId as TourId } /> }
 
-					<DashboardDataContext.Provider
-						value={ {
-							verifiedContacts: {
-								emails: verifiedContacts?.emails ?? [],
-								phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
-								refetchIfFailed: () => {
-									if ( fetchContactFailed ) {
-										refetchContacts();
-									}
-									return;
-								},
+				<DashboardDataContext.Provider
+					value={ {
+						verifiedContacts: {
+							emails: verifiedContacts?.emails ?? [],
+							phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+							refetchIfFailed: () => {
+								if ( fetchContactFailed ) {
+									refetchContacts();
+								}
+								return;
 							},
-							products: products ?? [],
-							isLargeScreen: isLargeScreen || false,
-						} }
-					>
-						<SitesDataViews
-							className={ classNames( 'sites-overview__content', {
-								'is-hiding-navigation': navItems.length <= 1,
-							} ) }
-							data={ data }
-							isLoading={ isLoading }
-							isLargeScreen={ isLargeScreen || false }
-							onSitesViewChange={ onSitesViewChange }
-							sitesViewState={ sitesViewState }
-						/>
-					</DashboardDataContext.Provider>
-				</LayoutColumn>
-			) }
+						},
+						products: products ?? [],
+						isLargeScreen: isLargeScreen || false,
+					} }
+				>
+					<SitesDataViews
+						className={ classNames( 'sites-overview__content', {
+							'is-hiding-navigation': navItems.length <= 1,
+						} ) }
+						data={ data }
+						isLoading={ isLoading }
+						isLargeScreen={ isLargeScreen || false }
+						onSitesViewChange={ onSitesViewChange }
+						sitesViewState={ sitesViewState }
+					/>
+				</DashboardDataContext.Provider>
+			</LayoutColumn>
 
 			{ sitesViewState.selectedSite && (
 				<LayoutColumn className="site-preview-pane" wide>

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -14,9 +14,6 @@ export interface SitesDashboardContextInterface {
 	sitesViewState: SitesViewState;
 	setSitesViewState: React.Dispatch< React.SetStateAction< SitesViewState > >;
 
-	hideListing?: boolean;
-	setHideListing: ( hideListing: boolean ) => void;
-
 	showOnlyFavorites?: boolean;
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 


### PR DESCRIPTION
This fixes an issue with the Sites list not showing when navigating back or refreshing the page during Preview mode. 


https://github.com/Automattic/automattic-for-agencies-dev/assets/390760/cf172e1c-19fd-4562-9275-df07126fe2a0


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/232

## Proposed Changes

* I have removed the `hideListing` props from `SitesDashboardContext`, which makes the Sites listing always visible. I have no historical context of the main intention of this prop, but if I were to guess, this is probably due to the fact that the Data view component does not allow us to set a default selected item. 
* **Note that the fix does not retain the selected site in the Site selector as the Data view component cannot set a default selected item as its limitation.**

## Testing Instructions

 
* Use the A4A live link below and go to `/overview`
* Next, Go to the sites page via the sidebar.
* select any sites to display the Preview Pane in the Sites section.
* Refresh the page or Press the Browsers **back** then **forward** history button.
* Confirm that the site listing still shows up.

https://github.com/Automattic/wp-calypso/assets/56598660/99ab4488-744c-4757-b42c-4b25173ca8bd




## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?