### PR TITLE
A4A: in sidebar move item creation to separate hooks

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -1,0 +1,89 @@
+import { category, currencyDollar, home, reusableBlock, tag } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { isSectionNameEnabled } from 'calypso/sections-filter';
+import {
+	A4A_MARKETPLACE_LINK,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_LICENSES_LINK,
+	A4A_OVERVIEW_LINK,
+	A4A_PURCHASES_LINK,
+	A4A_REFERRALS_LINK,
+	A4A_SITES_LINK,
+} from '../lib/constants';
+import { createItem } from '../lib/utils';
+
+const useMainMenuItems = ( path: string ) => {
+	const translate = useTranslate();
+	const menuItems = useMemo( () => {
+		return [
+			{
+				icon: home,
+				path: '/',
+				link: A4A_OVERVIEW_LINK,
+				title: translate( 'Overview' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Overview',
+				},
+			},
+			{
+				icon: category,
+				path: '/',
+				link: A4A_SITES_LINK,
+				title: translate( 'Sites' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Dashboard',
+				},
+				withChevron: true,
+			},
+			/*
+			// Hide this section until we support plugin management in A4A
+			{
+				icon: plugins,
+				path: '/',
+				link: A4A_PLUGINS_LINK,
+				title: translate( 'Plugins' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Plugins',
+				},
+			},
+			*/
+			{
+				icon: tag,
+				path: A4A_MARKETPLACE_LINK,
+				link: A4A_MARKETPLACE_PRODUCTS_LINK,
+				title: translate( 'Marketplace' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Marketplace',
+				},
+				withChevron: true,
+			},
+			{
+				icon: currencyDollar,
+				path: A4A_PURCHASES_LINK,
+				link: A4A_LICENSES_LINK,
+				title: translate( 'Purchases' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Purchases',
+				},
+				withChevron: true,
+			},
+			...( isSectionNameEnabled( 'a8c-for-agencies-referrals' )
+				? [
+						{
+							icon: reusableBlock,
+							path: '/',
+							link: A4A_REFERRALS_LINK,
+							title: translate( 'Referrals' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Referrals',
+							},
+						},
+				  ]
+				: [] ),
+		].map( ( item ) => createItem( item, path ) );
+	}, [ path, translate ] );
+	return menuItems;
+};
+
+export default useMainMenuItems;

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-marketplace-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-marketplace-menu-items.ts
@@ -1,0 +1,44 @@
+import { tool, plugins } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import {
+	A4A_MARKETPLACE_LINK,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_MARKETPLACE_HOSTING_LINK,
+} from '../lib/constants';
+import { createItem } from '../lib/utils';
+
+const useMarketplaceMenuItems = ( path: string ) => {
+	const translate = useTranslate();
+	const menuItems = useMemo( () => {
+		return [
+			createItem(
+				{
+					icon: plugins,
+					path: A4A_MARKETPLACE_LINK,
+					link: A4A_MARKETPLACE_PRODUCTS_LINK,
+					title: translate( 'Products' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Marketplace / Products',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: tool,
+					path: A4A_MARKETPLACE_LINK,
+					link: A4A_MARKETPLACE_HOSTING_LINK,
+					title: translate( 'Hosting' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Marketplace / Hosting',
+					},
+				},
+				path
+			),
+		].map( ( item ) => createItem( item, path ) );
+	}, [ path, translate ] );
+	return menuItems;
+};
+
+export default useMarketplaceMenuItems;

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-purchases-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-purchases-menu-items.ts
@@ -1,0 +1,70 @@
+import { store, key, payment, receipt } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import {
+	A4A_BILLING_LINK,
+	A4A_INVOICES_LINK,
+	A4A_LICENSES_LINK,
+	A4A_PAYMENT_METHODS_LINK,
+	A4A_PURCHASES_LINK,
+} from '../lib/constants';
+import { createItem } from '../lib/utils';
+
+const usePurchasesMenuItems = ( path: string ) => {
+	const translate = useTranslate();
+	const menuItems = useMemo( () => {
+		return [
+			createItem(
+				{
+					icon: key,
+					path: A4A_PURCHASES_LINK,
+					link: A4A_LICENSES_LINK,
+					title: translate( 'Licenses' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Purchases / Licenses',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: store,
+					path: A4A_PURCHASES_LINK,
+					link: A4A_BILLING_LINK,
+					title: translate( 'Billing' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Purchases / Billing',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: payment,
+					path: A4A_PURCHASES_LINK,
+					link: A4A_PAYMENT_METHODS_LINK,
+					title: translate( 'Payment Methods' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Purchases / Payment Methods',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: receipt,
+					path: A4A_PURCHASES_LINK,
+					link: A4A_INVOICES_LINK,
+					title: translate( 'Invoices' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Purchases / Invoices',
+					},
+				},
+				path
+			),
+		].map( ( item ) => createItem( item, path ) );
+	}, [ path, translate ] );
+	return menuItems;
+};
+
+export default usePurchasesMenuItems;

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -1,0 +1,78 @@
+import { category, starEmpty, warning } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
+import {
+	A4A_SITES_LINK,
+	A4A_SITES_LINK_FAVORITE,
+	A4A_SITES_LINK_NEEDS_ATTENTION,
+} from '../lib/constants';
+import { createItem } from '../lib/utils';
+
+const useSitesMenuItems = ( path: string ) => {
+	const translate = useTranslate();
+	const noActiveSite = useNoActiveSite();
+
+	return useMemo( () => {
+		if ( noActiveSite ) {
+			// We hide the rest of the options when we do not have sites yet.
+			return [
+				createItem(
+					{
+						id: 'sites-all-menu-item',
+						icon: category,
+						path: A4A_SITES_LINK,
+						link: A4A_SITES_LINK,
+						title: translate( 'All' ),
+						trackEventProps: {
+							menu_item: 'Automattic for Agencies / Sites / All',
+						},
+					},
+					path
+				),
+			];
+		}
+
+		return [
+			createItem(
+				{
+					icon: warning,
+					path: A4A_SITES_LINK,
+					link: A4A_SITES_LINK_NEEDS_ATTENTION,
+					title: translate( 'Needs Attention' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Sites / Needs Attention',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: starEmpty,
+					path: A4A_SITES_LINK,
+					link: A4A_SITES_LINK_FAVORITE,
+					title: translate( 'Favorites' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Sites / Favorites',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					id: 'sites-all-menu-item',
+					icon: category,
+					path: A4A_SITES_LINK,
+					link: A4A_SITES_LINK,
+					title: translate( 'All' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Sites / All',
+					},
+				},
+				path
+			),
+		].map( ( item ) => createItem( item, path ) );
+	}, [ noActiveSite, path, translate ] );
+};
+
+export default useSitesMenuItems;

--- a/client/a8c-for-agencies/components/sidebar-menu/main.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/main.tsx
@@ -1,93 +1,12 @@
-import { category, home, tag, currencyDollar, reusableBlock } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
-import { isSectionNameEnabled } from 'calypso/sections-filter';
 import Sidebar from '../sidebar';
-import {
-	A4A_OVERVIEW_LINK,
-	A4A_SITES_LINK,
-	A4A_MARKETPLACE_LINK,
-	A4A_PURCHASES_LINK,
-	A4A_LICENSES_LINK,
-	A4A_MARKETPLACE_PRODUCTS_LINK,
-	A4A_REFERRALS_LINK,
-} from './lib/constants';
-import { createItem } from './lib/utils';
+import useMainMenuItems from './hooks/use-main-menu-items';
 
 type Props = {
 	path: string;
 };
 
 export default function ( { path }: Props ) {
-	const translate = useTranslate();
-	const menuItems = useMemo( () => {
-		return [
-			{
-				icon: home,
-				path: '/',
-				link: A4A_OVERVIEW_LINK,
-				title: translate( 'Overview' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Overview',
-				},
-			},
-			{
-				icon: category,
-				path: '/',
-				link: A4A_SITES_LINK,
-				title: translate( 'Sites' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Dashboard',
-				},
-				withChevron: true,
-			},
-			/*
-			// Hide this section until we support plugin management in A4A
-			{
-				icon: plugins,
-				path: '/',
-				link: A4A_PLUGINS_LINK,
-				title: translate( 'Plugins' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Plugins',
-				},
-			},
-			*/
-			{
-				icon: tag,
-				path: A4A_MARKETPLACE_LINK,
-				link: A4A_MARKETPLACE_PRODUCTS_LINK,
-				title: translate( 'Marketplace' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Marketplace',
-				},
-				withChevron: true,
-			},
-			{
-				icon: currencyDollar,
-				path: A4A_PURCHASES_LINK,
-				link: A4A_LICENSES_LINK,
-				title: translate( 'Purchases' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Purchases',
-				},
-				withChevron: true,
-			},
-			...( isSectionNameEnabled( 'a8c-for-agencies-referrals' )
-				? [
-						{
-							icon: reusableBlock,
-							path: '/',
-							link: A4A_REFERRALS_LINK,
-							title: translate( 'Referrals' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Referrals',
-							},
-						},
-				  ]
-				: [] ),
-		].map( ( item ) => createItem( item, path ) );
-	}, [ path, translate ] );
+	const menuItems = useMainMenuItems( path );
 
 	return <Sidebar path="" menuItems={ menuItems } withUserProfileFooter />;
 }

--- a/client/a8c-for-agencies/components/sidebar-menu/marketplace.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/marketplace.tsx
@@ -1,16 +1,9 @@
 import page from '@automattic/calypso-router';
-import { chevronLeft, plugins, tool } from '@wordpress/icons';
+import { chevronLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import Sidebar from '../sidebar';
-import {
-	A4A_OVERVIEW_LINK,
-	A4A_PURCHASES_LINK,
-	A4A_MARKETPLACE_LINK,
-	A4A_MARKETPLACE_PRODUCTS_LINK,
-	A4A_MARKETPLACE_HOSTING_LINK,
-} from './lib/constants';
-import { createItem } from './lib/utils';
+import useMarketplaceMenuItems from './hooks/use-marketplace-menu-items';
+import { A4A_OVERVIEW_LINK, A4A_PURCHASES_LINK } from './lib/constants';
 
 type Props = {
 	path: string;
@@ -18,35 +11,7 @@ type Props = {
 
 export default function ( { path }: Props ) {
 	const translate = useTranslate();
-
-	const menuItems = useMemo( () => {
-		return [
-			createItem(
-				{
-					icon: plugins,
-					path: A4A_MARKETPLACE_LINK,
-					link: A4A_MARKETPLACE_PRODUCTS_LINK,
-					title: translate( 'Products' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Marketplace / Products',
-					},
-				},
-				path
-			),
-			createItem(
-				{
-					icon: tool,
-					path: A4A_MARKETPLACE_LINK,
-					link: A4A_MARKETPLACE_HOSTING_LINK,
-					title: translate( 'Hosting' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Marketplace / Hosting',
-					},
-				},
-				path
-			),
-		].map( ( item ) => createItem( item, path ) );
-	}, [ path, translate ] );
+	const menuItems = useMarketplaceMenuItems( path );
 
 	return (
 		<Sidebar

--- a/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
@@ -1,17 +1,9 @@
 import page from '@automattic/calypso-router';
-import { chevronLeft, key, store, receipt, payment } from '@wordpress/icons';
+import { chevronLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import Sidebar from '../sidebar';
-import {
-	A4A_OVERVIEW_LINK,
-	A4A_PURCHASES_LINK,
-	A4A_LICENSES_LINK,
-	A4A_BILLING_LINK,
-	A4A_INVOICES_LINK,
-	A4A_PAYMENT_METHODS_LINK,
-} from './lib/constants';
-import { createItem } from './lib/utils';
+import usePurchasesMenuItems from './hooks/use-purchases-menu-items';
+import { A4A_OVERVIEW_LINK, A4A_PURCHASES_LINK } from './lib/constants';
 
 type Props = {
 	path: string;
@@ -19,59 +11,7 @@ type Props = {
 
 export default function ( { path }: Props ) {
 	const translate = useTranslate();
-
-	const menuItems = useMemo( () => {
-		return [
-			createItem(
-				{
-					icon: key,
-					path: A4A_PURCHASES_LINK,
-					link: A4A_LICENSES_LINK,
-					title: translate( 'Licenses' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Purchases / Licenses',
-					},
-				},
-				path
-			),
-			createItem(
-				{
-					icon: store,
-					path: A4A_PURCHASES_LINK,
-					link: A4A_BILLING_LINK,
-					title: translate( 'Billing' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Purchases / Billing',
-					},
-				},
-				path
-			),
-			createItem(
-				{
-					icon: payment,
-					path: A4A_PURCHASES_LINK,
-					link: A4A_PAYMENT_METHODS_LINK,
-					title: translate( 'Payment Methods' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Purchases / Payment Methods',
-					},
-				},
-				path
-			),
-			createItem(
-				{
-					icon: receipt,
-					path: A4A_PURCHASES_LINK,
-					link: A4A_INVOICES_LINK,
-					title: translate( 'Invoices' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Purchases / Invoices',
-					},
-				},
-				path
-			),
-		].map( ( item ) => createItem( item, path ) );
-	}, [ path, translate ] );
+	const menuItems = usePurchasesMenuItems( path );
 
 	return (
 		<Sidebar

--- a/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
@@ -1,16 +1,9 @@
 import page from '@automattic/calypso-router';
-import { category, chevronLeft, starEmpty, warning } from '@wordpress/icons';
+import { chevronLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
-import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import Sidebar from '../sidebar';
-import {
-	A4A_OVERVIEW_LINK,
-	A4A_SITES_LINK,
-	A4A_SITES_LINK_FAVORITE,
-	A4A_SITES_LINK_NEEDS_ATTENTION,
-} from './lib/constants';
-import { createItem } from './lib/utils';
+import useSitesMenuItems from './hooks/use-sites-menu-items';
+import { A4A_OVERVIEW_LINK, A4A_SITES_LINK } from './lib/constants';
 
 type Props = {
 	path: string;
@@ -18,69 +11,7 @@ type Props = {
 
 export default function ( { path }: Props ) {
 	const translate = useTranslate();
-
-	const noActiveSite = useNoActiveSite();
-
-	const menuItems = useMemo( () => {
-		if ( noActiveSite ) {
-			// We hide the rest of the options when we do not have sites yet.
-			return [
-				createItem(
-					{
-						id: 'sites-all-menu-item',
-						icon: category,
-						path: A4A_SITES_LINK,
-						link: A4A_SITES_LINK,
-						title: translate( 'All' ),
-						trackEventProps: {
-							menu_item: 'Automattic for Agencies / Sites / All',
-						},
-					},
-					path
-				),
-			];
-		}
-
-		return [
-			createItem(
-				{
-					icon: warning,
-					path: A4A_SITES_LINK,
-					link: A4A_SITES_LINK_NEEDS_ATTENTION,
-					title: translate( 'Needs Attention' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Sites / Needs Attention',
-					},
-				},
-				path
-			),
-			createItem(
-				{
-					icon: starEmpty,
-					path: A4A_SITES_LINK,
-					link: A4A_SITES_LINK_FAVORITE,
-					title: translate( 'Favorites' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Sites / Favorites',
-					},
-				},
-				path
-			),
-			createItem(
-				{
-					id: 'sites-all-menu-item',
-					icon: category,
-					path: A4A_SITES_LINK,
-					link: A4A_SITES_LINK,
-					title: translate( 'All' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Sites / All',
-					},
-				},
-				path
-			),
-		].map( ( item ) => createItem( item, path ) );
-	}, [ noActiveSite, path, translate ] );
+	const menuItems = useSitesMenuItems( path );
 
 	return (
 		<Sidebar


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1

## Proposed Changes

While working on the task above I've decided to refactor code a bit and separate logic from the view. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open live link for agencies below and observe sidebar navigation works as before.
- Check the code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked. It just basically moves `createItems` for menu into separate hooks instead of doing that in containers. Please let me know if you find it not improving things.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?