### PR TITLE
A4A: Extend the site row's clickable area when in preview mode.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -336,6 +336,26 @@
 					width: 100%;
 				}
 
+				/* This styling is a bit of a hack: To make the site name clickable area larger, will need
+				 * to hide the other fields when in preview mode.
+				 */
+				.dataviews-view-list__field {
+					// Hide the field except first (Site name) and last (actions menu)
+					&:not(:first-child):not(:last-child) {
+						display: none;
+					}
+
+					// Force the site name to take up the full width
+					&:first-child {
+						flex-grow: 1;
+
+						.sites-dataviews__site {
+							width: 100%;
+							justify-content: flex-start;
+						}
+					}
+				}
+
 				.sites-overview__stats-trend,
 				.sites-overview__column-action-button,
 				.sites-overview__row-status,


### PR DESCRIPTION
The clickable area on the Site row during preview mode does not fully extend, which makes it harder for user to select a site without precisely clicking the name.


<img width="454" alt="image" src="https://github.com/Automattic/automattic-for-agencies-dev/assets/390760/b2087a81-1a96-4ab4-891e-32b694f0a6dc">

Closes  https://github.com/Automattic/automattic-for-agencies-dev/issues/230

## Proposed Changes
* The PR overrides the Site name column to fully expand in preview mode. 
* Currently, we only hide column contents not part of the selector during preview mode, but not the container that wraps it. This prevents the Site name column from expanding as these containers consume flex gaps. This PR fixes this by hiding those containers entirely.

## Testing Instructions

* Use the A4A live link below and go to /sites
* Click any sites to reveal the Preview mode.
* Now click any Site area outside the Site name and confirm that the click triggers the site switch.
<img width="372" alt="Screenshot 2024-04-17 at 9 17 19 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4ac88f33-2d04-40b4-91e5-7a50d34d0bf8">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?