### PR TITLE
Add site monitoring to Global site view

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -700,8 +700,8 @@ const sections = [
 	{
 		name: 'site-monitoring',
 		paths: [ '/site-monitoring', '/site-logs' ],
-		module: 'calypso/my-sites/site-monitoring',
-		group: 'sites',
+		module: 'calypso/site-monitoring',
+		group: 'sites-dashboard',
 	},
 	{
 		name: 'github-deployments',

--- a/client/sections.js
+++ b/client/sections.js
@@ -701,7 +701,7 @@ const sections = [
 		name: 'site-monitoring',
 		paths: [ '/site-monitoring', '/site-logs' ],
 		module: 'calypso/site-monitoring',
-		group: 'sites-dashboard',
+		group: 'sites',
 	},
 	{
 		name: 'github-deployments',

--- a/client/site-monitoring/components/php-logs.tsx
+++ b/client/site-monitoring/components/php-logs.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { LogsTab } from 'calypso/my-sites/site-monitoring/logs-tab';
+
+const SiteMonitoringPhpLogs: FC = () => {
+	return (
+		<div className="site-monitoring-php-logs">
+			<LogsTab logType="php" />
+		</div>
+	);
+};
+
+export default SiteMonitoringPhpLogs;

--- a/client/site-monitoring/components/server-logs.tsx
+++ b/client/site-monitoring/components/server-logs.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { LogsTab } from 'calypso/my-sites/site-monitoring/logs-tab';
+
+const SiteMonitoringServerLogs: FC = () => {
+	return (
+		<div className="site-monitoring-server-logs">
+			<LogsTab logType="web" />
+		</div>
+	);
+};
+
+export default SiteMonitoringServerLogs;

--- a/client/site-monitoring/components/site-monitoring-overview.tsx
+++ b/client/site-monitoring/components/site-monitoring-overview.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { MetricsTab } from 'calypso/my-sites/site-monitoring/metrics-tab';
+
+const SiteMonitoringOverview: FC = () => {
+	return (
+		<div className="site-monitoring-overview">
+			<MetricsTab />
+		</div>
+	);
+};
+
+export default SiteMonitoringOverview;

--- a/client/site-monitoring/controller.tsx
+++ b/client/site-monitoring/controller.tsx
@@ -1,0 +1,29 @@
+import MySitesNavigation from 'calypso/my-sites/navigation';
+import SiteMonitoringPhpLogs from './components/php-logs';
+import SiteMonitoringServerLogs from './components/server-logs';
+import SiteMonitoringOverview from './components/site-monitoring-overview';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+export function siteMonitoringOverview( context: PageJSContext, next: () => void ) {
+	context.secondary = <MySitesNavigation path={ context.path } />;
+
+	context.primary = <SiteMonitoringOverview />;
+
+	next();
+}
+
+export function siteMonitoringPhpLogs( context: PageJSContext, next: () => void ) {
+	context.secondary = <MySitesNavigation path={ context.path } />;
+
+	context.primary = <SiteMonitoringPhpLogs />;
+
+	next();
+}
+
+export function siteMonitoringServerLogs( context: PageJSContext, next: () => void ) {
+	context.secondary = <MySitesNavigation path={ context.path } />;
+
+	context.primary = <SiteMonitoringServerLogs />;
+
+	next();
+}

--- a/client/site-monitoring/index.tsx
+++ b/client/site-monitoring/index.tsx
@@ -1,6 +1,7 @@
-import page from '@automattic/calypso-router';
+import page, { type Callback } from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
+import { redirectHomeIfIneligible } from 'calypso/my-sites/site-monitoring/controller';
 import {
 	siteMonitoringOverview,
 	siteMonitoringPhpLogs,
@@ -9,10 +10,18 @@ import {
 
 export default function () {
 	page( '/site-monitoring', siteSelection, sites, makeLayout, clientRender );
-	page( '/site-monitoring/:site', siteSelection, siteMonitoringOverview, makeLayout, clientRender );
+	page(
+		'/site-monitoring/:site',
+		siteSelection,
+		redirectHomeIfIneligible,
+		siteMonitoringOverview,
+		makeLayout,
+		clientRender
+	);
 	page(
 		'/site-monitoring/:site/php',
 		siteSelection,
+		redirectHomeIfIneligible,
 		siteMonitoringPhpLogs,
 		makeLayout,
 		clientRender
@@ -20,8 +29,21 @@ export default function () {
 	page(
 		'/site-monitoring/:site/web',
 		siteSelection,
+		redirectHomeIfIneligible,
 		siteMonitoringServerLogs,
 		makeLayout,
 		clientRender
 	);
+
+	// Legacy redirect for Site Logs.
+	const redirectSiteLogsToMonitoring: Callback = ( context ) => {
+		if ( context.params?.siteId ) {
+			context.page.replace( `/site-monitoring/${ context.params.siteId }` );
+		} else {
+			context.page.replace( `/site-monitoring` );
+		}
+		return;
+	};
+	page( '/site-logs', redirectSiteLogsToMonitoring );
+	page( '/site-logs/:siteId', redirectSiteLogsToMonitoring );
 }

--- a/client/site-monitoring/index.tsx
+++ b/client/site-monitoring/index.tsx
@@ -1,0 +1,27 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { siteSelection, sites } from 'calypso/my-sites/controller';
+import {
+	siteMonitoringOverview,
+	siteMonitoringPhpLogs,
+	siteMonitoringServerLogs,
+} from './controller';
+
+export default function () {
+	page( '/site-monitoring', siteSelection, sites, makeLayout, clientRender );
+	page( '/site-monitoring/:site', siteSelection, siteMonitoringOverview, makeLayout, clientRender );
+	page(
+		'/site-monitoring/:site/php',
+		siteSelection,
+		siteMonitoringPhpLogs,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/site-monitoring/:site/web',
+		siteSelection,
+		siteMonitoringServerLogs,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -10,6 +10,9 @@ import type { AppState } from 'calypso/types';
 // as the Global Site View is still in development.
 const GLOBAL_SITE_VIEW_SECTION_NAMES: string[] = [];
 
+// Calypso pages listed here will show the global sidebar when on sites group.
+const GLOBAL_SIDEBAR_SECTION_NAMES: string[] = [ 'hosting', 'hosting-overview', 'site-monitoring' ];
+
 export const getShouldShowGlobalSidebar = (
 	_: AppState,
 	siteId: number,
@@ -20,7 +23,11 @@ export const getShouldShowGlobalSidebar = (
 		sectionGroup === 'me' ||
 		sectionGroup === 'reader' ||
 		sectionGroup === 'sites-dashboard' ||
-		( sectionGroup === 'sites' && ! siteId )
+		( sectionGroup === 'sites' &&
+			( ! siteId ||
+				( !! siteId &&
+					isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
+					GLOBAL_SIDEBAR_SECTION_NAMES.includes( sectionName ) ) ) )
 	);
 };
 
@@ -46,7 +53,8 @@ export const getShouldShowGlobalSiteSidebar = (
 		!! siteId &&
 		isGlobalSiteViewEnabled( state, siteId ) &&
 		sectionGroup === 'sites' &&
-		GLOBAL_SITE_VIEW_SECTION_NAMES.includes( sectionName )
+		GLOBAL_SITE_VIEW_SECTION_NAMES.includes( sectionName ) &&
+		! GLOBAL_SIDEBAR_SECTION_NAMES.includes( sectionName )
 	);
 };
 
@@ -60,6 +68,7 @@ export const getShouldShowUnifiedSiteSidebar = (
 		!! siteId &&
 		isGlobalSiteViewEnabled( state, siteId ) &&
 		sectionGroup === 'sites' &&
-		! GLOBAL_SITE_VIEW_SECTION_NAMES.includes( sectionName )
+		! GLOBAL_SITE_VIEW_SECTION_NAMES.includes( sectionName ) &&
+		! getShouldShowGlobalSidebar( state, siteId, sectionGroup, sectionName )
 	);
 };


### PR DESCRIPTION
This PR move site monitoring from the wp-admin menu to the Global site view (GSV).

Ref: https://github.com/Automattic/dotcom-forge/issues/6255

### Nav Uni - Hosting config (where it is now)
<img width="845" alt="Screenshot 2024-04-22 at 13 43 12" src="https://github.com/Automattic/wp-calypso/assets/5560595/237eb99b-9b4d-4f62-ad17-9c4e4a80367e">

### Site monitoring in GSV

<img width="1288" alt="Screenshot 2024-04-22 at 13 45 57" src="https://github.com/Automattic/wp-calypso/assets/5560595/6bcc9937-66dd-49c4-8a83-614e93e9fe87">
<img width="1280" alt="Screenshot 2024-04-22 at 13 45 44" src="https://github.com/Automattic/wp-calypso/assets/5560595/c8f31380-e717-419b-a940-ff4728f42d1e">
<img width="1289" alt="Screenshot 2024-04-22 at 13 45 29" src="https://github.com/Automattic/wp-calypso/assets/5560595/90ceb77a-631f-4732-8d76-32f7eaffac49">

These pages will eventually be tabs in the sites dashboard.

### Testing Instructions

Confirm the following URLs loads as expected
* `/site-monitoring/{atomic-site}`
* `/site-monitoring/{atomic-site}/php`
* `/site-monitoring/{atomic-site}/web`

## TODO

- [x] Add site-monitoring pages
- [x] Update `getShouldShowGlobalSidebar` to support showing global sidebar when feature flag is enabled

