### PR TITLE
Dotcom Pages Modal: Update order of patterns to show theme patterns first

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -248,7 +248,7 @@ class Starter_Page_Templates {
 		$config = apply_filters(
 			'fse_starter_page_templates_config',
 			array(
-				'templates'    => array_merge( $default_templates, $page_templates, $registered_page_templates ),
+				'templates'    => array_merge( $default_templates, $registered_page_templates, $page_templates ),
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'screenAction' => isset( $_GET['new-homepage'] ) ? 'add' : $screen->action,
 			)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdKhl6-37D-p2#comment-6213

## Proposed Changes

* Update the order of patterns to show theme patterns first

|BEFORE|AFTER|
|-|-|
|<img width="1728" alt="Screenshot 2567-04-22 at 18 43 01" src="https://github.com/Automattic/wp-calypso/assets/1881481/b0f20531-64b5-4ef0-9166-be2c5639fdcd">|<img width="1728" alt="Screenshot 2567-04-22 at 18 43 36" src="https://github.com/Automattic/wp-calypso/assets/1881481/a76760a2-14b2-460e-b215-09bc7cf52b9e">|

### Next tasks for the pages modal
Post a P2 with these and more opportunities to improve this modal: 
- Order page categories using the same order as in Assembler
- Add a custom hook to allow disabling the modal and show the core modal instead
- Improve the layout to list patterns horizontally rather than vertically:
  - so all theme patterns can appear in the same row
  - this will improve the loading effect too
  - the pattern explorer in core seems to work in this way and uses the height of the taller pattern for the row

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a site
* Patch this PR in your sandbox with `install-plugin.sh etk fix/add-page-modal`
* Active TT4 in your site or any other theme with full-page patterns
* Create a new page from the admin `{ SITE  }/wp-admin/post-new.php?post_type=page`
* Verify the page patterns appear at the top of any of their categories




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?