### PR TITLE
[WIP] Congrats: handle all types of failed purchases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-and-successful-purchases/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-and-successful-purchases/index.tsx
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import ThankYouHeader from 'calypso/components/thank-you-v2/header';
+import { FailedPurchasesThankYou } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-purchases';
+import type { FailedReceiptPurchase } from 'calypso/state/receipts/types';
+
+import './style.scss';
+
+type FailedAndSuccessfulPurchasesThankYouProps = {
+	failedPurchases: FailedReceiptPurchase[];
+	receiptTotalAmount?: string;
+	siteSlug?: string;
+	successfulPurchasesComponent: React.ReactElement;
+};
+
+export const FailedAndSuccessfulPurchasesThankYou = ( {
+	failedPurchases,
+	receiptTotalAmount,
+	siteSlug,
+	successfulPurchasesComponent,
+}: FailedAndSuccessfulPurchasesThankYouProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<ThankYouHeader
+				title={ translate( 'Almost there', {
+					comment:
+						'Title for the congrats page after purchasing a few WP products, but not all successfully',
+				} ) }
+				subtitle={ translate( 'The following items have been successfully purchased' ) }
+			/>
+			<div className="failed-and-successful-purchases-details__body">
+				{ successfulPurchasesComponent }
+			</div>
+			<FailedPurchasesThankYou
+				isFullPurchaseFailed={ false }
+				siteSlug={ siteSlug }
+				failedPurchases={ failedPurchases }
+				receiptTotalAmount={ receiptTotalAmount }
+			/>
+		</>
+	);
+};

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-and-successful-purchases/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-and-successful-purchases/style.scss
@@ -1,0 +1,7 @@
+.failed-and-successful-purchases-details__body {
+	.thank-you__header,
+	.thank-you__footer,
+	.thank-you__upsell {
+		display: none;
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-purchases/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-purchases/index.tsx
@@ -1,0 +1,94 @@
+import { CALYPSO_CONTACT } from '@automattic/urls';
+import { warning, Icon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import ThankYouFooter from 'calypso/components/thank-you-v2/footer';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { FailedReceiptPurchase } from 'calypso/state/receipts/types';
+
+import './style.scss';
+
+type FailedPurchasesThankYouProps = {
+	failedPurchases: FailedReceiptPurchase[];
+	isFullPurchaseFailed?: boolean;
+	receiptTotalAmount?: string;
+	siteSlug?: string;
+};
+
+export const FailedPurchasesThankYou = ( {
+	failedPurchases,
+	isFullPurchaseFailed = true,
+	receiptTotalAmount,
+	siteSlug,
+}: FailedPurchasesThankYouProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="failed-purchase-thank-you">
+			<div className="failed-purchase-thank-you__title">
+				<Icon icon={ warning } size={ 24 } />
+				{ isFullPurchaseFailed
+					? translate( 'Items failed', { comment: 'Failed purchase' } )
+					: translate( 'Some items failed', { comment: 'Failed purchase' } ) }
+			</div>
+			<div className="failed-purchase-thank-you__description">
+				{ receiptTotalAmount &&
+					translate(
+						'Apologies for the inconvenience. We charged you the total amount of %(totalAmount)s, but due to an issue on our side, failed to add the following items to your site.',
+						{
+							args: { totalAmount: receiptTotalAmount },
+						}
+					) }
+			</div>
+
+			<div className="failed-purchase-thank-you__items">
+				{ failedPurchases.map( ( item, index ) => (
+					<div
+						key={ `failed-purchase-${ index }-${ item.productId }` }
+						className="failed-purchase-thank-you__item"
+					>
+						<div className="failed-purchase-thank-you__item-title">
+							{ item.productName }
+							{ item.meta && `: ${ item.meta }` }
+						</div>
+					</div>
+				) ) }
+			</div>
+			<div className="failed-purchase-thank-you__footer">
+				<ThankYouFooter
+					details={ [
+						{
+							key: 'footer-failed-purchases-how-to-fix',
+							title: translate( 'How to fix this issue' ),
+							description: translate(
+								'We have added credits to your account, so you can purchase these item again with no cost added.'
+							),
+							buttonText: translate( 'Purchase the items' ),
+							buttonHref: `/checkout/${ siteSlug }`,
+							buttonOnClick: () => {
+								recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+									context: 'failed-purchase',
+									type: 'try-purchase-again',
+								} );
+							},
+						},
+						{
+							key: 'footer-failed-purchases-customers-support',
+							title: translate( 'We are here to help' ),
+							description: translate(
+								"If you have any concerns or the problem persist, please don't hesitate to contact us."
+							),
+							buttonText: translate( 'Contact costumer support' ),
+							buttonHref: CALYPSO_CONTACT,
+							buttonOnClick: () => {
+								recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+									context: 'failed-purchase',
+									type: 'support',
+								} );
+							},
+						},
+					] }
+				/>
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-purchases/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/failed-purchases/style.scss
@@ -1,0 +1,67 @@
+@import "@automattic/components/src/styles/typography";
+
+.failed-purchase-thank-you {
+	border: 1px solid #e65054;
+	border-radius: 2px;
+	margin: 60px auto;
+	padding: 36px 25px 0;
+	max-width: 600px;
+}
+
+.failed-purchase-thank-you__title {
+	font-family: $font-sf-pro-display;
+	font-size: rem(20px);
+	color: #e65054;
+	line-height: 1.3;
+	letter-spacing: 0.38px;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding-bottom: 8px;
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.failed-purchase-thank-you__description {
+	font-family: $font-sf-pro-text;
+	font-size: rem(14px);
+	color: #3c434a;
+	line-height: 1.4;
+	letter-spacing: -0.2px;
+	padding-bottom: 30px;
+}
+
+.failed-purchase-thank-you__items {
+	padding-bottom: 22px;
+
+	.failed-purchase-thank-you__item {
+		padding: 12px 24px;
+		border: 1px solid #dcdcde;
+		border-radius: 2px;
+		margin-bottom: 8px;
+
+		.failed-purchase-thank-you__item-title {
+			font-family: $font-sf-pro-text;
+			font-size: rem(16px);
+			color: #646970;
+			line-height: 1.5;
+			letter-spacing: -0.32px;
+			word-break: break-word;
+		}
+	}
+}
+
+.failed-purchase-thank-you__footer {
+	padding-bottom: 36px;
+
+	.thank-you__footer {
+		margin: 0;
+
+		.thank-you__footer-inner {
+			padding: 0;
+			margin: 0;
+		}
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -1,5 +1,5 @@
 import { isDelayedDomainTransfer } from '@automattic/calypso-products';
-import { CheckoutThankYouCombinedProps, getFailedPurchases, getPurchases } from '..';
+import { CheckoutThankYouCombinedProps, getPurchases } from '..';
 
 /**
  * Determines whether the current checkout flow renders a redesigned congrats page
@@ -9,17 +9,7 @@ import { CheckoutThankYouCombinedProps, getFailedPurchases, getPurchases } from 
  * @returns {boolean}
  */
 export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps ) => {
-	// Fallback to old design when there is a failed purchase.
-	const failedPurchases = getFailedPurchases( props );
-	if ( failedPurchases.length > 0 ) {
-		return false;
-	}
-
 	const purchases = getPurchases( props );
-
-	if ( ! purchases.length ) {
-		return false;
-	}
 
 	if ( purchases.find( isDelayedDomainTransfer ) ) {
 		return false;


### PR DESCRIPTION
## Work In Progress, whats left:
1) Populate shopping cart with failed purchases, details: p9Jlb4-7Hx-p2#comment-11302


Related to https://github.com/Automattic/dotcom-forge/issues/3026

## Proposed Changes
With this PR we are handling any failed purchase according to the design: VLoPHWqcewxNKZYjjkDu3O-fi-2916%3A2474

## Foreword
I spent quite a lot of time to consider a few options to implement it, and the current approach looks the best, since:
1) If all purchases fail - we just render the page immediately https://github.com/Automattic/wp-calypso/pull/89697/files#diff-daac408bb350333e9fb8ca7c03233e75f03656e02a45c152e574227e6d253ee7R537
2) For case when some failed and some successful - we don't modify existed success pages, also we don't have any extra conditions and logic, we keep the code quite clear and simple. Honetly, would be prefer to have some 1 condition in JS, instead of CSS (https://github.com/Automattic/wp-calypso/pull/89697/files#diff-86a63db58cb69113790b68431fd654183ba5b760b9f18a21e7ee03a68ac3a563R1), but taking into account the implementation of successful congrats pages - it looks like the simpliest and clear way with treating it with CSS exactly in this way.


## Testing Instructions
### Successful purchase
1.1 Add a few items to your shopping cart (e.g. 2 domains and Titan subscription for one of them)
1.2 Purchase them
1.3 Assert that you see appropriate congrats page and everything look as previously <br /> <img width="1521" alt="Screenshot 2024-04-19 at 13 33 12" src="https://github.com/Automattic/wp-calypso/assets/5598437/6fce4c22-905a-4e75-9fa0-691e7d4addcc">

### All purchases failed
Let's emulate a case when all purchases failed:

```
diff --git a/client/my-sites/checkout/checkout-thank-you/index.tsx b/client/my-sites/checkout/checkout-thank-you/index.tsx
index 524288e29e..b35c9b56e3 100644
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -162,13 +162,16 @@ export type CheckoutThankYouCombinedProps = CheckoutThankYouProps &

 export function getPurchases( props: CheckoutThankYouCombinedProps ): ReceiptPurchase[] {
        return [
-               ...( props?.receipt?.data?.purchases ?? [] ),
-               ...( props?.gsuiteReceipt?.data?.purchases ?? [] ),
+               // ...( props?.receipt?.data?.purchases ?? [] ),
+               // ...( props?.gsuiteReceipt?.data?.purchases ?? [] ),
        ];
 }

 export function getFailedPurchases( props: CheckoutThankYouCombinedProps ) {
-       return ( props.receipt.data && props.receipt.data.failedPurchases ) || [];
+       return [
+               ...( props?.receipt?.data?.purchases ?? [] ),
+               ...( props?.gsuiteReceipt?.data?.purchases ?? [] ),
+       ];
 }

 function findPurchaseAndDomain(
```
2.1 Open the URL from the `Successful purchase` testing steps and assert:
	2.1.1 You don't see confetti when the page is loaded
	2.1.2 You see one a component with the title `Items failed` and with the list of failed items to purchase
	2.1.3 Link `Contact costumer support` should lead to `https://wordpress.com/support/`
	2.1.4 Link `Purchase the items` should lead to checkout page
<img width="1514" alt="Screenshot 2024-04-19 at 13 43 12" src="https://github.com/Automattic/wp-calypso/assets/5598437/c2b8f0e0-e307-4886-b448-6c389d503207">


### Some purchases failed and some not
Let's emulate a case when some purchases failed (we will just duplicate successful purchases to failed):
```
diff --git a/client/my-sites/checkout/checkout-thank-you/index.tsx b/client/my-sites/checkout/checkout-thank-you/index.tsx
index 524288e29e..33cce2934d 100644
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -168,7 +168,10 @@ export function getPurchases( props: CheckoutThankYouCombinedProps ): ReceiptPur
 }

 export function getFailedPurchases( props: CheckoutThankYouCombinedProps ) {
-       return ( props.receipt.data && props.receipt.data.failedPurchases ) || [];
+       return [
+               ...( props?.receipt?.data?.purchases ?? [] ),
+               ...( props?.gsuiteReceipt?.data?.purchases ?? [] ),
+       ];
 }

 function findPurchaseAndDomain(
```
3.1 Open the URL from the `Successful purchase` testing steps and assert:
	3.1.1 You see the same page as previously, but title inside failed block purchases is changed to `Some items failed` and at the top you see the next data about successful purchases <br> <img width="682" alt="Screenshot 2024-04-19 at 13 46 53" src="https://github.com/Automattic/wp-calypso/assets/5598437/d740f134-c561-485b-abf4-17ece0e0e353"> <br /> So in general the page looks this way: <br /> <img width="1516" alt="Screenshot 2024-04-19 at 13 47 30" src="https://github.com/Automattic/wp-calypso/assets/5598437/d073ee16-ee0a-4402-b6a1-e789b79f8adc">