### PR TITLE
A4A: add feature flag to allow logged-out signup flow

### DIFF
--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx
@@ -8,10 +8,12 @@ import {
 	hasFetchedAgency,
 	isFetchingAgency,
 } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import SignupIntro from '../../intro';
 import SignupForm from '../../signup-form';
 
 export default function AgencySignup() {
+	const userLoggedIn = useSelector( isUserLoggedIn );
 	const agency = useSelector( getActiveAgency );
 	const hasFetched = useSelector( hasFetchedAgency );
 	const isFetching = useSelector( isFetchingAgency );
@@ -27,7 +29,7 @@ export default function AgencySignup() {
 	}, [ agency ] );
 
 	// Show nothing if we haven't fetched the agency record yet, or if we're in the process of fetching it.
-	if ( ! hasFetched || isFetching || agency ) {
+	if ( userLoggedIn && ( ! hasFetched || isFetching || agency ) ) {
 		return null;
 	}
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -12,6 +12,7 @@ import Modal from 'react-modal';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
 import { ProviderWrappedLayout } from 'calypso/controller';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
 import { tracksEvents } from 'calypso/lib/analytics/tracks';
@@ -50,8 +51,6 @@ import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 import { setupLocale } from './locale';
 
 const debug = debugFactory( 'calypso' );
-
-const isA8CForAgenciesEnabled = config.isEnabled( 'a8c-for-agencies' );
 
 const setupContextMiddleware = ( reduxStore, reactQueryClient ) => {
 	page( '*', ( context, next ) => {
@@ -136,7 +135,7 @@ function saveOauthFlags() {
 
 function authorizePath() {
 	const redirectUri = new URL(
-		isJetpackCloud() || isA8CForAgenciesEnabled ? '/connect/oauth/token' : '/api/oauth/token',
+		isJetpackCloud() || isA8CForAgencies() ? '/connect/oauth/token' : '/api/oauth/token',
 		window.location
 	);
 	redirectUri.search = new URLSearchParams( {
@@ -156,6 +155,7 @@ function authorizePath() {
 }
 
 const JP_CLOUD_PUBLIC_ROUTES = [ '/pricing', '/plans', '/features/comparison', '/manage/pricing' ];
+const A4A_PUBLIC_ROUTES = [ '/signup' ];
 
 const oauthTokenMiddleware = () => {
 	if ( config.isEnabled( 'oauth' ) ) {
@@ -168,6 +168,12 @@ const oauthTokenMiddleware = () => {
 					...JP_CLOUD_PUBLIC_ROUTES.map( ( route ) => `/${ slug }${ route }` )
 				);
 			} );
+		}
+
+		if ( isA8CForAgencies() ) {
+			if ( config.isEnabled( 'a4a-logged-out-signup' ) ) {
+				loggedOutRoutes.push( ...A4A_PUBLIC_ROUTES );
+			}
 		}
 
 		// Forces OAuth users to the /login page if no token is present

--- a/client/sections.js
+++ b/client/sections.js
@@ -786,6 +786,7 @@ const sections = [
 		paths: [ '/signup' ],
 		module: 'calypso/a8c-for-agencies/sections/signup',
 		group: 'a8c-for-agencies',
+		enableLoggedOut: true,
 	},
 ];
 

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -30,7 +30,8 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"oauth": true,
-		"a4a/site-details-pane": true
+		"a4a/site-details-pane": true,
+		"a4a-logged-out-signup": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/330

## Proposed Changes

This PR adds a feature flag to allow access to A4A signup page while logged out.
Note: there are some errors in console, but they will be addressed in future PRs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- While logged out from WPCOM navigate to `/singup`. You should see signup page.
- Note: if you use live link add `?flags=a4a-logged-out-signup` to url

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?