### PR TITLE
A4A: Decoupling potential A4A/JP cloud related styles from main styles related to Dataviews

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/a4a-style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/a4a-style.scss
@@ -95,3 +95,23 @@
 		}
 	}
 }
+
+.is-section-a8c-for-agencies-sites {
+	a.site-actions__menu-item {
+		&:hover,
+		&:focus {
+			background: var(--wp-components-color-accent);
+			color: var(--color-text-inverted);
+		}
+	}
+
+	.components-dropdown-menu {
+		padding: 8px;
+		border-radius: 4px;
+
+		[role="menuitem"],
+		[role="menuitemradio"] {
+			border-radius: 4px;
+		}
+	}
+}

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/a4a-style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/a4a-style.scss
@@ -1,0 +1,97 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.sites-overview__content {
+
+	.components-checkbox-control__input[type="checkbox"]:focus {
+		box-shadow: 0 0 0 var(--studio-jetpack-green-50) #fff, 0 0 0 calc(2* var(--studio-jetpack-green-50)) var(--studio-jetpack-green-50);
+		outline: 2px solid transparent;
+		outline-offset: 2px;
+	}
+
+	.components-checkbox-control__input[type="checkbox"]:checked,
+	.components-checkbox-control__input[type="checkbox"]:indeterminate {
+		background: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
+		border-color: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
+	}
+
+	.dataviews-bulk-edit-button.components-button.is-tertiary:active:not(:disabled),
+	.dataviews-bulk-edit-button.components-button.is-tertiary:hover:not(:disabled) {
+		box-shadow: none;
+		background-color: transparent;
+		color: var(--studio-jetpack-green-50);
+	}
+
+	.dataviews-view-table__actions-column {
+		display: none;
+	}
+
+	thead {
+		th.sites-dataviews__site {
+			background: var(--studio-white);
+			td {
+				padding: 16px 0;
+				border-bottom: 1px solid var(--color-neutral-5);
+			}
+		}
+	}
+
+	tr.dataviews-view-table__row {
+
+		&:hover {
+
+			.site-set-favorite__favorite-icon,
+			.components-checkbox-control__input {
+				opacity: 1;
+			}
+		}
+
+		td:has(.sites-dataviews__site) {
+			padding: 8px 16px 8px 4px;
+			width: 20%;
+		}
+
+		.site-sort__clickable {
+			cursor: pointer;
+		}
+
+	}
+
+}
+
+.sites-dataviews__site {
+	display: flex;
+	flex-direction: row;
+
+	.button {
+		padding: 0;
+	}
+}
+
+.sites-dataviews__site-name {
+	display: inline-block;
+	text-align: left;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	width: 180px;
+	font-weight: 500;
+	font-size: rem(14px);
+}
+
+.sites-dataviews__site-url {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	font-size: rem(12px);
+	color: var(--color-neutral-60);
+	font-weight: 400;
+}
+
+.preview-hidden {
+	@media (min-width: 2040px) {
+		.sites-dataviews__site-name {
+			width: 250px;
+		}
+	}
+}

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -6,6 +6,7 @@ import ReactDOM from 'react-dom';
 import { ItemsDataViewsType, DataViewsColumn } from './interfaces';
 // todo: Extract from style.scss not common styles (colors and specific to Jetpack Cloud components)
 import './style.scss';
