### PR TITLE
A4A: Set Signup from TOS font size to 1rem.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
@@ -37,4 +37,7 @@
 		}
 	}
 
+	.company-details-form__tos p {
+		font-size: 1rem;
+	}
 }


### PR DESCRIPTION
For consistency, we will need to update the font size of the TOS paragraph to 16px.

**Before**
<img width="773" alt="Screenshot 2024-04-19 at 6 33 35 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/053671cc-cc34-4a97-8cb1-9de9be57c59b">

**After**
<img width="766" alt="Screenshot 2024-04-19 at 6 33 41 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/becb958f-51fe-4cf7-af1a-a32c7c9d3dfe">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/271

## Proposed Changes

* Set `.company-details-form__tos p` font size to 1rem.

## Testing Instructions

* Create a new account.
* Spin up this branch locally.
* Go to `/signup` page
* Confirm that the TOS paragraph has a font size of 16px or 1rem.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?