### PR TITLE
Automattic for Agencies: Implement redirect to Unassigned Licenses from the Sites page.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -1,6 +1,7 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { getProductPricingInfo } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
 import { useSelector } from 'calypso/state';
@@ -17,6 +18,8 @@ type ItemProps = {
 export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps ) {
 	const translate = useTranslate();
 	const userProducts = useSelector( getProductsList );
+
+	const siteId = getQueryArg( window.location.href, 'site_id' )?.toString();
 
 	const { actualCost, discountedCost } = getProductPricingInfo( userProducts, item, item.quantity );
 

--- a/client/components/jetpack/unassigned-license-notice/index.tsx
+++ b/client/components/jetpack/unassigned-license-notice/index.tsx
@@ -3,12 +3,9 @@ import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { A4A_UNASSIGNED_LICENSES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { productHasFeatureType } from 'calypso/blocks/jetpack-benefits/feature-checks';
 import QueryJetpackPartnerPortalLicenses from 'calypso/components/data/query-jetpack-partner-portal-licenses';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { getProductSlugFromLicenseKey } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
-import getProductInfo from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-product-info';
 import {
 	LicenseFilter,
 	LicenseSortDirection,
@@ -18,6 +15,7 @@ import { JETPACK_MANAGE_LICENCES_LINK } from 'calypso/jetpack-cloud/sections/sid
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPaginatedLicenses } from 'calypso/state/partner-portal/licenses/selectors';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
+import { checkLicenseKeyForFeature } from './lib/check-license-key-for-feature';
 
 interface UnusedLicenseNoticeProps {
 	featureType: string;
@@ -33,29 +31,6 @@ const UnusedLicenseNotice = ( { featureType }: UnusedLicenseNoticeProps ) => {
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
 	const dispatch = useDispatch();
 
-	const checkLicenseKeyForFeature = useCallback(
-		( licenseKey: string ) => {
-			// Truncate unneeded data (e.g. 'jetpack-backup-t1')
-			const licenseProductSlug = getProductSlugFromLicenseKey( licenseKey );
-
-			if ( ! licenseProductSlug ) {
-				return false;
-			}
-
-			// Convert to a monthly product slug (e.g. 'jetpack_backup_t1_monthly')
-			const monthlyProduct = getProductInfo( licenseProductSlug );
-
-			if ( ! monthlyProduct ) {
-				return false;
-			}
-
-			// Verify product has feature
-			const hasFeature = productHasFeatureType( monthlyProduct.productSlug, featureType );
-			return hasFeature;
-		},
-		[ featureType ]
-	);
-
 	const licenses = useSelector( getPaginatedLicenses );
 
 	useEffect( () => {
@@ -63,13 +38,13 @@ const UnusedLicenseNotice = ( { featureType }: UnusedLicenseNoticeProps ) => {
 			return;
 		}
 		for ( const l in licenses.items ) {
-			const hasFeature = checkLicenseKeyForFeature( licenses.items[ l ].licenseKey );
+			const hasFeature = checkLicenseKeyForFeature( featureType, licenses.items[ l ].licenseKey );
 			if ( hasFeature ) {
 				setShowUnassignedLicenseNotice( true );
 				break;
 			}
 		}
-	}, [ checkLicenseKeyForFeature, licenses ] );
+	}, [ featureType, licenses ] );
 
 	const onDismissClick = useCallback( () => {
 		dispatch(

--- a/client/components/jetpack/unassigned-license-notice/lib/check-license-key-for-feature.ts
+++ b/client/components/jetpack/unassigned-license-notice/lib/check-license-key-for-feature.ts
@@ -1,0 +1,23 @@
+import { productHasFeatureType } from 'calypso/blocks/jetpack-benefits/feature-checks';
+import { getProductSlugFromLicenseKey } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import getProductInfo from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-product-info';
+
+export const checkLicenseKeyForFeature = ( featureType: string, licenseKey: string ) => {
+	// Truncate unneeded data (e.g. 'jetpack-backup-t1')
+	const licenseProductSlug = getProductSlugFromLicenseKey( licenseKey );
+
+	if ( ! licenseProductSlug ) {
+		return false;
+	}
+
+	// Convert to a monthly product slug (e.g. 'jetpack_backup_t1_monthly')
+	const monthlyProduct = getProductInfo( licenseProductSlug );
+
+	if ( ! monthlyProduct ) {
+		return false;
+	}
+
+	// Verify product has feature
+	const hasFeature = productHasFeatureType( monthlyProduct.productSlug, featureType );
+	return hasFeature;
+};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/lib/constants.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/lib/constants.ts
@@ -1,3 +1,8 @@
+import {
+	FEATURE_TYPE_JETPACK_BACKUP,
+	FEATURE_TYPE_JETPACK_SCAN,
+} from '@automattic/calypso-products';
+
 /**
  * Maps general product types to the more specific corresponding slug that's
  * available for purchase from the dashboard.
@@ -7,6 +12,11 @@ export const DASHBOARD_PRODUCT_SLUGS_BY_TYPE: Record< string, string > = {
 	boost: 'jetpack-boost',
 	scan: 'jetpack-scan',
 	monitor: 'jetpack-monitor',
+};
+
+export const FEATURE_TYPES_BY_TYPE: Record< string, string > = {
+	backup: FEATURE_TYPE_JETPACK_BACKUP,
+	scan: FEATURE_TYPE_JETPACK_SCAN,
 };
 
 export const WPCOM_HOSTING = 'wpcom-hosting';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -4,7 +4,17 @@ import { Gridicon, Tooltip } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_CHECKOUT_LINK,
+	A4A_UNASSIGNED_LICENSES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import { checkLicenseKeyForFeature } from 'calypso/components/jetpack/unassigned-license-notice/lib/check-license-key-for-feature';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -13,7 +23,7 @@ import {
 	hasSelectedSiteLicensesOfType,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
-import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from '../lib/constants';
+import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE, FEATURE_TYPES_BY_TYPE } from '../lib/constants';
 import { AllowedTypes, RowMetaData, SiteData } from '../types';
 
 type Props = {
@@ -36,6 +46,14 @@ export default function SiteStatusColumn( { type, rows, metadata, disabled }: Pr
 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	const { data } = useFetchLicenses(
+		LicenseFilter.Detached,
+		'',
+		LicenseSortField.IssuedAt,
+		LicenseSortDirection.Descending,
+		1
+	);
 
 	const siteId = rows.site.value.blog_id;
 
@@ -61,10 +79,20 @@ export default function SiteStatusColumn( { type, rows, metadata, disabled }: Pr
 
 	const handleA4AAddAction = useCallback( () => {
 		const productSlug = DASHBOARD_PRODUCT_SLUGS_BY_TYPE[ type ];
-		const productPurchaseLink = `${ A4A_MARKETPLACE_CHECKOUT_LINK }?product_slug=${ productSlug }&source=sitesdashboard&site_id=${ siteId }`;
-
+		let productPurchaseLink = `${ A4A_MARKETPLACE_CHECKOUT_LINK }?product_slug=${ productSlug }&source=sitesdashboard&site_id=${ siteId }`;
+		const licenses = data?.items ?? [];
+		const featureType = FEATURE_TYPES_BY_TYPE[ type ];
+		if ( featureType ) {
+			for ( const l in licenses ) {
+				const hasFeature = checkLicenseKeyForFeature( featureType, licenses[ l ].licenseKey );
+				if ( hasFeature ) {
+					productPurchaseLink = A4A_UNASSIGNED_LICENSES_LINK;
+					break;
+				}
+			}
+		}
 		return page( productPurchaseLink );
-	}, [ siteId, type ] );
+	}, [ data?.items, siteId, type ] );
 
 	const handleSelectLicenseAction = useCallback( () => {
 		if ( isStreamlinedPurchasesEnabled ) {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/287

## Proposed Changes

This PR redirects the licenses page(unassigned) if there are any unassigned `backup` or `scan` licenses when clicked on `+ Add` on the Sites Dashboard in A4A.

Note:

1) We are fetching only 50 licenses due to pagination. So, this may not work well if there are no licenses we are checking for in the first 50 unassigned licenses. 
2) We don't show any loader or disable the `+ Add ` button when the licenses are being fetched. Let me know if this doesn't make sense.

## Testing Instructions

1) Open the A4A live link.
2) Revoke all unassigned licenses.
3) Go to /sites > Click on the `+ Add` on the backup & scan column. Verify you are redirected to the checkout page.
4) Visit /marketplace > Issue a backup license, but don't assign it to a site > Go to /sites > Click on the `+ Add` on the backup column > Verify you are now redirected to /purchases/licenses/unassigned > Assign this license to any site.
5) Repeat step 4 with a scan license.
6) Go to /sites > Click on the `+ Add` on the backup column > Verify that you are redirected to the checkout page.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?