### PR TITLE
A4A: New Signup Flow - Add email to signup page

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -170,9 +170,33 @@ export default function AgencyDetailsForm( {
 		setProductsOffered( products.value );
 	};
 
+	const shouldShowEmail = true;
+	const isDisabledEmail = userLoggedIn;
+
 	return (
 		<div className="agency-details-form">
 			<form onSubmit={ handleSubmit }>
+				{ shouldShowEmail && (
+					<FormFieldset>
+						<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
+						<FormTextInput
+							id="email"
+							name="email"
+							value={ email || '' }
+							disabled={ isDisabledEmail }
+							isError={ !! validationError?.email }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+								setEmail( event.target.value );
+								setValidationError( { email: '' } );
+							} }
+						/>
+						{ validationError?.email && (
+							<div className="agency-details-form__footer-error" role="alert">
+								{ validationError.email }
+							</div>
+						) }
+					</FormFieldset>
+				) }
 				<div className="agency-details-form__fullname-container">
 					<FormFieldset>
 						<FormLabel htmlFor="firstName">{ translate( 'First name' ) }</FormLabel>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, Gridicon, FormLabel } from '@automattic/components';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
@@ -67,6 +68,7 @@ export default function AgencyDetailsForm( {
 	const showCountryFields = countryOptions.length > 0;
 	const userLoggedIn = useSelector( isUserLoggedIn );
 	const currentUserEmail = useSelector( getCurrentUserEmail );
+	const isA4ALoggedOutSignup = config.isEnabled( 'a4a-logged-out-signup' );
 
 	const [ countryValue, setCountryValue ] = useState( initialValues.country ?? '' );
 	const [ city, setCity ] = useState( initialValues.city ?? '' );
@@ -142,15 +144,17 @@ export default function AgencyDetailsForm( {
 				return;
 			}
 
-			if ( ! email || ! emailValidator.validate( email ) ) {
-				return setValidationError( {
-					email: translate( 'Please enter a valid email address.' ),
-				} );
+			if ( isA4ALoggedOutSignup ) {
+				if ( ! email || ! emailValidator.validate( email ) ) {
+					return setValidationError( {
+						email: translate( 'Please enter a valid email address.' ),
+					} );
+				}
 			}
 
 			onSubmit( payload );
 		},
-		[ showCountryFields, isLoading, email, onSubmit, payload, translate ]
+		[ showCountryFields, isLoading, isA4ALoggedOutSignup, onSubmit, payload, email, translate ]
 	);
 
 	const getServicesOfferedOptions = () => {
@@ -189,7 +193,7 @@ export default function AgencyDetailsForm( {
 		setProductsOffered( products.value );
 	};
 
-	const shouldShowEmail = true;
+	const shouldShowEmail = isA4ALoggedOutSignup;
 	const isDisabledEmail = userLoggedIn;
 
 	return (

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon, FormLabel } from '@automattic/components';
+import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
 import SearchableDropdown from 'calypso/a8c-for-agencies/components/searchable-dropdown';
@@ -7,6 +8,8 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import MultiCheckbox, { ChangeList } from 'calypso/components/forms/multi-checkbox';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn, getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { Option as CountryOption, useCountriesAndStates } from './hooks/use-countries-and-states';
 import { AgencyDetailsPayload } from './types';
 import type { FormEventHandler } from 'react';
@@ -33,6 +36,7 @@ interface Props {
 	onSubmit: ( payload: AgencyDetailsPayload ) => void;
 	referer?: string | null;
 	initialValues?: {
+		email?: string;
 		firstName?: string;
 		lastName?: string;
 		agencyName?: string;
@@ -61,6 +65,8 @@ export default function AgencyDetailsForm( {
 	const translate = useTranslate();
 	const { countryOptions, stateOptionsMap } = useCountriesAndStates();
 	const showCountryFields = countryOptions.length > 0;
+	const userLoggedIn = useSelector( isUserLoggedIn );
+	const currentUserEmail = useSelector( getCurrentUserEmail );
 
 	const [ countryValue, setCountryValue ] = useState( initialValues.country ?? '' );
 	const [ city, setCity ] = useState( initialValues.city ?? '' );
@@ -69,6 +75,7 @@ export default function AgencyDetailsForm( {
 	const [ postalCode, setPostalCode ] = useState( initialValues.postalCode ?? '' );
 	const [ addressState, setAddressState ] = useState( initialValues.state ?? '' );
 	const [ agencyName, setAgencyName ] = useState( initialValues.agencyName ?? '' );
+	const [ email, setEmail ] = useState( initialValues.email ?? currentUserEmail );
 	const [ firstName, setFirstName ] = useState( initialValues.firstName ?? '' );
 	const [ lastName, setLastName ] = useState( initialValues.lastName ?? '' );
 	const [ agencyUrl, setAgencyUrl ] = useState( initialValues.agencyUrl ?? '' );
@@ -79,6 +86,8 @@ export default function AgencyDetailsForm( {
 	const country = getCountry( countryValue, countryOptions );
 	const stateOptions = stateOptionsMap[ country ];
 
+	const [ validationError, setValidationError ] = useState< { email?: string } | undefined >( {} );
+
 	useEffect( () => {
 		// Reset the value of state since our options have changed.
 		setAddressState( stateOptions?.length ? stateOptions[ 0 ].value : '' );
@@ -86,6 +95,7 @@ export default function AgencyDetailsForm( {
 
 	const payload: AgencyDetailsPayload = useMemo(
 		() => ( {
+			email,
 			firstName,
 			lastName,
 			agencyName,
@@ -103,6 +113,7 @@ export default function AgencyDetailsForm( {
 			...( includeTermsOfService ? { tos: 'consented' } : {} ),
 		} ),
 		[
+			email,
 			firstName,
 			lastName,
 			agencyName,
@@ -125,13 +136,21 @@ export default function AgencyDetailsForm( {
 		( e: React.SyntheticEvent ) => {
 			e.preventDefault();
 
+			setValidationError( undefined );
+
 			if ( ! showCountryFields || isLoading ) {
 				return;
 			}
 
+			if ( ! email || ! emailValidator.validate( email ) ) {
+				return setValidationError( {
+					email: translate( 'Please enter a valid email address.' ),
+				} );
+			}
+
 			onSubmit( payload );
 		},
-		[ showCountryFields, isLoading, onSubmit, payload ]
+		[ showCountryFields, isLoading, email, onSubmit, payload, translate ]
 	);
 
 	const getServicesOfferedOptions = () => {

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
@@ -37,7 +37,16 @@
 		}
 	}
 
+	.agency-details-form__footer-error {
+		margin: 8px 0 0;
+		color: var(--color-scary-40);
+		font-style: italic;
+		font-size: 0.9rem; /* stylelint-disable-line scales/font-sizes */
+		line-height: 14px;
+	}
+
 	.company-details-form__tos p {
 		font-size: 1rem;
 	}
+
 }

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -1,4 +1,5 @@
 export interface AgencyDetailsPayload {
+	email?: string | null;
 	firstName: string;
 	lastName: string;
 	agencyName: string;


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/347

## Proposed Changes

* This PR adds the email field to the Signup page to support logged out users.

## Testing Instructions

**Important:** This PR is behind a feature flag, so when using a live link add `?flags=a4a-logged-out-signup` to the URL.

* Run `yarn start-a8c-for-agencies`
* Go to `http://agencies.localhost:3000/signup`
  * When not logged-in you should see an editable field to enter your email
    * Try to submit an invalid email. Verify that an error is displayed.
    * Upon submission, an error message should appear (`Sorry, you are not allowed to do that.`). This happens because the rest of the flow will be implemented in subsequent PRs.
  *  When logged-in, verify that the email field is hidden.
     * Also verify that the signup process works the same way as before for logged-in users


This field does nothing for now, it only populates the `payload` parameter that gets passed to the rest of the signup process.

Not logged-in users:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/f8c0c021-72db-4656-8d96-8ad8098de82a)

Logged-in users (that aren't yet registered in A4A):
![image](https://github.com/Automattic/wp-calypso/assets/37049295/2bfef2ef-396c-48d7-a71d-6cb7f5acce98)

Error Message:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/bd81754f-1133-410c-874d-e3c13e187d32)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?