### PR TITLE
Untangling: Show sidebar notices in Calypso

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -11,12 +11,14 @@ import { Spinner } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import { useSelector } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import Sidebar from 'calypso/layout/sidebar';
 import CollapseSidebar from 'calypso/layout/sidebar/collapse-sidebar';
 import SidebarRegion from 'calypso/layout/sidebar/region';
 import CurrentSite from 'calypso/my-sites/current-site';
 import MySitesSidebarUnifiedBody from 'calypso/my-sites/sidebar/body';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AddNewSite from './add-new-site';
 import useDomainsViewStatus from './use-domains-view-status';
 import useSiteMenuItems from './use-site-menu-items';
@@ -28,6 +30,7 @@ export const MySitesSidebarUnified = ( { path, isUnifiedSiteSidebarVisible } ) =
 	const menuItems = useSiteMenuItems();
 	const isAllDomainsView = useDomainsViewStatus();
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
+	const selectedSite = useSelector( getSelectedSite );
 
 	/**
 	 * If there are no menu items and we are currently requesting some,
@@ -42,6 +45,15 @@ export const MySitesSidebarUnified = ( { path, isUnifiedSiteSidebarVisible } ) =
 	return (
 		<Fragment>
 			<Sidebar>
+				{ isUnifiedSiteSidebarVisible && selectedSite && ! isAllDomainsView && (
+					<SidebarRegion>
+						<AsyncLoad
+							require="calypso/my-sites/current-site/notice"
+							placeholder={ null }
+							site={ selectedSite }
+						/>
+					</SidebarRegion>
+				) }
 				{ ! isUnifiedSiteSidebarVisible && (
 					<SidebarRegion>
 						<CurrentSite forceAllSitesView={ isAllDomainsView } />

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -546,7 +546,8 @@ $font-size: rem(14px);
 		.upsell-nudge.banner.card.is-compact {
 			margin-top: 0;
 			padding: 8px;
-			cursor: pointer;
+			display: flex;
+			flex-direction: column-reverse;
 
 			.banner__content {
 				padding: 0;
@@ -563,8 +564,9 @@ $font-size: rem(14px);
 			.banner__action {
 				width: 100%;
 				margin-top: 0;
+				margin-right: 0;
 
-				button {
+				.button {
 					width: 100%;
 					/* stylelint-disable-next-line scales/font-sizes */
 					font-size: 0.8125rem;
@@ -574,6 +576,43 @@ $font-size: rem(14px);
 					margin-bottom: 0;
 					padding-top: 0;
 					padding-bottom: 0;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					border-radius: 3px;
