### PR TITLE
Fix getDomainProductSlug function

### DIFF
--- a/client/lib/domains/get-domain-product-slug.js
+++ b/client/lib/domains/get-domain-product-slug.js
@@ -4,7 +4,7 @@ export function getDomainProductSlug( domain ) {
 	const tld = getTld( domain );
 	const tldSlug = tld.replace( /\./g, 'dot' );
 
-	if ( [ 'com', 'net', 'org' ].includes( tldSlug ) ) {
+	if ( 'com' === tldSlug ) {
 		return 'domain_reg';
 	}
 

--- a/client/lib/domains/test/index.js
+++ b/client/lib/domains/test/index.js
@@ -1,5 +1,9 @@
 import { forEach } from 'lodash';
-import { getFixedDomainSearch, getDomainSuggestionSearch } from 'calypso/lib/domains';
+import {
+	getFixedDomainSearch,
+	getDomainSuggestionSearch,
+	getDomainProductSlug,
+} from 'calypso/lib/domains';
 
 describe( 'index', () => {
 	describe( '#getFixedDomainSearch', () => {
@@ -53,6 +57,20 @@ describe( 'index', () => {
 		test( 'should return the original search string if it is long enough and is not one of the ignored strings', () => {
 			const search = 'hippos';
 			expect( getDomainSuggestionSearch( search ) ).toEqual( search );
+		} );
+	} );
+
+	describe( '#getDomainProductSlug', () => {
+		test( 'should return dotorg_domain for a .org domain', () => {
+			expect( getDomainProductSlug( 'test-domain.org' ) ).toEqual( 'dotorg_domain' );
+		} );
+
+		test( 'should return dotnet_domain for a .net domain', () => {
+			expect( getDomainProductSlug( 'test-domain.net' ) ).toEqual( 'dotnet_domain' );
+		} );
+
+		test( 'should return domain_reg for a .com domain', () => {
+			expect( getDomainProductSlug( 'test-domain.com' ) ).toEqual( 'domain_reg' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

`getDomainProductSlug` is returning `domain_reg` for `.net` and `.org` domains. We split `domain_reg` product, so those tlds have new product ids and slugs (`dotorg_domain` and `dotnet_domain`).

## Testing Instructions

I added a test for the function.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?