### PR TITLE
Change Razorpay to UPI in list of payment methods at checkout

### DIFF
--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -30,6 +30,7 @@ export function createRazorpayMethod( {
 			/>
 		),
 		inactiveContent: <RazorpaySummary />,
+		// translators: UPI stands for Unified Payments Interface and may not need to be transalted.
 		getAriaLabel: ( __ ) => __( 'UPI' ),
 	};
 }

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -30,7 +30,7 @@ export function createRazorpayMethod( {
 			/>
 		),
 		inactiveContent: <RazorpaySummary />,
-		getAriaLabel: ( __ ) => __( 'Razorpay' ),
+		getAriaLabel: ( __ ) => __( 'UPI' ),
 	};
 }
 
@@ -39,7 +39,7 @@ export function RazorpayLabel() {
 
 	return (
 		<Fragment>
-			<span>{ __( 'Razorpay' ) }</span>
+			<span>{ __( 'UPI' ) }</span>
 			<PaymentMethodLogos className="razorpay__logo payment-logos">
 				<RazorpayIcon />
 			</PaymentMethodLogos>
@@ -49,7 +49,7 @@ export function RazorpayLabel() {
 
 export function RazorpaySummary() {
 	const { __ } = useI18n();
-	return <Fragment>{ __( 'Razorpay' ) }</Fragment>;
+	return <Fragment>{ __( 'UPI' ) }</Fragment>;
 }
 
 export function RazorpaySubmitButton( {


### PR DESCRIPTION
Closes https://github.com/Automattic/payments-florin/issues/506

## Proposed Changes

This PR changes "Razorpay" to "UPI" in the list of payment methods available at checkout.

![upi](https://github.com/Automattic/wp-calypso/assets/1138631/5ec1ce27-fb4a-4e24-b82d-71944c372283)

## Testing Instructions

* Apply D145777-code if it hasn't been merged yet.
* Follow set-up instructions in D145777-code.
* Add a plan to your cart, set your country to India and make sure UPI appears as a payment option with the Razorpay logo displayed on the right.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?