### PR TITLE
Congrats: remove legacy header code

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -1,5 +1,4 @@
 import {
-	isChargeback,
 	isDelayedDomainTransfer,
 	isDomainMapping,
 	isDomainRegistration,
@@ -197,12 +196,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 						strong: <strong />,
 					},
 				}
-			);
-		}
-
-		if ( isChargeback( primaryPurchase ) ) {
-			return preventWidows(
-				translate( 'Your chargeback fee is paid. Your site is doing somersaults in excitement!' )
 			);
 		}
 
@@ -472,10 +465,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		if ( primaryPurchase && isPlan( primaryPurchase ) ) {
 			return translate( 'Get the best out of your site' );
-		}
-
-		if ( primaryPurchase && isChargeback( primaryPurchase ) ) {
-			return translate( 'Thank you!' );
 		}
 
 		if ( primaryPurchase && isDelayedDomainTransfer( primaryPurchase ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -1,6 +1,6 @@
 import { isDelayedDomainTransfer } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { withI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -25,14 +25,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 		hasFailedPurchases: PropTypes.bool,
 		isAtomic: PropTypes.bool,
 		isDataLoaded: PropTypes.bool.isRequired,
-		isSimplified: PropTypes.bool,
 		primaryCta: PropTypes.func,
 		primaryPurchase: PropTypes.object,
 		purchases: PropTypes.array,
 		recordTracksEvent: PropTypes.func.isRequired,
 		recordStartTransferClickInThankYou: PropTypes.func.isRequired,
 		selectedSite: PropTypes.object,
-		siteUnlaunchedBeforeUpgrade: PropTypes.bool,
 		translate: PropTypes.func.isRequired,
 		_n: PropTypes.func.isRequired,
 		upgradeIntent: PropTypes.string,
@@ -256,7 +254,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 	}
 
 	render() {
-		const { isDataLoaded, isSimplified, hasFailedPurchases, primaryPurchase } = this.props;
+		const { isDataLoaded, hasFailedPurchases, primaryPurchase } = this.props;
 		const classes = { 'is-placeholder': ! isDataLoaded };
 
 		let svg = 'thank-you.svg';
@@ -275,53 +273,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 						<h1 className="checkout-thank-you__header-heading">
 							{ preventWidows( this.getHeaderText() ) }
 						</h1>
-						{ primaryPurchase && isSimplified ? (
-							this.renderSimplifiedContent()
-						) : (
-							<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>
-						) }
-
+						<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>
 						{ this.props.children }
 						{ this.getButtons() }
 					</div>
 				</div>
 			</div>
-		);
-	}
-
-	renderSimplifiedContent() {
-		const { translate, primaryPurchase } = this.props;
-		const messages = [
-			translate(
-				'All set! Start exploring the features included with your {{strong}}%(productName)s{{/strong}} plan',
-				{
-					args: { productName: primaryPurchase.productName },
-					components: { strong: <strong /> },
-				}
-			),
-		];
-		if ( this.props.siteUnlaunchedBeforeUpgrade ) {
-			messages.push(
-				translate(
-					"Your site has been launched. You can share it with the world whenever you're ready."
-				)
-			);
-		}
-
-		if ( messages.length === 1 ) {
-			return <h2 className="checkout-thank-you__header-text">{ messages[ 0 ] }</h2>;
-		}
-
-		const CHECKMARK_SIZE = 24;
-		return (
-			<ul className="checkout-thank-you__success-messages">
-				{ messages.map( ( message, i ) => (
-					<li key={ i } className="checkout-thank-you__success-message-item">
-						<Gridicon icon="checkmark-circle" size={ CHECKMARK_SIZE } />
-						<div>{ preventWidows( message ) }</div>
-					</li>
-				) ) }
-			</ul>
 		);
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -7,7 +7,6 @@ import {
 	isGSuiteExtraLicenseProductSlug,
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 	isGSuiteOrGoogleWorkspaceProductSlug,
-	isPlan,
 	isSiteRedirect,
 	isTitanMail,
 } from '@automattic/calypso-products';
@@ -76,18 +75,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 			}
 
 			return translate( 'You will receive an email confirmation shortly.' );
-		}
-
-		if ( isPlan( primaryPurchase ) ) {
-			return preventWidows(
-				translate(
-					'All set! Start exploring the features included with your {{strong}}%(productName)s{{/strong}} plan',
-					{
-						args: { productName: primaryPurchase.productName },
-						components: { strong: <strong /> },
-					}
-				)
-			);
 		}
 
 		if ( isDomainRegistration( primaryPurchase ) ) {
@@ -316,10 +303,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 			return translate( 'Register domain' );
 		}
 
