### PR TITLE
Pattern Library: Restore scroll after pattern preview iframe loses focus

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -238,6 +238,39 @@ function PatternPreviewFragment( {
 		};
 	}, [ renderedPattern, idAttr ] );
 
+	// When an iframe loses focus, browsers will scroll them back into view. This behavior can be
+	// annoying and make for a glitchy impression. This callback continuously stores the latest
+	// window scroll position and restores it just after this preview iframe loses focus
+	useEffect( () => {
+		const iframe = ref.current?.querySelector( 'iframe' );
+
+		if ( ! iframe ) {
+			return;
+		}
+
+		let lastScrollPosition = window.scrollY;
+
+		function onWindowScroll() {
+			lastScrollPosition = window.scrollY;
+		}
+
+		function onIframeBlur() {
+			const storedLastScrollPosition = lastScrollPosition;
+
+			requestAnimationFrame( () => {
+				window.scrollTo( { top: storedLastScrollPosition } );
+			} );
+		}
+
+		window.addEventListener( 'scroll', onWindowScroll, { passive: true } );
+		iframe.contentWindow?.addEventListener( 'blur', onIframeBlur );
+
+		return () => {
+			window.removeEventListener( 'scroll', onWindowScroll );
+			iframe.contentWindow?.removeEventListener( 'blur', onIframeBlur );
+		};
+	} );
+
 	if ( ! pattern ) {
 		return null;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6473

## Proposed Changes

In Chrome and Safari, whenever an iframe goes out of focus, the page scrolls to ensure the iframe going out of focus is "in view". Very annoying.

This PR fixes that problem by continuously storing the last window scroll position and restoring it after a pattern preview iframe loses focus.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/about`
2. Click inside the first pattern preview
3. Scroll further down the page
4. Click on the page body
5. Ensure that you are not scrolled back up to the first pattern preview
