### PR TITLE
Scheduled updates: Create a site selector form control

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -1,4 +1,5 @@
 import { CheckboxControl, SearchControl } from '@wordpress/components';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useState } from 'react';
 import type { SiteExcerptData } from '@automattic/sites';
@@ -6,9 +7,10 @@ import type { SiteExcerptData } from '@automattic/sites';
 interface Props {
 	sites: SiteExcerptData[];
 	initSites?: number[];
+	boarderWrapper?: boolean;
 }
 export const ScheduleFormSites = ( props: Props ) => {
-	const { sites, initSites = [] } = props;
+	const { sites, initSites = [], boarderWrapper = true } = props;
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( initSites );
@@ -26,7 +28,7 @@ export const ScheduleFormSites = ( props: Props ) => {
 	return (
 		<div className="form-field">
 			<label htmlFor="sites">{ translate( 'Select sites' ) }</label>
-			<div className="form-control-container">
+			<div className={ classnames( { 'form-control-container': boarderWrapper } ) }>
 				<SearchControl
 					id="sites"
 					onChange={ ( s ) => setSearchTerm( s.trim() ) }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -1,21 +1,35 @@
-import { CheckboxControl, SearchControl } from '@wordpress/components';
+import { __experimentalText as Text, CheckboxControl, SearchControl } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { useEffect, Fragment, useCallback, useState } from 'react';
 import type { SiteExcerptData } from '@automattic/sites';
 
 interface Props {
 	sites: SiteExcerptData[];
 	selectedSites?: number[];
+	error?: string;
+	showError?: boolean;
 	onChange?: ( value: number[] ) => void;
+	onTouch?: ( touched: boolean ) => void;
 	borderWrapper?: boolean;
 }
 export const ScheduleFormSites = ( props: Props ) => {
-	const { sites, selectedSites: initSites = [], onChange, borderWrapper = true } = props;
+	const {
+		sites,
+		selectedSites: initSites = [],
+		error,
+		showError,
+		onChange,
+		onTouch,
+		borderWrapper = true,
+	} = props;
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( initSites );
+	const [ fieldTouched, setFieldTouched ] = useState( false );
 
+	useEffect( () => onTouch?.( fieldTouched ), [ fieldTouched ] );
 	useEffect( () => onChange?.( selectedSites ), [ selectedSites ] );
 
 	const onSiteSelectionChange = useCallback(
@@ -35,6 +49,12 @@ export const ScheduleFormSites = ( props: Props ) => {
 		<div className="form-field">
 			<label htmlFor="sites">{ translate( 'Select sites' ) }</label>
 			<div className={ classnames( { 'form-control-container': borderWrapper } ) }>
+				{ ( ( showError && error ) || ( fieldTouched && error ) ) && (
+					<Text className="validation-msg">
+						<Icon className="icon-info" icon={ info } size={ 16 } />
+						{ error }
+					</Text>
+				) }
 				<SearchControl
 					id="sites"
 					onChange={ ( s ) => setSearchTerm( s.trim() ) }
@@ -49,6 +69,7 @@ export const ScheduleFormSites = ( props: Props ) => {
 									label={ site.name }
 									onChange={ ( isChecked ) => {
 										onSiteSelectionChange( site, isChecked );
+										setFieldTouched( true );
 									} }
 									checked={ selectedSites.includes( site.ID ) }
 								/>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -15,15 +15,18 @@ export const ScheduleFormSites = ( props: Props ) => {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( initSites );
 
-	const onSiteSelectionChange = useCallback( ( site: SiteExcerptData, isChecked: boolean ) => {
-		if ( isChecked ) {
-			const _sites: number[] = [ ...selectedSites ];
-			_sites.push( site.ID );
-			setSelectedSites( _sites );
-		} else {
-			setSelectedSites( selectedSites.filter( ( id ) => id !== site.ID ) );
-		}
-	}, [] );
+	const onSiteSelectionChange = useCallback(
+		( site: SiteExcerptData, isChecked: boolean ) => {
+			if ( isChecked ) {
+				const _sites: number[] = [ ...selectedSites ];
+				_sites.push( site.ID );
+				setSelectedSites( _sites );
+			} else {
+				setSelectedSites( selectedSites.filter( ( id ) => id !== site.ID ) );
+			}
+		},
+		[ selectedSites ]
+	);
 
 	return (
 		<div className="form-field">

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -1,19 +1,22 @@
 import { CheckboxControl, SearchControl } from '@wordpress/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import type { SiteExcerptData } from '@automattic/sites';
 
 interface Props {
 	sites: SiteExcerptData[];
 	selectedSites?: number[];
+	onChange?: ( value: number[] ) => void;
 	borderWrapper?: boolean;
 }
 export const ScheduleFormSites = ( props: Props ) => {
-	const { sites, selectedSites: initSites = [], borderWrapper = true } = props;
+	const { sites, selectedSites: initSites = [], onChange, borderWrapper = true } = props;
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( initSites );
+
+	useEffect( () => onChange?.( selectedSites ), [ selectedSites ] );
 
 	const onSiteSelectionChange = useCallback(
 		( site: SiteExcerptData, isChecked: boolean ) => {

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -6,11 +6,11 @@ import type { SiteExcerptData } from '@automattic/sites';
 
 interface Props {
 	sites: SiteExcerptData[];
-	initSites?: number[];
+	selectedSites?: number[];
 	borderWrapper?: boolean;
 }
 export const ScheduleFormSites = ( props: Props ) => {
-	const { sites, initSites = [], borderWrapper = true } = props;
+	const { sites, selectedSites: initSites = [], borderWrapper = true } = props;
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( initSites );

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -60,6 +60,10 @@ export const ScheduleFormSites = ( props: Props ) => {
 					onChange={ ( s ) => setSearchTerm( s.trim() ) }
 					placeholder={ translate( 'Search site' ) }
 				/>
+				<Text className="info-msg">
+					You can only select sites with Creator plan. Please upgrade your site to enable this
+					feature.
+				</Text>
 				<div className="checkbox-options-container">
 					{ sites.map( ( site ) => (
 						<Fragment key={ site.ID }>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -1,0 +1,54 @@
+import { CheckboxControl, SearchControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { Fragment, useCallback, useState } from 'react';
+import type { SiteExcerptData } from '@automattic/sites';
+
+interface Props {
+	sites: SiteExcerptData[];
+	initSites?: number[];
+}
+export const ScheduleFormSites = ( props: Props ) => {
+	const { sites, initSites = [] } = props;
+	const translate = useTranslate();
+	const [ searchTerm, setSearchTerm ] = useState( '' );
+	const [ selectedSites, setSelectedSites ] = useState< number[] >( initSites );
+
+	const onSiteSelectionChange = useCallback( ( site: SiteExcerptData, isChecked: boolean ) => {
+		if ( isChecked ) {
+			const _sites: number[] = [ ...selectedSites ];
+			_sites.push( site.ID );
+			setSelectedSites( _sites );
+		} else {
+			setSelectedSites( selectedSites.filter( ( id ) => id !== site.ID ) );
+		}
+	}, [] );
+
+	return (
+		<div className="form-field">
+			<label htmlFor="sites">{ translate( 'Select sites' ) }</label>
+			<div className="form-control-container">
+				<SearchControl
+					id="sites"
+					onChange={ ( s ) => setSearchTerm( s.trim() ) }
+					placeholder={ translate( 'Search site' ) }
+				/>
+				<div className="checkbox-options-container">
+					{ sites.map( ( site ) => (
+						<Fragment key={ site.ID }>
+							{ site?.name && site.name.toLowerCase().includes( searchTerm.toLowerCase() ) && (
+								<CheckboxControl
+									key={ site.ID }
+									label={ site.name }
+									onChange={ ( isChecked ) => {
+										onSiteSelectionChange( site, isChecked );
+									} }
+									checked={ selectedSites.includes( site.ID ) }
+								/>
+							) }
+						</Fragment>
+					) ) }
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -7,10 +7,10 @@ import type { SiteExcerptData } from '@automattic/sites';
 interface Props {
 	sites: SiteExcerptData[];
 	initSites?: number[];
-	boarderWrapper?: boolean;
+	borderWrapper?: boolean;
 }
 export const ScheduleFormSites = ( props: Props ) => {
-	const { sites, initSites = [], boarderWrapper = true } = props;
+	const { sites, initSites = [], borderWrapper = true } = props;
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( initSites );
@@ -28,7 +28,7 @@ export const ScheduleFormSites = ( props: Props ) => {
 	return (
 		<div className="form-field">
 			<label htmlFor="sites">{ translate( 'Select sites' ) }</label>
-			<div className={ classnames( { 'form-control-container': boarderWrapper } ) }>
+			<div className={ classnames( { 'form-control-container': borderWrapper } ) }>
 				<SearchControl
 					id="sites"
 					onChange={ ( s ) => setSearchTerm( s.trim() ) }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -13,13 +13,14 @@ export const ScheduleForm = () => {
 			<div className="form-control-container">
 				<Flex direction={ [ 'column', 'row' ] } expanded={ true } align="start">
 					<FlexItem>
-						<ScheduleFormSites sites={ atomicSites } />
+						<ScheduleFormSites sites={ atomicSites } boarderWrapper={ false } />
 					</FlexItem>
 					<FlexItem>
 						<ScheduleFormPlugins
 							plugins={ [] }
 							isPluginsFetching={ false }
 							isPluginsFetched={ true }
+							boarderWrapper={ false }
 						/>
 					</FlexItem>
 				</Flex>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -13,14 +13,14 @@ export const ScheduleForm = () => {
 			<div className="form-control-container">
 				<Flex direction={ [ 'column', 'row' ] } expanded={ true } align="start">
 					<FlexItem>
-						<ScheduleFormSites sites={ atomicSites } boarderWrapper={ false } />
+						<ScheduleFormSites sites={ atomicSites } borderWrapper={ false } />
 					</FlexItem>
 					<FlexItem>
 						<ScheduleFormPlugins
 							plugins={ [] }
 							isPluginsFetching={ false }
 							isPluginsFetched={ true }
-							boarderWrapper={ false }
+							borderWrapper={ false }
 						/>
 					</FlexItem>
 				</Flex>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,19 +1,41 @@
 import { Flex, FlexItem } from '@wordpress/components';
+import { useState, useEffect } from 'react';
 import { useSiteExcerptsSorted } from 'calypso/data/sites/use-site-excerpts-sorted';
 import { ScheduleFormFrequency } from '../plugins-scheduled-updates/schedule-form-frequency';
 import { ScheduleFormPlugins } from '../plugins-scheduled-updates/schedule-form-plugins';
+import { validateSites } from '../plugins-scheduled-updates/schedule-form.helper';
 import { ScheduleFormSites } from './schedule-form-sites';
 
 export const ScheduleForm = () => {
 	const sites = useSiteExcerptsSorted();
 	const atomicSites = sites.filter( ( site ) => site.is_wpcom_atomic );
 
+	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
+	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {} );
+	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
+
+	// Sites selection validation
+	useEffect(
+		() =>
+			setValidationErrors( {
+				...validationErrors,
+				sites: validateSites( selectedSites ),
+			} ),
+		[ selectedSites ]
+	);
+
 	return (
 		<div className="schedule-form">
 			<div className="form-control-container">
 				<Flex direction={ [ 'column', 'row' ] } expanded={ true } align="start">
 					<FlexItem>
-						<ScheduleFormSites sites={ atomicSites } borderWrapper={ false } />
+						<ScheduleFormSites
+							sites={ atomicSites }
+							borderWrapper={ false }
+							onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, sites: touched } ) }
+							onChange={ setSelectedSites }
+							error={ validationErrors?.sites }
+						/>
 					</FlexItem>
 					<FlexItem>
 						<ScheduleFormPlugins

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,13 +1,20 @@
 import { Flex, FlexItem } from '@wordpress/components';
+import { useSiteExcerptsSorted } from 'calypso/data/sites/use-site-excerpts-sorted';
 import { ScheduleFormFrequency } from '../plugins-scheduled-updates/schedule-form-frequency';
 import { ScheduleFormPlugins } from '../plugins-scheduled-updates/schedule-form-plugins';
+import { ScheduleFormSites } from './schedule-form-sites';
 
 export const ScheduleForm = () => {
+	const sites = useSiteExcerptsSorted();
+	const atomicSites = sites.filter( ( site ) => site.is_wpcom_atomic );
+
 	return (
 		<div className="schedule-form">
 			<div className="form-control-container">
 				<Flex direction={ [ 'column', 'row' ] } expanded={ true } align="start">
-					<FlexItem>Site selection</FlexItem>
+					<FlexItem>
+						<ScheduleFormSites sites={ atomicSites } />
+					</FlexItem>
 					<FlexItem>
 						<ScheduleFormPlugins
 							plugins={ [] }

--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -21,7 +21,7 @@ interface Props {
 	showError?: boolean;
 	onTouch?: ( touched: boolean ) => void;
 	onChange?: ( value: string[] ) => void;
-	boarderWrapper?: boolean;
+	borderWrapper?: boolean;
 }
 export function ScheduleFormPlugins( props: Props ) {
 	const {
@@ -33,7 +33,7 @@ export function ScheduleFormPlugins( props: Props ) {
 		showError,
 		onChange,
 		onTouch,
-		boarderWrapper = true,
+		borderWrapper = true,
 	} = props;
 	const translate = useTranslate();
 
@@ -93,7 +93,7 @@ export function ScheduleFormPlugins( props: Props ) {
 					{ translate( 'Plugins not listed below are automatically updated by WordPress.com.' ) }
 				</Text>
 			) }
-			<div className={ classnames( { 'form-control-container': boarderWrapper } ) }>
+			<div className={ classnames( { 'form-control-container': borderWrapper } ) }>
 				<SearchControl id="plugins" onChange={ setPluginSearchTerm } value={ pluginSearchTerm } />
 				<div className="checkbox-options-container">
 					{ isPluginsFetching && <Spinner /> }

--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -21,6 +21,7 @@ interface Props {
 	showError?: boolean;
 	onTouch?: ( touched: boolean ) => void;
 	onChange?: ( value: string[] ) => void;
+	boarderWrapper?: boolean;
 }
 export function ScheduleFormPlugins( props: Props ) {
 	const {
@@ -32,6 +33,7 @@ export function ScheduleFormPlugins( props: Props ) {
 		showError,
 		onChange,
 		onTouch,
+		boarderWrapper = true,
 	} = props;
 	const translate = useTranslate();
 
@@ -91,7 +93,7 @@ export function ScheduleFormPlugins( props: Props ) {
 					{ translate( 'Plugins not listed below are automatically updated by WordPress.com.' ) }
 				</Text>
 			) }
-			<div className="form-control-container">
+			<div className={ classnames( { 'form-control-container': boarderWrapper } ) }>
 				<SearchControl id="plugins" onChange={ setPluginSearchTerm } value={ pluginSearchTerm } />
 				<div className="checkbox-options-container">
 					{ isPluginsFetching && <Spinner /> }

--- a/client/blocks/plugins-scheduled-updates/schedule-form.helper.ts
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.helper.ts
@@ -125,3 +125,11 @@ export const validatePlugins = ( plugins: string[], existingPlugins: Array< stri
 
 	return error;
 };
+
+/**
+ * Validate sites
+ * check if at least one site is selected
+ */
+export const validateSites = ( sites: number[] ): string => {
+	return sites.length === 0 ? translate( 'Please select at least one site.' ) : '';
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89473

## Proposed Changes

* Created Site selector form control
* Integrated into multisite create/edit form

NOTE: I'm aware that the position for the error message is not perfect, and we will probably move it from there. But the logic will stay the same, so for this phase, we are good.

## Testing Instructions

* Go to `plugins/scheduled-updates/create` (from `dev` env or provide a feature flag `plugins/multisite-scheduled-updates`)
* Check the site selection component

![Screen Capture on 2024-04-16 at 13-14-27](https://github.com/Automattic/wp-calypso/assets/1241413/2aa133fc-f3be-4d93-bb9c-f8122bb79ed6)

<img width="694" alt="Screenshot 2024-04-16 at 13 30 36" src="https://github.com/Automattic/wp-calypso/assets/1241413/786853f0-ded9-43ea-a206-36b5ad016764">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?