### PR TITLE
Site Migration: Fix links when the from param is not available

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -8,6 +8,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migraiton-key';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { MaybeLink } from './maybe-link';
 import { ShowHideInput } from './show-hide-input';
 import type { Step } from '../../types';
 
@@ -15,10 +16,14 @@ import './style.scss';
 
 const removeDuplicatedSlashes = ( url: string ) => url.replace( /(https?:\/\/)|(\/)+/g, '$1$2' );
 
-const getInstallationURL = ( fromUrl: string ) => {
-	return removeDuplicatedSlashes(
-		`${ fromUrl }/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term`
-	);
+const getPluginInstallationPage = ( fromUrl: string ) => {
+	if ( fromUrl !== '' ) {
+		return removeDuplicatedSlashes(
+			`${ fromUrl }/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term`
+		);
+	}
+
+	return 'https://wordpress.org/plugins/migrate-guru/';
 };
 
 const getMigrateGuruPageURL = ( siteURL: string ) =>
@@ -69,7 +74,13 @@ const SiteMigrationInstructions: Step = function () {
 						'Install and activate the {{a}}Migrate Guru plugin{{/a}} on your existing site.',
 						{
 							components: {
-								a: <a href={ getInstallationURL( fromUrl ) } target="_blank" rel="noreferrer" />,
+								a: (
+									<a
+										href={ getPluginInstallationPage( fromUrl ) }
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
 							},
 						}
 					) }
@@ -79,7 +90,14 @@ const SiteMigrationInstructions: Step = function () {
 						'Go to the {{a}}Migrate Guru page on your source site{{/a}}, enter your email address, and click {{strong}}{{migrateButton /}}{{/strong}}.',
 						{
 							components: {
-								a: <a href={ getMigrateGuruPageURL( fromUrl ) } target="_blank" rel="noreferrer" />,
+								a: (
+									<MaybeLink
+										href={ fromUrl ? getMigrateGuruPageURL( fromUrl ) : undefined }
+										target="_blank"
+										rel="noreferrer"
+										fallback={ <strong /> }
+									/>
+								),
 								migrateButton: <DoNotTranslateIt value="Migrate" />,
 								strong: <strong />,
 							},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/maybe-link/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/maybe-link/index.tsx
@@ -1,0 +1,10 @@
+import { type FC, AnchorHTMLAttributes, ReactNode, cloneElement } from 'react';
+
+export const MaybeLink: FC<
+	AnchorHTMLAttributes< HTMLAnchorElement > & { fallback: ReactNode }
+> = ( { children, fallback, ...props } ) => {
+	if ( props.href ) {
+		return <a { ...props }>{ children }</a>;
+	}
+	return cloneElement( fallback as JSX.Element, { children, ...props } );
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -16,12 +16,16 @@ jest.mock( 'calypso/landing/stepper/hooks/use-site' );
 	ID: 'some-site-id',
 } );
 
+const FROM_URL = 'some-source-site-url.example.com';
+
 describe( 'SiteMigrationInstructions', () => {
-	const FROM_URL = 'some-source-site-url.example.com';
-	const render = ( props?: Partial< StepProps > ) => {
+	const render = (
+		props?: Partial< StepProps >,
+		initialEntry = `/some-path?from=${ FROM_URL }`
+	) => {
 		const combinedProps = { ...mockStepProps( props ) };
 		return renderStep( <SiteMigrationInstructions { ...combinedProps } />, {
-			initialEntry: `/some-path?from=${ FROM_URL }`,
+			initialEntry,
 		} );
 	};
 
@@ -37,6 +41,26 @@ describe( 'SiteMigrationInstructions', () => {
 		} );
 
 		expect( link ).toHaveAttribute( 'href', `${ FROM_URL }/wp-admin/admin.php?page=migrateguru` );
+	} );
+
+	it( 'render link to the wordpress.org when the from is not available', async () => {
+		render( {}, '/some-path' );
+
+		const link = await screen.findByRole( 'link', {
+			name: /Migrate Guru plugin/,
+		} );
+
+		expect( link ).toHaveAttribute( 'href', `https://wordpress.org/plugins/migrate-guru/` );
+	} );
+
+	it( 'render link to the wordpress.org when the from is empty', async () => {
+		render( {}, '/some-path?from=' );
+
+		const link = await screen.findByRole( 'link', {
+			name: /Migrate Guru plugin/,
+		} );
+
+		expect( link ).toHaveAttribute( 'href', `https://wordpress.org/plugins/migrate-guru/` );
 	} );
 
 	it( 'copies the migration key', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #89589

<img width="881" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/f7b4fe6f-32f7-4e8f-827b-14f091ba9e4e">



## Proposed Changes
* Use "https://wordpress.org/plugins/migrate-guru/" as "href" on the Migration guru plugin when the "From" is not available. 
*  Remove the link from the CTA "Migrate Guru page on your source site"


## Testing Instructions
- Access `/setup/site-migration/site-migration-instructions&siteSlug=[YOUR WPCOMSITE]&siteId=[YOUR_SITE_ID]`
- Check the Migrate Guru plugin link
- Check the `Migrate Guru page on your source site` doesn't have a link.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?