### PR TITLE
Receipts: Merge cost_overrides, subtotal, and taxes for domain items with mapping

### DIFF
--- a/client/me/purchases/billing-history/test/utils.ts
+++ b/client/me/purchases/billing-history/test/utils.ts
@@ -153,6 +153,149 @@ describe( 'utils', () => {
 			expect( result[ 2 ].tax_integer ).toEqual( 33 );
 		} );
 
+		test( 'should sum the cost_overrides for multiple items with the same domain', () => {
+			const items = deepFreeze( [
+				{ foo: 'bar', product_slug: 'foobar' },
+				{
+					id: '1',
+					product_slug: 'wp-domains',
+					domain: 'bar.com',
+					variation_slug: 'none',
+					currency: 'USD',
+					raw_amount: 2,
+					amount_integer: 200,
+					subtotal_integer: 210,
+					tax_integer: 10,
+					cost_overrides: [
+						{
+							id: 'v12345',
+							human_readable_reason: 'Price change',
+							override_code: 'test-override',
+							does_override_original_cost: false,
+							old_price_integer: 100,
+							new_price_integer: 200,
+						},
+					],
+				},
+				{
+					id: '2',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'none',
+					currency: 'USD',
+					raw_amount: 3,
+					amount_integer: 300,
+					subtotal_integer: 310,
+					tax_integer: 10,
+					cost_overrides: [
+						{
+							id: 'v12345',
+							human_readable_reason: 'Price change',
+							override_code: 'test-override',
+							does_override_original_cost: false,
+							old_price_integer: 100,
+							new_price_integer: 200,
+						},
+						{
+							id: 'v12347',
+							human_readable_reason: 'Price change 2',
+							override_code: 'test-override-2',
+							does_override_original_cost: false,
+							old_price_integer: 200,
+							new_price_integer: 300,
+						},
+					],
+				},
+				{
+					id: '3',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+					currency: 'USD',
+					raw_amount: 7,
+					amount_integer: 700,
+					subtotal_integer: 711,
+					tax_integer: 11,
+					cost_overrides: [
+						{
+							id: 'v12345',
+							human_readable_reason: 'Price change',
+							override_code: 'test-override',
+							does_override_original_cost: false,
+							old_price_integer: 101,
+							new_price_integer: 301,
+						},
+						{
+							id: 'v12346',
+							human_readable_reason: 'Price change 3',
+							override_code: 'test-override-3',
+							does_override_original_cost: false,
+							old_price_integer: 301,
+							new_price_integer: 700,
+						},
+					],
+				},
+				{
+					id: '4',
+					product_slug: 'wp-domains',
+					domain: 'foo.com',
+					variation_slug: 'wp-private-registration',
+					currency: 'USD',
+					raw_amount: 9,
+					amount_integer: 900,
+					subtotal_integer: 912,
+					tax_integer: 12,
+					cost_overrides: [
+						{
+							id: 'v12345',
+							human_readable_reason: 'Price change',
+							override_code: 'test-override',
+							does_override_original_cost: false,
+							old_price_integer: 102,
+							new_price_integer: 900,
+						},
+					],
+				},
+			] );
+			const result = groupDomainProducts( items, ident );
+			expect( result[ 1 ].cost_overrides ).toEqual( [
+				{
+					id: 'v12345',
+					human_readable_reason: 'Price change',
+					override_code: 'test-override',
+					does_override_original_cost: false,
+					old_price_integer: 100,
+					new_price_integer: 200,
+				},
+			] );
+			expect( result[ 2 ].cost_overrides ).toEqual( [
+				{
+					id: 'v12345',
+					human_readable_reason: 'Price change',
+					override_code: 'test-override',
+					does_override_original_cost: false,
+					old_price_integer: 303,
+					new_price_integer: 1401,
+				},
+				{
+					id: 'v12347',
+					human_readable_reason: 'Price change 2',
+					override_code: 'test-override-2',
+					does_override_original_cost: false,
+					old_price_integer: 200,
+					new_price_integer: 300,
+				},
+				{
+					id: 'v12346',
+					human_readable_reason: 'Price change 3',
+					override_code: 'test-override-3',
+					does_override_original_cost: false,
+					old_price_integer: 301,
+					new_price_integer: 700,
+				},
+			] );
+		} );
+
 		test( 'should include the formatted, summed raw_amount as amount for multiple items with the same domain', () => {
 			const items = deepFreeze( [
 				{ foo: 'bar', product_slug: 'foobar' },

--- a/client/me/purchases/billing-history/test/utils.ts
+++ b/client/me/purchases/billing-history/test/utils.ts
@@ -36,12 +36,14 @@ describe( 'utils', () => {
 					product_slug: 'wp-domains',
 					domain: 'foo.com',
 					variation_slug: 'wp-private-registration',
+					cost_overrides: [],
 				},
 				{
 					id: '3',
 					product_slug: 'wp-domains',
 					domain: 'bar.com',
 					variation_slug: 'wp-private-registration',
+					cost_overrides: [],
 				},
 			] );
 			const expected = [
@@ -51,12 +53,14 @@ describe( 'utils', () => {
 					product_slug: 'wp-domains',
 					variation_slug: 'wp-private-registration',
 					domain: 'foo.com',
+					cost_overrides: [],
 				},
 				{
 					id: '3',
 					product_slug: 'wp-domains',
 					variation_slug: 'wp-private-registration',
 					domain: 'bar.com',
+					cost_overrides: [],
 				},
 			];
 			const result = groupDomainProducts( items, ident );
@@ -72,12 +76,14 @@ describe( 'utils', () => {
 					product_slug: 'wp-domains',
 					domain: 'foo.com',
 					variation_slug: 'wp-private-registration',
+					cost_overrides: [],
 				},
 				{
 					id: '3',
 					product_slug: 'wp-domains',
 					domain: 'foo.com',
 					variation_slug: 'wp-private-registration',
+					cost_overrides: [],
 				},
 			] );
 			const result = groupDomainProducts( items, ident );
@@ -95,6 +101,7 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 2,
 					amount_integer: 200,
+					cost_overrides: [],
 				},
 				{
 					id: '2',
@@ -104,6 +111,7 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 3,
 					amount_integer: 300,
+					cost_overrides: [],
 				},
 				{
 					id: '3',
@@ -113,6 +121,7 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 7,
 					amount_integer: 700,
+					cost_overrides: [],
 				},
 				{
 					id: '4',
@@ -122,6 +131,7 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 9,
 					amount_integer: 900,
+					cost_overrides: [],
 				},
 			] );
 			const result = groupDomainProducts( items, ident );