+import './a4a-style.scss';
 
 const getIdByPath = ( item: object, path: string ) => {
 	const fields = path.split( '.' );

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import ReactDOM from 'react-dom';
 import { ItemsDataViewsType, DataViewsColumn } from './interfaces';
-// todo: Extract from style.scss not common styles (colors and specific to Jetpack Cloud components)
+// todo: Move the `a4a-style.scss` file to its context
 import './style.scss';
 import './a4a-style.scss';
 

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -3,38 +3,6 @@
 
 .sites-overview__content {
 
-	.components-checkbox-control__input[type="checkbox"]:focus {
-		box-shadow: 0 0 0 var(--studio-jetpack-green-50) #fff, 0 0 0 calc(2* var(--studio-jetpack-green-50)) var(--studio-jetpack-green-50);
-		outline: 2px solid transparent;
-		outline-offset: 2px;
-	}
-	.components-checkbox-control__input[type="checkbox"]:checked,
-	.components-checkbox-control__input[type="checkbox"]:indeterminate {
-		background: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
-		border-color: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
-	}
-
-	.dataviews-bulk-edit-button.components-button.is-tertiary:active:not(:disabled),
-	.dataviews-bulk-edit-button.components-button.is-tertiary:hover:not(:disabled) {
-		box-shadow: none;
-		background-color: transparent;
-		color: var(--studio-jetpack-green-50);
-	}
-
-	.dataviews-view-table__actions-column {
-		display: none;
-	}
-
-	thead {
-		th.sites-dataviews__site {
-			background: var(--studio-white);
-			td {
-				padding: 16px 0;
-				border-bottom: 1px solid var(--color-neutral-5);
-			}
-		}
-	}
-
 	tr.dataviews-view-table__row {
 		background: var(--studio-white);
 
@@ -57,11 +25,6 @@
 
 		&:hover {
 			background: var(--color-neutral-0);
-
-			.site-set-favorite__favorite-icon,
-			.components-checkbox-control__input {
-				opacity: 1;
-			}
 		}
 
 		th {
@@ -76,15 +39,6 @@
 			padding: 16px 4px 16px 48px;
 			border-bottom: 1px solid var(--color-neutral-5);
 			vertical-align: middle;
-		}
-
-		td:has(.sites-dataviews__site) {
-			padding: 8px 16px 8px 4px;
-			width: 20%;
-		}
-
-		.site-sort__clickable {
-			cursor: pointer;
 		}
 
 		.dataviews-view-table__checkbox-column,
@@ -117,43 +71,6 @@
 	margin-bottom: 8px;
 }
 
-.sites-dataviews__site {
-	display: flex;
-	flex-direction: row;
-
-	.button {
-		padding: 0;
-	}
-}
-
-.sites-dataviews__site-name {
-	display: inline-block;
-	text-align: left;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
-	width: 180px;
-	font-weight: 500;
-	font-size: rem(14px);
-}
-
-.sites-dataviews__site-url {
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
-	font-size: rem(12px);
-	color: var(--color-neutral-60);
-	font-weight: 400;
-}
-
-.preview-hidden {
-	@media (min-width: 2040px) {
-		.sites-dataviews__site-name {
-			width: 250px;
-		}
-	}
-}
-
 .sites-dataviews__actions {
 	display: flex;
 	flex-direction: row;
@@ -180,10 +97,9 @@
 	padding-bottom: 32px !important;
 }
 
-.main.a4a-layout.sites-dashboard:has(.dataviews-pagination) {
+.main.sites-dashboard.sites-dashboard__layout:has(.dataviews-pagination) {
 	height: calc(100vh - 70px) !important;
 }
-
 
 .dataviews-pagination {
 	background: #fff;
@@ -230,7 +146,6 @@
 		}
 	}
 }
-
 
 .dataviews-wrapper {
 	.dataviews-no-results,

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -263,23 +263,3 @@
 		display: none;
 	}
 }
-
-.is-section-a8c-for-agencies-sites {
-	a.site-actions__menu-item {
-		&:hover,
-		&:focus {
-			background: var(--wp-components-color-accent);
-			color: var(--color-text-inverted);
-		}
-	}
-
-	.components-dropdown-menu {
-		padding: 8px;
-		border-radius: 4px;
-
-		[role="menuitem"],
-		[role="menuitemradio"] {
-			border-radius: 4px;
-		}
-	}
-}


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/308

## Proposed Changes

* This PR decouples some styles from items-dataviews/style.scss files into an a4a only version - a4a-style.scss, where they would be relevant to A4A (or Jetpack Cloud) only.


## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* To test, make sure that dataviews styles have not been impact at all - so making sure the dataviews table, columns, rows, pagination, filter and search display, all behave as expected.
* Check the stylesheet changes to see that they make sense and include all the would be expected.
* The menu styles will differ from those showing live, but should match the screenshots in this issue: https://github.com/Automattic/wp-calypso/pull/89683

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?