### PR TITLE
Scheduled updates: Adapt schedule form to match new design

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
@@ -3,7 +3,7 @@ import { ScheduleForm } from './schedule-form';
 export const ScheduleCreate = () => {
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
-			<h1 className="wp-brand-font">Weekly on Monday at 10AM</h1>
+			<h1 className="wp-brand-font">New schedule</h1>
 
 			<ScheduleForm />
 		</div>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -58,7 +58,7 @@ export const ScheduleFormSites = ( props: Props ) => {
 				<SearchControl
 					id="sites"
 					onChange={ ( s ) => setSearchTerm( s.trim() ) }
-					placeholder={ translate( 'Search site' ) }
+					placeholder={ translate( 'Search sites' ) }
 				/>
 				{ ! sites.length && (
 					<Text className="info-msg">

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,4 +1,3 @@
-import { Flex, FlexItem } from '@wordpress/components';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useCoreSitesPluginsQuery } from 'calypso/data/plugins/use-core-sites-plugins-query';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
@@ -59,33 +58,23 @@ export const ScheduleForm = () => {
 
 	return (
 		<div className="schedule-form">
-			<div className="form-control-container">
-				<Flex direction={ [ 'column', 'row' ] } expanded={ true } align="start">
-					<FlexItem>
-						<ScheduleFormSites
-							sites={ sites }
-							borderWrapper={ false }
-							onChange={ setSelectedSites }
-							onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, sites: touched } ) }
-							error={ validationErrors?.sites }
-							showError={ fieldTouched?.sites }
-						/>
-					</FlexItem>
-					<FlexItem>
-						<ScheduleFormPlugins
-							plugins={ getPlugins() }
-							selectedPlugins={ selectedPlugins }
-							isPluginsFetching={ isPluginsFetching }
-							isPluginsFetched={ isPluginsFetched }
-							onChange={ setSelectedPlugins }
-							onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, plugins: touched } ) }
-							error={ validationErrors?.plugins }
-							showError={ fieldTouched?.plugins }
-							borderWrapper={ false }
-						/>
-					</FlexItem>
-				</Flex>
-			</div>
+			<ScheduleFormSites
+				sites={ sites }
+				onChange={ setSelectedSites }
+				onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, sites: touched } ) }
+				error={ validationErrors?.sites }
+				showError={ fieldTouched?.sites }
+			/>
+			<ScheduleFormPlugins
+				plugins={ getPlugins() }
+				selectedPlugins={ selectedPlugins }
+				isPluginsFetching={ isPluginsFetching }
+				isPluginsFetched={ isPluginsFetched }
+				onChange={ setSelectedPlugins }
+				onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, plugins: touched } ) }
+				error={ validationErrors?.plugins }
+				showError={ fieldTouched?.plugins }
+			/>
 			<div className="form-control-container">
 				<ScheduleFormFrequency initFrequency="daily" />
 			</div>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -87,11 +87,7 @@ export const ScheduleForm = () => {
 				</Flex>
 			</div>
 			<div className="form-control-container">
-				<ScheduleFormFrequency
-					initFrequency="daily"
-					optionsDirection={ [ 'column', 'row' ] }
-					showAllOptionControls={ true }
-				/>
+				<ScheduleFormFrequency initFrequency="daily" />
 			</div>
 		</div>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -21,26 +21,5 @@
 				}
 			}
 		}
-
-		div.radio-option {
-			flex-basis: 100%;
-			min-height: 85px;
-
-			& > .components-radio-control {
-				margin-bottom: 1rem;
-			}
-		}
-	}
-
-	.form-field--frequency {
-		& > .components-flex {
-			gap: 2rem;
-
-			& > .components-flex-item {
-				margin-bottom: 0;
-				border: solid 1px var(--studio-gray-10);
-				border-radius: 2px;
-			}
-		}
 	}
 }

--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -24,7 +24,6 @@ interface Props {
 	initFrequency: Frequency;
 	error?: string;
 	showError?: boolean;
-	showAllOptionControls?: boolean;
 	onTouch?: ( touched: boolean ) => void;
 	onChange?: ( frequency: Frequency, timestamp: number ) => void;
 }
