### PR TITLE
Entrepreneur Trial: Cummulative fixes for entrepreneur signup flow.

### DIFF
--- a/client/data/ecommerce/use-add-ecommerce-trial-mutation.ts
+++ b/client/data/ecommerce/use-add-ecommerce-trial-mutation.ts
@@ -1,0 +1,26 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+
+interface Variables {
+	siteId: number;
+}
+
+export default function useAddEcommerceTrialMutation(
+	options: UseMutationOptions< unknown, unknown, Variables > = {}
+) {
+	const mutation = useMutation( {
+		mutationFn: async ( { siteId }: Variables ) => {
+			await wp.req.post( `/sites/${ siteId }/ecommerce-trial/add/ecommerce-trial-bundle-monthly`, {
+				apiVersion: '1.1',
+			} );
+		},
+		...options,
+	} );
+
+	const { mutate } = mutation;
+
+	const addEcommerceTrial = useCallback( ( siteId: number ) => mutate( { siteId } ), [ mutate ] );
+
+	return { addEcommerceTrial, ...mutation };
+}

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -66,7 +66,6 @@ const entrepreneurFlow: Flow = {
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
 			recordSubmitStep( providedDependencies, '' /* intent */, flowName, currentStep );
 
-			// Steps pre-site creation
 			switch ( currentStep ) {
 				case 'start': {
 					if ( userIsLoggedIn ) {

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -1,15 +1,13 @@
 import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useFlowLocale } from '../hooks/use-flow-locale';
-import { useSiteSlugParam } from '../hooks/use-site-slug-param';
-import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
-import { AssignTrialResult } from './internals/steps-repository/assign-trial-plan/constants';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import type { Flow, ProvidedDependencies } from './internals/types';
-import type { SiteSelect, UserSelect } from '@automattic/data-stores';
+import type { UserSelect } from '@automattic/data-stores';
 
 const entrepreneurFlow: Flow = {
 	name: ENTREPRENEUR_FLOW,
@@ -23,7 +21,6 @@ const entrepreneurFlow: Flow = {
 			{ ...STEPS.SEGMENTATION_SURVEY, ...{ slug: 'start' } },
 			STEPS.SITE_CREATION_STEP,
 			STEPS.PROCESSING,
-			STEPS.ASSIGN_TRIAL_PLAN, // TODO: See if this can be combined with addHostingTrial
 			STEPS.WAIT_FOR_ATOMIC,
 			STEPS.WAIT_FOR_PLUGIN_INSTALL,
 			STEPS.ERROR,
@@ -33,15 +30,8 @@ const entrepreneurFlow: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 
-		const siteSlugParam = useSiteSlugParam();
-
 		const { setPluginsToVerify } = useDispatch( ONBOARD_STORE );
 		setPluginsToVerify( [ 'woocommerce' ] );
-
-		const { getSiteIdBySlug, getSiteOption } = useSelect(
-			( select ) => select( SITE_STORE ) as SiteSelect,
-			[]
-		);
 
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
@@ -73,17 +63,10 @@ const entrepreneurFlow: Flow = {
 			return loginUrl + ( flags ? `&flags=${ flags }` : '' );
 		};
 
-		const exitFlow = ( to: string ) => {
-			window.location.assign( to );
-		};
-
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
 			recordSubmitStep( providedDependencies, '' /* intent */, flowName, currentStep );
 
-			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
-			const siteId = getSiteIdBySlug( siteSlug );
-			const adminUrl = siteId && getSiteOption( siteId, 'admin_url' );
-
+			// Steps pre-site creation
 			switch ( currentStep ) {
 				case 'start': {
 					if ( userIsLoggedIn ) {
@@ -108,34 +91,28 @@ const entrepreneurFlow: Flow = {
 						return navigate( 'error' );
 					}
 
+					const { siteId, siteSlug } = providedDependencies;
+
 					if ( providedDependencies?.finishedWaitingForAtomic ) {
 						return navigate( 'waitForPluginInstall', { siteId, siteSlug } );
 					}
 
 					if ( providedDependencies?.pluginsInstalled ) {
-						// Redirect users to the login page with the 'action=jetpack-sso' parameter to initiate Jetpack SSO login and redirect them to Woo CYS's Design With AI after.
+						const stagingUrl = ( siteSlug as string ).replace(
+							'.wordpress.com',
+							'.wpcomstaging.com'
+						);
 
-						// TODO: This is currently not working. Need to investigate in further PR.
+						// TODO: The cause of redirection failure is within Jetpack SSO.
+						// Remove this comment after Jetpack SSO is fixed.
 						const redirectTo = encodeURIComponent(
-							`${
-								adminUrl as string
-							}admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai&ref=wpcom-entrepreneur-signup`
+							`https://${ stagingUrl }/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai&ref=wpcom-entrepreneur-signup`
 						);
 
-						return exitFlow(
-							`//${ siteSlug }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`
-						);
-					}
+						// Redirect users to the login page with the 'action=jetpack-sso' parameter to initiate Jetpack SSO login and redirect them to Woo CYS's Design With AI after.
+						const redirectToWithSSO = `https://${ stagingUrl }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`;
 
-					return navigate( 'assignTrialPlan', { siteSlug } );
-				}
-
-				// TODO: See if this can be combined with addHostingTrial
-				case 'assignTrialPlan': {
-					const assignTrialResult = params[ 0 ] as AssignTrialResult;
-
-					if ( assignTrialResult === AssignTrialResult.FAILURE ) {
-						return navigate( 'error' );
+						return window.location.assign( redirectToWithSSO );
 					}
 
 					return navigate( 'waitForAtomic', { siteId, siteSlug } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -1,4 +1,4 @@
-import { isWooExpressFlow, isEntrepreneurFlow, StepContainer } from '@automattic/onboarding';
+import { isWooExpressFlow, StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
@@ -25,19 +25,6 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getProfilerData(), [] ) ||
 		{};
 
-	let requestBody = {};
-
-	if ( isWooExpressFlow( flow ) ) {
-		requestBody = {
-			wpcom_woocommerce_onboarding: profilerData,
-		};
-	}
-
-	if ( isEntrepreneurFlow( flow ) ) {
-		// TODO: Add WPCOM marker.
-		requestBody = {};
-	}
-
 	useEffect( () => {
 		if ( submit ) {
 			const assignTrialPlan = async () => {
@@ -51,7 +38,9 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						{
 							apiVersion: '1.1',
 						},
-						requestBody
+						{
+							wpcom_woocommerce_onboarding: profilerData,
+						}
 					);
 
 					submit?.( { siteSlug: data?.siteSlug }, AssignTrialResult.SUCCESS );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -31,6 +31,7 @@ import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation';
 import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
@@ -68,6 +69,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const { mutateAsync: addHostingTrial } = useAddHostingTrialMutation();
+	const { mutateAsync: addEcommerceTrial } = useAddEcommerceTrialMutation();
 
 	const urlData = useSelector( getUrlData );
 
@@ -197,6 +199,16 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 
 		if ( planCartItem?.product_slug === PLAN_HOSTING_TRIAL_MONTHLY && site ) {
 			await addHostingTrial( { siteId: site.siteId, planSlug: PLAN_HOSTING_TRIAL_MONTHLY } );
+
+			return {
+				siteId: site.siteId,
+				siteSlug: site.siteSlug,
+				goToCheckout: false,
+			};
+		}
+
+		if ( isEntrepreneurFlow( flow ) && site ) {
+			await addEcommerceTrial( { siteId: site.siteId } );
 
 			return {
 				siteId: site.siteId,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -117,7 +117,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
 			}
 
-			return { finishedWaitingForAtomic: true, siteSlug: data?.siteSlug };
+			return { finishedWaitingForAtomic: true, siteId, siteSlug: data?.siteSlug };
 		} );
 
 		submit?.();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix site creation loading flickering into assignTrialPlan step by:
  * Moving trial assignment logic into site creation step.
  * Introducing `useAddEcommerceTrialMutation`.
* Prevent calling `/sites` endpoint unnecessarily by:
  * Getting `waitForAtomic` site to pass also `siteId` back into the `providedDependencies` to prevent the need to requery siteId.
  * Removing the need for siteSlug fallback from url param.
* Enforce the use of staging url when redirecting out of the signup flow.

## Testing Instructions

* Go to `/setup/entrepreneur`.
* Test sign up for both scenarios:
  * As a new user (signup)
  * As a logged-out user. (login)
  * As a logged-in user. (straight to site creation step)
* You should not see a flicker during site creation step.
* You should be able to create a site successfully.
* You should land in `wp-admin/admin.php?page=wc-admin`.

**Important:**
 * Ensure `public-api.wordpress.com` is not sandboxed because the `waitForPluginsInstalled` step needs to retrieve list of plugins from the staging site which sandbox is unable to connect to.

## Known Issues

**Redirection issue:**
Redirect to DesignWithAI to be addressed in 2 places:
   * in the CYS code (see https://github.com/woocommerce/woocommerce/pull/46528)
   * in the Jetpack SSO code, something must've stripped off the `redirect_to` cookie (see [https://github.com/Automattic/jetpack/pull/33940](https://github.com/Automattic/jetpack/pull/33940/files))

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?