### PR TITLE
A4A: Fix Plugin updates filter not working in Sites Dashboard

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
+import { useRef } from 'react';
 import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import type {
 	AgencyDashboardFilter,
@@ -57,6 +58,9 @@ const useFetchDashboardSites = ( {
 		...( agencyId ? [ agencyId ] : [] ),
 	];
 
+	const esHitsRef = useRef< number >( 0 );
+	const esHitsPageRef = useRef< number >( 0 );
+
 	// If perPage is not provided, we want to remove perPage from the query_key as existing tests don't pass otherwise.
 	if ( ! perPage ) {
 		queryKey = [
@@ -89,9 +93,15 @@ const useFetchDashboardSites = ( {
 					...agencyDashboardSortToQueryObject( sort ),
 					per_page: perPage,
 					...( agencyId && { agency_id: agencyId } ),
+					...( esHitsRef.current && { es_hits: esHitsRef.current } ),
+					...( esHitsPageRef.current && { es_hits_page: esHitsPageRef.current } ),
 				}
 			),
 		select: ( data ) => {
+			esHitsRef.current = data.es_hits ?? 0;
+			// Pagination starts with 1
+			esHitsPageRef.current = data.es_hits_page ?? 1;
+
 			return {
 				sites: data.sites,
 				total: data.total,


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/258

## Proposed Changes

* This PR persists `es_hits` and `es_hits_page` between requests for dashboard site data. These two parameters were introduced in D145420-code to fix the 'Plugins Needing Updates' filter on the Sites Dashboard.

## Testing Instructions

* Apply diff D145420-code and point your hosts file to your sandbox
* Run yarn start-a8c-for-agencies
* Go to http://agencies.localhost:3000/sites
* Verify that the dashboard's behavior remains unchanged when not using any filters
* Verify that the dashboard's behavior remains unchanged when using all filters but 'Plugins Needing Updates' and 'Needs Attention'

Now comes the tricky part:
**Verify that the 'Plugins Needing Updates' filter works as intended**
* When the filter is enabled only plugins which need updates should be shown
* Test the pagination with the filter enabled
* Test skipping pages (going from page 1 to page 3)
* Test going back pages (going from page 3 to page 1)
* Reset filters and re-enable the 'Plugins Needing Updates' filter

If needed, you can change the `perPage` in `client/a8c-for-agencies/sections/sites/constants.ts` to 1, so you will need fewer sites to test pagination.

### Known issues

We assume the total number of filtered sites to be the same as the total number of sites because we cannot determine the exact number of filtered results without processing all of them. If a request attempts to access a page beyond the last available one, it will return an empty result.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?