### PR TITLE
Pass the section name to global sidebar functions

### DIFF
--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -158,11 +158,13 @@ class SidebarNotifications extends Component {
 
 const mapStateToProps = ( state, { currentSection } ) => {
 	const sectionGroup = currentSection?.group ?? null;
+	const sectionName = currentSection?.name ?? null;
 	const siteId = getSelectedSiteId( state );
 	const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 		state,
 		siteId,
-		sectionGroup
+		sectionGroup,
+		sectionName
 	);
 	return {
 		isNotificationsOpen: isNotificationsOpen( state ),

--- a/client/layout/global-sidebar/menu-items/search/index.jsx
+++ b/client/layout/global-sidebar/menu-items/search/index.jsx
@@ -17,7 +17,12 @@ export const SidebarSearch = ( { tooltip, onClick } ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const { currentSection } = useCurrentRoute();
 	const shouldShowCollapsedGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowCollapsedGlobalSidebar( state, selectedSiteId, currentSection?.group );
+		return getShouldShowCollapsedGlobalSidebar(
+			state,
+			selectedSiteId,
+			currentSection?.group,
+			currentSection?.name
+		);
 	} );
 	return (
 		<>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -448,11 +448,17 @@ export default withCurrentRoute(
 			const isWooCoreProfilerFlow =
 				[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 				isWooCommerceCoreProfilerFlow( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 				state,
 				siteId,
-				sectionGroup
+				sectionGroup,
+				sectionName
 			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -794,7 +794,8 @@ export default connect(
 		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
 			state,
 			currentSelectedSiteId,
-			sectionGroup
+			sectionGroup,
+			sectionName
 		);
 		const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
 			state,

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -229,8 +229,14 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
+			const sectionName = currentSection?.group ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			return {
 				currentUser: getCurrentUser( state ),
 				shouldShowGlobalSidebar,

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -110,7 +110,12 @@ export default withCurrentRoute(
 			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
 			const siteDomain = getSiteDomain( state, siteId );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,
 				siteId,

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -40,10 +40,20 @@ const useSiteMenuItems = () => {
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 	const { currentSection } = useCurrentRoute();
 	const shouldShowGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowGlobalSidebar( state, selectedSiteId, currentSection?.group );
+		return getShouldShowGlobalSidebar(
+			state,
+			selectedSiteId,
+			currentSection?.group,
+			currentSection?.name
+		);
 	} );
 	const shouldShowCollapsedGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowCollapsedGlobalSidebar( state, selectedSiteId, currentSection?.group );
+		return getShouldShowCollapsedGlobalSidebar(
+			state,
+			selectedSiteId,
+			currentSection?.group,
+			currentSection?.name
+		);
 	} );
 	useEffect( () => {
 		if ( selectedSiteId && siteDomain ) {

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -11,7 +11,7 @@ export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'notifications';
 	const state = context.store.getState();
-	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, null, 'reader' );
+	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, null, 'reader', null );
 
 	trackPageLoad( basePath, 'Reader > Notifications', mcKey );
 	recordTrack(

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -11,7 +11,12 @@ export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'notifications';
 	const state = context.store.getState();
-	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, null, 'reader', null );
+	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+		state,
+		null,
+		'reader',
+		'notifications'
+	);
 
 	trackPageLoad( basePath, 'Reader > Notifications', mcKey );
 	recordTrack(

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -334,8 +334,14 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
+			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			return {
 				isListsOpen: isListsOpen( state ),
 				isTagsOpen: isTagsOpen( state ),

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -10,7 +10,12 @@ import type { AppState } from 'calypso/types';
 // as the Global Site View is still in development.
 const GLOBAL_SITE_VIEW_SECTION_NAMES: string[] = [];
 
-export const getShouldShowGlobalSidebar = ( _: AppState, siteId: number, sectionGroup: string ) => {
+export const getShouldShowGlobalSidebar = (
+	_: AppState,
+	siteId: number,
+	sectionGroup: string,
+	sectionName: string // eslint-disable-line @typescript-eslint/no-unused-vars
+) => {
 	return (
 		sectionGroup === 'me' ||
 		sectionGroup === 'reader' ||
@@ -22,7 +27,8 @@ export const getShouldShowGlobalSidebar = ( _: AppState, siteId: number, section
 export const getShouldShowCollapsedGlobalSidebar = (
 	state: AppState,
 	siteId: number,
-	sectionGroup: string
+	sectionGroup: string,
+	sectionName: string // eslint-disable-line @typescript-eslint/no-unused-vars
 ) => {
 	// Global sidebar should be collapsed when in sites dashboard and a site is selected.
 	return (


### PR DESCRIPTION
This PR is needed in advance of adding pages for hosting, site monitoring and github deployments.

Ref: https://github.com/Automattic/dotcom-forge/issues/6255

We need to pass in the `sectionName` when determining when handling pages with `sectionGroup` as `sites-dashboard` to know if we should show either the global or collapsed global sidebar or continue showing the current sidebar.

An example of this new check can be found in https://github.com/Automattic/wp-calypso/pull/89735. In this PR, we want to show the global sidebar if the section group is sites dashboard, the section name is hosting and the `layout/dotcom-nav-redesign-v2` feature flag is enabled.

### Testing Instructions

* This PR shouldn't affect behaviour of sidebars on Calypso
* Apply patch and confirm they load and behave as normal