### PR TITLE
A4A: Use Automattic brand colours when connecting a site from the A4A plugin

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -792,6 +792,7 @@ class Login extends Component {
 			isGravPoweredLoginPage,
 			isSignupExistingAccount,
 			isSocialFirst,
+			isFromAutomatticForAgenciesPlugin,
 			loginButtons,
 		} = this.props;
 
@@ -900,6 +901,7 @@ class Login extends Component {
 							signupUrl={ signupUrl }
 							showSocialLoginFormOnly={ true }
 							sendMagicLoginLink={ this.sendMagicLoginLink }
+							isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
 						/>
 					</div>
 				);
@@ -928,6 +930,7 @@ class Login extends Component {
 				isSendingEmail={ this.props.isSendingEmail }
 				isSocialFirst={ isSocialFirst }
 				loginButtons={ loginButtons }
+				isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
 			/>
 		);
 	}
@@ -937,13 +940,15 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale, isWoo } = this.props;
+		const { isJetpack, oauth2Client, locale, isWoo, isFromAutomatticForAgenciesPlugin } =
+			this.props;
 
 		return (
 			<div
 				className={ classNames( 'login', {
 					'is-jetpack': isJetpack,
 					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
+					'is-automattic-for-agencies-flow': isFromAutomatticForAgenciesPlugin,
 					'is-a4a': isA4AOAuth2Client( oauth2Client ),
 				} ) }
 			>

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -2,10 +2,12 @@
 @import "@wordpress/base-styles/mixins";
 @import "calypso/assets/stylesheets/p2-extends";
 
+@import "~@automattic/color-studio/dist/color-variables";
+
 $breakpoint-mobile: 782px; //Mobile size.
 
 .layout:not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
-	.login.is-jetpack {
+	.login.is-jetpack:not(.is-automattic-for-agencies-flow) {
 		.button.is-primary {
 			background-color: var(--studio-jetpack-green-50);
 			border-color: var(--studio-jetpack-green-70);
@@ -19,6 +21,24 @@ $breakpoint-mobile: 782px; //Mobile size.
 				box-shadow: 0 0 0 2px var(--studio-jetpack-green-30);
 			}
 		}
+	}
+}
+
+.is-automattic-for-agencies-flow {
+	// Override accent variables with A4A colors
+	--color-accent: #{$studio-automattic-blue};
+	--color-accent-light: #{$studio-automattic-blue-20};
+	--color-accent-dark: #{$studio-automattic-blue-50};
+	--color-accent-60: #{$studio-automattic-blue-40};
+
+	// Override global colors with accent variables
+	--color-primary: #{$studio-automattic-blue};
+	--color-primary-light: #{$studio-automattic-blue-40};
+	--color-primary-dark: #{$studio-automattic-blue-50};
+
+	::selection {
+		color: var(--color-text-inverted);
+		background: var(--color-accent);
 	}
 }
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1249,6 +1249,7 @@ export class JetpackAuthorize extends Component {
 				isWooOnboarding={ this.isWooOnboarding() }
 				isWooCoreProfiler={ this.isWooCoreProfiler() }
 				isWpcomMigration={ this.isFromMigrationPlugin() }
+				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 				wooDnaConfig={ wooDna }
 				pageTitle={
 					wooDna.isWooDnaFlow() ? wooDna.getServiceName() + ' — ' + translate( 'Connect' ) : ''

--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -1,3 +1,5 @@
+@import "~@automattic/color-studio/dist/color-variables";
+
 @mixin jetpack-connect-colors() {
 	// Override accent variables with Jetpack colors
 	--color-accent: var(--studio-jetpack-green-30);
@@ -44,4 +46,22 @@
 	--color-primary: var(--studio-blue-40);
 	--color-accent-dark: var(--studio-blue-60);
 	--color-accent-60: var(--studio-blue-60);
+}
+
+@mixin automattic-for-agencies-colors() {
+	// Override accent variables with Jetpack colors
+	--color-accent: #{$studio-automattic-blue};
+	--color-accent-light: #{$studio-automattic-blue-20};
+	--color-accent-dark: #{$studio-automattic-blue-50};
+	--color-accent-60: #{$studio-automattic-blue-40};
+
+	// Override global colors with accent variables
+	--color-primary: #{$studio-automattic-blue};
+	--color-primary-light: #{$studio-automattic-blue-40};
+	--color-primary-dark: #{$studio-automattic-blue-50};
+
+	::selection {
+		color: var(--color-text-inverted);
+		background: var(--color-accent);
+	}
 }

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -34,6 +34,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 			isWooOnboarding,
 			isWooCoreProfiler,
 			isWpcomMigration,
+			isFromAutomatticForAgenciesPlugin,
 			className,
 			children,
 			partnerSlug,
@@ -50,6 +51,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 			'is-woocommerce-core-profiler-flow': isWooCoreProfiler,
 			'is-mobile-app-flow': !! retrieveMobileRedirect(),
 			'is-wpcom-migration': isWpcomMigration,
+			'is-automattic-for-agencies-flow': isFromAutomatticForAgenciesPlugin,
 		} );
 
 		const width = isWooOnboarding || isWooDna ? 200 : undefined;

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -155,6 +155,10 @@ export class JetpackSignup extends Component {
 		} );
 	}
 
