### PR TITLE
A4A: purchases/licenses improve clickable area of expand button

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -126,6 +126,13 @@
 	padding: 0;
 }
 
+.license-preview__toggle::before {
+	content: "";
+	position: absolute;
+	width: 3.9rem;
+	height: 3.9rem;
+}
+
 .license-preview__assign-button {
 	font-size: 0.75rem;
 	font-weight: 400;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/303

## Proposed Changes

Tiny change to improve clickable are over the Chevron button
<img width="167" alt="Screenshot at Apr 18 10-25-15" src="https://github.com/Automattic/wp-calypso/assets/60262784/ac516aa6-66eb-403c-9d08-31e1871d9d13">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below for A4A navigate to `purchases/licenses` and check the expand functionality. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?