### PR TITLE
Automattic for Agencies: Fix the assign license to site flow

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -1,9 +1,8 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { SiteDetails } from '@automattic/data-stores';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -11,9 +10,14 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { useDispatch } from 'calypso/state';
+import {
+	A4A_MARKETPLACE_LINK,
+	A4A_SITES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getSites from 'calypso/state/selectors/get-sites';
+import useProductsBySlug from '../hooks/use-products-by-slug';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import useSubmitForm from '../products-overview/product-listing/hooks/use-submit-form';
 import PricingSummary from './pricing-summary';
@@ -27,18 +31,16 @@ export default function Checkout() {
 	const dispatch = useDispatch();
 
 	const { selectedCartItems, onRemoveCartItem, onClearCart } = useShoppingCart();
+	const sites = useSelector( getSites );
 
-	const [ selectedSite ] = useState< SiteDetails | null | undefined >( null ); // FIXME: Need to fetch from state
+	const siteId = getQueryArg( window.location.href, 'site_id' )?.toString();
+	const selectedSite =
+		siteId && sites ? sites.find( ( site ) => site?.ID === parseInt( siteId ) ) : null;
 
-	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
-	// track if the user purchases a different set of products.
-	const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
-		?.toString()
-		.split( ',' );
+	const { selectedProductsBySlug } = useProductsBySlug();
 
 	const { isReady, submitForm } = useSubmitForm( {
 		selectedSite,
-		suggestedProductSlugs,
 		onSuccessCallback: onClearCart,
 	} );
 
@@ -55,20 +57,20 @@ export default function Checkout() {
 			.flat();
 	}, [ selectedCartItems ] );
 
+	const checkoutItems = siteId ? selectedProductsBySlug : sortedSelectedItems;
+
 	const onCheckout = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_checkout_click' ) );
 
-		submitForm( sortedSelectedItems );
+		submitForm( checkoutItems );
 
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_checkout_checkout_click', {
-				total_licenses: sortedSelectedItems.length,
-				items: sortedSelectedItems
-					?.map( ( item ) => `${ item.slug } x ${ item.quantity }` )
-					.join( ',' ),
+				total_licenses: checkoutItems.length,
+				items: checkoutItems?.map( ( item ) => `${ item.slug } x ${ item.quantity }` ).join( ',' ),
 			} )
 		);
-	}, [ dispatch, sortedSelectedItems, submitForm ] );
+	}, [ dispatch, checkoutItems, submitForm ] );
 
 	const onEmptyCart = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_empty_cart_click' ) );
@@ -88,6 +90,11 @@ export default function Checkout() {
 		},
 		[ dispatch, onRemoveCartItem ]
 	);
