### PR TITLE
Fix paid stats modal styles

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/style.scss
+++ b/client/my-sites/stats/stats-upsell-modal/style.scss
@@ -2,12 +2,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.stats-upsell-modal {
+.components-modal__frame.stats-upsell-modal {
 	max-width: 375px;
 	margin: auto;
 	background: var(--studio-gray-0);
 	@include break-medium {
-		max-width: calc(100% - 32px);
+		max-width: 700px;
 	}
 	.components-modal__content {
 		padding: 0;
@@ -43,7 +43,7 @@
 		background: var(--studio-white);
 		gap: 24px;
 		@include break-medium {
-			width: 294px;
+			flex: 1;
 		}
 	}
 
@@ -51,7 +51,7 @@
 
 		gap: 8px;
 		@include break-medium {
-			width: 245px;
+			flex: 1;
 		}
 	}
 


### PR DESCRIPTION
FIxes https://github.com/Automattic/dotcom-forge/issues/6398

## Proposed Changes

* The layout seemed to have diverged from the original design (https://github.com/Automattic/wp-calypso/pull/85457#issuecomment-1866087718)

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/8a5cf781-80f2-4ce7-b11b-9aa21109e866">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/76f0f5d2-e206-4414-8ec9-ce3c571d807a">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Prerequisite 1
Create a new Simple site due to stats are gated after a specific date

* Go to /stats in Calypso, click on upgrade
* Make sure the upgrade button still works

Test the same in Simple Classic

## How to set Simple Classic
To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```
1. Go to apps/odyssey-stats
2. Run `NODE_ENV=production yarn dev --sync`
3. Sandbox `widgets.wp.com`
4. Go to `/wp-admin/admin.php?page=stats`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?