### PR TITLE
Stats: Use purchases from usage api

### DIFF
--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -1,4 +1,5 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { Purchase } from 'calypso/lib/purchases/types';
 import wpcom from 'calypso/lib/wp';
 import { PriceTierListItemProps } from '../stats-purchase/types';
 import getDefaultQueryParams from './default-query-params';
@@ -18,6 +19,7 @@ export interface PlanUsage {
 	current_tier: PriceTierListItemProps;
 	is_internal: boolean;
 	billableMonthlyViews: number;
+	purchases: Purchase[];
 }
 
 function selectPlanUsage( payload: PlanUsage ): PlanUsage {

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -36,7 +36,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 	const statsPurchases = useMemo( () => {
 		const sitePurchases = planUsage?.purchases;
 
-		if ( isFetching || isPending || ! sitePurchases ) {
+		if ( isPending || ! sitePurchases ) {
 			return { isLoading: true };
 		}
 
@@ -76,7 +76,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 			hasAnyPlan: isFreeOwned || isCommercialOwned || isPWYWOwned || supportCommercialUse,
 			isLoading: isPending,
 		};
-	}, [ isFetching ] );
+	}, [ isPending, planUsage ] );
 
 	return statsPurchases;
 }


### PR DESCRIPTION
Related to #

## Proposed Changes

* Use purchases from usage API to overcome the issue where the purchases API in Jetpack is not accessible for non-admin users
* Backend diff `D146236-code`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?