### PR TITLE
Scheduled Updates: Add batch mutations

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -2,6 +2,10 @@ import { ScheduleCreate } from './schedule-create';
 
 import './styles.scss';
 
-export const PluginsScheduledUpdatesMultisite = () => {
-	return <ScheduleCreate />;
+type Props = {
+	onNavBack?: () => void;
+};
+
+export const PluginsScheduledUpdatesMultisite = ( { onNavBack }: Props ) => {
+	return <ScheduleCreate onNavBack={ onNavBack } />;
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
@@ -1,11 +1,15 @@
 import { ScheduleForm } from './schedule-form';
 
-export const ScheduleCreate = () => {
+type Props = {
+	onNavBack?: () => void;
+};
+
+export const ScheduleCreate = ( { onNavBack }: Props ) => {
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
 			<h1 className="wp-brand-font">New schedule</h1>
 
-			<ScheduleForm />
+			<ScheduleForm onNavBack={ onNavBack } />
 		</div>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,20 +1,27 @@
-import { __experimentalText as Text } from '@wordpress/components';
+import { __experimentalText as Text, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useCoreSitesPluginsQuery } from 'calypso/data/plugins/use-core-sites-plugins-query';
+import { useBatchCreateUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { ScheduleFormFrequency } from '../plugins-scheduled-updates/schedule-form-frequency';
 import { ScheduleFormPlugins } from '../plugins-scheduled-updates/schedule-form-plugins';
 import { validateSites, validatePlugins } from '../plugins-scheduled-updates/schedule-form.helper';
 import { ScheduleFormSites } from './schedule-form-sites';
 
-export const ScheduleForm = () => {
-	const translate = useTranslate();
+type Props = {
+	onNavBack?: () => void;
+};
 
+export const ScheduleForm = ( { onNavBack }: Props ) => {
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( [] );
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
+	const [ frequency, setFrequency ] = useState< 'daily' | 'weekly' >( 'daily' );
+	const [ timestamp, setTimestamp ] = useState< number >( Date.now() );
+
+	const translate = useTranslate();
 
 	const { data: sites } = useSiteExcerptsQuery( [ 'atomic' ] );
 	const {
@@ -60,31 +67,82 @@ export const ScheduleForm = () => {
 		}
 	}, [ plugins ] );
 
+	const selectedSiteSlugs = sites
+		? sites.filter( ( site ) => selectedSites.includes( site.ID ) ).map( ( site ) => site.slug )
+		: [];
+
+	const { mutateAsync: createUpdateScheduleAsync, isPending: createUpdateSchedulePending } =
+		useBatchCreateUpdateScheduleMutation( selectedSiteSlugs );
+
+	const submitForm = async ( event: React.FormEvent ) => {
+		event.preventDefault();
+
+		const params = {
+			plugins: selectedPlugins,
+			schedule: {
+				timestamp,
+				interval: frequency,
+			},
+		};
+
+		try {
+			await createUpdateScheduleAsync( params );
+			// Handle successful case
+			onNavBack && onNavBack();
+		} catch ( error ) {
+			// TODO: store errors in context?
+			onNavBack && onNavBack();
+		}
+	};
+
 	return (
-		<div className="schedule-form">
-			<Text>{ translate( 'Step 1' ) }</Text>
-			<ScheduleFormSites
-				sites={ sites }
-				onChange={ setSelectedSites }
-				onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, sites: touched } ) }
-				error={ validationErrors?.sites }
-				showError={ fieldTouched?.sites }
-			/>
+		<form id="schedule" onSubmit={ submitForm }>
+			<div className="schedule-form">
+				<Text>{ translate( 'Step 1' ) }</Text>
+				<ScheduleFormSites
+					sites={ sites }
+					onChange={ setSelectedSites }
+					onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, sites: touched } ) }
+					error={ validationErrors?.sites }
+					showError={ fieldTouched?.sites }
+				/>
 
-			<Text>{ translate( 'Step 2' ) }</Text>
-			<ScheduleFormPlugins
-				plugins={ getPlugins() }
-				selectedPlugins={ selectedPlugins }
-				isPluginsFetching={ isPluginsFetching }
-				isPluginsFetched={ isPluginsFetched }
-				onChange={ setSelectedPlugins }
-				onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, plugins: touched } ) }
-				error={ validationErrors?.plugins }
-				showError={ fieldTouched?.plugins }
-			/>
+				<Text>{ translate( 'Step 2' ) }</Text>
+				<ScheduleFormPlugins
+					plugins={ getPlugins() }
+					selectedPlugins={ selectedPlugins }
+					isPluginsFetching={ isPluginsFetching }
+					isPluginsFetched={ isPluginsFetched }
+					onChange={ setSelectedPlugins }
+					onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, plugins: touched } ) }
+					error={ validationErrors?.plugins }
+					showError={ fieldTouched?.plugins }
+				/>
 
