### PR TITLE
Adds the possibility to define different setup pages for Blaze Dashboard

### DIFF
--- a/apps/blaze-dashboard/src/load-config.js
+++ b/apps/blaze-dashboard/src/load-config.js
@@ -22,7 +22,7 @@ productionConfig.features.is_running_in_jetpack_site =
 // Set is is_running_in_woo_site to true if the dashboard is running on the Woo Blaze plugin
 productionConfig.features.is_running_in_woo_site = isWooStore;
 
-productionConfig.features.blaze_setup_mode = needSetup;
+productionConfig.features.blaze_setup_mode = !! needSetup;
 
 // The option enables loading of the whole translation file, and could be optimized by setting it to `true`, which needs the translation chunks in place.
 // @see https://github.com/Automattic/wp-calypso/blob/trunk/docs/translation-chunks.md

--- a/apps/blaze-dashboard/src/pages/controller.js
+++ b/apps/blaze-dashboard/src/pages/controller.js
@@ -1,6 +1,7 @@
+import config from '@automattic/calypso-config';
 import BlazeSetup from './setup/main';
 
 export const setup = ( context, next ) => {
-	context.primary = <BlazeSetup />;
+	context.primary = <BlazeSetup setupInfo={ config( 'need_setup' ) } />;
 	next();
 };

--- a/apps/blaze-dashboard/src/pages/setup/components/blaze-disabled.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/blaze-disabled.jsx
@@ -1,0 +1,45 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export default function BlazeDisabled() {
+	const selectedSiteData = useSelector( getSelectedSite );
+	const adminUrl = selectedSiteData?.options?.admin_url;
+
+	const translate = useTranslate();
+
+	return (
+		<>
+			<h3 className="empty-promotion-list__title wp-brand-font">
+				{ translate( 'Set up Blaze and start promoting your store' ) }
+			</h3>
+			<p className="empty-promotion-list__body">
+				{ translate(
+					"You're on the brink of unleashing the advertising potential of your store. To get started, follow these simple steps below:"
+				) }
+			</p>
+
+			<ol className="promote-post-i2__active-steps">
+				<li>
+					{ translate( 'Go to the {{a}}traffic section{{/a}} of the Jetpack settings page.', {
+						components: {
+							a: (
+								<a
+									href={ `${ adminUrl }/admin.php?page=jetpack#/traffic` }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					} ) }
+				</li>
+				<li>{ translate( 'Scroll down to the Blaze section and toggle it to active.' ) }</li>
+			</ol>
+			<p className="empty-promotion-list__body">
+				{ translate(
+					"After completing these steps, you're all set! Return here, refresh the page and start promoting your store with Blaze!"
+				) }
+			</p>
+		</>
+	);
+}

--- a/apps/blaze-dashboard/src/pages/setup/main.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/main.jsx
@@ -7,14 +7,21 @@ import MainWrapper from 'calypso/my-sites/promote-post-i2/components/main-wrappe
 import PostsListBanner from 'calypso/my-sites/promote-post-i2/components/posts-list-banner';
 import WooBanner from 'calypso/my-sites/promote-post-i2/components/woo-banner';
 import { getAdvertisingDashboardPath } from 'calypso/my-sites/promote-post-i2/utils';
-import { useSelector } from 'calypso/state';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import GenericHeader from '../../components/generic-header';
+import BlazeDisabled from './components/blaze-disabled';
 
-export default function BlazeSetup() {
-	const selectedSiteData = useSelector( getSelectedSite );
-	const adminUrl = selectedSiteData?.options?.admin_url;
+const renderSetupComponent = ( setupInfo ) => {
+	// Compatibility with previous Jetpack's version
+	const reason = typeof setupInfo === 'boolean' ? 'blaze_disabled' : setupInfo;
 
+	switch ( reason ) {
+		case 'blaze_disabled':
+		default:
+			return <BlazeDisabled />;
+	}
+};
+
+export default function BlazeSetup( { setupInfo } ) {
 	const isWooBlaze = config.isEnabled( 'is_running_in_woo_site' );
 	const translate = useTranslate();
 
@@ -43,36 +50,7 @@ export default function BlazeSetup() {
 
 			<div className="promote-post-i2__aux-wrapper">
 				<div className="empty-promotion-list__container promote-post-i2__setup-container">
-					<h3 className="empty-promotion-list__title wp-brand-font">
-						{ translate( 'Set up Blaze and start promoting your store' ) }
-					</h3>
-					<p className="empty-promotion-list__body">
-						{ translate(
-							"You're on the brink of unleashing the advertising potential of your store. To get started, follow these simple steps below:"
-						) }
-					</p>
-
-					<ol className="promote-post-i2__active-steps">
-						<li>
-							{ translate( 'Go to the {{a}}traffic section{{/a}} of the Jetpack settings page.', {
-								components: {
-									a: (
-										<a
-											href={ `${ adminUrl }/admin.php?page=jetpack#/traffic` }
-											target="_blank"
-											rel="noreferrer"
-										/>
-									),
-								},
-							} ) }
-						</li>
-						<li>{ translate( 'Scroll down to the Blaze section and toggle it to active.' ) }</li>
-					</ol>
-					<p className="empty-promotion-list__body">
-						{ translate(
-							"After completing these steps, you're all set! Return here, refresh the page and start promoting your store with Blaze!"
-						) }
-					</p>
+					{ renderSetupComponent( setupInfo ) }
 				</div>
 			</div>
 		</MainWrapper>


### PR DESCRIPTION
I am adding the possibility to define different setup pages in the Blaze Dashboard app. This will be useful in the implementation of the Woo Blaze plugin.
It will default to the Blaze disabled page, which is the only one we support.

## Proposed Changes

* Adds the possibility to define different setup pages using the `need_setup` config parameter

## Testing Instructions

* In your sandbox, execute `bin/install-plugin.sh blaze add/blaze-dashboard-customized-setup-page`
* Then, you need to move the traffic from `widgets.wp.com` to your sandbox.
* Go to any site using the Woo Blaze plugin and navigate to Marketing->Blaze for WooCommerce (you will need a new flag for atomic sites. Ping me, and I can help you with that).
* Verify that the dashboard loads correctly and works as expected
* Go to Jetpack->Settings, and change to the Traffic tab
* Scroll down and Disable the Blaze module
* Go back to Marketing->Blaze for WooCommerce and verify that you can see the setup page


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?