### PR TITLE
Automattic for Agencies: Add status badge to show account status

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Badge } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import React from 'react';
 
@@ -11,6 +11,7 @@ interface StepSectionItemProps {
 	heading: string;
 	description: string;
 	buttonProps?: React.ComponentProps< typeof Button >;
+	statusProps?: React.ComponentProps< typeof Badge >;
 }
 
 export default function StepSectionItem( {
@@ -18,6 +19,7 @@ export default function StepSectionItem( {
 	heading,
 	description,
 	buttonProps,
+	statusProps,
 }: StepSectionItemProps ) {
 	return (
 		<div className="step-section-item">
@@ -32,6 +34,7 @@ export default function StepSectionItem( {
 			<div className="step-section-item__content">
 				<div className="step-section-item__heading">{ heading }</div>
 				<div className="step-section-item__description">{ description }</div>
+				{ statusProps && <Badge className="step-section-item__status" { ...statusProps } /> }
 			</div>
 			{ buttonProps && (
 				<div className="step-section-item__button">

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -45,3 +45,16 @@
 		}
 	}
 }
+
+.step-section-item__status {
+	margin-block-start: 8px;
+
+	&.badge--success {
+		background-color: var(--color-success-5);
+		color: var(--color-success-80);
+	}
+	&.badge--warning {
+		background-color: var(--color-warning-5);
+		color: var(--color-warning-80);
+	}
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -28,6 +28,9 @@ export default function ReferralsOverview() {
 	}, [ dispatch ] );
 
 	const hasPayeeAccount = false; // FIXME: Replace with actual check
+	const showStatus = true; // FIXME: Replace with actual check
+	const statusType = 'warning'; // FIXME: Replace with actual check
+	const status = 'Pending'; // FIXME: Replace with actual check
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -59,6 +62,14 @@ export default function ReferralsOverview() {
 								onClick: onAddBankDetailsClick,
 								primary: true,
 							} }
+							statusProps={
+								showStatus
+									? {
+											children: status,
+											type: statusType,
+									  }
+									: undefined
+							}
 						/>
 						<StepSectionItem
 							icon={ plugins }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/325

## Proposed Changes

This PR implements a status badge to show the bank account status.

Note:

- The status text will be updated later. This is just a dummy text.

## Testing Instructions

1) Open the A4A live link.
2) Go to Referrals > Verify that you can see a badge as shown below:

<img width="1059" alt="Screenshot 2024-04-22 at 4 16 58 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f0893bc2-ebce-410d-be5f-ffc2df0e8ad5">

3) Go to /sections/referrals/primary/referrals-overview/index.tsx > Change the `statusType` to "success" & `status` to "Confirmed" > Refresh the page > Verify that you can see a badge as shown below:

<img width="1059" alt="Screenshot 2024-04-22 at 4 17 18 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9e7fddba-ce7a-473b-b4da-af45087e7443">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?