### PR TITLE
Rebase GSV GitHub deployments with trunk

### DIFF
--- a/client/github-deployments/controller.tsx
+++ b/client/github-deployments/controller.tsx
@@ -1,0 +1,115 @@
+import { __ } from '@wordpress/i18n';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { GitHubDeploymentCreation } from 'calypso/my-sites/github-deployments/deployment-creation';
+import { GitHubDeploymentManagement } from 'calypso/my-sites/github-deployments/deployment-management';
+import { DeploymentRunsLogs } from 'calypso/my-sites/github-deployments/deployment-run-logs';
+import { GitHubDeployments } from 'calypso/my-sites/github-deployments/deployments';
+import { indexPage } from 'calypso/my-sites/github-deployments/routes';
+import MySitesNavigation from 'calypso/my-sites/navigation';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import type { Callback } from '@automattic/calypso-router';
+
+export const deploymentsList: Callback = ( context, next ) => {
+	context.secondary = <MySitesNavigation path={ context.path } />;
+	context.primary = (
+		<div className="deployment-list">
+			<PageViewTracker path="/github-deployments/:site" title="GitHub Deployments" delay={ 500 } />
+			<GitHubDeployments />
+		</div>
+	);
+	next();
+};
+
+export const deploymentCreation: Callback = ( context, next ) => {
+	context.secondary = <MySitesNavigation path={ context.path } />;
+	context.primary = (
+		<div className="deployment-creation">
+			<PageViewTracker
+				path="/github-deployments/:site/create"
+				title="Create GitHub Deployments"
+				delay={ 500 }
+			/>
+			<GitHubDeploymentCreation />
+		</div>
+	);
+	next();
+};
+
+export const deploymentManagement: Callback = ( context, next ) => {
+	const codeDeploymentId = parseInt( context.params.deploymentId, 10 ) || null;
+	const state = context.store.getState();
+	const siteSlug = getSelectedSiteSlug( state );
+
+	if ( ! codeDeploymentId ) {
+		return context.page.replace( indexPage( siteSlug! ) );
+	}
+
+	context.secondary = <MySitesNavigation path={ context.path } />;
+	context.primary = (
+		<div className="deployment-management">
+			<PageViewTracker
+				path="/github-deployments/:site/manage/:deploymentId"
+				title="Manage GitHub Deployment"
+				delay={ 500 }
+			/>
+			<GitHubDeploymentManagement codeDeploymentId={ codeDeploymentId } />
+		</div>
+	);
+	next();
+};
+
+export const deploymentRunLogs: Callback = ( context, next ) => {
+	const codeDeploymentId = parseInt( context.params.deploymentId, 10 ) || null;
+	const state = context.store.getState();
+	const siteSlug = getSelectedSiteSlug( state );
+
+	if ( ! codeDeploymentId ) {
+		return context.page.replace( indexPage( siteSlug! ) );
+	}
+
+	context.secondary = <MySitesNavigation path={ context.path } />;
+	context.primary = (
+		<div className="deployment-run-logs">
+			<PageViewTracker
+				path="/github-deployments/:site/logs/:deploymentId"
+				title="GitHub Deployments"
+				delay={ 500 }
+			/>
+			<DeploymentRunsLogs codeDeploymentId={ codeDeploymentId } />
+		</div>
+	);
+	next();
+};
+
+export const redirectHomeIfIneligible: Callback = ( context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
+	if ( ! siteId ) {
+		context.page.replace( `/home/${ siteSlug }` );
+		return;
+	}
+
+	if ( isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ) ) {
+		context.page.replace( `/stats/day/${ siteSlug }` );
+		return;
+	}
+
+	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+
+	if ( ! canManageOptions ) {
+		context.store.dispatch(
+			errorNotice( __( 'You are not authorized to manage GitHub Deployments for this site.' ), {
+				displayOnNextPage: true,
+			} )
+		);
+		context.page.replace( `/home/${ siteSlug }` );
+		return;
+	}
+
+	next();
+};

--- a/client/github-deployments/controller.tsx
+++ b/client/github-deployments/controller.tsx
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { GitHubDeploymentCreation } from 'calypso/my-sites/github-deployments/deployment-creation';
 import { GitHubDeploymentManagement } from 'calypso/my-sites/github-deployments/deployment-management';
@@ -6,10 +5,7 @@ import { DeploymentRunsLogs } from 'calypso/my-sites/github-deployments/deployme
 import { GitHubDeployments } from 'calypso/my-sites/github-deployments/deployments';
 import { indexPage } from 'calypso/my-sites/github-deployments/routes';
 import MySitesNavigation from 'calypso/my-sites/navigation';
