### PR TITLE
Scheduled Updates Add notification settings query, mutation and UI

### DIFF
--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -16,6 +16,7 @@ import { PluginUpdateManagerContextProvider } from './context';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
+import { NotificationSettings } from './notification-settings';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleEdit } from './schedule-edit';
 import { ScheduleList } from './schedule-list';
@@ -24,11 +25,12 @@ import './styles.scss';
 
 interface Props {
 	siteSlug: string;
-	context: 'list' | 'create' | 'edit' | 'logs';
+	context: 'list' | 'create' | 'edit' | 'logs' | 'notifications';
 	scheduleId?: string;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 	onEditSchedule: ( id: string ) => void;
+	onNotificationManagement?: () => void;
 	onShowLogs: ( id: string ) => void;
 }
 
@@ -40,6 +42,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		scheduleId,
 		onNavBack,
 		onCreateNewSchedule,
+		onNotificationManagement,
 		onEditSchedule,
 		onShowLogs,
 	} = props;
@@ -48,7 +51,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 	const { isEligibleForFeature, isSitePlansLoaded } = useIsEligibleForFeature();
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 
-	const hideCreateButton =
+	const hideButtons =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins( siteSlug );
@@ -84,6 +87,10 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
 			title: translate( 'Edit schedule' ),
 		},
+		notifications: {
+			component: <NotificationSettings onNavBack={ onNavBack } />,
+			title: translate( 'Notification management' ),
+		},
 	}[ context ];
 
 	return (
@@ -98,16 +105,30 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 						'Streamline your workflow with scheduled updates, timed to suit your needs.'
 					) }
 				>
-					{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
-						<Button
-							__next40pxDefaultSize
-							icon={ plus }
-							variant={ canCreateSchedules && siteHasEligiblePlugins ? 'primary' : 'secondary' }
-							onClick={ onCreateNewSchedule }
-							disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
-						>
-							{ translate( 'Add new schedule' ) }
-						</Button>
+					{ context === 'list' && ! hideButtons && (
+						<>
+							{ onNotificationManagement && (
+								<Button
+									__next40pxDefaultSize
+									variant="secondary"
+									onClick={ onNotificationManagement }
+								>
+									{ translate( 'Notification management' ) }
+								</Button>
+							) }
+
+							{ onCreateNewSchedule && (
+								<Button
+									__next40pxDefaultSize
+									icon={ plus }
+									variant={ canCreateSchedules && siteHasEligiblePlugins ? 'primary' : 'secondary' }
+									onClick={ onCreateNewSchedule }
+									disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
+								>
+									{ translate( 'Add new schedule' ) }
+								</Button>
+							) }
+						</>
 					) }
 				</NavigationHeader>
 				<ScheduledUpdatesGate siteId={ siteId as number }>{ component }</ScheduledUpdatesGate>

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -51,7 +51,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 	const { isEligibleForFeature, isSitePlansLoaded } = useIsEligibleForFeature();
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 
-	const hideButtons =
+	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins( siteSlug );
@@ -89,7 +89,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		},
 		notifications: {
 			component: <NotificationSettings onNavBack={ onNavBack } />,
-			title: translate( 'Notification management' ),
+			title: translate( 'Notification settings' ),
 		},
 	}[ context ];
 
@@ -105,7 +105,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 						'Streamline your workflow with scheduled updates, timed to suit your needs.'
 					) }
 				>
