### PR TITLE
Remove processing from migration flow: Skip processing steps behind a flag

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -163,6 +163,8 @@ const siteMigration: Flow = {
 			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
 			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
 			const siteId = getSiteIdBySlug( siteSlug );
+			// TODO - this should be replaced by a proper check for the processing flag.
+			const removeProcessingFlag = false;
 
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
@@ -226,6 +228,9 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.BUNDLE_TRANSFER.slug: {
+					if ( removeProcessingFlag ) {
+						return navigate( STEPS.SITE_MIGRATION_INSTRUCTIONS.slug );
+					}
 					return navigate( STEPS.PROCESSING.slug, { bundleProcessing: true } );
 				}
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -163,8 +164,6 @@ const siteMigration: Flow = {
 			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
 			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
 			const siteId = getSiteIdBySlug( siteSlug );
-			// TODO - this should be replaced by a proper check for the processing flag.
-			const removeProcessingFlag = false;
 
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
@@ -228,7 +227,7 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.BUNDLE_TRANSFER.slug: {
-					if ( removeProcessingFlag ) {
+					if ( config.isEnabled( 'migration-flow/remove-processing-step' ) ) {
 						return navigate( STEPS.SITE_MIGRATION_INSTRUCTIONS.slug );
 					}
 					return navigate( STEPS.PROCESSING.slug, { bundleProcessing: true } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/89759
Depends on https://github.com/Automattic/wp-calypso/pull/89767

## Proposed Changes

Skips the process step based on the corresponding feature flag

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the flow, select to migrate and verify you don't see a processing screen after selecting the plan. You should be redirected straight through to the instructions step.
* Verify that turning the flag off gives you the current behaviour.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?