### PR TITLE
Upsell Nudge: reduce excessive loading placeholders

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -74,6 +74,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 			planDiscountedRawPrice,
 			currencyCode,
 			hasSevenDayRefundPeriod,
+			isLoading,
 		} = this.props;
 		return (
 			<>
@@ -148,10 +149,13 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 					</p>
 					<p>
 						{ translate(
-							'Simply click below to upgrade. You’ll only have to pay the difference to the %(planName)s Plan ({{del}}%(fullPrice)s{{/del}} %(discountPrice)s).',
+							'Simply click below to upgrade. You’ll only have to pay the difference to the %(planName)s Plan {{PriceWrapper}}({{del}}%(fullPrice)s{{/del}} %(discountPrice)s).{{/PriceWrapper}}',
 							{
 								components: {
 									del: <del />,
+									PriceWrapper: (
+										<span className={ isLoading ? 'upsell-nudge__small-placeholder' : '' } />
+									),
 								},
 								args: {
 									fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
@@ -170,12 +174,13 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 	}
 
 	footer() {
-		const { translate, handleClickAccept, handleClickDecline } = this.props;
+		const { translate, handleClickAccept, handleClickDecline, isLoading } = this.props;
 		return (
 			<footer>
 				<Button
 					primary
 					className="business-plan-upgrade-upsell-new-design__accept-offer-button"
+					busy={ isLoading }
 					onClick={ () => handleClickAccept( 'accept' ) }
 				>
 					{ translate( 'Upgrade Now' ) }

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -183,7 +183,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 					busy={ isLoading }
 					onClick={ () => handleClickAccept( 'accept' ) }
 				>
-					{ translate( 'Upgrade Now' ) }
+					{ isLoading ? translate( 'Loading' ) : translate( 'Upgrade Now' ) }
 				</Button>
 				<Button
 					data-e2e-button="decline"

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -231,9 +231,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				);
 
 			case BUSINESS_PLAN_UPGRADE_UPSELL:
-				return isLoading ? (
-					this.renderGenericPlaceholder()
-				) : (
+				return (
 					<BusinessPlanUpgradeUpsell
 						currencyCode={ currencyCode }
 						planRawPrice={ planRawPrice }
@@ -243,6 +241,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }
 						hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
+						isLoading={ isLoading }
 					/>
 				);
 			case PROFESSIONAL_EMAIL_UPSELL:

--- a/client/my-sites/checkout/upsell-nudge/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/style.scss
@@ -11,6 +11,12 @@
 	}
 }
 
+.upsell-nudge__small-placeholder {
+	animation: pulse-light 800ms ease-in-out infinite;
+	background: var(--color-neutral-10);
+	color: transparent;
+}
+
 .upsell-nudge__placeholder-row {
 	height: 40px;
 	flex: 0 0 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2907

## Proposed Changes

* This PR removes the excessive loading placeholders from the post-checkout Creator plan upsell. Now, the placeholder will only show where the price text is.

Note: This component also needs a cleanup since the quick start product is no longer in use.

**Production:**

https://github.com/Automattic/wp-calypso/assets/5436027/0194863c-44e5-4ada-9a9c-b5921b579cb6

**This PR:**

https://github.com/Automattic/wp-calypso/assets/5436027/575c5b6c-a87c-48aa-8f0c-a1314dc08590



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/checkout/<site slug>/offer-plan-upgrade/business/12345` for a site on the Explorer plan.
* Confirm that the loading placeholders are not shown and are only shown for the price. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?