-			<Text>{ translate( 'Step 3' ) }</Text>
-			<ScheduleFormFrequency initFrequency="daily" />
-		</div>
+				<Text>{ translate( 'Step 3' ) }</Text>
+				<ScheduleFormFrequency
+					initFrequency="daily"
+					onChange={ ( frequency, timestamp ) => {
+						setTimestamp( timestamp );
+						setFrequency( frequency );
+					} }
+					onTouch={ ( touched ) => {
+						setFieldTouched( { ...fieldTouched, timestamp: touched } );
+					} }
+				/>
+			</div>
+
+			<Button
+				form="schedule"
+				type="submit"
+				variant="primary"
+				isBusy={ createUpdateSchedulePending }
+				disabled={
+					! selectedSites.length || ! selectedPlugins.length || createUpdateSchedulePending
+				}
+			>
+				{ translate( 'Create' ) }
+			</Button>
+		</form>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -72,7 +72,7 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 		? sites.filter( ( site ) => selectedSites.includes( site.ID ) ).map( ( site ) => site.slug )
 		: [];
 
-	const { createMonitors } = useCreateMonitors( selectedSiteSlugs );
+	const { createMonitors } = useCreateMonitors();
 
 	const { mutateAsync: createUpdateScheduleAsync, isPending: createUpdateSchedulePending } =
 		useBatchCreateUpdateScheduleMutation( selectedSiteSlugs );
@@ -88,16 +88,13 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 			},
 		};
 
-		try {
-			await createUpdateScheduleAsync( params );
-			// Handle successful case
-			createMonitors();
-			onNavBack && onNavBack();
-		} catch ( error ) {
-			createMonitors();
-			// TODO: store errors in context?
-			onNavBack && onNavBack();
-		}
+		const createResults = await createUpdateScheduleAsync( params );
+		const successfulSiteSlugs = createResults
+			.filter( ( result ) => ! result.error )
+			.map( ( result ) => result.siteSlug );
+		// Create monitors for sites that have been successfully scheduled
+		createMonitors( successfulSiteSlugs );
+		onNavBack && onNavBack();
 	};
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,6 +1,7 @@
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useCreateMonitors } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-create-monitor';
 import { useCoreSitesPluginsQuery } from 'calypso/data/plugins/use-core-sites-plugins-query';
 import { useBatchCreateUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
@@ -71,6 +72,8 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 		? sites.filter( ( site ) => selectedSites.includes( site.ID ) ).map( ( site ) => site.slug )
 		: [];
 
+	const { createMonitors } = useCreateMonitors( selectedSiteSlugs );
+
 	const { mutateAsync: createUpdateScheduleAsync, isPending: createUpdateSchedulePending } =
 		useBatchCreateUpdateScheduleMutation( selectedSiteSlugs );
 
@@ -88,8 +91,10 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 		try {
 			await createUpdateScheduleAsync( params );
 			// Handle successful case
+			createMonitors();
 			onNavBack && onNavBack();
 		} catch ( error ) {
+			createMonitors();
 			// TODO: store errors in context?
 			onNavBack && onNavBack();
 		}

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -5,6 +5,8 @@
 	}
 
 	.schedule-form {
+		margin-bottom: 1.25rem;
+
 		& > .form-control-container {
 			margin-bottom: 1.25rem;
 

--- a/client/data/plugins/use-monitor-settings-mutation.ts
+++ b/client/data/plugins/use-monitor-settings-mutation.ts
@@ -48,48 +48,91 @@ export const useMonitorSettingsQuery = (
 	} );
 };
 
