### PR TITLE
Hosting Overview: Make design responsive

### DIFF
--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -20,7 +20,14 @@ const ActiveDomainsCard: FC = () => {
 			<div className="hosting-overview__card-header">
 				<h3 className="hosting-overview__card-title">{ translate( 'Active domains' ) }</h3>
 
-				<Button className="hosting-overview__link-button" plain href="/start/domain">
+				<Button
+					className={ classNames(
+						'hosting-overview__link-button',
+						'hosting-overview__mobile-hidden-link-button'
+					) }
+					plain
+					href="/start/domain"
+				>
 					{ translate( 'Add new domain' ) }
 				</Button>
 				<Button

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -1,6 +1,7 @@
 import { Button, Card } from '@automattic/components';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable } from '@automattic/domains-table';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
@@ -15,7 +16,7 @@ const ActiveDomainsCard: FC = () => {
 	const translate = useTranslate();
 
 	return (
-		<Card className="hosting-overview__card">
+		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__active-domains' ) }>
 			<div className="hosting-overview__card-header">
 				<h3 className="hosting-overview__card-title">{ translate( 'Active domains' ) }</h3>
 

--- a/client/hosting-overview/components/hosting-overview.tsx
+++ b/client/hosting-overview/components/hosting-overview.tsx
@@ -6,13 +6,11 @@ import './style.scss';
 
 const HostingOverview: FC = () => {
 	return (
-		<>
-			<div className="hosting-overview__top-cards-wrapper">
-				<PlanCard />
-				<QuickActionsCard />
-			</div>
+		<div className="hosting-overview">
+			<PlanCard />
+			<QuickActionsCard />
 			<ActiveDomainsCard />
-		</>
+		</div>
 	);
 };
 

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -41,7 +41,14 @@ const PlanCard: FC = () => {
 				<div className="hosting-overview__plan-card-header">
 					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
 
-					<Button className="hosting-overview__link-button" plain href={ `/plans/${ site?.slug }` }>
+					<Button
+						className={ classNames(
+							'hosting-overview__link-button',
+							'hosting-overview__mobile-hidden-link-button'
+						) }
+						plain
+						href={ `/plans/${ site?.slug }` }
+					>
 						{ translate( 'Manage plan' ) }
 					</Button>
 				</div>

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -38,85 +38,79 @@ const PlanCard: FC = () => {
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
 			<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__plan' ) }>
-				<div>
-					<div className="hosting-overview__plan-card-header">
-						<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
+				<div className="hosting-overview__plan-card-header">
+					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
 
+					<Button className="hosting-overview__link-button" plain href={ `/plans/${ site?.slug }` }>
+						{ translate( 'Manage plan' ) }
+					</Button>
+				</div>
+				{ isPaidPlan && (
+					<>
+						<PlanPrice
+							className="hosting-overview__plan-price"
+							currencyCode={ planData?.currencyCode }
+							displayPerMonthNotation
+							isSmallestUnit
+							rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
+						/>
+						<div className="hosting-overview__plan-info">
+							{ translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
+								args: {
+									rawPrice: formatCurrency(
+										pricing?.[ planSlug ].originalPrice.full ?? 0,
+										planData?.currencyCode ?? '',
+										{
+											stripZeros: true,
+											isSmallestUnit: true,
+										}
+									),
+								},
+								components: {
+									span: <span />,
+								},
+							} ) }
+						</div>
+						<div className="hosting-overview__plan-info">
+							{ translate( 'Expires on %s.', {
+								args: moment( planData?.expiryDate ).format( 'LL' ),
+							} ) }
+						</div>
+					</>
+				) }
+				<div className="hosting-overview__plan-storage">
+					<div className="hosting-overview__plan-storage-title-wrapper">
+						<div className="hosting-overview__plan-storage-title">
+							<Icon icon={ cloud } />
+							{ translate( 'Storage' ) }
+						</div>
+						<span>
+							{ translate(
+								'Using {{usedStorage}}%(usedGigabytes).1f GB{{/usedStorage}} of %(availableUnitAmount)d GB',
+								'Using {{usedStorage}}%(usedGigabytes).1f GB{{/usedStorage}} of %(availableUnitAmount)d GB',
+								{
+									count: usedGigabytes,
+									args: { usedGigabytes, availableUnitAmount },
+									comment:
+										'Must use unit abbreviation; describes used vs available storage amounts (e.g., Using 20.0GB of 30GB, Using 0.5GB of 20GB)',
+									components: { usedStorage: <span className="used-space__span" /> },
+								}
+							) }
+						</span>
+					</div>
+					<ProgressBar
+						color="var(--studio-red-30)"
+						value={ usedGigabytes / availableUnitAmount }
+						total={ 1 }
+					/>
+					<div className="hosting-overview__plan-storage-footer">
 						<Button
 							className="hosting-overview__link-button"
 							plain
 							href={ `/plans/${ site?.slug }` }
 						>
-							{ translate( 'Manage plan' ) }
+							{ translate( 'Need more storage?' ) }
 						</Button>
-					</div>
-					{ isPaidPlan && (
-						<>
-							<PlanPrice
-								className="hosting-overview__plan-price"
-								currencyCode={ planData?.currencyCode }
-								displayPerMonthNotation
-								isSmallestUnit
-								rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
-							/>
-							<div className="hosting-overview__plan-info">
-								{ translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
-									args: {
-										rawPrice: formatCurrency(
-											pricing?.[ planSlug ].originalPrice.full ?? 0,
-											planData?.currencyCode ?? '',
-											{
-												stripZeros: true,
-												isSmallestUnit: true,
-											}
-										),
-									},
-									components: {
-										span: <span />,
-									},
-								} ) }
-							</div>
-							<div className="hosting-overview__plan-info">
-								{ translate( 'Expires on %s.', {
-									args: moment( planData?.expiryDate ).format( 'LL' ),
-								} ) }
-							</div>
-						</>
-					) }
-					<div className="hosting-overview__plan-storage">
-						<div className="hosting-overview__plan-storage-title-wrapper">
-							<div className="hosting-overview__plan-storage-title">
-								<Icon icon={ cloud } />
-								{ translate( 'Storage' ) }
-							</div>
-							<span>
-								{ translate(
-									'Using {{usedStorage}}%(usedGigabytes).1f GB{{/usedStorage}} of %(availableUnitAmount)d GB',
-									'Using {{usedStorage}}%(usedGigabytes).1f GB{{/usedStorage}} of %(availableUnitAmount)d GB',
-									{
-										count: usedGigabytes,
-										args: { usedGigabytes, availableUnitAmount },
-										comment:
-											'Must use unit abbreviation; describes used vs available storage amounts (e.g., Using 20.0GB of 30GB, Using 0.5GB of 20GB)',
-										components: { usedStorage: <span className="used-space__span" /> },
-									}
-								) }
-							</span>
-						</div>
-						<ProgressBar
-							color="var(--studio-red-30)"
-							value={ usedGigabytes / availableUnitAmount }
-							total={ 1 }
-						/>
-						<div className="hosting-overview__plan-storage-footer">
-							<Button
-								className="hosting-overview__link-button"
-								plain
-								href={ `/plans/${ site?.slug }` }
-							>
-								{ translate( 'Need more storage?' ) }
-							</Button>
-						</div>
 					</div>
 				</div>
 			</Card>

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -3,6 +3,7 @@ import { ProgressBar, Button, Card, PlanPrice } from '@automattic/components';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { formatCurrency } from '@automattic/format-currency';
 import { Icon, cloud } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import { useSelector } from 'react-redux';
