### PR TITLE
A4A: Modify hasHorizontalScroll checks in SectionNav NavTabs to prevent early dropdown display

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/style.scss
@@ -55,7 +55,6 @@
 
 		@media (min-width: 481px) {
 			.section-nav-group {
-				overflow-x: auto;
 
 				.is-dropdown {
 					width: 100%;

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -145,6 +145,13 @@
 			width: 0;
 			flex: 1 0 auto;
 		}
+
+	}
+}
+
+@include breakpoint-deprecated( ">480px" ) {
+	.section-nav-group.has-horizontal-scroll {
+		overflow-x: auto;
 	}
 }
 

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -77,7 +77,14 @@ class NavTabs extends Component {
 
 		return (
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
-			<div className="section-nav-group" ref={ this.navGroupRef }>
+			<div
+				className={ classNames( {
+					'section-nav-group': true,
+					'has-horizontal-scroll':
+						this.props.hasHorizontalScroll && innerWidth > MOBILE_PANEL_THRESHOLD,
+				} ) }
+				ref={ this.navGroupRef }
+			>
 				<div className={ tabsClassName }>
 					{ this.props.label && <h6 className="section-nav-group__label">{ this.props.label }</h6> }
 					<ul className="section-nav-tabs__list" role="menu" onKeyDown={ this.keyHandler }>
@@ -137,13 +144,9 @@ class NavTabs extends Component {
 			this.getTabWidths();
 
 			if (
-				( navGroupWidth <= this.tabsWidth &&
-					! this.state.isDropdown &&
-					this.props.hasHorizontalScroll &&
-					navGroupWidth < 480 ) ||
-				( navGroupWidth <= this.tabsWidth &&
-					! this.state.isDropdown &&
-					! this.props.hasHorizontalScroll )
+				navGroupWidth <= this.tabsWidth &&
+				! this.state.isDropdown &&
+				! this.props.hasHorizontalScroll
 			) {
 				this.setState( {
 					isDropdown: true,


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/337

## Proposed Changes

* This PR removes a check within the `setDropdown` function to see if the navigation group width was less than 480. This was intended to prevent the navigation showing as a dropdown unless on mobile view, but the result was that the dropdown was showing in some cases when the preview pane was open - only if the site title and / or URL were quite short. In those cases, the navigation parent width was considered to be shorter, and on some screen widths that was shorter than 480px, hence the dropdown displayed.
* Removing the check ensures the dropdown only displays on mobile screens now.
* This PR also moves the CSS adding the horizontal scroll to the SectionNav component itself. To help with that, it adds a CSS class `has-horizontal-scroll`, which the CSS is applied to.

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* Open the preview pane in different screen widths, and the dropdown should now only display on mobile (or on screens smaller than 480px).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?