### PR TITLE
[Odie] Attempt to get user and avatar from Help Center wp-admin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,6 +120,10 @@
 /packages/wpcom.js/src/lib/domain.js @Automattic/nomado
 /packages/wpcom.js/src/lib/domains.js @Automattic/nomado
 
+# Odie chat client
+/packages/odie-client @Automattic/ @Automattic/applied-ai-team
+/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php @Automattic/ @Automattic/applied-ai-team
+
 # Plans
 /client/my-sites/plans-grid @Automattic/martech-decepticons
 /packages/plans-grid @Automattic/martech-decepticons

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,8 +121,8 @@
 /packages/wpcom.js/src/lib/domains.js @Automattic/nomado
 
 # Odie chat client
-/packages/odie-client @Automattic/ @Automattic/applied-ai-team
-/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php @Automattic/ @Automattic/applied-ai-team
+/packages/odie-client @Automattic/applied-ai-team
+/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php @Automattic/applied-ai-team
 
 # Plans
 /client/my-sites/plans-grid @Automattic/martech-decepticons

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,10 +120,6 @@
 /packages/wpcom.js/src/lib/domain.js @Automattic/nomado
 /packages/wpcom.js/src/lib/domains.js @Automattic/nomado
 
-# Odie chat client
-/packages/odie-client @Automattic/applied-ai-team
-/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php @Automattic/applied-ai-team
-
 # Plans
 /client/my-sites/plans-grid @Automattic/martech-decepticons
 /packages/plans-grid @Automattic/martech-decepticons

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -128,17 +128,13 @@ class Help_Center {
 		);
 
 		$current_user = wp_get_current_user();
-		$avatar_url   = \wpcom_get_avatar_url( $current_user->ID, 32 );
-		$user_data    = array(
-			'displayName' => $current_user->first_name,
-			'avatarUrl'   => $avatar_url,
-		);
 
 		wp_localize_script(
 			'help-center-script',
 			'odieUserData',
 			array(
-				'userData' => $user_data,
+				'displayName' => $current_user->data->display_name,
+				'email'       => $current_user->data->user_email,
 			)
 		);
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -128,7 +128,7 @@ class Help_Center {
 		);
 
 		$current_user = wp_get_current_user();
-		$avatar_url   = wpcom_get_avatar_url( $current_user->ID, 32 );
+		$avatar_url   = \wpcom_get_avatar_url( $current_user->ID, 32 );
 		$user_data    = array(
 			'displayName' => $current_user->first_name,
 			'avatarUrl'   => $avatar_url,

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -127,6 +127,21 @@ class Help_Center {
 			)
 		);
 
+		$current_user = wp_get_current_user();
+		$avatar_url   = wpcom_get_avatar_url( $current_user->ID, 32 );
+		$user_data    = array(
+			'displayName' => $current_user->first_name,
+			'avatarUrl'   => $avatar_url,
+		);
+
+		wp_localize_script(
+			'help-center-script',
+			'odieUserData',
+			array(
+				'userData' => $user_data,
+			)
+		);
+
 		wp_set_script_translations( 'help-center-script', 'full-site-editing' );
 	}
 

--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -38,7 +38,10 @@ const ChatMessage = (
 	const { botName, extraContactOptions, addMessage, trackEvent } = useOdieAssistantContext();
 	const [ scrolledToBottom, setScrolledToBottom ] = useState( false );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
-	const currentUser = useSelector( getCurrentUser ) ?? { display_name: 'Me' };
+	const currentUser = useSelector( getCurrentUser ) ?? {
+		display_name: window?.odieUserData?.displayName ?? 'Me',
+		avatar_URL: window?.odieUserData?.avatarUrl,
+	};
 	const translate = useTranslate();
 
 	const realTimeMessage = useTyper( message.content, ! isUser && message.type === 'message', {

--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -40,7 +40,6 @@ const ChatMessage = (
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const currentUser = useSelector( getCurrentUser ) ?? {
 		display_name: window?.odieUserData?.displayName ?? 'Me',
-		avatar_URL: window?.odieUserData?.avatarUrl,
 	};
 	const translate = useTranslate();
 

--- a/packages/odie-client/types/index.d.ts
+++ b/packages/odie-client/types/index.d.ts
@@ -73,3 +73,10 @@ declare module 'calypso/components/async-load' {
 
 	export default AsyncLoad;
 }
+
+interface Window {
+	odieUserData: {
+		displayName: string;
+		avatarUrl?: string;
+	};
+}

--- a/packages/odie-client/types/index.d.ts
+++ b/packages/odie-client/types/index.d.ts
@@ -77,6 +77,6 @@ declare module 'calypso/components/async-load' {
 interface Window {
 	odieUserData: {
 		displayName: string;
-		avatarUrl?: string;
+		email?: string;
 	};
 }


### PR DESCRIPTION
This patch adds name in the Odie Client when chatting with Wapuu

## Proposed Changes

Add user display name for the Odie client when used through wp-admin

## Testing Instructions

Install the ETK Plugin via a creator plan

1. Go to a wp-admin screen
2. Set in the URL ?flags=wapuu
3. Open Help Center
4. Click Still Need Help
5. Chat with Wapuu
6. Assert that the name for your user si the one that correspond to your "display_name" in WordPress

## Pre-merge Checklist
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?