### PR TITLE
Site Migration: Optionally skip polling if the email is verified

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
@@ -12,7 +12,7 @@ import type { Step } from '../../types';
 import type { UserData } from 'calypso/lib/user/user';
 import './style.scss';
 
-const ImportVerifyEmail: Step = function ImportVerifyEmail( { navigation } ) {
+const ImportVerifyEmail: Step = function ImportVerifyEmail( { navigation, data } ) {
 	const dispatch = useDispatch();
 	const { goBack, submit } = navigation;
 	const user = useSelector( getCurrentUser ) as UserData;
@@ -27,13 +27,27 @@ const ImportVerifyEmail: Step = function ImportVerifyEmail( { navigation } ) {
 		return null;
 	}
 
+	// Default behavior is to poll to see if the email has been verified
+	let pollForEmailVerification = true;
+	if ( data?.pollForEmailVerification !== undefined ) {
+		// But we can optionally disable polling by passing data.pollForEmailVerification = false
+		pollForEmailVerification = data?.pollForEmailVerification as boolean;
+	}
+
 	return (
 		<>
-			{ ! user.email_verified && (
-				<Interval
-					onTick={ () => dispatch( fetchCurrentUser() as any ) }
-					period={ EVERY_FIVE_SECONDS }
-				/>
+			{ pollForEmailVerification && ! user.email_verified && (
+				<>
+					<span
+						id="email-verification-interval"
+						data-testid="email-verification-interval"
+						style={ { display: 'none' } }
+					/>
+					<Interval
+						onTick={ () => dispatch( fetchCurrentUser() as any ) }
+						period={ EVERY_FIVE_SECONDS }
+					/>
+				</>
 			) }
 			<StepContainer
 				className="import-layout__center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/test/index.tsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import ImportVerifyEmail from '..';
+import { StepProps } from '../../../types';
+import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
+
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
+	useSite: jest.fn(),
+} ) );
+
+const render = ( props?: Partial< StepProps >, renderOptions?: RenderStepOptions ) => {
+	const combinedProps = { ...mockStepProps( props ) };
+	return renderStep( <ImportVerifyEmail { ...combinedProps } />, renderOptions );
+};
+
+describe( 'ImportVerifyEmail', () => {
+	beforeAll( () => {
+		nock.disableNetConnect();
+		( useSelector as jest.Mock ).mockReturnValue( { email_verified: false } );
+		( useSite as jest.Mock ).mockReturnValue( { domain: 'example.wordpress.com' } );
+	} );
+
+	test( 'show <Interval> by default', () => {
+		render();
+		expect( screen.getByTestId( 'email-verification-interval' ) ).toBeInTheDocument();
+	} );
+
+	test( "don't show <Interval> when pollForEmailVerification is false", () => {
+		render( { data: { pollForEmailVerification: false } } );
+		expect( screen.queryByTestId( 'email-verification-interval' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'show <Interval> when pollForEmailVerification is true', () => {
+		render( { data: { pollForEmailVerification: true } } );
+		expect( screen.getByTestId( 'email-verification-interval' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -290,7 +290,11 @@ const siteMigration: Flow = {
 								in_site_migration_flow: true,
 							} );
 						}
-						return navigate( STEPS.VERIFY_EMAIL.slug );
+
+						// We don't want the Verify Email step to poll for email verification since the new verification email will redirect them back into the flow.
+						return navigate( STEPS.VERIFY_EMAIL.slug, {
+							pollForEmailVerification: false,
+						} );
 					}
 
 					if ( providedDependencies?.goToCheckout ) {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -234,7 +234,9 @@ describe( 'Site Migration Flow', () => {
 			await waitFor( () => {
 				expect( getFlowLocation() ).toEqual( {
 					path: `/${ STEPS.VERIFY_EMAIL.slug }`,
-					state: null,
+					state: {
+						pollForEmailVerification: false,
+					},
 				} );
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89401

## Proposed Changes

**NOTE: This shouldn't be merged until D146149-code has landed.**

The import-verify-email step, by default, will poll continuously to see if the email has been verified. Once the email is verified, the `submit` function is triggered.

This allows us to optionally disable polling. In the case of the site-migration flow, we don't want to submit the step since the user is going to be redirect back to the flow after clicking on the verification email.

## Testing Instructions

* Verify tests pass:
```
yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/test
```

* Visual inspection.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
- [ ]