### PR TITLE
Automattic for Agencies: Update Jetpack connect flow to redirect with a success message if a site is already connected

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -7,9 +7,10 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
-import { JETPACK_ADMIN_PATH } from 'calypso/jetpack-connect/constants';
+import { JETPACK_ADMIN_PATH, JPC_A4A_PATH } from 'calypso/jetpack-connect/constants';
 import { navigate } from 'calypso/lib/navigate';
 import { addQueryArgs } from 'calypso/lib/route';
+import { urlToSlug } from 'calypso/lib/url';
 import versionCompare from 'calypso/lib/version-compare';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
@@ -103,8 +104,15 @@ const jetpackConnection = ( WrappedComponent ) => {
 			if ( status === ALREADY_CONNECTED && ! this.state.redirecting ) {
 				const currentPlan = retrievePlan();
 				clearPlan();
-				if ( source === 'jetpack-manage' || source === 'a8c-for-agencies' ) {
+				if ( source === 'jetpack-manage' ) {
 					this.setState( { status: ALREADY_CONNECTED } );
+				} else if ( source === 'a8c-for-agencies' ) {
+					const urlRedirect = addQueryArgs(
+						{ site_already_connected: urlToSlug( this.props.siteHomeUrl ) },
+						JPC_A4A_PATH
+					);
+					navigate( urlRedirect );
+					return;
 				} else if ( currentPlan ) {
 					if ( currentPlan === PLAN_JETPACK_FREE ) {
 						debug( `Redirecting to wpadmin` );


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/196

## Proposed Changes

This PR:

- Updates Jetpack connection flow to redirect to A4A if a site is already connected.
- Shows a success message when a user is redirected to A4A when a site is already connected. 

## Testing Instructions

1) Open Calypso live link
2) Visit /jetpack/connect?source=a8c-for-agencies > 
3) Enter a site URL that is already connected > Verify that you are redirected to the A4A portal with `site_already_connected` set to the site URL.
4) Now visit the A4A live link >Append the URL with `sites?site_already_connected=example.com` and hit enter > Verify that you can see a success message as shown below.

<img width="397" alt="Screenshot 2024-04-17 at 2 54 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a8a0fe89-5c3d-45ec-aefc-cc77d87bfea5">

5) Enter a site that is not connected > Verify that you are redirected after the site is connected successfully. 

6) Visit the Jetpack Cloud live link > Repeat Step 3 > Verify that you can see a message the site is already connected and you don't get redirected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?