### PR TITLE
A4A: Standardize the Menu component style.

### DIFF
--- a/client/a8c-for-agencies/components/foldable-nav/style.scss
+++ b/client/a8c-for-agencies/components/foldable-nav/style.scss
@@ -43,4 +43,16 @@
 		list-style: none;
 		margin: 0;
 	}
+
+	.sidebar-v2__menu-item {
+		&:hover,
+		&:focus {
+			background: var(--wp-components-color-accent);
+
+			.components-flex-item,
+			.sidebar__menu-icon {
+				color: var(--color-text-inverted);
+			}
+		}
+	}
 }

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -71,7 +71,7 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 
 	background: var(--color-surface);
 	border: 1px solid var(--color-accent-0);
-	border-radius: 2px;
+	border-radius: 4px;
 	box-shadow:
 		0 4px 6px rgba(var(--color-accent-100-rgb), 0.1),
 		0 1px 2px rgba(var(--color-accent-100-rgb), 0.1);
@@ -91,7 +91,13 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 
 	&:hover,
 	&:focus {
-		background: var(--color-sidebar-text-alternative);
+		background: var(--wp-components-color-accent);
+
+		a.button.is-borderless,
+		button.button.is-borderless {
+			color: var(--color-text-inverted);
+			fill: var(--color-text-inverted);
+		}
 	}
 
 	a,

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -167,61 +167,14 @@
 	background-color: #fafafa;
 }
 
-.button.is-borderless.license-bundle-dropdown__button {
+button.button.is-borderless.license-bundle-dropdown__button {
 	text-overflow: clip;
 	padding: 4px;
 	max-height: 24px;
 	&:hover,
 	&:focus {
-		background: var(--color-sidebar-text-alternative);
-		color: var(--color-text);
-		fill: var(--color-text);
-	}
-}
-
-.license-actions__menu {
-	font-size: rem(14px);
-	font-weight: 400;
-	border-radius: 2px;
-
-	.popover__arrow {
-		display: none;
-	}
-
-	.popover__menu {
-		padding: 8px 4px;
-	}
-
-	.popover__menu-item {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		border: none;
-		outline: none;
-		margin-block: 5px;
-		min-height: 40px;
-		box-sizing: border-box;
-	}
-
-	.popover__menu-item .gridicon {
-		margin: 0;
-	}
-
-	.popover__menu-item:hover,
-	.popover__menu-item:focus {
-		background: var(--color-sidebar-text-alternative);
-		color: var(--color-text);
-		fill: var(--color-text);
-
-		.gridicon {
-			fill: var(--color-text);
-		}
-	}
-
-	.popover__menu-item.is-destructive {
-		color: var(--color-scary-50);
-		.gridicon {
-			fill: var(--color-error-50);
-		}
+		background: var(--wp-components-color-accent);
+		color: var(--color-text-inverted);
+		fill: var(--color-text-inverted);
 	}
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/style.scss
@@ -118,27 +118,7 @@ button.button.stored-credit-card__card-footer-actions {
 }
 
 .stored-credit-card__card-footer-actions-popover {
-	.popover__menu-item {
-		padding-block: 12px;
-
-		&:hover,
-		&:focus {
-			background: var(--color-sidebar-text-alternative);
-			color: var(--color-text);
-			fill: var(--color-text);
-
-			.gridicon {
-				fill: var(--color-text);
-			}
-		}
-	}
-
-
 	.popover__menu-item.stored-credit-card__card-footer-actions-delete {
-		&,
-		&:hover,
-		&:focus {
-			color: var(--color-error);
-		}
+		color: var(--color-error);
 	}
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -263,3 +263,11 @@
 		display: none;
 	}
 }
+
+a.site-actions__menu-item {
+	&:hover,
+	&:focus {
+		background: var(--wp-components-color-accent);
+		color: var(--color-text-inverted);
+	}
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -264,10 +264,22 @@
 	}
 }
 
