### PR TITLE
Use isRunningInWpAdmin instead of isRunningInJetpack for Blaze to run in Simple Classic

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -30,8 +30,8 @@ import {
 	getCampaignDurationFormatted,
 } from 'calypso/my-sites/promote-post-i2/utils';
 import { useSelector } from 'calypso/state';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import useIsRunningInWpAdmin from '../../hooks/use-is-running-in-wpadmin';
 import {
 	formatCents,
 	formatNumber,
@@ -88,11 +88,7 @@ const getExternalTabletIcon = ( fillColor = '#A7AAAD' ) => (
 );
 
 export default function CampaignItemDetails( props: Props ) {
-	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
-	const isRunningInClassicSimple = useSelector( ( state ) =>
-		getSiteOption( state, props.siteId, 'is_wpcom_simple' )
-	);
-	const isRunningJetpackOrClassicSimple = isRunningInJetpack || isRunningInClassicSimple;
+	const isRunningInWpAdmin = useIsRunningInWpAdmin();
 	const translate = useTranslate();
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const [ showErrorDialog, setShowErrorDialog ] = useState( false );
@@ -940,7 +936,7 @@ export default function CampaignItemDetails( props: Props ) {
 									className="is-link components-button campaign-item-details__support-link"
 									supportContext="advertising"
 									showIcon={ false }
-									showSupportModal={ ! isRunningJetpackOrClassicSimple }
+									showSupportModal={ ! isRunningInWpAdmin }
 								>
 									{ translate( 'View documentation' ) }
 									{ getExternalLinkIcon() }

--- a/client/my-sites/promote-post-i2/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post-i2/components/credit-balance/index.tsx
@@ -1,19 +1,17 @@
-import config from '@automattic/calypso-config';
 import { memo } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-
+import useIsRunningInWpAdmin from '../../hooks/use-is-running-in-wpadmin';
 interface Props {
 	balance?: string;
 }
 
 const CreditBalance = ( { balance = '0.00' }: Props ) => {
+	const isRunningInWpAdmin = useIsRunningInWpAdmin();
 	// Hide the section if balance is invalid or is 0
 	if ( ! balance || balance === '0.00' ) {
 		return null;
 	}
-
-	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	return (
 		<div className="promote-post-i2__aux-wrapper">
@@ -28,7 +26,7 @@ const CreditBalance = ( { balance = '0.00' }: Props ) => {
 									<InlineSupportLink
 										supportContext="blaze_credits"
 										showIcon={ false }
-										showSupportModal={ ! isRunningInJetpack }
+										showSupportModal={ ! isRunningInWpAdmin }
 									/>
 								),
 							},

--- a/client/my-sites/promote-post-i2/components/empty-promotion-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/empty-promotion-list/index.tsx
@@ -1,7 +1,7 @@
-import config from '@automattic/calypso-config';
 import './style.scss';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import useIsRunningInWpAdmin from '../../hooks/use-is-running-in-wpadmin';
 
 type Props = {
 	type: 'campaigns' | 'posts';
@@ -10,7 +10,7 @@ type Props = {
 export default function EmptyPromotionList( props: Props ) {
 	const { type } = props;
 
-	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isRunningInWpAdmin = useIsRunningInWpAdmin();
 
 	const translate = useTranslate();
 
@@ -27,7 +27,7 @@ export default function EmptyPromotionList( props: Props ) {
 						<InlineSupportLink
 							supportContext="advertising"
 							showIcon={ false }
-							showSupportModal={ ! isRunningInJetpack }
+							showSupportModal={ ! isRunningInWpAdmin }
 						/>
 					),
 				},

--- a/client/my-sites/promote-post-i2/hooks/use-is-running-in-wpadmin.ts
+++ b/client/my-sites/promote-post-i2/hooks/use-is-running-in-wpadmin.ts
@@ -1,0 +1,10 @@
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isRunningInWpAdmin } from '../utils';
+
+const useIsRunningInWpAdmin = (): boolean => {
+	const site = useSelector( getSelectedSite );
+	return isRunningInWpAdmin( site );
+};
+
+export default useIsRunningInWpAdmin;

--- a/client/my-sites/promote-post-i2/hooks/use-open-promote-widget.ts
+++ b/client/my-sites/promote-post-i2/hooks/use-open-promote-widget.ts
@@ -1,12 +1,12 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { recordDSPEntryPoint, useDspOriginProps } from 'calypso/lib/promote-post';
 import { useRouteModal } from 'calypso/lib/route-modal';
-import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getAdvertisingDashboardPath } from '../utils';
+import useIsRunningInWpAdmin from './use-is-running-in-wpadmin';
 
 export interface Props {
 	keyValue: string;
@@ -17,11 +17,7 @@ export interface Props {
 const useOpenPromoteWidget = ( { keyValue, entrypoint, external }: Props ) => {
 	const { openModal } = useRouteModal( 'blazepress-widget', keyValue );
 	const siteId = useSelector( getSelectedSiteId );
-	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
-	const isRunningInClassicSimple = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'is_wpcom_simple' )
-	);
-	const isRunningJetpackOrClassicSimple = isRunningInJetpack || isRunningInClassicSimple;
+	const isRunningInWpAdmin = useIsRunningInWpAdmin();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const dspOriginProps = useDspOriginProps();
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
@@ -29,7 +25,7 @@ const useOpenPromoteWidget = ( { keyValue, entrypoint, external }: Props ) => {
 
 	const onOpenPromoteWidget = useCallback( () => {
 		dispatch( recordDSPEntryPoint( entrypoint, dspOriginProps ) );
-		if ( isRunningJetpackOrClassicSimple ) {
+		if ( isRunningInWpAdmin ) {
 			const blazeURL = getAdvertisingDashboardPath( `/posts/promote/${ keyValue }/${ siteSlug }` );
 
 			if ( external ) {
@@ -51,7 +47,7 @@ const useOpenPromoteWidget = ( { keyValue, entrypoint, external }: Props ) => {
 		dspOriginProps,
 		external,
 		siteAdminUrl,
-		isRunningJetpackOrClassicSimple,
+		isRunningInWpAdmin,
 		openModal,
 		dispatch,
 	] );

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -38,6 +38,7 @@ import CreditBalance from './components/credit-balance';
 import MainWrapper from './components/main-wrapper';
 import PostsListBanner from './components/posts-list-banner';
 import WooBanner from './components/woo-banner';
+import useIsRunningInWpAdmin from './hooks/use-is-running-in-wpadmin';
 import useOpenPromoteWidget from './hooks/use-open-promote-widget';
 import { getAdvertisingDashboardPath } from './utils';
 export const TAB_OPTIONS = [ 'posts', 'campaigns', 'credits' ] as const;
@@ -78,11 +79,9 @@ const POST_DEFAULT_SEARCH_OPTIONS: SearchOptions = {
 };
 
 export default function PromotedPosts( { tab }: Props ) {
-	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
 	const selectedTab = tab && TAB_OPTIONS.includes( tab ) ? tab : 'posts';
 	const selectedSite = useSelector( getSelectedSite );
-	const isRunningInClassicSimple = selectedSite?.options?.is_wpcom_simple;
-	const isRunningJetpackOrClassicSimple = isRunningInJetpack || isRunningInClassicSimple;
+	const isRunningInWpAdmin = useIsRunningInWpAdmin();
 	const selectedSiteId = selectedSite?.ID || 0;
 	const translate = useTranslate();
 	const onClickPromote = useOpenPromoteWidget( {
@@ -250,7 +249,7 @@ export default function PromotedPosts( { tab }: Props ) {
 						supportContext="advertising"
 						className="button posts-list-banner__learn-more"
 						showIcon={ false }
-						showSupportModal={ ! isRunningJetpackOrClassicSimple }
+						showSupportModal={ ! isRunningInWpAdmin }
 					/>
 					<Button
 						variant="primary"

--- a/client/my-sites/promote-post-i2/test/utils.test.tsx
+++ b/client/my-sites/promote-post-i2/test/utils.test.tsx
@@ -1,7 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { getShortDateString, getLongDateString } from '../utils';
+import config from '@automattic/calypso-config';
+import { SiteDetails } from '@automattic/data-stores';
+import { getShortDateString, getLongDateString, isRunningInWpAdmin } from '../utils';
 
 describe( 'Promote Post Utils', () => {
 	const timestamp = 1687521600000; // 2023-06-23 12:00:00 GMT+0000
@@ -31,5 +33,36 @@ describe( 'Promote Post Utils', () => {
 	test( "formats date that doesn't have timezones", () => {
 		expect( getShortDateString( '2023-06-23 11:55' ) ).toBe( '5 minutes ago' );
 		expect( getLongDateString( '2021-03-22 16:10:00' ) ).toBe( 'Mar 22, 2021 at 4:10 PM' );
+	} );
+} );
+
+jest.mock( '@automattic/calypso-config' );
+
+describe( 'isRunningInWpAdmin', () => {
+	it( 'should return true if running in a Jetpack site', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( true );
+		// using unknown to avoid having to mock the entire SiteDetails object
+		const site = { options: { is_wpcom_simple: false } } as unknown as SiteDetails;
+		expect( isRunningInWpAdmin( site ) ).toBe( true );
+	} );
+
+	it( 'should return true if running in a classic simple site', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( false );
+		// using unknown to avoid having to mock the entire SiteDetails object
+		const site = { options: { is_wpcom_simple: true } } as unknown as SiteDetails;
+		expect( isRunningInWpAdmin( site ) ).toBe( true );
+	} );
+
+	it( 'should return false if not running in Jetpack and not a classic simple site', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( false );
+		// using unknown to avoid having to mock the entire SiteDetails object
+		const site = { options: { is_wpcom_simple: false } } as unknown as SiteDetails;
+		expect( isRunningInWpAdmin( site ) ).toBe( false );
+	} );
+
+	it( 'should handle empty site gracefully', () => {
+		// using unknown to avoid having to mock the entire SiteDetails object
+		( config.isEnabled as jest.Mock ).mockReturnValue( false ) as unknown as SiteDetails;
+		expect( isRunningInWpAdmin( null ) ).toBe( false );
 	} );
 } );

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { SiteDetails } from '@automattic/data-stores';
 import { getCurrencyObject } from '@automattic/format-currency';
 import { InfiniteData } from '@tanstack/react-query';
 import { __, _x } from '@wordpress/i18n';
@@ -319,4 +320,13 @@ export const formatAmount = ( amount: number, currencyCode: string ) => {
 	}
 	const money = getCurrencyObject( amount, currencyCode, { stripZeros: false } );
 	return `${ money.symbol }${ money.integer }${ money.fraction }`;
+};
+
+export const isRunningInWpAdmin = ( site: SiteDetails | null | undefined ): boolean => {
+	if ( ! site ) {
+		return false;
+	}
+	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isRunningInClassicSimple = site?.options?.is_wpcom_simple;
+	return isRunningInClassicSimple || isRunningInJetpack;
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6569

## Proposed Changes

After consolidation, whenever we're in /wp-admin, Blaze Dashboard is loaded from Jetpack code instead of Calypso, hence updating the logic to fulfill it.

* Created a common hook useIsRunningInWpAdmin
* Applied it wherever isRunningInJetpack is used

## Testing Instructions

### Prerequisite 1: Simple Classic
To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```

### Prerequisite 2: Public site

* Run `install-plugin.sh blaze-dashboard branch-name` in your sandbox and sandbox widgets.wp.com for testing, alternatively, locally you can checkout to this branch and cd to `apps/blaze-dashboard` and run `yarn dev --sync`
* Go to `/wp-admin/tools.php?page=advertising`
* Go through the code and make sure touch point works.

Other notes: Instructions on how to create a campaign: https://github.com/Automattic/wp-calypso/pull/89484#issuecomment-2051848954

Test on Self-hosted/Atomic/Simple Calypso to make sure we didn't break anything. In Calypso, instead of opening a link, it will open support docs in help center.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?