### PR TITLE
DIFM: open help center on in-progress page

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -50,10 +50,8 @@ import {
 	PlanPrice,
 	MaterialIcon,
 } from '@automattic/components';
-import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
-import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import classNames from 'classnames';
 import { localize, LocalizeProps, numberFormat, useTranslate } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
@@ -133,7 +131,7 @@ import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { useGetWebsiteContentQuery } from 'calypso/state/signup/steps/website-content/hooks/use-get-website-content-query';
 import { hasLoadedSiteDomains, getAllDomains } from 'calypso/state/sites/domains/selectors';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
-import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import { getSite, getSiteSlug, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch, IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -1444,18 +1442,7 @@ function addPaymentMethodLinkText( {
 
 function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 	const translate = useTranslate();
-	const site = useSelector( ( state ) => getSite( state, purchase.siteId ) );
-	const siteSlug = site?.slug;
-
-	// Create URLSearchParams for send feedback by email command
-	const { setInitialRoute, setShowHelpCenter, setSubject, setUserDeclaredSite } =
-		useDataStoreDispatch( HELP_CENTER_STORE );
-
-	const emailUrl = `/contact-form?${ new URLSearchParams( {
-		mode: 'EMAIL',
-		'disable-gpt': 'true',
-	} ).toString() }`;
-
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, purchase.siteId ) );
 	const { isLoading, data: websiteContentQueryResult } = useGetWebsiteContentQuery( siteSlug );
 	const difmTieredPurchaseDetails = getDIFMTieredPurchaseDetails( purchase );
 	if ( ! difmTieredPurchaseDetails ) {
@@ -1467,12 +1454,9 @@ function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 
 	const BBESupportLink = (
 		<a
-			onClick={ () => {
-				setInitialRoute( emailUrl );
-				setUserDeclaredSite( site );
-				setSubject( `I have a question about my project` );
-				setShowHelpCenter( true );
-			} }
+			href={ `mailto:services+express@wordpress.com?subject=${ encodeURIComponent(
+				`I have a question about my project: ${ siteSlug }`
+			) }` }
 		/>
 	);
 

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.scss
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.scss
@@ -20,4 +20,8 @@
 	.empty-content__action {
 		margin-inline-start: 10px;
 	}
+
+	.difm-lite-in-progress__help-button {
+		font-size: 1rem;
+	}
 }

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -56,7 +56,7 @@ function SupportLink( { siteId }: { siteId?: number } ) {
 			onClick={ () => {
 				setInitialRoute( emailUrl );
 				setSite( site );
-				setSubject( `I have a question about my project` );
+				setSubject( translate( 'I have a question about my project' ) );
 				setShowHelpCenter( true );
 			} }
 		>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Since DIFM support queries are now routed automatically to the correct support queue, we can replace the `mailto` links on the DIFM in-progress page with the help center. This is a better experience for the user and also takes care of cases where the user does not have an email client installed.


https://github.com/Automattic/wp-calypso/assets/5436027/4897941c-4e98-4a2e-8931-6b491fc49bab



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Toggle the DIFM sticker using the Blog RC for a site.
* Go to `/home/<site slug>` for this site.
* On the DIFM in-progress page, click on the "Contact Support" link.
* Confirm that it opens the help center.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?