-		if ( isPlan( primaryPurchase ) ) {
-			return translate( 'Let’s work on the site' );
-		}
-
 		if (
 			isDomainRegistration( primaryPurchase ) ||
 			isDomainTransfer( primaryPurchase ) ||
@@ -463,10 +446,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 			return preventWidows( translate( 'Almost done!' ) );
 		}
 
-		if ( primaryPurchase && isPlan( primaryPurchase ) ) {
-			return translate( 'Get the best out of your site' );
-		}
-
 		if ( primaryPurchase && isDelayedDomainTransfer( primaryPurchase ) ) {
 			return preventWidows( translate( 'Almost done!' ) );
 		}
@@ -501,7 +480,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 						<h1 className="checkout-thank-you__header-heading">
 							{ preventWidows( this.getHeaderText() ) }
 						</h1>
-						{ primaryPurchase && isPlan( primaryPurchase ) && isSimplified ? (
+						{ primaryPurchase && isSimplified ? (
 							this.renderSimplifiedContent()
 						) : (
 							<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>

--- a/client/my-sites/checkout/checkout-thank-you/test/header.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/header.js
@@ -34,28 +34,5 @@ describe( 'CheckoutThankYouHeader', () => {
 			render( <CheckoutThankYouHeader isDataLoaded={ false } { ...defaultProps } /> );
 			expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent( 'Loading…' );
 		} );
-		test( 'Should display a list of success messages when siteUnlaunchedBeforeUpgrade=true', () => {
-			render(
-				<CheckoutThankYouHeader
-					isDataLoaded={ true }
-					siteUnlaunchedBeforeUpgrade={ true }
-					{ ...defaultProps }
-				/>
-			);
-			expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent(
-				'Get the best out of your site'
-			);
-			expect( screen.queryByRole( 'heading', { level: 2 } ) ).not.toBeInTheDocument();
-
-			const messages = screen.queryAllByRole( 'listitem' );
-
-			expect( messages ).toHaveLength( 2 );
-			expect( messages[ 0 ] ).toHaveTextContent(
-				'All set! Start exploring the features included with your {{strong}}%(productName)s{{/strong}} plan'
-			);
-			expect( messages[ 1 ] ).toHaveTextContent(
-				"Your site has been launched. You can share it with the world whenever you're ready."
-			);
-		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout-thank-you/test/header.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/header.js
@@ -34,32 +34,10 @@ describe( 'CheckoutThankYouHeader', () => {
 			render( <CheckoutThankYouHeader isDataLoaded={ false } { ...defaultProps } /> );
 			expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent( 'Loading…' );
 		} );
-
-		test( 'Should display getText()-based success message when isSimplified=false (default)', () => {
-			render( <CheckoutThankYouHeader isDataLoaded={ true } { ...defaultProps } /> );
-			expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent(
-				'Get the best out of your site'
-			);
-			expect( screen.getByRole( 'heading', { level: 2 } ) ).toHaveTextContent(
-				'All set! Start exploring the features included with your {{strong}}%(productName)s{{/strong}} plan'
-			);
-		} );
-		test( 'Should display an alternative success message when isSimplified=true', () => {
-			render(
-				<CheckoutThankYouHeader isDataLoaded={ true } isSimplified={ true } { ...defaultProps } />
-			);
-			expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent(
-				'Get the best out of your site'
-			);
-			expect( screen.getByRole( 'heading', { level: 2 } ) ).toHaveTextContent(
-				'All set! Start exploring the features included with your {{strong}}%(productName)s{{/strong}} plan'
-			);
-		} );
 		test( 'Should display a list of success messages when siteUnlaunchedBeforeUpgrade=true', () => {
 			render(
 				<CheckoutThankYouHeader
 					isDataLoaded={ true }
-					isSimplified={ true }
 					siteUnlaunchedBeforeUpgrade={ true }
 					{ ...defaultProps }
 				/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6015-gh-Automattic/dotcom-forge

## Proposed Changes

Remove the unreachable/unused code present in `client/my-sites/checkout/checkout-thank-you/header.jsx`. This code is no longer needed now that the refactored Congrats pages are live.

I also wound up removing several of the existing unit tests. The `isSimplified` and `siteUnlaunchedBeforeUpgrade` props were only being used for plan purchases, which are now handled by the new Congrats components. There were a few different tests checking those props that are gone now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm tests all pass
- Perform test purchases for plans, domains, emails, and addons. confirm the Congrats page continues to render as expected.