### PR TITLE
A4A: Standardize A4A search input fields to follow a 4px border-radius.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -74,4 +74,5 @@
 
 .card:has(.next-steps) {
 	padding: 16px 24px;
+	border-radius: 4px;
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -38,6 +38,10 @@
 		}
 	}
 
+	.components-input-base {
+		border-radius: 4px;
+	}
+
 	@media (min-width: $break-large) {
 		background: inherit;
 

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -226,6 +226,14 @@
 		color: var(--color-primary-60);
 	}
 
+	.search {
+		&,
+		& > *,
+		input[type="search"] {
+			border-radius: 4px;
+		}
+	}
+
 	// Masterbar
 	@media only screen and ( min-width: 782px ) {
 		--masterbar-height: 46px;

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -77,7 +77,6 @@
 	.filterbar__selection.button {
 		padding: 8px;
 		border: 1px solid var(--color-neutral-20);
-		border-radius: 2px;
 		overflow: hidden;
 		white-space: nowrap;
 		background: #fff;
@@ -101,7 +100,6 @@
 	.filterbar__selection.is-active:focus,
 	.filterbar__selection.is-active:hover,
 	.date-range.toggle-visible .filterbar__selection.button:not(.is-selected) {
-		border-radius: 2px;
 		border: 1px solid var(--color-neutral-60);
 		background: var(--color-neutral-60);
 		color: var(--color-text-inverted);


### PR DESCRIPTION
This pull request addresses a few inconsistencies in the border-radius of the search input fields and Overview page cards.

| Component | Before | After |
|--------|--------|--------|
| Overview Page Next Steps card | <img width="1012" alt="Screenshot 2024-04-23 at 6 57 00 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c360a4a1-d196-44b3-bace-f5093aa7e558"> | <img width="1022" alt="Screenshot 2024-04-23 at 6 51 58 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/16a900a3-e1a1-4446-8cef-2a43047a8cd0"> |
| Marketplace search | <img width="426" alt="Screenshot 2024-04-23 at 7 00 01 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/39a8e4d4-c8bf-4141-9968-e8ee72694dcf"> | <img width="393" alt="Screenshot 2024-04-23 at 6 52 33 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d3aaf01f-439b-4782-b393-23ad4f76cb26"> |
| Site search filter | <img width="282" alt="Screenshot 2024-04-23 at 6 59 05 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7706f9fb-17dd-4c32-a109-ede9ef4f9ef4"> | <img width="278" alt="Screenshot 2024-04-23 at 6 52 07 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/64f26d93-bf1b-42db-bc04-2006d1ce8fb9"> | 
| Sites Preview Pane search | <img width="497" alt="Screenshot 2024-04-23 at 7 01 40 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/10e22ff6-0875-4513-8e2b-43473b198505"> | <img width="281" alt="Screenshot 2024-04-23 at 6 53 01 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c85d6a58-dda4-4fb1-a621-7a966fc42f9b"> |

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/335

## Proposed Changes

* Add global `border-radius` style rule for search components.
* Fix the **Next steps card's** `border-radius` rule.
* Remove some incorrect `border-radius` overrides in the Sites' data view component.

## Testing Instructions

* Use the A4A live link below
* Test all components that are subject to this change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?