### PR TITLE
Add UPI/Razorpay payment method to list of purchases

### DIFF
--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -10,6 +10,7 @@ import creditCardJCBImage from 'calypso/assets/images/upgrades/cc-jcb.svg';
 import creditCardMasterCardImage from 'calypso/assets/images/upgrades/cc-mastercard.svg';
 import creditCardUnionPayImage from 'calypso/assets/images/upgrades/cc-unionpay.svg';
 import creditCardVisaImage from 'calypso/assets/images/upgrades/cc-visa.svg';
+import razorpayImage from 'calypso/assets/images/upgrades/upi.svg';
 
 import './style.scss';
 
@@ -21,6 +22,7 @@ const LOGO_PATHS = {
 	mastercard: creditCardMasterCardImage,
 	unionpay: creditCardUnionPayImage,
 	visa: creditCardVisaImage,
+	razorpay: razorpayImage,
 };
 
 const ALT_TEXT = {
@@ -39,6 +41,7 @@ const ALT_TEXT = {
 	p24: 'Przelewy24',
 	paypal: 'PayPal',
 	placeholder: 'Payment logo',
+	razorpay: 'Razorpay',
 	unionpay: 'UnionPay',
 	visa: 'Visa',
 	wechat: i18n.translate( 'WeChat Pay', {

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -10,7 +10,7 @@ import creditCardJCBImage from 'calypso/assets/images/upgrades/cc-jcb.svg';
 import creditCardMasterCardImage from 'calypso/assets/images/upgrades/cc-mastercard.svg';
 import creditCardUnionPayImage from 'calypso/assets/images/upgrades/cc-unionpay.svg';
 import creditCardVisaImage from 'calypso/assets/images/upgrades/cc-visa.svg';
-import razorpayImage from 'calypso/assets/images/upgrades/upi.svg';
+import upiImage from 'calypso/assets/images/upgrades/upi.svg';
 
 import './style.scss';
 
@@ -22,7 +22,7 @@ const LOGO_PATHS = {
 	mastercard: creditCardMasterCardImage,
 	unionpay: creditCardUnionPayImage,
 	visa: creditCardVisaImage,
-	razorpay: razorpayImage,
+	upi: upiImage,
 };
 
 const ALT_TEXT = {
@@ -41,7 +41,7 @@ const ALT_TEXT = {
 	p24: 'Przelewy24',
 	paypal: 'PayPal',
 	placeholder: 'Payment logo',
-	razorpay: 'Razorpay',
+	upi: 'UPI',
 	unionpay: 'UnionPay',
 	visa: 'Visa',
 	wechat: i18n.translate( 'WeChat Pay', {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
 import payPalImage from 'calypso/assets/images/upgrades/paypal-full.svg';
-import razorpayImage from 'calypso/assets/images/upgrades/upi.svg';
+import upiImage from 'calypso/assets/images/upgrades/upi.svg';
 import SiteIcon from 'calypso/blocks/site-icon';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -506,13 +506,9 @@ class PurchaseItem extends Component {
 				);
 			}
 
-			if ( purchase.payment.type === 'razorpay' ) {
+			if ( purchase.payment.type === 'upi' ) {
 				return (
-					<img
-						src={ razorpayImage }
-						alt={ purchase.payment.type }
-						className="purchase-item__razorpay"
-					/>
+					<img src={ upiImage } alt={ purchase.payment.type } className="purchase-item__upi" />
 				);
 			}
 

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
 import payPalImage from 'calypso/assets/images/upgrades/paypal-full.svg';
+import razorpayImage from 'calypso/assets/images/upgrades/upi.svg';
 import SiteIcon from 'calypso/blocks/site-icon';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -501,6 +502,16 @@ class PurchaseItem extends Component {
 						src={ payPalImage }
 						alt={ purchase.payment.type }
 						className="purchase-item__paypal"
+					/>
+				);
+			}
+
+			if ( purchase.payment.type === 'razorpay' ) {
+				return (
+					<img
+						src={ razorpayImage }
+						alt={ purchase.payment.type }
+						className="purchase-item__razorpay"
 					/>
 				);
 			}

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -507,9 +507,7 @@ class PurchaseItem extends Component {
 			}
 
 			if ( purchase.payment.type === 'upi' ) {
-				return (
-					<img src={ upiImage } alt={ purchase.payment.type } className="purchase-item__upi" />
-				);
+				return <img src={ upiImage } alt={ purchase.payment.type } />;
 			}
 
 			return null;


### PR DESCRIPTION
Closes https://github.com/Automattic/payments-florin/issues/510

Depends on server-side changes in D145777-code

This will replace https://github.com/Automattic/wp-calypso/pull/88637

## Proposed Changes

* When a customer views their list of purchases, the payment method used for that subscription is listed.  We need to include this for Razorpay/UPI purchases too.
* This also needs to be included on the purchase details page so customers can see which payment method was used.

Purchase list
![purchases list](https://github.com/Automattic/wp-calypso/assets/1138631/be357ba0-7977-4469-b039-ba0b7ddf7bd3)

Purchase details
![purchase details](https://github.com/Automattic/wp-calypso/assets/1138631/d58c0434-bd77-4667-9c8f-e39e01e119c2)


## Testing Instructions
* Apply D145777-code if it hasn't been merged yet.
* Follow set-up instructions in D145777-code.
* Add a plan to your cart and set your country to India.  
* Select Razorpay as the payment method with `success@razorpay` as the ID.
* Complete your purchase and make sure that the UPI logo appears as the payment method in the list of purchases.
* Click on the purchase to open up the detail view.  Make sure that the UPI logo appears here too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?