-export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptions = {} ) {
-	const MAX_RETRIES = 3;
-	const isMonitorNotActiveErrorMsg = 'Monitor is not active.';
+const isMonitorActive = ( data: UpdateMonitorSettingsCreate ) => {
+	return data?.settings && data?.settings?.monitor_active === true;
+};
 
-	const isMonitorActive = ( data: UpdateMonitorSettingsCreate ) => {
-		return data?.settings && data?.settings?.monitor_active === true;
-	};
+const isMonitorNotActiveError = ( error: Error ) => {
+	return error.message === 'Monitor is not active.';
+};
 
-	const isMonitorNotActiveError = ( error: Error ) => {
-		return error.message === isMonitorNotActiveErrorMsg;
-	};
+const createMonitorSettingsMutateFn = async ( siteSlug: string, params: object ) => {
+	const response: UpdateMonitorSettingsCreate = await wpcomRequest( {
+		path: `/sites/${ siteSlug }/jetpack-monitor-settings`,
+		apiNamespace: 'wpcom/v2',
+		method: 'POST',
+		body: params,
+	} );
+	if ( ! isMonitorActive( response ) ) {
+		throw new Error( 'Monitor is not active.' );
+	}
+	return response;
+};
 
-	const mutation = useMutation( {
-		mutationFn: async ( params: object ) => {
-			const response: UpdateMonitorSettingsCreate = await wpcomRequest( {
-				path: `/sites/${ siteSlug }/jetpack-monitor-settings`,
-				apiNamespace: 'wpcom/v2',
-				method: 'POST',
-				body: params,
-			} );
-			if ( ! isMonitorActive( response ) ) {
-				throw new Error( isMonitorNotActiveErrorMsg );
+const createMonitorSettingsRetryFn =
+	( siteSlug?: string ) => ( failureCount: number, error: Error ) => {
+		const MAX_RETRIES = 3;
+
+		if ( isMonitorNotActiveError( error ) ) {
+			if ( failureCount < MAX_RETRIES ) {
+				return true;
 			}
-			return response;
-		},
-		...queryOptions,
-		retry: ( failureCount, error ) => {
-			if ( isMonitorNotActiveError( error ) ) {
-				if ( failureCount < MAX_RETRIES ) {
-					return true;
-				}
+			if ( siteSlug ) {
 				recordTracksEvent( 'calypso_scheduled_updates_retry_monitor_settings_failed', {
 					site_slug: siteSlug,
 				} );
+			} else {
+				recordTracksEvent( 'calypso_scheduled_updates_batch_retry_monitor_settings_failed' );
 			}
-			return false;
-		},
+		}
+		return false;
+	};
+
+export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptions = {} ) {
+	const mutation = useMutation( {
+		mutationFn: async ( params: object ) => createMonitorSettingsMutateFn( siteSlug, params ),
+		...queryOptions,
+		retry: createMonitorSettingsRetryFn( siteSlug ),
 		retryDelay: 3000,
 	} );
 
 	const { mutate } = mutation;
 	const createMonitorSettings = useCallback( ( params: object ) => mutate( params ), [ mutate ] );
+
+	return { createMonitorSettings, ...mutation };
+}
+
+export function useBatchCreateMonitorSettingsMutation( queryOptions = {} ) {
+	const mutation = useMutation( {
+		mutationKey: [ 'batch-create-monitor-settings' ],
+		mutationFn: async ( params: { [ siteSlug: string ]: object } ) => {
+			const results = await Promise.all(
+				Object.keys( params ).map( async ( siteSlug ) => {
+					try {
+						const response = await createMonitorSettingsMutateFn( siteSlug, params[ siteSlug ] );
+						return { siteSlug, response, error: null };
+					} catch ( error ) {
+						throw { siteSlug, error };
+					}
+				} )
+			);
+
+			// check if any of the requests failed
+			const failedRequests = results.filter( ( result ) => result?.error );
+			if ( failedRequests.length ) {
+				throw failedRequests;
+			}
+		},
+		...queryOptions,
+		retry: createMonitorSettingsRetryFn(),
+		retryDelay: 3000,
+	} );
+
+	const { mutate } = mutation;
+	const createMonitorSettings = useCallback(
+		( params: { [ siteSlug: string ]: object } ) => mutate( params ),
+		[ mutate ]
+	);
 
 	return { createMonitorSettings, ...mutation };
 }

--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -61,6 +61,82 @@ export function useCreateUpdateScheduleMutation( siteSlug: SiteSlug, queryOption
 	return { createUpdateSchedule, ...mutation };
 }
 
+export function useBatchCreateUpdateScheduleMutation( siteSlugs: SiteSlug[], queryOptions = {} ) {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation( {
+		mutationKey: [ 'batch-create-update-schedule', ...siteSlugs ],
+		mutationFn: async ( params: object ) => {
+			const results: { siteSlug: string; response?: unknown; error?: unknown }[] =
+				await Promise.all(
+					siteSlugs.map( async ( siteSlug ) => {
+						try {
+							const response = await wpcomRequest( {
+								path: `/sites/${ siteSlug }/update-schedules`,
+								apiNamespace: 'wpcom/v2',
+								method: 'POST',
+								body: params,
+							} );
+							return { siteSlug, response };
+						} catch ( error ) {
+							throw { siteSlug, error };
+						}
+					} )
+				);
+
+			// check if any of the requests failed
+			const failedRequests = results.filter( ( result ) => result.error );
+			if ( failedRequests.length ) {
+				throw failedRequests;
+			}
+		},
+		onMutate: ( params: CreateRequestParams ) => {
+			const prevSchedulesMap = new Map< SiteSlug, ScheduleUpdates[] >();
+
+			siteSlugs.forEach( ( siteSlug ) => {
+				const prevSchedules: ScheduleUpdates[] =
+					queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
+
+				prevSchedulesMap.set( siteSlug, prevSchedules );
+
+				const newSchedules = [
+					...prevSchedules,
+					{
+						id: 'temp-id',
+						args: params.plugins,
+						timestamp: params.schedule.timestamp,
+						schedule: params.schedule.interval,
+						interval: params.schedule.timestamp,
+					},
+				];
+
+				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], newSchedules );
+			} );
+
+			return { prevSchedulesMap };
+		},
+		onError: ( err, params, context ) => {
+			context?.prevSchedulesMap.forEach( ( prevSchedules, siteSlug ) => {
+				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], prevSchedules );
+			} );
+		},
+		onSettled: () => {
+			siteSlugs.forEach( ( siteSlug ) => {
+				queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
+			} );
+		},
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const createUpdateSchedule = useCallback(
+		( params: CreateRequestParams ) => mutate( params ),
+		[ mutate ]
+	);
+
+	return { createUpdateSchedule, ...mutation };
+}
+
 export function useEditUpdateScheduleMutation( siteSlug: SiteSlug, queryOptions = {} ) {
 	const queryClient = useQueryClient();
 
@@ -118,6 +194,90 @@ export function useEditUpdateScheduleMutation( siteSlug: SiteSlug, queryOptions 
 	return { editUpdateSchedule, ...mutation };
 }
 
+export function useBatchEditUpdateScheduleMutation( siteSlugs: SiteSlug[], queryOptions = {} ) {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation( {
+		mutationKey: [ 'batch-edit-update-schedule', ...siteSlugs ],
+		mutationFn: async ( obj: { id: string; params: object } ) => {
+			const { id, params } = obj;
+
+			const results: { siteSlug: string; response?: unknown; error?: unknown }[] =
+				await Promise.all(
+					siteSlugs.map( async ( siteSlug ) => {
+						try {
+							const response = await wpcomRequest( {
+								path: `/sites/${ siteSlug }/update-schedules/${ id }`,
+								apiNamespace: 'wpcom/v2',
+								method: 'PUT',
+								body: params,
+							} );
+							return { siteSlug, response };
+						} catch ( error ) {
+							throw { siteSlug, error };
+						}
+					} )
+				);
+
+			// check if any of the requests failed
+			const failedRequests = results.filter( ( result ) => result.error );
+			if ( failedRequests.length ) {
+				throw failedRequests;
+			}
+		},
+		onMutate: ( props ) => {
+			const id = props.id;
+			const params = props.params as CreateRequestParams;
+
+			const prevSchedulesMap = new Map< SiteSlug, ScheduleUpdates[] >();
+
+			siteSlugs.forEach( ( siteSlug ) => {
+				const prevSchedules: ScheduleUpdates[] =
+					queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
+				const scheduleIndex = prevSchedules.findIndex( ( x ) => x.id === id );
+
+				prevSchedulesMap.set( siteSlug, prevSchedules );
+
+				// Replace schedule with new data without mutating the original array
+				const newSchedules = [
+					...prevSchedules.slice( 0, scheduleIndex ),
+					{
+						...prevSchedules[ scheduleIndex ],
+						args: params.plugins,
+						timestamp: params.schedule.timestamp,
+						schedule: params.schedule.interval,
+						interval: params.schedule.timestamp,
+					},
+					...prevSchedules.slice( scheduleIndex + 1 ),
+				];
+
+				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], newSchedules );
+			} );
+
+			return { prevSchedulesMap };
+		},
+		onError: ( err, props, context ) => {
+			context?.prevSchedulesMap.forEach( ( prevSchedules, siteSlug ) => {
+				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], prevSchedules );
+			} );
+		},
+		onSettled: () => {
+			siteSlugs.forEach( ( siteSlug ) => {
+				queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
+			} );
+		},
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const editUpdateSchedule = useCallback(
+		( id: string, params: object ) => mutate( { id, params } ),
+		[ mutate ]
+	);
+
+	return { editUpdateSchedule, ...mutation };
+}
+
 export function useDeleteUpdateScheduleMutation( siteSlug: SiteSlug, queryOptions = {} ) {
 	const queryClient = useQueryClient();
 
@@ -134,6 +294,66 @@ export function useDeleteUpdateScheduleMutation( siteSlug: SiteSlug, queryOption
 				queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
 			const schedules = prevSchedules.filter( ( x ) => x.id !== id );
 			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], schedules );
+		},
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const deleteUpdateSchedule = useCallback( ( id: string ) => mutate( id ), [ mutate ] );
+
+	return { deleteUpdateSchedule, ...mutation };
+}
+
+export function useBatchDeleteUpdateScheduleMutation( siteSlugs: SiteSlug[], queryOptions = {} ) {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation( {
+		mutationFn: async ( id: string ) => {
+			const results: { siteSlug: string; response?: unknown; error?: unknown }[] =
+				await Promise.all(
+					siteSlugs.map( async ( siteSlug ) => {
+						try {
+							const response = await wpcomRequest( {
+								path: `/sites/${ siteSlug }/update-schedules/${ id }`,
+								apiNamespace: 'wpcom/v2',
+								method: 'DELETE',
+							} );
+							return { siteSlug, response };
+						} catch ( error ) {
+							throw { siteSlug, error };
+						}
+					} )
+				);
+
+			// check if any of the requests failed
+			const failedRequests = results.filter( ( result ) => result.error );
+			if ( failedRequests.length ) {
+				throw failedRequests;
+			}
+		},
+		onMutate: ( id ) => {
+			const prevSchedulesMap = new Map< SiteSlug, ScheduleUpdates[] >();
+
+			siteSlugs.forEach( ( siteSlug ) => {
+				const prevSchedules: ScheduleUpdates[] =
+					queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
+				const schedules = prevSchedules.filter( ( x ) => x.id !== id );
+
+				prevSchedulesMap.set( siteSlug, prevSchedules );
+				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], schedules );
+			} );
+
+			return { prevSchedulesMap };
+		},
+		onError: ( err, id, context ) => {
+			context?.prevSchedulesMap.forEach( ( prevSchedules, siteSlug ) => {
+				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], prevSchedules );
+			} );
+		},
+		onSettled: () => {
+			siteSlugs.forEach( ( siteSlug ) => {
+				queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
+			} );
 		},
 		...queryOptions,
 	} );

