### PR TITLE
Plans: Fix term selector from being hidden in production

### DIFF
--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -109,7 +109,6 @@
 		}
 
 		.components-flex {
-			overflow: hidden;
 			width: 100%;
 			.components-input-control__container {
 				.components-custom-select-control__button {

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -4,6 +4,7 @@
 	width: fit-content;
 	min-width: 275px;
 	background-color: var(--studio-white);
+	z-index: 2;
 }
 
 .is-sticky-plan-type-selector {

--- a/packages/plans-grid-next/src/components/shared/plan-pill/style.scss
+++ b/packages/plans-grid-next/src/components/shared/plan-pill/style.scss
@@ -4,7 +4,6 @@
 	position: absolute;
 	bottom: -10px;
 	left: 14px;
-	z-index: 1;
 
 	padding: 4px;
 	border-radius: 2px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to issue reported in Slack: p1713794132101329-slack-C02FMH4G8

## Proposed Changes

The plan term selector seems to be broken in production:

https://github.com/Automattic/wp-calypso/assets/1705499/fcb9a880-c10e-4922-a69c-4a99587dd8bd

I couldn't reproduce this locally right now, but debugging in production points to the fixes in this PR. I am not sure of any other breakage that may be introduced from the changes, but they seem to work.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and confirm term dropdown functions properly
* Go to `/plans/[ site ]` and confirm the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?