### PR TITLE
Pattern Library: Remove `max-height` from pattern previews

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -265,6 +265,7 @@ function PatternPreviewFragment( {
 
 			<div className="pattern-preview__renderer">
 				<PatternRenderer
+					maxHeight="none"
 					minHeight={ nodeSize.width ? nodeSize.width / ASPECT_RATIO : undefined }
 					patternId={ patternId }
 					scripts={ redrawScript }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6585

## Proposed Changes

Tall pattern previews get cut off at the bottom, because `BlockRendererContainer` applies a `max-height` of 2000px by default. This PR fixes that by unsetting the max-height.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/layouts/posts?grid=1`
2. Ensure that the `Page: Blog Posts` pattern isn't cut off at the bottom