### PR TITLE
Entrepreneur Signup: Add is_entrepreneur_signup marker

### DIFF
--- a/client/data/ecommerce/use-add-ecommerce-trial-mutation.ts
+++ b/client/data/ecommerce/use-add-ecommerce-trial-mutation.ts
@@ -11,9 +11,15 @@ export default function useAddEcommerceTrialMutation(
 ) {
 	const mutation = useMutation( {
 		mutationFn: async ( { siteId }: Variables ) => {
-			await wp.req.post( `/sites/${ siteId }/ecommerce-trial/add/ecommerce-trial-bundle-monthly`, {
-				apiVersion: '1.1',
-			} );
+			await wp.req.post(
+				`/sites/${ siteId }/ecommerce-trial/add/ecommerce-trial-bundle-monthly`,
+				{
+					apiVersion: '1.1',
+				},
+				{
+					is_entrepreneur_signup: 1,
+				}
+			);
 		},
 		...options,
 	} );

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -102,13 +102,14 @@ const entrepreneurFlow: Flow = {
 							'.wpcomstaging.com'
 						);
 
-						// TODO: The cause of redirection failure is within Jetpack SSO.
-						// Remove this comment after Jetpack SSO is fixed.
 						const redirectTo = encodeURIComponent(
-							`https://${ stagingUrl }/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai&ref=wpcom-entrepreneur-signup`
+							`https://${ stagingUrl }/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai&ref=entrepreneur-signup`
 						);
 
 						// Redirect users to the login page with the 'action=jetpack-sso' parameter to initiate Jetpack SSO login and redirect them to Woo CYS's Design With AI after.
+
+						// Note: This is just symbolic because somewhere within Jetpack SSO
+						// or some plugin is stripping off the `redirect_to` param. The actual work that is doing the redirection is in wpcomsh/1801.
 						const redirectToWithSSO = `https://${ stagingUrl }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`;
 
 						return window.location.assign( redirectToWithSSO );

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -106,10 +106,7 @@ const entrepreneurFlow: Flow = {
 							`https://${ stagingUrl }/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai&ref=entrepreneur-signup`
 						);
 
-						// Redirect users to the login page with the 'action=jetpack-sso' parameter to initiate Jetpack SSO login and redirect them to Woo CYS's Design With AI after.
-
-						// Note: This is just symbolic because somewhere within Jetpack SSO
-						// or some plugin is stripping off the `redirect_to` param. The actual work that is doing the redirection is in wpcomsh/1801.
+						// Redirect users to the login page with the 'action=jetpack-sso' parameter to initiate Jetpack SSO login and redirect them to Woo CYS's Design With AI after. This URL, however, is just symbolic because somewhere within Jetpack SSO or some plugin is stripping off the `redirect_to` param. The actual work that is doing the redirection is in wpcomsh/1801.
 						const redirectToWithSSO = `https://${ stagingUrl }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`;
 
 						return window.location.assign( redirectToWithSSO );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* When a site is created using the `setup/entrepreneur` signup flow, add a `is_entrepreneur_signup` marker which will be stored in site option.

## Testing Instructions

#### Frontend
* Apply the patch D145988-code and sandbox `public-api.wordpress.com`.
* Open the network panel.
* Go through the `calypso.localhost:3000/setup/entrepreneur` signup flow. 
  * Your signup flow will fail in the end because the `waitForPluginsInstalled` step can't run when `public-api.wordpress.com` is sandboxed.
  * But you will have your site created. So look for it in the network panel.
* On the network panel, filter down to the `add/ecommerce-trial-bundle-monthly` endpoint. 
  * You should see the `is_entrepreneur_signup` param being added to the API call.

#### Backend
* Enter WP CLI via `your-new-site.wpcomstaging.com/_cli`.
* Run the following command `wp option get wpcom_is_entrepreneur_signup`.
* You should see the value `1`.

<img width="861" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/03e6d83d-4127-42f6-8d7f-144955905f55">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?