### PR TITLE
Stats: Avoid conflict array item keys by the Home page

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -153,7 +153,7 @@ const StatsListCard = ( {
 					{ data?.map( ( item, index ) => {
 						const leftSideItem = generateLeftItem( item );
 						const isInteractive = item?.link || item?.page || item?.children;
-						const key = item?.id || index; // not every item has an id
+						const key = item?.id ?? index; // not every item has an id
 
 						return (
 							<HorizontalBarListItem

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -173,7 +173,7 @@ const HorizontalBarListItem = ( {
 
 							return (
 								<HorizontalBarListItem
-									key={ `group-${ child?.id || index }` }
+									key={ `group-${ child?.id ?? index }` }
 									data={ child }
 									className={ className }
 									maxValue={ maxValue }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Use the array index as the item key only when the id is `null` or `undefined` rather than `0` to avoid an unexpected conflict between index and key, like showing the Home page (post id is 0) as an item.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change on the local Calypso.
* Navigate to the Stats > Traffic page.
* Ensure there is no console error `Warning: Encountered two children with the same key...` when the Home page occurs in any module made of the `StatsListCard`.

<img width="1118" alt="截圖 2024-04-17 下午11 17 36" src="https://github.com/Automattic/wp-calypso/assets/6869813/776f8845-45ea-42de-a96b-844e714a513e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?