### PR TITLE
Scheduled Updates logs: Set icon to checkmark on successful rollback

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-logs.helper.ts
+++ b/client/blocks/plugins-scheduled-updates/schedule-logs.helper.ts
@@ -50,11 +50,11 @@ export const getLogIcon = ( log: ScheduleLog ) => {
 		case 'PLUGIN_UPDATES_SUCCESS':
 		case 'PLUGIN_UPDATE_SUCCESS':
 		case 'PLUGIN_SITE_HEALTH_CHECK_SUCCESS':
+		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK':
 			return 'checkmark';
 		case 'PLUGIN_UPDATES_FAILURE':
 		case 'PLUGIN_UPDATE_FAILURE':
 		case 'PLUGIN_SITE_HEALTH_CHECK_FAILURE':
-		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK':
 		case 'PLUGIN_UPDATE_FAILURE_AND_ROLLBACK_FAIL':
 			return 'cross';
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89679#issuecomment-2066886055

## Proposed Changes

![CleanShot 2024-04-20 at 07 40 56@2x](https://github.com/Automattic/wp-calypso/assets/528287/357277b8-c4c1-45a4-8ace-cb5d9bc5aa30)

## Testing Instructions

Test instructions in D145971-code 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?