### PR TITLE
WIP - Add/site dashboard v2 search

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-v2/index.tsx
@@ -85,19 +85,35 @@ const SitesDashboardV2 = ( {
 		}
 	}, [ dataViewsState.selectedItem ] );
 
+	const setQueryParams = useCallback(
+		( queryParams: SitesDashboardQueryParams ) => {
+			// There is a chance that the URL is not up to date when it mounts, so delay
+			// the onQueryParamChange call to avoid it getting the incorrect URL and then
+			// redirecting back to the previous path.
+			if ( window.location.pathname.startsWith( `/${ section?.group }` ) ) {
+				onQueryParamChange( queryParams );
+			} else {
+				window.setTimeout( () => onQueryParamChange( queryParams ) );
+			}
+		},
+		[ onQueryParamChange, section?.group ]
+	);
+
 	// Update URL with search param on change
 	useEffect( () => {
-		const queryParams = { search: dataViewsState.search?.trim(), page: undefined };
+		const queryParams = { search: dataViewsState.search?.trim() };
 
-		// There is a chance that the URL is not up to date when it mounts, so delay
-		// the onQueryParamChange call to avoid it getting the incorrect URL and then
-		// redirecting back to the previous path.
-		if ( window.location.pathname.startsWith( `/${ section?.group }` ) ) {
-			onQueryParamChange( queryParams );
-		} else {
-			window.setTimeout( () => onQueryParamChange( queryParams ) );
-		}
-	}, [ dataViewsState.search, onQueryParamChange, section?.group ] );
+		setQueryParams( queryParams );
+	}, [ dataViewsState.search, setQueryParams ] );
+
+	useEffect( () => {
+		const queryParams = {
+			page: dataViewsState.page === 1 ? undefined : dataViewsState.page,
+			// todo: get rid of magic number for default perPage value 96
+			perPage: dataViewsState.perPage === 96 ? undefined : dataViewsState.perPage,
+		};
+		setQueryParams( queryParams );
+	}, [ dataViewsState.page, dataViewsState.perPage, setQueryParams ] );
 
 	// Search, filtering, pagination and sorting sites:
 	useEffect( () => {

--- a/client/sites-dashboard/components/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-v2/index.tsx
@@ -1,3 +1,4 @@
+import { useSitesListFiltering } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
@@ -63,6 +64,9 @@ const SitesDashboardV2 = ( {
 	initialDataViewsState.hiddenFields = [ 'status' ];
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( initialDataViewsState );
 
+	// Filter sites list state
+	const filteredSites = useSitesListFiltering( allSites, { search: dataViewsState.search } );
+
 	// Site is selected:
 	useEffect( () => {
 		if ( dataViewsState.selectedItem ) {
@@ -122,7 +126,7 @@ const SitesDashboardV2 = ( {
 
 					<DocumentHead title={ __( 'Sites' ) } />
 					<DotcomSitesDataViews
-						sites={ allSites }
+						sites={ filteredSites }
 						isLoading={ isLoading }
 						dataViewsState={ dataViewsState }
 						setDataViewsState={ setDataViewsState }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds filtering of sites per search input
* Adds/updates search param to the url on change
* Adds/updates pagination params to the url on change - however there seems to be a pre-existing issue where these get reset on load anyways. more to investigate...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
