### PR TITLE
Untangling: point the Explore Plugins link to wp-admin on Atomic early classic sites

### DIFF
--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -71,6 +71,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		list: {
 			component: (
 				<ScheduleList
+					siteId={ siteId }
 					onNavBack={ onNavBack }
 					onCreateNewSchedule={ onCreateNewSchedule }
 					onEditSchedule={ onEditSchedule }

--- a/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
@@ -2,17 +2,16 @@ import { __experimentalText as Text, Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
-import { useSiteSlug } from './hooks/use-site-slug';
 
 interface Props {
+	pluginsUrl: string;
 	canCreateSchedules: boolean;
 	onCreateNewSchedule?: () => void;
 }
 export const ScheduleListEmpty = ( props: Props ) => {
-	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 
-	const { onCreateNewSchedule, canCreateSchedules } = props;
+	const { pluginsUrl, onCreateNewSchedule, canCreateSchedules } = props;
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins();
 
 	return (
@@ -37,7 +36,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 						<Button
 							__next40pxDefaultSize
 							variant={ canCreateSchedules ? 'primary' : 'secondary' }
-							href={ `/plugins/${ siteSlug }` }
+							href={ pluginsUrl }
 						>
 							{ translate( 'Explore plugins' ) }
 						</Button>

--- a/client/blocks/plugins-scheduled-updates/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list.tsx
@@ -14,6 +14,11 @@ import { useState } from 'react';
 import { useDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSelector } from 'calypso/state';
+import {
+	getSiteAdminUrl,
+	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
+} from 'calypso/state/sites/selectors';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteHasEligiblePlugins } from './hooks/use-site-has-eligible-plugins';
@@ -23,6 +28,7 @@ import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListTable } from './schedule-list-table';
 
 interface Props {
+	siteId: number | null;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 	onEditSchedule: ( id: string ) => void;
@@ -36,9 +42,14 @@ export const ScheduleList = ( props: Props ) => {
 	const { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading } =
 		useSiteHasEligiblePlugins();
 
-	const { onNavBack, onCreateNewSchedule, onEditSchedule, onShowLogs } = props;
+	const { siteId, onNavBack, onCreateNewSchedule, onEditSchedule, onShowLogs } = props;
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< undefined | string >();
+
+	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
+		getIsGlobalSiteViewEnabled( state, siteId )
+	);
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
 	const {
 		data: schedules = [],
@@ -117,6 +128,11 @@ export const ScheduleList = ( props: Props ) => {
 					{ schedules.length === 0 && isLoading && <Spinner /> }
 					{ ! isLoading && showScheduleListEmpty && (
 						<ScheduleListEmpty
+							pluginsUrl={
+								isGlobalSiteViewEnabled
+									? `${ siteAdminUrl }plugin-install.php`
+									: `/plugins/${ siteSlug }`
+							}
 							onCreateNewSchedule={ onCreateNewSchedule }
 							canCreateSchedules={ canCreateSchedules }
 						/>


### PR DESCRIPTION
## Proposed Changes

This PR updates the "Explore Plugins" button on Plugins -> Scheduled Updates to point to `/wp-admin/plugin-install.php` on Atomic early classic sites. This is because on such sites, the Calypso plugin marketplace is (currently) not accessible from any interface (Calypso or wp-admin).

<img width="713" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/eb71bdd9-746e-45e0-b1a1-920c353f3f0a">

## Testing Instructions

1. Prepare a fresh Atomic site.
2. Make sure not to install any new plugin.
3. Go to Plugins -> Scheduled Updates, verify that the Explore Plugins button points to `/plugins/:siteSlug`.
4. Go Settings -> Hosting Configuration and set the admin interface style to Classic.
5. Go to Plugins -> Scheduled Updates, verify that the Explore Plugins button points to `/plugins/:siteSlug`.
6. Go to your site's `/_cli` and run `wp option update wpcom_classic_early_release 1`.
5. Go to Plugins -> Scheduled Updates, verify that the Explore Plugins button points to `/wp-admin/plugin-install.php`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?