### PR TITLE
A4a: fix sites dashboard mobile UI

### DIFF
--- a/client/a8c-for-agencies/sections/overview/header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/overview/header-actions/style.scss
@@ -17,8 +17,6 @@
 	}
 
 	.button.split-button__toggle {
-		border-radius: 0 4px 4 0;
-
 		svg {
 			fill: #000;
 		}

--- a/client/a8c-for-agencies/sections/overview/header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/overview/header-actions/style.scss
@@ -25,7 +25,7 @@
 			height: 18px;
 			margin-top: -2px;
 			position: relative;
-			top: 4px;
+			top: 2px;
 			width: 18px;
 		}
 	}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
 import { isWithinBreakpoint } from '@automattic/viewport';
-import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState } from 'react';
@@ -65,7 +64,6 @@ export default function SitesDashboard() {
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
-	const isNarrowView = useBreakpoint( '<660px' );
 	// FIXME: We should switch to a new A4A-specific endpoint when it becomes available, instead of using the public-facing endpoint for A4A
 	const { data: products } = useProductsQuery( true );
 
@@ -215,15 +213,15 @@ export default function SitesDashboard() {
 				! dataViewsState.selectedItem && 'preview-hidden'
 			) }
 			wide
-			sidebarNavigation={ <MobileSidebarNavigation /> }
 			title={ dataViewsState.selectedItem ? null : translate( 'Sites' ) }
 		>
 			{ ! hideListing && (
 				<LayoutColumn className="sites-overview" wide>
 					<LayoutTop withNavigation={ navItems.length > 1 }>
 						<LayoutHeader>
-							{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
+							<Title>{ translate( 'Sites' ) }</Title>
 							<Actions>
+								<MobileSidebarNavigation />
 								<SitesHeaderActions />
 							</Actions>
 						</LayoutHeader>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -99,7 +99,6 @@
 				}
 
 				.current-section button {
-					margin-top: 12px;
 					padding: 14px 8px;
 				}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -33,6 +33,9 @@
 
 	.a4a-layout__top-wrapper:not(.preview-hidden) {
 		padding-block-start: 24px;
+		@include breakpoint-deprecated( "<660px" ) {
+			padding-block-start: 0;
+		}
 	}
 
 	@media (min-width: $break-large) {

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
@@ -16,8 +16,6 @@
 	}
 
 	.button.split-button__toggle {
-		border-radius: 0 4px 4 0;
-
 		svg {
 			fill: #000;
 		}

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
@@ -24,7 +24,7 @@
 			height: 18px;
 			margin-top: -2px;
 			position: relative;
-			top: 4px;
+			top: 2px;
 			width: 18px;
 		}
 	}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -145,6 +145,9 @@
 
 	.button.split-button__toggle {
 		border-radius: 0 4px 4px 0;
+		@include breakpoint-deprecated( "<660px" ) {
+			border-radius: 4px;
+		}
 	}
 
 	.button.split-button__main {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/314

## Proposed Changes

Fix sites mobile UI in the same way as in other places of an app. Also added back rounding to `+` buttons in mobile view.
<img width="454" alt="Screenshot 2024-04-19 at 11 20 56 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/a63ab283-8fd5-49af-a66c-f14e6c4a6f6b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- With live link below check both, mobile and desktop versions of `sites dashboard` and verify it acts normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?