### PR TITLE
Stats: Use mininum usage in the last three months to populate lowest tier

### DIFF
--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -25,14 +25,21 @@ function selectPlanUsage( payload: PlanUsage ): PlanUsage {
 	const recent_usages = payload?.recent_usages
 		?.map( ( usage ) => usage?.views_count ?? 0 )
 		.filter( ( views ) => views > 0 );
+	if ( payload?.current_usage?.views_count > 0 ) {
+		recent_usages.push( payload.current_usage.views_count );
+	}
 
 	if ( recent_usages.length === 1 ) {
+		// Only one number non-zero, use it.
 		billableMonthlyViews = recent_usages[ 0 ];
 	} else if ( recent_usages.length === 2 ) {
+		// Two numbers non-zero, use the average.
 		billableMonthlyViews = ( recent_usages[ 0 ] + recent_usages[ 1 ] ) / 2;
 	} else if ( recent_usages.length === 3 ) {
+		// Three numbers non-zero, use the middle one.
 		billableMonthlyViews = recent_usages[ 1 ];
 	} else if ( recent_usages.length === 4 ) {
+		// Four numbers non-zero, use the average of the second and third.
 		billableMonthlyViews = ( recent_usages[ 1 ] + recent_usages[ 2 ] ) / 2;
 	}
 

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -21,31 +21,13 @@ export interface PlanUsage {
 }
 
 function selectPlanUsage( payload: PlanUsage ): PlanUsage {
-	let billableMonthlyViews = 0;
 	const recent_usages = payload?.recent_usages
 		?.map( ( usage ) => usage?.views_count ?? 0 )
 		.filter( ( views ) => views > 0 );
-	if ( payload?.current_usage?.views_count > 0 ) {
-		recent_usages.push( payload.current_usage.views_count );
-	}
-
-	if ( recent_usages.length === 1 ) {
-		// Only one number non-zero, use it.
-		billableMonthlyViews = recent_usages[ 0 ];
-	} else if ( recent_usages.length === 2 ) {
-		// Two numbers non-zero, use the average.
-		billableMonthlyViews = ( recent_usages[ 0 ] + recent_usages[ 1 ] ) / 2;
-	} else if ( recent_usages.length === 3 ) {
-		// Three numbers non-zero, use the middle one.
-		billableMonthlyViews = recent_usages[ 1 ];
-	} else if ( recent_usages.length === 4 ) {
-		// Four numbers non-zero, use the average of the second and third.
-		billableMonthlyViews = ( recent_usages[ 1 ] + recent_usages[ 2 ] ) / 2;
-	}
 
 	return {
 		...payload,
-		billableMonthlyViews,
+		billableMonthlyViews: Math.min( ...recent_usages, 0 ),
 	};
 }
 

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -21,9 +21,10 @@ export interface PlanUsage {
 }
 
 function selectPlanUsage( payload: PlanUsage ): PlanUsage {
-	const recent_usages = payload?.recent_usages
-		?.map( ( usage ) => usage?.views_count ?? 0 )
-		.filter( ( views ) => views > 0 );
+	const recent_usages =
+		payload?.recent_usages
+			?.map( ( usage ) => usage?.views_count ?? 0 )
+			.filter( ( views ) => views > 0 ) ?? [];
 
 	return {
 		...payload,

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -21,15 +21,24 @@ export interface PlanUsage {
 }
 
 function selectPlanUsage( payload: PlanUsage ): PlanUsage {
+	let billableMonthlyViews = 0;
+	const recent_usages = payload?.recent_usages
+		?.map( ( usage ) => usage?.views_count ?? 0 )
+		.filter( ( views ) => views > 0 );
+
+	if ( recent_usages.length === 1 ) {
+		billableMonthlyViews = recent_usages[ 0 ];
+	} else if ( recent_usages.length === 2 ) {
+		billableMonthlyViews = ( recent_usages[ 0 ] + recent_usages[ 1 ] ) / 2;
+	} else if ( recent_usages.length === 3 ) {
+		billableMonthlyViews = recent_usages[ 1 ];
+	} else if ( recent_usages.length === 4 ) {
+		billableMonthlyViews = ( recent_usages[ 1 ] + recent_usages[ 2 ] ) / 2;
+	}
+
 	return {
 		...payload,
-		billableMonthlyViews: Math.max(
-			payload?.recent_usages[ 0 ]?.views_count ?? 0,
-			payload?.recent_usages[ 1 ]?.views_count ?? 0,
-			payload?.recent_usages[ 2 ]?.views_count ?? 0,
-			payload?.current_usage?.views_count ?? 0,
-			0
-		),
+		billableMonthlyViews,
 	};
 }
 

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -28,7 +28,7 @@ function selectPlanUsage( payload: PlanUsage ): PlanUsage {
 
 	return {
 		...payload,
-		billableMonthlyViews: Math.min( ...recent_usages, 0 ),
+		billableMonthlyViews: recent_usages.length > 0 ? Math.min( ...recent_usages ) : 0,
 	};
 }
 


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/2

## Proposed Changes

We are currently using the highest usage in the past three months, which is not very fair for the users, because we have spike forgiveness advertised. The PR changes that to the minimum non-zero usage in the last three months to overcome that.

## Testing Instructions

* Open an existing site with 1k+ monthly views without any Stats subscription - you'll have to tweak the usage endpoint and sandbox if you don't have any site like that
* Open the purchase page, ensure the starting tier is based on the lowest usage in the last 3 months

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?