### PR TITLE
A4A: Sites Dashboard - Fix last site item (row) in the table being cut off

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -242,7 +242,7 @@
 
 			.is-hiding-navigation .dataviews-view-table-wrapper {
 				overflow-y: auto;
-				max-height: calc(100vh - 182px); /* 182px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
+				max-height: calc(100vh - 260px); /* 260px is the size of all content above the dataview in table style, which includes our CTA elements, the pagination bottom bar, and an additional 10px margin. */
 			}
 		}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -319,7 +319,7 @@
 				margin: 0;
 				padding: 0;
 				overflow-y: auto;
-				max-height: calc(100vh - 175px); /* It subtracts the header height to allow scrolling in this block, plus a 10px margin */
+				max-height: calc(100vh - 300px); /* 300px is the size of all content above the dataview in list style, which includes our CTA elements, the pagination bottom bar, and an additional 20px margin. */
 
 				li {
 					padding: 8px 24px;


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/299

## Proposed Changes

* This PR adjusts the margin for the site dashboard table. Our previous margin setting did not account for the pagination's bottom bar.

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* To test, add a sufficient number of sites to trigger pagination while simultaneously filling the entire window.
* Verify that the last site is not being cut off.

Before
![image](https://github.com/Automattic/wp-calypso/assets/37049295/38636361-2809-40cb-a587-0bd4246daecb)

After
![image](https://github.com/Automattic/wp-calypso/assets/37049295/4dcd2218-04bb-47e1-9166-ae3b2b3b1b3d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?