### PR TITLE
Site Migration: Set new setting for tracking the migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -173,13 +173,6 @@ const siteMigration: Flow = {
 						action: SiteMigrationIdentifyAction;
 					};
 
-					if ( siteSlug ) {
-						// Set the in_site_migration_flow option at the start of the flow.
-						await saveSiteSettings( siteSlug, {
-							in_site_migration_flow: true,
-						} );
-					}
-
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
 						return exitFlow(
 							addQueryArgs(
@@ -280,6 +273,12 @@ const siteMigration: Flow = {
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
 					if ( providedDependencies?.verifyEmail ) {
+						if ( siteSlug ) {
+							// Set the in_site_migration_flow option at the start of the flow.
+							await saveSiteSettings( siteSlug, {
+								in_site_migration_flow: true,
+							} );
+						}
 						return navigate( STEPS.VERIFY_EMAIL.slug );
 					}
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -173,10 +173,12 @@ const siteMigration: Flow = {
 						action: SiteMigrationIdentifyAction;
 					};
 
-					// Set the in_site_migration_flow option at the start of the flow.
-					await saveSiteSettings( providedDependencies?.siteSlug, {
-						in_site_migration_flow: true,
-					} );
+					if ( siteSlug ) {
+						// Set the in_site_migration_flow option at the start of the flow.
+						await saveSiteSettings( siteSlug, {
+							in_site_migration_flow: true,
+						} );
+					}
 
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
 						return exitFlow(
@@ -247,10 +249,12 @@ const siteMigration: Flow = {
 
 					// If the plugin was installed successfully, go to the migration instructions.
 					if ( providedDependencies?.pluginInstall ) {
-						// Remove the in_site_migration_flow option at the end of the flow.
-						await saveSiteSettings( providedDependencies?.siteSlug, {
-							in_site_migration_flow: false,
-						} );
+						if ( siteSlug ) {
+							// Remove the in_site_migration_flow option at the end of the flow.
+							await saveSiteSettings( siteSlug, {
+								in_site_migration_flow: false,
+							} );
+						}
 
 						return navigate( STEPS.SITE_MIGRATION_INSTRUCTIONS.slug );
 					}

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
+import { waitFor } from '@testing-library/react';
+import nock from 'nock';
 import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
 import { addQueryArgs } from '../../../../lib/url';
 import { goToCheckout } from '../../utils/checkout';
@@ -32,6 +34,11 @@ describe( 'Site Migration Flow', () => {
 		( useIsSiteOwner as jest.Mock ).mockReturnValue( {
 			isOwner: true,
 		} );
+
+		const apiBaseUrl = 'https://public-api.wordpress.com';
+		const testSettingsEndpoint = '/rest/v1.4/sites/example.wordpress.com/settings';
+		nock( apiBaseUrl ).get( testSettingsEndpoint ).reply( 200, {} );
+		nock( apiBaseUrl ).post( testSettingsEndpoint ).reply( 200, {} );
 	} );
 
 	describe( 'useAssertConditions', () => {
@@ -214,7 +221,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'redirects from upgrade-plan to verifyEmail if user is unverified', () => {
+		it( 'redirects from upgrade-plan to verifyEmail if user is unverified', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
@@ -224,9 +231,11 @@ describe( 'Site Migration Flow', () => {
 				},
 			} );
 
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.VERIFY_EMAIL.slug }`,
-				state: null,
+			await waitFor( () => {
+				expect( getFlowLocation() ).toEqual( {
+					path: `/${ STEPS.VERIFY_EMAIL.slug }`,
+					state: null,
+				} );
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89401

## Proposed Changes

This updates the site migration flow so that we set the `in_site_migration_flow` site option to `true` when the flow starts and to `false` when it reaches the end.

We'll use this option on the backend when a new user is completing the email verification process.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply https://github.com/Automattic/jetpack/pull/36974 on your sandbox and sandbox the public-api.
* Open an incognito window.
* Either run this branch locally or use the calypso.live url.
* Go to `/start` and create a new user account.
* When you reach the Goals step, copy the site id from the url.
* Now open `wpsh` on your sandbox and run the following:
```
switch_to_blog( :siteId ); // Using the site id from above
return get_option( 'in_site_migration_flow' );
```
* You should get a value of `false`.

* Select the "Import existing content or website" goal.
* Enter a valid WordPress site to continue until you reach the "Verify email" step.
* Now open `wpsh` on your sandbox and run the following:
```
switch_to_blog( :siteId ); // Using the site id from above
return get_option( 'in_site_migration_flow' );
```
* You should get a value of `true`.

* Continue through the migration flow until you get to the "Migration Instructions" step.
* Now open `wpsh` on your sandbox and run the following:
```
switch_to_blog( :siteId ); // Using the site id from above
return get_option( 'in_site_migration_flow' );
```
* You should get a value of `false`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?