### PR TITLE
A4A: Make sure that preview pane headings are being wrapped on to the next line, preventing content display issues

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/site-preview-pane-header/style.scss
@@ -2,6 +2,13 @@
 
 .site-preview__header {
 
+	.site-preview__header-content {
+		.site-preview__header-title-summary {
+			word-wrap: anywhere;
+		}
+
+	}
+
 	@media ( min-width: $break-large ) {
 		.site-preview__header-favicon {
 			margin-right: 24px;
@@ -60,7 +67,6 @@
 			display: flex;
 			justify-content: space-between;
 			.site-preview__header-title-summary {
-				word-wrap: anywhere;
 				flex-grow: 1;
 				display: flex;
 				flex-direction: column;


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/338

## Proposed Changes

* This PR moves a CSS word-wrap property out of a media query to ensure it is relevant for all screen sizes.
* This prevents an issue that was occurring when site names (ad also URLs) were too long without whitespace, and not wrapping onto the next line. This had a knock-on effect of increase the site preview pane content width, therefore truncating the header (the close button wouldn't show), as well as preview pane content itself, and the navigation in some cases as well.

## Testing Instructions

For the below testing steps, make sure to run `yarn start-a8c-for-agencies` locally and then visit `http://agencies.localhost:3000/sites`.

* To test, replicate the issue in trunk with a site that has a long site nam with no whitespace (edit this in the inspector for example, for one of your test sites). 
* With the preview pane open for that site and a screen width of approximately 1300px (large enough to show the sites dashboard as well as the preview pane - not a full width preview pane)

## Screenshots

In trunk (navigation scrolling not possible in this example):

<img width="1046" alt="Screenshot 2024-04-23 at 14 11 32" src="https://github.com/Automattic/wp-calypso/assets/16754605/80a2dfcb-4d82-43a0-b7bb-122511bf27a8">

In this branch (navigation scrolling possible in this example):

<img width="1054" alt="Screenshot 2024-04-23 at 14 12 49" src="https://github.com/Automattic/wp-calypso/assets/16754605/ee625029-306d-41a9-82b6-e6eb635f454e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?