### PR TITLE
Scheduled updates: Create paths selector form control

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,3 +1,5 @@
+import { __experimentalText as Text } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useCoreSitesPluginsQuery } from 'calypso/data/plugins/use-core-sites-plugins-query';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
@@ -7,6 +9,8 @@ import { validateSites, validatePlugins } from '../plugins-scheduled-updates/sch
 import { ScheduleFormSites } from './schedule-form-sites';
 
 export const ScheduleForm = () => {
+	const translate = useTranslate();
+
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( [] );
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {} );
@@ -58,6 +62,7 @@ export const ScheduleForm = () => {
 
 	return (
 		<div className="schedule-form">
+			<Text>{ translate( 'Step 1' ) }</Text>
 			<ScheduleFormSites
 				sites={ sites }
 				onChange={ setSelectedSites }
@@ -65,6 +70,8 @@ export const ScheduleForm = () => {
 				error={ validationErrors?.sites }
 				showError={ fieldTouched?.sites }
 			/>
+
+			<Text>{ translate( 'Step 2' ) }</Text>
 			<ScheduleFormPlugins
 				plugins={ getPlugins() }
 				selectedPlugins={ selectedPlugins }
@@ -75,9 +82,9 @@ export const ScheduleForm = () => {
 				error={ validationErrors?.plugins }
 				showError={ fieldTouched?.plugins }
 			/>
-			<div className="form-control-container">
-				<ScheduleFormFrequency initFrequency="daily" />
-			</div>
+
+			<Text>{ translate( 'Step 3' ) }</Text>
+			<ScheduleFormFrequency initFrequency="daily" />
 		</div>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/config.ts
+++ b/client/blocks/plugins-scheduled-updates/config.ts
@@ -1,2 +1,3 @@
 export const MAX_SCHEDULES = 2;
 export const MAX_SELECTABLE_PLUGINS = 10;
+export const MAX_SELECTABLE_PATHS = 5;

--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -91,8 +91,8 @@ export function ScheduleFormPaths( props: Props ) {
 							<FlexItem isBlock={ true }>
 								<InputControl
 									value={ newPath }
-									name="path"
 									size="__unstable-large"
+									autoComplete="off"
 									placeholder={ translate( '/add-path' ) }
 									onChange={ ( p ) => setNewPath( p || '' ) }
 									onKeyPress={ ( e ) => {

--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -1,0 +1,54 @@
+import {
+	__experimentalText as Text,
+	__experimentalInputControl as InputControl,
+	Button,
+	Flex,
+	FlexItem,
+} from '@wordpress/components';
+import { check, plus } from '@wordpress/icons';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	borderWrapper?: boolean;
+}
+export function ScheduleFormPaths( props: Props ) {
+	const translate = useTranslate();
+	const { borderWrapper = true } = props;
+
+	return (
+		<div className="form-field form-field--paths">
+			<label htmlFor="paths">{ translate( 'Test URL paths' ) }</label>
+
+			<Text className="info-msg">
+				{ translate(
+					'Your schedule will test your front page for errors. Do you want to add additional paths?'
+				) }
+			</Text>
+			<div className={ classnames( { 'form-control-container': borderWrapper } ) }>
+				<Text className="info-msg">Website URL paths</Text>
+
+				<div className="paths">
+					<Flex className="path" gap={ 2 }>
+						<FlexItem isBlock={ true }>
+							<InputControl value="lorem-ipsum-dolor.sit" size="__unstable-large" readOnly />
+						</FlexItem>
+						<FlexItem>
+							<Button disabled icon={ check } __next40pxDefaultSize />
+						</FlexItem>
+					</Flex>
+				</div>
+				<div className="new-path">
+					<Flex className="path" gap={ 2 }>
+						<FlexItem isBlock={ true }>
+							<InputControl value="lorem-ipsum-dolor.sit" size="__unstable-large" />
+						</FlexItem>
+						<FlexItem>
+							<Button variant="secondary" icon={ plus } __next40pxDefaultSize />
+						</FlexItem>
+					</Flex>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -5,7 +5,7 @@ import {
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
-import { check, plus } from '@wordpress/icons';
+import { check, plus, closeSmall } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
@@ -25,6 +25,13 @@ export function ScheduleFormPaths( props: Props ) {
 	const [ paths, setPaths ] = useState( initPaths );
 	const [ newPath, setNewPath ] = useState( '' );
 	const [ newPathError, setNewPathError ] = useState( '' );
+
+	const removePath = useCallback(
+		( index: number ) => {
+			setPaths( paths.filter( ( _, i ) => i !== index ) );
+		},
+		[ paths ]
+	);
 
 	const onNewPathSubmit = useCallback( () => {
 		const pathError = validatePath( newPath );
@@ -69,7 +76,11 @@ export function ScheduleFormPaths( props: Props ) {
 								<InputControl value={ path } size="__unstable-large" readOnly />
 							</FlexItem>
 							<FlexItem>
-								<Button disabled icon={ check } __next40pxDefaultSize />
+								<Button
+									icon={ closeSmall }
+									__next40pxDefaultSize
+									onClick={ () => removePath( i ) }
+								/>
 							</FlexItem>
 						</Flex>
 					) ) }
@@ -86,6 +97,7 @@ export function ScheduleFormPaths( props: Props ) {
 									onChange={ ( p ) => setNewPath( p || '' ) }
 									onKeyPress={ ( e ) => {
 										if ( e.key === 'Enter' ) {
+											// Prevent form submission on Enter key press
 											e.preventDefault();
 											onNewPathSubmit();
 										}

--- a/client/blocks/plugins-scheduled-updates/schedule-form.helper.ts
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.helper.ts
@@ -133,3 +133,20 @@ export const validatePlugins = ( plugins: string[], existingPlugins: Array< stri
 export const validateSites = ( sites: number[] ): string => {
 	return sites.length === 0 ? translate( 'Please select at least one site.' ) : '';
 };
+
+/**
+ * Validate path
+ * check if path passes URL_PATH_REGEX
+ */
+export const validatePath = ( path: string ): string => {
+	const URL_PATH_REGEX = /^\/[a-zA-Z0-9-._~:/?#[\]@!$&'()*+,;=]*$/;
+	let error = '';
+
+	if ( path.length === 0 ) {
+		error = translate( 'Please enter a path.' );
+	} else if ( ! URL_PATH_REGEX.test( path ) ) {
+		error = translate( 'Please enter a valid path.' );
+	}
+
+	return error;
+};

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -189,4 +189,27 @@
 			}
 		}
 	}
+
+	.form-field--paths {
+		.paths {
+			.components-input-control__backdrop {
+				border-color: var(--studio-gray-0);
+			}
+		}
+
+		.new-path {
+			.components-input-control__backdrop {
+				border-color: var(--studio-gray-10);
+			}
+		}
+
+		.path {
+			margin-bottom: 0.75rem;
+		}
+
+		input[readonly] {
+			color: var(--studio-gray-50);
+			background: var(--studio-gray-0);
+		}
+	}
 }

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -201,6 +201,12 @@
 			.components-input-control__backdrop {
 				border-color: var(--studio-gray-10);
 			}
+
+			.components-input-base[class*="Root-rootFocusedStyles"] {
+				.components-input-control__backdrop {
+					border-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+				}
+			}
 		}
 
 		.path {

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -1,3 +1,6 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { __experimentalText as Text } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import {
@@ -11,6 +14,7 @@ import {
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleFormFrequency } from './schedule-form-frequency';
+import { ScheduleFormPaths } from './schedule-form-paths';
 import { ScheduleFormPlugins } from './schedule-form-plugins';
 import { validatePlugins, validateTimeSlot } from './schedule-form.helper';
 import type { SyncSuccessParams } from './types';
@@ -24,6 +28,7 @@ interface Props {
 }
 export const ScheduleForm = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
 
@@ -121,6 +126,7 @@ export const ScheduleForm = ( props: Props ) => {
 				onFormSubmit();
 			} }
 		>
+			<Text>{ translate( 'Step 1' ) }</Text>
 			<ScheduleFormFrequency
 				initTimestamp={ timestamp }
 				initFrequency={ frequency }
@@ -134,6 +140,7 @@ export const ScheduleForm = ( props: Props ) => {
 					setFieldTouched( { ...fieldTouched, timestamp: touched } );
 				} }
 			/>
+			<Text>{ translate( 'Step 2' ) }</Text>
 			<ScheduleFormPlugins
 				plugins={ plugins }
 				selectedPlugins={ selectedPlugins }
@@ -146,6 +153,12 @@ export const ScheduleForm = ( props: Props ) => {
 					setFieldTouched( { ...fieldTouched, plugins: touched } );
 				} }
 			/>
+			{ isEnabled( 'plugins/multisite-scheduled-updates' ) && (
+				<>
+					<Text>{ translate( 'Step 3' ) }</Text>
+					<ScheduleFormPaths borderWrapper={ false } />
+				</>
+			) }
 		</form>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -140,6 +140,7 @@ export const ScheduleForm = ( props: Props ) => {
 					setFieldTouched( { ...fieldTouched, timestamp: touched } );
 				} }
 			/>
+
 			<Text>{ translate( 'Step 2' ) }</Text>
 			<ScheduleFormPlugins
 				plugins={ plugins }
@@ -153,6 +154,7 @@ export const ScheduleForm = ( props: Props ) => {
 					setFieldTouched( { ...fieldTouched, plugins: touched } );
 				} }
 			/>
+
 			{ isEnabled( 'plugins/multisite-scheduled-updates' ) && (
 				<>
 					<Text>{ translate( 'Step 3' ) }</Text>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89677

## Proposed Changes

* Created paths selector form the control
* Introduced the paths selector into form guarded with a feature flag
* Added steps indicator to match the design

NOTE: It's only a FE change; BE integration will be in the next PRs

## Testing Instructions

* Go to `/plugins/scheduled-updates/create/{SITE_SLUT}?flags=plugins/multisite-scheduled-updates`
* Check if there is a path selector component renders
* Check the validation logic; add, remove paths

--
* Go to `/plugins/scheduled-updates/create?flags=plugins/multisite-scheduled-updates`
* Check if there is a "Step #" labels renders


![Screen Capture on 2024-04-22 at 18-09-25](https://github.com/Automattic/wp-calypso/assets/1241413/0bc523bf-aee5-43c2-9ab8-8c0730bd32cf)

Single site context
<img width="1727" alt="Screenshot 2024-04-22 at 18 28 42" src="https://github.com/Automattic/wp-calypso/assets/1241413/1ee8e497-0fc1-4b1d-94c7-5f9bc8b62d8b">

Multisite context
<img width="1728" alt="Screenshot 2024-04-22 at 18 28 17" src="https://github.com/Automattic/wp-calypso/assets/1241413/ea55bbbd-d1ec-498e-8e57-c8302bab697c">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?