@@ -36,7 +37,7 @@ const PlanCard: FC = () => {
 	return (
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
-			<Card className="hosting-overview__card">
+			<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__plan' ) }>
 				<div>
 					<div className="hosting-overview__plan-card-header">
 						<h3 className="hosting-overview__plan-card-title">{ planName }</h3>

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -1,5 +1,6 @@
 import { Button, Card } from '@automattic/components';
 import { chevronRightSmall, Icon } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
@@ -33,7 +34,7 @@ const QuickActionsCard: FC = () => {
 	const translate = useTranslate();
 
 	return (
-		<Card className="hosting-overview__card">
+		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
 			<div className="hosting-overview__card-header">
 				<h3 className="hosting-overview__card-title">{ translate( 'Quick actions' ) }</h3>
 			</div>

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -34,7 +34,7 @@
 
 @media ( max-width: $break-xlarge ) {
 	.hosting-overview {
-		grid-template-columns: 1fr;
+		grid-template-columns: minmax(300px, 1fr);
 		grid-template-rows: auto auto auto;
 		grid-row-gap: 16px;
 	}

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -1,15 +1,33 @@
-.hosting-overview__top-cards-wrapper {
-	display: flex;
-	gap: 33px;
-	margin-bottom: 38px;
+.hosting-overview {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-template-rows: auto auto;
+	grid-column-gap: 33px;
+	grid-row-gap: 38px;
 }
 
 .hosting-overview__card {
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-5);
 	box-shadow: none;
-	flex: 1;
 	padding: 22px;
+	width: 100%;
+	height: 100%;
+}
+
+.hosting-overview__plan {
+	grid-column: 1 / 2;
+	grid-row: 1 / 2;
+}
+
+.hosting-overview__quick-actions {
+	grid-column: 2 / 3;
+	grid-row: 1 / 2;
+}
+
+.hosting-overview__active-domains {
+	grid-column: 1 / 3;
+	grid-row: 2 / 3;
 }
 
 .hosting-overview__plan-card-header,

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .hosting-overview {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
@@ -28,6 +30,21 @@
 .hosting-overview__active-domains {
 	grid-column: 1 / 3;
 	grid-row: 2 / 3;
+}
+
+@media ( max-width: $break-xlarge ) {
+	.hosting-overview {
+		grid-template-columns: 1fr;
+		grid-template-rows: auto auto auto;
+		grid-row-gap: 16px;
+	}
+
+	.hosting-overview__plan,
+	.hosting-overview__quick-actions,
+	.hosting-overview__active-domains {
+		grid-column: 1 / 2;
+		grid-row: auto;
+	}
 }
 
 .hosting-overview__plan-card-header,

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -73,6 +73,12 @@ a.hosting-overview__link-button {
 	text-decoration-line: underline;
 }
 
+@media ( max-width: $break-xlarge ) {
+	.hosting-overview__mobile-hidden-link-button {
+		display: none;
+	}
+}
+
 .hosting-overview__card-header {
 	display: flex;
 	gap: var(--grid-unit-15, 12px);
@@ -130,6 +136,12 @@ a.hosting-overview__link-button {
 
 .hosting-overview__plan-storage-footer {
 	text-align: right;
+}
+
+@media ( max-width: $break-xlarge ) {
+	.hosting-overview__plan-storage-footer {
+		text-align: left;
+	}
 }
 
 .hosting-overview__actions-list {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6384

## Proposed Changes

This is a followup on https://github.com/Automattic/wp-calypso/pull/89476.

This PR modifies the layout so it's responsive, according to the designs on IQgFHqGiN0eXkPn7Qkth4s-fi-6%3A8897, and the comments left on the previous PR (https://github.com/Automattic/wp-calypso/pull/89476#issuecomment-2051949953 & https://github.com/Automattic/wp-calypso/pull/89476#issuecomment-2059177300)

## Testing Instructions

* Open the live preview
* Go to `/hosting-overview`
* Set the browser to responsive mode
* Check that with a width below 1080px, the three cards are stacked on top of each other:

![image](https://github.com/Automattic/wp-calypso/assets/8511199/4c1317c2-6489-4cb6-ab3b-0a7e210aec8d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?