### PR TITLE
Checkout: Fix promotional period TOS for renewals

### DIFF
--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -81,6 +81,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 		const endDate = moment( args.subscription_end_of_promotion_date ).format( 'll' );
 		const numberOfDays = args.subscription_pre_renew_reminder_days || 7;
 		const renewalDate = moment( args.subscription_auto_renew_date ).format( 'll' );
+		const regularRenewalDate = moment( args.subscription_regular_auto_renew_date ).format( 'll' );
 
 		const termLengthText = translate(
 			'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s.',
@@ -108,7 +109,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 			'On %(endDate)s, we will attempt to renew your subscription for %(maybeProratedRegularPrice)s.',
 			{
 				args: {
-					endDate,
+					endDate: regularRenewalDate,
 					maybeProratedRegularPrice,
 				},
 			}
@@ -147,9 +148,9 @@ function getMessageForTermsOfServiceRecordUnknown(
 		// we are already showing as the next renewal info is the same as the
 		// end of promotion renewal info.
 		const shouldShowEndOfPromotionText =
-			// Show the endOfPromotionChargeText if the endDate differs from
-			// the renewalDate because it is about the endDate.
-			renewalDate !== endDate ||
+			// Show the endOfPromotionChargeText if the regularRenewalDate differs from
+			// the renewalDate because it is about the regularRenewalDate.
+			renewalDate !== regularRenewalDate ||
 			// Show the endOfPromotionChargeText if the
 			// maybeProratedRegularPrice differs from the renewalPrice because
 			// it is about the maybeProratedRegularPrice.

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -8,7 +8,6 @@ import {
 import { EDIT_PAYMENT_DETAILS } from '@automattic/urls';
 import debugFactory from 'debug';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import moment from 'moment';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector } from 'calypso/state';
@@ -46,6 +45,17 @@ export default function AdditionalTermsOfServiceInCart() {
 	);
 }
 
+function formatDate( isoDate: string ): string {
+	// This somewhat mimics `moment.format('ll')` (used here formerly) without
+	// needing the depdecated `moment` package.
+	return new Date( Date.parse( isoDate ) ).toLocaleDateString( 'en-US', {
+		weekday: undefined,
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric',
+	} );
+}
+
 function getMessageForTermsOfServiceRecordUnknown(
 	termsOfServiceRecord: TermsOfServiceRecord,
 	translate: ReturnType< typeof useTranslate >,
@@ -66,7 +76,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
-	const startDate = moment( args.subscription_start_date ).format( 'll' );
+	const startDate = formatDate( args.subscription_start_date );
 	const maybeProratedRegularPrice = formatCurrency(
 		args.maybe_prorated_regular_renewal_price_integer,
 		currency,
@@ -78,10 +88,12 @@ function getMessageForTermsOfServiceRecordUnknown(
 	const manageSubscriptionLink = `/purchases/subscriptions/${ siteSlug }`;
 
 	if ( doesTermsOfServiceRecordHaveDates( args ) ) {
-		const endDate = moment( args.subscription_end_of_promotion_date ).format( 'll' );
+		const endDate = formatDate( args.subscription_end_of_promotion_date );
 		const numberOfDays = args.subscription_pre_renew_reminder_days || 7;
-		const renewalDate = moment( args.subscription_auto_renew_date ).format( 'll' );
-		const regularRenewalDate = moment( args.subscription_regular_auto_renew_date ).format( 'll' );
+		const renewalDate = formatDate( args.subscription_auto_renew_date );
+		const proratedRenewalDate = formatDate(
+			args.subscription_maybe_prorated_regular_auto_renew_date
+		);
 
 		const termLengthText = translate(
 			'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s.',
@@ -109,7 +121,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 			'On %(endDate)s, we will attempt to renew your subscription for %(maybeProratedRegularPrice)s.',
 			{
 				args: {
-					endDate: regularRenewalDate,
+					endDate: proratedRenewalDate,
 					maybeProratedRegularPrice,
 				},
 			}
@@ -148,9 +160,9 @@ function getMessageForTermsOfServiceRecordUnknown(
 		// we are already showing as the next renewal info is the same as the
 		// end of promotion renewal info.
 		const shouldShowEndOfPromotionText =
-			// Show the endOfPromotionChargeText if the regularRenewalDate differs from
-			// the renewalDate because it is about the regularRenewalDate.
-			renewalDate !== regularRenewalDate ||
+			// Show the endOfPromotionChargeText if the proratedRenewalDate differs from
+			// the renewalDate because it is about the proratedRenewalDate.
+			renewalDate !== proratedRenewalDate ||
 			// Show the endOfPromotionChargeText if the
 			// maybeProratedRegularPrice differs from the renewalPrice because
 			// it is about the maybeProratedRegularPrice.

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -793,12 +793,6 @@ export interface TermsOfServiceRecordArgsBase {
 	renewal_price_integer: number;
 
 	/**
-	 * If the promotional price is due to an introductory offer, this is true
-	 * when `should_prorate_when_offer_ends` is set on the offer.
-	 */
-	is_renewal_price_prorated: boolean;
-
-	/**
 	 * The price of the product after the promotional pricing expires. If the
 	 * next auto-renewal after the price expires would prorate the renewal price,
 	 * this DOES NOT include that proration. See
@@ -829,7 +823,7 @@ export interface TermsOfServiceRecordArgsBase {
 	 * included.
 	 *
 	 * This is the price that we will attempt to charge on
-	 * `subscription_regular_auto_renew_date`.
+	 * `subscription_maybe_prorated_regular_auto_renew_date`.
 	 *
 	 * This price is an integer in the currency's smallest unit.
 	 */
@@ -852,17 +846,20 @@ export interface TermsOfServiceRecordArgsRenewal extends TermsOfServiceRecordArg
 
 	/**
 	 * This date that an auto-renew will be attempted with the non-promotional
-	 * price (`maybe_prorated_regular_renewal_price_integer`).
+	 * possibly prorated price (`maybe_prorated_regular_renewal_price_integer`).
 	 *
 	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
 	 *
-	 * If the promotional price only lasts for the initial purchase, then this
-	 * will be the same as `subscription_auto_renew_date`.
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
+	subscription_maybe_prorated_regular_auto_renew_date: string;
+
+	/**
+	 * This date that an auto-renew will be attempted with the non-promotional
+	 * regular recurring price (`regular_renewal_price_integer`).
 	 *
-	 * If the auto-renewal happens on the same date as the end of the
-	 * promotion, this may be the same as `subscription_end_of_promotion_date`,
-	 * but if the subscription renews earlier than its expiry date, it will be
-	 * before that.
+	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
 	 *
 	 * Only set if we can easily determine when the product will renew. Does not
 	 * apply to domain transfers or multi-year domains.

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -839,17 +839,35 @@ export interface TermsOfServiceRecordArgsBase {
 export interface TermsOfServiceRecordArgsRenewal extends TermsOfServiceRecordArgsBase {
 	/**
 	 * The date that the promotional pricing will end, formatted as a ISO 8601
-	 * date (eg: `2004-02-12T15:19:21+00:00`). This will be the date that an
-	 * auto-renew will be attempted with the non-promotional price
-	 * (`maybe_prorated_regular_renewal_price_integer`).
-	 *
-	 * If the promotional price only lasts for the initial purchase, then this
-	 * will be the same as `subscription_auto_renew_date`.
+	 * date (eg: `2004-02-12T15:19:21+00:00`). This may be the date that an
+	 * auto-renew will be attempted with the non-promotional price, but if the
+	 * subscription renews earlier than the expiry date, the renewal may happen
+	 * earlier than this date. See `subscription_regular_auto_renew_date` for
+	 * the actual date of the non-promotional renewal.
 	 *
 	 * Only set if we can easily determine when the product will renew. Does not
 	 * apply to domain transfers or multi-year domains.
 	 */
 	subscription_end_of_promotion_date: string;
+
+	/**
+	 * This date that an auto-renew will be attempted with the non-promotional
+	 * price (`maybe_prorated_regular_renewal_price_integer`).
+	 *
+	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
+	 *
+	 * If the promotional price only lasts for the initial purchase, then this
+	 * will be the same as `subscription_auto_renew_date`.
+	 *
+	 * If the auto-renewal happens on the same date as the end of the
+	 * promotion, this may be the same as `subscription_end_of_promotion_date`,
+	 * but if the subscription renews earlier than its expiry date, it will be
+	 * before that.
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
+	subscription_regular_auto_renew_date: string;
 
 	/**
 	 * The date when the product's subscription will expire if not renewed. This

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -829,7 +829,7 @@ export interface TermsOfServiceRecordArgsBase {
 	 * included.
 	 *
 	 * This is the price that we will attempt to charge on
-	 * `subscription_end_of_promotion_date`.
+	 * `subscription_regular_auto_renew_date`.
 	 *
 	 * This price is an integer in the currency's smallest unit.
 	 */


### PR DESCRIPTION
## Proposed Changes

When purchasing a product that has an introductory offer, we display "promotional price" text at the bottom of checkout to tell the user how long the different pricing lasts and explicitly show the dates of upcoming renewals and their prices.

[Here](https://github.com/Automattic/wp-calypso/blob/11f901af8af829213e27ee858c43171382474de2/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx#L86) the promotional period data uses `subscription_end_of_promotion_date` as the date that the promotional period ends, but then [here](https://github.com/Automattic/wp-calypso/blob/11f901af8af829213e27ee858c43171382474de2/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx#L108) that same date is used to mean when the next auto-renewal will be for the non-promotional price. If the product renews eg: 30 days early, then those two are different things.

In this PR we modify the promotional price text to use separate dates for the end of the promotional period (`subscription_end_of_promotion_date`) and the non-promotional auto-renewal date (`subscription_regular_auto_renew_date`).

The following screenshots show what would happen for a renewal of an annual Titan Mail subscription (3 months free).

Before (without D145411 or this PR)             |  After (with D145411 and this PR)
:-------------------------:|:-------------------------:
<img width="563" alt="renewal-before" src="https://github.com/Automattic/wp-calypso/assets/2036909/4eb7b7ee-4eb7-4aef-9e8f-4fae725c19b3"> | <img width="555" alt="renewal-after" src="https://github.com/Automattic/wp-calypso/assets/2036909/bab25cad-3685-446f-accb-26c6575e2869">

Requires D145411-code which also fixes a bunch of edge cases around dates for renewals.

## Testing Instructions

- Buy a Professional Email 3-month free trial (**make sure it has the free trial as sandboxed plans do not include this**).
- Apply D145411-code and sandbox the API.
- Go to renew the email trial and verify that the "promotional period" text at the bottom of checkout has the correct dates and prices.

