### PR TITLE
Reader: minor css fixes

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -385,6 +385,7 @@
 
 .reader-post-card__byline-secondary-item {
 	// Add extra margin to give space for the bullet that may exist between items.
+	white-space: nowrap;
 	margin-right: 12px;
 	&:last-of-type {
 		margin-right: 0;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -259,8 +259,9 @@
 .is-reader-page {
 
 	.reader__card.card.is-x-post {
-		margin: 0 15px;
-		padding: 16px 0 16px;
+		margin: 0;
+		padding: 16px 0 32px;
+		border-bottom: 1px solid #e9e9ea;
 
 		+ .reader-post-card {
 			margin-top: 16px;
@@ -291,6 +292,10 @@
 		.gravatar {
 			border: 1px solid var(--color-border-inverted);
 		}
+	}
+
+	.reader__card.card.is-x-post + .reader__card.card.is-x-post {
+		padding-top: 32px;
 	}
 }
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -68,7 +68,7 @@
 
 .reader__post-title {
 	clear: none;
-	font-family: $serif;
+	font-family: $sans;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	font-weight: 700;


### PR DESCRIPTION
This PR fixes the font and spacing of the Cross post and how it appears in the reader.



## Proposed Changes
This is a follow up PR to https://github.com/Automattic/wp-calypso/pull/89635 

Before:
![Screenshot_2024-04-22_at_4_31_18 PM](https://github.com/Automattic/wp-calypso/assets/115071/6459e5d7-3708-466e-9274-4aa2336297bc)

After:
![Screenshot_2024-04-22_at_4_33_13 PM](https://github.com/Automattic/wp-calypso/assets/115071/38cd72cf-0fcb-47f0-875f-2340916778e9)



## Testing Instructions

Load this PR. Notice the spacing and fonts are as expected when you visit 
/read 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?