### PR TITLE
Segmentation Survey: Add WordPress logo to navbar and small improvements

### DIFF
--- a/client/components/survey-container/components/style.scss
+++ b/client/components/survey-container/components/style.scss
@@ -4,7 +4,8 @@
 @import "client/components/forms/form-radio/style.scss";
 
 $blueberry-color: #2145e6;
-$blueberry-hover-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+$blueberry-hover-color: #3858e9;
+$blueberry-focus-color: #abc0f5;
 
 @mixin question-options-container {
 	display: flex;
@@ -76,7 +77,7 @@ $blueberry-hover-color: var(--wp-components-color-accent, var(--wp-admin-theme-c
 			}
 
 			// Radio styles
-			input[type="radio"] {
+			input[type="radio"].form-radio {
 				height: 20px;
 				width: 20px;
 				min-width: 20px;
@@ -92,6 +93,11 @@ $blueberry-hover-color: var(--wp-components-color-accent, var(--wp-admin-theme-c
 					width: 14px;
 					height: 14px;
 					background-color: $blueberry-color;
+				}
+
+				&:focus {
+					border-color: $blueberry-color;
+					box-shadow: 0 0 0 2px $blueberry-focus-color;
 				}
 			}
 
@@ -117,12 +123,13 @@ $blueberry-hover-color: var(--wp-components-color-accent, var(--wp-admin-theme-c
 					box-shadow: inset 0 0 0 1px $studio-white;
 
 					&:focus {
-						box-shadow: inset 0 0 0 1px #fff, 0 0 0 2px $studio-gray-10;
+						box-shadow: inset 0 0 0 1px #fff, 0 0 0 2px $blueberry-focus-color;
 					}
 				}
 
 				&:focus {
-					box-shadow: 0 0 0 2px $studio-gray-10;
+					border-color: $blueberry-color;
+					box-shadow: 0 0 0 2px $blueberry-focus-color;
 				}
 			}
 

--- a/client/components/survey-container/components/survey-checkbox-control.tsx
+++ b/client/components/survey-container/components/survey-checkbox-control.tsx
@@ -11,7 +11,7 @@ const SurveyCheckboxControl = ( { onChange, question, value }: QuestionSelection
 					question={ question }
 					onChange={ onChange }
 					value={ value }
-				></SurveyCheckboxOption>
+				/>
 			) ) }
 		</div>
 	);

--- a/client/components/survey-container/components/survey-radio-control.tsx
+++ b/client/components/survey-container/components/survey-radio-control.tsx
@@ -1,7 +1,17 @@
+import { useCallback } from 'react';
 import { QuestionSelectionType } from './question-step';
 import SurveyRadioOption from './survey-radio-option';
 
 const SurveyRadioControl = ( { onChange, question, value }: QuestionSelectionType ) => {
+	const handleChange = useCallback(
+		( questionKey: string, newValue: string[] ) => {
+			if ( ! value.includes( newValue[ 0 ] ) ) {
+				onChange( questionKey, newValue );
+			}
+		},
+		[ onChange, value ]
+	);
+
 	return (
 		<div className="question-options__container" role="radiogroup">
 			{ question.options.map( ( option, index ) => (
@@ -9,9 +19,9 @@ const SurveyRadioControl = ( { onChange, question, value }: QuestionSelectionTyp
 					key={ index }
 					question={ question }
 					option={ option }
-					onChange={ onChange }
+					onChange={ handleChange }
 					value={ value }
-				></SurveyRadioOption>
+				/>
 			) ) }
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -102,7 +102,8 @@ button {
 .update-design,
 .update-options,
 .hundred-year-plan,
-.link-in-bio-tld {
+.link-in-bio-tld,
+.entrepreneur {
 	box-sizing: border-box;
 
 	&.step-route {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/89775

## Proposed Changes

* Add WordPress logo to the navbar
* Fix focus and hover colors for checkbox, radio, and continue button
  * Button: eqlepL7MHifK8Bgr1OWqLr-fi-301_10021
  * Checkbox: eqlepL7MHifK8Bgr1OWqLr-fi-15133_12587
  * Radio: eqlepL7MHifK8Bgr1OWqLr-fi-15133_13574
* Call onChange only when the value actually changes

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur/start?flags=ecommerce-segmentation-survey
* Check if the WordPress logo is displayed on the top-left
* Check if the checkbox and radio controls have the new focus color
* Check if the Continue button has the new hover color
* To test the onChange fix, go to the first question (single-choice question)
  * Add a breakpoint to `onChangeAnswer` on `client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx`
  * Select an option. It should stop at the breakpoint, then click to resume
  * Click on the same option again. In this case, the breakpoint shouldn't stop
  * Click on another option, and it should break again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?