### PR TITLE
A4A: Marketplace - Volume pricing slider causing  overflow issues

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
@@ -39,7 +39,7 @@ p.listing-section-description {
 		grid-template-columns: repeat(2, 1fr);
 	}
 
-	@include break-wide {
+	@include break-huge {
 		grid-template-columns: repeat(3, 1fr);
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/220

## Proposed Changes

* This PR adjusts the breakpoint for the 3-column grid, from wide (1280px) to huge (1440px).

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

- Go to `http://agencies.localhost:3000/marketplace/products`
- Change the width of your browser window to 1285px.
- Click on the volume slider and increase it.
- Scroll down.
- Notice you can scroll side to side.
- Verify that no horizontal scrollbar is shown.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?