### PR TITLE
Add Domain Product Type to QueryProductList in /Domains

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1409,7 +1409,7 @@ export class RenderDomainsStep extends Component {
 				shouldHideNavButtons={ this.shouldHideNavButtons() }
 				stepContent={
 					<div>
-						<QueryProductsList />
+						<QueryProductsList type="domains" />
 						{ this.renderContent() }
 					</div>
 				}


### PR DESCRIPTION
Related to # https://github.com/Automattic/martech/issues/2731

## Proposed Changes

/domains in Calypso only requires the domain products, however, the current API request to /products retrieves all products. To optimize the request, this PR adds the product type (domains) which ensures only domain products are returned by the API. 

## Testing Instructions

1. Checkout branch 
2. Launch Browser and open Network tab in dev tools
3. Navigate to `Calypso`/domains 
4. Enter a domain name
5. Verify prices are loaded for domain suggestions
6. Filter Network requests to products endpoint 
7. Verify requests has type=domains 
