### PR TITLE
Jetpack Manage: Filter auto-managed plugins with updates, to not be displayed

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -1,12 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import {
-	AUTOMOMANAGED_PLUGINS,
-	ECOMMERCE_BUNDLED_PLUGINS,
-	PREINSTALLED_PLUGINS,
-	PREINSTALLED_PREMIUM_PLUGINS,
-} from 'calypso/my-sites/plugins/constants';
-import {
 	BackupNode,
 	BoostNode,
 	MonitorNode,
@@ -155,15 +149,11 @@ const useFormatPluginData = () => {
 
 	return useCallback(
 		( site: Site ): PluginNode => {
-			const pluginUpdates = site.is_atomic
-				? site.awaiting_plugin_updates?.filter(
-						( plugin ) =>
-							! PREINSTALLED_PLUGINS.includes( plugin ) &&
-							! AUTOMOMANAGED_PLUGINS.includes( plugin ) &&
-							! ECOMMERCE_BUNDLED_PLUGINS.includes( plugin ) &&
-							! Object.keys( PREINSTALLED_PREMIUM_PLUGINS ).includes( plugin )
-				  )
-				: site.awaiting_plugin_updates;
+			// Filter auto-managed Plugins that requires updates and leave only plugins that the user can update
+			const managedPluginsWithUpdates = new Set( site.awaiting_plugin_autoupdates );
+			const pluginUpdates = site.awaiting_plugin_updates?.filter(
+				( element ) => ! managedPluginsWithUpdates.has( element )
+			);
 
 			if ( ! pluginUpdates ) {
 				return {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -89,6 +89,7 @@ export interface Site {
 	latest_backup_status: string;
 	is_connection_healthy: boolean;
 	awaiting_plugin_updates: Array< string >;
+	awaiting_plugin_autoupdates: Array< string >;
 	is_favorite: boolean;
 	monitor_settings: MonitorSettings;
 	monitor_last_status_change: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