@@ -38,7 +37,6 @@ export function ScheduleFormFrequency( props: Props ) {
 		initFrequency = 'daily',
 		error,
 		showError,
-		showAllOptionControls,
 		onChange,
 		onTouch,
 	} = props;
@@ -69,30 +67,28 @@ export function ScheduleFormFrequency( props: Props ) {
 			<label htmlFor="frequency">{ translate( 'Select frequency' ) }</label>
 			<Flex direction={ [ 'column', 'row' ] }>
 				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
-					{ ( showAllOptionControls || frequency === 'daily' ) && (
-						<Flex gap={ 6 }>
-							<FlexItem>
-								<RadioControl
-									name="frequency"
-									options={ [ DAILY_OPTION ] }
-									selected={ frequency }
-									onChange={ ( f ) => setFrequency( f as 'daily' ) }
-									onBlur={ () => setFieldTouched( true ) }
-								></RadioControl>
-							</FlexItem>
-							<FlexItem>
-								<ScheduleFormTime
-									hour={ hour }
-									period={ period }
-									isAmPmFormat={ isAmPmFormat }
-									onChange={ ( hour, period ) => {
-										setHour( hour );
-										setPeriod( period );
-									} }
-								/>
-							</FlexItem>
-						</Flex>
-					) }
+					<Flex gap={ 6 }>
+						<FlexItem>
+							<RadioControl
+								name="frequency"
+								options={ [ DAILY_OPTION ] }
+								selected={ frequency }
+								onChange={ ( f ) => setFrequency( f as 'daily' ) }
+								onBlur={ () => setFieldTouched( true ) }
+							></RadioControl>
+						</FlexItem>
+						<FlexItem>
+							<ScheduleFormTime
+								hour={ hour }
+								period={ period }
+								isAmPmFormat={ isAmPmFormat }
+								onChange={ ( hour, period ) => {
+									setHour( hour );
+									setPeriod( period );
+								} }
+							/>
+						</FlexItem>
+					</Flex>
 				</FlexItem>
 				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'weekly' } ) }>
 					<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>

--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -1,7 +1,6 @@
 import {
 	__experimentalText as Text,
 	Flex,
-	FlexBlock,
 	FlexItem,
 	RadioControl,
 	SelectControl,
@@ -70,16 +69,18 @@ export function ScheduleFormFrequency( props: Props ) {
 			<label htmlFor="frequency">{ translate( 'Select frequency' ) }</label>
 			<Flex direction={ [ 'column', 'row' ] }>
 				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
-					<RadioControl
-						name="frequency"
-						options={ [ DAILY_OPTION ] }
-						selected={ frequency }
-						onChange={ ( f ) => setFrequency( f as 'daily' ) }
-						onBlur={ () => setFieldTouched( true ) }
-					></RadioControl>
 					{ ( showAllOptionControls || frequency === 'daily' ) && (
 						<Flex gap={ 6 }>
-							<FlexBlock>
+							<FlexItem>
+								<RadioControl
+									name="frequency"
+									options={ [ DAILY_OPTION ] }
+									selected={ frequency }
+									onChange={ ( f ) => setFrequency( f as 'daily' ) }
+									onBlur={ () => setFieldTouched( true ) }
+								></RadioControl>
+							</FlexItem>
+							<FlexItem>
 								<ScheduleFormTime
 									hour={ hour }
 									period={ period }
@@ -89,22 +90,24 @@ export function ScheduleFormFrequency( props: Props ) {
 										setPeriod( period );
 									} }
 								/>
-							</FlexBlock>
+							</FlexItem>
 						</Flex>
 					) }
 				</FlexItem>
 				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'weekly' } ) }>
