### PR TITLE
Hosting Overview: Add loading placeholders

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -1,5 +1,5 @@
 import { PlanSlug } from '@automattic/calypso-products';
-import { Button, Card, PlanPrice } from '@automattic/components';
+import { Button, Card, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
@@ -31,6 +31,8 @@ const PlanCard: FC = () => {
 	} );
 	const translate = useTranslate();
 
+	const isLoading = ! pricing || ! planData;
+
 	return (
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
@@ -51,35 +53,59 @@ const PlanCard: FC = () => {
 				</div>
 				{ isPaidPlan && (
 					<>
-						<PlanPrice
-							className="hosting-overview__plan-price"
-							currencyCode={ planData?.currencyCode }
-							displayPerMonthNotation
-							isSmallestUnit
-							rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
-						/>
-						<div className="hosting-overview__plan-info">
-							{ translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
-								args: {
-									rawPrice: formatCurrency(
-										pricing?.[ planSlug ].originalPrice.full ?? 0,
-										planData?.currencyCode ?? '',
-										{
-											stripZeros: true,
-											isSmallestUnit: true,
-										}
-									),
-								},
-								components: {
-									span: <span />,
-								},
-							} ) }
-						</div>
-						<div className="hosting-overview__plan-info">
-							{ translate( 'Expires on %s.', {
-								args: moment( planData?.expiryDate ).format( 'LL' ),
-							} ) }
-						</div>
+						{ isLoading ? (
+							<LoadingPlaceholder
+								className="hosting-overview__plan-price-loading-placeholder"
+								width="100px"
+								height="32px"
+							/>
+						) : (
+							<PlanPrice
+								className="hosting-overview__plan-price"
+								currencyCode={ planData?.currencyCode }
+								displayPerMonthNotation
+								isSmallestUnit
+								rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
+							/>
+						) }
+						{ isLoading ? (
+							<LoadingPlaceholder
+								className="hosting-overview__plan-info-loading-placeholder"
+								width="200px"
+								height="16px"
+							/>
+						) : (
+							<div className="hosting-overview__plan-info">
+								{ translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
+									args: {
+										rawPrice: formatCurrency(
+											pricing?.[ planSlug ].originalPrice.full ?? 0,
+											planData?.currencyCode ?? '',
+											{
+												stripZeros: true,
+												isSmallestUnit: true,
+											}
+										),
+									},
+									components: {
+										span: <span />,
+									},
+								} ) }
+							</div>
+						) }
+						{ isLoading ? (
+							<LoadingPlaceholder
+								className="hosting-overview__plan-info-loading-placeholder"
+								width="200px"
+								height="16px"
+							/>
+						) : (
+							<div className="hosting-overview__plan-info">
+								{ translate( 'Expires on %s.', {
+									args: moment( planData?.expiryDate ).format( 'LL' ),
+								} ) }
+							</div>
+						) }
 					</>
 				) }
 				<PlanStorage

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -48,7 +48,8 @@
 }
 
 .hosting-overview__plan-card-header,
-.hosting-overview__plan-price {
+.hosting-overview__plan-price,
+.hosting-overview__plan-price-loading-placeholder {
 	display: flex;
 	margin-bottom: 8px;
 }
@@ -107,6 +108,10 @@ a.hosting-overview__link-button {
 	margin-bottom: 4px;
 }
 
+.hosting-overview__plan-info-loading-placeholder {
+	margin-bottom: 4px;
+}
+
 .hosting-overview__plan-storage {
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-0);
@@ -139,11 +144,13 @@ a.hosting-overview__link-button {
 }
 
 @media ( max-width: $break-xlarge ) {
-	.hosting-overview__plan-price {
+	.hosting-overview__plan-price,
+	.hosting-overview__plan-price-loading-placeholder {
 		margin-bottom: 4px;
 	}
 
-	.hosting-overview__plan-info {
+	.hosting-overview__plan-info,
+	.hosting-overview__plan-info-loading-placeholder {
 		margin-bottom: 2px;
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6384

## Proposed Changes

* There's some flickering on the plan data priceing and units while the data is loaded, so I'm adding loading placeholders to prevent that.

## Testing Instructions

- Open the live preview
- Go to `/hosting-overview`
- Choose a site
- Check that a loading placeholder is shown before the plan price data is available

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?