### PR TITLE
Trail map: Conditionalise custom domain feature & eligibility hook

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
+++ b/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
@@ -1,0 +1,15 @@
+import config from '@automattic/calypso-config';
+import type { DataResponse } from '@automattic/plans-grid-next';
+
+interface Props {
+	flowName?: string | null;
+}
+
+function useExperimentForTrailMap( { flowName }: Props ): DataResponse< boolean > {
+	return {
+		isLoading: false,
+		result: config.isEnabled( 'onboarding/trail-map-feature-grid' ) && flowName === 'onboarding',
+	};
+}
+
+export default useExperimentForTrailMap;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -69,6 +69,7 @@ import useGenerateActionCallback from './hooks/use-action-callback';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useDeemphasizeFreePlan from './hooks/use-deemphasize-free-plan';
+import useExperimentForTrailMap from './hooks/use-experiment-for-trail-map';
 import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-intervals';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
@@ -736,6 +737,8 @@ const PlansFeaturesMain = ( {
 
 	const onFreePlanCTAClick = useActionCallback( { planSlug: PLAN_FREE } );
 
+	const trailMapExperiment = useExperimentForTrailMap( { flowName } );
+
 	return (
 		<>
 			<div
@@ -845,7 +848,7 @@ const PlansFeaturesMain = ( {
 										isInSignup={ isInSignup }
 										isLaunchPage={ isLaunchPage }
 										onStorageAddOnClick={ handleStorageAddOnClick }
-										paidDomainName={ paidDomainName }
+										paidDomainName={ trailMapExperiment.result ? undefined : paidDomainName }
 										planActionOverrides={ planActionOverrides }
 										planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 										recordTracksEvent={ recordTracksEvent }

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -91,7 +91,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				const isHighlightedFeature = selectedFeature
 					? currentFeature.getSlug() === selectedFeature
 					: currentFeature?.isHighlighted ||
-					  currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN ||
+					  ( currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN && paidDomainName ) ||
 					  ! currentFeature.availableForCurrentPlan;
 
 				const divClasses = classNames( '', getPlanClass( planSlug ), {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/89682
Fixes https://github.com/Automattic/wp-calypso/issues/89686

## Proposed Changes

* Introduces feature flag (`onboarding/trail-map-feature-grid`) and eligibility hook for trail map (language change) experiment. Currently only effective on `/start/plans` flow.
* Makes the domain name rendered for custom domain optional based on said feature flag

### Media

#### with feature flag

<img width="500" alt="Screenshot 2024-04-23 at 3 17 46 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/6ff9a50d-e5b7-4a4e-b1dd-73013ca3cbc9">

#### without feature flag

<img width="500" alt="Screenshot 2024-04-23 at 3 18 05 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/b5d8298d-f78f-4925-8330-6f1d91a4729e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans?flags=onboarding/trail-map-feature-grid` with a custom/paid domain selected in previous step
  * Confirm media above
* Repeat with the feature flag disabled `/start/plans?flags=onboarding/trail-map-feature-grid`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?