### PR TITLE
Untangling: correctly show global sidebar width

### DIFF
--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -54,6 +54,7 @@ export const getShouldShowGlobalSiteSidebar = (
 	sectionName: string
 ) => {
 	return (
+		!! siteId &&
 		isGlobalSiteViewEnabled( state, siteId ) &&
 		shouldShowGlobalSiteViewSection( siteId, sectionGroup, sectionName )
 	);
@@ -66,6 +67,7 @@ export const getShouldShowUnifiedSiteSidebar = (
 	sectionName: string
 ) => {
 	return (
+		!! siteId &&
 		isGlobalSiteViewEnabled( state, siteId ) &&
 		! shouldShowGlobalSiteViewSection( siteId, sectionGroup, sectionName )
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/89735

## Proposed Changes

This PR fixes the broken sidebar layout caused by the addition of the `is-unified-site-sidebar-visible` class unexpectedly:

<img width="698" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/8437b396-d874-4b05-92e6-e0fe75a304a0">

This PR fixes the logic by re-adding the required `!! siteId` condition to the `getShouldShowUnifiedSiteSidebar()` and `getShouldShowGlobalSiteSidebar()` that was removed by the previous PR.

## Testing Instructions

1. Open the Live URL
2. Go to `/sites`
3. Verify that the class is not there anymore (see the above screenshot)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?