### PR TITLE
Stats purchase: Reduce verification time to 30 min and improve copy

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -539,7 +539,7 @@ function StatsCommercialFlowOptOutForm( {
 					{ isClassificationFinished && ! errorMessage && (
 						<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
 							{ translate(
-								'We have finished verifying your site. If you still think this is an error, please contact support by clicking the button above. '
+								'We have finished verifying your site. If you still think this is an error, please contact support by clicking the button above.'
 							) }
 						</p>
 					) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -412,7 +412,7 @@ function StatsCommercialFlowOptOutForm( {
 		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 1; // 1 day
 	const isClassificationInProgress =
 		commercialClassificationLastRunAt > 0 &&
-		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60; // 1 hour
+		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 30; // half an hour
 
 	const isFormSubmissionDisabled =
 		! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked;
@@ -508,7 +508,7 @@ function StatsCommercialFlowOptOutForm( {
 				{ ( ! supportsOnDemandCommercialClassification ||
 					! isCommercial ||
 					( ! isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
-					<Button variant="secondary" disabled={ isFormSubmissionDisabled } onClick={ formHandler }>
+					<Button variant="secondary" onClick={ formHandler }>
 						{ formButton }
 					</Button>
 				) }
@@ -520,17 +520,21 @@ function StatsCommercialFlowOptOutForm( {
 					) }
 					{ isClassificationInProgress && ! errorMessage && (
 						<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
-							{ translate( 'We are verifying your site. Please come back later…' ) }
+							{ translate(
+								'We are working on verifying your site… Please come back in about 30 minutes. You will have an option to contact support when the process is finished.'
+							) }
 						</p>
 					) }
 					{ ! isClassificationInProgress &&
 						commercialClassificationLastRunAt > 0 &&
 						! errorMessage && (
-							<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
-								{ translate(
-									'We have finished verify your site. If you still think this is an error, please contact our support.'
-								) }
-							</p>
+							<>
+								<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
+									{ translate(
+										'We have finished verify your site. If you still think this is an error, please contact support clicking the button above. '
+									) }
+								</p>
+							</>
 						) }
 				</>
 			) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -534,17 +534,13 @@ function StatsCommercialFlowOptOutForm( {
 							) }
 						</p>
 					) }
-					{ ! isClassificationInProgress &&
-						commercialClassificationLastRunAt > 0 &&
-						! errorMessage && (
-							<>
-								<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
-									{ translate(
-										'We have finished verifying your site. If you still think this is an error, please contact support by clicking the button above. '
-									) }
-								</p>
-							</>
-						) }
+					{ isClassificationFinished && ! errorMessage && (
+						<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
+							{ translate(
+								'We have finished verifying your site. If you still think this is an error, please contact support by clicking the button above. '
+							) }
+						</p>
+					) }
 				</>
 			) }
 		</>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -514,7 +514,9 @@ function StatsCommercialFlowOptOutForm( {
 								{ translate( 'Reverify' ) }
 							</Button>
 						) }
-						{ ( ! supportsOnDemandCommercialClassification || isClassificationFinished ) && (
+						{ ( ! supportsOnDemandCommercialClassification ||
+							isClassificationFinished ||
+							errorMessage ) && (
 							<Button variant="secondary" onClick={ handleRequestUpdateClick }>
 								{ translate( 'Contact support' ) }
 							</Button>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -408,11 +408,11 @@ function StatsCommercialFlowOptOutForm( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ comemercialClassificationRunAt, siteId ]
 	);
-	const hasRunLessThan3DAgo =
-		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 1; // 1 day
+	const canReverify = Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 1; // 1 day
+	const hasClassificationStarted = commercialClassificationLastRunAt > 0;
 	const isClassificationInProgress =
-		commercialClassificationLastRunAt > 0 &&
-		Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 30; // half an hour
+		hasClassificationStarted && Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 30; // half an hour
+	const isClassificationFinished = hasClassificationStarted && ! isClassificationInProgress;
 
 	const isFormSubmissionDisabled =
 		! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked;
@@ -444,8 +444,6 @@ function StatsCommercialFlowOptOutForm( {
 				}
 		  )
 		: translate( 'To use a non-commercial license you must agree to the following:' );
-	const formButton = isCommercial ? translate( 'Contact support' ) : translate( 'Continue' );
-	const formHandler = isCommercial ? handleRequestUpdateClick : handleSwitchToPersonalClick;
 
 	return (
 		<>
@@ -496,21 +494,32 @@ function StatsCommercialFlowOptOutForm( {
 				</ul>
 			</div>
 			<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist-button` }>
-				{ supportsOnDemandCommercialClassification && isCommercial && (
+				{ ! isCommercial && (
 					<Button
 						variant="secondary"
-						disabled={ hasRunLessThan3DAgo || isFormSubmissionDisabled }
-						onClick={ handleCommercialClassification }
+						disabled={ isFormSubmissionDisabled }
+						onClick={ handleSwitchToPersonalClick }
 					>
-						{ translate( 'Reverify' ) }
+						{ translate( 'Continue' ) }
 					</Button>
 				) }
-				{ ( ! supportsOnDemandCommercialClassification ||
-					! isCommercial ||
-					( ! isClassificationInProgress && commercialClassificationLastRunAt > 0 ) ) && (
-					<Button variant="secondary" onClick={ formHandler }>
-						{ formButton }
-					</Button>
+				{ isCommercial && (
+					<>
+						{ supportsOnDemandCommercialClassification && isCommercial && (
+							<Button
+								variant="secondary"
+								disabled={ canReverify || isFormSubmissionDisabled }
+								onClick={ handleCommercialClassification }
+							>
+								{ translate( 'Reverify' ) }
+							</Button>
+						) }
+						{ ( ! supportsOnDemandCommercialClassification || isClassificationFinished ) && (
+							<Button variant="secondary" onClick={ handleRequestUpdateClick }>
+								{ translate( 'Contact support' ) }
+							</Button>
+						) }
+					</>
 				) }
 			</div>
 			{ supportsOnDemandCommercialClassification && isCommercial && (

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -531,7 +531,7 @@ function StatsCommercialFlowOptOutForm( {
 							<>
 								<p className={ `${ COMPONENT_CLASS_NAME }__error-msg` }>
 									{ translate(
-										'We have finished verify your site. If you still think this is an error, please contact support clicking the button above. '
+										'We have finished verifying your site. If you still think this is an error, please contact support by clicking the button above. '
 									) }
 								</p>
 							</>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -408,7 +408,7 @@ function StatsCommercialFlowOptOutForm( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ comemercialClassificationRunAt, siteId ]
 	);
-	const canReverify = Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 60 * 24 * 1; // 1 day
+	const canReverify = Date.now() - commercialClassificationLastRunAt > 1000 * 60 * 60 * 24 * 1; // 1 day
 	const hasClassificationStarted = commercialClassificationLastRunAt > 0;
 	const isClassificationInProgress =
 		hasClassificationStarted && Date.now() - commercialClassificationLastRunAt < 1000 * 60 * 30; // half an hour
@@ -505,10 +505,10 @@ function StatsCommercialFlowOptOutForm( {
 				) }
 				{ isCommercial && (
 					<>
-						{ supportsOnDemandCommercialClassification && isCommercial && (
+						{ supportsOnDemandCommercialClassification && (
 							<Button
 								variant="secondary"
-								disabled={ canReverify || isFormSubmissionDisabled }
+								disabled={ ! canReverify || isFormSubmissionDisabled }
 								onClick={ handleCommercialClassification }
 							>
 								{ translate( 'Reverify' ) }


### PR DESCRIPTION
Related: p1713825715562799/1713473741.895119-slack-C06PK2W8F42

## Proposed Changes

* Reduced wait time from 1hr to 30min and set expectation in copy
* Removed the disabled status of the support button regardless of the status of the checkboxes


## Testing Instructions

* Ensure the copy looks okay
* Ensure 1hour changed to 30min

Clicked 'Reverify':
<img width="691" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/11e7e727-2970-48aa-a0d6-d84db0d1e121">

After re-verification:
<img width="701" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/e0863c09-9cc7-4599-ab89-a1eb96a2edc1">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?