### PR TITLE
Stats: Updating visuals for the Devices module

### DIFF
--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -8,9 +8,9 @@ import DataType from './data-type';
 
 import './style.scss';
 
-const SVG_SIZE = 224;
+const SVG_SIZE = 300;
 const NUM_COLOR_SECTIONS = 3;
-const TOOLTIP_OFFSET_X = -164; // SVG_SIZE - 2x tip offset (30px in CSS)
+const TOOLTIP_OFFSET_X = -207;
 const TOOLTIP_OFFSET_Y = 0;
 
 function transformData( data, { donut = false, startAngle = -Math.PI } ) {

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -8,9 +8,9 @@ import DataType from './data-type';
 
 import './style.scss';
 
-const SVG_SIZE = 300;
+const SVG_SIZE = 224;
 const NUM_COLOR_SECTIONS = 3;
-const TOOLTIP_OFFSET_X = -207;
+const TOOLTIP_OFFSET_X = -164; // SVG_SIZE - 2x tip offset (30px in CSS)
 const TOOLTIP_OFFSET_Y = 0;
 
 function transformData( data, { donut = false, startAngle = -Math.PI } ) {

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -10,6 +10,9 @@ import './style.scss';
 
 const SVG_SIZE = 300;
 const NUM_COLOR_SECTIONS = 3;
+
+// Bottom left position relative to the cursor for the tooltip,
+// which is the tooltip width offset the distance from the right edge to the arrow.
 const TOOLTIP_OFFSET_X = -207;
 const TOOLTIP_OFFSET_Y = 0;
 

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -13,7 +13,7 @@ const NUM_COLOR_SECTIONS = 3;
 const TOOLTIP_OFFSET_X = -207;
 const TOOLTIP_OFFSET_Y = 0;
 
-function transformData( data, { donut = false, startAngle = -Math.PI } ) {
+function transformData( data, { donut = false, startAngle = -Math.PI, svgSize = SVG_SIZE } ) {
 	const sortedData = sortBy( data, ( datum ) => datum.value )
 		.reverse()
 		.map( ( datum, index ) => ( {
@@ -26,8 +26,8 @@ function transformData( data, { donut = false, startAngle = -Math.PI } ) {
 		.value( ( datum ) => datum.value )( sortedData );
 
 	const arcGen = d3Arc()
-		.innerRadius( donut ? SVG_SIZE / 4 : 0 )
-		.outerRadius( SVG_SIZE / 2 );
+		.innerRadius( donut ? svgSize / 4 : 0 )
+		.outerRadius( svgSize / 2 );
 
 	const paths = arcs.map( ( arc ) => arcGen( arc ) );
 
@@ -45,6 +45,7 @@ class PieChart extends Component {
 		translate: PropTypes.func.isRequired,
 		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
 		hasTooltip: PropTypes.bool,
+		svgSize: PropTypes.number,
 	};
 
 	state = {
@@ -55,7 +56,7 @@ class PieChart extends Component {
 	chartRef = createRef();
 
 	// Listen to mousemove and mouseleave events on the chart to operate the tooltip.
-	bindEvents = ( svg, data ) => {
+	bindEvents = ( svg, data, svgSize ) => {
 		const dataTotal = this.state.dataTotal;
 		const tooltip = d3Select( '.pie-chart__tooltip' );
 
@@ -64,8 +65,8 @@ class PieChart extends Component {
 				const percent =
 					dataTotal > 0 ? Math.round( ( current.value / dataTotal ) * 100 ).toString() : '0';
 
-				tooltip.style( 'left', coordinates[ 0 ] + SVG_SIZE / 2 + TOOLTIP_OFFSET_X + 'px' );
-				tooltip.style( 'top', coordinates[ 1 ] + SVG_SIZE / 2 + TOOLTIP_OFFSET_Y + 'px' );
+				tooltip.style( 'left', coordinates[ 0 ] + svgSize / 2 + TOOLTIP_OFFSET_X + 'px' );
+				tooltip.style( 'top', coordinates[ 1 ] + svgSize / 2 + TOOLTIP_OFFSET_Y + 'px' );
 				tooltip.style( 'visibility', 'visible' );
 				tooltip.html(
 					`${ current.icon }<div class="pie-chart__tooltip-content"><div>${ current.name }</div><div>${ percent }%</div></div>`
@@ -100,6 +101,7 @@ class PieChart extends Component {
 				transformedData: transformData( nextProps.data, {
 					donut: nextProps.donut,
 					startAngle: nextProps.startAngle,
+					svgSize: nextProps.svgSize,
 				} ),
 			};
 		}
@@ -122,20 +124,20 @@ class PieChart extends Component {
 		} );
 	}
 
-	renderEmptyChart() {
+	renderEmptyChart( svgSize ) {
 		return (
-			<circle cx={ 0 } cy={ 0 } r={ SVG_SIZE / 2 } className="pie-chart__chart-drawing-empty" />
+			<circle cx={ 0 } cy={ 0 } r={ svgSize / 2 } className="pie-chart__chart-drawing-empty" />
 		);
 	}
 
 	componentDidMount() {
 		if ( this.props.hasTooltip ) {
-			this.bindEvents( d3Select( this.chartRef.current ), this.state.data );
+			this.bindEvents( d3Select( this.chartRef.current ), this.state.data, this.props.svgSize );
 		}
 	}
 
 	render() {
-		const { title, translate, hasTooltip } = this.props;
+		const { title, translate, hasTooltip, svgSize } = this.props;
 		const { dataTotal } = this.state;
 
 		return (
@@ -147,22 +149,24 @@ class PieChart extends Component {
 						<svg
 							ref={ this.chartRef }
 							className="pie-chart__chart-drawing"
-							viewBox={ `0 0 ${ SVG_SIZE } ${ SVG_SIZE }` }
+							width={ svgSize }
+							height={ svgSize }
+							viewBox={ `0 0 ${ svgSize } ${ svgSize }` }
 							preserveAspectRatio="xMidYMid meet"
 						>
-							<g transform={ `translate(${ SVG_SIZE / 2 }, ${ SVG_SIZE / 2 })` }>
-								{ dataTotal > 0 ? this.renderPieChart() : this.renderEmptyChart() }
+							<g transform={ `translate(${ svgSize / 2 }, ${ svgSize / 2 })` }>
+								{ dataTotal > 0 ? this.renderPieChart() : this.renderEmptyChart( svgSize ) }
 							</g>
 						</svg>
 					</div>
 				) : (
 					<svg
 						className="pie-chart__chart-drawing"
-						viewBox={ `0 0 ${ SVG_SIZE } ${ SVG_SIZE }` }
+						viewBox={ `0 0 ${ svgSize } ${ svgSize }` }
 						preserveAspectRatio="xMidYMid meet"
 					>
-						<g transform={ `translate(${ SVG_SIZE / 2 }, ${ SVG_SIZE / 2 })` }>
-							{ dataTotal > 0 ? this.renderPieChart() : this.renderEmptyChart() }
+						<g transform={ `translate(${ svgSize / 2 }, ${ svgSize / 2 })` }>
+							{ dataTotal > 0 ? this.renderPieChart() : this.renderEmptyChart( svgSize ) }
 						</g>
 					</svg>
 				) }
@@ -176,5 +180,12 @@ class PieChart extends Component {
 		);
 	}
 }
+
+PieChart.defaultProps = {
+	donut: false,
+	startAngle: -Math.PI,
+	hasTooltip: false,
+	svgSize: SVG_SIZE,
+};
 
 export default localize( PieChart );

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -4,11 +4,6 @@
 .pie-chart__chart-container {
 	position: relative;
 
-	& > svg {
-		width: 100%;
-		height: auto;
-	}
-
 	.pie-chart__chart-drawing {
 		max-width: unset;
 	}

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.scss
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/breakpoints";
 @import "../modernized-mixins";
 
 .stats-module-devices {
@@ -72,5 +73,15 @@
 		// Prevent blur elements from being interactable.
 		pointer-events: none;
 		user-select: none;
+	}
+}
+
+.stats-module-devices__tabs {
+	.segmented-control__item {
+		min-width: 80px;
+
+		@media (max-width: $break-small ) {
+			min-width: auto;
+		}
 	}
 }

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
@@ -100,7 +100,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 		},
 	};
 
-	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.BROWSER );
+	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SIZE );
 
 	const { isFetching, data } = useModuleDevicesQuery( siteId, selectedOption, query );
 
@@ -116,6 +116,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 
 	const toggleControlComponent = (
 		<SimplifiedSegmentedControl
+			className="stats-module-devices__tabs"
 			options={ Object.entries( optionLabels ).map( ( entry ) => ( {
 				value: entry[ 0 ], // optionLabels key
 				label: entry[ 1 ].selectLabel, // optionLabels object value
@@ -137,6 +138,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 				titleURL=""
 				metricLabel=""
 				splitHeader
+				isNew
 				mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 				toggleControl={ toggleControlComponent }
 				isEmpty={ ! showLoader && ( ! chartData || ! chartData.length ) }
@@ -146,7 +148,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 					<StatsModulePlaceholder isLoading={ showLoader } />
 				) : (
 					<div className="stats-card--body__chart">
-						<PieChart data={ chartData } donut hasTooltip />
+						<PieChart data={ chartData } donut hasTooltip startAngle={ 0 } />
 						<PieChartLegend
 							data={ chartData }
 							onlyPercent

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
@@ -148,7 +148,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 					<StatsModulePlaceholder isLoading={ showLoader } />
 				) : (
 					<div className="stats-card--body__chart">
-						<PieChart data={ chartData } donut hasTooltip startAngle={ 0 } />
+						<PieChart data={ chartData } startAngle={ 0 } svgSize={ 224 } donut hasTooltip />
 						<PieChartLegend
 							data={ chartData }
 							onlyPercent

--- a/config/development.json
+++ b/config/development.json
@@ -201,7 +201,7 @@
 		"ssr/prefetch-timebox": false,
 		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
-		"stats/devices": false,
+		"stats/devices": true,
 		"stats/new-video-summary": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/paid-wpcom-v2": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89671 #89673

## Proposed Changes

* reducing pie chart size
* updating origin angle for the chart
* adding `min-width` for the header buttons

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch
* Navigate to Stats > Traffic page for a Jetpack site that has a Stats commercial license with the feature flag `?flags=stats/devices`
* Ensure the Devices module works as previously and the header buttons look good across width breakpoints

| Before | After |
| --- | --- |
| ![SCR-20240422-pdkj](https://github.com/Automattic/wp-calypso/assets/112354940/e5bcd07e-9c50-48e3-a896-74a1b3921b40) | <img width="289" alt="SCR-20240422-pdhe" src="https://github.com/Automattic/wp-calypso/assets/112354940/ee986831-2d09-4abc-8b70-94d64e7e6179"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?