+
+	const cancelPurchase = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_cancel_purchase_click' ) );
+		page( A4A_SITES_LINK );
+	}, [ dispatch ] );
 
 	return (
 		<Layout
@@ -120,7 +127,7 @@ export default function Checkout() {
 						<h1 className="checkout__main-title">{ translate( 'Checkout' ) }</h1>
 
 						<div className="checkout__main-list">
-							{ sortedSelectedItems.map( ( items ) => (
+							{ checkoutItems.map( ( items ) => (
 								<ProductInfo
 									key={ `product-info-${ items.product_id }-${ items.quantity }` }
 									product={ items }
@@ -129,29 +136,37 @@ export default function Checkout() {
 						</div>
 					</div>
 					<div className="checkout__aside">
-						<PricingSummary items={ sortedSelectedItems } onRemoveItem={ onRemoveItem } />
+						<PricingSummary items={ checkoutItems } onRemoveItem={ onRemoveItem } />
 
 						<div className="checkout__aside-actions">
 							<Button
 								primary
 								onClick={ onCheckout }
-								disabled={ ! sortedSelectedItems.length || ! isReady }
+								disabled={ ! checkoutItems.length || ! isReady }
 								busy={ ! isReady }
 							>
 								{ translate( 'Purchase %(count)d plan', 'Purchase %(count)d plans', {
 									context: 'button label',
-									count: sortedSelectedItems.length,
+									count: checkoutItems.length,
 									args: {
-										count: sortedSelectedItems.length,
+										count: checkoutItems.length,
 									},
 								} ) }
 							</Button>
 
-							<Button onClick={ onContinueShopping }>{ translate( 'Continue shopping' ) }</Button>
+							{ siteId ? (
+								<Button onClick={ cancelPurchase }>{ translate( 'Cancel' ) }</Button>
+							) : (
+								<>
+									<Button onClick={ onContinueShopping }>
+										{ translate( 'Continue shopping' ) }
+									</Button>
 
-							<Button borderless onClick={ onEmptyCart }>
-								{ translate( 'Empty cart' ) }
-							</Button>
+									<Button borderless onClick={ onEmptyCart }>
+										{ translate( 'Empty cart' ) }
+									</Button>
+								</>
+							) }
 						</div>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -136,7 +136,10 @@ export default function Checkout() {
 						</div>
 					</div>
 					<div className="checkout__aside">
-						<PricingSummary items={ checkoutItems } onRemoveItem={ onRemoveItem } />
+						<PricingSummary
+							items={ checkoutItems }
+							onRemoveItem={ siteId ? undefined : onRemoveItem }
+						/>
 
 						<div className="checkout__aside-actions">
 							<Button

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -10,7 +10,7 @@ import type { ShoppingCartItem } from '../types';
 
 type Props = {
 	items: ShoppingCartItem[];
-	onRemoveItem: ( item: ShoppingCartItem ) => void;
+	onRemoveItem?: ( item: ShoppingCartItem ) => void;
 };
 
 export default function PricingSummary( { items, onRemoveItem }: Props ) {

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-products-by-slug.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-products-by-slug.ts
@@ -1,0 +1,31 @@
+import { getQueryArg } from '@wordpress/url';
+import { useEffect, useState } from 'react';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { ShoppingCartItem } from '../types';
+
+export default function useProductsBySlug() {
+	const { data } = useProductsQuery();
+
+	const [ selectedProductsBySlug, setSelectedProductsSlug ] = useState< ShoppingCartItem[] | [] >(
+		[]
+	);
+
+	useEffect( () => {
+		if ( data ) {
+			const slugs = getQueryArg( window.location.href, 'product_slug' )?.toString().split( ',' );
+			if ( ! slugs ) {
+				return setSelectedProductsSlug( [] );
+			}
+			const allProducts = slugs
+				.map( ( slug ) => {
+					return { ...data.find( ( product ) => product.slug === slug ), quantity: 1 };
+				} )
+				.filter( ( product ) => product ) as ShoppingCartItem[];
+			setSelectedProductsSlug( allProducts );
+		}
+	}, [ data ] );
+
+	return {
+		selectedProductsBySlug,
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-submit-form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-submit-form.tsx
@@ -92,7 +92,7 @@ const useSubmitForm = ( { selectedSite, suggestedProductSlugs, onSuccessCallback
 
 			maybeTrackUnsuggestedSelection( licensesToIssue );
 
-			const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
+			const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'sitesdashboard';
 
 			// If we need a payment method, redirect now to have the user enter one
 			if ( paymentMethodRequired ) {
@@ -100,7 +100,7 @@ const useSubmitForm = ( { selectedSite, suggestedProductSlugs, onSuccessCallback
 					{
 						products: serializedLicenses,
 						...( selectedSite?.ID && { site_id: selectedSite?.ID } ),
-						...( fromDashboard && { source: 'dashboard' } ),
+						...( fromDashboard && { source: 'sitesdashboard' } ),
 					},
 					A4A_PAYMENT_METHODS_ADD_LINK
 				);

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -10,6 +10,7 @@ import ShoppingCartMenuItem from './item';
 import type { ShoppingCartItem } from '../../types';
 
 import './style.scss';
+
 type Props = {
 	onClose: () => void;
 	onRemoveItem: ( item: ShoppingCartItem ) => void;

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -7,6 +7,8 @@ import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import type { ShoppingCartItem } from '../../types';
 
+import './style.scss';
+
 type ItemProps = {
 	item: ShoppingCartItem;
 	onRemoveItem: ( item: ShoppingCartItem ) => void;

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -11,7 +11,7 @@ import './style.scss';
 
 type ItemProps = {
 	item: ShoppingCartItem;
-	onRemoveItem: ( item: ShoppingCartItem ) => void;
+	onRemoveItem?: ( item: ShoppingCartItem ) => void;
 };
 
 export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps ) {
@@ -42,13 +42,15 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 					) }
 				</div>
 			</div>
-			<Button
-				className="shopping-cart__menu-item-remove-button"
-				variant="link"
-				onClick={ () => onRemoveItem( item ) }
-			>
-				{ translate( 'Remove' ) }
-			</Button>
+			{ onRemoveItem && (
+				<Button
+					className="shopping-cart__menu-item-remove-button"
+					variant="link"
+					onClick={ () => onRemoveItem( item ) }
+				>
+					{ translate( 'Remove' ) }
+				</Button>
+			) }
 		</li>
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -22,11 +22,12 @@ import { getQueryArg } from '@wordpress/url';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useEffect } from 'react';
 import {
+	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_LINK,
 	A4A_PAYMENT_METHODS_ADD_LINK,
 	A4A_PAYMENT_METHODS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useIssueAndAssignLicenses from 'calypso/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses';
+import useIssueAndAssignLicenses from 'calypso/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses';
 import { parseQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -118,7 +119,6 @@ function PaymentMethodForm() {
 
 	const dispatch = useDispatch();
 
-	// FIXME: We will need to change this hook to use A4A-based hook.
 	const { issueAndAssignLicenses, isReady: isIssueAndAssignLicensesReady } =
 		useIssueAndAssignLicenses(
 			siteId ? sites.find( ( site ) => site?.ID === parseInt( siteId ) ) : null,
@@ -238,6 +238,20 @@ function PaymentMethodForm() {
 
 	const getPreviousPageLink = () => {
 		if ( products ) {
+			if ( source === 'sitesdashboard' ) {
+				const productsSlugs = products
+					.split( ',' )
+					.map( ( product ) => product.split( ':' )[ 0 ] )
+					.join( ',' );
+				return addQueryArgs(
+					{
+						product_slug: productsSlugs,
+						...( siteId && { site_id: siteId } ),
+						...( source && { source } ),
+					},
+					A4A_MARKETPLACE_CHECKOUT_LINK
+				);
+			}
 			return addQueryArgs(
 				{
 					products,

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
@@ -44,7 +44,13 @@ const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
 					{ translate( 'Go back' ) }
 				</Button>,
 
-				<Button disabled={ isDeleteInProgress } onClick={ onConfirm } primary scary>
+				<Button
+					busy={ isDeleteInProgress }
+					disabled={ isDeleteInProgress }
+					onClick={ onConfirm }
+					primary
+					scary
+				>
 					{ translate( 'Delete payment method' ) }
 				</Button>,
 			] }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -9,8 +9,7 @@ import {
 import { Gridicon } from '@automattic/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ReactNode, useMemo, useState } from 'react';
-import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { CART_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/marketplace/shopping-cart';
+import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import BackupImage from 'calypso/assets/images/jetpack/rna-image-backup.png';
 import DefaultImage from 'calypso/assets/images/jetpack/rna-image-default.png';
 import ScanImage from 'calypso/assets/images/jetpack/rna-image-scan.png';
@@ -97,7 +96,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	if ( hasJetpackPartnerAccess ) {
 		const manageProductSlug = nonManageProductSlug.replace( '_yearly', '' ).replace( /_/g, '-' );
 		const productPurchaseLink = isA4AEnabled
-			? `${ A4A_MARKETPLACE_PRODUCTS_LINK }?product_slug=${ manageProductSlug }&source=sitesdashboard&site_id=${ siteId }${ CART_URL_HASH_FRAGMENT }`
+			? `${ A4A_MARKETPLACE_CHECKOUT_LINK }?product_slug=${ manageProductSlug }&source=sitesdashboard&site_id=${ siteId }`
 			: '#';
 		manageProduct = products?.find( ( product ) => product.slug === manageProductSlug );
 		isFetchingPrices = isFetchingManagePrices || !! isFetchingNonManagePrices;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo } from 'react';
-import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -86,7 +86,7 @@ export default function LicenseInfoModal( {
 						source: 'sitesdashboard',
 						site_id: siteId,
 					},
-					A4A_MARKETPLACE_PRODUCTS_LINK
+					A4A_MARKETPLACE_CHECKOUT_LINK
 				)
 			);
 		} else {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -2,8 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useMemo } from 'react';
-import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { CART_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/marketplace/shopping-cart';
+import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import ExternalLink from 'calypso/components/external-link';
@@ -103,8 +102,8 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 	}, [ status, onClose ] );
 
 	const productPurchaseLink = isA4AEnabled
-		? `${ A4A_MARKETPLACE_PRODUCTS_LINK }?product_slug=jetpack-boost&source=sitesdashboard&site_id=${ siteId }${ CART_URL_HASH_FRAGMENT }`
-		: undefined;
+		? `${ A4A_MARKETPLACE_CHECKOUT_LINK }?product_slug=jetpack-boost&source=sitesdashboard&site_id=${ siteId }`
+		: '#';
 
 	return (
 		<LicenseInfoModal

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -4,8 +4,7 @@ import { Gridicon, Tooltip } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { CART_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/marketplace/shopping-cart';
+import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -62,7 +61,7 @@ export default function SiteStatusColumn( { type, rows, metadata, disabled }: Pr
 
 	const handleA4AAddAction = useCallback( () => {
 		const productSlug = DASHBOARD_PRODUCT_SLUGS_BY_TYPE[ type ];
-		const productPurchaseLink = `${ A4A_MARKETPLACE_PRODUCTS_LINK }?product_slug=${ productSlug }&source=sitesdashboard&site_id=${ siteId }${ CART_URL_HASH_FRAGMENT }`;
+		const productPurchaseLink = `${ A4A_MARKETPLACE_CHECKOUT_LINK }?product_slug=${ productSlug }&source=sitesdashboard&site_id=${ siteId }`;
 
 		return page( productPurchaseLink );
 	}, [ siteId, type ] );

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper.ts
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper.ts
@@ -12,7 +12,12 @@ export function usePaymentMethodStepper( { withAssignLicense }: { withAssignLice
 	const isIssueLicenseFlow = !! products;
 	const isSiteCreationFlow = source === 'create-site' && !! product;
 
+	const isCheckoutFlow = source === 'sitesdashboard';
+
 	return useMemo( () => {
+		if ( isCheckoutFlow ) {
+			return null;
+		}
 		if ( isIssueLicenseFlow ) {
 			const steps = [
 				translate( 'Select licenses' ),
@@ -42,5 +47,5 @@ export function usePaymentMethodStepper( { withAssignLicense }: { withAssignLice
 		}
 
 		return null;
-	}, [ isIssueLicenseFlow, isSiteCreationFlow, translate, withAssignLicense ] );
+	}, [ isCheckoutFlow, isIssueLicenseFlow, isSiteCreationFlow, translate, withAssignLicense ] );
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/287

## Proposed Changes

This PR:

- Redirects users to the checkout page with the selected product when clicking on `+ Add` on the Backup or Scan column.
- Updates the Go Back link & redirect link to the checkout page for the direct checkout flow.
- Does minor enhancement to the `Delete payment method` button by showing the busy state when deleting is in progress.
- Updates the redirect link to the Sites page from the useSubmit hook for direct checkout.
- Adds a new hook: `useProductsBySlug`` that lists products based on the slugs.
- Updates the Checkout page to hide a few CTA for direct checkout.

NOTE: 

- Redirect to purchases/licenses/unassigned when there are available licenses will be done in another PR.
- The checkout may not show the products when redirected from the buttons on the preview pane. This is a different issue which will be fixed later.

## Testing Instructions

1) Open the A4A live link
2) Visit /purchases/payment-methods > Delete all the payment methods. Verify that the busy state for the delete button as now shown.
3) Visit /sites > Click on the `+ Add` button on the backup or scan column > Verify that you are redirected to the checkout page with the selected product as shown below:

<img width="1514" alt="Screenshot 2024-04-19 at 2 03 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/56016411-4d2b-439f-aa1e-0a0e0e0c9d82">

4) Click the `Purchase 1 plan` button > Verify that you are redirected to the add payment method page > Enter the card details > Verify that the license is issued and assigned to the site, and you are redirected to the Sites page along with a success message as shown below:

<img width="996" alt="Screenshot 2024-04-19 at 10 17 55 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7a45aec3-970e-4ca4-8fdc-774436e61cb2">

Fallback message. The screenshot is only to help the translators. 

<img width="685" alt="Screenshot 2024-04-19 at 10 19 01 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/54ef2095-2066-4c07-ba93-a1a3e82010f4">

5) Repeat step 3 > Click the `Purchase 1 plan` button >  Verify that the license is directly assigned to the site, and you are redirected to the Sites page along with a success message.

6) Repeat purchasing a license from the site preview pane (backup, boost, scan), it should redirect you to the Checkout page with the selected product. Refresh the page if you don't see the product loaded. This will be fixed in a different PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?