### PR TITLE
Stats: Update the Devices module strings

### DIFF
--- a/client/my-sites/stats/stats-module-devices/index.tsx
+++ b/client/my-sites/stats/stats-module-devices/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import StatsModulePlaceholder from '../stats-module/placeholder';
+import statsStrings from '../stats-strings';
 import StatsModuleDevices from './stats-module-devices';
 import StatsModuleUpgradeOverlay from './stats-module-upgrade-overlay';
 
@@ -25,6 +26,8 @@ const StatsModuleDevicesWrapper: React.FC< StatsModuleDevicesWrapperProps > = ( 
 	// summary,
 	className,
 } ) => {
+	const { devices: devicesStrings } = statsStrings();
+
 	// Check if blog is internal.
 	const { isPending: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
 	const { isLoading: isLoadingFeatureCheck, supportCommercialUse } = useStatsPurchases( siteId );
@@ -43,7 +46,7 @@ const StatsModuleDevicesWrapper: React.FC< StatsModuleDevicesWrapperProps > = ( 
 			{ isFetching && (
 				// @ts-expect-error TODO: Refactor StatsCard with TypeScript.
 				<StatsCard
-					title="Devices"
+					title={ devicesStrings.title }
 					className={ classNames( className, DEVICES_CLASS_NAME, 'stats-module__card', 'devices' ) }
 					isNew
 				>

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
@@ -1,5 +1,4 @@
 import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -7,13 +6,13 @@ import PieChart from 'calypso/components/pie-chart';
 import PieChartLegend from 'calypso/components/pie-chart/legend';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { JETPACK_SUPPORT_URL } from '../const';
 import useModuleDevicesQuery, {
 	QueryStatsDevicesParams,
 	StatsDevicesData,
 } from '../hooks/use-modeule-devices-query';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from '../stats-module/placeholder';
+import statsStrings from '../stats-strings';
 
 // import '../stats-module/style.scss';
 // import '../stats-list/style.scss';
@@ -84,6 +83,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 	isLoading,
 	query,
 } ) => {
+	const { devices: devicesStrings } = statsStrings();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const translate = useTranslate();
 
@@ -128,8 +128,6 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 		/>
 	);
 
-	const title = translate( 'Devices', { context: 'Stats: title of module', textOnly: true } );
-
 	// Use dedicated StatsCard for the screen size chart section.
 	if ( OPTION_KEYS.SIZE === selectedOption ) {
 		const chartData = prepareChartData( data );
@@ -137,7 +135,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 		return (
 			<StatsCard
 				className={ classNames( className, 'stats-module__card', path ) }
-				title={ title }
+				title={ devicesStrings.title }
 				titleURL=""
 				metricLabel=""
 				splitHeader
@@ -176,17 +174,8 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 			className={ classNames( className, 'stats-module__card', path ) }
 			moduleType={ path }
 			data={ data }
-			title={ title }
-			emptyMessage={ translate(
-				'If you use UTM codes, your {{link}}campaign performance data{{/link}} will show here.',
-				{
-					comment: '{{link}} links to support documentation.',
-					components: {
-						link: <a href={ localizeUrl( `${ JETPACK_SUPPORT_URL }#devices-stats` ) } />,
-					},
-					context: 'Stats: Info box label when the UTM module is empty',
-				}
-			) }
+			title={ devicesStrings.title }
+			emptyMessage={ devicesStrings.empty }
 			metricLabel={ translate( 'Visitors' ) }
 			loader={ showLoader && <StatsModulePlaceholder isLoading={ showLoader } /> }
 			splitHeader

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
@@ -104,10 +104,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 
 	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.BROWSER );
 
-	const { isFetching, data } = useModuleDevicesQuery( siteId, selectedOption, {
-		...query,
-		days: 7,
-	} );
+	const { isFetching, data } = useModuleDevicesQuery( siteId, selectedOption, query );
 
 	const showLoader = isLoading || isFetching;
 

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
@@ -141,6 +141,8 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 				splitHeader
 				mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 				toggleControl={ toggleControlComponent }
+				isEmpty={ ! showLoader && ( ! chartData || ! chartData.length ) }
+				emptyMessage={ devicesStrings.empty }
 			>
 				{ showLoader ? (
 					<StatsModulePlaceholder isLoading={ showLoader } />

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -210,9 +210,16 @@ export default function () {
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views from a country.',
 		} ),
-		empty: translate( 'No devices recorded', {
-			context: 'Stats: Info box label when the Devices module is empty',
-		} ),
+		empty: translate(
+			'Stats on visitors and {{link}}their viewing device{{/link}} will appear here.',
+			{
+				comment: '{{link}} links to support documentation.',
+				components: {
+					link: <a href={ localizeUrl( `${ JETPACK_SUPPORT_URL }#devices-stats` ) } />,
+				},
+				context: 'Stats: Info box label when the Devices module is empty',
+			}
+		),
 	};
 
 	statsStrings.clients = {

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -71,7 +71,7 @@ export type StatsCardProps = {
 	};
 	isEmpty?: boolean;
 	isNew?: boolean;
-	emptyMessage?: string;
+	emptyMessage?: string | React.ReactNode;
 	/**
 	 * @property {string} metricLabel - a label to use for the values on the right side of the bars - `Views` by default
 	 */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove the `query.days` number for a single day's data on the Traffic page according to the selected date.
* Refactor module strings of the Devices module.
* Update the empty message on the Devices module when there is no data.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > `Traffic` page for a Jetpack site that has a Stats commercial license with the feature flag `?flags=stats/devices`
* Ensure the Devices module works as previously when there is data.
* Select a date without any traffic data on the main bar chart of the Traffic page.
* Ensure the Devices module shows empty messages for all tabs.

<img width="650" alt="截圖 2024-04-19 上午12 05 33" src="https://github.com/Automattic/wp-calypso/assets/6869813/d70593e4-c256-456e-87ec-1cccb2570827">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?