### PR TITLE
A4A: Revert changes that made Site listing always visible when in preview mode.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -14,6 +14,7 @@ function configureSitesContext( context: Context ) {
 	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
+	const hideListingInitialState = !! siteUrl;
 
 	const {
 		s: search,
@@ -35,6 +36,7 @@ function configureSitesContext( context: Context ) {
 			categoryInitialState={ category }
 			siteUrlInitialState={ siteUrl }
 			siteFeatureInitialState={ siteFeature }
+			hideListingInitialState={ hideListingInitialState }
 			showOnlyFavoritesInitialState={
 				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
 			}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -9,6 +9,9 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	selectedSiteFeature: undefined,
 	setSelectedSiteFeature: () => {},
 
+	hideListing: undefined,
+	setHideListing: () => {},
+
 	showOnlyFavorites: undefined,
 	setShowOnlyFavorites: () => {},
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -9,6 +9,7 @@ import SitesDashboardContext from './sites-dashboard-context';
 
 interface Props {
 	showOnlyFavoritesInitialState?: boolean;
+	hideListingInitialState?: boolean;
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
@@ -36,6 +37,7 @@ const buildFilters = ( { issueTypes }: { issueTypes: string } ) => {
 };
 
 export const SitesDashboardProvider = ( {
+	hideListingInitialState = false,
 	showOnlyFavoritesInitialState = false,
 	categoryInitialState,
 	siteUrlInitialState,
@@ -48,6 +50,7 @@ export const SitesDashboardProvider = ( {
 	sort,
 	featurePreview,
 }: Props ) => {
+	const [ hideListing, setHideListing ] = useState( hideListingInitialState );
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
 	const [ showOnlyFavorites, setShowOnlyFavorites ] = useState( showOnlyFavoritesInitialState );
@@ -85,6 +88,7 @@ export const SitesDashboardProvider = ( {
 		setInitialSelectedSiteUrl( siteUrlInitialState );
 		if ( ! siteUrlInitialState ) {
 			setShowOnlyFavorites( showOnlyFavoritesInitialState );
+			setHideListing( false );
 		}
 
 		setSitesViewState( ( previousState ) => ( {
@@ -114,6 +118,8 @@ export const SitesDashboardProvider = ( {
 		setSelectedCategory: setSelectedCategory,
 		selectedSiteFeature: selectedSiteFeature,
 		setSelectedSiteFeature: setSelectedSiteFeature,
+		hideListing: hideListing,
+		setHideListing: setHideListing,
 		showOnlyFavorites: showOnlyFavorites,
 		setShowOnlyFavorites: setShowOnlyFavorites,
 		path,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -56,6 +56,8 @@ export default function SitesDashboard() {
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
 		showOnlyFavorites,
+		hideListing,
+		setHideListing,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
@@ -98,6 +100,7 @@ export default function SitesDashboard() {
 	useEffect( () => {
 		if ( sitesViewState.selectedSite && ! initialSelectedSiteUrl ) {
 			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
+			setHideListing( false );
 			return;
 		}
 
@@ -116,7 +119,7 @@ export default function SitesDashboard() {
 		}
 		// Omitting sitesViewState to prevent infinite loop
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ data, isError, isLoading, initialSelectedSiteUrl, setSitesViewState ] );
+	}, [ data, isError, isLoading, initialSelectedSiteUrl, setSitesViewState, setHideListing ] );
 
 	const onSitesViewChange = useCallback(
 		( sitesViewData: SitesViewState ) => {
@@ -127,7 +130,7 @@ export default function SitesDashboard() {
 
 	useEffect( () => {
 		// If there isn't a selected site and we are showing only the preview pane we should wait for the selected site to load from the endpoint
-		if ( ! sitesViewState.selectedSite ) {
+		if ( hideListing && ! sitesViewState.selectedSite ) {
 			return;
 		}
 
@@ -160,13 +163,15 @@ export default function SitesDashboard() {
 		sitesViewState.page,
 		showOnlyFavorites,
 		sitesViewState.sort,
+		hideListing,
 	] );
 
 	const closeSitePreviewPane = useCallback( () => {
 		if ( sitesViewState.selectedSite ) {
 			setSitesViewState( { ...sitesViewState, type: 'table', selectedSite: undefined } );
+			setHideListing( false );
 		}
-	}, [ sitesViewState, setSitesViewState ] );
+	}, [ sitesViewState, setSitesViewState, setHideListing ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {
@@ -213,52 +218,54 @@ export default function SitesDashboard() {
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 			title={ sitesViewState.selectedSite ? null : translate( 'Sites' ) }
 		>
-			<LayoutColumn className="sites-overview" wide>
-				<LayoutTop withNavigation={ navItems.length > 1 }>
-					<LayoutHeader>
-						{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
-						<Actions>
-							<SitesHeaderActions />
-						</Actions>
-					</LayoutHeader>
-					{ navItems.length > 1 && (
-						<LayoutNavigation { ...selectedItemProps }>
-							<NavigationTabs { ...selectedItemProps } items={ navItems } />
-						</LayoutNavigation>
-					) }
-				</LayoutTop>
+			{ ! hideListing && (
+				<LayoutColumn className="sites-overview" wide>
+					<LayoutTop withNavigation={ navItems.length > 1 }>
+						<LayoutHeader>
+							{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
+							<Actions>
+								<SitesHeaderActions />
+							</Actions>
+						</LayoutHeader>
+						{ navItems.length > 1 && (
+							<LayoutNavigation { ...selectedItemProps }>
+								<NavigationTabs { ...selectedItemProps } items={ navItems } />
+							</LayoutNavigation>
+						) }
+					</LayoutTop>
 
-				<SiteNotifications />
-				{ tourId && <GuidedTour defaultTourId={ tourId as TourId } /> }
+					<SiteNotifications />
+					{ tourId && <GuidedTour defaultTourId={ tourId as TourId } /> }
 
-				<DashboardDataContext.Provider
-					value={ {
-						verifiedContacts: {
-							emails: verifiedContacts?.emails ?? [],
-							phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
-							refetchIfFailed: () => {
-								if ( fetchContactFailed ) {
-									refetchContacts();
-								}
-								return;
+					<DashboardDataContext.Provider
+						value={ {
+							verifiedContacts: {
+								emails: verifiedContacts?.emails ?? [],
+								phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+								refetchIfFailed: () => {
+									if ( fetchContactFailed ) {
+										refetchContacts();
+									}
+									return;
+								},
 							},
-						},
-						products: products ?? [],
-						isLargeScreen: isLargeScreen || false,
-					} }
-				>
-					<SitesDataViews
-						className={ classNames( 'sites-overview__content', {
-							'is-hiding-navigation': navItems.length <= 1,
-						} ) }
-						data={ data }
-						isLoading={ isLoading }
-						isLargeScreen={ isLargeScreen || false }
-						onSitesViewChange={ onSitesViewChange }
-						sitesViewState={ sitesViewState }
-					/>
-				</DashboardDataContext.Provider>
-			</LayoutColumn>
+							products: products ?? [],
+							isLargeScreen: isLargeScreen || false,
+						} }
+					>
+						<SitesDataViews
+							className={ classNames( 'sites-overview__content', {
+								'is-hiding-navigation': navItems.length <= 1,
+							} ) }
+							data={ data }
+							isLoading={ isLoading }
+							isLargeScreen={ isLargeScreen || false }
+							onSitesViewChange={ onSitesViewChange }
+							sitesViewState={ sitesViewState }
+						/>
+					</DashboardDataContext.Provider>
+				</LayoutColumn>
+			) }
 
 			{ sitesViewState.selectedSite && (
 				<LayoutColumn className="site-preview-pane" wide>

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -14,6 +14,9 @@ export interface SitesDashboardContextInterface {
 	sitesViewState: SitesViewState;
 	setSitesViewState: React.Dispatch< React.SetStateAction< SitesViewState > >;
 
+	hideListing?: boolean;
+	setHideListing: ( hideListing: boolean ) => void;
+
 	showOnlyFavorites?: boolean;
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 


### PR DESCRIPTION
Due to some regression with URL context no longer working correctly when doing search filtering in the Sites table, the changes must be reverted. 

Reverts https://github.com/Automattic/wp-calypso/pull/89554

## Proposed Changes

* Revert #89554. 

## Testing Instructions

* Use the A4A live link below and go to `/sites`
* Select any site in the Table.
* Type some search filter.
* Confirm that the filtering is also reflected in the URL.
* Refresh the page and confirm the issue describe in 89554 is back again.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?