### PR TITLE
A4A: Replace isEnabled( 'a8c-for-agencies' ) with new isA8CForAgencies environment const

### DIFF
--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -1,12 +1,11 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import { getQueryArgs, addQueryArgs } from '@wordpress/url';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { A4A_LANDING_LINK } from './components/sidebar-menu/lib/constants';
 
 export const redirectToLandingContext: Callback = () => {
-	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
-	if ( isA4AEnabled ) {
+	if ( isA8CForAgencies() ) {
 		const args = getQueryArgs( window.location.href );
 		page.redirect( addQueryArgs( A4A_LANDING_LINK, args ) );
 		return;

--- a/client/a8c-for-agencies/sections/auth/index.ts
+++ b/client/a8c-for-agencies/sections/auth/index.ts
@@ -1,10 +1,10 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { connect, tokenRedirect } from './controller';
 
 export default (): void => {
-	if ( config.isEnabled( 'a8c-for-agencies' ) ) {
+	if ( isA8CForAgencies() ) {
 		page( '/connect', connect, makeLayout, clientRender );
 		page( '/connect/oauth/token', tokenRedirect, makeLayout, clientRender );
 	}

--- a/client/components/jetpack/unassigned-license-notice/index.tsx
+++ b/client/components/jetpack/unassigned-license-notice/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -12,6 +11,7 @@ import {
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { JETPACK_MANAGE_LICENCES_LINK } from 'calypso/jetpack-cloud/sections/sidebar-navigation/lib/constants';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPaginatedLicenses } from 'calypso/state/partner-portal/licenses/selectors';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
@@ -84,7 +84,7 @@ const UnusedLicenseNotice = ( { featureType }: UnusedLicenseNoticeProps ) => {
 				>
 					<NoticeAction
 						href={
-							isEnabled( 'a8c-for-agencies' )
+							isA8CForAgencies()
 								? `${ A4A_UNASSIGNED_LICENSES_LINK }`
 								: `${ JETPACK_MANAGE_LICENCES_LINK }/unassigned`
 						}

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
@@ -20,6 +19,7 @@ import QueryJetpackPartnerKey from 'calypso/components/data/query-jetpack-partne
 import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/display-price';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
 import SingleSiteUpsellLightbox from 'calypso/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import productAboveButtonText from 'calypso/my-sites/plans/jetpack-plans/product-card/product-above-button-text';
 import productTooltip from 'calypso/my-sites/plans/jetpack-plans/product-card/product-tooltip';
@@ -67,7 +67,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	const siteProduct: SiteProduct | undefined = useSelector( ( state ) =>
 		getSiteAvailableProduct( state, siteId, item.productSlug )
 	);
-	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+	const isA4AEnabled = isA8CForAgencies();
 
 	let aboveButtonText: TranslateResult | null;
 	let billingTerm: Duration;

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -1,12 +1,12 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import type {
 	AgencyDashboardFilter,
 	DashboardSortInterface,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
-const client = isEnabled( 'a8c-for-agencies' ) ? wpcom : wpcomJpl;
+const client = isA8CForAgencies() ? wpcom : wpcomJpl;
 
 const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => {
 	return {

--- a/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-verified-contacts.ts
@@ -1,9 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { MonitorContactsResponse } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 
-const client = isEnabled( 'a8c-for-agencies' ) ? wpcom : wpcomJpl;
+const client = isA8CForAgencies() ? wpcom : wpcomJpl;
 
 const isMultipleEmailEnabled = isEnabled(
 	'jetpack/pro-dashboard-monitor-multiple-email-recipients'

--- a/client/data/agency-dashboard/use-toggle-favourite-site-mutation.ts
+++ b/client/data/agency-dashboard/use-toggle-favourite-site-mutation.ts
@@ -1,13 +1,13 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
 import {
 	APIError,
 	APIToggleFavorite,
 	ToggleFavoriteOptions,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 
-const client = isEnabled( 'a8c-for-agencies' ) ? wpcom : wpcomJpl;
+const client = isA8CForAgencies() ? wpcom : wpcomJpl;
 
 function mutationToggleFavoriteSite( {
 	siteId,

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -1,9 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext } from 'react';
 import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { setSiteMonitorStatus } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -29,7 +29,7 @@ export default function useToggleActivateMonitor(
 
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const queryKey = isEnabled( 'a8c-for-agencies' )
+	const queryKey = isA8CForAgencies()
 		? [
 				'jetpack-agency-dashboard-sites',
 				dataViewsState.search,

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
@@ -1,9 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useContext } from 'react';
 import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import useUpdateMonitorSettingsMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation';
@@ -32,7 +32,7 @@ export default function useUpdateMonitorSettings(
 
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const queryKey = isEnabled( 'a8c-for-agencies' )
+	const queryKey = isA8CForAgencies()
 		? [
 				'jetpack-agency-dashboard-sites',
 				dataViewsState.search,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -6,6 +5,7 @@ import { useContext, useMemo } from 'react';
 import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
@@ -46,7 +46,7 @@ export default function LicenseInfoModal( {
 	const partner = useSelector( getCurrentPartner );
 	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
-	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+	const isA4AEnabled = isA8CForAgencies();
 	const { hideLicenseInfo } = useContext( SitesOverviewContext );
 
 	const { products: dashboardProducts } = useContext( DashboardDataContext );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -1,9 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon, Tooltip } from '@automattic/components';
 import { Icon, help } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useMemo } from 'react';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useSelector } from 'calypso/state';
 import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import { jetpackBoostDesktopIcon, jetpackBoostMobileIcon } from '../../icons';
@@ -24,7 +24,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 
 	const partner = useSelector( getCurrentPartner );
 	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
-	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+	const isA4AEnabled = isA8CForAgencies();
 
 	const helpIconRef = useRef< HTMLElement | null >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useMemo } from 'react';
@@ -6,6 +5,7 @@ import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/componen
 import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import ExternalLink from 'calypso/components/external-link';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../../hooks';
@@ -25,7 +25,7 @@ interface Props {
 
 export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: Props ) {
 	const translate = useTranslate();
-	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+	const isA4AEnabled = isA8CForAgencies();
 
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -15,6 +15,7 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -65,7 +66,7 @@ export default function SiteStatusColumn( { type, rows, metadata, disabled }: Pr
 			: hasSelectedLicensesOfType( state, siteId, type )
 	);
 
-	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+	const isA4AEnabled = isA8CForAgencies();
 	const partner = useSelector( getCurrentPartner );
 	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/pricing-summary.tsx
@@ -1,9 +1,9 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -33,7 +33,7 @@ export default function PricingSummary( {
 		.map( ( license ) => license.quantity )
 		.reduce( ( a, b ) => a + b, 0 );
 
-	const isA4A = config.isEnabled( 'a8c-for-agencies' );
+	const isA4A = isA8CForAgencies();
 
 	const handleCTAClick = useCallback( () => {
 		if ( ! isFormReady ) {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -28,6 +28,7 @@ import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
 import WooCoreProfilerMasterbar from 'calypso/layout/masterbar/woo-core-profiler';
 import OfflineStatus from 'calypso/layout/offline-status';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
 import { navigate } from 'calypso/lib/navigate';
@@ -389,7 +390,7 @@ class Layout extends Component {
 				{ isJetpackCloud() && (
 					<AsyncLoad require="calypso/jetpack-cloud/style" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'a8c-for-agencies' ) && (
+				{ isA8CForAgencies() && (
 					<>
 						<AsyncLoad require="calypso/a8c-for-agencies/style" placeholder={ null } />
 						<QueryAgencies />
@@ -505,7 +506,7 @@ export default withCurrentRoute(
 				isWpMobileApp() ||
 				isWcMobileApp() ||
 				isJetpackCloud() ||
-				config.isEnabled( 'a8c-for-agencies' );
+				isA8CForAgencies();
 			const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 			const isJetpackWooCommerceFlow =
 				[ 'jetpack-connect', 'login' ].includes( sectionName ) &&

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -16,6 +16,7 @@ import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import MasterbarLogin from 'calypso/layout/masterbar/login';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
 import WooCoreProfilerMasterbar from 'calypso/layout/masterbar/woo-core-profiler';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import {
@@ -237,7 +238,7 @@ const LayoutLoggedOut = ( {
 			{ isJetpackCloud() && (
 				<AsyncLoad require="calypso/jetpack-cloud/style" placeholder={ null } />
 			) }
-			{ config.isEnabled( 'a8c-for-agencies' ) && (
+			{ isA8CForAgencies() && (
 				<AsyncLoad require="calypso/a8c-for-agencies/style" placeholder={ null } />
 			) }
 			<div id="content" className="layout__content">

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -1,4 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 const pathIncludes = ( currentPath, term, position ) =>
@@ -75,7 +75,7 @@ export const itemLinkMatches = ( path, currentPath ) => {
 
 	// All URLs in the A4A Purchases start with 'purchases' or 'marketplace' will need to compare at the second position.
 	if (
-		isEnabled( 'a8c-for-agencies' ) &&
+		isA8CForAgencies() &&
 		( pathIncludes( currentPath, 'purchases', 1 ) || pathIncludes( currentPath, 'marketplace', 1 ) )
 	) {
 		return fragmentIsEqual( path, currentPath, 2 );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -22,6 +22,7 @@ import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { STEPPER_SECTION_DEFINITION } from 'calypso/landing/stepper/section';
 import { SUBSCRIPTIONS_SECTION_DEFINITION } from 'calypso/landing/subscriptions/section';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { shouldSeeCookieBanner } from 'calypso/lib/analytics/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { login } from 'calypso/lib/paths';
@@ -899,7 +900,7 @@ export default function pages() {
 	app.use( setupLoggedInContext );
 	app.use( middlewareUnsupportedBrowser() );
 
-	if ( ! ( isJetpackCloud() || config.isEnabled( 'a8c-for-agencies' ) ) ) {
+	if ( ! ( isJetpackCloud() || isA8CForAgencies() ) ) {
 		wpcomPages( app );
 	}
 

--- a/client/state/jetpack-agency-dashboard/hooks/use-install-plugin-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-install-plugin-mutation.ts
@@ -1,5 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import type { APIError } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
@@ -13,7 +13,7 @@ interface InstallPluginParams {
 	agency_id?: number;
 }
 
-const client = isEnabled( 'a8c-for-agencies' ) ? wpcom : wpcomJpl;
+const client = isA8CForAgencies() ? wpcom : wpcomJpl;
 
 function mutationInstallPlugin( params: InstallPluginParams ): Promise< APIResponse > {
 	return client.req.post( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/268

## Proposed Changes

* Replaces uses of `config.isEnabled( 'a8c-for-agencies' )` with the recently added `isA8CForAgencies()` lib function.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live links to test the platform for regression.
  * Test screens inside and outside of the A8C for agencies context, i.e. Jetpack Cloud components

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
