### PR TITLE
Scheduled updates: Show placeholder when the plugins feature is not available

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -36,6 +36,7 @@ export function ScheduleFormPlugins( props: Props ) {
 	} = props;
 	const translate = useTranslate();
 	const plugins = useMemo( () => props.plugins || [], [ props.plugins ] );
+	const pluginsAvailable = props.plugins !== undefined;
 
 	const [ pluginSearchTerm, setPluginSearchTerm ] = useState( '' );
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( initSelectedPlugins );
@@ -86,57 +87,72 @@ export function ScheduleFormPlugins( props: Props ) {
 	return (
 		<div className="form-field form-field--plugins">
 			<label htmlFor="plugins">{ translate( 'Select plugins' ) }</label>
-			<span className="plugin-select-stats">
-				{ selectedPlugins.length }/
-				{ plugins.length < MAX_SELECTABLE_PLUGINS ? plugins.length : MAX_SELECTABLE_PLUGINS }
-			</span>
+			{ pluginsAvailable && (
+				<span className="plugin-select-stats">
+					{ selectedPlugins.length }/
+					{ plugins.length < MAX_SELECTABLE_PLUGINS ? plugins.length : MAX_SELECTABLE_PLUGINS }
+				</span>
+			) }
 
-			<Text className="info-msg">
-				{ translate( 'Plugins not listed below are automatically updated by WordPress.com.' ) }
-			</Text>
+			{ pluginsAvailable && (
+				<Text className="info-msg">
+					{ translate( 'Plugins not listed below are automatically updated by WordPress.com.' ) }
+				</Text>
+			) }
 
 			<div className={ classnames( { 'form-control-container': borderWrapper } ) }>
-				<SearchControl
-					id="plugins"
-					onChange={ setPluginSearchTerm }
-					value={ pluginSearchTerm }
-					placeholder={ translate( 'Search plugins' ) }
-				/>
-				<div className="checkbox-options-container">
-					{ isPluginsFetching && <Spinner /> }
-					{ isPluginsFetched &&
-						plugins.length !== 0 &&
-						plugins.length <= MAX_SELECTABLE_PLUGINS && (
-							<CheckboxControl
-								label={ translate( 'Select all' ) }
-								indeterminate={
-									selectedPlugins.length > 0 && selectedPlugins.length < plugins.length
-								}
-								checked={ selectedPlugins.length === plugins.length }
-								onChange={ onPluginSelectAllChange }
-							/>
-						) }
-					{ isPluginsFetched &&
-						plugins.map( ( plugin ) => (
-							<Fragment key={ plugin.plugin }>
-								{ plugin.name.toLowerCase().includes( pluginSearchTerm.toLowerCase() ) && (
+				{ pluginsAvailable && (
+					<>
+						<SearchControl
+							id="plugins"
+							onChange={ setPluginSearchTerm }
+							value={ pluginSearchTerm }
+							placeholder={ translate( 'Search plugins' ) }
+						/>
+						<div className="checkbox-options-container">
+							{ isPluginsFetching && <Spinner /> }
+							{ isPluginsFetched &&
+								plugins.length !== 0 &&
+								plugins.length <= MAX_SELECTABLE_PLUGINS && (
 									<CheckboxControl
-										key={ plugin.plugin }
-										label={ plugin.name }
-										checked={ selectedPlugins.includes( plugin.plugin ) }
-										disabled={ isPluginSelectionDisabled( plugin ) }
-										className={ classnames( {
-											disabled: isPluginSelectionDisabled( plugin ),
-										} ) }
-										onChange={ ( isChecked ) => {
-											onPluginSelectionChange( plugin, isChecked );
-											setFieldTouched( true );
-										} }
+										label={ translate( 'Select all' ) }
+										indeterminate={
+											selectedPlugins.length > 0 && selectedPlugins.length < plugins.length
+										}
+										checked={ selectedPlugins.length === plugins.length }
+										onChange={ onPluginSelectAllChange }
 									/>
 								) }
-							</Fragment>
-						) ) }
-				</div>
+							{ isPluginsFetched &&
+								plugins.map( ( plugin ) => (
+									<Fragment key={ plugin.plugin }>
+										{ plugin.name.toLowerCase().includes( pluginSearchTerm.toLowerCase() ) && (
+											<CheckboxControl
+												key={ plugin.plugin }
+												label={ plugin.name }
+												checked={ selectedPlugins.includes( plugin.plugin ) }
+												disabled={ isPluginSelectionDisabled( plugin ) }
+												className={ classnames( {
+													disabled: isPluginSelectionDisabled( plugin ),
+												} ) }
+												onChange={ ( isChecked ) => {
+													onPluginSelectionChange( plugin, isChecked );
+													setFieldTouched( true );
+												} }
+											/>
+										) }
+									</Fragment>
+								) ) }
+						</div>
+					</>
+				) }
+				{ ! pluginsAvailable && (
+					<p className="placeholder-info">
+						{ translate(
+							'Once you select the sites that you want to include in your schedule, we will show you the plugins included in the selection.'
+						) }
+					</p>
+				) }
 			</div>
 			{ ( () => {
 				if ( ( showError && error ) || ( fieldTouched && error ) ) {

--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -36,7 +36,7 @@ export function ScheduleFormPlugins( props: Props ) {
 	} = props;
 	const translate = useTranslate();
 	const plugins = useMemo( () => props.plugins || [], [ props.plugins ] );
-	const pluginsAvailable = props.plugins !== undefined;
+	const pluginsAvailable = props.plugins !== undefined || isPluginsFetching;
 
 	const [ pluginSearchTerm, setPluginSearchTerm ] = useState( '' );
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( initSelectedPlugins );

--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -148,9 +148,7 @@ export function ScheduleFormPlugins( props: Props ) {
 				) }
 				{ ! pluginsAvailable && (
 					<p className="placeholder-info">
-						{ translate(
-							'Once you select the sites that you want to include in your schedule, we will show you the plugins included in the selection.'
-						) }
+						{ translate( 'Please select a site to view available plugins.' ) }
 					</p>
 				) }
 			</div>

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -63,6 +63,10 @@
 			border: solid 1px var(--studio-gray-10);
 			background-color: var(--studio-white);
 		}
+
+		.components-base-control__field {
+			display: block !important;
+		}
 	}
 
 	.checkbox-options-container {

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -45,6 +45,15 @@
 		margin-bottom: 0.5rem;
 	}
 
+	.placeholder-info {
+		max-width: 510px;
+		margin: 3rem auto;
+		color: var(--studio-gray-100);
+		text-align: center;
+		font-weight: 500;
+		font-size: 1rem;
+	}
+
 	.components-spinner {
 		display: block;
 		margin: 3rem auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Show placeholder when the plugins list is not available
* Handle search control width issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Multi-site context: Go to `/plugins/scheduled-updates/create?flags=plugins/multisite-scheduled-updates`
* Check the placeholder info is rendered in case when sites are not selected

<img width="1042" alt="Screenshot 2024-04-23 at 18 42 45" src="https://github.com/Automattic/wp-calypso/assets/1241413/a3021325-411e-4eb0-a847-c8b4f310bd1f">

| Before | After |
|--------|--------|
| <img width="489" alt="Screenshot 2024-04-23 at 18 33 40" src="https://github.com/Automattic/wp-calypso/assets/1241413/fbbf4b34-b24f-4c7d-845d-a5c76e327786"> | <img width="439" alt="Screenshot 2024-04-23 at 18 33 50" src="https://github.com/Automattic/wp-calypso/assets/1241413/3bdf1a96-0ccc-4a83-98af-991996b8bb41"> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?