### PR TITLE
`PlanStorageBar`: Extract `return null` logic to `PlanStorage`

### DIFF
--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -1,4 +1,3 @@
-import { planHasFeature, FEATURE_UNLIMITED_STORAGE } from '@automattic/calypso-products';
 import { ProgressBar } from '@automattic/components';
 import classNames from 'classnames';
 import filesize from 'filesize';
@@ -14,19 +13,10 @@ export class PlanStorageBar extends Component {
 		className: PropTypes.string,
 		mediaStorage: PropTypes.object,
 		displayUpgradeLink: PropTypes.bool,
-		sitePlanSlug: PropTypes.string.isRequired,
 	};
 
 	render() {
-		const { className, displayUpgradeLink, mediaStorage, sitePlanSlug, translate } = this.props;
-
-		if ( planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE ) ) {
-			return null;
-		}
-
-		if ( ! mediaStorage || mediaStorage.maxStorageBytes === -1 ) {
-			return null;
-		}
+		const { className, displayUpgradeLink, mediaStorage, translate } = this.props;
 
 		const percent = Math.min(
 			Math.round(

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -86,11 +86,9 @@ export function PlanStorage( { children, className, siteId } ) {
 	const displayUpgradeLink = canUserUpgrade && ! planHasTopStorageSpace && ! isStagingSite;
 	const isSharedQuota = isStagingSite || hasStagingSite;
 
-	const hasPlanUnlimitedStorage = planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE );
-	const noMediaStorage = ! mediaStorage || mediaStorage.maxStorageBytes === -1;
-	const shouldRenderStorageBar = ! hasPlanUnlimitedStorage && ! noMediaStorage;
+	const hasMediaStorage = !! mediaStorage && mediaStorage.maxStorageBytes !== -1;
 
-	const planStorageComponents = shouldRenderStorageBar && (
+	const planStorageComponents = hasMediaStorage && (
 		<PlanStorageBar
 			sitePlanSlug={ sitePlanSlug }
 			mediaStorage={ mediaStorage }

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -86,16 +86,18 @@ export function PlanStorage( { children, className, siteId } ) {
 	const displayUpgradeLink = canUserUpgrade && ! planHasTopStorageSpace && ! isStagingSite;
 	const isSharedQuota = isStagingSite || hasStagingSite;
 
-	const planStorageComponents = (
-		<>
-			<PlanStorageBar
-				sitePlanSlug={ sitePlanSlug }
-				mediaStorage={ mediaStorage }
-				displayUpgradeLink={ displayUpgradeLink }
-			>
-				{ children }
-			</PlanStorageBar>
-		</>
+	const hasPlanUnlimitedStorage = planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE );
+	const noMediaStorage = ! mediaStorage || mediaStorage.maxStorageBytes === -1;
+	const shouldRenderStorageBar = ! hasPlanUnlimitedStorage && ! noMediaStorage;
+
+	const planStorageComponents = shouldRenderStorageBar && (
+		<PlanStorageBar
+			sitePlanSlug={ sitePlanSlug }
+			mediaStorage={ mediaStorage }
+			displayUpgradeLink={ displayUpgradeLink }
+		>
+			{ children }
+		</PlanStorageBar>
 	);
 
 	const showTooltip = () => setTooltipVisible( true );
@@ -121,6 +123,7 @@ export function PlanStorage( { children, className, siteId } ) {
 			</>
 		);
 	}
+
 	if ( isSharedQuota ) {
 		return (
 			<>
@@ -140,6 +143,7 @@ export function PlanStorage( { children, className, siteId } ) {
 			</>
 		);
 	}
+
 	return <div className={ classNames( className, 'plan-storage' ) }>{ planStorageComponents }</div>;
 }
 

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -89,11 +89,7 @@ export function PlanStorage( { children, className, siteId } ) {
 	const hasMediaStorage = !! mediaStorage && mediaStorage.maxStorageBytes !== -1;
 
 	const planStorageComponents = hasMediaStorage && (
-		<PlanStorageBar
-			sitePlanSlug={ sitePlanSlug }
-			mediaStorage={ mediaStorage }
-			displayUpgradeLink={ displayUpgradeLink }
-		>
+		<PlanStorageBar mediaStorage={ mediaStorage } displayUpgradeLink={ displayUpgradeLink }>
 			{ children }
 		</PlanStorageBar>
 	);

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -105,26 +105,6 @@ describe( 'PlanStorageBar basic tests', () => {
 		expect( storage50.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 	} );
 
-	test( 'should not render when storage is falsey or -1', () => {
-		const { container: storage0 } = render( <PlanStorageBar { ...props } mediaStorage={ 0 } /> );
-		expect( storage0.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
-
-		const { container: storageFalse } = render(
-			<PlanStorageBar { ...props } mediaStorage={ false } />
-		);
-		expect( storageFalse.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
-
-		const { container: storageNull } = render(
-			<PlanStorageBar { ...props } mediaStorage={ null } />
-		);
-		expect( storageNull.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
-
-		const { container: storageUnlimited } = render(
-			<PlanStorageBar { ...props } mediaStorage={ { maxStorageBytes: -1 } } />
-		);
-		expect( storageUnlimited.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
-	} );
-
 	test( 'should include upgrade link when displayUpgradeLink is true', () => {
 		const { container } = render( <PlanStorageBar { ...props } displayUpgradeLink={ true } /> );
 		expect( container.getElementsByClassName( 'plan-storage__storage-link' ) ).toHaveLength( 1 );

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -1,7 +1,15 @@
 /**
  * @jest-environment jsdom
  */
-import {
+import * as calypsoProducts from '@automattic/calypso-products';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import nock from 'nock';
+import { Provider } from 'react-redux';
+import { PlanStorage } from '../index';
+
+const siteId = 123;
+const {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_BUSINESS,
@@ -11,14 +19,12 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
-} from '@automattic/calypso-products';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
-import nock from 'nock';
-import { Provider } from 'react-redux';
-import { PlanStorage } from '../index';
+} = calypsoProducts;
 
-const siteId = 123;
+jest.mock( '@automattic/calypso-products', () => ( {
+	...jest.requireActual( '@automattic/calypso-products' ),
+	planHasFeature: jest.fn(),
+} ) );
 
 function renderComponent( component, additionalState = {}, planSlug = 'free_plan' ) {
 	const queryClient = new QueryClient();
@@ -59,6 +65,10 @@ describe( 'PlanStorage basic tests', () => {
 			.persist()
 			.get( '/rest/v1.1/sites/123/media-storage' )
 			.reply( 200 );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
 	} );
 
 	test( 'should not blow up and have class .plan-storage', () => {
@@ -235,6 +245,17 @@ describe( 'PlanStorage basic tests', () => {
 
 	test( 'should not render when site plan slug is empty', () => {
 		const { container } = renderComponent( <PlanStorage siteId={ siteId } />, {}, null );
+		expect( container.getElementsByClassName( '.plan-storage' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'should not render when plan has unlimited storage', () => {
+		jest.spyOn( calypsoProducts, 'planHasFeature' ).mockImplementation( () => true );
+
+		const { container } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			'some_unlimited_storage_plan'
+		);
 		expect( container.getElementsByClassName( '.plan-storage' ) ).toHaveLength( 0 );
 	} );
 } );


### PR DESCRIPTION
On https://github.com/Automattic/wp-calypso/pull/89752 I'm doing a small refactor on the `PlanStorage` component. I need to reuse it, but the layout of the storage bar is not quite what I need, so I'm adding a `StorageBarComponent` prop there and creating a new storage bar component. 

In order to duplicate less code on the new component, I'm lifting some rendering logic from `PlanStorageBar` to its parent `PlanStorage`.

## Proposed Changes

* Remove the `planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE )` check on `PlanStorageBar`, since it's already in place on `PlanStorage`:

https://github.com/Automattic/wp-calypso/blob/9438a5976d86e738bd5290bddbd464738c93a213/client/blocks/plan-storage/index.jsx#L53-L55

* Lift the `! mediaStorage || mediaStorage.maxStorageBytes === -1` check to the parent.

## Testing Instructions

Just check the code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?