-					<RadioControl
-						name="frequency"
-						options={ [ WEEKLY_OPTION ] }
-						selected={ frequency }
-						onChange={ ( f ) => setFrequency( f as 'weekly' ) }
-						onBlur={ () => setFieldTouched( true ) }
-					></RadioControl>
-					{ ( showAllOptionControls || frequency === 'weekly' ) && (
-						<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>
-							<FlexItem>
-								<div className="form-field">
+					<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>
+						<FlexItem>
+							<RadioControl
+								name="frequency"
+								options={ [ WEEKLY_OPTION ] }
+								selected={ frequency }
+								onChange={ ( f ) => setFrequency( f as 'weekly' ) }
+								onBlur={ () => setFieldTouched( true ) }
+							></RadioControl>
+						</FlexItem>
+						<FlexItem>
+							<Flex direction={ [ 'column', 'row' ] } gap={ 5 }>
+								<FlexItem>
 									<SelectControl
 										__next40pxDefaultSize
 										name="day"
@@ -112,21 +115,21 @@ export function ScheduleFormFrequency( props: Props ) {
 										options={ DAY_OPTIONS }
 										onChange={ setDay }
 									/>
-								</div>
-							</FlexItem>
-							<FlexBlock>
-								<ScheduleFormTime
-									hour={ hour }
-									period={ period }
-									isAmPmFormat={ isAmPmFormat }
-									onChange={ ( hour, period ) => {
-										setHour( hour );
-										setPeriod( period );
-									} }
-								/>
-							</FlexBlock>
-						</Flex>
-					) }
+								</FlexItem>
+								<FlexItem>
+									<ScheduleFormTime
+										hour={ hour }
+										period={ period }
+										isAmPmFormat={ isAmPmFormat }
+										onChange={ ( hour, period ) => {
+											setHour( hour );
+											setPeriod( period );
+										} }
+									/>
+								</FlexItem>
+							</Flex>
+						</FlexItem>
+					</Flex>
 				</FlexItem>
 			</Flex>
 			{ ( ( showError && error ) || ( fieldTouched && error ) ) && (

--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -18,13 +18,11 @@ import { DAILY_OPTION, DAY_OPTIONS, DEFAULT_HOUR, WEEKLY_OPTION } from './schedu
 import { prepareTimestamp } from './schedule-form.helper';
 
 type Frequency = 'daily' | 'weekly';
-type FlexDirection = 'column' | 'row';
 
 interface Props {
 	className?: string;
 	initTimestamp?: number;
 	initFrequency: Frequency;
-	optionsDirection?: FlexDirection[];
 	error?: string;
 	showError?: boolean;
 	showAllOptionControls?: boolean;
@@ -39,7 +37,6 @@ export function ScheduleFormFrequency( props: Props ) {
 		className = '',
 		initTimestamp,
 		initFrequency = 'daily',
-		optionsDirection = [ 'column' ],
 		error,
 		showError,
 		showAllOptionControls,
@@ -71,7 +68,7 @@ export function ScheduleFormFrequency( props: Props ) {
 	return (
 		<div className={ `form-field form-field--frequency ${ className }` }>
 			<label htmlFor="frequency">{ translate( 'Select frequency' ) }</label>
-			<Flex direction={ optionsDirection }>
+			<Flex direction={ [ 'column', 'row' ] }>
 				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
 					<RadioControl
 						name="frequency"

--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -67,7 +67,7 @@ export function ScheduleFormFrequency( props: Props ) {
 			<label htmlFor="frequency">{ translate( 'Select frequency' ) }</label>
 			<Flex direction={ [ 'column', 'row' ] }>
 				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
-					<Flex gap={ 6 }>
+					<Flex className="form-field--frequency-container" gap={ 6 }>
 						<FlexItem>
 							<RadioControl
 								name="frequency"
@@ -91,7 +91,11 @@ export function ScheduleFormFrequency( props: Props ) {
 					</Flex>
 				</FlexItem>
 				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'weekly' } ) }>
-					<Flex gap={ 6 } direction={ [ 'column', 'row' ] }>
+					<Flex
+						className="form-field--frequency-container"
+						gap={ 6 }
+						direction={ [ 'column', 'row' ] }
+					>
 						<FlexItem>
 							<RadioControl
 								name="frequency"

--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -70,7 +70,7 @@ export function ScheduleFormFrequency( props: Props ) {
 
 	return (
 		<div className={ `form-field form-field--frequency ${ className }` }>
-			<label htmlFor="frequency">{ translate( 'Update every' ) }</label>
+			<label htmlFor="frequency">{ translate( 'Select frequency' ) }</label>
 			<Flex direction={ optionsDirection }>
 				<FlexItem className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>
 					<RadioControl

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -129,6 +129,17 @@
 	.radio-option {
 		padding: 1.5rem;
 		flex-basis: 100%;
+		margin-bottom: 0.5rem !important;
+
+		.form-field--frequency-container {
+			flex-direction: column;
+			align-items: flex-start;
+
+			@include break-wide {
+				flex-direction: row;
+				align-items: center;
+			}
+		}
 
 		& > .components-radio-control {
 			margin-bottom: 1rem;
@@ -161,6 +172,7 @@
 			gap: 2rem;
 
 			& > .components-flex-item {
+				flex-basis: 100%;
 				margin-bottom: 0;
 				border: solid 1px var(--studio-gray-10);
 				border-radius: 2px;

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .schedule-form {
 	& > div {
 		width: 100%;
@@ -64,8 +67,26 @@
 		margin: -3px;
 		padding: 3px;
 
+		display: flex;
+		flex-wrap: wrap;
+
 		> * {
-			margin-bottom: 0.875rem;
+			box-sizing: border-box;
+			margin-bottom: 0.5rem;
+
+			flex: 0 0 calc(100% - 2rem);
+			max-width: calc(100% - 2rem);
+			margin-right: 2rem;
+
+			@include break-large {
+				flex: 0 0 calc(50% - 2rem);
+				max-width: calc(50% - 2rem);
+			}
+
+			@include break-xlarge {
+				flex: 0 0 calc(33.33% - 2rem);
+				max-width: calc(33.33% - 2rem);
+			}
 
 			&:last-child:not(.components-spinner) {
 				margin-bottom: 0;

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -91,14 +91,15 @@
 			margin-bottom: 0;
 		}
 
-		& > label {
-			display: inline-block;
-			margin-bottom: 0.5rem;
-		}
-
 		label {
 			font-size: 0.875rem;
 			font-weight: 500;
+		}
+
+		& > label {
+			display: inline-block;
+			margin-bottom: 0.875rem;
+			font-size: 1.25rem;
 		}
 	}
 

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -52,6 +52,7 @@
 	}
 
 	.components-search-control {
+		max-width: 300px;
 		margin-bottom: 1.5rem;
 
 		.components-input-control__container {

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -16,6 +16,7 @@
 
 	.components-radio-control__input {
 		padding: 0;
+		margin-right: 1rem;
 		background: transparent;
 		border-color: var(--studio-gray-50);
 
@@ -106,7 +107,6 @@
 	.radio-option {
 		padding: 1.5rem;
 		flex-basis: 100%;
-		min-height: 85px;
 
 		& > .components-radio-control {
 			margin-bottom: 1rem;
@@ -131,6 +131,10 @@
 	}
 
 	.form-field--frequency {
+		.components-base-control__field {
+			margin: 0;
+		}
+
 		& > .components-flex {
 			gap: 2rem;
 

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -105,14 +105,17 @@
 
 	.radio-option {
 		padding: 1.5rem;
+		flex-basis: 100%;
+		min-height: 85px;
+
+		& > .components-radio-control {
+			margin-bottom: 1rem;
+		}
 
 		&.selected {
 			border: solid 1px var(--wp-admin-theme-color) !important;
 			border-radius: 2px;
 
-			& > .components-radio-control {
-				margin-bottom: 1rem;
-			}
 		}
 
 		&:not(.selected) {
@@ -125,10 +128,17 @@
 				border-color: var(--studio-gray-20);
 			}
 		}
+	}
 
-		&:last-of-type {
-			border-bottom: solid 1px var(--color-border-subtle);
-			margin-bottom: 1rem;
+	.form-field--frequency {
+		& > .components-flex {
+			gap: 2rem;
+
+			& > .components-flex-item {
+				margin-bottom: 0;
+				border: solid 1px var(--studio-gray-10);
+				border-radius: 2px;
+			}
 		}
 	}
 

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -124,7 +124,6 @@ export const ScheduleForm = ( props: Props ) => {
 			<ScheduleFormFrequency
 				initTimestamp={ timestamp }
 				initFrequency={ frequency }
-				optionsDirection={ [ 'column', 'row' ] }
 				showAllOptionControls={ true }
 				error={ validationErrors?.timestamp }
 				showError={ fieldTouched?.timestamp }

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -116,48 +116,39 @@ export const ScheduleForm = ( props: Props ) => {
 	return (
 		<form
 			id="schedule"
+			className="schedule-form"
 			onSubmit={ ( e ) => {
 				e.preventDefault();
 				onFormSubmit();
 			} }
 		>
-			<Flex
-				className="schedule-form"
-				direction={ [ 'column', 'row' ] }
-				expanded={ true }
-				align="start"
-				gap={ 12 }
-			>
-				<FlexItem>
-					<ScheduleFormFrequency
-						initTimestamp={ timestamp }
-						initFrequency={ frequency }
-						error={ validationErrors?.timestamp }
-						showError={ fieldTouched?.timestamp }
-						onChange={ ( frequency, timestamp ) => {
-							setTimestamp( timestamp );
-							setFrequency( frequency );
-						} }
-						onTouch={ ( touched ) => {
-							setFieldTouched( { ...fieldTouched, timestamp: touched } );
-						} }
-					/>
-				</FlexItem>
-				<FlexItem>
-					<ScheduleFormPlugins
-						plugins={ plugins }
-						selectedPlugins={ selectedPlugins }
-						isPluginsFetching={ isPluginsFetching }
-						isPluginsFetched={ isPluginsFetched }
-						error={ validationErrors?.plugins }
-						showError={ fieldTouched?.plugins }
-						onChange={ setSelectedPlugins }
-						onTouch={ ( touched ) => {
-							setFieldTouched( { ...fieldTouched, plugins: touched } );
-						} }
-					/>
-				</FlexItem>
-			</Flex>
+			<ScheduleFormFrequency
+				initTimestamp={ timestamp }
+				initFrequency={ frequency }
+				optionsDirection={ [ 'column', 'row' ] }
+				showAllOptionControls={ true }
+				error={ validationErrors?.timestamp }
+				showError={ fieldTouched?.timestamp }
+				onChange={ ( frequency, timestamp ) => {
+					setTimestamp( timestamp );
+					setFrequency( frequency );
+				} }
+				onTouch={ ( touched ) => {
+					setFieldTouched( { ...fieldTouched, timestamp: touched } );
+				} }
+			/>
+			<ScheduleFormPlugins
+				plugins={ plugins }
+				selectedPlugins={ selectedPlugins }
+				isPluginsFetching={ isPluginsFetching }
+				isPluginsFetched={ isPluginsFetched }
+				error={ validationErrors?.plugins }
+				showError={ fieldTouched?.plugins }
+				onChange={ setSelectedPlugins }
+				onTouch={ ( touched ) => {
+					setFieldTouched( { ...fieldTouched, plugins: touched } );
+				} }
+			/>
 		</form>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -124,7 +124,6 @@ export const ScheduleForm = ( props: Props ) => {
 			<ScheduleFormFrequency
 				initTimestamp={ timestamp }
 				initFrequency={ frequency }
-				showAllOptionControls={ true }
 				error={ validationErrors?.timestamp }
 				showError={ fieldTouched?.timestamp }
 				onChange={ ( frequency, timestamp ) => {

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -1,4 +1,3 @@
-import { Flex, FlexItem } from '@wordpress/components';
 import { useState, useEffect } from 'react';
 import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89696

## Proposed Changes

* Updates form layout
* Updates form styles to match design

**Note:** I skipped adding "Step #" labels since there are only two controls, "frequency" and "plugins". We can add it once we introduce path control.
<img width="103" alt="Screenshot 2024-04-19 at 20 00 43" src="https://github.com/Automattic/wp-calypso/assets/1241413/9b1a7f84-4fee-4faa-bdd0-653a71c6e55a">

## Testing Instructions

* Go to `/plugins/scheduled-updates/{SITE_SLUG}`
* Create new or edit existing schedule
* Check if everything works as expected

<img width="1095" alt="Screenshot 2024-04-19 at 19 36 58" src="https://github.com/Automattic/wp-calypso/assets/1241413/213a5bbc-eb88-4cf7-8078-93b31e235c74">

<img width="591" alt="Screenshot 2024-04-19 at 19 37 30" src="https://github.com/Automattic/wp-calypso/assets/1241413/4a69e162-59d7-4071-8f16-6479558f3341">

Multisite context
<img width="1728" alt="Screenshot 2024-04-19 at 20 15 38" src="https://github.com/Automattic/wp-calypso/assets/1241413/cf19b7b9-af1a-4766-ba99-4c68318436bb">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?