### PR TITLE
Create valid checkout links for theme related plan upgrades in showcase

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -55,6 +55,21 @@ import {
 import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
+/**
+ * Get the checkout path slug for the given site and minimum plan.
+ * @param {Object} state
+ * @param {number} siteId
+ * @param {string} minimumPlan
+ * @returns
+ */
+function getPlanPathSlugForFirstPartyThemes( state, siteId, minimumPlan ) {
+	const currentPlanSlug = getSitePlanSlug( state, siteId );
+	const requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
+	const requiredPlanSlug = findFirstSimilarPlanKey( minimumPlan, { term: requiredTerm } );
+	const mappedPlan = getPlan( requiredPlanSlug );
+	return mappedPlan?.getPathSlug();
+}
+
 function getAllThemeOptions( { translate, isFSEActive } ) {
 	const purchase = {
 		label: translate( 'Purchase', {
@@ -85,12 +100,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 					? PLAN_PREMIUM
 					: tierMinimumUpsellPlan;
 
-			const currentPlanSlug = getSitePlanSlug( state, siteId );
-			const requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
-			const requiredPlanSlug = findFirstSimilarPlanKey( minimumPlan, { term: requiredTerm } );
-
-			const mappedPlan = getPlan( requiredPlanSlug );
-			const planPathSlug = mappedPlan?.getPathSlug();
+			const planPathSlug = getPlanPathSlugForFirstPartyThemes( state, siteId, minimumPlan );
 
 			return `/checkout/${ slug }/${ planPathSlug }?redirect_to=${ redirectTo }`;
 		},
@@ -178,11 +188,9 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 				} )
 			);
 
-			const currentPlanSlug = getSitePlanSlug( state, siteId );
-			const requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
-			const requiredPlanSlug = findFirstSimilarPlanKey( PLAN_BUSINESS, { term: requiredTerm } );
+			const planPathSlug = getPlanPathSlugForFirstPartyThemes( state, siteId, PLAN_BUSINESS );
 
-			return `/checkout/${ slug }/${ requiredPlanSlug }?redirect_to=${ redirectTo }`;
+			return `/checkout/${ slug }/${ planPathSlug }?redirect_to=${ redirectTo }`;
 		},
 		hideForTheme: ( state, themeId, siteId ) =>
 			isJetpackSite( state, siteId ) ||

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -2,6 +2,7 @@ import {
 	WPCOM_FEATURES_INSTALL_PLUGINS,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
+	PLAN_BUSINESS,
 	getPlan,
 	TERM_ANNUALLY,
 	findFirstSimilarPlanKey,
@@ -177,7 +178,11 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 				} )
 			);
 
-			return `/checkout/${ slug }/business?redirect_to=${ redirectTo }`;
+			const currentPlanSlug = getSitePlanSlug( state, siteId );
+			const requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
+			const requiredPlanSlug = findFirstSimilarPlanKey( PLAN_BUSINESS, { term: requiredTerm } );
+
+			return `/checkout/${ slug }/${ requiredPlanSlug }?redirect_to=${ redirectTo }`;
 		},
 		hideForTheme: ( state, themeId, siteId ) =>
 			isJetpackSite( state, siteId ) ||

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -3,6 +3,8 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	getPlan,
+	TERM_ANNUALLY,
+	findFirstSimilarPlanKey,
 } from '@automattic/calypso-products';
 import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import { addQueryArgs } from '@wordpress/url';
@@ -19,7 +21,12 @@ import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { isJetpackSite, isJetpackSiteMultiSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import {
+	isJetpackSite,
+	isJetpackSiteMultiSite,
+	getSiteSlug,
+	getSitePlanSlug,
+} from 'calypso/state/sites/selectors';
 import {
 	activate as activateAction,
 	tryAndCustomize as tryAndCustomizeAction,
@@ -77,7 +84,11 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 					? PLAN_PREMIUM
 					: tierMinimumUpsellPlan;
 
-			const mappedPlan = getPlan( minimumPlan );
+			const currentPlanSlug = getSitePlanSlug( state, siteId );
+			const requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
+			const requiredPlanSlug = findFirstSimilarPlanKey( minimumPlan, { term: requiredTerm } );
+
+			const mappedPlan = getPlan( requiredPlanSlug );
 			const planPathSlug = mappedPlan?.getPathSlug();
 
 			return `/checkout/${ slug }/${ planPathSlug }?redirect_to=${ redirectTo }`;

--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -1,7 +1,10 @@
 import {
 	PLAN_BUSINESS_MONTHLY,
-	isWpComMonthlyPlan,
 	PLAN_BUSINESS,
+	TERM_MONTHLY,
+	findFirstSimilarPlanKey,
+	getPlan,
+	isFreePlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -10,8 +13,7 @@ import { marketplaceThemeProduct } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
@@ -67,8 +69,15 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 			throw new Error( 'No products available' );
 		}
 
-		const currentPlan = getCurrentPlan( state, siteId );
-		const productSlug = getPreferredBillingCycleProductSlug( products, currentPlan );
+		const currentPlanSlug = getSitePlanSlug( state, siteId );
+		let requiredTerm = TERM_MONTHLY;
+		if ( currentPlanSlug && ! isFreePlan( currentPlanSlug ) ) {
+			requiredTerm = getPlan( currentPlanSlug )?.term || TERM_MONTHLY;
+		}
+		const requiredPlanSlug =
+			findFirstSimilarPlanKey( PLAN_BUSINESS, { term: requiredTerm } ) || PLAN_BUSINESS_MONTHLY;
+
+		const productSlug = getPreferredBillingCycleProductSlug( products, requiredPlanSlug );
 
 		const externalManagedThemeProduct = marketplaceThemeProduct( productSlug );
 
@@ -89,10 +98,7 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
 			cartItems.push( {
-				product_slug:
-					currentPlan && ! isWpComMonthlyPlan( currentPlan.productSlug )
-						? PLAN_BUSINESS
-						: PLAN_BUSINESS_MONTHLY,
+				product_slug: requiredPlanSlug,
 			} );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88378

## Proposed Changes

When a user needs to upgrade their site plan to get access to a theme, checkout to a plan with a valid term. A valid term is one that is longer, or as long as the current plans term. I.e you can go from two year starter to two year explorer but not to one year explorer - the checkout would display an error.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Get a site on the two year starter plan
2. Go to /themes and choose a theme that requires Explorer e.g. Cakely
3. You should see an 'Upgrade to activate' button, press it
4. You should go to the checkout and it should add a two year explorer plan to the checkout. It should not display an empty checkout with a 'Sorry that plan is not a valid upgrade from your current plan' message.
5. Press back, choose to empty the cart
6. Repeat with a Woo theme, it should do the same but for an Explorer plan
7. Repeat with a Marketplace theme, it should do the same but for an Explorer plan and a 1 year theme subscription

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?