### PR TITLE
Automattic for Agencies: Implement Bank Details iFrame

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -16,6 +16,7 @@ export const A4A_MARKETPLACE_CHECKOUT_LINK = `${ A4A_MARKETPLACE_LINK }/checkout
 export const A4A_MARKETPLACE_ASSIGN_LICENSE_LINK = `${ A4A_MARKETPLACE_LINK }/assign-license`;
 export const A4A_PURCHASES_LINK = '/purchases';
 export const A4A_REFERRALS_LINK = '/referrals';
+export const A4A_REFERRALS_BANK_DETAILS_LINK = '/referrals/bank-details';
 export const A4A_LICENSES_LINK = `${ A4A_PURCHASES_LINK }/licenses`;
 export const A4A_UNASSIGNED_LICENSES_LINK = `${ A4A_LICENSES_LINK }/unassigned`;
 export const A4A_BILLING_LINK = `${ A4A_PURCHASES_LINK }/billing`;

--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -1,9 +1,16 @@
 import { type Callback } from '@automattic/calypso-router';
 import MainSidebar from '../../components/sidebar-menu/main';
+import ReferralsBankDetails from './primary/bank-details';
 import ReferralsOverview from './primary/referrals-overview';
 
 export const referralsContext: Callback = ( context, next ) => {
 	context.primary = <ReferralsOverview />;
+	context.secondary = <MainSidebar path={ context.path } />;
+	next();
+};
+
+export const referralsBankDetailsContext: Callback = ( context, next ) => {
+	context.primary = <ReferralsBankDetails />;
 	context.secondary = <MainSidebar path={ context.path } />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/referrals/index.ts
+++ b/client/a8c-for-agencies/sections/referrals/index.ts
@@ -1,8 +1,17 @@
 import page from '@automattic/calypso-router';
-import { A4A_REFERRALS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_REFERRALS_LINK,
+	A4A_REFERRALS_BANK_DETAILS_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
 export default function () {
 	page( A4A_REFERRALS_LINK, controller.referralsContext, makeLayout, clientRender );
+	page(
+		A4A_REFERRALS_BANK_DETAILS_LINK,
+		controller.referralsBankDetailsContext,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -1,0 +1,48 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderBreadcrumb as Breadcrumb,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_REFERRALS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+import './style.scss';
+
+export default function ReferralsBankDetails() {
+	const translate = useTranslate();
+
+	const title = translate( 'Add bank details' );
+
+	const iFrameSrc = '';
+
+	return (
+		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<PageViewTracker title="Add bank details" path="/referrals/bank-details" />
+
+			<LayoutTop>
+				<LayoutHeader>
+					<Breadcrumb
+						items={ [
+							{
+								label: translate( 'Referrals' ),
+								href: A4A_REFERRALS_LINK,
+							},
+							{
+								label: title,
+							},
+						] }
+					/>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<div className="bank-details__iframe-container">
+					<iframe width="100%" src={ iFrameSrc } title={ title }></iframe>
+				</div>
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -1,0 +1,7 @@
+.bank-details__iframe-container {
+	margin-block-start: 24px;
+
+	iframe {
+		height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
+	}
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,5 +1,6 @@
 import { pages, plugins, payment, percent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -7,7 +8,10 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_REFERRALS_BANK_DETAILS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../common/step-section';
 import StepSectionItem from '../../common/step-section-item';
 
@@ -15,8 +19,15 @@ import './style.scss';
 
 export default function ReferralsOverview() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const title = translate( 'Referrals' );
+
+	const onAddBankDetailsClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );
+	}, [ dispatch ] );
+
+	const hasPayeeAccount = false; // FIXME: Replace with actual check
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -40,7 +51,14 @@ export default function ReferralsOverview() {
 							description={ translate(
 								'Once confirmed, we’ll be able to send you a commission payment at the end of each month.'
 							) }
-							buttonProps={ { children: translate( 'Add bank details' ), primary: true } }
+							buttonProps={ {
+								children: hasPayeeAccount
+									? translate( 'Edit bank details' )
+									: translate( 'Add bank details' ),
+								href: A4A_REFERRALS_BANK_DETAILS_LINK,
+								onClick: onAddBankDetailsClick,
+								primary: true,
+							} }
 						/>
 						<StepSectionItem
 							icon={ plugins }

--- a/client/sections.js
+++ b/client/sections.js
@@ -777,7 +777,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-referrals',
-		paths: [ '/referrals' ],
+		paths: [ '/referrals', '/referrals/bank-details' ],
 		module: 'calypso/a8c-for-agencies/sections/referrals',
 		group: 'a8c-for-agencies',
 	},


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/322
Resolves https://github.com/Automattic/jetpack-genesis/issues/323
Resolves https://github.com/Automattic/jetpack-genesis/issues/324

## Proposed Changes

This PR implements bank details iFrame, including:

- Add context for bank details
- Component for adding bank details
- Redirect to `/referrals/bank-details` when clicking on the `Add Bank Details` button 

## Testing Instructions

1) Open the A4A live link.
2) Go to `sections/referrals/primary/bank-details/index.tsx` file > Update the iFrameSrc. Please message me for the iFrameSrc as it is not implemented yet.
3) Go to the referrals page (/referrals) > Click the `Add Bank Details` button > Verify that you are navigated to `/referrals/bank-details` and the page is displayed is shown below:

<img width="1437" alt="Screenshot 2024-04-22 at 1 05 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/763c9567-c812-40e8-b932-bf05c2ba17e2">



Tablet view: 

<img width="764" alt="Screenshot 2024-04-22 at 1 08 09 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3193eef9-307c-437e-8871-e79d95c9f8af">

Mobile view:

<img width="370" alt="Screenshot 2024-04-22 at 1 05 47 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4a932a12-fb7f-4a9e-bbd1-694b7c42004d">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?