### PR TITLE
Scheduled updates: Unify validation errors position and improve time picker on touch event

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-frequency.tsx
@@ -82,6 +82,7 @@ export function ScheduleFormFrequency( props: Props ) {
 								hour={ hour }
 								period={ period }
 								isAmPmFormat={ isAmPmFormat }
+								onTouch={ ( touched ) => setFieldTouched( touched ) }
 								onChange={ ( hour, period ) => {
 									setHour( hour );
 									setPeriod( period );
@@ -121,6 +122,7 @@ export function ScheduleFormFrequency( props: Props ) {
 										hour={ hour }
 										period={ period }
 										isAmPmFormat={ isAmPmFormat }
+										onTouch={ ( touched ) => setFieldTouched( touched ) }
 										onChange={ ( hour, period ) => {
 											setHour( hour );
 											setPeriod( period );

--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -49,15 +49,11 @@ export function ScheduleFormPaths( props: Props ) {
 		<div className="form-field form-field--paths">
 			<label htmlFor="paths">{ translate( 'Test URL paths' ) }</label>
 
-			{ newPathError ? (
-				<Text className="validation-msg">{ newPathError }</Text>
-			) : (
-				<Text className="info-msg">
-					{ translate(
-						'Your schedule will test your front page for errors. Do you want to add additional paths?'
-					) }
-				</Text>
-			) }
+			<Text className="info-msg">
+				{ translate(
+					'Your schedule will test your front page for errors. Do you want to add additional paths?'
+				) }
+			</Text>
 			<div className={ classnames( { 'form-control-container': borderWrapper } ) }>
 				<Text className="info-msg">Website URL paths</Text>
 
@@ -87,7 +83,7 @@ export function ScheduleFormPaths( props: Props ) {
 				</div>
 				{ paths.length < MAX_SELECTABLE_PATHS && (
 					<div className="new-path">
-						<Flex className="path" gap={ 2 }>
+						<Flex gap={ 2 }>
 							<FlexItem isBlock={ true }>
 								<InputControl
 									value={ newPath }
@@ -116,6 +112,7 @@ export function ScheduleFormPaths( props: Props ) {
 					</div>
 				) }
 			</div>
+			{ newPathError && <Text className="validation-msg">{ newPathError }</Text> }
 		</div>
 	);
 }

--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -91,30 +91,9 @@ export function ScheduleFormPlugins( props: Props ) {
 				{ plugins.length < MAX_SELECTABLE_PLUGINS ? plugins.length : MAX_SELECTABLE_PLUGINS }
 			</span>
 
-			{ ( () => {
-				if ( ( showError && error ) || ( fieldTouched && error ) ) {
-					return (
-						<Text className="validation-msg">
-							<Icon className="icon-info" icon={ info } size={ 16 } />
-							{ error }
-						</Text>
-					);
-				} else if ( isPluginsFetched && plugins.length === 0 ) {
-					return (
-						<Text className="validation-msg">
-							<Icon className="icon-info" icon={ info } size={ 16 } />
-							{ translate(
-								'The current site selection does not have any plugins that can be scheduled for updates.'
-							) }
-						</Text>
-					);
-				}
-				return (
-					<Text className="info-msg">
-						{ translate( 'Plugins not listed below are automatically updated by WordPress.com.' ) }
-					</Text>
-				);
-			} )() }
+			<Text className="info-msg">
+				{ translate( 'Plugins not listed below are automatically updated by WordPress.com.' ) }
+			</Text>
 
 			<div className={ classnames( { 'form-control-container': borderWrapper } ) }>
 				<SearchControl
@@ -159,6 +138,25 @@ export function ScheduleFormPlugins( props: Props ) {
 						) ) }
 				</div>
 			</div>
+			{ ( () => {
+				if ( ( showError && error ) || ( fieldTouched && error ) ) {
+					return (
+						<Text className="validation-msg">
+							<Icon className="icon-info" icon={ info } size={ 16 } />
+							{ error }
+						</Text>
+					);
+				} else if ( isPluginsFetched && plugins.length === 0 ) {
+					return (
+						<Text className="validation-msg">
+							<Icon className="icon-info" icon={ info } size={ 16 } />
+							{ translate(
+								'The current site selection does not have any plugins that can be scheduled for updates.'
+							) }
+						</Text>
+					);
+				}
+			} )() }
 		</div>
 	);
 }

--- a/client/blocks/plugins-scheduled-updates/schedule-form-time.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-time.tsx
@@ -7,15 +7,17 @@ interface Props {
 	hour: string;
 	period: string;
 	isAmPmFormat: boolean;
+	onTouch?: ( touched: boolean ) => void;
 	onChange: ( hour: string, period: string ) => void;
 }
 export function ScheduleFormTime( props: Props ) {
-	const { hour: initHour, period: initPeriod, isAmPmFormat, onChange } = props;
+	const { hour: initHour, period: initPeriod, isAmPmFormat, onTouch, onChange } = props;
 
 	const [ hour, setHour ] = useState(
 		isAmPmFormat ? initHour : convertHourTo24( initHour, initPeriod )
 	);
 	const [ period, setPeriod ] = useState( initPeriod );
+	const [ fieldTouched, setFieldTouched ] = useState( false );
 
 	useEffect( () => {
 		if ( isAmPmFormat ) {
@@ -29,6 +31,7 @@ export function ScheduleFormTime( props: Props ) {
 	useEffect( () => {
 		setPeriod( initPeriod );
 	}, [ initPeriod ] );
+	useEffect( () => onTouch?.( fieldTouched ), [ fieldTouched ] );
 
 	return (
 		<div className="form-field">
@@ -40,6 +43,7 @@ export function ScheduleFormTime( props: Props ) {
 					options={ isAmPmFormat ? HOUR_OPTIONS : HOUR_OPTIONS_24 }
 					onChange={ ( hour ) => {
 						setHour( hour );
+						setFieldTouched( true );
 
 						if ( isAmPmFormat ) {
 							onChange?.( hour, period );
@@ -60,6 +64,7 @@ export function ScheduleFormTime( props: Props ) {
 						options={ PERIOD_OPTIONS }
 						onChange={ ( period ) => {
 							setPeriod( period );
+							setFieldTouched( true );
 							onChange?.( hour, period );
 						} }
 					/>

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -13,6 +13,10 @@
 		border-radius: 2px;
 	}
 
+	.validation-msg {
+		margin: 0.5rem 0;
+	}
+
 	.components-text-control__input {
 		border-color: var(--studio-gray-10);
 	}
@@ -129,7 +133,6 @@
 	.radio-option {
 		padding: 1.5rem;
 		flex-basis: 100%;
-		margin-bottom: 0.5rem !important;
 
 		.form-field--frequency-container {
 			flex-direction: column;
@@ -198,6 +201,8 @@
 		}
 
 		.new-path {
+			margin-bottom: 0.75rem;
+
 			.components-input-control__backdrop {
 				border-color: var(--studio-gray-10);
 			}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/89763

## Proposed Changes

* Unify the position of the validation errors component inside the scheduled updates form
* Improved onTouch event on time-picker component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that you have one scheduled updates item (example, at 2pm)
* Try to create a new one, select 2pm
* Check if there is a validation message (before this change, it only reacts if you switch between frequencies or press create/update button)

| Before | After |
|--------|--------|
| ![Screen Capture on 2024-04-23 at 17-37-58](https://github.com/Automattic/wp-calypso/assets/1241413/e8179b6b-9a40-4ede-b0fc-1cc7d15634ea) | ![Screen Capture on 2024-04-23 at 17-38-38](https://github.com/Automattic/wp-calypso/assets/1241413/bcc12c21-28f1-4a1a-b35e-267b0dabb4ef) | 

* Check the validation component position
* See the attachment 👇 

<img width="1042" alt="Screenshot 2024-04-23 at 17 40 05" src="https://github.com/Automattic/wp-calypso/assets/1241413/8507f43a-00f8-4a3e-9a16-b20406c093e5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?