+	isFromAutomatticForAgenciesPlugin() {
+		return 'automattic-for-agencies-client' === this.props.authQuery.from;
+	}
+
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
 		debug( 'submitting new account', userData );
 		this.setState( { isCreatingAccount: true }, () =>
@@ -483,6 +487,7 @@ export class JetpackSignup extends Component {
 			<MainWrapper
 				isWooOnboarding={ this.isWooOnboarding() }
 				isWooCoreProfiler={ this.isWooCoreProfiler() }
+				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 			>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,14 +3,32 @@
 
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
-.jetpack-connect__main:not(.is-woocommerce):not(.is-wpcom-migration),
-.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wpcom-migration):not(.is-woocommerce-core-profiler-flow) {
+.jetpack-connect__main:not(.is-woocommerce):not(.is-wpcom-migration):not(.is-automattic-for-agencies-flow),
+.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wpcom-migration):not(.is-woocommerce-core-profiler-flow):not(.is-automattic-for-agencies-flow) {
 	@include jetpack-connect-colors();
 }
 
 .layout.is-jetpack-woocommerce-flow,
 .layout.is-jetpack-woo-dna-flow {
 	@include woocommerce-colors();
+}
+
+.is-automattic-for-agencies-flow,
+.layout.is-automattic-for-agencies-flow {
+	@include automattic-for-agencies-colors();
+
+	.formatted-header__title {
+		margin: 32px 0;
+		font-size: 1.25rem;
+	}
+
+	.jetpack-connect__tos-link {
+		font-size: 0.875rem;
+	}
+}
+
+.jetpack-connect__main.main.is-automattic-for-agencies-flow {
+	max-width: 426px;
 }
 
 .is-section-jetpack-connect,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -294,6 +294,7 @@ class Layout extends Component {
 			'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
 			'is-woocommerce-core-profiler-flow': this.props.isWooCoreProfilerFlow,
+			'is-automattic-for-agencies-flow': this.props.isFromAutomatticForAgenciesPlugin,
 			woo: this.props.isWooCoreProfilerFlow,
 			'is-global-sidebar-visible': this.props.isGlobalSidebarVisible,
 			'is-global-sidebar-collapsed': this.props.isGlobalSidebarCollapsed,
@@ -468,6 +469,8 @@ export default withCurrentRoute(
 				// hide the masterBar until the section is loaded. To flicker the masterBar in, is better than to flicker it out.
 				! sectionName ||
 				( ! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName ) );
+			const isFromAutomatticForAgenciesPlugin =
+				'automattic-for-agencies-client' === currentQuery?.from;
 			const masterbarIsHidden =
 				! masterbarIsVisible( state ) ||
 				noMasterbarForSection ||
@@ -511,6 +514,7 @@ export default withCurrentRoute(
 				isJetpackWooDnaFlow,
 				isJetpackMobileFlow,
 				isWooCoreProfilerFlow,
+				isFromAutomatticForAgenciesPlugin,
 				isEligibleForJITM,
 				oauth2Client,
 				wccomFrom,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/48

## Proposed Changes

* Applies the A4A brand colors to the connection screens when coming from the A4A client plugin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* While signed in, in Calypso, visit the `/jetpack/connect/authorize` and `/log-in/jetpack` screens
  * This link can't be accessed directly, so you will need to start a new site connection from a test site. You can use Jurassic Ninja with the Automattic For Agenceis Client plugin installed via Jetpack Beta, and get a full connection URL by connecting with the A4A plugin.
  * If you've got the A4A plugin running locally in any other form, that will work just as well.
  * Finally, you could also access the URL from any Jetpack connection flow, just manually add the "from=automattic-for-agencies-client" query string value to the URL.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots
| Sign Up | Signed In | Sign In |
| - | - | - |
| <img width="492" alt="Screenshot 2024-04-15 at 10 45 37 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/9a2cb8da-e9f1-40f6-acb5-97f50304c61d"> | <img width="454" alt="Screenshot 2024-04-15 at 10 45 53 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/e2bf9e3a-10c4-4a40-9572-21696c097cb5"> | <img width="512" alt="Screenshot 2024-04-15 at 10 45 26 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/7bc35280-465a-49c4-b26a-e5e157d1dbaf"> |
