### PR TITLE
Entrepreneur trial plan page

### DIFF
--- a/client/my-sites/plans/components/upgrade-button/style.scss
+++ b/client/my-sites/plans/components/upgrade-button/style.scss
@@ -1,0 +1,13 @@
+.trial-current-plan__trial-card-cta {
+	&.blue {
+		background-color: var(--studio-blue-60);
+		color: var(--studio-blue-0);
+		border: unset;
+
+		&:hover {
+			background-color: var(--studio-blue-60);
+			opacity: 0.85;
+			transition: 0.7s;
+		}
+	}
+}

--- a/client/my-sites/plans/components/upgrade-button/upgrade-button.tsx
+++ b/client/my-sites/plans/components/upgrade-button/upgrade-button.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+
+interface UpgradeButtonProps {
+	goToCheckoutWithPlan: ( planSlug: string ) => void;
+	isEntrepreneurTrial?: boolean;
+}
+
+const UpgradeButton = ( { goToCheckoutWithPlan, isEntrepreneurTrial }: UpgradeButtonProps ) => {
+	const translate = useTranslate();
+	const label = isEntrepreneurTrial
+		? translate( 'Add payment method' )
+		: translate( 'Upgrade now' );
+
+	return (
+		<Button
+			className={ classNames( 'trial-current-plan__trial-card-cta', {
+				[ 'blue' ]: isEntrepreneurTrial,
+			} ) }
+			primary
+			onClick={ () => goToCheckoutWithPlan( 'card' ) }
+		>
+			{ label }
+		</Button>
+	);
+};
+
+export default UpgradeButton;

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -1,12 +1,13 @@
-import { isFreePlanProduct } from '@automattic/calypso-products';
+import { PLAN_ECOMMERCE_TRIAL_MONTHLY, isFreePlanProduct } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedPurchase } from 'calypso/state/ui/selectors';
 import CurrentPlan from './';
 
 export function currentPlan( context, next ) {
 	const state = context.store.getState();
 
 	const selectedSite = getSelectedSite( state );
+	const purchase = getSelectedPurchase( state );
 
 	if ( ! selectedSite ) {
 		page.redirect( '/plans/' );
@@ -14,7 +15,12 @@ export function currentPlan( context, next ) {
 		return null;
 	}
 
-	if ( isFreePlanProduct( selectedSite.plan ) ) {
+	const isFreePlan = isFreePlanProduct( selectedSite.plan );
+	const currentPlanSlug = selectedSite?.plan?.product_slug ?? '';
+	const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+	const isEntrepreneurTrial = isEcommerceTrial && ! purchase?.isWooExpressTrial;
+
+	if ( isFreePlan || isEntrepreneurTrial ) {
 		page.redirect( `/plans/${ selectedSite.slug }` );
 
 		return null;

--- a/client/my-sites/plans/current-plan/feature-included-card/index.tsx
+++ b/client/my-sites/plans/current-plan/feature-included-card/index.tsx
@@ -1,24 +1,38 @@
 import { Button, Card } from '@automattic/components';
+import classNames from 'classnames';
 
 import './style.scss';
 
 interface Props {
 	title: string;
 	text: string;
-	illustration: string;
+	illustration?: string;
 	showButton: boolean;
+	reducedPadding?: boolean;
 	buttonText?: string;
 	buttonClick?: () => void;
 }
 
 const FeatureIncludedCard = ( props: Props ) => {
-	const { illustration, title, text, showButton, buttonText, buttonClick } = props;
+	const { illustration, title, text, showButton, buttonText, buttonClick, reducedPadding } = props;
 
 	return (
-		<Card className="feature-included-card__card">
-			<img className="feature-included-card__illustration" alt={ title } src={ illustration } />
+		<Card
+			className={ classNames( 'feature-included-card__card', {
+				[ 'reduced-padding' ]: reducedPadding,
+			} ) }
+		>
+			{ illustration && (
+				<img className="feature-included-card__illustration" alt={ title } src={ illustration } />
+			) }
 			<div className="feature-included-card__content">
-				<p className="feature-included-card__title">{ title }</p>
+				<p
+					className={ classNames( 'feature-included-card__title', {
+						[ 'reduced-padding' ]: reducedPadding,
+					} ) }
+				>
+					{ title }
+				</p>
 				<p className="feature-included-card__text">{ text }</p>
 				{ showButton && (
 					<Button className="feature-included-card__link" onClick={ buttonClick }>

--- a/client/my-sites/plans/current-plan/feature-included-card/style.scss
+++ b/client/my-sites/plans/current-plan/feature-included-card/style.scss
@@ -35,6 +35,10 @@
 			font-weight: 600;
 			font-size: $font-body;
 
+			&.reduced-padding {
+				margin-top: 0;
+			}
+
 			@media (max-width: $break-mobile) {
 				margin: 0;
 				font-size: $font-body-small;

--- a/client/my-sites/plans/current-plan/trials/ecommerce-trial-included.tsx
+++ b/client/my-sites/plans/current-plan/trials/ecommerce-trial-included.tsx
@@ -13,9 +13,10 @@ import FeatureIncludedCard from '../feature-included-card';
 interface Props {
 	translate: typeof translate;
 	displayAll: boolean;
+	isWooExpressTrial?: boolean;
 }
 const ECommerceTrialIncluded: FunctionComponent< Props > = ( props ) => {
-	const { translate, displayAll = true } = props;
+	const { translate, displayAll = true, isWooExpressTrial } = props;
 
 	// TODO: translate when final copy is available
 	const allIncludedFeatures = [
@@ -92,11 +93,12 @@ const ECommerceTrialIncluded: FunctionComponent< Props > = ( props ) => {
 			{ whatsIncluded.map( ( feature ) => (
 				<FeatureIncludedCard
 					key={ feature.title }
-					illustration={ feature.illustration }
+					illustration={ isWooExpressTrial ? feature.illustration : undefined }
 					title={ feature.title }
 					text={ feature.text }
 					showButton={ false }
 					buttonText={ feature.buttonText }
+					reducedPadding={ ! isWooExpressTrial }
 				></FeatureIncludedCard>
 			) ) }
 		</>

--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.scss
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.scss
@@ -62,6 +62,9 @@ body.is-section-plans.is-business-trial-plan {
 			margin-left: 12px;
 			margin-bottom: 24px;
 			padding: 48px 24px 24px;
+			&.reduced-padding {
+				padding: 16px 16px 8px 16px;
+			}
 		}
 
 		@media (min-width: $break-wide) {

--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { useSelector } from 'calypso/state';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
 import useOneDollarOfferTrack from '../../hooks/use-onedollar-offer-track';
 import TrialBanner from '../../trials/trial-banner';
 import BusinessTrialIncluded from './business-trial-included';
@@ -36,11 +36,13 @@ const TrialCurrentPlan = () => {
 
 	const currentPlanSlug = selectedSite?.plan?.product_slug ?? '';
 	const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+	const purchase = useSelector( getSelectedPurchase );
 	// const isMigrationTrial = currentPlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY;
 
 	const isMobile = useMediaQuery( '(max-width: 480px)' );
 	const displayAllIncluded = ! isMobile || showAllTrialFeaturesInMobileView;
 	const bodyClass = isEcommerceTrial ? [ 'is-ecommerce-trial-plan' ] : [ 'is-business-trial-plan' ];
+	const isWooExpressTrial = purchase?.isWooExpressTrial;
 
 	const targetPlan = isEcommerceTrial ? PLAN_WOOEXPRESS_MEDIUM_MONTHLY : PLAN_BUSINESS;
 	const trackEvent = isEcommerceTrial
@@ -89,7 +91,7 @@ const TrialCurrentPlan = () => {
 			<BodySectionCssClass bodyClass={ bodyClass } />
 
 			<div className="trial-current-plan__banner-wrapper">
-				<TrialBanner callToAction={ bannerCallToAction } isEcommerceTrial={ isEcommerceTrial } />
+				<TrialBanner callToAction={ bannerCallToAction } isWooExpressTrial={ isWooExpressTrial } />
 			</div>
 
 			<h2 className="trial-current-plan__section-title">

--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
@@ -1,26 +1,20 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-import {
-	PLAN_BUSINESS,
-	PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
-} from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
+import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useMediaQuery } from '@wordpress/compose';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
-import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { useSelector } from 'calypso/state';
 import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
+import UpgradeButton from '../../components/upgrade-button/upgrade-button';
 import useOneDollarOfferTrack from '../../hooks/use-onedollar-offer-track';
 import TrialBanner from '../../trials/trial-banner';
 import BusinessTrialIncluded from './business-trial-included';
 import EcommerceTrialIncluded from './ecommerce-trial-included';
 import EcommerceTrialNotIncluded from './ecommerce-trial-not-included';
-
 import './trial-current-plan.scss';
+import useGoToCheckoutWithPlan from './use-go-to-checkout-with-plan';
 
 const TrialCurrentPlan = () => {
 	const selectedSite = useSelector( getSelectedSite );
@@ -44,43 +38,22 @@ const TrialCurrentPlan = () => {
 	const bodyClass = isEcommerceTrial ? [ 'is-ecommerce-trial-plan' ] : [ 'is-business-trial-plan' ];
 	const isWooExpressTrial = purchase?.isWooExpressTrial;
 
-	const targetPlan = isEcommerceTrial ? PLAN_WOOEXPRESS_MEDIUM_MONTHLY : PLAN_BUSINESS;
-	const trackEvent = isEcommerceTrial
-		? 'calypso_wooexpress_my_plan_cta'
-		: 'calypso_migration_my_plan_cta';
-
 	useOneDollarOfferTrack( selectedSite?.ID, 'plans' );
 
 	/**
 	 * Redirects to the checkout page with Plan on cart.
 	 * @param ctaPosition - The position of the CTA that triggered the redirect.
 	 */
-	const goToCheckoutWithPlan = ( ctaPosition: string ) => {
-		recordTracksEvent( trackEvent, {
-			cta_position: ctaPosition,
-		} );
-
-		const checkoutUrl = getTrialCheckoutUrl( {
-			productSlug: targetPlan,
-			siteSlug: selectedSite?.slug ?? '',
-		} );
-
-		page.redirect( checkoutUrl );
-	};
-
-	const bannerCallToAction = (
-		<Button
-			className="trial-current-plan__trial-card-cta"
-			primary
-			onClick={ () => goToCheckoutWithPlan( 'card' ) }
-		>
-			{ translate( 'Upgrade now' ) }
-		</Button>
-	);
+	const goToCheckoutWithPlan = useGoToCheckoutWithPlan();
 
 	const includedFeatures = () => {
 		if ( isEcommerceTrial ) {
-			return <EcommerceTrialIncluded displayAll={ displayAllIncluded } />;
+			return (
+				<EcommerceTrialIncluded
+					displayAll={ displayAllIncluded }
+					isWooExpressTrial={ isWooExpressTrial }
+				/>
+			);
 		}
 
 		return <BusinessTrialIncluded displayAll={ displayAllIncluded } tracksContext="current_plan" />;
@@ -91,7 +64,10 @@ const TrialCurrentPlan = () => {
 			<BodySectionCssClass bodyClass={ bodyClass } />
 
 			<div className="trial-current-plan__banner-wrapper">
-				<TrialBanner callToAction={ bannerCallToAction } isWooExpressTrial={ isWooExpressTrial } />
+				<TrialBanner
+					callToAction={ <UpgradeButton goToCheckoutWithPlan={ goToCheckoutWithPlan } /> }
+					isWooExpressTrial={ isWooExpressTrial }
+				/>
 			</div>
 
 			<h2 className="trial-current-plan__section-title">

--- a/client/my-sites/plans/current-plan/trials/use-go-to-checkout-with-plan.tsx
+++ b/client/my-sites/plans/current-plan/trials/use-go-to-checkout-with-plan.tsx
@@ -1,0 +1,59 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
+} from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
+import { useSelector } from 'calypso/state';
+import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
+import useOneDollarOfferTrack from '../../hooks/use-onedollar-offer-track';
+
+const getTargetPlanAndTrackEvent = ( isEcommerceTrial: boolean, isWooExpressTrial: boolean ) => {
+	if ( isEcommerceTrial ) {
+		return isWooExpressTrial
+			? [ PLAN_WOOEXPRESS_MEDIUM_MONTHLY, 'calypso_wooexpress_my_plan_cta' ]
+			: [ PLAN_ECOMMERCE_MONTHLY, 'calypso_entrepreneur_my_plan_cta' ];
+	}
+
+	return [ PLAN_BUSINESS, 'calypso_migration_my_plan_cta' ];
+};
+
+const useGoToCheckoutWithPlan = () => {
+	const selectedSite = useSelector( getSelectedSite );
+	const purchase = useSelector( getSelectedPurchase );
+
+	const currentPlanSlug = selectedSite?.plan?.product_slug ?? '';
+	const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+	const isWooExpressTrial = purchase?.isWooExpressTrial;
+
+	const [ targetPlan, trackEvent ] = getTargetPlanAndTrackEvent(
+		isEcommerceTrial,
+		!! isWooExpressTrial
+	);
+
+	useOneDollarOfferTrack( selectedSite?.ID, 'plans' );
+
+	/**
+	 * Redirects to the checkout page with Plan on cart.
+	 * @param ctaPosition - The position of the CTA that triggered the redirect.
+	 */
+	const goToCheckoutWithPlan = ( ctaPosition: string ) => {
+		recordTracksEvent( trackEvent, {
+			cta_position: ctaPosition,
+		} );
+
+		const checkoutUrl = getTrialCheckoutUrl( {
+			productSlug: targetPlan,
+			siteSlug: selectedSite?.slug ?? '',
+		} );
+
+		page.redirect( checkoutUrl );
+	};
+
+	return goToCheckoutWithPlan;
+};
+
+export default useGoToCheckoutWithPlan;

--- a/client/my-sites/plans/doughnut-chart/index.tsx
+++ b/client/my-sites/plans/doughnut-chart/index.tsx
@@ -1,9 +1,11 @@
+import classNames from 'classnames';
 import { CSSProperties } from 'react';
 import './style.scss';
 
 interface DoughnutChartProps {
 	progress: number;
 	text: string;
+	isEntrepreneurTrial?: boolean;
 }
 
 interface CustomPercentageVariable extends CSSProperties {
@@ -11,12 +13,17 @@ interface CustomPercentageVariable extends CSSProperties {
 }
 
 const DoughnutChart = ( props: DoughnutChartProps ) => {
-	const { progress, text } = props;
+	const { progress, text, isEntrepreneurTrial } = props;
 
 	const style: CustomPercentageVariable = { '--percentage': progress * 100 };
 
 	return (
-		<div className="doughnut-chart__wrapper" style={ style }>
+		<div
+			className={ classNames( 'doughnut-chart__wrapper', {
+				blue: isEntrepreneurTrial,
+			} ) }
+			style={ style }
+		>
 			{ text }
 		</div>
 	);

--- a/client/my-sites/plans/doughnut-chart/style.scss
+++ b/client/my-sites/plans/doughnut-chart/style.scss
@@ -10,6 +10,10 @@
 	--line-width: 9px;
 	--main-color: var(--color-accent-rgb);
 
+	&.blue {
+		--main-color: var(--studio-blue-60-rgb);
+	}
+
 	background-color: var(--color-surface);
 	width: var(--width);
 	aspect-ratio: 1;

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.jsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.jsx
@@ -1,0 +1,158 @@
+import {
+	PLAN_ECOMMERCE,
+	PLAN_ECOMMERCE_2_YEARS,
+	PLAN_ECOMMERCE_3_YEARS,
+	PLAN_ECOMMERCE_MONTHLY,
+	getPlans,
+} from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { PlanPrice } from '@automattic/components';
+import Card from '@automattic/components/src/card';
+import { CustomSelectControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import './style.scss';
+import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import UpgradeButton from '../../components/upgrade-button/upgrade-button';
+import EcommerceTrialIncluded from '../../current-plan/trials/ecommerce-trial-included';
+
+const useEntrepreneurPlanPrices = () => {
+	const translate = useTranslate();
+	const state = useSelector( ( stateValue ) => stateValue );
+	const rawPlans = getPlans();
+
+	const baseMontlyPrice =
+		getPlanRawPrice( state, rawPlans[ PLAN_ECOMMERCE_MONTHLY ].getProductId(), false ) || 0;
+
+	const planPrices = {
+		PLAN_ECOMMERCE: {
+			term: translate( 'Pay yearly' ),
+			slug: PLAN_ECOMMERCE,
+		},
+		PLAN_ECOMMERCE_2_YEARS: {
+			term: translate( 'Pay every 2 years' ),
+			slug: PLAN_ECOMMERCE_2_YEARS,
+		},
+		PLAN_ECOMMERCE_3_YEARS: {
+			term: translate( 'Pay every 3 years' ),
+			slug: PLAN_ECOMMERCE_3_YEARS,
+		},
+		PLAN_ECOMMERCE_MONTHLY: {
+			term: translate( 'Pay monthly' ),
+			slug: PLAN_ECOMMERCE_MONTHLY,
+			price: baseMontlyPrice,
+			montlyPrice: baseMontlyPrice,
+		},
+	};
+
+	Object.keys( planPrices ).forEach( ( key ) => {
+		if ( key === 'PLAN_ECOMMERCE_MONTHLY' ) {
+			return;
+		}
+		const plan = planPrices[ key ];
+		plan.price = getPlanRawPrice( state, rawPlans[ plan.slug ].getProductId(), false ) || 0;
+		plan.montlyPrice = getPlanRawPrice( state, rawPlans[ plan.slug ].getProductId(), true ) || 0;
+		plan.discount = Math.floor( ( 1 - plan.montlyPrice / baseMontlyPrice ) * 100 );
+		plan.discountText = translate( '%(discount)d%% off', {
+			args: { discount: plan.discount },
+			comment: 'Discount percentage',
+		} );
+		switch ( key ) {
+			case 'PLAN_ECOMMERCE':
+				plan.subText = translate( 'per month, %(rawPrice)s billed annually, excl. taxes', {
+					args: { rawPrice: plan.price },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				} );
+				break;
+			case 'PLAN_ECOMMERCE_2_YEARS':
+				plan.subText = translate( 'per month, %(rawPrice)s billed every two years, excl. taxes', {
+					args: { rawPrice: plan.price },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				} );
+				break;
+			case 'PLAN_ECOMMERCE_3_YEARS':
+				plan.subText = translate( 'per month, %(rawPrice)s billed every three years, excl. taxes', {
+					args: { rawPrice: plan.price },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				} );
+				break;
+		}
+	} );
+
+	return planPrices;
+};
+
+export function EntrepreneurPlan() {
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const plans = useEntrepreneurPlanPrices();
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const [ selectedInterval, setSelectedInterval ] = useState( 'PLAN_ECOMMERCE' );
+	const selectedPlan = plans[ selectedInterval ];
+
+	const selectControlOptions = Object.keys( plans ).map( ( key ) => {
+		const plan = plans[ key ];
+		return {
+			key,
+			name: (
+				<div>
+					{ plan.term } <span>{ plan.discountText }</span>
+				</div>
+			),
+		};
+	} );
+
+	const upgradeClick = () => {
+		const checkoutUrl = getTrialCheckoutUrl( {
+			productSlug: selectedPlan.slug,
+			siteSlug: selectedSite.slug,
+		} );
+
+		page.redirect( checkoutUrl );
+	};
+
+	return (
+		<>
+			<h2 className="entrepreneur-trial-plan__section-title">
+				{ translate( "What's included in your free trial" ) }
+			</h2>
+			<div className="entrepreneur-trial-plan__included-wrapper">
+				<EcommerceTrialIncluded displayAll={ true } />
+			</div>
+			<div className="plan-heading">
+				<h2 className="entrepreneur-trial-plan__section-title">
+					{ translate( 'Keep all the features for your site' ) }
+				</h2>
+				<CustomSelectControl
+					options={ selectControlOptions }
+					className="period-select"
+					hideLabelFromVision
+					onChange={ ( { selectedItem: { key } } ) => {
+						setSelectedInterval( key );
+					} }
+				/>
+			</div>
+			<Card>
+				<div className="plan-wrapper">
+					<div className="plan-description">
+						<h3 className="entrepreneur-trial-plan__plan-title">{ translate( 'Entrepreneur' ) }</h3>
+						<p className="card-text">
+							{ translate(
+								"Continue enjoying the full benefits of Entrepreneur plan, simply add your pay method and maximize your store's potential."
+							) }
+						</p>
+					</div>
+					<div className="price-block">
+						<PlanPrice rawPrice={ selectedPlan.montlyPrice } currencyCode={ currencyCode } />
+						<p className="card-text">{ selectedPlan.subText }</p>
+					</div>
+				</div>
+				<UpgradeButton goToCheckoutWithPlan={ upgradeClick } isEntrepreneurTrial />
+			</Card>
+		</>
+	);
+}

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.jsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.jsx
@@ -46,6 +46,10 @@ const useEntrepreneurPlanPrices = () => {
 			slug: PLAN_ECOMMERCE_MONTHLY,
 			price: baseMontlyPrice,
 			montlyPrice: baseMontlyPrice,
+			subText: translate( 'per month, excl. taxes', {
+				args: { rawPrice: baseMontlyPrice },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} ),
 		},
 	};
 
@@ -59,7 +63,7 @@ const useEntrepreneurPlanPrices = () => {
 		plan.discount = Math.floor( ( 1 - plan.montlyPrice / baseMontlyPrice ) * 100 );
 		plan.discountText = translate( '%(discount)d%% off', {
 			args: { discount: plan.discount },
-			comment: 'Discount percentage',
+			comment: '%discount is a number representing a discount percentage on a plan price',
 		} );
 		switch ( key ) {
 			case 'PLAN_ECOMMERCE':
@@ -142,7 +146,7 @@ export function EntrepreneurPlan() {
 						<h3 className="entrepreneur-trial-plan__plan-title">{ translate( 'Entrepreneur' ) }</h3>
 						<p className="card-text">
 							{ translate(
-								"Continue enjoying the full benefits of Entrepreneur plan, simply add your pay method and maximize your store's potential."
+								"Continue enjoying the full benefits of Entrepreneur plan, simply add your payment method and maximize your store's potential."
 							) }
 						</p>
 					</div>

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/style.scss
@@ -1,0 +1,99 @@
+@import "@automattic/onboarding/styles/mixins";
+
+.entrepreneur-trial-plan__included-wrapper {
+	display: flex;
+	flex-flow: row wrap;
+	margin-top: 30px;
+	margin-left: -12px;
+	margin-right: -12px;
+}
+.entrepreneur-trial-plan__section-title {
+	font-size: 1.5rem;
+	font-weight: 400;
+	color: var(--color-neutral-80);
+	margin: 40px 0 10px;
+	flex: 1;
+}
+
+.entrepreneur-trial-plan__plan-title {
+	font-size: $font-title-large;
+	line-height: 0.7;
+	color: var(--studio-gray-100);
+	margin: 16px 0;
+	@include onboarding-font-recoleta;
+}
+
+.plan-heading {
+	display: flex;
+	align-items: center;
+	margin-bottom: 20px;
+	@media ( max-width: $break-large ) {
+		display: block;
+
+		.period-select {
+			width: 275px;
+			margin-right: auto;
+			margin-top: 10px;
+		}
+	}
+
+	.entrepreneur-trial-plan__section-title {
+		margin: 0;
+	}
+
+	.period-select {
+		span {
+			color: var(--studio-green-50);
+		}
+		ul {
+			margin: 0;
+			box-sizing: border-box;
+			border: 1px solid var(--studio-gray-10);
+			margin-top: -2px;
+
+			li {
+				padding: 13px 13px 13px 16px;
+			}
+		}
+
+		.components-input-control__container {
+			.components-input-control__backdrop {
+				border: 1px solid var(--studio-gray-10);
+				box-shadow: none;
+			}
+			.components-custom-select-control__button {
+				height: auto;
+				min-width: 275px;
+				padding: 13px 13px 13px 16px;
+			}
+		}
+	}
+}
+
+.plan-wrapper {
+	display: flex;
+	justify-content: space-between;
+
+	@media ( max-width: $break-large ) {
+		display: block;
+	}
+
+	.card-text {
+		font-size: 0.875rem;
+		color: var(--color-neutral-40);
+	}
+
+	.plan-description {
+		max-width: 600px;
+	}
+
+	.price-block {
+		text-align: right;
+		max-width: 150px;
+
+		@media ( max-width: $break-large ) {
+			margin-right: auto;
+			text-align: left;
+		}
+	}
+}

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/style.scss
@@ -3,15 +3,13 @@
 .entrepreneur-trial-plan__included-wrapper {
 	display: flex;
 	flex-flow: row wrap;
-	margin-top: 30px;
-	margin-left: -12px;
-	margin-right: -12px;
+	margin: 24px -12px 64px -12px;
 }
 .entrepreneur-trial-plan__section-title {
-	font-size: 1.5rem;
+	font-size: $font-title-medium;
 	font-weight: 400;
 	color: var(--color-neutral-80);
-	margin: 40px 0 10px;
+	margin: 64px 0 10px;
 	flex: 1;
 }
 
@@ -79,7 +77,7 @@
 	}
 
 	.card-text {
-		font-size: 0.875rem;
+		font-size: $font-body-small;
 		color: var(--color-neutral-40);
 	}
 

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -49,10 +49,10 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 					isWooExpressTrial={ isWooExpressTrial }
 					isEntrepreneurTrial={ isEntrepreneurTrial }
 					callToAction={
-						! isWooExpressTrial ? (
+						isEntrepreneurTrial ? (
 							<UpgradeButton
 								goToCheckoutWithPlan={ goToCheckoutWithPlan }
-								isEntrepreneurTrial={ ! isWooExpressTrial }
+								isEntrepreneurTrial={ isWooExpressTrial }
 							/>
 						) : null
 					}

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -1,9 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { plansLink } from '@automattic/calypso-products';
+import classNames from 'classnames';
 import { useCallback } from 'react';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import UpgradeButton from '../components/upgrade-button/upgrade-button';
+import useGoToCheckoutWithPlan from '../current-plan/trials/use-go-to-checkout-with-plan';
 import useOneDollarOfferTrack from '../hooks/use-onedollar-offer-track';
 import TrialBanner from '../trials/trial-banner';
+import { EntrepreneurPlan } from './entrepreneur-plan/entrepreneur-plan';
 import { WooExpressPlans } from './wooexpress-plans';
 import type { Site } from 'calypso/my-sites/scan/types';
 import './style.scss';
@@ -19,6 +23,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const siteSlug = props.site?.slug;
 	const siteId = props.site?.ID;
 	const { isWooExpressTrial } = props;
+	const isEntrepreneurTrial = ! isWooExpressTrial;
 
 	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
 		recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', {
@@ -27,25 +32,46 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		} );
 	}, [] );
 
+	const goToCheckoutWithPlan = useGoToCheckoutWithPlan();
+
 	useOneDollarOfferTrack( siteId, 'plans' );
 
 	return (
 		<>
 			<BodySectionCssClass bodyClass={ [ 'is-ecommerce-trial-plan' ] } />
 
-			<div className="e-commerce-trial-plans__banner-wrapper">
-				<TrialBanner isWooExpressTrial={ isWooExpressTrial } />
+			<div
+				className={ classNames( 'e-commerce-trial-plans__banner-wrapper', {
+					'reduced-margin': isEntrepreneurTrial,
+				} ) }
+			>
+				<TrialBanner
+					isWooExpressTrial={ isWooExpressTrial }
+					isEntrepreneurTrial={ isEntrepreneurTrial }
+					callToAction={
+						! isWooExpressTrial ? (
+							<UpgradeButton
+								goToCheckoutWithPlan={ goToCheckoutWithPlan }
+								isEntrepreneurTrial={ ! isWooExpressTrial }
+							/>
+						) : null
+					}
+				/>
 			</div>
 
-			<WooExpressPlans
-				siteId={ siteId }
-				siteSlug={ siteSlug }
-				interval={ interval }
-				yearlyControlProps={ { path: plansLink( '/plans', siteSlug, 'yearly', true ) } }
-				monthlyControlProps={ { path: plansLink( '/plans', siteSlug, 'monthly', true ) } }
-				showIntervalToggle={ true }
-				triggerTracksEvent={ triggerPlansGridTracksEvent }
-			/>
+			{ isWooExpressTrial ? (
+				<WooExpressPlans
+					siteId={ siteId }
+					siteSlug={ siteSlug }
+					interval={ interval }
+					yearlyControlProps={ { path: plansLink( '/plans', siteSlug, 'yearly', true ) } }
+					monthlyControlProps={ { path: plansLink( '/plans', siteSlug, 'monthly', true ) } }
+					showIntervalToggle={ true }
+					triggerTracksEvent={ triggerPlansGridTracksEvent }
+				/>
+			) : (
+				<EntrepreneurPlan />
+			) }
 		</>
 	);
 };

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -11,12 +11,14 @@ import './style.scss';
 interface ECommerceTrialPlansPageProps {
 	interval?: 'monthly' | 'yearly';
 	site: Site;
+	isWooExpressTrial: boolean;
 }
 
 const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const interval = props.interval ?? 'monthly';
 	const siteSlug = props.site?.slug;
 	const siteId = props.site?.ID;
+	const { isWooExpressTrial } = props;
 
 	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
 		recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', {
@@ -32,7 +34,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 			<BodySectionCssClass bodyClass={ [ 'is-ecommerce-trial-plan' ] } />
 
 			<div className="e-commerce-trial-plans__banner-wrapper">
-				<TrialBanner isEcommerceTrial={ true } />
+				<TrialBanner isWooExpressTrial={ isWooExpressTrial } />
 			</div>
 
 			<WooExpressPlans

--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -12,6 +12,10 @@ body.is-section-plans.is-ecommerce-trial-plan {
 
 	.e-commerce-trial-plans__banner-wrapper {
 		margin: 20px 0;
+
+		&.reduced-margin {
+			margin-top: -20px;
+		}
 	}
 
 	.plans,

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -300,7 +300,7 @@ class Plans extends Component {
 	}
 
 	renderEcommerceTrialPage() {
-		const { selectedSite } = this.props;
+		const { selectedSite, purchase } = this.props;
 
 		if ( ! selectedSite ) {
 			return this.renderPlaceholder();
@@ -308,7 +308,13 @@ class Plans extends Component {
 
 		const interval = this.getIntervalForWooExpressPlans();
 
-		return <ECommerceTrialPlansPage interval={ interval } site={ selectedSite } />;
+		return (
+			<ECommerceTrialPlansPage
+				isWooExpressTrial={ !! purchase?.isWooExpressTrial }
+				interval={ interval }
+				site={ selectedSite }
+			/>
+		);
 	}
 
 	renderBusinessTrialPage() {
@@ -411,6 +417,7 @@ class Plans extends Component {
 
 		// Hide for WooExpress plans
 		const showPlansNavigation = ! isWooExpressPlan;
+		// const showPlansNavigation = false;
 
 		return (
 			<div>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -302,7 +302,7 @@ class Plans extends Component {
 	renderEcommerceTrialPage() {
 		const { selectedSite, purchase } = this.props;
 
-		if ( ! selectedSite ) {
+		if ( ! selectedSite || ! purchase ) {
 			return this.renderPlaceholder();
 		}
 
@@ -375,6 +375,7 @@ class Plans extends Component {
 			currentPlanIntervalType,
 			domainFromHomeUpsellFlow,
 			jetpackAppPlans,
+			purchase,
 		} = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
@@ -395,8 +396,17 @@ class Plans extends Component {
 		const wooExpressSubHeaderText = translate(
 			"Discover what's available in your Woo Express plan."
 		);
+		const entrepreneurTrialSubHeaderText = translate(
+			"Discover what's available in your Entrepreneur plan"
+		);
+
+		const isWooExpressTrial = purchase?.isWooExpressTrial;
+
 		// Use the Woo Express subheader text if the current plan has the Performance or trial plans or fallback to the default subheader text.
-		const subHeaderText = isWooExpressPlan || isEcommerceTrial ? wooExpressSubHeaderText : null;
+		let subHeaderText = null;
+		if ( isWooExpressPlan || isEcommerceTrial ) {
+			subHeaderText = isWooExpressTrial ? wooExpressSubHeaderText : entrepreneurTrialSubHeaderText;
+		}
 
 		const allDomains = isDomainAndPlanPackageFlow ? getDomainRegistrations( this.props.cart ) : [];
 		const yourDomainName = allDomains.length
@@ -415,9 +425,9 @@ class Plans extends Component {
 				? translate( 'Get your domain’s first year for free' )
 				: translate( 'Choose the perfect plan' );
 
-		// Hide for WooExpress plans
-		const showPlansNavigation = ! isWooExpressPlan;
-		// const showPlansNavigation = false;
+		// Hide for WooExpress plans and Entrepreneur trials that are not WooExpress trials
+		const isEntrepreneurTrial = isEcommerceTrial && ! purchase?.isWooExpressTrial;
+		const showPlansNavigation = ! ( isWooExpressPlan || isEntrepreneurTrial );
 
 		return (
 			<div>
@@ -458,7 +468,7 @@ class Plans extends Component {
 						) }
 						<div id="plans" className="plans plans__has-sidebar">
 							{ showPlansNavigation && <PlansNavigation path={ this.props.context.path } /> }
-							<Main fullWidthLayout={ ! isEcommerceTrial } wideLayout={ isEcommerceTrial }>
+							<Main fullWidthLayout={ ! isWooExpressTrial } wideLayout={ isWooExpressTrial }>
 								{ ! isDomainAndPlanPackageFlow && domainAndPlanPackage && (
 									<DomainAndPlanUpsellNotice />
 								) }

--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -15,11 +15,11 @@ import './style.scss';
 
 interface TrialBannerProps {
 	callToAction?: JSX.Element | null;
-	isEcommerceTrial?: boolean;
+	isWooExpressTrial?: boolean;
 }
 
 const TrialBanner = ( props: TrialBannerProps ) => {
-	const { callToAction, isEcommerceTrial } = props;
+	const { callToAction, isWooExpressTrial } = props;
 	const selectedSiteId = useSelector( getSelectedSiteId ) || -1;
 
 	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );
@@ -48,7 +48,7 @@ const TrialBanner = ( props: TrialBannerProps ) => {
 		trialDaysLeftToDisplay,
 		trialExpiration,
 		selectedSiteId,
-		isEcommerceTrial
+		isWooExpressTrial
 	);
 
 	return (

--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useSelector } from 'calypso/state';
@@ -16,10 +17,11 @@ import './style.scss';
 interface TrialBannerProps {
 	callToAction?: JSX.Element | null;
 	isWooExpressTrial?: boolean;
+	isEntrepreneurTrial?: boolean;
 }
 
 const TrialBanner = ( props: TrialBannerProps ) => {
-	const { callToAction, isWooExpressTrial } = props;
+	const { callToAction, isWooExpressTrial, isEntrepreneurTrial } = props;
 	const selectedSiteId = useSelector( getSelectedSiteId ) || -1;
 
 	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );
@@ -48,18 +50,23 @@ const TrialBanner = ( props: TrialBannerProps ) => {
 		trialDaysLeftToDisplay,
 		trialExpiration,
 		selectedSiteId,
-		isWooExpressTrial
+		isWooExpressTrial,
+		isEntrepreneurTrial
 	);
 
 	return (
-		<Card className="trial-banner">
+		<Card className={ classNames( 'trial-banner', { 'entrepreneur-trial': isEntrepreneurTrial } ) }>
 			<div className="trial-banner__content">
 				<p className="trial-banner__title">{ translate( 'You’re in a free trial' ) }</p>
 				<p className="trial-banner__subtitle">{ bannerSubtitle }</p>
 				{ callToAction }
 			</div>
 			<div className="trial-banner__chart-wrapper">
-				<DoughnutChart progress={ trialProgress } text={ trialDaysLeftToDisplay?.toString() } />
+				<DoughnutChart
+					progress={ trialProgress }
+					text={ trialDaysLeftToDisplay?.toString() }
+					isEntrepreneurTrial={ isEntrepreneurTrial }
+				/>
 				<br />
 				<span className="trial-banner__chart-label">
 					{ trialExpired

--- a/client/my-sites/plans/trials/trial-banner/style.scss
+++ b/client/my-sites/plans/trials/trial-banner/style.scss
@@ -11,6 +11,18 @@
 		margin: 0 20px;
 	}
 
+	&.entrepreneur-trial {
+		color: var(--studio-black);
+		background-color: #ebeefd;
+		.trial-banner__content {
+			.banner__content {
+				.trial-banner__subtitle {
+					color: var(--studio-black);
+				}
+			}
+		}
+	}
+
 	.trial-banner__content {
 		flex: 1;
 		padding-right: 25%;

--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -90,6 +90,8 @@ export default function useBannerSubtitle(
 							daysLeft: trialDaysLeftToDisplay,
 							expirationdate: readableExpirationDate as string,
 						},
+						comment:
+							'%daysLeft is the number of days left in the trial, %expirationdate is the date the trial ends',
 					}
 				);
 			}

--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -15,7 +15,8 @@ export default function useBannerSubtitle(
 	trialDaysLeftToDisplay: number,
 	trialExpiration: Moment | null,
 	selectedSiteId: number | null,
-	isEcommerceTrial?: boolean
+	isWooExpressTrial?: boolean,
+	isEntrepreneurTrial?: boolean
 ): string {
 	const locale = useLocale();
 	const translate = useTranslate();
@@ -36,7 +37,7 @@ export default function useBannerSubtitle(
 		// this may need updating for intro offers with singly counted units e.g. 1 month|year
 		let introOfferSubtitle;
 		if (
-			isEcommerceTrial &&
+			isWooExpressTrial &&
 			anyWooExpressIntroOffer &&
 			'month' === anyWooExpressIntroOffer.intervalUnit
 		) {
@@ -65,6 +66,29 @@ export default function useBannerSubtitle(
 							expirationdate: readableExpirationDate as string,
 							introOfferFormattedPrice: anyWooExpressIntroOffer.formattedPrice,
 							introOfferIntervalCount: anyWooExpressIntroOffer.intervalCount,
+						},
+					}
+				);
+			}
+		}
+		let entrepreneurTrialSubtitle;
+		if ( isEntrepreneurTrial ) {
+			if ( trialDaysLeftToDisplay < 1 ) {
+				entrepreneurTrialSubtitle = translate(
+					'Your free trial ends today. Add payment method by %(expirationdate)s to continue selling your products and access all the power.',
+					{
+						args: {
+							expirationdate: readableExpirationDate as string,
+						},
+					}
+				);
+			} else {
+				entrepreneurTrialSubtitle = translate(
+					'Your free trial will end in %(daysLeft)d day. Add payment method by %(expirationdate)s to continue selling your products and access all the power.',
+					{
+						args: {
+							daysLeft: trialDaysLeftToDisplay,
+							expirationdate: readableExpirationDate as string,
 						},
 					}
 				);
@@ -136,6 +160,8 @@ export default function useBannerSubtitle(
 					subtitle = translate(
 						'Your free trial has expired. Upgrade to a plan to unlock new features and start selling.'
 					);
+				} else if ( entrepreneurTrialSubtitle ) {
+					subtitle = entrepreneurTrialSubtitle;
 				} else if ( introOfferSubtitle ) {
 					subtitle = introOfferSubtitle;
 				} else if ( trialDaysLeftToDisplay < 1 ) {
@@ -170,7 +196,8 @@ export default function useBannerSubtitle(
 		trialDaysLeftToDisplay,
 		readableExpirationDate,
 		anyWooExpressIntroOffer,
-		isEcommerceTrial,
+		isWooExpressTrial,
+		isEntrepreneurTrial,
 		translate,
 	] );
 

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -110,6 +110,7 @@ describe( 'selectors', () => {
 				isRefundable: false,
 				isRenewable: false,
 				isRenewal: false,
+				isWooExpressTrial: false,
 				meta: undefined,
 				mostRecentRenewDate: undefined,
 				ownershipId: NaN,

--- a/client/state/sites/plans/selectors/get-current-plan.js
+++ b/client/state/sites/plans/selectors/get-current-plan.js
@@ -2,7 +2,7 @@ import debugFactory from 'debug';
 import { find } from 'lodash';
 import { createSitePlanObject } from 'calypso/state/sites/plans/assembler';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
-import { getSite } from 'calypso/state/sites/selectors';
+import { default as getSite } from 'calypso/state/sites/selectors/get-site';
 
 const debug = debugFactory( 'calypso:state:sites:plans:selectors' );
 

--- a/client/state/ui/selectors/get-selected-purchase.ts
+++ b/client/state/ui/selectors/get-selected-purchase.ts
@@ -1,0 +1,17 @@
+import { Purchase } from 'calypso/lib/purchases/types';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors/get-by-purchase-id';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors/get-current-plan';
+import getSelectedSiteId from './get-selected-site-id';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns the purchase object for the currently selected site.
+ */
+export default function getSelectedPurchase( state: AppState ): Purchase | null | undefined {
+	const selectedSiteId = getSelectedSiteId( state );
+	const currentPlan = getCurrentPlan( state, selectedSiteId );
+	if ( ! currentPlan?.id ) {
+		return null;
+	}
+	return getByPurchaseId( state, currentPlan.id );
+}

--- a/client/state/ui/selectors/index.js
+++ b/client/state/ui/selectors/index.js
@@ -1,3 +1,4 @@
+export { default as getSelectedPurchase } from './get-selected-purchase';
 export { default as getSelectedSite } from './get-selected-site';
 export { default as getSelectedSiteId } from './get-selected-site-id';
 export { default as getSelectedSiteSlug } from './get-selected-site-slug';

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -64,6 +64,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		isRefundable: Boolean( purchase.is_refundable ),
 		isRenewable: Boolean( purchase.is_renewable ),
 		isRenewal: Boolean( purchase.is_renewal ),
+		isWooExpressTrial: Boolean( purchase.is_woo_express_trial ),
 		meta: purchase.meta,
 		ownershipId: Number( purchase.ownership_id ),
 		priceText: purchase.price_text,

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -35,6 +35,7 @@ export interface Purchase {
 	isRefundable: boolean;
 	isRenewable: boolean;
 	isRenewal: boolean;
+	isWooExpressTrial: boolean;
 	meta?: string;
 	mostRecentRenewDate?: string;
 	ownershipId?: number;
@@ -208,6 +209,7 @@ export interface RawPurchase {
 	is_refundable: boolean;
 	is_renewable: boolean;
 	is_renewal: boolean;
+	is_woo_express_trial: boolean;
 	meta: string | undefined;
 	ownership_id: number | undefined;
 	partner_name: string | undefined;


### PR DESCRIPTION
## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/33497086/74873b1a-d03d-4a56-91e2-dbcac16cc052)
We are introducing the new Entrepreneur trial plan, which share some similarities with Woo Express trial, but requires customized experience on Plans page.

Unlike the Woo Express trial, we are not going to offer the 1U$ offer when upgrading the Entrepreneur trial.

## Testing Instructions

For testing this you will need an Entrepreneur trial account:
p1712672819187649-slack-C02TCEHP3HA

You will also need a Woo Express trial to check that we didn't break the original experience
https://woocommerce.com/start/

Access `http://calypso.localhost:3000/plans/{your-site-here}`
- Check that the trial banner does not refer to the 1U$ offer.
- Click on **Add payment method**.
- You should be redirected to checkout page targeting the Entrepreneur plan and the 1U$ offer should **not** be offered.
- Go back to the `http://calypso.localhost:3000/plans/{your-site-here}`.
- On the bottom of the page there should be the **Keep all the features for your site** section.
- Select different billing periods, this should update the price of the plan inside the card.
- Click on the second button **Add payment method** button, the one inside the card.
- The checkout page billing period should match the one you selected before.

Do a regression test with Woo Express trial account and check that:
- The 1U$ offer is presented on the banner and checkout page.
- Checkout page should target `Woo Express: Performance` plan instead of `Entrepreneur.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?