### PR TITLE
 A4A: Sites Dashboard - Fix history state when selecting a site

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -150,7 +150,7 @@ export default function SitesDashboard() {
 			showOnlyFavorites,
 		} );
 		if ( page.current !== updatedUrl && updatedUrl !== undefined ) {
-			page.replace( updatedUrl );
+			page.show( updatedUrl );
 		}
 	}, [
 		sitesViewState.selectedSite,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -104,7 +104,10 @@ export default function SitesDashboard() {
 			return;
 		}
 
-		if ( sitesViewState.selectedSite ) {
+		if (
+			sitesViewState.selectedSite &&
+			sitesViewState.selectedSite.url === initialSelectedSiteUrl
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/231

## Proposed Changes

* This PR resolves a navigation issue in the Sites Dashboard. Previously, when users selected a new site and then navigated back in the browser, they returned to the page they were on before reaching /sites, usually the overview page.

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally.

* Open up DuckDuckGo (`https://duckduckgo.com/`).
* In the same browser tab, open up the Sites Dashboard (`http://agencies.localhost:3000/sites`).
* Select some sites, let's call them  `Site A`, `Site B`, and `Site C`.
* Click the Back button in your browser.
* **Expected Result (Trunk):** In trunk, DuckDuckGo will load.
* **Expected Result (Branch):** In this branch, the back button goes in the sequence from `Site C` to `Site B`, then from `Site B` to `Site A`, and finally from `Site A` to `/sites`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?