+				}
+			}
+
+			.dismissible-card__close-button {
+				position: relative;
+				width: 100%;
+				height: auto;
+				top: auto;
+				right: auto;
+				margin-top: 4px;
+				margin-right: 0;
+				font-size: 0.75rem;
+				line-height: 16px;
+				color: var(--studio-black);
+
+				&::before {
+					content: attr(aria-label);
+					text-decoration: underline;
+				}
+
+				svg {
+					display: none;
+				}
+			}
+		}
+	}
+
+	&.is-classic-bright,
+	&.is-contrast {
+		.is-unified-site-sidebar-visible {
+			.dismissible-card__close-button {
+				&::before {
+					color: var(--color-text-inverted);
 				}
 			}
 		}
@@ -701,7 +740,16 @@ $font-size: rem(14px);
 
 		.is-unified-site-sidebar-visible {
 			.upsell-nudge.banner.card.is-compact {
-				margin-top: 0;
+				margin: 0 4px 4px;
+				padding: 4px;
+
+				&::before {
+					margin: 0;
+				}
+
+				.dismissible-card__close-button {
+					display: none;
+				}
 			}
 		}
 
@@ -1016,6 +1064,12 @@ $font-size: rem(14px);
 		.sidebar {
 			position: absolute;
 			padding-bottom: 120px;
+		}
+
+		.is-unified-site-sidebar-visible {
+			.upsell-nudge.banner.card.is-compact {
+				margin-top: 8px;
+			}
 		}
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -537,6 +537,12 @@ $font-size: rem(14px);
 
 	/* stylelint-disable-next-line no-duplicate-selectors */
 	.is-unified-site-sidebar-visible {
+		.current-site__notices {
+			max-width: 220px;
+			margin-left: auto;
+			margin-right: auto;
+		}
+
 		.upsell-nudge.banner.card.is-compact {
 			margin-top: 0;
 			padding: 8px;
@@ -556,6 +562,7 @@ $font-size: rem(14px);
 
 			.banner__action {
 				width: 100%;
+				margin-top: 0;
 
 				button {
 					width: 100%;
@@ -690,6 +697,12 @@ $font-size: rem(14px);
 		.upsell-nudge.banner.card.is-compact {
 			margin: 8px 3px 7px;
 			padding: 2px 12px 2px 4px;
+		}
+
+		.is-unified-site-sidebar-visible {
+			.upsell-nudge.banner.card.is-compact {
+				margin-top: 0;
+			}
 		}
 
 		.current-site__notices > .banner {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -535,6 +535,43 @@ $font-size: rem(14px);
 		fill: var(--color-text);
 	}
 
+	/* stylelint-disable-next-line no-duplicate-selectors */
+	.is-unified-site-sidebar-visible {
+		.upsell-nudge.banner.card.is-compact {
+			margin-top: 0;
+			padding: 8px;
+			cursor: pointer;
+
+			.banner__content {
+				padding: 0;
+				flex-direction: column;
+				gap: 6px;
+			}
+
+			.banner__info {
+				margin: 0;
+				font-size: 0.75rem;
+				line-height: 16px;
+			}
+
+			.banner__action {
+				width: 100%;
+
+				button {
+					width: 100%;
+					/* stylelint-disable-next-line scales/font-sizes */
+					font-size: 0.8125rem;
+					line-height: 20px;
+					cursor: pointer;
+					min-height: 32px;
+					margin-bottom: 0;
+					padding-top: 0;
+					padding-bottom: 0;
+				}
+			}
+		}
+	}
+
 	// client/my-sites/current-site/style.scss
 	.current-site__switch-sites:hover .button.is-borderless:hover {
 		background-color: var(--color-sidebar-menu-hover-background);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6403
Counterpart of https://github.com/Automattic/jetpack/pull/36797

## Proposed Changes

Adds sidebar upsells/notices to the new sidebar of sites using the classic admin interface.

Non-dismissible | Dismissible
--- | ---
<img width="348" alt="Screenshot 2024-04-24 at 12 07 15" src="https://github.com/Automattic/wp-calypso/assets/1233880/c7cd98c9-fafb-47b7-8817-e138398f8f4f"> | <img width="386" alt="Screenshot 2024-04-24 at 12 07 38" src="https://github.com/Automattic/wp-calypso/assets/1233880/86fc1523-1bf6-4725-a350-3a1b7aa6887f">


## Testing Instructions

- Use the Calypso live link below
- Switch to an untangled site
  - If you don't have one:
    - Simple sites:
      - Open `wp shell` in your sandbox and run these commands: `update_blog_option( blog_id, 'wpcom_admin_interface', 'wp-admin' );update_blog_option( blog_id, 'wpcom_classic_early_release', 1 );`
    - Atomic sites:
      - Go to `/hosting-config/:site`
      - Switch to the classic admin interface
      - Go to <SITE_DOMAIN>/_cli and run this command: `wp option update wpcom_classic_early_release 1`
- Make sure the sidebar notice shows up correctly
  - If you don't see any notice, it's because your site is not eligible to see any JITM:
    - Modify the rules of any `:sidebar_notice` message in the `jitm-engine.php` file in your sandbox to make your site eligible.
    - Add this to your `mu-plugins/0-sandbox.php` file: `add_filter( 'jetpack_just_in_time_msg_cache', '__return_false', 1000 );`
    - If you're testing with an Atomic site, follow these instructions to connect your Atomic site to your sandbox: PCYsg-cLC-p2#testing-jitms-on-an-atomic-site