### PR TITLE
Scheduled updates: Adjust plugins control styles for the mobile viewport

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -84,7 +84,7 @@ export function ScheduleFormPlugins( props: Props ) {
 	useEffect( () => removeUnlistedSelectedPlugins(), [ plugins ] );
 
 	return (
-		<div className="form-field">
+		<div className="form-field form-field--plugins">
 			<label htmlFor="plugins">{ translate( 'Select plugins' ) }</label>
 			<span className="plugin-select-stats">
 				{ selectedPlugins.length }/

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -190,6 +190,18 @@
 		}
 	}
 
+	.form-field--plugins {
+		.components-base-control__field {
+			display: flex;
+		}
+
+		.components-checkbox-control__label {
+			text-overflow: ellipsis;
+			overflow: hidden;
+			white-space: nowrap;
+		}
+	}
+
 	.form-field--paths {
 		.paths {
 			.components-input-control__backdrop {

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { __experimentalText as Text } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
@@ -29,6 +30,7 @@ interface Props {
 export const ScheduleForm = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
+	const isMobile = useMobileBreakpoint();
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
 
@@ -147,6 +149,7 @@ export const ScheduleForm = ( props: Props ) => {
 				selectedPlugins={ selectedPlugins }
 				isPluginsFetching={ isPluginsFetching }
 				isPluginsFetched={ isPluginsFetched }
+				borderWrapper={ ! isMobile }
 				error={ validationErrors?.plugins }
 				showError={ fieldTouched?.plugins }
 				onChange={ setSelectedPlugins }


### PR DESCRIPTION
Related to #

## Proposed Changes

* Remove border container for the mobile viewports
* Add text-overflow ellipsis to plugins name

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/create/{SITE_SLUG}`
* Check the mobile screen behaviour

| Before | After |
|--------|--------|
| <img width="461" alt="Screenshot 2024-04-23 at 14 58 05" src="https://github.com/Automattic/wp-calypso/assets/1241413/3cff8212-9f0b-4f3e-9666-ed6d7eae48cd"> | <img width="462" alt="Screenshot 2024-04-23 at 14 57 56" src="https://github.com/Automattic/wp-calypso/assets/1241413/e65bf752-b035-49e3-abad-c34d107dcf1f"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?