### PR TITLE
Hosting Overview: Adjust domains table styles

### DIFF
--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -1,6 +1,7 @@
 import { Button, Card } from '@automattic/components';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable } from '@automattic/domains-table';
+import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -9,6 +10,7 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const ActiveDomainsCard: FC = () => {
+	const forceMobile = useBreakpoint( '<660px' );
 	const site = useSelector( getSelectedSite );
 	const { data, isLoading } = useSiteDomainsQuery( site?.ID, {
 		queryFn: () => fetchSiteDomains( site?.ID ),
@@ -44,6 +46,7 @@ const ActiveDomainsCard: FC = () => {
 				isLoadingDomains={ isLoading }
 				domains={ data?.domains }
 				isAllSitesView={ false }
+				useMobileCards={ forceMobile }
 				siteSlug={ site?.slug ?? null }
 			/>
 		</Card>

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -43,6 +43,7 @@ const ActiveDomainsCard: FC = () => {
 
 			<DomainsTable
 				className="hosting-overview__domains-table"
+				hideCheckbox
 				isLoadingDomains={ isLoading }
 				domains={ data?.domains }
 				isAllSitesView={ false }

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -40,6 +40,7 @@ const ActiveDomainsCard: FC = () => {
 			</div>
 
 			<DomainsTable
+				className="hosting-overview__domains-table"
 				isLoadingDomains={ isLoading }
 				domains={ data?.domains }
 				isAllSitesView={ false }

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -265,6 +265,11 @@ a.hosting-overview__link-button {
 	font-family: "SF Pro Text", $sans;
 	padding: 0;
 
+	table {
+		border-top: 1px solid var(--gutenberg-gray-100, #f0f0f0);
+		margin-top: 0;
+	}
+
 	button {
 		font-family: "SF Pro Text", $sans;
 	}

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -279,4 +279,8 @@ a.hosting-overview__link-button {
 	.components-dropdown-menu__toggle {
 		transform: rotate(90deg);
 	}
+
+	.domains-table-mobile-card > div:not(:first-child) {
+		display: none;
+	}
 }

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -282,7 +282,19 @@ a.hosting-overview__link-button {
 		transform: rotate(90deg);
 	}
 
-	.domains-table-mobile-card > div:not(:first-child) {
-		display: none;
+	.domains-table-mobile-card {
+		padding: 12px 16px;
+
+		> div:not(:first-child) {
+			display: none;
+		}
+
+		.domains-table__primary-domain-label {
+			margin: 0;
+		}
+
+		&:last-child {
+			border: 0;
+		}
 	}
 }

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -282,9 +282,15 @@ a.hosting-overview__link-button {
 		transform: rotate(90deg);
 	}
 
+	.domains-table__bulk-action-container {
+		display: none;
+
+	}
+
 	.domains-table-mobile-card {
 		padding: 12px 16px;
 
+		.components-checkbox-control,
 		> div:not(:first-child) {
 			display: none;
 		}

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -262,6 +262,20 @@ a.hosting-overview__link-button {
 }
 
 .hosting-overview__domains-table {
+	.domains-table__primary-domain-label {
+		background-color: inherit;
+		color: var(--studio-green-40, #00a32a);
+		font-family: "SF Pro", $sans;
+		font-size: $font-body-small;
+		font-weight: 500;
+		line-height: 20px;
+		padding: 0;
+
+		svg {
+			display: none;
+		}
+	}
+
 	.components-dropdown-menu__toggle {
 		transform: rotate(90deg);
 	}

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -269,8 +269,10 @@ a.hosting-overview__link-button {
 		border-top: 1px solid var(--gutenberg-gray-100, #f0f0f0);
 		margin-top: 0;
 
-		th:first-child,
-		td:first-child {
+		th:not(.domains-table-checkbox-th):first-child,
+		th.domains-table-checkbox-th + th,
+		td:not(.domains-table-checkbox-td):first-child,
+		td.domains-table-checkbox-td + td {
 			padding-left: 16px;
 		}
 
@@ -310,9 +312,10 @@ a.hosting-overview__link-button {
 		transform: rotate(90deg);
 	}
 
-	.domains-table__bulk-action-container {
+	.domains-table__bulk-action-container,
+	.domains-table-checkbox-td,
+	.domains-table-checkbox-th {
 		display: none;
-
 	}
 
 	.domains-table-mobile-card {

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -268,10 +268,21 @@ a.hosting-overview__link-button {
 	table {
 		border-top: 1px solid var(--gutenberg-gray-100, #f0f0f0);
 		margin-top: 0;
+
+		th:first-child,
+		td:first-child {
+			padding-left: 16px;
+		}
+
+		th:last-child,
+		td:last-child {
+			padding-right: 16px;
+		}
 	}
 
 	button {
 		font-family: "SF Pro Text", $sans;
+		font-weight: 400;
 	}
 
 	.domains-table__primary-domain-label {

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -261,3 +261,8 @@ a.hosting-overview__link-button {
 	}
 }
 
+.hosting-overview__domains-table {
+	.components-dropdown-menu__toggle {
+		transform: rotate(90deg);
+	}
+}

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -262,20 +262,32 @@ a.hosting-overview__link-button {
 }
 
 .hosting-overview__domains-table {
+	font-family: "SF Pro Text", $sans;
 	padding: 0;
+
+	button {
+		font-family: "SF Pro Text", $sans;
+	}
 
 	.domains-table__primary-domain-label {
 		background-color: inherit;
 		color: var(--studio-green-40, #00a32a);
 		font-family: "SF Pro", $sans;
-		font-size: $font-body-small;
+		font-size: $font-body-extra-small;
 		font-weight: 500;
 		line-height: 20px;
+		margin: 0;
 		padding: 0;
 
 		svg {
 			display: none;
 		}
+	}
+
+	.domains-table__domain-name {
+		font-size: $font-body-small;
+		font-style: normal;
+		line-height: 20px;
 	}
 
 	.components-dropdown-menu__toggle {
@@ -295,12 +307,12 @@ a.hosting-overview__link-button {
 			display: none;
 		}
 
-		.domains-table__primary-domain-label {
-			margin: 0;
-		}
-
 		&:last-child {
 			border: 0;
 		}
 	}
+}
+
+.domains-table-row__actions-group {
+	font-family: "SF Pro Text", $sans;
 }

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -261,7 +261,7 @@ a.hosting-overview__link-button {
 	}
 }
 
-.hosting-overview__domains-table {
+.domains-table.hosting-overview__domains-table {
 	font-family: "SF Pro Text", $sans;
 	padding: 0;
 

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -262,6 +262,8 @@ a.hosting-overview__link-button {
 }
 
 .hosting-overview__domains-table {
+	padding: 0;
+
 	.domains-table__primary-domain-label {
 		background-color: inherit;
 		color: var(--studio-green-40, #00a32a);

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -97,7 +97,7 @@ export const DomainsTableHeader = ( {
 		<thead className={ listHeaderClasses }>
 			<tr>
 				{ canSelectAnyDomains && (
-					<th>
+					<th className="domains-table-checkbox-th">
 						<CheckboxControl
 							data-testid="domains-select-all-checkbox"
 							__nextHasNoMarginBottom

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -83,7 +83,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	return (
 		<tr key={ domain.domain }>
 			{ canSelectAnyDomains && (
-				<td>
+				<td className="domains-table-checkbox-td">
 					{ canBulkUpdate( domain ) && (
 						<CheckboxControl
 							__nextHasNoMarginBottom

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -53,6 +53,7 @@ interface BaseDomainsTableProps {
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
 	onDomainAction?: OnDomainAction;
 	userCanSetPrimaryDomains?: boolean;
+	hideCheckbox?: boolean;
 	isLoadingDomains?: boolean;
 	useMobileCards?: boolean;
 
@@ -304,10 +305,11 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 
 	const hasSelectedDomains = selectedDomains.size > 0;
 	const selectableDomains = ( domains ?? [] ).filter( canBulkUpdate );
-	const canSelectAnyDomains = isAllSitesView
-		? selectableDomains.length > 0
-		: ( ( domains as unknown as DomainData[] ) ?? [] ).filter( ( domain ) => ! domain.is_subdomain )
-				.length > 1;
+	const canSelectAnyDomains = true;
+	// const canSelectAnyDomains = isAllSitesView
+	// 	? selectableDomains.length > 0
+	// 	: ( ( domains as unknown as DomainData[] ) ?? [] ).filter( ( domain ) => ! domain.is_subdomain )
+	// 			.length > 1;
 	const areAllDomainsSelected = selectableDomains.length === selectedDomains.size;
 
 	const getBulkSelectionStatus = () => {

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -54,6 +54,7 @@ interface BaseDomainsTableProps {
 	onDomainAction?: OnDomainAction;
 	userCanSetPrimaryDomains?: boolean;
 	isLoadingDomains?: boolean;
+	useMobileCards?: boolean;
 
 	// These props allow table users to provide their own fetching functions. This is used for
 	// testing and for Calypso to provide functions that handle authentication in a special way.

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -47,6 +47,7 @@ type OnDomainAction = (
 ) => DomainActionDescription | void;
 
 interface BaseDomainsTableProps {
+	className?: string;
 	domains: PartialDomainData[] | DomainData[] | undefined;
 	isAllSitesView: boolean;
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions;

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -15,7 +15,7 @@ import { DomainsTableToolbar } from './domains-table-toolbar';
 import './style.scss';
 
 export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } ) {
-	const { className, footer, useMobileCards, ...allProps } = props;
+	const { className, hideCheckbox, footer, useMobileCards, ...allProps } = props;
 
 	const isMobile = useMobileBreakpoint();
 
@@ -40,7 +40,7 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 				) : (
 					<table
 						className={ classnames( `is-${ state.domainsTableColumns.length }-column`, {
-							'has-checkbox': state.canSelectAnyDomains,
+							'has-checkbox': state.canSelectAnyDomains && ! hideCheckbox,
 						} ) }
 					>
 						<DomainsTableHeader />

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -16,7 +16,7 @@ import './style.scss';
 
 export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } ) {
 	const isMobile = useMobileBreakpoint();
-	const { footer, ...allProps } = props;
+	const { className, footer, ...allProps } = props;
 
 	const state = useGenerateDomainsTableState( allProps );
 
@@ -31,7 +31,7 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 
 	return (
 		<DomainsTableStateContext.Provider value={ state }>
-			<div className="domains-table">
+			<div className={ classnames( className, 'domains-table' ) }>
 				<DomainsTableBulkUpdateNotice />
 				{ showDomainsToolbar && <DomainsTableToolbar /> }
 				{ isMobile ? (

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -15,8 +15,9 @@ import { DomainsTableToolbar } from './domains-table-toolbar';
 import './style.scss';
 
 export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } ) {
+	const { className, footer, useMobileCards, ...allProps } = props;
+
 	const isMobile = useMobileBreakpoint();
-	const { className, footer, ...allProps } = props;
 
 	const state = useGenerateDomainsTableState( allProps );
 
@@ -34,7 +35,7 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 			<div className={ classnames( className, 'domains-table' ) }>
 				<DomainsTableBulkUpdateNotice />
 				{ showDomainsToolbar && <DomainsTableToolbar /> }
-				{ isMobile ? (
+				{ useMobileCards ?? isMobile ? (
 					<DomainsTableMobileCards />
 				) : (
 					<table


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6384

## Proposed Changes

* This PR addresses some design inconsistencies noticed by @mmtr on https://github.com/Automattic/wp-calypso/pull/89584#issuecomment-2063547956

## Testing Instructions

* Open the live preview
* Go to `/hosting-overview`
* Check that the domains table matches the desktop (PZtnZ1nHhnBrsuXDoMJHPD-fi-446%3A153354) and mobile (IQgFHqGiN0eXkPn7Qkth4s-fi-6%3A8860) designs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?