### PR TITLE
Add Razorpay UPI ID to payment methods list

### DIFF
--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -85,6 +85,7 @@ export interface StoredPaymentMethodStripeSource extends StoredPaymentMethodBase
 
 export interface StoredPaymentMethodRazorpay extends StoredPaymentMethodBase {
 	payment_partner: 'razorpay';
+	razorpay_vpa: string;
 }
 
 export interface StoredPaymentMethodTaxLocation {
@@ -138,17 +139,23 @@ export const PaymentMethodSummary = ( {
 	type,
 	digits,
 	email,
+	razorpayVpa,
 }: {
 	type: string;
 	digits?: string;
 	email?: string;
+	razorpayVpa?: string;
 } ) => {
 	const translate = useTranslate();
 	if ( type === PARTNER_PAYPAL_EXPRESS ) {
 		return <>{ email || '' }</>;
 	}
 	if ( type === PARTNER_RAZORPAY ) {
-		return <>{ translate( 'Unified Payments Interface (UPI)' ) }</>;
+		return (
+			<>
+				{ translate( 'Unified Payments Interface (UPI)' ) } { razorpayVpa || '' }{ ' ' }
+			</>
+		);
 	}
 	let displayType: TranslateResult;
 	switch ( type && type.toLocaleLowerCase() ) {

--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -139,23 +139,17 @@ export const PaymentMethodSummary = ( {
 	type,
 	digits,
 	email,
-	razorpayVpa,
 }: {
 	type: string;
 	digits?: string;
 	email?: string;
-	razorpayVpa?: string;
 } ) => {
 	const translate = useTranslate();
 	if ( type === PARTNER_PAYPAL_EXPRESS ) {
 		return <>{ email || '' }</>;
 	}
 	if ( type === PARTNER_RAZORPAY ) {
-		return (
-			<>
-				{ translate( 'Unified Payments Interface (UPI)' ) } { razorpayVpa || '' }{ ' ' }
-			</>
-		);
+		return <>{ translate( 'Unified Payments Interface (UPI)' ) }</>;
 	}
 	let displayType: TranslateResult;
 	switch ( type && type.toLocaleLowerCase() ) {

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -50,12 +50,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 			/>
 			<div className="payment-method-details__details">
 				<span className="payment-method-details__number">
-					<PaymentMethodSummary
-						type={ type }
-						digits={ lastDigits }
-						email={ email }
-						razorpayVpa={ razorpayVpa }
-					/>
+					<PaymentMethodSummary type={ type } digits={ lastDigits } email={ email } />
 				</span>
 
 				{ displayExpirationDate && (
@@ -77,6 +72,9 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 						{ translate( 'Credit card expired' ) }
 					</span>
 				) }
+
+				{ razorpayVpa && <span className="payment-method-details__vpa">{ razorpayVpa }</span> }
+
 				<span className="payment-method-details__name">{ name }</span>
 			</div>
 		</div>

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -19,6 +19,7 @@ interface Props {
 	paymentPartner?: string;
 	selected?: boolean;
 	isExpired?: boolean;
+	razorpayVpa?: string;
 }
 
 const PaymentMethodDetails: FunctionComponent< Props > = ( {
@@ -29,6 +30,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 	email,
 	paymentPartner,
 	isExpired,
+	razorpayVpa,
 } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -48,7 +50,12 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 			/>
 			<div className="payment-method-details__details">
 				<span className="payment-method-details__number">
-					<PaymentMethodSummary type={ type } digits={ lastDigits } email={ email } />
+					<PaymentMethodSummary
+						type={ type }
+						digits={ lastDigits }
+						email={ email }
+						razorpayVpa={ razorpayVpa }
+					/>
 				</span>
 
 				{ displayExpirationDate && (

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -26,6 +26,7 @@ export default function PaymentMethod( { paymentMethod }: { paymentMethod: Store
 					name={ paymentMethod.name }
 					expiry={ paymentMethod.expiry }
 					isExpired={ paymentMethod.is_expired }
+					razorpayVpa={ 'razorpay_vpa' in paymentMethod ? paymentMethod.razorpay_vpa : undefined }
 				/>
 				{ isCreditCard( paymentMethod ) && <PaymentMethodBackupToggle card={ paymentMethod } /> }
 				<TaxInfoArea

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -95,7 +95,8 @@
 	}
 }
 
-.payment-method-details__name {
+.payment-method-details__name,
+.payment-method-details__vpa {
 	color: var(--color-neutral-50);
 	display: block;
 	font-size: 0.875rem;


### PR DESCRIPTION
Closes https://github.com/Automattic/payments-florin/issues/509

## Proposed Changes

* We've begun saving Razorpay's UPI ID as the `razorpay_vpa` property on saved payment methods in D144960-code.  This PR adds support for displaying these details to customers in the saved payment methods list.  This will help customers identify specific payment methods when they have multiple UPI/Razorpay methods saved.

## Testing Instructions

* Follow set-up instructions in D145777-code.
* Add a plan to your cart and set your country to India.  
* Select Razorpay as the payment method with `success@razorpay` as the ID.
* After completing the purchase, go to `/me/purchases/payment-methods` and you should see the UPI ID listed by the payment method.


![razorpay](https://github.com/Automattic/wp-calypso/assets/1138631/abea9df4-07f4-4cde-b762-882d883fbf59)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?