### PR TITLE
A4A: Hide site tag fields when no managed site exists

### DIFF
--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -52,13 +52,15 @@ export default function AgencySiteTags( { tags, isLoading, onAddTags, onRemoveTa
 					{ translate( 'Add' ) }
 				</Button>
 			</Card>
-			<Card tagName="ul" className="agency-site-tags__list">
-				{ tags.map( ( tag ) => (
-					<li>
-						<AgencySiteTag key={ tag } tag={ tag } onRemoveTag={ onRemoveTag } />
-					</li>
-				) ) }
-			</Card>
+			{ tags.length > 0 && (
+				<Card tagName="ul" className="agency-site-tags__list">
+					{ tags.map( ( tag ) => (
+						<li>
+							<AgencySiteTag key={ tag } tag={ tag } onRemoveTag={ onRemoveTag } />
+						</li>
+					) ) }
+				</Card>
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-details.tsx
@@ -12,7 +12,7 @@ export default function SiteDetails( { site }: any ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	/* eslint-disable-next-line */
-	const { a4a_site_id: siteId, a4a_site_tags: initialTags } = site;
+	const { a4a_agency_id: agencyId, a4a_site_id: siteId, a4a_site_tags: initialTags } = site;
 
 	const [ tags, setTags ] = useState(
 		initialTags ? initialTags.map( ( tag: SiteTagType ) => tag.label ) : []
@@ -66,15 +66,19 @@ export default function SiteDetails( { site }: any ) {
 
 	return (
 		<div className="site-details">
-			<h3 className="site-details__section-header">{ translate( 'Tags' ) }</h3>
-			<AgencySiteTags
-				{ ...{
-					tags,
-					onAddTags,
-					onRemoveTag,
-					isLoading,
-				} }
-			/>
+			{ agencyId && siteId && (
+				<>
+					<h3 className="site-details__section-header">{ translate( 'Tags' ) }</h3>
+					<AgencySiteTags
+						{ ...{
+							tags,
+							onAddTags,
+							onRemoveTag,
+							isLoading,
+						} }
+					/>
+				</>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

* Hides the entire Tags section in A4A when a managed site does not exist for the current site in context
* Hides the tags list Card component when no tags are assigned to the site

## Testing Instructions

* View the Details section for a site which doesn't have a managed site. You should essentially see a blank feature pane.
* View the Details section for a site which DOES have a managed site, but has not tags assigned. You shouldn't see the empty tag list container.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
