### PR TITLE
A4A: Pass all query arguments when redirecting from /landing

### DIFF
--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -1,14 +1,14 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
-import { addQueryArgs } from 'calypso/lib/route';
+import { getQueryArgs, addQueryArgs } from '@wordpress/url';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { A4A_LANDING_LINK } from './components/sidebar-menu/lib/constants';
 
 export const redirectToLandingContext: Callback = () => {
 	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
-
 	if ( isA4AEnabled ) {
-		page.redirect( A4A_LANDING_LINK );
+		const args = getQueryArgs( window.location.href );
+		page.redirect( addQueryArgs( A4A_LANDING_LINK, args ) );
 		return;
 	}
 	window.location.href = 'https://automattic.com/for/agencies';
@@ -25,12 +25,6 @@ export const requireAccessContext: Callback = ( context, next ) => {
 		return;
 	}
 
-	page.redirect(
-		addQueryArgs(
-			{
-				return: pathname + hash + search,
-			},
-			A4A_LANDING_LINK
-		)
-	);
+	const args = getQueryArgs( window.location.href );
+	page.redirect( addQueryArgs( A4A_LANDING_LINK, { ...args, return: pathname + hash + search } ) );
 };

--- a/client/a8c-for-agencies/sections/landing/landing.tsx
+++ b/client/a8c-for-agencies/sections/landing/landing.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { getQueryArg } from '@wordpress/url';
+import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -16,6 +16,15 @@ import { useSelector } from 'calypso/state';
 import { getActiveAgency, hasFetchedAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 import './style.scss';
+
+/**
+ * Redirect with Current Query
+ * Adds all of the current location's query parameters to the provided URL before redirecting.
+ */
+const redirectWithCurrentQuery = ( url: string ) => {
+	const args = getQueryArgs( window.location.href );
+	return page.redirect( addQueryArgs( url, args ) );
+};
 
 export default function Landing() {
 	const translate = useTranslate();
@@ -37,10 +46,10 @@ export default function Landing() {
 				return;
 			}
 
-			return page.redirect( A4A_OVERVIEW_LINK );
+			return redirectWithCurrentQuery( A4A_OVERVIEW_LINK );
 		}
 
-		page.redirect( A4A_SIGNUP_LINK );
+		redirectWithCurrentQuery( A4A_SIGNUP_LINK );
 	}, [ agency, hasFetched ] );
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/48

Alternative to https://github.com/Automattic/wp-calypso/pull/89667

After opening a PR to add support for a specific query parameter ("source"), I then realized I also needed a second, the wp-admin site URL. Instead of adding a second check for a "wp-admin-url" parameter, I figured we could support maintaining the entire query string from the root request in these initial internal redirects.

## Proposed Changes

* When redirecting from the landing page to either the overview, or the sign up form, keep all of the query parameters from the original request in the final URL.
* This enables the final rendered screens to use the query arguments from the original request, such as using a "source" parameter to determine where the user is coming from, or other site information when coming from a plugin or other external source.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the root URL with a test query string i.e. `?foo=bar`.
* Validate the redirected URL includes the query string.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
