### PR TITLE
Segmentation Survey: Add segmentation survey tracks events

### DIFF
--- a/client/components/survey-container/components/question-step.tsx
+++ b/client/components/survey-container/components/question-step.tsx
@@ -2,6 +2,7 @@ import { StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Question, QuestionType } from '../types';
 import SurveyCheckboxControl from './survey-checkbox-control';
 import SurveyRadioControl from './survey-radio-control';
@@ -23,7 +24,6 @@ type QuestionStepType = {
 	previousPage: () => void;
 	nextPage: () => void;
 	skip: () => void;
-	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
 } & QuestionSelectionType;
 
 const QuestionStep = ( {
@@ -34,7 +34,6 @@ const QuestionStep = ( {
 	question,
 	value,
 	onChange,
-	recordTracksEvent,
 }: QuestionStepType ) => {
 	const translate = useTranslate();
 	const SelectionComponent = questionTypeComponentMap[ question.type ];

--- a/client/components/survey-container/index.tsx
+++ b/client/components/survey-container/index.tsx
@@ -6,14 +6,12 @@ type SurveyContainerType = {
 	answers: Answers;
 	hideBackOnFirstPage?: boolean;
 	onChange: ( questionKey: string, value: string[] ) => void;
-	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
 };
 
 const SurveyContainer = ( {
 	answers,
 	hideBackOnFirstPage = true,
 	onChange,
-	recordTracksEvent,
 }: SurveyContainerType ) => {
 	const { currentPage, currentQuestion, nextPage, previousPage, skip } = useSurveyContext();
 	const hideBack = hideBackOnFirstPage && currentPage === 1;
@@ -28,7 +26,6 @@ const SurveyContainer = ( {
 			previousPage={ previousPage }
 			nextPage={ nextPage }
 			skip={ skip }
-			recordTracksEvent={ recordTracksEvent }
 			onChange={ onChange }
 			question={ currentQuestion }
 			value={ answers[ currentQuestion.key ] || [] }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -62,7 +62,9 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 			<SegmentationSurveyProvider
 				navigation={ navigation }
 				onSubmitQuestion={ onSubmitQuestion }
+				surveyKey={ SURVEY_KEY }
 				questions={ questions }
+				answers={ answers }
 			>
 				<SegmentationSurveyDocumentHead />
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -66,11 +66,7 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 			>
 				<SegmentationSurveyDocumentHead />
 
-				<SurveyContainer
-					answers={ answers }
-					onChange={ onChangeAnswer }
-					recordTracksEvent={ () => undefined }
-				/>
+				<SurveyContainer answers={ answers } onChange={ onChangeAnswer } />
 			</SegmentationSurveyProvider>
 		</Main>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/provider.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/provider.tsx
@@ -1,21 +1,26 @@
 import { useCallback, useMemo } from 'react';
 import { useLocation } from 'react-router';
 import { SurveyContext } from 'calypso/components/survey-container/context';
-import { Question } from 'calypso/components/survey-container/types';
+import { Answers, Question } from 'calypso/components/survey-container/types';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { NavigationControls } from '../../types';
 
 type SegmentationSurveyProviderType = {
 	children: React.ReactNode;
 	navigation: NavigationControls;
 	onSubmitQuestion: ( currentQuestion: Question ) => void;
+	surveyKey: string;
 	questions?: Question[];
+	answers?: Answers;
 };
 
 const SegmentationSurveyProvider = ( {
 	children,
 	navigation,
 	onSubmitQuestion,
+	surveyKey,
 	questions,
+	answers,
 }: SegmentationSurveyProviderType ) => {
 	const { hash } = useLocation();
 	const currentPage = useMemo( () => parseInt( hash.replace( '#', '' ), 10 ) || 1, [ hash ] );
@@ -32,7 +37,12 @@ const SegmentationSurveyProvider = ( {
 		}
 
 		window.location.hash = `${ currentPage - 1 }`;
-	}, [ currentPage, navigation ] );
+
+		recordTracksEvent( 'calypso_segmentation_survey_back', {
+			survey_key: surveyKey,
+			question_key: currentQuestion?.key,
+		} );
+	}, [ currentPage, currentQuestion?.key, navigation, surveyKey ] );
 
 	const nextPage = useCallback( () => {
 		if ( currentPage === questions?.length ) {
@@ -46,9 +56,25 @@ const SegmentationSurveyProvider = ( {
 	const submitAndNextPage = useCallback( () => {
 		if ( currentQuestion ) {
 			onSubmitQuestion( currentQuestion );
+
+			recordTracksEvent( 'calypso_segmentation_survey_continue', {
+				survey_key: surveyKey,
+				question_key: currentQuestion.key,
+				answer_keys: answers?.[ currentQuestion.key ].join( ',' ) || '',
+			} );
 		}
+
 		nextPage();
-	}, [ currentQuestion, nextPage, onSubmitQuestion ] );
+	}, [ answers, currentQuestion, nextPage, onSubmitQuestion, surveyKey ] );
+
+	const skip = useCallback( () => {
+		nextPage();
+
+		recordTracksEvent( 'calypso_segmentation_survey_skip', {
+			survey_key: surveyKey,
+			question_key: currentQuestion?.key,
+		} );
+	}, [ currentQuestion?.key, nextPage, surveyKey ] );
 
 	return (
 		<SurveyContext.Provider
@@ -57,7 +83,7 @@ const SegmentationSurveyProvider = ( {
 				currentPage,
 				previousPage,
 				nextPage: submitAndNextPage,
-				skip: nextPage,
+				skip,
 			} }
 		>
 			{ children }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89746

## Proposed Changes

* Add tracks events to continue, skip, and back buttons
* Record default stepper events

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur/start?flags=ecommerce-segmentation-survey
* Open the Network tab and filter tracks requests
* Answer the first question and click continue
* Check if the event request is consistent
* Click to go back to the first question, and check the back event request
* Skip the first question, and check the skip event request
* Go to the second question, select multiple options, and click continue
* Check if the event request is consistent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?