-import { errorNotice } from 'calypso/state/notices/actions';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { Callback } from '@automattic/calypso-router';
 
 export const deploymentsList: Callback = ( context, next ) => {
@@ -81,35 +77,5 @@ export const deploymentRunLogs: Callback = ( context, next ) => {
 			<DeploymentRunsLogs codeDeploymentId={ codeDeploymentId } />
 		</div>
 	);
-	next();
-};
-
-export const redirectHomeIfIneligible: Callback = ( context, next ) => {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state );
-
-	if ( ! siteId ) {
-		context.page.replace( `/home/${ siteSlug }` );
-		return;
-	}
-
-	if ( isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ) ) {
-		context.page.replace( `/stats/day/${ siteSlug }` );
-		return;
-	}
-
-	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-
-	if ( ! canManageOptions ) {
-		context.store.dispatch(
-			errorNotice( __( 'You are not authorized to manage GitHub Deployments for this site.' ), {
-				displayOnNextPage: true,
-			} )
-		);
-		context.page.replace( `/home/${ siteSlug }` );
-		return;
-	}
-
 	next();
 };

--- a/client/github-deployments/index.tsx
+++ b/client/github-deployments/index.tsx
@@ -1,12 +1,12 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
+import { siteSelection, sites } from 'calypso/my-sites/controller';
+import { redirectHomeIfIneligible } from 'calypso/my-sites/github-deployments/controller';
 import {
 	deploymentCreation,
 	deploymentManagement,
 	deploymentRunLogs,
 	deploymentsList,
-	redirectHomeIfIneligible,
 } from './controller';
 
 export default function () {
@@ -16,7 +16,6 @@ export default function () {
 		'/github-deployments/:site',
 		siteSelection,
 		redirectHomeIfIneligible,
-		navigation,
 		deploymentsList,
 		makeLayout,
 		clientRender
@@ -26,7 +25,6 @@ export default function () {
 		'/github-deployments/:site/create',
 		siteSelection,
 		redirectHomeIfIneligible,
-		navigation,
 		deploymentCreation,
 		makeLayout,
 		clientRender
@@ -36,7 +34,6 @@ export default function () {
 		'/github-deployments/:site/manage/:deploymentId',
 		siteSelection,
 		redirectHomeIfIneligible,
-		navigation,
 		deploymentManagement,
 		makeLayout,
 		clientRender
@@ -46,7 +43,6 @@ export default function () {
 		'/github-deployments/:site/logs/:deploymentId',
 		siteSelection,
 		redirectHomeIfIneligible,
-		navigation,
 		deploymentRunLogs,
 		makeLayout,
 		clientRender

--- a/client/github-deployments/index.tsx
+++ b/client/github-deployments/index.tsx
@@ -1,0 +1,54 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
+import {
+	deploymentCreation,
+	deploymentManagement,
+	deploymentRunLogs,
+	deploymentsList,
+	redirectHomeIfIneligible,
+} from './controller';
+
+export default function () {
+	page( '/github-deployments', siteSelection, sites, makeLayout, clientRender );
+
+	page(
+		'/github-deployments/:site',
+		siteSelection,
+		redirectHomeIfIneligible,
+		navigation,
+		deploymentsList,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/github-deployments/:site/create',
+		siteSelection,
+		redirectHomeIfIneligible,
+		navigation,
+		deploymentCreation,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/github-deployments/:site/manage/:deploymentId',
+		siteSelection,
+		redirectHomeIfIneligible,
+		navigation,
+		deploymentManagement,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/github-deployments/:site/logs/:deploymentId',
+		siteSelection,
+		redirectHomeIfIneligible,
+		navigation,
+		deploymentRunLogs,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -706,8 +706,8 @@ const sections = [
 	{
 		name: 'github-deployments',
 		paths: [ '/github-deployments' ],
-		module: 'calypso/my-sites/github-deployments',
-		group: 'sites',
+		module: 'calypso/github-deployments',
+		group: 'sites-dashboard',
 	},
 	{
 		name: 'a8c-for-agencies',

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -20,6 +20,13 @@ function shouldShowGlobalSiteViewSection(
 	);
 }
 
+// Calypso pages listed here will show the global sidebar when on sites group.
+const GLOBAL_SIDEBAR_SECTION_NAMES: string[] = [
+	'hosting',
+	'hosting-overview',
+	'github-deployments',
+];
+
 export const getShouldShowGlobalSidebar = (
 	_: AppState,
 	siteId: number,
@@ -55,7 +62,9 @@ export const getShouldShowGlobalSiteSidebar = (
 ) => {
 	return (
 		isGlobalSiteViewEnabled( state, siteId ) &&
-		shouldShowGlobalSiteViewSection( siteId, sectionGroup, sectionName )
+		sectionGroup === 'sites' &&
+		GLOBAL_SITE_VIEW_SECTION_NAMES.includes( sectionName ) &&
+		! GLOBAL_SIDEBAR_SECTION_NAMES.includes( sectionName )
 	);
 };
 
@@ -67,6 +76,8 @@ export const getShouldShowUnifiedSiteSidebar = (
 ) => {
 	return (
 		isGlobalSiteViewEnabled( state, siteId ) &&
-		! shouldShowGlobalSiteViewSection( siteId, sectionGroup, sectionName )
+		sectionGroup === 'sites' &&
+		! GLOBAL_SITE_VIEW_SECTION_NAMES.includes( sectionName ) &&
+		! getShouldShowGlobalSidebar( state, siteId, sectionGroup, sectionName )
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
