### PR TITLE
Stats: Show the first extended tier info for the Stats commercial purchase page

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -102,7 +102,7 @@ function StatsCommercialUpgradeSlider( {
 	if ( tiers[ 0 ].views && tiers[ 0 ].views > INITIAL_FIRST_TIER_VIEWS_LIMIT ) {
 		firstTierInfo = translate(
 			// TBD: This message should be updated with a more appropriate or detailed copy.
-			'The purchasable views limit starts from your purchased tier or current usage.'
+			'The minimum view limit is determined based on your current tier and usage.'
 		);
 	}
 

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -14,6 +14,8 @@ import { StatsPlanTierUI } from '../types';
 
 import './styles.scss';
 
+const INITIAL_FIRST_TIER_VIEWS_LIMIT = 10000;
+
 function useTranslatedStrings() {
 	const translate = useTranslate();
 	const limits = translate( 'Monthly views limit', {
@@ -94,6 +96,16 @@ function StatsCommercialUpgradeSlider( {
 	const tiers = useAvailableUpgradeTiers( siteId );
 	const uiStrings = useTranslatedStrings();
 
+	// Show a message with a tooltip for the first tier when it's over 10k views,
+	// which means the user is extending the limit based on the purchased tier or current usage.
+	let firstTierInfo;
+	if ( tiers[ 0 ].views && tiers[ 0 ].views > INITIAL_FIRST_TIER_VIEWS_LIMIT ) {
+		firstTierInfo = translate(
+			// TBD: This message should be updated with a more appropriate or detailed copy.
+			'The purchasable views limit starts from your purchased tier or current usage.'
+		);
+	}
+
 	// Special case for per-unit fees.
 	// Determine this based on last tier in the list.
 	// The translate() call returns a node so we need to set the type correctly.
@@ -143,6 +155,7 @@ function StatsCommercialUpgradeSlider( {
 		<TierUpgradeSlider
 			className="stats-commercial-upgrade-slider"
 			uiStrings={ uiStrings }
+			firstTierInfo={ firstTierInfo }
 			popupInfoString={ perUnitFeeMessaging }
 			steps={ steps }
 			onSliderChange={ handleSliderChanged }

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -82,13 +82,15 @@ function TierUpgradeSlider( {
 		onSliderChange( value );
 	};
 
+	// Handle the first-tier info display.
+	const firstTierInfoRef = useRef( null );
+	const showFirstTierInfoIcon = currentPlanIndex === sliderMin && firstTierInfo !== undefined;
+	const [ showFirstTierInfo, setShowFirstTierInfo ] = useState( false );
+
 	// Info popup state.
 	// Only visible if the slider is at the max value and we have a string/node to display.
 	const infoReferenceElement = useRef( null );
 	const showPopup = currentPlanIndex === sliderMax && popupInfoString !== undefined;
-
-	const firstTierInfoRef = useRef( null );
-	const showFirstTierInfo = currentPlanIndex === 0 && firstTierInfo !== undefined;
 
 	const lhValue = steps[ currentPlanIndex ]?.lhValue;
 	const originalPrice = steps[ currentPlanIndex ]?.rhValue;
@@ -103,7 +105,17 @@ function TierUpgradeSlider( {
 					<h2>{ uiStrings.limits }</h2>
 					<b ref={ firstTierInfoRef }>
 						{ lhValue }
-						{ showFirstTierInfo && <Icon icon={ info } /> }
+						{ showFirstTierInfoIcon && (
+							<Icon
+								icon={ info }
+								onMouseEnter={ () => {
+									setShowFirstTierInfo( true );
+								} }
+								onMouseLeave={ () => {
+									setShowFirstTierInfo( false );
+								} }
+							/>
+						) }
 					</b>
 				</div>
 				{ ! secondaryCalloutIsHidden && (

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -41,23 +41,32 @@ function TierUpgradeSlider( {
 
 	const handleRenderThumb = ( ( props ) => {
 		const thumbSVG = (
-			<svg
-				width="32"
-				height="32"
-				viewBox="0 0 32 32"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-				style={ { scale: '8' } }
-			>
-				<path
-					d="M11.8208 13.3594L9.54192 16.0181L11.8208 18.6768L12.5801 18.026L10.859 16.0181L12.5801 14.0102L11.8208 13.3594Z"
-					fill="white"
-				/>
-				<path
-					d="M20.3042 13.3594L22.5831 16.0181L20.3042 18.6768L19.5449 18.026L21.266 16.0181L19.5449 14.0102L20.3042 13.3594Z"
-					fill="white"
-				/>
-			</svg>
+			<div className="tier-upgrade-slider__thumb-icon">
+				<svg
+					width="9"
+					height="16"
+					viewBox="0 0 9 16"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						d="M4.82079 5.35938L2.54192 8.01809L4.82079 10.6768L5.58008 10.026L3.85899 8.01809L5.58008 6.01017L4.82079 5.35938Z"
+						fill="white"
+					/>
+				</svg>
+				<svg
+					width="9"
+					height="16"
+					viewBox="0 0 9 16"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						d="M3.30421 5.35938L5.58308 8.01809L3.30421 10.6768L2.54492 10.026L4.26601 8.01809L2.54492 6.01017L3.30421 5.35938Z"
+						fill="white"
+					/>
+				</svg>
+			</div>
 		);
 		return <div { ...props }>{ thumbSVG }</div>;
 	} ) as RenderThumbFunction;

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -19,6 +19,7 @@ interface TierStep {
 type TierUpgradeSliderProps = {
 	className?: string;
 	uiStrings: TierUIStrings;
+	firstTierInfo?: string;
 	popupInfoString?: string;
 	steps: TierStep[];
 	initialValue?: number;
@@ -29,6 +30,7 @@ type TierUpgradeSliderProps = {
 function TierUpgradeSlider( {
 	className,
 	uiStrings,
+	firstTierInfo,
 	popupInfoString,
 	steps,
 	initialValue = 0,
@@ -84,6 +86,10 @@ function TierUpgradeSlider( {
 	// Only visible if the slider is at the max value and we have a string/node to display.
 	const infoReferenceElement = useRef( null );
 	const showPopup = currentPlanIndex === sliderMax && popupInfoString !== undefined;
+
+	const firstTierInfoRef = useRef( null );
+	const showFirstTierInfo = currentPlanIndex === 0 && firstTierInfo !== undefined;
+
 	const lhValue = steps[ currentPlanIndex ]?.lhValue;
 	const originalPrice = steps[ currentPlanIndex ]?.rhValue;
 	const discountedPrice = steps[ currentPlanIndex ]?.upgradePrice;
@@ -95,12 +101,15 @@ function TierUpgradeSlider( {
 			<div className="tier-upgrade-slider__step-callouts">
 				<div className="tier-upgrade-slider__step-callout">
 					<h2>{ uiStrings.limits }</h2>
-					<p>{ lhValue }</p>
+					<b ref={ firstTierInfoRef }>
+						{ lhValue }
+						{ showFirstTierInfo && <Icon icon={ info } /> }
+					</b>
 				</div>
 				{ ! secondaryCalloutIsHidden && (
 					<div className="tier-upgrade-slider__step-callout right-aligned">
 						<h2>{ uiStrings.price }</h2>
-						<p ref={ infoReferenceElement }>
+						<b ref={ infoReferenceElement }>
 							{ discountedPrice ? (
 								<>
 									<span className="full-price-label">{ originalPrice }</span>
@@ -110,7 +119,7 @@ function TierUpgradeSlider( {
 								<span>{ originalPrice }</span>
 							) }
 							{ showPopup && <Icon icon={ info } /> }
-						</p>
+						</b>
 					</div>
 				) }
 			</div>
@@ -128,12 +137,21 @@ function TierUpgradeSlider( {
 			) }
 			<Popover
 				position="right"
+				context={ firstTierInfoRef?.current }
+				isVisible={ showFirstTierInfo }
+				focusOnShow={ false }
+				className="stats-purchase__info-popover"
+			>
+				<div className="stats-purchase__info-popover-content">{ firstTierInfo }</div>
+			</Popover>
+			<Popover
+				position="right"
 				context={ infoReferenceElement?.current }
 				isVisible={ showPopup }
 				focusOnShow={ false }
 				className="stats-purchase__info-popover"
 			>
-				<div className="stats-purchase__info-popover-content">{ showPopup && popupInfoString }</div>
+				<div className="stats-purchase__info-popover-content">{ popupInfoString }</div>
 			</Popover>
 			<p className="tier-upgrade-slider__info-message">{ uiStrings.strategy }</p>
 		</div>

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -90,7 +90,8 @@ function TierUpgradeSlider( {
 	// Info popup state.
 	// Only visible if the slider is at the max value and we have a string/node to display.
 	const infoReferenceElement = useRef( null );
-	const showPopup = currentPlanIndex === sliderMax && popupInfoString !== undefined;
+	const showExtendedTierInfoIcon = currentPlanIndex === sliderMax && popupInfoString !== undefined;
+	const [ showExtendedTierInfo, setShowExtendedTierInfo ] = useState( false );
 
 	const lhValue = steps[ currentPlanIndex ]?.lhValue;
 	const originalPrice = steps[ currentPlanIndex ]?.rhValue;
@@ -130,7 +131,17 @@ function TierUpgradeSlider( {
 							) : (
 								<span>{ originalPrice }</span>
 							) }
-							{ showPopup && <Icon icon={ info } /> }
+							{ showExtendedTierInfoIcon && (
+								<Icon
+									icon={ info }
+									onMouseEnter={ () => {
+										setShowExtendedTierInfo( true );
+									} }
+									onMouseLeave={ () => {
+										setShowExtendedTierInfo( false );
+									} }
+								/>
+							) }
 						</b>
 					</div>
 				) }
@@ -159,7 +170,7 @@ function TierUpgradeSlider( {
 			<Popover
 				position="right"
 				context={ infoReferenceElement?.current }
-				isVisible={ showPopup }
+				isVisible={ showExtendedTierInfo }
 				focusOnShow={ false }
 				className="stats-purchase__info-popover"
 			>

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -21,7 +21,6 @@ $track-height: 4px;
 
 .tier-upgrade-slider {
 	--jp-white: #fff;
-	--jp-green-50: #008710;
 	--gray-gray-5: #dcdcde;
 
 	margin-top: 42px;
@@ -31,6 +30,19 @@ $track-height: 4px;
 	border: 1px solid var(--gray-gray-5);
 	border-radius: 5px; // stylelint-disable-line scales/radii
 	padding: 16px;
+
+	// Make sure the icon size is not affected by the slider thumb size.
+	.tier-upgrade-slider__thumb-icon {
+		position: absolute;
+		width: 32px;
+		height: 32px;
+		display: flex;
+		align-items: center;
+		justify-content: space-around;
+		padding: 0 4px;
+		left: 3px;
+		box-sizing: border-box;
+	}
 
 	// Remove the box shadow on the slider thumb when not holding.
 	.tier-upgrade-slider__slider:not(.jp-components-pricing-slider--is-holding) {
@@ -43,7 +55,7 @@ $track-height: 4px;
 		width: $thumb-width;
 		height: $slider-height;
 		border-radius: 50%;
-		background-color: var(--jp-green-50);
+		background-color: var(--jp-green-40);
 		color: var(--jp-white);
 	}
 

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -124,7 +124,7 @@ $track-height: 4px;
 		}
 	}
 
-	p {
+	b {
 		font-size: $font-headline-small;
 		font-weight: bold;
 		margin: 0;

--- a/packages/components/src/pricing-slider/style.scss
+++ b/packages/components/src/pricing-slider/style.scss
@@ -18,7 +18,6 @@ $thumb-horizontal-padding: 16px;
 	--jp-white: #fff;
 	--jp-gray: #dcdcde;
 	--jp-green-40: #069e08;
-	--jp-green-50: #008710;
 }
 
 // On holding thumb styling
@@ -52,7 +51,7 @@ $thumb-horizontal-padding: 16px;
 	align-items: center;
 	background-color: var(--jp-white);
 	border-radius: 4px;
-	border: 1.5px solid var(--jp-green-50);
+	border: 1.5px solid var(--jp-green-40);
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 8px rgba(0, 0, 0, 0.08);
 	color: var(--jp-black);
 	cursor: pointer;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1713301762460509/1713264194.624129-slack-C82FZ5T4G

## Proposed Changes

* When the first tier starts beyond the `10k` tier, add the info tooltip to the first tier of Stars commercial purchase tier slider.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin the change on the Calypso Live branch.
* Navigate to the Stats commercial purchase page with a Jetpack site **_without_** any purchased tier and view traffic: `/stats/purchase/{site-slug}?productType=commercial`.
* Ensure the tier pricing slider works as previously, starting from the `10k` tier.

<img width="561" alt="截圖 2024-04-23 下午1 01 46" src="https://github.com/Automattic/wp-calypso/assets/6869813/53a01dae-02ac-4dae-abaf-c3bd36b4ca17">

* Navigate to the Stats commercial purchase page with a Jetpack site with purchased tier or some view traffic greater than `10k`: `/stats/purchase/{site-slug}?productType=commercial`.
* Ensure the tier pricing slider starts from a specific tier with a tooltip explaining the start point.

|Upgrade|Current usage is 2.5M|
|-|-|
|<img width="597" alt="截圖 2024-04-23 下午1 02 07" src="https://github.com/Automattic/wp-calypso/assets/6869813/1eb8c479-a87d-4875-8661-32aa83506ab9">|<img width="554" alt="截圖 2024-04-23 下午1 03 59" src="https://github.com/Automattic/wp-calypso/assets/6869813/051214e7-b185-4fc5-94c4-1812d0788fc4">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?