### PR TITLE
Command Palette: Capitalise "Reader"

### DIFF
--- a/client/sites-dashboard/components/hosting-command-palette-banner.tsx
+++ b/client/sites-dashboard/components/hosting-command-palette-banner.tsx
@@ -157,7 +157,7 @@ const AnimatedCommand = () => {
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 	const commands = [
 		{ icon: domainsIcon, label: __( 'Register new domain' ) },
-		{ icon: <Gridicon icon="reader" />, label: __( 'Open reader' ) },
+		{ icon: <Gridicon icon="reader" />, label: __( 'Open Reader' ) },
 		{ icon: plusIcon, label: __( 'Add new post' ) },
 		{ icon: wordpressIcon, label: __( 'View my sites' ) },
 		{ icon: settingsIcon, label: __( 'Open hosting configuration' ) },

--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -330,7 +330,7 @@ export const COMMANDS: { [ key: string ]: Command } = {
 	},
 	openReader: {
 		name: 'openReader',
-		label: __( 'Open reader', __i18n_text_domain__ ),
+		label: __( 'Open Reader', __i18n_text_domain__ ),
 		callback: commandNavigation( '/read' ),
 		icon: (
 			<svg height="24" viewBox="4 4 24 24" width="24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Proposed Changes

More than happy to be corrected (!), but my understanding is that "Reader" is a proper noun, and should be capitalised accordingly - for example: https://github.com/search?q=repo%3AAutomattic%2Fwp-calypso%20%22WordPress.com%20Reader%22%20&type=code

<img width="450" alt="Screenshot 2024-04-16 at 18 18 03" src="https://github.com/Automattic/wp-calypso/assets/43215253/5fc96f91-c2a2-4472-af73-af1f9d48c5e5">

Can be tested on the Command Palette (cmd + k). Sorry - slightly pedantic change...but just something I noticed and felt was out-of-place! 

cc @dsas 
