### PR TITLE
Hosting Overview page: Fix add domain link

### DIFF
--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -4,8 +4,10 @@ import { DomainsTable } from '@automattic/domains-table';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
+import { navigate } from 'calypso/lib/navigate';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { setRoute } from 'calypso/state/route/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const ActiveDomainsCard: FC = () => {
@@ -14,6 +16,7 @@ const ActiveDomainsCard: FC = () => {
 		queryFn: () => fetchSiteDomains( site?.ID ),
 	} );
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	return (
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__active-domains' ) }>
@@ -26,7 +29,10 @@ const ActiveDomainsCard: FC = () => {
 						'hosting-overview__mobile-hidden-link-button'
 					) }
 					plain
-					href={ `/domains/add/${ site?.slug }` }
+					onClick={ () => {
+						navigate( `/domains/add/${ site?.slug }` );
+						dispatch( setRoute( `/domains/add/${ site?.slug }`, { from: 'foo' } ) );
+					} }
 				>
 					{ translate( 'Add new domain' ) }
 				</Button>

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -26,7 +26,7 @@ const ActiveDomainsCard: FC = () => {
 						'hosting-overview__mobile-hidden-link-button'
 					) }
 					plain
-					href="/start/domain"
+					href={ `/domains/add/${ site?.slug }` }
 				>
 					{ translate( 'Add new domain' ) }
 				</Button>

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -26,7 +26,7 @@ const ActiveDomainsCard: FC = () => {
 						'hosting-overview__mobile-hidden-link-button'
 					) }
 					plain
-					href={ `/domains/add/${ site?.slug }` }
+					href={ `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }` }
 				>
 					{ translate( 'Add new domain' ) }
 				</Button>

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -4,10 +4,8 @@ import { DomainsTable } from '@automattic/domains-table';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
-import { navigate } from 'calypso/lib/navigate';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
-import { useDispatch, useSelector } from 'calypso/state';
-import { setRoute } from 'calypso/state/route/actions';
+import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const ActiveDomainsCard: FC = () => {
@@ -16,7 +14,6 @@ const ActiveDomainsCard: FC = () => {
 		queryFn: () => fetchSiteDomains( site?.ID ),
 	} );
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	return (
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__active-domains' ) }>
@@ -29,10 +26,7 @@ const ActiveDomainsCard: FC = () => {
 						'hosting-overview__mobile-hidden-link-button'
 					) }
 					plain
-					onClick={ () => {
-						navigate( `/domains/add/${ site?.slug }` );
-						dispatch( setRoute( `/domains/add/${ site?.slug }`, { from: 'foo' } ) );
-					} }
+					href={ `/domains/add/${ site?.slug }` }
 				>
 					{ translate( 'Add new domain' ) }
 				</Button>

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -64,6 +64,7 @@
 	line-height: 32px;
 }
 
+.hosting-overview__link-button,
 a.hosting-overview__link-button {
 	color: var(--Primary-Blue, #007cba);
 	font-family: "SF Pro Text", $sans;
@@ -83,6 +84,10 @@ a.hosting-overview__link-button {
 	display: flex;
 	gap: var(--grid-unit-15, 12px);
 	margin-bottom: 16px;
+}
+
+.hosting-overview__active-domains-card-header {
+	align-items: center;
 }
 
 .hosting-overview__card-title {

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -64,7 +64,6 @@
 	line-height: 32px;
 }
 
-.hosting-overview__link-button,
 a.hosting-overview__link-button {
 	color: var(--Primary-Blue, #007cba);
 	font-family: "SF Pro Text", $sans;
@@ -84,10 +83,6 @@ a.hosting-overview__link-button {
 	display: flex;
 	gap: var(--grid-unit-15, 12px);
 	margin-bottom: 16px;
-}
-
-.hosting-overview__active-domains-card-header {
-	align-items: center;
 }
 
 .hosting-overview__card-title {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -239,11 +239,18 @@ class DomainSearch extends Component {
 	}
 
 	getBackButtonHref() {
-		const { selectedSiteSlug, currentRoute, isFromMyHome } = this.props;
+		const {
+			context: { query },
+			selectedSiteSlug,
+			currentRoute,
+			isFromMyHome,
+		} = this.props;
 
 		// If we have the from query param, we should use that as the back button href
 		if ( isFromMyHome ) {
 			return `/home/${ selectedSiteSlug }`;
+		} else if ( query?.redirect_to ) {
+			return query.redirect_to;
 		}
 
 		return domainManagementList( selectedSiteSlug, currentRoute );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6384

## Proposed Changes

* Make the `Add domain link` go to `/domains/add/{SITE-URL}`, as mentioned on https://github.com/Automattic/wp-calypso/pull/89476#issuecomment-2059177300

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/hosting-overview`
* On the `Active domains` card, click on `Add new domain`
* Check that it takes you to `/domains/add/{SITE-URL}`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?