### PR TITLE
Signup: enable hotjar based on flow prop

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -566,8 +566,9 @@ export function generateFlows( {
 			description: 'A flow for DIFM onboarding',
 			excludeFromManageSiteFlows: true,
 			providesDependenciesInQuery: [ 'siteSlug' ],
-			lastModified: '2024-05-16',
+			lastModified: '2024-06-14',
 			enablePresales: false,
+			enableHotjar: true,
 		},
 
 		{
@@ -577,8 +578,9 @@ export function generateFlows( {
 			description: 'A flow to collect DIFM lite site content',
 			excludeFromManageSiteFlows: true,
 			providesDependenciesInQuery: [ 'siteSlug' ],
-			lastModified: '2023-10-11',
+			lastModified: '2024-06-14',
 			hideProgressIndicator: true,
+			enableHotjar: true,
 		},
 		{
 			name: 'woocommerce-install',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -250,9 +250,7 @@ class Signup extends Component {
 	componentDidMount() {
 		debug( 'Signup component mounted' );
 
-		if (
-			[ 'website-design-services', 'site-content-collection' ].includes( this.props.flowName )
-		) {
+		if ( flows.getFlow( this.props.flowName, this.props.isLoggedIn )?.enableHotjar ) {
 			addHotJarScript();
 		}
 

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -20,6 +20,9 @@ export interface Flow {
 	disallowResume?: boolean;
 	showRecaptcha?: boolean;
 	enableBranchSteps?: boolean;
+	hideProgressIndicator?: boolean;
+	enablePresales?: boolean;
+	enableHotjar?: boolean;
 	onEnterFlow?: ( flowName: string ) => void;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR is a small refactor that enables hotjar via a `enableHotjar` prop on the flow config instead of hardcoding the flow names.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since the `'ad-tracking'` config is only enabled in production, manually change the value to `true` and then re-run the Calypso build process.
https://github.com/Automattic/wp-calypso/blob/8abbe89d443c737d8ac47b9b5d243a5cfff096e8/config/development.json#L32
* Go to `/start/website-design-services?siteSlug=<siteSlug>` and confirm that the hotjar script has been loaded by inspecting the network log.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?