### PR TITLE
A4A: Updating the SiteSetFavorite and SiteSort components to use the A4A versions

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -27,7 +27,7 @@ interface Props {
 	siteUrl: string;
 }
 
-export default function A4ASiteSetFavorite( { isFavorite, siteId, siteUrl }: Props ) {
+export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();

--- a/client/a8c-for-agencies/sections/sites/site-sort/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-sort/index.tsx
@@ -19,7 +19,7 @@ const SITE_COLUMN_KEY_MAP: { [ key: string ]: string } = {
 	site: 'url',
 };
 
-export default function A4ASiteSort( {
+export default function SiteSort( {
 	columnKey,
 	isLargeScreen,
 	children,

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
@@ -6,7 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
-import A4ASiteSetFavorite from 'calypso/a8c-for-agencies/sections/sites/site-set-favorite';
+import SiteSetFavorite from 'calypso/a8c-for-agencies/sections/sites/site-set-favorite';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import SiteDataField from 'calypso/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
@@ -15,7 +15,6 @@ import SiteSort from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-over
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-import SiteSetFavorite from '../site-set-favorite';
 import { AllowedTypes, Site } from '../types';
 import { SitesDataViewsProps, SiteInfo } from './interfaces';
 import './style.scss';
@@ -288,19 +287,11 @@ const SitesDataViews = ( {
 					}
 					return (
 						<span className="sites-dataviews__favorite-btn-wrapper">
-							{ isA4AEnabled ? (
-								<A4ASiteSetFavorite
-									isFavorite={ item.isFavorite || false }
-									siteId={ item.site.value.blog_id }
-									siteUrl={ item.site.value.url }
-								/>
-							) : (
-								<SiteSetFavorite
-									isFavorite={ item.isFavorite || false }
-									siteId={ item.site.value.blog_id }
-									siteUrl={ item.site.value.url }
-								/>
-							) }
+							<SiteSetFavorite
+								isFavorite={ item.isFavorite || false }
+								siteId={ item.site.value.blog_id }
+								siteUrl={ item.site.value.url }
+							/>
 						</span>
 					);
 				},

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon, Spinner } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
 import { Icon, starFilled } from '@wordpress/icons';
@@ -7,11 +6,11 @@ import { useCallback, useContext, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
 import SiteSetFavorite from 'calypso/a8c-for-agencies/sections/sites/site-set-favorite';
+import SiteSort from 'calypso/a8c-for-agencies/sections/sites/site-sort';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import SiteDataField from 'calypso/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
-import SiteSort from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
@@ -34,7 +33,6 @@ const SitesDataViews = ( {
 	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );
-	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
@@ -347,7 +345,6 @@ const SitesDataViews = ( {
 			isLoading,
 			openSitePreviewPane,
 			renderField,
-			isA4AEnabled,
 			isLargeScreen,
 		]
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -5,7 +5,6 @@ import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useMemo } from 'react';
 import ReactDOM from 'react-dom';
-import A4ASiteSetFavorite from 'calypso/a8c-for-agencies/sections/sites/site-set-favorite';
 import A4ASiteSort from 'calypso/a8c-for-agencies/sections/sites/site-sort';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
@@ -195,19 +194,11 @@ const SitesDataViews = ( {
 					}
 					return (
 						<span className="sites-dataviews__favorite-btn-wrapper">
-							{ isA4AEnabled ? (
-								<A4ASiteSetFavorite
-									isFavorite={ item.isFavorite || false }
-									siteId={ item.site.value.blog_id }
-									siteUrl={ item.site.value.url }
-								/>
-							) : (
-								<SiteSetFavorite
-									isFavorite={ item.isFavorite || false }
-									siteId={ item.site.value.blog_id }
-									siteUrl={ item.site.value.url }
-								/>
-							) }
+							<SiteSetFavorite
+								isFavorite={ item.isFavorite || false }
+								siteId={ item.site.value.blog_id }
+								siteUrl={ item.site.value.url }
+							/>
 						</span>
 					);
 				},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -1,11 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon, Spinner } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useMemo } from 'react';
 import ReactDOM from 'react-dom';
-import A4ASiteSort from 'calypso/a8c-for-agencies/sections/sites/site-sort';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
@@ -35,7 +33,6 @@ const SitesDataViews = ( {
 	const sitesPerPage = sitesViewState.perPage > 0 ? sitesViewState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );
-	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
@@ -98,19 +95,11 @@ const SitesDataViews = ( {
 				id: 'site',
 				header: (
 					<>
-						{ isA4AEnabled ? (
-							<A4ASiteSort isSortable={ true } columnKey="site">
-								<span className="sites-dataview__site-header">
-									{ translate( 'Site' ).toUpperCase() }
-								</span>
-							</A4ASiteSort>
-						) : (
-							<SiteSort isSortable={ true } columnKey="site">
-								<span className="sites-dataview__site-header">
-									{ translate( 'Site' ).toUpperCase() }
-								</span>
-							</SiteSort>
-						) }
+						<SiteSort isSortable={ true } columnKey="site">
+							<span className="sites-dataview__site-header">
+								{ translate( 'Site' ).toUpperCase() }
+							</span>
+						</SiteSort>
 					</>
 				),
 				getValue: ( { item }: { item: SiteInfo } ) => item.site.value.url,


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/208

## Proposed Changes

* This PR renames the A4ASiteSetFavorite and A4ASiteSort components in A4A to be SiteSetFavorite and SiteSort, and updates the imports in the dataviews file to make sure we use the correct versions. 
* It also removes the 'isA4AEnabled' checks to determine which component to show as we're now only using the version relevant to either Jetpack Cloud or A4A.

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally.

* Visit `http://agencies.localhost:3000/sites`, and check both the site sort functionality (clicking on the arrows by the site column title) and the favorites functionality (adding and removing favorites from the favorites column). Make sure these still work.
* The components should also still work at `jetpack.cloud.localhost:3000/sites`
* Also make sure that the first onboarding tour from `http://agencies.localhost:3000/overview` works ('Get familiar with the sites management dashboard') as it targets the sites column header, which is wrapped in the SiteSort component.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?