--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -79,16 +79,12 @@ export function useBatchCreateUpdateScheduleMutation( siteSlugs: SiteSlug[], que
 							} );
 							return { siteSlug, response };
 						} catch ( error ) {
-							throw { siteSlug, error };
+							return { siteSlug, error };
 						}
 					} )
 				);
 
-			// check if any of the requests failed
-			const failedRequests = results.filter( ( result ) => result.error );
-			if ( failedRequests.length ) {
-				throw failedRequests;
-			}
+			return results;
 		},
 		onMutate: ( params: CreateRequestParams ) => {
 			const prevSchedulesMap = new Map< SiteSlug, ScheduleUpdates[] >();

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -180,9 +180,12 @@ export function scheduledUpdates( context, next ) {
 }
 
 export function scheduledUpdatesMultisite( context, next ) {
+	const goToScheduledUpdatesList = () => page.show( `/plugins/scheduled-updates/` );
 	switch ( context.params.action ) {
 		case 'create':
-			context.primary = createElement( PluginsScheduledUpdatesMultisite );
+			context.primary = createElement( PluginsScheduledUpdatesMultisite, {
+				onNavBack: goToScheduledUpdatesList,
+			} );
 			break;
 
 		case 'edit':


### PR DESCRIPTION
## Proposed Changes

This PR lays the groundwork for batch creating, updating & deleting scheduled updates across sites. Since the feature is behind a feature flag for now, I believe we can merge this (if there's no discussion on code design) and iterate later.

* Adds mutations for `useBatchCreateUpdateScheduleMutation`, `useBatchEditUpdateScheduleMutation` and `useDeleteUpdateScheduleMutation`
* Implement Save button (for create)

When running the mutations, an error array will be thrown for all encountered errors. 

TODO (in future PR's):

- Do something with the errors

## Exploration

This task started with an exploration into being able to do add a `useMultiSiteMutation(siteSlugs, mutation)` hook. The idea was that this hook would allow you to pass in an array of slugs and a mutation, which in turn would trigger a mutation for each site passed in.

```
const { mutate } = useMultiSiteMutation( siteSlugs,  useCreateUpdateScheduleMutation);

...
mutate(params)
```

However, this broke the [rules of hooks](https://legacy.reactjs.org/docs/hooks-rules.html). React expects the same amount of hooks to be called on every render. Since siteSlugs would be of variable length, a variable amount of mutation hooks would be created on every render and React would explode.

I tried some workaround, but they didn't feel like great design, so I resorted to creating new variations of the existing mutation hooks.

Some discussion on batching mutations: https://github.com/TanStack/query/discussions/4009 

## Testing Instructions

1. Apply this PR
2. Go to `http://calypso.localhost:3000/plugins/scheduled-updates/create?flags=plugins/multisite-scheduled-updates`
3. Create a schedule for multiple sites
4. Check in network inspector if multiple requests go out.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?