### PR TITLE
Plugins details: Fix Server Side Rendering

### DIFF
--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -56,7 +56,9 @@ const BillingIntervalSwitcher: FunctionComponent< Props > = ( props: Props ) => 
 	const annualLabel = translate( 'Annually' );
 	const saveLabel = translate( 'Save', { context: 'save money' } );
 
-	const searchParams = new URLSearchParams( document.location.search );
+	const searchParams = new URLSearchParams(
+		typeof document !== 'undefined' ? document.location.search : ''
+	);
 	const billingIntervalParam = searchParams.get( 'interval' );
 
 	/**

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -210,7 +210,11 @@ export async function fetchPlugin( context, next ) {
 export function validatePlugin( { path, params: { plugin } }, next ) {
 	const siteFragment = getSiteFragment( path );
 
-	if ( siteFragment || Number.isInteger( parseInt( plugin, 10 ) ) ) {
+	if (
+		plugin === 'scheduled-updates' ||
+		siteFragment ||
+		Number.isInteger( parseInt( plugin, 10 ) )
+	) {
 		return next( 'route' );
 	}
 	next();

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -46,7 +46,7 @@ export default function ( router ) {
 
 	if ( isEnabled( 'plugins/ssr-details' ) ) {
 		router(
-			`/${ langParam }/plugins/:plugin(^((scheduled-updates)?)*$)`,
+			`/${ langParam }/plugins/:plugin`,
 			skipIfLoggedIn,
 			validatePlugin,
 			ssrSetupLocale,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89154

## Proposed Changes

The logged out plugins detail pages stopped rendering on the server side after a couple a changes:
* #88454 adds a route fix that ended up never matching the plugin details paths
* #79552 references the `document` object which is undefined in the server context.
<img width="240" alt="Screenshot 2024-04-22 at 09 03 20" src="https://github.com/Automattic/wp-calypso/assets/2749938/3ad5aca1-a00c-4233-84d9-64d6c097751c">

This hopes to fix a potential cause for the traffic loss on /plugins - pau2Xa-5Pt-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Behaviour of http://calypso.localhost:3000/plugins/scheduled-updates should be unaffected (as per [instructions](https://github.com/Automattic/wp-calypso/pull/88454))
* Visit a few  plugin details pages with JavaScript disabled
* You should be able to see most of the Plugins Details content
<img width="240" alt="Screenshot 2024-04-22 at 09 16 01" src="https://github.com/Automattic/wp-calypso/assets/2749938/9a38c5df-232c-4cbd-9475-212e196ed038">
<img width="240" alt="Screenshot 2024-04-22 at 09 15 48" src="https://github.com/Automattic/wp-calypso/assets/2749938/ec01c4c0-f638-4e72-91c0-e73ba6521d66">
<img width="240" alt="Screenshot 2024-04-22 at 09 15 34" src="https://github.com/Automattic/wp-calypso/assets/2749938/dbcfd7f0-58fe-40c6-a880-0fc5cb098c4e">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
