### PR TITLE
Gravatar: Hide the unsubscribe / resubscribe button and the manage link from the unsubscribe page

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -256,6 +256,7 @@ class MainComponent extends Component {
 		const messageLabel = this.state.isSubscribed
 			? translate( "We'll send you updates for this mailing list." )
 			: translate( 'You will no longer receive updates for this mailing list.' );
+		const categoryName = this.getCategoryName();
 
 		return (
 			<div className="mailing-lists">
@@ -266,34 +267,40 @@ class MainComponent extends Component {
 					<p>{ preventWidows( messageLabel, 2 ) }</p>
 				</div>
 
-				<Card className="mailing-lists__details">
-					<h4>{ this.getCategoryName() }</h4>
-					<p>{ this.getCategoryDescription() }</p>
-					{ this.state.isSubscribed ? (
-						<button
-							className="mailing-lists__unsubscribe-button button is-primary"
-							onClick={ this.onUnsubscribeClick }
-						>
-							{ translate( 'Unsubscribe' ) }
-						</button>
-					) : (
-						<button
-							className="mailing-lists__resubscribe-button button"
-							onClick={ this.onResubscribeClick }
-						>
-							{ translate( 'Resubscribe' ) }
-						</button>
-					) }
-				</Card>
-
-				<p className="mailing-lists__manage-link">
-					<button
-						className="mailing-lists__manage-button button is-link"
-						onClick={ this.onManageUpdatesClick }
-					>
-						{ translate( 'Manage all your email subscriptions' ) }
-					</button>
-				</p>
+				{
+					// Don't show the unsubscribe / resubscribe button and the manage link for Gravatar.
+					! categoryName.startsWith( 'gravatar_' ) && (
+						<>
+							<Card className="mailing-lists__details">
+								<h4>{ categoryName }</h4>
+								<p>{ this.getCategoryDescription() }</p>
+								{ this.state.isSubscribed ? (
+									<button
+										className="mailing-lists__unsubscribe-button button is-primary"
+										onClick={ this.onUnsubscribeClick }
+									>
+										{ translate( 'Unsubscribe' ) }
+									</button>
+								) : (
+									<button
+										className="mailing-lists__resubscribe-button button"
+										onClick={ this.onResubscribeClick }
+									>
+										{ translate( 'Resubscribe' ) }
+									</button>
+								) }
+							</Card>
+							<p className="mailing-lists__manage-link">
+								<button
+									className="mailing-lists__manage-button button is-link"
+									onClick={ this.onManageUpdatesClick }
+								>
+									{ translate( 'Manage all your email subscriptions' ) }
+								</button>
+							</p>
+						</>
+					)
+				}
 			</div>
 		);
 	}

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -269,7 +269,7 @@ class MainComponent extends Component {
 
 				{
 					// Don't show the unsubscribe / resubscribe button and the manage link for Gravatar-related categories.
-					! categoryName.startsWith( 'gravatar_' ) && (
+					! categoryName?.startsWith( 'gravatar_' ) && (
 						<>
 							<Card className="mailing-lists__details">
 								<h4>{ categoryName }</h4>

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -268,7 +268,7 @@ class MainComponent extends Component {
 				</div>
 
 				{
-					// Don't show the unsubscribe / resubscribe button and the manage link for Gravatar.
+					// Don't show the unsubscribe / resubscribe button and the manage link for Gravatar-related categories.
 					! categoryName.startsWith( 'gravatar_' ) && (
 						<>
 							<Card className="mailing-lists__details">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 107576-gh-Automattic/gravatar

## Proposed Changes

* Hide the unsubscribe / resubscribe button and the manage link from the unsubscribe page for Gravatar-related email categories

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On the unsubscribe page, we rely on the URL's `category` parameter to display the relevant UI info for each email category. Similarly, this PR uses the parameter to hide UI elements for Gravatar-related email categories. So we can test the PR by:

* Modify [the isSubscribed](https://github.com/Automattic/wp-calypso/blob/trunk/client/mailing-lists/main.jsx#L15) as `false` to enable the "unsubscribed mode"
* Run Calypso by referring to [the doc](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started)
* Go to: http://calypso.localhost:3000/mailing-lists/unsubscribe?category=gravatar_onboarding, you will see the UI below:

<img width="1218" alt="截圖 2024-04-17 晚上10 22 15" src="https://github.com/Automattic/wp-calypso/assets/21308003/3abc57f6-fc43-4ee9-aef3-a08c9798684e">

* For other email categories, still work the same (as shown below), e.g. http://calypso.localhost:3000/mailing-lists/unsubscribe?category=marketing
  * We can test more categories by referring to [the relevant code](https://github.com/Automattic/wp-calypso/blob/trunk/client/mailing-lists/main.jsx#L93-L129)

<img width="1217" alt="截圖 2024-04-17 晚上10 38 15" src="https://github.com/Automattic/wp-calypso/assets/21308003/4cf51f9a-6b8f-4679-b71d-537abc184f00">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
