### PR TITLE
A4A: Add support for "source" query parameter

### DIFF
--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -1,14 +1,16 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
+import { getQueryArg } from '@wordpress/url';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { A4A_LANDING_LINK } from './components/sidebar-menu/lib/constants';
 
 export const redirectToLandingContext: Callback = () => {
 	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+	const source = getQueryArg( window.location.href, 'source' ) as string;
 
 	if ( isA4AEnabled ) {
-		page.redirect( A4A_LANDING_LINK );
+		page.redirect( addQueryArgs( { source }, A4A_LANDING_LINK ) );
 		return;
 	}
 	window.location.href = 'https://automattic.com/for/agencies';

--- a/client/a8c-for-agencies/sections/landing/landing.tsx
+++ b/client/a8c-for-agencies/sections/landing/landing.tsx
@@ -12,6 +12,7 @@ import {
 	A4A_OVERVIEW_LINK,
 	A4A_SIGNUP_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency, hasFetchedAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
@@ -40,7 +41,8 @@ export default function Landing() {
 			return page.redirect( A4A_OVERVIEW_LINK );
 		}
 
-		page.redirect( A4A_SIGNUP_LINK );
+		const source = getQueryArg( window.location.href, 'source' ) as string;
+		page.redirect( addQueryArgs( { source }, A4A_SIGNUP_LINK ) );
 	}, [ agency, hasFetched ] );
 
 	return (


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/48

## Proposed Changes

* Captures the `source` query string value and ensures it is preserved through the initial redirects from the `/landing` page to the `/signup` route.
* This will be used to allow the signup form to display a custom banner for users coming from the client plugin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sign in with an account that is not part of the agencies program.
* Visit the root of the site with the `?source=foo` query string.
* Validate that you are redirected to the sign up form, and the `source` parameter stays in the URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
