### PR TITLE
Automattic for Agencies: Implement Referrals iFrame URL API endpoint

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-iframe-url.tsx
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-iframe-url.tsx
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function useGetTipaltiIFrameURL() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: [ 'a4a-tipalti-iframe-url', agencyId ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: '/agency/embeds/tipalti',
+				},
+				{
+					...( agencyId && { agency_id: agencyId } ),
+				}
+			),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -7,7 +7,9 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_REFERRALS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import useGetTipaltiIFrameURL from '../../hooks/use-get-tipalti-iframe-url';
 
 import './style.scss';
 
@@ -16,7 +18,9 @@ export default function ReferralsBankDetails() {
 
 	const title = translate( 'Add bank details' );
 
-	const iFrameSrc = '';
+	const { data, isFetching } = useGetTipaltiIFrameURL();
+
+	const iFrameSrc = data?.iframe_url || '';
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -40,7 +44,11 @@ export default function ReferralsBankDetails() {
 
 			<LayoutBody>
 				<div className="bank-details__iframe-container">
-					<iframe width="100%" src={ iFrameSrc } title={ title }></iframe>
+					{ isFetching ? (
+						<TextPlaceholder />
+					) : (
+						<iframe width="100%" height="100%" src={ iFrameSrc } title={ title } />
+					) }
 				</div>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -1,7 +1,9 @@
 .bank-details__iframe-container {
 	margin-block-start: 24px;
+	height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
 
-	iframe {
-		height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
+	.a4a-text-placeholder {
+		display: block;
+		height: 100%;
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/326

## Proposed Changes

This PR implements the Referrals iFrame URL API endpoint.

## Testing Instructions

1) Open the A4A live link.
2) Make sure you are sandboxed.
2) Go to the Referrals page (/referrals) > Click the `Add Bank Details` button > Verify that the iFrame is loaded. Fill the details > Save changes(next step) > Refresh the page and verify that the saved data is loaded.

<img width="1437" alt="Screenshot 2024-04-22 at 1 05 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a0409863-c0f0-4429-a606-95ab4f79ec23">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?