-					{ context === 'list' && ! hideButtons && (
+					{ context === 'list' && (
 						<>
 							{ onNotificationManagement && (
 								<Button
@@ -113,11 +113,11 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 									variant="secondary"
 									onClick={ onNotificationManagement }
 								>
-									{ translate( 'Notification management' ) }
+									{ translate( 'Notification settings' ) }
 								</Button>
 							) }
 
-							{ onCreateNewSchedule && (
+							{ onCreateNewSchedule && ! hideCreateButton && (
 								<Button
 									__next40pxDefaultSize
 									icon={ plus }

--- a/client/blocks/plugins-scheduled-updates/notification-settings.scss
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.scss
@@ -7,18 +7,18 @@
 			font-size: $font-body-small;
 			font-weight: 500;
 			color: $studio-black;
-			margin-bottom: 8px;
+			margin-bottom: 0.5rem;
 		}
 
 		.components-text.info-msg {
 			font-size: $font-body-small;
 			color: $studio-gray-60;
 			line-height: 20px;
-			margin-bottom: 16px;
+			margin-bottom: 1rem;
 		}
 
 		.form-field {
-			margin-bottom: 16px;
+			margin-bottom: 1rem;
 		}
 	}
 }

--- a/client/blocks/plugins-scheduled-updates/notification-settings.scss
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.scss
@@ -1,0 +1,24 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+
+.plugins-update-manager {
+	.notification-settings-form {
+		label {
+			font-size: $font-body-small;
+			font-weight: 500;
+			color: $studio-black;
+			margin-bottom: 8px;
+		}
+
+		.components-text.info-msg {
+			font-size: $font-body-small;
+			color: $studio-gray-60;
+			line-height: 20px;
+			margin-bottom: 16px;
+		}
+
+		.form-field {
+			margin-bottom: 16px;
+		}
+	}
+}

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -121,7 +121,7 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 				{ hasGlobalNotificationsDisabled && (
 					<Text className="info-msg">
 						{ translate(
-							'You have opted out of scheduled updates notifications on WordPress.com. Visit {{notificationSettingsLink}}Notification Settings{{/notificationSettingsLink}} to enable scheduled updates notifications.',
+							"You've opted out of WordPress.com's scheduled update notifications. Head to {{notificationSettingsLink}}Notification Settings{{/notificationSettingsLink}} to re-enable them.",
 							{
 								components: {
 									notificationSettingsLink: <a href="/me/notifications/updates" />,

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -37,8 +37,9 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 		dispatch( fetchSettings() );
 	}, [ dispatch ] );
 
-	const wpcomNotificationSettings = useSelector( ( state ) => {
-		return getNotificationSettings( state, 'wpcom' );
+	const hasGlobalNotificationsDisabled = useSelector( ( state ) => {
+		const settings = getNotificationSettings( state, 'wpcom' );
+		return settings && ! settings.scheduled_updates;
 	} );
 
 	const { updateNotificationSettings, isPending: isSaving } =
@@ -74,7 +75,7 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 						</Button>
 					) }
 				</div>
-				<Text>{ translate( 'Notification management' ) }</Text>
+				<Text>{ translate( 'Notification Settings' ) }</Text>
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody className="notification-settings-form">
@@ -90,7 +91,7 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 						label={ translate( 'On successful updates' ) }
 						checked={ formValues.success }
 						onChange={ handleCheckboxChange( 'success' ) }
-						disabled={ ! isFetched || ! wpcomNotificationSettings?.scheduled_updates }
+						disabled={ ! isFetched || ! hasGlobalNotificationsDisabled }
 					/>
 				</div>
 				<div className="form-field">
@@ -98,11 +99,11 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 						label={ translate( 'On failed updates' ) }
 						checked={ formValues.failure }
 						onChange={ handleCheckboxChange( 'failure' ) }
-						disabled={ ! isFetched || ! wpcomNotificationSettings?.scheduled_updates }
+						disabled={ ! isFetched || hasGlobalNotificationsDisabled }
 					/>
 				</div>
 
-				{ ! wpcomNotificationSettings?.scheduled_updates && (
+				{ hasGlobalNotificationsDisabled && (
 					<Text className="info-msg">
 						{ translate(
 							'You have opted out of scheduled updates notifications on WordPress.com. Visit {{notificationSettingsLink}}Notification Settings{{/notificationSettingsLink}} to enable scheduled updates notifications.',

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useScheduledUpdatesNotificationSettingsMutation } from 'calypso/data/plugins/use-scheduled-updates-notification-settings-mutation';
 import { useScheduledUpdatesNotificationSettingsQuery } from 'calypso/data/plugins/use-scheduled-updates-notification-settings-query';
 import { useDispatch, useSelector } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { fetchSettings } from 'calypso/state/notification-settings/actions';
 import { getNotificationSettings } from 'calypso/state/notification-settings/selectors';
 import { useSiteSlug } from './hooks/use-site-slug';
@@ -42,8 +43,12 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 		return settings && ! settings.scheduled_updates;
 	} );
 
-	const { updateNotificationSettings, isPending: isSaving } =
-		useScheduledUpdatesNotificationSettingsMutation( siteSlug );
+	const {
+		updateNotificationSettings,
+		isPending: isSaving,
+		isSuccess,
+		isError,
+	} = useScheduledUpdatesNotificationSettingsMutation( siteSlug );
 
 	useEffect( () => {
 		if ( isFetched && settings ) {
@@ -53,6 +58,16 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 			} );
 		}
 	}, [ isFetched, settings ] );
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			dispatch( successNotice( translate( 'Your notification settings have been saved.' ) ) );
+		} else if ( isError ) {
+			dispatch(
+				errorNotice( translate( 'Failed to save notification settings. Please try again.' ) )
+			);
+		}
+	}, [ isSuccess, isError ] );
 
 	const handleCheckboxChange = ( field: keyof typeof formValues ) => ( checked: boolean ) => {
 		setFormValues( ( prevValues ) => ( {

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -91,7 +91,7 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 						label={ translate( 'On successful updates' ) }
 						checked={ formValues.success }
 						onChange={ handleCheckboxChange( 'success' ) }
-						disabled={ ! isFetched || ! hasGlobalNotificationsDisabled }
+						disabled={ ! isFetched || hasGlobalNotificationsDisabled }
 					/>
 				</div>
 				<div className="form-field">

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -23,12 +23,14 @@ type Props = {
 export const NotificationSettings = ( { onNavBack }: Props ) => {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
-	const [ touched, setIsTouched ] = useState( false );
 	const { data: settings, isFetched } = useScheduledUpdatesNotificationSettingsQuery( siteSlug );
 	const [ formValues, setFormValues ] = useState( {
 		success: false,
 		failure: false,
 	} );
+
+	const { updateNotificationSettings, isPending: isSaving } =
+		useScheduledUpdatesNotificationSettingsMutation( siteSlug );
 
 	useEffect( () => {
 		if ( isFetched && settings ) {
@@ -44,15 +46,10 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 			...prevValues,
 			[ field ]: checked,
 		} ) );
-		setIsTouched( true );
 	};
-
-	const { updateNotificationSettings } =
-		useScheduledUpdatesNotificationSettingsMutation( siteSlug );
 
 	const onSave = useCallback( () => {
 		updateNotificationSettings( formValues );
-		setIsTouched( false );
 	}, [ formValues, updateNotificationSettings ] );
 
 	return (
@@ -94,7 +91,7 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 				</div>
 			</CardBody>
 			<CardFooter>
-				<Button variant="primary" disabled={ ! touched } onClick={ onSave }>
+				<Button variant="primary" disabled={ isSaving } onClick={ onSave }>
 					{ translate( 'Save' ) }
 				</Button>
 			</CardFooter>

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -1,0 +1,45 @@
+import {
+	__experimentalText as Text,
+	PanelRow,
+	PanelBody,
+	CheckboxControl,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useScheduledUpdatesNotificationSettingsMutation } from 'calypso/data/plugins/use-scheduled-updates-notification-settings-mutation';
+import { useScheduledUpdatesNotificationSettingsQuery } from 'calypso/data/plugins/use-scheduled-updates-notification-settings-query';
+import { useSiteSlug } from './hooks/use-site-slug';
+
+export const NotificationSettings = () => {
+	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
+	const { data: settings, isFetched } = useScheduledUpdatesNotificationSettingsQuery( siteSlug );
+	const { updateNotificationSettings } =
+		useScheduledUpdatesNotificationSettingsMutation( siteSlug );
+
+	return isFetched ? (
+		<PanelBody>
+			<PanelRow>
+				<Text className="notification-settings__title">{ translate( 'Email me' ) }</Text>
+			</PanelRow>
+			<PanelRow>
+				<CheckboxControl
+					label={ translate( 'On successful updates' ) }
+					checked={ settings?.success }
+					onChange={ ( checked ) =>
+						updateNotificationSettings( { success: checked, failure: settings?.failure ?? false } )
+					}
+				/>
+			</PanelRow>
+
+			<PanelRow>
+				<CheckboxControl
+					label={ translate( 'On failed updates' ) }
+					checked={ settings?.failure }
+					onChange={ ( checked ) =>
+						updateNotificationSettings( { success: settings?.success ?? false, failure: checked } )
+					}
+				/>
+			</PanelRow>
+		</PanelBody>
+	) : null;
+};

--- a/client/blocks/plugins-scheduled-updates/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list.tsx
@@ -18,6 +18,7 @@ import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
 import { useSiteSlug } from './hooks/use-site-slug';
+import { NotificationSettings } from './notification-settings';
 import { ScheduleListCards } from './schedule-list-cards';
 import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListTable } from './schedule-list-table';
@@ -142,6 +143,7 @@ export const ScheduleList = ( props: Props ) => {
 								) }
 							</>
 						) }
+					{ ! isLoading && ! showScheduleListEmpty && <NotificationSettings /> }
 				</CardBody>
 			</Card>
 		</>

--- a/client/blocks/plugins-scheduled-updates/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list.tsx
@@ -18,7 +18,6 @@ import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
 import { useSiteSlug } from './hooks/use-site-slug';
-import { NotificationSettings } from './notification-settings';
 import { ScheduleListCards } from './schedule-list-cards';
 import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListTable } from './schedule-list-table';
@@ -143,7 +142,6 @@ export const ScheduleList = ( props: Props ) => {
 								) }
 							</>
 						) }
-					{ ! isLoading && ! showScheduleListEmpty && <NotificationSettings /> }
 				</CardBody>
 			</Card>
 		</>

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -157,6 +157,10 @@
 		}
 	}
 
+	.notification-settings__title {
+		font-size: $font-body;
+	}
+
 	.timeline {
 		margin: 0;
 

--- a/client/data/plugins/use-scheduled-updates-notification-settings-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-notification-settings-mutation.ts
@@ -16,7 +16,7 @@ export function useScheduledUpdatesNotificationSettingsMutation(
 	const queryClient = useQueryClient();
 
 	const mutation = useMutation( {
-		mutationKey: [ 'create-update-schedule', siteSlug ],
+		mutationKey: [ 'scheduled-updates-notification-settings', siteSlug ],
 		mutationFn: ( params: ScheduledUpdatesNotificationSettings ) =>
 			wpcomRequest( {
 				path: `/sites/${ siteSlug }/scheduled-updates/notifications`,

--- a/client/data/plugins/use-scheduled-updates-notification-settings-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-notification-settings-mutation.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { ScheduledUpdatesNotificationSettings } from './use-scheduled-updates-notification-settings-query';
+import type { SiteSlug } from 'calypso/types';
+
+export type CreateRequestParams = {
+	success: boolean;
+	failure: boolean;
+};
+
+export function useScheduledUpdatesNotificationSettingsMutation(
+	siteSlug: SiteSlug,
+	queryOptions = {}
+) {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation( {
+		mutationKey: [ 'create-update-schedule', siteSlug ],
+		mutationFn: ( params: ScheduledUpdatesNotificationSettings ) =>
+			wpcomRequest( {
+				path: `/sites/${ siteSlug }/scheduled-updates/notifications`,
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+				body: params,
+			} ),
+		onMutate: async ( params: ScheduledUpdatesNotificationSettings ) => {
+			// cancel in-flight queries because we don't want them to overwrite our optimistic update.
+			await queryClient.cancelQueries( {
+				queryKey: [ 'scheduled-updates-notification-settings', siteSlug ],
+			} );
+
+			// Optimistically update the cache.
+			const prevSettings: ScheduledUpdatesNotificationSettings = queryClient.getQueryData( [
+				'scheduled-updates-notification-settings',
+				siteSlug,
+			] ) || { success: false, failure: false };
+
+			queryClient.setQueryData( [ 'scheduled-updates-notification-settings', siteSlug ], params );
+
+			return { prevSettings };
+		},
+		onError: ( _err, _params, context ) =>
+			// Set previous value on error.
+			queryClient.setQueryData(
+				[ 'scheduled-updates-notification-settings', siteSlug ],
+				context?.prevSettings
+			),
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const updateNotificationSettings = useCallback(
+		( params: CreateRequestParams ) => mutate( params ),
+		[ mutate ]
+	);
+
+	return { updateNotificationSettings, ...mutation };
+}

--- a/client/data/plugins/use-scheduled-updates-notification-settings-query.ts
+++ b/client/data/plugins/use-scheduled-updates-notification-settings-query.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteSlug } from 'calypso/types';
+
+export type ScheduledUpdatesNotificationSettings = {
+	success: boolean;
+	failure: boolean;
+};
+
+export const useScheduledUpdatesNotificationSettingsQuery = ( siteSlug: SiteSlug ) => {
+	return useQuery< ScheduledUpdatesNotificationSettings, Error >( {
+		queryKey: [ 'scheduled-updates-notification-settings', siteSlug ],
+		queryFn: () =>
+			wpcomRequest( {
+				path: `/sites/${ siteSlug }/scheduled-updates/notifications`,
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+			} ),
+		enabled: !! siteSlug,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -154,13 +154,21 @@ export function scheduledUpdates( context, next ) {
 				onNavBack: goToScheduledUpdatesList,
 			} );
 			break;
-
+		case 'notifications':
+			context.primary = createElement( PluginsScheduledUpdates, {
+				siteSlug,
+				context: 'notifications',
+				onNavBack: goToScheduledUpdatesList,
+			} );
+			break;
 		case 'list':
 		default:
 			context.primary = createElement( PluginsScheduledUpdates, {
 				siteSlug,
 				context: 'list',
 				onCreateNewSchedule: () => page.show( `/plugins/scheduled-updates/create/${ siteSlug }` ),
+				onNotificationManagement: () =>
+					page.show( `/plugins/scheduled-updates/notifications/${ siteSlug }` ),
 				onEditSchedule: ( id ) =>
 					page.show( `/plugins/scheduled-updates/edit/${ siteSlug }/${ id }` ),
 				onShowLogs: ( id ) => page.show( `/plugins/scheduled-updates/logs/${ siteSlug }/${ id }` ),


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89566

🚧⚠️ Do not merge until we have everything in place ⚠️🚧

## Proposed Changes

* Adds `useScheduledUpdatesNotificationSettingsQuery`
* Adds `useScheduledUpdatesNotificationSettingsMutation`
* Adds /notifications route
* Adds UI to manage notification settings


![CleanShot 2024-04-17 at 14 35 26@2x](https://github.com/Automattic/wp-calypso/assets/528287/bf340fbb-293c-4c6e-a490-298b5f88486f)
![CleanShot 2024-04-17 at 14 35 43@2x](https://github.com/Automattic/wp-calypso/assets/528287/dcc81fca-5caf-4e68-ba9c-6620e7635877)

## Testing Instructions

- Apply this PR
- Visit Scheduled Updates
- Play around

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?