### PR TITLE
WooExpress Plans: Update pricing in plans page to utilise the Plans data-store

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -3,11 +3,11 @@ import {
 	PLAN_WOOEXPRESS_MEDIUM,
 	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
 	getPlanPath,
-	getPlans,
 	isWooExpressPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
+import { Plans } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
@@ -16,8 +16,7 @@ import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import PlanIntervalSelector from 'calypso/my-sites/plans-features-main/components/plan-interval-selector';
-import { useSelector } from 'calypso/state';
-import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 import './style.scss';
@@ -49,14 +48,18 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 
-	const mediumPlanAnnual = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
-	const mediumPlanMonthly = getPlans()[ PLAN_WOOEXPRESS_MEDIUM_MONTHLY ];
-	const annualPlanMonthlyPrice = useSelector(
-		( state ) => getPlanRawPrice( state, mediumPlanAnnual.getProductId(), true ) || 0
-	);
-	const monthlyPlanPrice = useSelector(
-		( state ) => getPlanRawPrice( state, mediumPlanMonthly.getProductId() ) || 0
-	);
+	const pricingMeta = Plans.usePricingMetaForGridPlans( {
+		planSlugs: [ PLAN_WOOEXPRESS_MEDIUM, PLAN_WOOEXPRESS_MEDIUM_MONTHLY ],
+		siteId,
+		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
+	} );
+
+	const annualPlanMonthlyPrice =
+		pricingMeta?.[ PLAN_WOOEXPRESS_MEDIUM ]?.originalPrice?.monthly ?? 0;
+	const monthlyPlanPrice =
+		pricingMeta?.[ PLAN_WOOEXPRESS_MEDIUM_MONTHLY ]?.originalPrice?.full ?? 0;
 	const percentageSavings = Math.floor( ( 1 - annualPlanMonthlyPrice / monthlyPlanPrice ) * 100 );
 
 	const planIntervals = useMemo( () => {

--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -11,16 +11,15 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card } from '@automattic/components';
+import { Plans, type SiteDetails } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { SitePlanData } from 'calypso/my-sites/checkout/src/hooks/product-variants';
-import { useSelector } from 'calypso/state';
-import { getPlanRawPrice, getPlan } from 'calypso/state/plans/selectors';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { WooExpressPlans } from '../ecommerce-trial/wooexpress-plans';
-import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
@@ -38,29 +37,37 @@ const WooExpressPlansPage = ( {
 	showIntervalToggle,
 }: WooExpressPlansPageProps ) => {
 	const translate = useTranslate();
-
 	const annualPlanSlug = isWooExpressSmallPlan( currentPlan.productSlug )
 		? PLAN_WOOEXPRESS_SMALL
 		: PLAN_WOOEXPRESS_MEDIUM;
 	const monthlyPlanSlug = isWooExpressSmallPlan( currentPlan.productSlug )
 		? PLAN_WOOEXPRESS_SMALL_MONTHLY
 		: PLAN_WOOEXPRESS_MEDIUM_MONTHLY;
-
 	const annualPlan = getPlans()[ annualPlanSlug ];
 	const monthlyPlan = getPlans()[ monthlyPlanSlug ];
 
-	const annualPlanPrice = useSelector(
-		( state ) => getPlanRawPrice( state, annualPlan.getProductId(), false ) || 0
-	);
-	const annualPlanMonthlyPrice = useSelector(
-		( state ) => getPlanRawPrice( state, annualPlan.getProductId(), true ) || 0
-	);
-	const monthlyPlanPrice = useSelector(
-		( state ) => getPlanRawPrice( state, monthlyPlan.getProductId() ) || 0
-	);
-	const currencyCode = useSelector(
-		( state ) => getPlan( state, annualPlan.getProductId() )?.currency_code || ''
-	);
+	const pricingMeta = Plans.usePricingMetaForGridPlans( {
+		planSlugs: [ annualPlanSlug, monthlyPlanSlug ],
+		siteId: null,
+		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
+	} );
+
+	// Using `discountedPrice` below will give us the price with any currency/conversion discounts applied.
+	const annualPlanPrice =
+		pricingMeta?.[ annualPlanSlug ]?.discountedPrice?.full ??
+		pricingMeta?.[ annualPlanSlug ]?.originalPrice?.full ??
+		0;
+	const annualPlanMonthlyPrice =
+		pricingMeta?.[ annualPlanSlug ]?.discountedPrice?.monthly ??
+		pricingMeta?.[ annualPlanSlug ]?.originalPrice?.monthly ??
+		0;
+	const monthlyPlanPrice =
+		pricingMeta?.[ monthlyPlanSlug ]?.discountedPrice?.full ??
+		pricingMeta?.[ monthlyPlanSlug ]?.originalPrice?.full ??
+		0;
+	const currencyCode = pricingMeta?.[ annualPlanSlug ]?.currencyCode ?? '';
 
 	const isAnnualSubscription = ! isMonthly( currentPlan.productSlug );
 	const activePlan = isAnnualSubscription ? annualPlan : monthlyPlan;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

Update WooExpress plans and plans page to use pricing from the Plans data-store (`usePricingMetaForGridPlans`).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/wooexpress` and create a trial site
* Go to `/plans/[ trial site ]` and confirm the plans prices in `My plan` card and the term selector are reflected correclty

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?