### PR TITLE
GF Signup: Modal experiment to offer higher tier options

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
@@ -67,6 +67,6 @@ export const DomainName = styled.div`
 	overflow-wrap: break-word;
 	max-width: 100%;
 	@media ( min-width: 780px ) {
-		max-width: 50%;
+		max-width: 54%;
 	}
 `;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -60,7 +60,7 @@ function SuggestedPlanExplorerCreator( {
 	);
 }
 
-function SuggestedPlanStartedExplorerCreator( {
+function SuggestedPlanStarterExplorerCreator( {
 	paidDomainName,
 	onPlanSelected,
 	isBusy,
@@ -120,16 +120,18 @@ export default function SuggestedPlanSection( props: {
 } ) {
 	const translate = useTranslate();
 	const { paidDomainName, onPlanSelected, isBusy } = props;
-	const [ isExperimentLoaded, assignment ] = useExperiment( 'calypso_plans_modal_experiment' );
+	const [ isExperimentLoaded, assignment ] = useExperiment(
+		'calypso_signup_onboarding_plans_paid_domain_free_plan_modal_optimization'
+	);
 
 	if ( ! isExperimentLoaded ) {
 		return null;
 	}
 
-	if ( assignment?.experimentName === 'variant_explorer_creator' ) {
+	if ( assignment?.experimentName === 'creator_for_starter' ) {
 		return <SuggestedPlanExplorerCreator { ...props } />;
-	} else if ( assignment?.experimentName === 'variant_starter_explorer_creator' ) {
-		return <SuggestedPlanStartedExplorerCreator { ...props } />;
+	} else if ( assignment?.experimentName === 'creator_and_free_link' ) {
+		return <SuggestedPlanStarterExplorerCreator { ...props } />;
 	}
 
 	return (

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -120,11 +120,11 @@ export default function SuggestedPlanSection( props: {
 } ) {
 	const translate = useTranslate();
 	const { paidDomainName, onPlanSelected, isBusy } = props;
-	const [ isExperimentLoaded, assignment ] = useExperiment(
+	const [ isExperimentLoading, assignment ] = useExperiment(
 		'calypso_signup_onboarding_plans_paid_domain_free_plan_modal_optimization'
 	);
 
-	if ( ! isExperimentLoaded ) {
+	if ( isExperimentLoading ) {
 		return null;
 	}
 

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -1,6 +1,12 @@
-import { type PlanSlug, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
+import {
+	type PlanSlug,
+	PLAN_BUSINESS,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+} from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useExperiment } from 'calypso/lib/explat';
 import PlanUpsellButton from './plan-upsell-button';
 import { DomainName } from '.';
 
@@ -12,7 +18,7 @@ const FreeDomainText = styled.div`
 	margin-top: 4px;
 `;
 
-export default function SuggestedPlanSection( {
+function SuggestedPlanExplorerCreator( {
 	paidDomainName,
 	onPlanSelected,
 	isBusy,
@@ -22,6 +28,109 @@ export default function SuggestedPlanSection( {
 	isBusy: boolean;
 } ) {
 	const translate = useTranslate();
+	return (
+		<>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>
+						{ translate( 'Free domain and premium themes included.' ) }
+					</FreeDomainText>
+				</DomainName>
+			) }
+			<PlanUpsellButton
+				planSlug={ PLAN_PREMIUM }
+				onPlanSelected={ onPlanSelected }
+				isBusy={ isBusy }
+			/>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>
+						{ translate( 'Best for developers. Free domain and plugins.' ) }
+					</FreeDomainText>
+				</DomainName>
+			) }
+			<PlanUpsellButton
+				planSlug={ PLAN_BUSINESS }
+				onPlanSelected={ onPlanSelected }
+				isBusy={ isBusy }
+			/>
+		</>
+	);
+}
+
+function SuggestedPlanStartedExplorerCreator( {
+	paidDomainName,
+	onPlanSelected,
+	isBusy,
+}: {
+	paidDomainName?: string;
+	onPlanSelected: ( planSlug: PlanSlug ) => void;
+	isBusy: boolean;
+} ) {
+	const translate = useTranslate();
+	return (
+		<>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>{ translate( 'Free domain for one year included.' ) }</FreeDomainText>
+				</DomainName>
+			) }
+			<PlanUpsellButton
+				planSlug={ PLAN_PERSONAL }
+				onPlanSelected={ onPlanSelected }
+				isBusy={ isBusy }
+			/>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>
+						{ translate( 'Free domain and premium themes included.' ) }
+					</FreeDomainText>
+				</DomainName>
+			) }
+			<PlanUpsellButton
+				planSlug={ PLAN_PREMIUM }
+				onPlanSelected={ onPlanSelected }
+				isBusy={ isBusy }
+			/>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>
+						{ translate( 'Best for developers. Free domain and plugins.' ) }
+					</FreeDomainText>
+				</DomainName>
+			) }
+			<PlanUpsellButton
+				planSlug={ PLAN_BUSINESS }
+				onPlanSelected={ onPlanSelected }
+				isBusy={ isBusy }
+			/>
+		</>
+	);
+}
+
+export default function SuggestedPlanSection( props: {
+	paidDomainName?: string;
+	onPlanSelected: ( planSlug: PlanSlug ) => void;
+	isBusy: boolean;
+} ) {
+	const translate = useTranslate();
+	const { paidDomainName, onPlanSelected, isBusy } = props;
+	const [ isExperimentLoaded, assignment ] = useExperiment( 'calypso_plans_modal_experiment' );
+
+	if ( ! isExperimentLoaded ) {
+		return null;
+	}
+
+	if ( assignment?.experimentName === 'variant_explorer_creator' ) {
+		return <SuggestedPlanExplorerCreator { ...props } />;
+	} else if ( assignment?.experimentName === 'variant_starter_explorer_creator' ) {
+		return <SuggestedPlanStartedExplorerCreator { ...props } />;
+	}
 
 	return (
 		<>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -128,9 +128,9 @@ export default function SuggestedPlanSection( props: {
 		return null;
 	}
 
-	if ( assignment?.experimentName === 'creator_for_starter' ) {
+	if ( assignment?.variationName === 'creator_for_starter' ) {
 		return <SuggestedPlanExplorerCreator { ...props } />;
-	} else if ( assignment?.experimentName === 'creator_and_free_link' ) {
+	} else if ( assignment?.variationName === 'creator_and_free_link' ) {
 		return <SuggestedPlanStarterExplorerCreator { ...props } />;
 	}
 

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -61,6 +61,7 @@ export default function PaidPlanIsRequiredDialog( {
 						) }
 					</DomainName>
 					<PlanButton
+						borderless
 						disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 						busy={ isBusy }
 						onClick={ handleFreeDomainClick }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -61,7 +61,6 @@ export default function PaidPlanIsRequiredDialog( {
 						) }
 					</DomainName>
 					<PlanButton
-						borderless
 						disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 						busy={ isBusy }
 						onClick={ handleFreeDomainClick }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -737,7 +737,9 @@ const PlansFeaturesMain = ( {
 			'is-hidden': ! showPlansComparisonGrid,
 		}
 	);
-	const [ isModalExperimentLoaded ] = useExperiment( 'calypso_plans_modal_experiment' );
+	const [ isModalExperimentLoaded ] = useExperiment(
+		'calypso_signup_onboarding_plans_paid_domain_free_plan_modal_optimization'
+	);
 	const isLoadingGridPlans = Boolean(
 		! intent ||
 			! gridPlansForFeaturesGrid ||

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -55,6 +55,7 @@ import {
 	planItem as getCartItemForPlan,
 	getPlanCartItem,
 } from 'calypso/lib/cart-values/cart-items';
+import { useExperiment } from 'calypso/lib/explat';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { addQueryArgs } from 'calypso/lib/url';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
@@ -736,14 +737,18 @@ const PlansFeaturesMain = ( {
 			'is-hidden': ! showPlansComparisonGrid,
 		}
 	);
-
+	const [ isModalExperimentLoaded ] = useExperiment( 'calypso_plans_modal_experiment' );
 	const isLoadingGridPlans = Boolean(
-		! intent || ! gridPlansForFeaturesGrid || ! gridPlansForComparisonGrid
+		! intent ||
+			! gridPlansForFeaturesGrid ||
+			! gridPlansForComparisonGrid ||
+			! isModalExperimentLoaded
 	);
 	const isPlansGridReady =
 		! isLoadingGridPlans &&
 		! resolvedSubdomainName.isLoading &&
 		! resolvedDeemphasizeFreePlan.isLoading;
+
 	const isMobile = useMobileBreakpoint();
 	const enablePlanTypeSelectorStickyBehavior = isMobile && showPlanTypeSelectorDropdown;
 	const stickyPlanTypeSelectorHeight = isMobile ? 62 : 48;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -737,14 +737,11 @@ const PlansFeaturesMain = ( {
 			'is-hidden': ! showPlansComparisonGrid,
 		}
 	);
-	const [ isModalExperimentLoaded ] = useExperiment(
+	const [ isExperimentLoading ] = useExperiment(
 		'calypso_signup_onboarding_plans_paid_domain_free_plan_modal_optimization'
 	);
 	const isLoadingGridPlans = Boolean(
-		! intent ||
-			! gridPlansForFeaturesGrid ||
-			! gridPlansForComparisonGrid ||
-			! isModalExperimentLoaded
+		! intent || ! gridPlansForFeaturesGrid || ! gridPlansForComparisonGrid || isExperimentLoading
 	);
 	const isPlansGridReady =
 		! isLoadingGridPlans &&

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -45,6 +45,9 @@ jest.mock( '@automattic/data-stores', () => ( {
 
 jest.mock( 'calypso/components/data/query-active-promotions', () => jest.fn() );
 jest.mock( 'calypso/components/data/query-products-list', () => jest.fn() );
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: () => [ false, { experimentName: 'control' } ],
+} ) );
 
 import {
 	PLAN_FREE,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
- Automattic/martech#2793


## Proposed Changes

* Adds an experiment to show multiple buttons on the paid plan required modal

- Control
<img width="600" alt="Screenshot 2024-04-18 at 6 27 57 PM" src="https://github.com/Automattic/wp-calypso/assets/3422709/8d324a25-31a8-458d-a953-1f232cd6ea9f">

- Variant creator_for_starter
<img width="600" alt="Screenshot 2024-04-18 at 6 27 36 PM" src="https://github.com/Automattic/wp-calypso/assets/3422709/f1a7831d-709e-443d-8378-849b0e34ac3c">

- Variant creator_and_free_link
<img width="600" alt="Screenshot 2024-04-18 at 6 27 15 PM" src="https://github.com/Automattic/wp-calypso/assets/3422709/fc3c5933-3231-4466-840e-8913a9b155cc">




## Testing Instructions


* Assign yourself to experiment from 21735-explat-experiment
* Go to `/start` 
* Select a paid domain 
* Click on the free plan
* Make sure the modal relevant to the variant appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?