### PR TITLE
Fix: Cancel plan scroll + title

### DIFF
--- a/client/components/blank-canvas/style.scss
+++ b/client/components/blank-canvas/style.scss
@@ -11,7 +11,7 @@
 	width: 100%;
 	min-height: 100vh;
 	background: #fdfdfd;
-	overflow: hidden;
+	overflow: auto;
 	overscroll-behavior: contain;
 
 	// Hide masterbar behind.

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -9,11 +9,16 @@
 	font-size: 0.75rem;
 	font-weight: 600;
 	border-radius: 4px;
-	max-width: calc(100vw - 250px);
 	text-overflow: ellipsis;
 	overflow: hidden;
 	display: inline-block;
 	vertical-align: middle;
+	text-align: center;
+
+	@include break-small {
+		max-width: calc(100vw - 400px);
+		text-align: left;
+	}
 }
 
 .cancel-purchase-form__feedback,
@@ -212,7 +217,7 @@
 
 	.blank-canvas__header {
 		padding: 0 1rem;
-		margin-bottom: 4rem;
+		margin-bottom: 3rem;
 		box-shadow: none;
 
 		.wordpress-logo {
@@ -226,7 +231,7 @@
 
 	.blank-canvas__header-title {
 		z-index: 0;
-		top: 5rem;
+		top: 3rem;
 		left: 1rem;
 
 		@include break-small {


### PR DESCRIPTION
Slack: p1713540751622809-slack-C02FMH4G8

## Proposed Changes

When canceling a plan, the last confirmation screen is not scrolling, and in some cases, the button shows outside the screen.
The same screen shows the title with the incorrect style.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/ad042d45-95fd-4107-b5a6-3a0ff3a06d89) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/92682f9e-79ec-44df-b526-eb2d1be2743a) |

## Testing Instructions

* With a Creator's plan site
* Go to My plan
* Cancel the plan
* Confirm all the Feedback questions
* The last screen should show as Before (on screenshots)
* Use an iPhone 14 Pro device (you can use Dev tools)
* Check if scroll works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?