### PR TITLE
A4A: fix split button text size

### DIFF
--- a/client/a8c-for-agencies/sections/overview/header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/overview/header-actions/style.scss
@@ -13,7 +13,6 @@
 	.button.split-button__main {
 		border-radius: 4px 0 0 4px;
 		border-right: none;
-		font-size: 1rem;
 		height: 40px;
 	}
 

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -197,7 +197,7 @@
 	}
 
 	.split-button .button {
-		font-size: 1rem;
+		font-size: 0.875rem;
 		height: 40px;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/296

## Proposed Changes
Update button text size accordingly to design. 14px instead of 16px.
<img width="327" alt="Screenshot 2024-04-18 at 12 02 54 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/34e194bc-3d64-4257-bb03-e802374ed0d0">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check the live branch and pages `/overview` and `/sites` for Add new site button. Font size should be 14px (0.875rem)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?