### PR TITLE
[DRAFT] Automattic for Agencies: Implement referrals API endpoints

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -53,8 +53,14 @@
 		background-color: var(--color-success-5);
 		color: var(--color-success-80);
 	}
+
 	&.badge--warning {
 		background-color: var(--color-warning-5);
 		color: var(--color-warning-80);
+	}
+
+	&.badge--error {
+		background-color: var(--color-error-5);
+		color: var(--color-error-80);
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-iframe-url.tsx
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-iframe-url.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export const getGetTipaltiIFrameURLQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-tipalti-iframe-url', agencyId ];
+};
+
+const showDummyData = false;
+
+export default function useGetTipaltiIFrameURL() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: getGetTipaltiIFrameURLQueryKey( agencyId ),
+		queryFn: () =>
+			showDummyData
+				? 'https://example.com/iframe-url'
+				: wpcom.req.get(
+						{
+							apiNamespace: 'wpcom/v2',
+							path: '/agency/embeds/tipalti',
+						},
+						{
+							...( agencyId && { agency_id: agencyId } ),
+						}
+				  ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export const getGetTipaltiPayeeQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-tipalti-payee', agencyId ];
+};
+
+const showDummyData = true;
+
+export default function useGetTipaltiPayee() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const data = useQuery( {
+		queryKey: getGetTipaltiPayeeQueryKey( agencyId ),
+		queryFn: () =>
+			showDummyData
+				? {
+						status: 'SUSPENDED',
+						isPayable: false,
+						hasPayeeAccount: true,
+				  }
+				: wpcom.req.get( {
+						apiNamespace: 'wpcom/v2',
+						path: `agency/${ agencyId }/tipalti-payee`,
+				  } ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+
+	return data;
+}

--- a/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
@@ -1,0 +1,29 @@
+export const getAccountStatus = (
+	status: string,
+	translate: ( key: string ) => string
+): {
+	statusType: 'success' | 'warning' | 'error';
+	status: string;
+} | null => {
+	switch ( status ) {
+		case 'ACTIVE':
+			return {
+				statusType: 'success',
+				status: translate( 'Active' ),
+			};
+
+		case 'SUSPENDED':
+			return {
+				statusType: 'error',
+				status: 'Suspended',
+			};
+		case 'BLOCKED_BY_TIPALTI':
+		case 'BLOCKED':
+			return {
+				statusType: 'error',
+				status: 'Blocked',
+			};
+		default:
+			return null;
+	}
+};

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -7,7 +7,9 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_REFERRALS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import useGetTipaltiIFrameURL from '../../hooks/use-get-tipalti-iframe-url';
 
 import './style.scss';
 
@@ -16,7 +18,9 @@ export default function ReferralsBankDetails() {
 
 	const title = translate( 'Add bank details' );
 
-	const iFrameSrc = '';
+	const { data, isFetching } = useGetTipaltiIFrameURL();
+
+	const iFrameSrc = data?.iframe_url || '';
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -40,7 +44,11 @@ export default function ReferralsBankDetails() {
 
 			<LayoutBody>
 				<div className="bank-details__iframe-container">
-					<iframe width="100%" src={ iFrameSrc } title={ title }></iframe>
+					{ isFetching ? (
+						<TextPlaceholder />
+					) : (
+						<iframe width="100%" height="100%" src={ iFrameSrc } title={ title } />
+					) }
 				</div>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -1,7 +1,9 @@
 .bank-details__iframe-container {
 	margin-block-start: 24px;
+	height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
 
-	iframe {
-		height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
+	.a4a-text-placeholder {
+		display: block;
+		height: 100%;
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -9,11 +9,14 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_REFERRALS_BANK_DETAILS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../common/step-section';
 import StepSectionItem from '../../common/step-section-item';
+import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
+import { getAccountStatus } from '../../lib/get-account-status';
 
 import './style.scss';
 
@@ -27,10 +30,11 @@ export default function ReferralsOverview() {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );
 	}, [ dispatch ] );
 
-	const hasPayeeAccount = false; // FIXME: Replace with actual check
-	const showStatus = true; // FIXME: Replace with actual check
-	const statusType = 'warning'; // FIXME: Replace with actual check
-	const status = 'Pending'; // FIXME: Replace with actual check
+	const { data, isFetching } = useGetTipaltiPayee();
+
+	const hasPayeeAccount = data?.hasPayeeAccount || false;
+
+	const accountStatus = getAccountStatus( data?.status, translate );
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -47,55 +51,66 @@ export default function ReferralsOverview() {
 					{ translate( 'Earn a 30% commission for every purchase made by a client' ) }
 				</div>
 				<div className="referrals-overview__section-container">
-					<StepSection heading={ translate( 'Get set up' ) } stepCount={ 1 }>
-						<StepSectionItem
-							icon={ pages }
-							heading={ translate( 'Add your bank details and upload tax forms' ) }
-							description={ translate(
-								'Once confirmed, we’ll be able to send you a commission payment at the end of each month.'
-							) }
-							buttonProps={ {
-								children: hasPayeeAccount
-									? translate( 'Edit bank details' )
-									: translate( 'Add bank details' ),
-								href: A4A_REFERRALS_BANK_DETAILS_LINK,
-								onClick: onAddBankDetailsClick,
-								primary: true,
-							} }
-							statusProps={
-								showStatus
-									? {
-											children: status,
-											type: statusType,
-									  }
-									: undefined
-							}
-						/>
-						<StepSectionItem
-							icon={ plugins }
-							heading={ translate( 'Install the A4A plugin on your clients’ sites' ) }
-							description={ translate(
-								'Our plugin can confirm that your agency is connected to the Automattic products your clients buy.'
-							) }
-							buttonProps={ { children: translate( 'Download plugin' ) } }
-						/>
-					</StepSection>
-					<StepSection heading={ translate( 'Get paid' ) } stepCount={ 2 }>
-						<StepSectionItem
-							icon={ payment }
-							heading={ translate( 'Have your client purchase Automattic Products' ) }
-							description={ translate(
-								'We offer commissions for each purchase of Automattic products by your clients, including Woo, Jetpack, and hosting from either Pressable or WordPress.com.'
-							) }
-						/>
-						<StepSectionItem
-							icon={ percent }
-							heading={ translate( 'Get paid a commission on your referrals' ) }
-							description={ translate(
-								'At the end of each month, we will review your clients’ purchases and pay you a commission based on them.'
-							) }
-						/>
-					</StepSection>
+					{ isFetching ? (
+						<>
+							<TextPlaceholder />
+							<TextPlaceholder />
+							<TextPlaceholder />
+							<TextPlaceholder />
+						</>
+					) : (
+						<>
+							<StepSection heading={ translate( 'Get set up' ) } stepCount={ 1 }>
+								<StepSectionItem
+									icon={ pages }
+									heading={ translate( 'Add your bank details and upload tax forms' ) }
+									description={ translate(
+										'Once confirmed, we’ll be able to send you a commission payment at the end of each month.'
+									) }
+									buttonProps={ {
+										children: hasPayeeAccount
+											? translate( 'Edit bank details' )
+											: translate( 'Add bank details' ),
+										href: A4A_REFERRALS_BANK_DETAILS_LINK,
+										onClick: onAddBankDetailsClick,
+										primary: true,
+									} }
+									statusProps={
+										accountStatus
+											? {
+													children: accountStatus?.status,
+													type: accountStatus?.statusType,
+											  }
+											: undefined
+									}
+								/>
+								<StepSectionItem
+									icon={ plugins }
+									heading={ translate( 'Install the A4A plugin on your clients’ sites' ) }
+									description={ translate(
+										'Our plugin can confirm that your agency is connected to the Automattic products your clients buy.'
+									) }
+									buttonProps={ { children: translate( 'Download plugin' ) } }
+								/>
+							</StepSection>
+							<StepSection heading={ translate( 'Get paid' ) } stepCount={ 2 }>
+								<StepSectionItem
+									icon={ payment }
+									heading={ translate( 'Have your client purchase Automattic Products' ) }
+									description={ translate(
+										'We offer commissions for each purchase of Automattic products by your clients, including Woo, Jetpack, and hosting from either Pressable or WordPress.com.'
+									) }
+								/>
+								<StepSectionItem
+									icon={ percent }
+									heading={ translate( 'Get paid a commission on your referrals' ) }
+									description={ translate(
+										'At the end of each month, we will review your clients’ purchases and pay you a commission based on them.'
+									) }
+								/>
+							</StepSection>
+						</>
+					) }
 				</div>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -9,3 +9,7 @@
 	flex-direction: column;
 	gap: 48px;
 }
+
+.referrals-overview__section-container .a4a-text-placeholder {
+	height: 80px;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/326
Resolves https://github.com/Automattic/jetpack-genesis/issues/327

## Proposed Changes

TBD

## Testing Instructions

1) Open the A4A live link.
2) TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
