### PR TITLE
Automattic for Agencies: Remove enableLoggedOut flags in sections & unnecessary FIXME comments

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -23,7 +23,6 @@ import {
 } from './controller';
 
 export default function () {
-	// FIXME: check access, TOS consent, valid payment method, all sites context and partner key selection if needed
 	page( A4A_MARKETPLACE_LINK, requireAccessContext, marketplaceContext, makeLayout, clientRender );
 	page(
 		A4A_MARKETPLACE_PRODUCTS_LINK,

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -1,5 +1,3 @@
-// FIXME: Lets decide later if we need to move the calypso/jetpack-cloud imports to a shared common folder.
-
 import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -1,4 +1,3 @@
-// FIXME: Lets decide later if we need to move the calypso/jetpack-cloud imports to a shared common folder.
 import { JetpackLogo, WooLogo } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';

--- a/client/a8c-for-agencies/sections/purchases/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/index.tsx
@@ -11,8 +11,6 @@ import {
 } from './controller';
 
 export default function () {
-	// FIXME: check access, TOS consent, and partner key selection
-
 	// Purchases
 	page( '/purchases', requireAccessContext, purchasesContext, makeLayout, clientRender );
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -721,7 +721,6 @@ const sections = [
 		paths: [ '/landing' ],
 		module: 'calypso/a8c-for-agencies/sections/landing',
 		group: 'a8c-for-agencies',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'a8c-for-agencies-auth',
@@ -735,21 +734,18 @@ const sections = [
 		paths: [ '/overview' ],
 		module: 'calypso/a8c-for-agencies/sections/overview',
 		group: 'a8c-for-agencies',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'a8c-for-agencies-sites',
 		paths: [ '/sites', 'sites/favorite' ],
 		module: 'calypso/a8c-for-agencies/sections/sites',
 		group: 'a8c-for-agencies',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'a8c-for-agencies-plugins',
 		paths: [ '/plugins' ],
 		module: 'calypso/a8c-for-agencies/sections/plugins',
 		group: 'a8c-for-agencies',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'a8c-for-agencies-marketplace',
@@ -765,7 +761,6 @@ const sections = [
 		],
 		module: 'calypso/a8c-for-agencies/sections/marketplace',
 		group: 'a8c-for-agencies',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'a8c-for-agencies-purchases',
@@ -779,7 +774,6 @@ const sections = [
 		],
 		module: 'calypso/a8c-for-agencies/sections/purchases',
 		group: 'a8c-for-agencies',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'a8c-for-agencies-referrals',


### PR DESCRIPTION
## Proposed Changes

This PR:

- Removes the `enableLoggedOut` flags in A4A sections where we don't have a public page.
- Removes unnecessary `FIXME` comments

## Testing Instructions

- Open the A4A live link
- Disable the proxy
- Visit /landing, /overview, /sites, /plugins, /marketplace, /purchases manually & verify that you are redirected to /login.
- Enable proxy and repeat step 4. Now verify that you can see the page as expected and are not being redirected. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?