### PR TITLE
Help Center: Tailored Articles fetch optimization

### DIFF
--- a/client/data/help/use-help-search-query.ts
+++ b/client/data/help/use-help-search-query.ts
@@ -43,7 +43,6 @@ const fetchArticlesAPI = async (
 	let queryString;
 	let articlesResponse: SearchResult[] = [];
 	let searchResultResponse: SearchResult[] = [];
-	let searchResult: SearchResult[] = [];
 
 	if ( articles ) {
 		const { post_ids, blog_id } = articles;
@@ -63,10 +62,6 @@ const fetchArticlesAPI = async (
 				path: `/help-center/articles?${ queryString }`,
 			} as APIFetchOptions ) ) as SearchResult[];
 		}
-
-		if ( articlesResponse?.length >= 0 ) {
-			searchResult = articlesResponse;
-		}
 	}
 
 	// If less than 5 tailored articles are returned, fetch search results.
@@ -85,11 +80,11 @@ const fetchArticlesAPI = async (
 			} as APIFetchOptions ) ) as SearchResult[];
 		}
 		// Remove articles that are already in the tailored articles.
-		searchResult = filterOutDuplicatedItems( articlesResponse, searchResultResponse );
+		searchResultResponse = filterOutDuplicatedItems( articlesResponse, searchResultResponse );
 	}
 
 	//Add tailored results first then add search results.
-	const combinedResults = [ ...articlesResponse, ...searchResult ];
+	const combinedResults = [ ...articlesResponse, ...searchResultResponse ];
 	return combinedResults.slice( 0, 5 );
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/89703

## Proposed Changes

* Currently, the tailored articles and search result-based articles are both fetched. These changes will prevent the search result-based article API request if the number of tailored articles returned exceeds 5.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Open the help center and 
* Verify the tailored article API request is always made ( You can navigate to `/home/{SITE_SLUG}`, open the Help Center, and verify the network request).
* Verify both search results and tailored article-based API requests are made when navigating to `/mailboxes/{SITE_SLUG}`.
* Verify only the search results-based API request is made on `/subscribers/{SITE_SLUG}`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?