-a.site-actions__menu-item {
-	&:hover,
-	&:focus {
-		background: var(--wp-components-color-accent);
-		color: var(--color-text-inverted);
+.is-section-a8c-for-agencies-sites {
+	a.site-actions__menu-item {
+		&:hover,
+		&:focus {
+			background: var(--wp-components-color-accent);
+			color: var(--color-text-inverted);
+		}
+	}
+
+	.components-dropdown-menu {
+		padding: 8px;
+		border-radius: 4px;
+
+		[role="menuitem"],
+		[role="menuitemradio"] {
+			border-radius: 4px;
+		}
 	}
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -12,7 +12,7 @@
 	--color-text-gray: "#333";
 	--color-text-white: var(--studio-white);
 	--color-text-black: var(--studio-black);
-	--color-sidebar-text-alternative: #bbe0fa;
+	--wp-components-color-accent: var(--studio-automattic-blue-50);
 
 	// FIXME: Need to move this colors to a color scheme file
 	--color-scary-0: var(--studio-red-0);
@@ -351,4 +351,58 @@ html {
 
 .site-selector .site-selector__actions {
 	padding: 16px;
+}
+
+.popover {
+	font-size: rem(14px);
+	font-weight: 400;
+	border-radius: 4px;
+
+	.popover__arrow {
+		display: none;
+	}
+
+
+	.popover__inner {
+		border-radius: 4px;
+	}
+
+	.popover__menu {
+		padding: 8px;
+	}
+
+	.popover__menu-item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		border: none;
+		outline: none;
+		margin-block: 0;
+		min-height: 40px;
+		box-sizing: border-box;
+		border-radius: 4px;
+		gap: 8px;
+	}
+
+	.popover__menu-item .gridicon {
+		margin: 0;
+	}
+
+	button.popover__menu-item:hover,
+	button.popover__menu-item:focus {
+		background: var(--wp-components-color-accent);
+		color: var(--color-text-inverted);
+
+		.gridicon {
+			fill: var(--color-text-inverted);
+		}
+	}
+
+	.popover__menu-item.is-destructive {
+		color: var(--color-scary-50);
+
+		.gridicon {
+			fill: var(--color-error-50);
+		}
+	}
 }


### PR DESCRIPTION
This PR standardizes the appearance of Menu components across the A4A portal, fixing discrepancies in their styling, to enhance the user experience.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/277

## Proposed Changes

* Add a global style for the popover Menu. Fix colors and spacing that match the A4A design guidelines. Note that the majority of our Menu components are based on the Popover menu component.
* Fix the rest of the components that do not popover menus but act as Menu items. (e.g. User Profile dropdown,  Site actions, Overview sidebar menu, etc.)

## Testing Instructions
We will need to test a couple of pages and verify that all menu items follow the same styling.

### Go to the Overview page and test the following components

* Sidebar quick link menu
   <img width="510" alt="Screenshot 2024-04-19 at 5 41 31 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/454225ea-94e5-4a60-a6b7-9c6ca1a1266f">

* Add Site split button
   <img width="303" alt="Screenshot 2024-04-19 at 5 41 37 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f4208972-3e0d-4900-ac3d-d7effc848a96">

* Use profile dropdown
   <img width="274" alt="Screenshot 2024-04-19 at 5 42 46 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/37102b31-2411-433a-9227-fa1a8e3ee7bd">

### Go to the Sites page and test the following components

* Page size selector
   <img width="400" alt="Screenshot 2024-04-19 at 5 35 22 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/bcd94cf6-fb7c-440c-9686-582ac2fbd833">

* Filtering
   <img width="489" alt="Screenshot 2024-04-19 at 5 46 23 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/bb236001-8184-426e-a97b-591aad5d5919">

* Site Action
   <img width="269" alt="Screenshot 2024-04-19 at 5 47 47 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0fa62332-00d4-491e-8113-c8674a40699d">


### Go to the Licenses page and test the following component

* License row actions
   <img width="325" alt="Screenshot 2024-04-19 at 5 49 21 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ccd79497-912d-451c-8c65-fa0b39d71af6">


### Go to the Payment Methods page and test the following component

* Card actions
   <img width="319" alt="Screenshot 2024-04-19 at 5 50 34 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/29620b6b-d728-4694-a241-a6294e8d435a">



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?