### PR TITLE
Automattic for Agencies: Hide invalid links

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -28,6 +28,8 @@ export default function PricingSummary( { items, onRemoveItem }: Props ) {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_learn_more_click' ) );
 	}, [ dispatch ] );
 
+	const showLearnMoreLink = false; // FIXME: Remove this once the correct link is added
+
 	return (
 		<div className="checkout__summary">
 			<div className="checkout__summary-pricing">
@@ -62,21 +64,25 @@ export default function PricingSummary( { items, onRemoveItem }: Props ) {
 			</div>
 
 			<div className="checkout__summary-notice">
-				{ translate(
-					'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
-					{
-						components: {
-							a: (
-								<a
-									href={ learnMoreLink }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ onClickLearnMore }
-								/>
-							),
-						},
-					}
-				) }
+				{ showLearnMoreLink
+					? translate(
+							'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
+							{
+								components: {
+									a: (
+										<a
+											href={ learnMoreLink }
+											target="_blank"
+											rel="noopener noreferrer"
+											onClick={ onClickLearnMore }
+										/>
+									),
+								},
+							}
+					  )
+					: translate(
+							'You will be billed at the end of every month. Your first month may be less than the above amount.'
+					  ) }
 			</div>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/empty.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/empty.tsx
@@ -35,11 +35,13 @@ export default function LicenseListEmpty( { filter }: Props ) {
 		dispatch( recordTracksEvent( 'calypso_a4a_license_list_empty_issue_license_click' ) );
 	};
 
+	const showLearnMoreLink = false; // FIXME: Remove this once the correct link is added
+
 	return (
 		<div className="license-list__empty-list">
 			<h2>{ licenseFilterStatusTitle }</h2>
 
-			{ filter === LicenseFilter.NotRevoked && (
+			{ showLearnMoreLink && filter === LicenseFilter.NotRevoked && (
 				<p>
 					{ translate(
 						'Learn more about {{a}}adding licenses and billing {{icon}}{{/icon}}{{/a}}.',

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
@@ -143,23 +143,29 @@ export default function RevokeLicenseDialog( {
 			);
 		}
 
+		const showLearnMoreLink = false; // FIXME: Remove this once the correct link is added
+
 		return (
 			<>
 				<p>
 					{ translate(
 						'A revoked license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
 					) }
-					&nbsp;
-					<a
-						className="revoke-license-dialog__learn-more"
-						href="https://" // FIXME: Add URL
-						target="_blank"
-						rel="noreferrer noopener"
-					>
-						{ translate( 'Learn more about revoking licenses' ) }
-						&nbsp;
-						<Gridicon icon="external" size={ 18 } />
-					</a>
+					{ showLearnMoreLink && (
+						<>
+							&nbsp;
+							<a
+								className="revoke-license-dialog__learn-more"
+								href="https://" // FIXME: Add URL
+								target="_blank"
+								rel="noreferrer noopener"
+							>
+								{ translate( 'Learn more about revoking licenses' ) }
+								&nbsp;
+								<Gridicon icon="external" size={ 18 } />
+							</a>
+						</>
+					) }
 				</p>
 				<ul>
 					{ siteUrl && (


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/290
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/291

## Proposed Changes

This PR hides the link in:

- License list empty state
- License revoke modal
- Checkout page

## Testing Instructions

- Open the A4A live link
-  Visit /purchases/licenses > Enter any text on the search box > Notice the link is unavailable now.
- Visit /purchases/licenses > Open any license details > Click the Revoke button >  Notice the link is unavailable now.
- Visit /purchases/licenses > Select any license > Go to Checkout >  Notice the link is unavailable now.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td colSpan=2 align="center">
License list empty state
</td>
</tr>
<tr>
<td>
<img width="418" alt="Screenshot 2024-04-16 at 2 32 51 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/50e406b9-0ca3-4be7-9591-943c3ebbc970">
</td>
<td>

<img width="418" alt="Screenshot 2024-04-16 at 2 32 57 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/80821ae6-543c-4c59-b32e-898d4eb66b8f">
</td>
</tr>
<tr>
<td colSpan=2 align="center">
License Revoke modal
</td>
</tr>
<tr>
<td>
<img width="702" alt="Screenshot 2024-04-16 at 2 32 11 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4fe9598c-ba4e-431e-af59-34cedcb47a57">
</td>
<td>
<img width="702" alt="Screenshot 2024-04-16 at 2 30 47 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7d319357-c457-4334-a0d8-6655cf1fbbcd">
</td>
</tr>
<tr>
<td colSpan=2 align="center">
Checkout page
</td>
</tr>
<tr>
<td>
<img width="525" alt="Screenshot 2024-04-16 at 2 33 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/56c09423-32a1-435f-8e55-9f15f2647b22">
</td>
<td>
<img width="525" alt="Screenshot 2024-04-16 at 2 33 38 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/28b62910-aeff-41ee-9418-2a34fd994772">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?