### PR TITLE
Theme Showcase: Fix Broken Layout on users without sites

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -83,7 +83,8 @@ body.command-palette-modal-open {
 		margin: 0;
 	}
 
-	.is-section-themes.has-no-sidebar.is-logged-in & {
+	.is-section-themes.has-no-sidebar.is-logged-in &,
+	.theme-default .is-section-themes.has-no-sidebar.is-logged-in & {
 		padding: 79px 32px 32px;
 	}
 


### PR DESCRIPTION
This PR fixes the theme showcase for users without sites, which currently looks broken:

![Screenshot from 2024-04-19 15-17-50](https://github.com/Automattic/wp-calypso/assets/8511199/3f0da862-185a-4184-85d0-87b035b65f30)

## Proposed Changes

* The proper `padding` should be applied by the `.is-section-themes.has-no-sidebar.is-logged-in .layout__content` selector, but it's overriden by `.theme-default .layout.is-section-themes.has-no-sidebar .layout__content`, so I'm adding the `.theme-default ` bit in order for it to work.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Create a new account
* Skip the site creation process 
* Go to `/themes`, check that it looks good
* On an account with sites, repeat the previous step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?