### PR TITLE
Stats: Fix translations for the purchase page

### DIFF
--- a/apps/odyssey-stats/.size-limit.js
+++ b/apps/odyssey-stats/.size-limit.js
@@ -3,7 +3,7 @@ const path = require( 'path' );
 module.exports = [
 	{
 		path: path.join( __dirname, 'dist/build.min.js' ),
-		limit: '400 KiB',
+		limit: '500 KiB',
 	},
 	{
 		path: path.join( __dirname, 'dist/widget-loader.min.js' ),

--- a/client/my-sites/stats/pages/purchase/controller.tsx
+++ b/client/my-sites/stats/pages/purchase/controller.tsx
@@ -1,15 +1,10 @@
-import AsyncLoad from 'calypso/components/async-load';
-import PageLoading from '../shared/page-loading';
+import StatsPurchasePage from 'calypso/my-sites/stats/pages/purchase';
 import type { Context } from '@automattic/calypso-router';
 
 function purchase( context: Context, next: () => void ) {
 	context.primary = (
 		// DO NOT WRAP WITH <LoadStatsPage /> or you will get an infinite loop
-		<AsyncLoad
-			require="calypso/my-sites/stats/pages/purchase"
-			placeholder={ PageLoading }
-			query={ context.query }
-		/>
+		<StatsPurchasePage query={ context.query } />
 	);
 	next();
 }


### PR DESCRIPTION
## Proposed Changes

The issue is surfaced by pejTkB-1jU-p2, where the translation wouldn't load. I took a look at it, and found out it is because the chunk map plugin doesn't work for async loaded bundles, which we didn't expect.

## Testing Instructions

- Test Odyssey Stats by sandboxing `widgets.wp.com`
  - `bin/install-plugin.sh odyssey-stats fix/translation-for-purchase-page`
  - `jetpack build plugins/jetpack`
- Change site language to Japanese or other languages than English
- Return to the site and open Jetpack->Stats
- Ensure the purchase wizard mostly translated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?