### PR TITLE
Gravatar: Show the unsubscribe / resubscribe button from the unsubscribe page

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -126,6 +126,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Akismet Marketing' );
 		} else if ( 'woopay_marketing' === category ) {
 			return this.props.translate( 'WooPay Marketing' );
+		} else if ( 'gravatar_onboarding' === category ) {
+			return this.props.translate( 'Gravatar Onboarding' );
 		}
 
 		return category;
@@ -185,6 +187,10 @@ class MainComponent extends Component {
 			);
 		} else if ( 'woopay_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of WooPay.' );
+		} else if ( 'gravatar_onboarding' === category ) {
+			return this.props.translate(
+				'Get tips and reminders to optimize your Gravatar profile setup.'
+			);
 		}
 
 		return null;
@@ -256,7 +262,6 @@ class MainComponent extends Component {
 		const messageLabel = this.state.isSubscribed
 			? translate( "We'll send you updates for this mailing list." )
 			: translate( 'You will no longer receive updates for this mailing list.' );
-		const categoryName = this.getCategoryName();
 
 		return (
 			<div className="mailing-lists">
@@ -267,38 +272,37 @@ class MainComponent extends Component {
 					<p>{ preventWidows( messageLabel, 2 ) }</p>
 				</div>
 
+				<Card className="mailing-lists__details">
+					<h4>{ this.getCategoryName() }</h4>
+					<p>{ this.getCategoryDescription() }</p>
+					{ this.state.isSubscribed ? (
+						<button
+							className="mailing-lists__unsubscribe-button button is-primary"
+							onClick={ this.onUnsubscribeClick }
+						>
+							{ translate( 'Unsubscribe' ) }
+						</button>
+					) : (
+						<button
+							className="mailing-lists__resubscribe-button button"
+							onClick={ this.onResubscribeClick }
+						>
+							{ translate( 'Resubscribe' ) }
+						</button>
+					) }
+				</Card>
+
 				{
-					// Don't show the unsubscribe / resubscribe button and the manage link for Gravatar-related categories.
-					! categoryName?.startsWith( 'gravatar_' ) && (
-						<>
-							<Card className="mailing-lists__details">
-								<h4>{ categoryName }</h4>
-								<p>{ this.getCategoryDescription() }</p>
-								{ this.state.isSubscribed ? (
-									<button
-										className="mailing-lists__unsubscribe-button button is-primary"
-										onClick={ this.onUnsubscribeClick }
-									>
-										{ translate( 'Unsubscribe' ) }
-									</button>
-								) : (
-									<button
-										className="mailing-lists__resubscribe-button button"
-										onClick={ this.onResubscribeClick }
-									>
-										{ translate( 'Resubscribe' ) }
-									</button>
-								) }
-							</Card>
-							<p className="mailing-lists__manage-link">
-								<button
-									className="mailing-lists__manage-button button is-link"
-									onClick={ this.onManageUpdatesClick }
-								>
-									{ translate( 'Manage all your email subscriptions' ) }
-								</button>
-							</p>
-						</>
+					// Don't show the manage link for Gravatar-related categories.
+					! this.getCategoryFromMessageTypeId()?.startsWith( 'gravatar_' ) && (
+						<p className="mailing-lists__manage-link">
+							<button
+								className="mailing-lists__manage-button button is-link"
+								onClick={ this.onManageUpdatesClick }
+							>
+								{ translate( 'Manage all your email subscriptions' ) }
+							</button>
+						</p>
 					)
 				}
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 107576-gh-Automattic/gravatar

## Proposed Changes

* Show the unsubscribe / resubscribe button from the unsubscribe page for Gravatar-related email categories
* Add a category name for Gravatar onboarding relevant emails
* Add a category description for Gravatar onboarding relevant emails
* (Still) Hide the manage link for Gravatar onboarding relevant emails

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On the unsubscribe page, we rely on the URL's `category` parameter to display the relevant UI info for each email category. Similarly, this PR uses the parameter to hide UI elements for Gravatar-related email categories. So we can test the PR by:

* Modify [the isSubscribed](https://github.com/Automattic/wp-calypso/blob/trunk/client/mailing-lists/main.jsx#L15) as `false` to enable the "unsubscribed mode"
* Run Calypso by referring to [the doc](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started)
* Go to: http://calypso.localhost:3000/mailing-lists/unsubscribe?category=gravatar_onboarding, you will see the UI below:
> Note: The "Resubscribe" button doesn't work in the local ENV. I have tested it, and it works great. So, let's focus on the UI part for this PR.

<img width="983" alt="截圖 2024-04-22 下午5 36 41" src="https://github.com/Automattic/wp-calypso/assets/21308003/63bd8976-3d76-4c55-8530-f26267b61bc9">

* For other email categories, still work the same (as shown below), e.g. http://calypso.localhost:3000/mailing-lists/unsubscribe?category=learn
  * We can test more categories by referring to [the relevant code](https://github.com/Automattic/wp-calypso/blob/trunk/client/mailing-lists/main.jsx#L93-L129)

<img width="983" alt="截圖 2024-04-22 下午5 37 13" src="https://github.com/Automattic/wp-calypso/assets/21308003/41020872-b3d5-4c9e-8a32-7d651c70f6ce">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
