### PR TITLE
Site Migration: Allow direct-linking to the assign-trial-plan step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
@@ -35,8 +35,7 @@ const SiteMigrationAssignTrialPlanStep: Step = ( { navigation } ) => {
 
 			assignMigrationTrialPlan();
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ site, isAddingTrial ] );
+	}, [ site, isAddingTrial, addHostingTrial ] );
 
 	return null;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
@@ -1,5 +1,5 @@
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import useAddHostingTrialMutation, {
 	HOSTING_INTENT_MIGRATE,
 } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
@@ -11,6 +11,7 @@ import { Step } from '../../types';
 const SiteMigrationAssignTrialPlanStep: Step = ( { navigation } ) => {
 	const { submit } = navigation;
 	const site = useSite();
+	const [ isAddingTrial, setIsAddingTrial ] = useState( false );
 
 	const dispatch = useDispatch();
 	const { addHostingTrial } = useAddHostingTrialMutation( {
@@ -26,7 +27,8 @@ const SiteMigrationAssignTrialPlanStep: Step = ( { navigation } ) => {
 	} );
 
 	useEffect( () => {
-		if ( site ) {
+		if ( site && ! isAddingTrial ) {
+			setIsAddingTrial( true );
 			const assignMigrationTrialPlan = () => {
 				site.ID && addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY, HOSTING_INTENT_MIGRATE );
 			};
@@ -34,7 +36,7 @@ const SiteMigrationAssignTrialPlanStep: Step = ( { navigation } ) => {
 			assignMigrationTrialPlan();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ site, isAddingTrial ] );
 
 	return null;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
@@ -27,7 +27,7 @@ const SiteMigrationAssignTrialPlanStep: Step = ( { navigation } ) => {
 	} );
 
 	useEffect( () => {
-		if ( site && ! isAddingTrial ) {
+		if ( site && ! site?.plan && ! isAddingTrial ) {
 			setIsAddingTrial( true );
 			const assignMigrationTrialPlan = () => {
 				site.ID && addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY, HOSTING_INTENT_MIGRATE );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89401

## Proposed Changes

Previously, the step only tried to assign the trial plan once when the step first renders. This was fine for progressing through the flow normally but doesn't work if we try to directly link to the step.
    
Now we check the `site` dependency so we can try to assign the trial plan again after any updates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection and passing tests should be sufficient

```
yarn test-client client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?