@@ -143,6 +153,7 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 2,
 					amount_integer: 200,
+					cost_overrides: [],
 				},
 				{
 					id: '2',
@@ -153,6 +164,7 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 3,
 					amount_integer: 300,
+					cost_overrides: [],
 				},
 				{
 					id: '3',
@@ -163,6 +175,7 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 7,
 					amount_integer: 700,
+					cost_overrides: [],
 				},
 				{
 					id: '4',
@@ -173,6 +186,7 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 9,
 					amount_integer: 900,
+					cost_overrides: [],
 				},
 			] );
 			const result = groupDomainProducts( items, ident );

--- a/client/me/purchases/billing-history/test/utils.ts
+++ b/client/me/purchases/billing-history/test/utils.ts
@@ -90,7 +90,7 @@ describe( 'utils', () => {
 			expect( result.length ).toEqual( 2 );
 		} );
 
-		test( 'should sum the raw_amount for multiple items with the same domain', () => {
+		test( 'should sum the prices for multiple items with the same domain', () => {
 			const items = deepFreeze( [
 				{ foo: 'bar', product_slug: 'foobar' },
 				{
@@ -101,6 +101,8 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 2,
 					amount_integer: 200,
+					subtotal_integer: 210,
+					tax_integer: 10,
 					cost_overrides: [],
 				},
 				{
@@ -111,6 +113,8 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 3,
 					amount_integer: 300,
+					subtotal_integer: 310,
+					tax_integer: 10,
 					cost_overrides: [],
 				},
 				{
@@ -121,6 +125,8 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 7,
 					amount_integer: 700,
+					subtotal_integer: 711,
+					tax_integer: 11,
 					cost_overrides: [],
 				},
 				{
@@ -131,17 +137,23 @@ describe( 'utils', () => {
 					currency: 'USD',
 					raw_amount: 9,
 					amount_integer: 900,
+					subtotal_integer: 912,
+					tax_integer: 12,
 					cost_overrides: [],
 				},
 			] );
 			const result = groupDomainProducts( items, ident );
 			expect( result[ 1 ].raw_amount ).toEqual( 2 );
 			expect( result[ 1 ].amount_integer ).toEqual( 200 );
+			expect( result[ 1 ].subtotal_integer ).toEqual( 210 );
+			expect( result[ 1 ].tax_integer ).toEqual( 10 );
 			expect( result[ 2 ].raw_amount ).toEqual( 19 );
 			expect( result[ 2 ].amount_integer ).toEqual( 1900 );
+			expect( result[ 2 ].subtotal_integer ).toEqual( 1933 );
+			expect( result[ 2 ].tax_integer ).toEqual( 33 );
 		} );
 
-		test( 'should include the formatted, summed raw_amount as amount for multiple items with teh same domain', () => {
+		test( 'should include the formatted, summed raw_amount as amount for multiple items with the same domain', () => {
 			const items = deepFreeze( [
 				{ foo: 'bar', product_slug: 'foobar' },
 				{

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -38,8 +38,27 @@ export const groupDomainProducts = (
 	>( ( groups, product ) => {
 		const existingGroup = groups.get( product.domain );
 		if ( existingGroup ) {
+			existingGroup.product.cost_overrides = existingGroup.product.cost_overrides.map(
+				( existingGroupOverride ) => {
+					const productOverride = product.cost_overrides.find(
+						( override ) => override.id === existingGroupOverride.id
+					);
+					if ( productOverride ) {
+						return {
+							...existingGroupOverride,
+							new_price_integer:
+								existingGroupOverride.new_price_integer + productOverride.new_price_integer,
+							old_price_integer:
+								existingGroupOverride.old_price_integer + productOverride.old_price_integer,
+						};
+					}
+					return existingGroupOverride;
+				}
+			);
 			existingGroup.product.raw_amount += product.raw_amount;
 			existingGroup.product.amount_integer += product.amount_integer;
+			existingGroup.product.subtotal_integer += product.subtotal_integer;
+			existingGroup.product.tax_integer += product.tax_integer;
 			existingGroup.groupCount++;
 		} else {
 			const newGroup = {

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -12,6 +12,7 @@ import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list
 import {
 	BillingTransaction,
 	BillingTransactionItem,
+	ReceiptCostOverride,
 } from 'calypso/state/billing-transactions/types';
 
 interface GroupedDomainProduct {
@@ -38,12 +39,14 @@ export const groupDomainProducts = (
 	>( ( groups, product ) => {
 		const existingGroup = groups.get( product.domain );
 		if ( existingGroup ) {
+			const mergedOverrides: ReceiptCostOverride[] = [];
 			existingGroup.product.cost_overrides = existingGroup.product.cost_overrides.map(
 				( existingGroupOverride ) => {
 					const productOverride = product.cost_overrides.find(
 						( override ) => override.override_code === existingGroupOverride.override_code
 					);
 					if ( productOverride ) {
+						mergedOverrides.push( productOverride );
 						return {
 							...existingGroupOverride,
 							new_price_integer:
@@ -55,6 +58,11 @@ export const groupDomainProducts = (
 					return existingGroupOverride;
 				}
 			);
+			product.cost_overrides.forEach( ( override ) => {
+				if ( ! mergedOverrides.some( ( merged ) => merged.id === override.id ) ) {
+					existingGroup.product.cost_overrides.push( override );
+				}
+			} );
 			existingGroup.product.raw_amount += product.raw_amount;
 			existingGroup.product.amount_integer += product.amount_integer;
 			existingGroup.product.subtotal_integer += product.subtotal_integer;

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -41,7 +41,7 @@ export const groupDomainProducts = (
 			existingGroup.product.cost_overrides = existingGroup.product.cost_overrides.map(
 				( existingGroupOverride ) => {
 					const productOverride = product.cost_overrides.find(
-						( override ) => override.id === existingGroupOverride.id
+						( override ) => override.override_code === existingGroupOverride.override_code
 					);
 					if ( productOverride ) {
 						return {


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/83768 which started displaying cost overrides on receipt items in calypso. In that PR we change each line item on the receipt to display its original, undiscounted cost followed by a list of cost overrides (price changes) for that item.

However, domain items have a special consideration: the domain mapping products we include for each domain registration are hidden from the user by merging them with the domain registration. For receipts this is done using the function `groupDomainProducts()`. That function, however has not been updated to support all the properties in a receipt item like `subtotal_integer`, `tax_integer`, or `cost_overrides`. The result is that domain items in receipts will display the price of the registration only and not the hidden mapping.

This PR updates the merging function to also merge these missing properties.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1064" alt="Screenshot 2024-04-16 at 10 55 56 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/6a3740d8-50a1-4cbd-a5e7-2fddf69ad748"> | <img width="1059" alt="Screenshot 2024-04-16 at 10 55 01 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/245af33f-5b4c-433e-9601-b96b74094075">

## Testing Instructions

View a receipt in calypso for a domain registration. Verify its prices are correct.

Automated tests are also included.