### PR TITLE
DIFM: Update DIFM help center email logic

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -47,7 +47,7 @@ function SupportLink( { siteId }: { siteId?: number } ) {
 	const emailUrl = `/contact-form?${ new URLSearchParams( {
 		mode: 'EMAIL',
 		'disable-gpt': 'true',
-		'difm-in-progress': 'true',
+		'skip-resources': 'true',
 	} ).toString() }`;
 
 	return (

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -47,6 +47,7 @@ function SupportLink( { siteId }: { siteId?: number } ) {
 	const emailUrl = `/contact-form?${ new URLSearchParams( {
 		mode: 'EMAIL',
 		'disable-gpt': 'true',
+		'difm-in-progress': 'true',
 	} ).toString() }`;
 
 	return (

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -197,6 +197,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 		! wapuuFlow;
 
 	const showingSearchResults = params.get( 'show-results' ) === 'true';
+	const DIFMInProgress = params.get( 'difm-in-progress' ) === 'true';
 	const showingGPTResponse = enableGPTResponse && params.get( 'show-gpt' ) === 'true';
 
 	const redirectToArticle = useCallback(
@@ -266,7 +267,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 	}
 
 	function handleCTA() {
-		if ( ! enableGPTResponse && ! showingSearchResults && ! wapuuFlow ) {
+		if ( ! enableGPTResponse && ! showingSearchResults && ! wapuuFlow && ! DIFMInProgress ) {
 			params.set( 'show-results', 'true' );
 			navigate( {
 				pathname: '/contact-form',
@@ -515,7 +516,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 	const getCTALabel = () => {
 		const showingHelpOrGPTResults = showingSearchResults || showingGPTResponse;
 
-		if ( ! showingGPTResponse && ! showingSearchResults ) {
+		if ( ! showingGPTResponse && ! showingSearchResults && ! DIFMInProgress ) {
 			return __( 'Continue', __i18n_text_domain__ );
 		}
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -197,7 +197,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 		! wapuuFlow;
 
 	const showingSearchResults = params.get( 'show-results' ) === 'true';
-	const DIFMInProgress = params.get( 'difm-in-progress' ) === 'true';
+	const skipResources = params.get( 'skip-resources' ) === 'true';
 	const showingGPTResponse = enableGPTResponse && params.get( 'show-gpt' ) === 'true';
 
 	const redirectToArticle = useCallback(
@@ -267,7 +267,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 	}
 
 	function handleCTA() {
-		if ( ! enableGPTResponse && ! showingSearchResults && ! wapuuFlow && ! DIFMInProgress ) {
+		if ( ! enableGPTResponse && ! showingSearchResults && ! wapuuFlow && ! skipResources ) {
 			params.set( 'show-results', 'true' );
 			navigate( {
 				pathname: '/contact-form',
@@ -516,7 +516,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 	const getCTALabel = () => {
 		const showingHelpOrGPTResults = showingSearchResults || showingGPTResponse;
 
-		if ( ! showingGPTResponse && ! showingSearchResults && ! DIFMInProgress ) {
+		if ( ! showingGPTResponse && ! showingSearchResults && ! skipResources ) {
 			return __( 'Continue', __i18n_text_domain__ );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/89717

## Proposed Changes

* When your site is DIFM in progress, the `contact support` link should open up the help center and prompt you to email a Happiness Engineer via the provided form. After you fill out the form and click "Continue" , you will see another button to confirm that you want to send the Email, "Email us". 

With these changes, the "Continue" button will be changed to "Email us" and will directly email the Happiness Engineers after submission.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or use live link.
* Toggle the `difm-lite-in-progress` blog sticker via the Blog Report Card.
* Navigate to `/home/{SITE_SLUG}`, click on "Contact Support" and verify the behavior of the Help Center email form.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?