### PR TITLE
User Invite: Hide invite button for simple sites

### DIFF
--- a/client/my-sites/people/people-list-item/index.tsx
+++ b/client/my-sites/people/people-list-item/index.tsx
@@ -7,12 +7,13 @@ import React from 'react';
 import { getRole } from 'calypso/blocks/importer/wordpress/import-everything/import-users/utils';
 import { userCan } from 'calypso/lib/site/utils';
 import PeopleProfile from 'calypso/my-sites/people/people-profile';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordGoogleEvent, composeAnalytics } from 'calypso/state/analytics/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { requestSiteInvites } from 'calypso/state/invites/actions';
 import { createNotice, removeNotice } from 'calypso/state/notices/actions';
 import { NoticeStatus } from 'calypso/state/notices/types';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { Invite } from '../team-invites/types';
 import type { Member, SiteDetails } from '@automattic/data-stores';
 import './style.scss';
@@ -45,6 +46,7 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 	const siteId = site && site?.ID;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isSimple = useSelector( isSimpleSite );
 
 	const { isPending: isSubmittingInvites, mutateAsync: sendInvites } = useSendInvites(
 		siteId as number
@@ -77,7 +79,8 @@ const PeopleListItem: React.FC< PeopleListItemProps > = ( {
 			! user.linked_user_ID &&
 			site &&
 			site.slug &&
-			! isSelectable
+			! isSelectable &&
+			! isSimple
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89783

## Proposed Changes

* Hides broken invite button on Calypso "All users" screen for Simple Sites.

Simple site before:

<img width="500" alt="CleanShot 2024-04-23 at 12 26 40@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/cd31998b-bc16-4d28-92a1-1cf58a5b20bb">


Simple site after:

<img width="500" alt="CleanShot 2024-04-23 at 12 29 25@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/4d7600c2-6919-4834-b9a0-ea4cec0d0e47">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/people/team/{SITE_SLUG}` (simple site)
* Verify the invite button is not visible for site users
* Navigate to all users screen for atomic and verify the invite button is visible for users below the `Invite the users below to join WordPress.com, so they can log in securely using Secure Sign On.` banner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?