### PR TITLE
change color on whats-new modal

### DIFF
--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -173,7 +173,8 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 	height: 50%;
 	max-height: 230px;
 	padding: 32px 52px 0;
-	background: #a6b1ee;
+	// Hardcoding color here so that it's guranteed to match what's recorded in the "Find anything" video
+	background: #3858e9;
 	text-align: center;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Fixes 6272-gh-Automattic/dotcom-forge

The modal color was #a6b1ee which is no longer a color used by the design.

What makes it a bit tricky is that the color is baked in to the video for the "Command Pallet" video. 

It was a bit of a headache because a white or grey background doesn't look very good, but we don't neccessarily guarantee that the new color will be used as part of the selected theme, but it does have to match what's baked into the video backgrounds.

I've recorded a new video with the new color [New video](https://en-blog.files.wordpress.com/2024/04/cmd-k-2.png) but this PR just needs to be released at the same time as the new video, which I can do.

<img width="934" alt="Screenshot 2024-04-16 at 12 01 18 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/f4bda0e1-9d6e-4c65-94a4-5765b87dd437">

### Test instructions

Color on the whats-new modal should be updated

