### PR TITLE
Revert full-width layout on logged-out `/plugins` page

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -133,7 +133,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 		return <NoPermissionsError title={ __( 'Plugins' ) } />;
 	}
 	return (
-		<MainComponent fullWidthLayout isLoggedOut={ ! isLoggedIn }>
+		<MainComponent wideLayout isLoggedOut={ ! isLoggedIn }>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5976

## Proposed Changes

Revert the full-width layout for the `/plugins` page that was introduced in https://github.com/Automattic/wp-calypso/pull/87389. See https://github.com/Automattic/dotcom-forge/issues/5976 for more context.

| Before | After |
| - | - |
| ![wordpress com_plugins](https://github.com/Automattic/wp-calypso/assets/1101677/890246da-f050-4db2-8e2f-ce3215e5908c) | ![calypso localhost_3000_plugins](https://github.com/Automattic/wp-calypso/assets/1101677/fa0788f7-c846-4db8-9f9b-4a900e5447c3) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open `/plugins` in an incognito window
2. Ensure that the page looks good
3. Ensure that the page looks good on narrower viewports as well
