### PR TITLE
A4A: Add Marketplace product section anchoring.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/listing-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/listing-section/index.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import './style.scss';
 
 type Props = {
+	id?: string;
 	icon?: ReactNode;
 	title: string;
 	description: string;
@@ -12,6 +13,7 @@ type Props = {
 };
 
 export default function ListingSection( {
+	id,
 	icon,
 	title,
 	description,
@@ -19,7 +21,10 @@ export default function ListingSection( {
 	isTwoColumns,
 }: Props ) {
 	return (
-		<div className={ classNames( 'listing-section', { 'is-two-columns': isTwoColumns } ) }>
+		<div
+			id={ id }
+			className={ classNames( 'listing-section', { 'is-two-columns': isTwoColumns } ) }
+		>
 			<h2 className="listing-section-title">
 				{ icon }
 				<span>{ title }</span>

--- a/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
@@ -3,6 +3,7 @@
 
 .listing-section {
 	margin-block-end: 32px;
+	scroll-margin-block-start: 16px;
 }
 
 h2.listing-section-title {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -41,6 +41,20 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 		}
 	}, [ siteId, sites ] );
 
+	useEffect( () => {
+		if ( window.location.hash ) {
+			const target = window.location.hash.replace( '#', '' );
+			const element = document.getElementById( target );
+
+			if ( element ) {
+				element.scrollIntoView( {
+					behavior: 'smooth',
+					block: 'start',
+				} );
+			}
+		}
+	}, [] );
+
 	return (
 		<Layout
 			className={ classNames( 'products-overview' ) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -294,6 +294,7 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 
 			{ wooExtensions.length > 0 && (
 				<ListingSection
+					id="woocommerce-extensions"
 					icon={ <WooLogo width={ 45 } height={ 28 } /> }
 					title={ translate( 'WooCommerce Extensions' ) }
 					description={ translate(
@@ -306,6 +307,7 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 
 			{ plans.length > 0 && (
 				<ListingSection
+					id="jetpack-plans"
 					icon={ <JetpackLogo size={ 26 } /> }
 					title={ translate( 'Jetpack Plans' ) }
 					description={ translate(

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -48,7 +48,7 @@ const OverviewBodyProducts = () => {
 		expanded: false,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'jetpack' );
-			page( A4A_PRODUCTS_MARKETPLACE_LINK );
+			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }#jetpack-plans` );
 		},
 	};
 
@@ -76,7 +76,7 @@ const OverviewBodyProducts = () => {
 		expanded: true,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'woocommerce' );
-			page( A4A_PRODUCTS_MARKETPLACE_LINK );
+			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }#woocommerce-extensions` );
 		},
 	};
 

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -45,7 +45,7 @@ const OverviewBodyProducts = () => {
 		],
 		// translators: Button navigating to A4A Marketplace
 		buttonTitle: translate( 'View all Jetpack products' ),
-		expanded: false,
+		expanded: true,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'jetpack' );
 			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }#jetpack-plans` );


### PR DESCRIPTION
This pull request introduces a new feature to the Marketplace: Anchors for product links in the Overview page. When a user clicks on a product link, the page scrolls smoothly to the relevant section, enhancing the user experience.

https://github.com/Automattic/wp-calypso/assets/56598660/a59e181c-c730-4eff-878a-ee97a785bae7


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/333
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/332

## Proposed Changes

* Update ListingSection components to support `id` props. This will be needed to target the product section in the marketplace from a URL hash fragment.
* Add a `useEffect` to the Marketplace product page that looks at the current URL hash fragment. If an element matches the hash value, the hook will trigger a page scroll.
* Update the Overview page Woocommerce and Jetpack overview links to include a hash fragment. 
* Additionally: Update the Jetpack product card to be expanded by default. This fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/332

## Testing Instructions

* Use the A4A live link below and go to `/overview` page.
* Click Woocommerce or Jetpack product links.
* Confirm that the page is redirected to the Marketplace page and scrolls to the appropriate section (Jetpack or Woocommerce extensions).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?