### PR TITLE
Fix stats upsell modal for Simple Classic

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -13,6 +13,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { useSelector } from 'calypso/state';
 import { getPlanBySlug } from 'calypso/state/plans/selectors';
+import { getSiteOption } from 'calypso/state/sites/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getUpsellModalStatType } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -36,7 +37,11 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const planName = plan?.product_name_short ?? '';
 	const isLoading = ! plan || ! planMonthly;
-	const eventPrefix = isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack_odyssey' : 'calypso';
+	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
+	const eventPrefix = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+	const isSimpleClassic = useSelector( ( state ) =>
+		getSiteOption( state, selectedSiteId, 'is_wpcom_simple' )
+	);
 	const statType = useSelector( ( state ) => getUpsellModalStatType( state, siteId ) );
 
 	const closeModal = () => {
@@ -49,8 +54,15 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_modal_submit`, {
 			stat_type: statType,
 		} );
-
-		page( `/checkout/${ siteSlug }/${ plan?.path_slug ?? 'premium' }` );
+		if ( isSimpleClassic ) {
+			const checkoutProductUrl = new URL(
+				`https://wordpress.com/checkout/${ siteSlug }/${ PLAN_PREMIUM }`
+			);
+			checkoutProductUrl.searchParams.set( 'redirect_to', window.location.href );
+			window.open( checkoutProductUrl, '_self' );
+		} else {
+			page( `/checkout/${ siteSlug }/${ plan?.path_slug ?? 'premium' }` );
+		}
 	};
 
 	return (


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6398

## Proposed Changes

* Go to WordPress.com checkout page for plan upgrades
* Redirects to the Simple Classic Jetpack Stats page

![explorer](https://github.com/Automattic/wp-calypso/assets/6586048/1ff2b27e-1b65-406b-82fa-051231c79822)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisite 1: Simple Classic
To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```

### Prerequisite 2:
I'd encourage you to create a new Simple site as we had a cutoff date for paid stats
The modal is triggered through the upgrade buttons.
![upgrade plan](https://github.com/Automattic/wp-calypso/assets/6586048/de69509b-a903-4d86-9354-34b4ca21ea0f)


* Run `install-plugin.sh odyssey-stats fix/paid-stats-upgrade-simple-classic` in your sandbox and sandbox widgets.wp.com for testing, alternatively, locally you can checkout to this branch and cd to `apps/odyssey-stats` and run `yarn dev --sync`
* Go to `/wp-admin/admin.php?page=stats` and click on the Upgrade button shown in the modal
Test on Self-hosted/Atomic/Simple Calypso to make sure we didn't break anything.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?