### PR TITLE
Updates the promote post origin for classic simple sites

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -18,7 +18,7 @@ import {
 	isJetpackModuleActive,
 	isJetpackMinimumVersion,
 } from 'calypso/state/sites/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const debug = debugFactory( 'calypso:promote-post' );
 
@@ -123,6 +123,7 @@ const getWidgetOptions = () => {
 
 export interface DSPOriginProps {
 	isAtomic?: boolean;
+	isClassicSimple?: boolean;
 }
 
 export const getDSPOrigin = ( originProps: DSPOriginProps | undefined ) => {
@@ -333,9 +334,11 @@ export enum PromoteWidgetStatus {
  * @returns The props to use when calculating the DSP origin
  */
 export const useDspOriginProps = (): DSPOriginProps => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSiteId ?? 0 ) );
-	return { isAtomic };
+	const selectedSite = useSelector( getSelectedSite );
+
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSite?.ID ?? 0 ) );
+	const isClassicSimple = selectedSite?.options?.is_wpcom_simple ?? false;
+	return { isAtomic, isClassicSimple };
 };
 
 /**


### PR DESCRIPTION
See: https://github.com/Automattic/wp-calypso/pull/89523#pullrequestreview-2001176638

This PR adds a prop to the DSP Widget Origin to differentiate simple sites using the classic view.
The idea is to use that new prop in the Promote post widget to prevent it from altering the Hash URL.

The main problem is that Simple Classic sites will use the Jetpack Blaze version of the dashboard in the future, and that version depends on hashbang navigation. By default, the widget operates with the hash to let mobile apps know the current step the user is in (mobile apps are displaying a web view of the WPCOM Advertising page). 

We need to change this to prevent possible problems with page refresh or redirections.


## Proposed Changes

* Adds the `isClassicSimple` prop  to the widget origin props to differentiate simple sites running in Jetpack Blaze

## Testing Instructions

To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```

First, let's test compatibility with the mobile apps:

* Open the live preview and navigate to Tools->Advertising
* Change the site name from the URL to the simple site you modify to classic early release
* Promote a post and verify that the URL hash changes in each step of the process

We will need to wait for the fix in the Widget to be published before testing this in classic simple sites, but this is what we can do now:

* In a console, connect to your sandbox (we need an active connection)
* On a different console tab, checkout this branch and go to `wp-calypso/apps/blaze-dashboard`
* Execute `yarn dev --sync`. This will sync the Blaze dashboard app to your sandbox
* Move the traffic from `widgets.wp.com` to your sandbox
* Now, in the browser, click on Tools->Advertising for your classic simple site. YOu should be redirected to `wp-admin/tools.php?page=advertising` (Jetpack Blaze version of the dashboard)
* Go to [this file](https://github.com/Automattic/wp-calypso/blob/6e14af26add66282bf704e8949414b7af00c5dc6/client/lib/promote-post/index.ts#L162), and add a console log like this one:
```
console.log( 'OriginProps: ', dspOriginProps );
```
* Wait until the changes get synced to your sandbox and refresh the page
* Click the Promote button for any of your posts and check the browser console for the log that we just added
* Verify that the `isClassicSimple` prop is in there with the value of `true`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?