### PR TITLE
Patterns: fix tracking empty strings for calypso_pattern_library_view

### DIFF
--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -52,7 +52,7 @@ export function PatternsPageViewTracker( {
 				category,
 				is_logged_in: isLoggedIn,
 				user_is_dev_account: isDevAccount ? '1' : '0',
-				search_term: searchTerm ? searchTerm : undefined,
+				search_term: searchTerm || undefined,
 				type: getTracksPatternType( patternTypeFilter ),
 				view,
 				referrer,

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -52,7 +52,7 @@ export function PatternsPageViewTracker( {
 				category,
 				is_logged_in: isLoggedIn,
 				user_is_dev_account: isDevAccount ? '1' : '0',
-				search_term: searchTerm,
+				search_term: searchTerm ? searchTerm : undefined,
 				type: getTracksPatternType( patternTypeFilter ),
 				view,
 				referrer,

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -10,7 +10,7 @@ import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import type { AppState } from 'calypso/types';
 
 type PatternsPageViewTrackerProps = {
-	category: string;
+	category?: string;
 	searchTerm?: string;
 	patternPermalinkName?: string;
 	patternTypeFilter?: PatternTypeFilter;

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -252,7 +252,6 @@ export const PatternLibrary = ( {
 		<>
 			{ isHomePage ? (
 				<PatternsPageViewTracker
-					patternPermalinkName={ patternPermalinkName }
 					searchTerm={ searchTerm }
 					referrer={ referrer }
 					patternsCount={ ! isFetchingPatterns ? patterns.length : undefined }

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -250,15 +250,24 @@ export const PatternLibrary = ( {
 
 	return (
 		<>
-			<PatternsPageViewTracker
-				category={ category }
-				patternPermalinkName={ patternPermalinkName }
-				patternTypeFilter={ patternTypeFilter }
-				view={ currentView }
-				searchTerm={ searchTerm }
-				referrer={ referrer }
-				patternsCount={ ! isFetchingPatterns ? patterns.length : undefined }
-			/>
+			{ isHomePage ? (
+				<PatternsPageViewTracker
+					patternPermalinkName={ patternPermalinkName }
+					searchTerm={ searchTerm }
+					referrer={ referrer }
+					patternsCount={ ! isFetchingPatterns ? patterns.length : undefined }
+				/>
+			) : (
+				<PatternsPageViewTracker
+					category={ category }
+					patternPermalinkName={ patternPermalinkName }
+					patternTypeFilter={ patternTypeFilter }
+					view={ currentView }
+					searchTerm={ searchTerm }
+					referrer={ referrer }
+					patternsCount={ ! isFetchingPatterns ? patterns.length : undefined }
+				/>
+			) }
 
 			<PatternsDocumentHead category={ category } />
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6589

## Proposed Changes
With this PR we are fixing tracking props for `calypso_pattern_library_view`.

I was thinking and I went this way intentionally since earlier I raised the point that I don't think that it's good idea to have one huge component for all pages -- https://github.com/Automattic/dotcom-forge/issues/6110#issuecomment-2051842981

So later I am going to make refactoring with having at least two different component for home-page and all other (pattern category / search). And this case is good example - if we had different components, we would define different `PatternsPageViewTracker` with different props. So with this PR I am making small preparation with the help of the condition `isHomePage`. Also, anyway I think that it's much better to make two instances based on the condition, instead of complicating logic inside `PatternsPageViewTracker`.

Also, would be much better if we make `searchTearm` and `category` as `undefined` by default (instead of empty string), but such change will need much more effort, and maybe we could do it as a second step, after splitting home page and other to different components.

## Testing Instructions
1) Open `/patterns` and assert that `view`, `type` and `category ` wasn't tracked
2) Open `/patterns/about` and assert that `view`, `type` and `category ` was tracked correctly
3) Also assert that `searchTerm` is tracked only if we have some search term (before we tracked also empty string, when we didn't have a search).
