### PR TITLE
Congrats: Line up placeholder with congrats page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/placeholder/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/placeholder/style.scss
@@ -21,8 +21,7 @@
 .congrats-placeholder__title {
 	@include congrats-placeholder-title;
 	width: 70%;
-	margin: 0 auto;
-	margin-bottom: 20px;
+	margin: 60px auto 20px auto;
 }
 
 .congrats-placeholder__description {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89487

## Proposed Changes

Currently, the placeholder does not quite line up with the congrats page. 

<img width="2359" alt="Screen Shot 2024-04-21 at 2 49 47 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/c8d5f55d-b655-4175-91cb-85575f82dc15">

This PR adjusts the top margin for a seamless transition from the placeholder to the congrats page.

https://github.com/Automattic/wp-calypso/assets/104910361/601cad29-f9d2-42a3-8b92-ce1de55f194c

## Testing Instructions

* If you haven't purchased any plan, domain, email product from WordRress.com, make a purchase to get to the Congrats Page.
* If you have made a purchase before, navigate to the congrats page with:
```
/checkout/thank-you/<SITE>/<RECEIPT_ID>
```
* Assert that the placeholder lines up with the congrats page.
