### PR TITLE
Assembler: Device viewport sizes are not updated in large preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -93,12 +93,7 @@ export const ORDERED_PATTERN_PAGES_CATEGORIES = [
 	'contact',
 ];
 
-// From URL params for testing
-const searchParams = new URLSearchParams( window.location.search );
-const viewportWidth = searchParams.get( 'viewportWidth' );
-const placeholderHeight = searchParams.get( 'placeholderHeight' );
-
 // Pattern rendering
 export const DEFAULT_VIEWPORT_HEIGHT = 500;
-export const DEFAULT_VIEWPORT_WIDTH = Number( viewportWidth ) || 1200;
-export const PLACEHOLDER_HEIGHT = Number( placeholderHeight ) || 150;
+export const DEFAULT_VIEWPORT_WIDTH = 1200;
+export const PLACEHOLDER_HEIGHT = 150;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useRef, useEffect, useState, useMemo, CSSProperties, useCallback } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
-import { DEFAULT_VIEWPORT_WIDTH } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { injectTitlesToPageListBlock } from './html-transformers';
 import PatternActionBar from './pattern-action-bar';
@@ -168,7 +167,6 @@ const PatternLargePreview = ( {
 						key={ device }
 						patternId={ encodePatternId( pattern.ID ) }
 						viewportHeight={ viewportHeight }
-						viewportWidth={ DEFAULT_VIEWPORT_WIDTH }
 						// Disable default max-height
 						maxHeight="none"
 						transformHtml={ transformPatternHtml }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1713280899465289-slack-CRWCHQGUB

## Proposed Changes

* Revert URL param for testing viewport width that forced 1200px in the large preview

|BEFORE|AFTER|
|-|-|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/a6c73c2b-ef45-4992-b6ba-c35953d5a2d7">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/6ba1ebe6-b7ee-4673-abe0-004ee6952202">|

This bug was introduced in https://github.com/Automattic/wp-calypso/pull/86900 by myself 😅

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler https://wordpress.com/setup/assembler-first
* Switch devices to verify the breakpoints work as expected



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?