### PR TITLE
Memoize the filtered result for `deemphasizeFreePlan`

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -458,31 +458,36 @@ const PlansFeaturesMain = ( {
 	} );
 
 	// we need only the visible ones for features grid (these should extend into plans-ui data store selectors)
-	const gridPlansForFeaturesGrid =
-		useGridPlansForFeaturesGrid( {
-			allFeaturesList: getFeaturesList(),
-			coupon,
-			eligibleForFreeHostingTrial,
-			hiddenPlans,
-			intent,
-			isDisplayingPlansNeededForFeature,
-			isInSignup,
-			isSubdomainNotGenerated: ! resolvedSubdomainName.result,
-			selectedFeature,
-			selectedPlan,
-			showLegacyStorageFeature,
-			siteId,
-			storageAddOns,
-			term,
-			useCheckPlanAvailabilityForPurchase,
-			useFreeTrialPlanSlugs,
-		} )?.filter( ( { planSlug } ) => {
-			// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.
-			if ( deemphasizeFreePlan ) {
-				return planSlug !== PLAN_FREE;
-			}
-			return true;
-		} ) ?? null; // optional chaining can result in `undefined`; we don't want to introduce it here.
+	const gridPlansForFeaturesGridRaw = useGridPlansForFeaturesGrid( {
+		allFeaturesList: getFeaturesList(),
+		coupon,
+		eligibleForFreeHostingTrial,
+		hiddenPlans,
+		intent,
+		isDisplayingPlansNeededForFeature,
+		isInSignup,
+		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
+		selectedFeature,
+		selectedPlan,
+		showLegacyStorageFeature,
+		siteId,
+		storageAddOns,
+		term,
+		useCheckPlanAvailabilityForPurchase,
+		useFreeTrialPlanSlugs,
+	} );
+
+	// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.
+	const gridPlansForFeaturesGrid = useMemo(
+		() =>
+			gridPlansForFeaturesGridRaw?.filter( ( { planSlug } ) => {
+				if ( deemphasizeFreePlan ) {
+					return planSlug !== PLAN_FREE;
+				}
+				return true;
+			} ) ?? null, // optional chaining can result in `undefined`; we don't want to introduce it here.
+		[ gridPlansForFeaturesGridRaw, deemphasizeFreePlan ]
+	);
 
 	let hidePlanSelector = false;
 	// In the "purchase a plan and free domain" flow we do not want to show


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Thie is a follow-up PR addressing @chriskmnds [feedback](https://github.com/Automattic/wp-calypso/pull/89395/files#r1567315085):

> This creates a new structure, so any form of optimization/memoization done from useGridPlansForFeaturesGrid will be undone via this transformation. You may want to consider wrapping with a useMemo call.

In the PR, the filtered result is memoized by `useMemo` 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The plans grid should work intact.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
