### PR TITLE
Automattic for Agencies: Button style fixes & add a tracking event.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
@@ -10,6 +10,8 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import BillingDetails from './billing-details';
 import BillingSummary from './billing-summary';
 
@@ -17,13 +19,14 @@ import './style.scss';
 
 export default function BillingDashboard() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const title = translate( 'Billing' );
 
 	const partnerCanIssueLicense = true; // FIXME: get this from state
 
 	const onIssueNewLicenseClick = () => {
-		// TODO: dispatch action to open issue license modal
+		dispatch( recordTracksEvent( 'calypso_a4a_billing_page_issue_license_click' ) );
 	};
 
 	return (

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -120,11 +120,6 @@
 	font-weight: 500;
 	line-height: 1.375;
 
-	&:hover {
-		background-color: var(--color-accent-0);
-
-	}
-
 	@include break-large {
 		padding: 7px;
 		font-size: 0.75rem;

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -122,7 +122,28 @@
 			fill: var(--color-text-inverted);
 			color: var(--color-text-inverted);
 			box-shadow: none;
-			border: 1px solid;
+		}
+	}
+
+	.button.is-scary {
+		color: var(--color-scary-50);
+		border-color: var(--color-scary-50);
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-scary-0);
+			border-color: var(--color-scary-60);
+			color: var(--color-scary-60);
+		}
+	}
+
+	.button.is-primary.is-scary {
+		background-color: var(--color-scary-50);
+		color: var(--color-text-inverted);
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-scary-60);
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/289

## Proposed Changes

This PR:

- Adds a tracking event to the Issue License button on the Billing page. I didn't want to create a different PR for this small change.
- Fixes the style for the Primary button which was reducing the button size when hovered over.
- Fixes the style for the Primary button on the Licenses page that was making the background to invisible when hovered over.
- Fixes the Scary & Primary-Scary button styles.

## Testing Instructions

- Open the A4A live link
- Hover over any primary button & verify that the button doesn't shrink. 

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="301" alt="Screenshot 2024-04-16 at 9 26 02 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e30f63df-2b44-46b5-a662-d19c8f634c7c">
</td>
<td>
<img width="301" alt="Screenshot 2024-04-16 at 9 25 57 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/77ec3814-c05a-4431-9abd-09bfe789f91e">
</td>
</tr>
</table>

- Visit /marketplace/hosting/pressable  > Assign a Pressable license if you haven't already.
- Go to the Licenses page > Expand the Pressable license and verify that the buttons look as shown below and work well when hovered over

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td colSpan=2 align="center">
Primary Button
</td>
</tr>
<tr>
<td>
<img width="311" alt="Screenshot 2024-04-16 at 9 26 21 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/baad0cc1-bed0-4df8-b5ab-ab49b4658d8c">
</td>
<td>
<img width="311" alt="Screenshot 2024-04-16 at 9 26 26 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c1f8a467-145d-4942-ab9d-8e197f21b029"></td>
</tr>
<tr>
<td colSpan=2 align="center">
Scary Button
</td>
</tr>
<tr>
<td>
<img width="311" alt="Screenshot 2024-04-16 at 9 26 42 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4d382a8a-b8a4-446d-bdcd-f7bea6f54d2e">
</td>
<td>
<img width="311" alt="Screenshot 2024-04-16 at 9 26 48 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0b23207e-425a-459a-b0bd-afbb15f7582f">
</td>
</tr>
</table>

- Click the Revoke button and verify that the Revoke license button on the modal is as shown below

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td colSpan=2 align="center">
Primary Scary Button
</td>
</tr>
<tr>
<td>
<img width="311" alt="Screenshot 2024-04-16 at 9 27 08 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/52ba84c8-d682-4900-aba4-a0dd5d5ebe73">
</td>
<td>
<img width="311" alt="Screenshot 2024-04-16 at 9 27 03 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ba5f111a-8ea5-457a-88ff-d7def2002514">
</tr>
<tr>
<td colSpan=2 align="center">
Primary Scary Button (Hover)
</td>
</tr>
<tr>
<td>
<img width="311" alt="Screenshot 2024-04-16 at 9 27 14 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5f352549-54d0-42ae-8abc-aad9ced6afee">

</td>
<td>
<img width="311" alt="Screenshot 2024-04-16 at 9 27 17 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/107182c5-edab-4b8f-8961-a8420e2e73c2">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?