### PR TITLE
Hosting Overview: Show site selector

### DIFF
--- a/client/hosting-overview/index.tsx
+++ b/client/hosting-overview/index.tsx
@@ -1,24 +1,9 @@
-import page, { type Context } from '@automattic/calypso-router';
+import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { siteSelection } from 'calypso/my-sites/controller';
-import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { siteSelection, sites } from 'calypso/my-sites/controller';
 import hostingOverview from './controller';
 
 export default function () {
-	page( '/hosting-overview', ( { store: { getState } }: Context ) => {
-		const state = getState();
-
-		const primarySiteId = getPrimarySiteId( state );
-		const selectedSite = getSelectedSite( state );
-
-		page.redirect(
-			`/hosting-overview/${
-				selectedSite ? selectedSite?.slug : getSiteSlug( state, primarySiteId )
-			}`
-		);
-	} );
-
+	page( '/hosting-overview', siteSelection, sites, makeLayout, clientRender );
 	page( '/hosting-overview/:site', siteSelection, hostingOverview, makeLayout, clientRender );
 }

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -147,6 +147,9 @@ class Sites extends Component {
 			case 'hosting-config':
 				path = translate( 'Hosting Configuration' );
 				break;
+			case 'hosting-overview':
+				path = translate( 'Hosting Overview' );
+				break;
 			case 'jetpack-search':
 				path = 'Jetpack Search';
 				break;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6384

## Proposed Changes

* Show the site selector if no site is added to the URL instead of choosing the primary site, as mentioned on https://github.com/Automattic/wp-calypso/pull/89476#issuecomment-2059177300

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/hosting-overview`
* Check that you see the site selector:

![image](https://github.com/Automattic/wp-calypso/assets/8511199/887eb441-e506-4e1c-b380-81e884e86114)

* Check that clicking on a site takes you to the hosting overview page for that site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?