### PR TITLE
Scheduled updates: time frequency control updates to support multisite context design

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -87,7 +87,11 @@ export const ScheduleForm = () => {
 				</Flex>
 			</div>
 			<div className="form-control-container">
-				<ScheduleFormFrequency initFrequency="daily" optionsDirection={ [ 'column', 'row' ] } />
+				<ScheduleFormFrequency
+					initFrequency="daily"
+					optionsDirection={ [ 'column', 'row' ] }
+					showAllOptionControls={ true }
+				/>
 			</div>
 		</div>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -25,6 +25,10 @@
 		div.radio-option {
 			flex-basis: 100%;
 			min-height: 85px;
+
+			& > .components-radio-control {
+				margin-bottom: 1rem;
+			}
 		}
 	}
 

--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -84,8 +84,8 @@ export function ScheduleFormFrequency( props: Props ) {
 						<Flex gap={ 6 }>
 							<FlexBlock>
 								<ScheduleFormTime
-									initHour={ hour }
-									initPeriod={ period }
+									hour={ hour }
+									period={ period }
 									isAmPmFormat={ isAmPmFormat }
 									onChange={ ( hour, period ) => {
 										setHour( hour );
@@ -119,8 +119,8 @@ export function ScheduleFormFrequency( props: Props ) {
 							</FlexItem>
 							<FlexBlock>
 								<ScheduleFormTime
-									initHour={ hour }
-									initPeriod={ period }
+									hour={ hour }
+									period={ period }
 									isAmPmFormat={ isAmPmFormat }
 									onChange={ ( hour, period ) => {
 										setHour( hour );

--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -27,6 +27,7 @@ interface Props {
 	optionsDirection?: FlexDirection[];
 	error?: string;
 	showError?: boolean;
+	showAllOptionControls?: boolean;
 	onTouch?: ( touched: boolean ) => void;
 	onChange?: ( frequency: Frequency, timestamp: number ) => void;
 }
@@ -41,6 +42,7 @@ export function ScheduleFormFrequency( props: Props ) {
 		optionsDirection = [ 'column' ],
 		error,
 		showError,
+		showAllOptionControls,
 		onChange,
 		onTouch,
 	} = props;
@@ -78,7 +80,7 @@ export function ScheduleFormFrequency( props: Props ) {
 						onChange={ ( f ) => setFrequency( f as 'daily' ) }
 						onBlur={ () => setFieldTouched( true ) }
 					></RadioControl>
-					{ frequency === 'daily' && (
+					{ ( showAllOptionControls || frequency === 'daily' ) && (
 						<Flex gap={ 6 }>
 							<FlexBlock>
 								<ScheduleFormTime
@@ -102,7 +104,7 @@ export function ScheduleFormFrequency( props: Props ) {
 						onChange={ ( f ) => setFrequency( f as 'weekly' ) }
 						onBlur={ () => setFieldTouched( true ) }
 					></RadioControl>
-					{ frequency === 'weekly' && (
+					{ ( showAllOptionControls || frequency === 'weekly' ) && (
 						<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>
 							<FlexItem>
 								<div className="form-field">

--- a/client/blocks/plugins-scheduled-updates/schedule-form-time.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-time.tsx
@@ -1,5 +1,5 @@
 import { SelectControl } from '@wordpress/components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { HOUR_OPTIONS, HOUR_OPTIONS_24, PERIOD_OPTIONS } from './schedule-form.const';
 import { convertHourTo12, convertHourTo24 } from './schedule-form.helper';
 
@@ -16,6 +16,19 @@ export function ScheduleFormTime( props: Props ) {
 		isAmPmFormat ? initHour : convertHourTo24( initHour, initPeriod )
 	);
 	const [ period, setPeriod ] = useState( initPeriod );
+
+	useEffect( () => {
+		if ( isAmPmFormat ) {
+			setHour( initHour );
+		} else {
+			setHour( convertHourTo24( initHour, initPeriod ) );
+			setPeriod( parseInt( initHour ) < 12 ? 'am' : 'pm' );
+		}
+	}, [ initHour ] );
+
+	useEffect( () => {
+		setPeriod( initPeriod );
+	}, [ initPeriod ] );
 
 	return (
 		<div className="form-field">

--- a/client/blocks/plugins-scheduled-updates/schedule-form-time.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-time.tsx
@@ -4,13 +4,13 @@ import { HOUR_OPTIONS, HOUR_OPTIONS_24, PERIOD_OPTIONS } from './schedule-form.c
 import { convertHourTo12, convertHourTo24 } from './schedule-form.helper';
 
 interface Props {
-	initHour: string;
-	initPeriod: string;
+	hour: string;
+	period: string;
 	isAmPmFormat: boolean;
 	onChange: ( hour: string, period: string ) => void;
 }
 export function ScheduleFormTime( props: Props ) {
-	const { initHour, initPeriod, isAmPmFormat, onChange } = props;
+	const { hour: initHour, period: initPeriod, isAmPmFormat, onChange } = props;
 
 	const [ hour, setHour ] = useState(
 		isAmPmFormat ? initHour : convertHourTo24( initHour, initPeriod )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89473

## Proposed Changes

* Adjust the frequency component to show all controls
* Adapt the time component to have two way data binding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/create`
* Check if control is visible on both frequency variants (daily, weekly)
* Check if the time change reflects between daily and weekly


| Before | After |
|--------|--------|
| <img width="1396" alt="Screenshot 2024-04-17 at 12 22 46" src="https://github.com/Automattic/wp-calypso/assets/1241413/00719c76-94d1-4c55-bd30-5d5f7ba446c3"> | <img width="1401" alt="Screenshot 2024-04-17 at 12 22 58" src="https://github.com/Automattic/wp-calypso/assets/1241413/15192f84-0b98-480a-af51-b9984223d0fe"> | 

![Screen Capture on 2024-04-17 at 12-16-43](https://github.com/Automattic/wp-calypso/assets/1241413/cadade5b-1887-4335-ba73-61108181d6f9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?