### PR TITLE
Big Sky: Fix Skip Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -87,6 +87,10 @@ const withAIAssemblerFlow: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 			[]
 		);
+		const siteId = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSite(),
+			[]
+		);
 
 		const { setPendingAction, setSelectedSite } = useDispatch( ONBOARD_STORE );
 
@@ -285,10 +289,7 @@ const withAIAssemblerFlow: Flow = {
 			}
 		};
 
-		const goNext = ( providedDependencies: ProvidedDependencies = {} ) => {
-			const selectedSiteSlug = providedDependencies?.siteSlug as string;
-			const selectedSiteId = providedDependencies?.siteId as string;
-
+		const goNext = () => {
 			switch ( _currentStep ) {
 				case 'site-prompt': {
 					return navigate( 'pattern-assembler' );
@@ -297,8 +298,8 @@ const withAIAssemblerFlow: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: AI_ASSEMBLER_FLOW,
-						siteId: selectedSiteId,
-						siteSlug: selectedSiteSlug,
+						siteId: siteId || null,
+						siteSlug: null,
 					} );
 					return;
 			}


### PR DESCRIPTION
## Proposed Changes

![Zrzut ekranu 2024-04-17 o 18 15 57](https://github.com/Automattic/wp-calypso/assets/3775068/4ac3c88a-300c-4045-8b18-af6b456a1c5b)


* Fix the broken "Skip for now" button in launchpad for ai-assembler. On trunk its broken

## Testing Instructions

* Go to something like http://calypso.localhost:3000/setup/ai-assembler/launchpad?siteSlug=arturpiszek95.wordpress.com
* Click "Skip for now" in the top right
* Observe it working

