### PR TITLE
BIG SKy: Enable the onboarding flow on staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -20,7 +20,7 @@
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/ai-blogging-prompts": false,
-		"calypso/ai-assembler": false,
+		"calypso/ai-assembler": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,


### PR DESCRIPTION
This enables the ai-assembler flow on the staging environment.

This is to allow Automatticians to test with this redirect which does not properly handle wpcalypso:

<img width="904" alt="Zrzut ekranu 2024-04-16 o 10 05 32" src="https://github.com/Automattic/wp-calypso/assets/3775068/1c51aa10-cde0-42c8-b586-6d99ea676c9a">
