### PR TITLE
Segmentation Survey: Clear survey answers in local storage upon survey submission

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -29,7 +29,7 @@ const SegmentationSurveyDocumentHead = () => {
 const SegmentationSurveyStep: Step = ( { navigation } ) => {
 	const { data: questions } = useSurveyStructureQuery( { surveyKey: SURVEY_KEY } );
 	const { mutate } = useSaveAnswersMutation( { surveyKey: SURVEY_KEY } );
-	const { answers, setAnswers } = useCachedAnswers( SURVEY_KEY );
+	const { answers, setAnswers, clearAnswers } = useCachedAnswers( SURVEY_KEY );
 
 	const onChangeAnswer = useCallback(
 		( questionKey: string, value: string[] ) => {
@@ -45,8 +45,12 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 				questionKey: currentQuestion.key,
 				answerKeys: answers[ currentQuestion.key ] || [],
 			} );
+
+			if ( questions?.[ questions.length - 1 ].key === currentQuestion.key ) {
+				clearAnswers();
+			}
 		},
-		[ answers, mutate ]
+		[ answers, clearAnswers, mutate, questions ]
 	);
 
 	if ( ! config.isEnabled( 'ecommerce-segmentation-survey' ) ) {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89744

## Proposed Changes

* Clear survey answers in local storage upon survey submission

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur/start?flags=ecommerce-segmentation-survey
* The entrepreneur survey should be displayed
* Answer the two questions, but do not click continue or skip on the second one
* Check if the answers are present on the local storage (search for `entrepreneur-trial-answers` key)
* Submit the second question and the previous answers should be emptied
* Check the local storage, you shouldn't see the previous answers
* Go to http://calypso.localhost:3000/setup/entrepreneur/start?flags=ecommerce-segmentation-survey again
* The survey should be rendered without prefilled answers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?