### PR TITLE
Create a migration first signup flow

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -29,6 +29,7 @@ interface Props {
 	onCtaClick: () => void;
 	onContentOnlyClick?: () => void;
 	trackingEventsProps?: Record< string, unknown >;
+	hideFreeMigrationTrialForNonVerifiedEmail?: boolean;
 }
 
 export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) => {
@@ -48,11 +49,16 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		onCtaClick,
 		isBusy,
 		trackingEventsProps,
+		hideFreeMigrationTrialForNonVerifiedEmail = false,
 	} = props;
 	const { data: migrationTrialEligibility } = useCheckEligibilityMigrationTrialPlan( site.ID );
 	const isEligibleForTrialPlan =
 		migrationTrialEligibility?.eligible ||
 		// If the user's email is unverified, we still want to show the trial plan option
+		migrationTrialEligibility?.error_code === 'email-unverified';
+
+	const hideFreeMigrationTrial =
+		hideFreeMigrationTrialForNonVerifiedEmail &&
 		migrationTrialEligibility?.error_code === 'email-unverified';
 
 	const { addHostingTrial, isPending: isAddingTrial } = useAddHostingTrialMutation( {
@@ -83,7 +89,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		const cta = ctaText === '' ? translate( 'Continue' ) : ctaText;
 		const trialText = translate( 'Try 7 days for free' );
 
-		if ( ! isEnabled( 'plans/migration-trial' ) ) {
+		if ( ! isEnabled( 'plans/migration-trial' ) || hideFreeMigrationTrial ) {
 			return (
 				<NextButton isBusy={ isBusy } onClick={ onCtaClick }>
 					{ cta }

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -74,6 +74,7 @@ button {
 .import-hosted-site,
 .site-setup,
 .site-migration,
+.migration-signup,
 .import-focused,
 .plugin-bundle,
 .newsletter-setup,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
@@ -74,7 +74,10 @@ const SiteMigrationPluginInstall: Step = ( { navigation } ) => {
 			} );
 
 			setProgress( 1 );
-			return true;
+
+			return {
+				pluginInstalled: true,
+			};
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
@@ -55,8 +55,8 @@ describe( 'SiteMigrationPluginInstall', () => {
 			.post( '/rest/v1.2/sites/123/plugins/migrate-guru%2fmigrateguru', { active: true } )
 			.reply( 200 );
 
-		const result = getPendingAction()();
-		await expect( result ).resolves.toBe( true );
+		const result = await getPendingAction()();
+		expect( result.pluginInstalled ).toBe( true );
 
 		expect( nock.isDone() ).toBe( true );
 		expect( getProgress() ).toBe( 1 );
@@ -81,8 +81,8 @@ describe( 'SiteMigrationPluginInstall', () => {
 			.post( '/rest/v1.2/sites/123/plugins/migrate-guru%2fmigrateguru', { active: true } )
 			.reply( 200 );
 
-		const result = getPendingAction()();
-		await expect( result ).resolves.toBe( true );
+		const result = await getPendingAction()();
+		expect( result.pluginInstalled ).toBe( true );
 
 		expect( nock.isDone() ).toBe( true );
 		expect( getProgress() ).toBe( 1 );
@@ -105,8 +105,8 @@ describe( 'SiteMigrationPluginInstall', () => {
 			.post( '/rest/v1.2/sites/123/plugins/migrate-guru%2fmigrateguru', { active: true } )
 			.reply( 200 );
 
-		const result = getPendingAction()();
-		await expect( result ).resolves.toBe( true );
+		const result = await getPendingAction()();
+		expect( result.pluginInstalled ).toBe( true );
 
 		expect( nock.isDone() ).toBe( true );
 		expect( getProgress() ).toBe( 1 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -10,10 +10,12 @@ import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
-const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
+const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
+	const hideFreeMigrationTrialForNonVerifiedEmail =
+		( data?.hideFreeMigrationTrialForNonVerifiedEmail as boolean | undefined ) ?? false;
 
 	const selectedPlanData = useSelectedPlanUpgradeQuery();
 	const selectedPlanPathSlug = selectedPlanData.data;
@@ -46,12 +48,13 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
 			navigateToVerifyEmailStep={ () => {
 				navigation.submit?.( { verifyEmail: true } );
 			} }
+			hideFreeMigrationTrialForNonVerifiedEmail={ hideFreeMigrationTrialForNonVerifiedEmail }
 		/>
 	);
 
 	return (
 		<>
-			<DocumentHead title="Upgrade your plan" />
+			<DocumentHead title={ translate( 'Upgrade your plan', { textOnly: true } ) } />
 			<StepContainer
 				stepName="site-migration-upgrade-plan"
 				shouldHideNavButtons={ false }

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -1,0 +1,315 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useSiteData } from '../hooks/use-site-data';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import { goToCheckout } from '../utils/checkout';
+import { getLoginUrl } from '../utils/path';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
+import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
+import { AssertConditionState } from './internals/types';
+import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
+import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
+
+const FLOW_NAME = 'migration-signup';
+
+const migrationSignup: Flow = {
+	name: FLOW_NAME,
+	isSignupFlow: true,
+
+	useSteps() {
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+		useEffect( () => {
+			resetOnboardStore();
+		}, [] );
+
+		return [
+			STEPS.SITE_MIGRATION_IDENTIFY,
+			STEPS.SITE_CREATION_STEP,
+			//STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
+			STEPS.BUNDLE_TRANSFER,
+			STEPS.SITE_MIGRATION_PLUGIN_INSTALL,
+			STEPS.PROCESSING,
+			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
+			//STEPS.VERIFY_EMAIL,
+			STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN,
+			STEPS.SITE_MIGRATION_INSTRUCTIONS,
+			STEPS.ERROR,
+		];
+	},
+	useAssertConditions(): AssertConditionResult {
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		const flowName = this.name;
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
+		const queryParams = new URLSearchParams( window.location.search );
+		const aff = queryParams.get( 'aff' );
+		const vendorId = queryParams.get( 'vid' );
+		const ref = queryParams.get( 'ref' );
+
+		const getStartUrl = () => {
+			let hasFlowParams = false;
+			const flowParams = new URLSearchParams();
+			const queryParams = new URLSearchParams();
+
+			if ( vendorId ) {
+				queryParams.set( 'vid', vendorId );
+			}
+
+			if ( aff ) {
+				queryParams.set( 'aff', aff );
+			}
+
+			if ( ref ) {
+				queryParams.set( 'ref', ref );
+			}
+
+			if ( locale && locale !== 'en' ) {
+				flowParams.set( 'locale', locale );
+				hasFlowParams = true;
+			}
+
+			const redirectTarget =
+				`/setup/${ FLOW_NAME }` +
+				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+
+			let queryString = `redirect_to=${ redirectTarget }`;
+
+			if ( queryParams.toString() ) {
+				queryString = `${ queryString }&${ queryParams.toString() }`;
+			}
+
+			const logInUrl = getLoginUrl( {
+				variationName: flowName,
+				locale,
+			} );
+
+			return `${ logInUrl }&${ queryString }`;
+		};
+
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				const logInUrl = getStartUrl();
+				window.location.assign( logInUrl );
+			}
+		}, [] );
+
+		if ( ! userIsLoggedIn ) {
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'migration-signup requires a logged in user',
+			};
+		}
+
+		return result;
+	},
+
+	useSideEffect( currentStep, navigate ) {
+		const { siteSlug, siteId } = useSiteData();
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+		const urlQueryParams = useQuery();
+		const fromQueryParam = urlQueryParams.get( 'from' );
+
+		// Ensure we navigate to the site creation step if we have a logged-in user, we don't have the from parameter,
+		// we don't have a site defined, and we are not on the site creation, processing, or error steps.
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				return;
+			}
+
+			if ( ! fromQueryParam ) {
+				return;
+			}
+
+			if (
+				[ STEPS.SITE_CREATION_STEP.slug, STEPS.PROCESSING.slug, STEPS.ERROR.slug ].includes(
+					currentStep
+				)
+			) {
+				return;
+			}
+
+			if ( ! siteSlug && ! siteId ) {
+				navigate( STEPS.SITE_CREATION_STEP.slug );
+			}
+		}, [ fromQueryParam, siteSlug, siteId, userIsLoggedIn ] );
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const intent = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
+			[]
+		);
+		const siteSlugParam = useSiteSlugParam();
+		const urlQueryParams = useQuery();
+		const fromQueryParam = urlQueryParams.get( 'from' );
+
+		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
+		const exitFlow = ( to: string ) => {
+			window.location.assign( to );
+		};
+
+		// TODO - We may need to add `...params: string[]` back once we start adding more steps.
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
+			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
+			const siteId = getSiteIdBySlug( siteSlug );
+
+			switch ( currentStep ) {
+				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
+					const { from, platform, action } = providedDependencies as {
+						from: string;
+						platform: string;
+						action: SiteMigrationIdentifyAction;
+					};
+
+					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
+						return exitFlow(
+							addQueryArgs(
+								{
+									siteId,
+									siteSlug,
+									from,
+									origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+									backToFlow: `/${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+								},
+								'/setup/site-setup/importList'
+							)
+						);
+					}
+
+					return navigate(
+						addQueryArgs( { from: from, siteSlug, siteId }, STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug )
+					);
+				}
+
+				case STEPS.SITE_CREATION_STEP.slug: {
+					return navigate(
+						addQueryArgs(
+							{ from: fromQueryParam, siteSlug, siteId },
+							STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+						)
+					);
+				}
+
+				case STEPS.BUNDLE_TRANSFER.slug: {
+					return navigate( STEPS.PROCESSING.slug, { bundleProcessing: true } );
+				}
+
+				case STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug: {
+					return navigate( STEPS.PROCESSING.slug );
+				}
+
+				case STEPS.PROCESSING.slug: {
+					// If we just created the site, go to the upgrade plan step.
+					if ( providedDependencies?.siteId && providedDependencies?.siteSlug ) {
+						return navigate(
+							addQueryArgs( { siteId, siteSlug }, STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug )
+						);
+					}
+
+					// Any process errors go to the error step.
+					if ( providedDependencies?.error ) {
+						return navigate( STEPS.ERROR.slug );
+					}
+
+					// If the plugin was installed successfully, go to the migration instructions.
+					if ( providedDependencies?.pluginInstalled ) {
+						return navigate( STEPS.SITE_MIGRATION_INSTRUCTIONS.slug );
+					}
+
+					// Otherwise processing has finished from the BundleTransfer step and we need to install the plugin.
+					return navigate( STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug );
+				}
+
+				case STEPS.VERIFY_EMAIL.slug: {
+					return navigate( STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug );
+				}
+
+				case STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug: {
+					if ( providedDependencies?.error ) {
+						return navigate( STEPS.ERROR.slug );
+					}
+
+					return navigate( STEPS.BUNDLE_TRANSFER.slug, {
+						siteId,
+						siteSlug,
+					} );
+				}
+
+				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
+					/*
+					if ( providedDependencies?.verifyEmail ) {
+						return navigate( STEPS.VERIFY_EMAIL.slug );
+					}
+					*/
+
+					if ( providedDependencies?.goToCheckout ) {
+						const destination = addQueryArgs(
+							{
+								siteSlug,
+								from: fromQueryParam,
+							},
+							`/setup/${ FLOW_NAME }/${ STEPS.BUNDLE_TRANSFER.slug }`
+						);
+						goToCheckout( {
+							flowName: FLOW_NAME,
+							stepName: currentStep,
+							siteSlug: siteSlug,
+							destination: destination,
+							plan: providedDependencies.plan as string,
+						} );
+						return;
+					}
+					if ( providedDependencies?.freeTrialSelected ) {
+						return navigate( STEPS.BUNDLE_TRANSFER.slug, {
+							siteId,
+							siteSlug,
+						} );
+					}
+				}
+
+				case STEPS.SITE_MIGRATION_INSTRUCTIONS.slug: {
+					return exitFlow( `/home/${ siteSlug }` );
+				}
+			}
+		}
+
+		const goBack = () => {
+			switch ( currentStep ) {
+				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
+					return navigate( `${ STEPS.SITE_MIGRATION_IDENTIFY.slug }?${ urlQueryParams }` );
+				}
+			}
+		};
+
+		return { goBack, submit, exitFlow };
+	},
+};
+
+export default migrationSignup;

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -201,7 +201,11 @@ const migrationSignup: Flow = {
 					}
 
 					return navigate(
-						addQueryArgs( { from: from, siteSlug, siteId }, STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug )
+						addQueryArgs(
+							{ from: from, siteSlug, siteId },
+							STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+						),
+						{ hideFreeMigrationTrialForNonVerifiedEmail: true }
 					);
 				}
 
@@ -210,7 +214,8 @@ const migrationSignup: Flow = {
 						addQueryArgs(
 							{ from: fromQueryParam, siteSlug, siteId },
 							STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
-						)
+						),
+						{ hideFreeMigrationTrialForNonVerifiedEmail: true }
 					);
 				}
 
@@ -229,7 +234,8 @@ const migrationSignup: Flow = {
 							addQueryArgs(
 								{ siteId, siteSlug, from: fromQueryParam },
 								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
-							)
+							),
+							{ hideFreeMigrationTrialForNonVerifiedEmail: true }
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -131,14 +131,10 @@ const migrationSignup: Flow = {
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
 
-		// Ensure we navigate to the site creation step if we have a logged-in user, we don't have the from parameter,
+		// Ensure we navigate to the site creation step if we have a logged-in user,
 		// we don't have a site defined, and we are not on the site creation, processing, or error steps.
 		useEffect( () => {
 			if ( ! userIsLoggedIn ) {
-				return;
-			}
-
-			if ( ! fromQueryParam ) {
 				return;
 			}
 
@@ -211,11 +207,7 @@ const migrationSignup: Flow = {
 
 				case STEPS.SITE_CREATION_STEP.slug: {
 					return navigate(
-						addQueryArgs(
-							{ from: fromQueryParam, siteSlug, siteId },
-							STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
-						),
-						{ hideFreeMigrationTrialForNonVerifiedEmail: true }
+						addQueryArgs( { from: fromQueryParam, siteSlug, siteId }, STEPS.PROCESSING.slug )
 					);
 				}
 
@@ -273,10 +265,19 @@ const migrationSignup: Flow = {
 					}
 
 					if ( providedDependencies?.freeTrialSelected ) {
-						return navigate( STEPS.BUNDLE_TRANSFER.slug, {
-							siteId,
-							siteSlug,
-						} );
+						return navigate(
+							addQueryArgs(
+								{
+									siteSlug,
+									from: fromQueryParam,
+								},
+								STEPS.BUNDLE_TRANSFER.slug
+							),
+							{
+								siteId,
+								siteSlug,
+							}
+						);
 					}
 				}
 

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -154,7 +154,7 @@ const migrationSignup: Flow = {
 			}
 
 			if ( ! siteSlug && ! siteId ) {
-				navigate( STEPS.SITE_CREATION_STEP.slug );
+				navigate( addQueryArgs( { from: fromQueryParam }, STEPS.SITE_CREATION_STEP.slug ) );
 			}
 		}, [ fromQueryParam, siteSlug, siteId, userIsLoggedIn ] );
 	},
@@ -229,7 +229,10 @@ const migrationSignup: Flow = {
 					// If we just created the site, go to the upgrade plan step.
 					if ( providedDependencies?.siteId && providedDependencies?.siteSlug ) {
 						return navigate(
-							addQueryArgs( { siteId, siteSlug }, STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug )
+							addQueryArgs(
+								{ siteId, siteSlug, from: fromQueryParam },
+								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+							)
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -32,13 +32,10 @@ const migrationSignup: Flow = {
 		return [
 			STEPS.SITE_MIGRATION_IDENTIFY,
 			STEPS.SITE_CREATION_STEP,
-			//STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
 			STEPS.BUNDLE_TRANSFER,
 			STEPS.SITE_MIGRATION_PLUGIN_INSTALL,
 			STEPS.PROCESSING,
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
-			//STEPS.VERIFY_EMAIL,
-			STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN,
 			STEPS.SITE_MIGRATION_INSTRUCTIONS,
 			STEPS.ERROR,
 		];
@@ -250,28 +247,7 @@ const migrationSignup: Flow = {
 					return navigate( STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug );
 				}
 
-				case STEPS.VERIFY_EMAIL.slug: {
-					return navigate( STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug );
-				}
-
-				case STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug: {
-					if ( providedDependencies?.error ) {
-						return navigate( STEPS.ERROR.slug );
-					}
-
-					return navigate( STEPS.BUNDLE_TRANSFER.slug, {
-						siteId,
-						siteSlug,
-					} );
-				}
-
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
-					/*
-					if ( providedDependencies?.verifyEmail ) {
-						return navigate( STEPS.VERIFY_EMAIL.slug );
-					}
-					*/
-
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = addQueryArgs(
 							{
@@ -289,6 +265,7 @@ const migrationSignup: Flow = {
 						} );
 						return;
 					}
+
 					if ( providedDependencies?.freeTrialSelected ) {
 						return navigate( STEPS.BUNDLE_TRANSFER.slug, {
 							siteId,

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -136,6 +136,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ REBLOGGING_FLOW ]: () =>
 		import( /* webpackChunkName: "reblogging-flow" */ '../declarative-flow/reblogging' ),
+
+	'migration-signup': () =>
+		import( /* webpackChunkName: "migration-signup" */ '../declarative-flow/migration-signup' ),
 };
 
 const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(

--- a/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
@@ -117,5 +117,81 @@ describe( 'Migration Signup Flow', () => {
 				state: null,
 			} );
 		} );
+
+		it( 'redirects the user to instructions step if the plugin was installed successfully', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.PROCESSING.slug,
+				dependencies: {
+					pluginInstalled: true,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects the user to error step if there was an error during the process', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.PROCESSING.slug,
+				dependencies: {
+					error: true,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.ERROR.slug }`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects the user to the plugin install step from the processing step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.PROCESSING.slug,
+				dependencies: {
+					bundleTransfer: true,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug }`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects the user to the processing step from the migration plugin install step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.PROCESSING.slug }`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects the user to the processing step from the bundle transfer step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.BUNDLE_TRANSFER.slug,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.PROCESSING.slug }`,
+				state: {
+					bundleProcessing: true,
+				},
+			} );
+		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
@@ -27,6 +27,7 @@ describe( 'Migration Signup Flow', () => {
 
 	beforeEach( () => {
 		( window.location.assign as jest.Mock ).mockClear();
+		window.location.search = '';
 		( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( true );
 		( useIsSiteOwner as jest.Mock ).mockReturnValue( {
 			isOwner: true,
@@ -36,14 +37,33 @@ describe( 'Migration Signup Flow', () => {
 	describe( 'useAssertConditions', () => {
 		it( 'redirects the user to the login page when they are not logged in', () => {
 			( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( false );
+			const searchValue = '?ref=logged-out-homepage&aff=aff123&vid=vid321';
+			window.location.search = searchValue;
 
 			const { runUseAssertionCondition } = renderFlow( migrationSignupFlow );
 			runUseAssertionCondition( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+				currentURL: `/setup/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }${ searchValue }`,
 			} );
 
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				`/start/account/user-social?variationName=migration-signup&toStepper=true&redirect_to=/setup/migration-signup`
+				`/start/account/user-social?variationName=migration-signup&toStepper=true&redirect_to=/setup/migration-signup&vid=vid321&aff=aff123&ref=logged-out-homepage`
+			);
+		} );
+
+		it( 'redirects the user to the login page with the correct locale when they are not logged in', () => {
+			( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( false );
+			const searchValue = '?ref=logged-out-homepage&aff=aff123&vid=vid321&locale=fr';
+			window.location.search = searchValue;
+
+			const { runUseAssertionCondition } = renderFlow( migrationSignupFlow );
+			runUseAssertionCondition( {
+				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+				currentURL: `/setup/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }${ searchValue }`,
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				`/start/account/user-social/fr?variationName=migration-signup&toStepper=true&redirect_to=/setup/migration-signup%3Flocale%3Dfr&vid=vid321&aff=aff123&ref=logged-out-homepage`
 			);
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
+import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
+import { goToCheckout } from '../../utils/checkout';
+import { STEPS } from '../internals/steps';
+import migrationSignupFlow from '../migration-signup';
+import { getFlowLocation, renderFlow } from './helpers';
+// we need to save the original object for later to not affect tests from other files
+const originalLocation = window.location;
+
+jest.mock( '../../utils/checkout' );
+jest.mock( '@automattic/data-stores/src/user/selectors' );
+jest.mock( 'calypso/landing/stepper/hooks/use-is-site-owner' );
+
+describe( 'Migration Signup Flow', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+		} );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', originalLocation );
+	} );
+
+	beforeEach( () => {
+		( window.location.assign as jest.Mock ).mockClear();
+		( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( true );
+		( useIsSiteOwner as jest.Mock ).mockReturnValue( {
+			isOwner: true,
+		} );
+	} );
+
+	describe( 'useAssertConditions', () => {
+		it( 'redirects the user to the login page when they are not logged in', () => {
+			( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( false );
+
+			const { runUseAssertionCondition } = renderFlow( migrationSignupFlow );
+			runUseAssertionCondition( {
+				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				`/start/account/user-social?variationName=migration-signup&toStepper=true&redirect_to=/setup/migration-signup`
+			);
+		} );
+	} );
+
+	describe( 'useStepNavigation', () => {
+		it( 'redirects the user to the processing step from the create-site step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_CREATION_STEP.slug,
+				currentURL: `/setup/create-site`,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.PROCESSING.slug }?siteSlug=`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects the user to the site-migration-upgrade-plan step from the processing step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.PROCESSING.slug,
+				currentURL: `/setup/${ STEPS.PROCESSING.slug }?siteSlug=`,
+				dependencies: {
+					siteSlug: 'example.wordpress.com',
+					siteId: 123,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com`,
+				state: {
+					hideFreeMigrationTrialForNonVerifiedEmail: true,
+				},
+			} );
+		} );
+
+		it( 'redirects the user to the checkout page with the correct destination params', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentURL: `/setup/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com`,
+				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+				dependencies: {
+					goToCheckout: true,
+					plan: 'plan',
+				},
+			} );
+
+			expect( goToCheckout ).toHaveBeenCalledWith( {
+				destination: `/setup/migration-signup/${ STEPS.BUNDLE_TRANSFER.slug }?siteSlug=example.wordpress.com`,
+				flowName: 'migration-signup',
+				siteSlug: 'example.wordpress.com',
+				plan: 'plan',
+				stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+			} );
+		} );
+
+		it( 'redirects the user to the processing step from the site creation step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_CREATION_STEP.slug,
+				currentURL: `/setup/${ STEPS.SITE_CREATION_STEP.slug }?siteSlug=example.wordpress.com`,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.PROCESSING.slug }?siteSlug=example.wordpress.com`,
+				state: null,
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR creates a new `migration-signup` flow to make it possible for us to get new user signups to a migration as quickly as possible. The flow uses the following steps:
  - [Pseudo-step] If the user isn't logged in, we get the user logged in via a redirect to `/start/user/social`
  - We request site creation - `create-site`
    * We do this so we can safely push them to import content from other platforms later in the flow
  - We wait for the site to be created - `processing`
  - We ask the user to enter their source site - `site-migration-identify`
     * If the user doesn't have a WordPress site, we push them to `/setup/site-setup/importList`
     * If the user has a WordPress site, we proceed with the flow
  - We show the user monthly and annual Creator plan options and possibly a free trial plan (which depends on their email verification status) - `site-migration-upgrade-plan`
     * If the user selects a paid Creator plan, send them to checkout to pay - when they complete checkout, they should get redirected to the next step
     * If the user picks a trial, add the trial to the site, and proceed to the next step
  - Request a transfer to Atomic - `bundleTransfer`
  - Wait for the site to be transferred to Atomic - `processing`
  - Once the site has been transferred, install the Migrate Guru plugin - `site-migration-plugin-install`
  - Wait for the plugin to be installed - `processing`
  - Show the migration instructions - `site-migration-instructions`

Internal discussion about the flow and some impending improvements is in paYKcK-4uW-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* We basically want to test the `/setup/migration-signup` flow as much as possible, starting in logged-out and logged-in states.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?