### PR TITLE
Segmentation Survey: Use real entrepreneur survey data

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -14,7 +14,7 @@ import SegmentationSurveyProvider from './provider';
 import type { Step } from '../../types';
 import './style.scss';
 
-const SURVEY_KEY = 'survey-1';
+const SURVEY_KEY = 'entrepreneur-trial';
 
 const SegmentationSurveyDocumentHead = () => {
 	const { currentQuestion } = useSurveyContext();


### PR DESCRIPTION
ℹ️  This PR should be merged and deployed only once D146119-code is in production.

---

Resolves https://github.com/Automattic/wp-calypso/issues/89731.

## Proposed Changes

* instead of `mock` use `entrepreneur-trial` survey data

## Testing Instructions

Please test together with D146119-code. The test instructions are available there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?