### PR TITLE
Automattic for Agencies: Implement Account Status API endpoint

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Badge } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import React from 'react';
+import StatusBadge from './status-badge';
 
 import './style.scss';
 
@@ -11,7 +12,7 @@ interface StepSectionItemProps {
 	heading: string;
 	description: string;
 	buttonProps?: React.ComponentProps< typeof Button >;
-	statusProps?: React.ComponentProps< typeof Badge >;
+	statusProps?: React.ComponentProps< typeof Badge > & { tooltip?: string };
 }
 
 export default function StepSectionItem( {
@@ -21,7 +22,7 @@ export default function StepSectionItem( {
 	buttonProps,
 	statusProps,
 }: StepSectionItemProps ) {
-	const status = <Badge { ...statusProps } />;
+	const status = <StatusBadge statusProps={ statusProps } />;
 
 	return (
 		<div className="step-section-item">

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge.tsx
@@ -1,0 +1,38 @@
+import { Badge, Tooltip } from '@automattic/components';
+import { useRef, useState, ComponentProps } from 'react';
+
+import './style.scss';
+
+export default function StatusBadge( {
+	statusProps,
+}: {
+	statusProps?: ComponentProps< typeof Badge > & { tooltip?: string };
+} ) {
+	const [ showPopover, setShowPopover ] = useState( false );
+
+	const wrapperRef = useRef< HTMLDivElement | null >( null );
+
+	const { tooltip, ...badgeProps } = statusProps || {};
+
+	if ( ! tooltip ) {
+		return <Badge className="step-section-item__status" { ...badgeProps } />;
+	}
+
+	return (
+		<span
+			className="step-section-item__status-wrapper"
+			onMouseEnter={ () => setShowPopover( true ) }
+			onMouseLeave={ () => setShowPopover( false ) }
+			onMouseDown={ () => setShowPopover( false ) }
+			role="button"
+			tabIndex={ 0 }
+			ref={ wrapperRef }
+		>
+			<Badge className="step-section-item__status" { ...badgeProps } />
+
+			<Tooltip context={ wrapperRef.current } isVisible={ showPopover } position="bottom">
+				{ tooltip }
+			</Tooltip>
+		</span>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge.tsx
@@ -15,7 +15,11 @@ export default function StatusBadge( {
 	const { tooltip, ...badgeProps } = statusProps || {};
 
 	if ( ! tooltip ) {
-		return <Badge className="step-section-item__status" { ...badgeProps } />;
+		return (
+			<span className="step-section-item__status-wrapper">
+				<Badge className="step-section-item__status" { ...badgeProps } />
+			</span>
+		);
 	}
 
 	return (

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -70,8 +70,11 @@
 		}
 	}
 
-	.badge {
+	.step-section-item__status-wrapper {
 		margin-left: auto;
+	}
+
+	.badge {
 		white-space: nowrap;
 	}
 
@@ -79,9 +82,15 @@
 		background-color: var(--color-success-5);
 		color: var(--color-success-80);
 	}
+
 	.badge--warning {
 		background-color: var(--color-warning-5);
 		color: var(--color-warning-80);
+	}
+
+	.badge--error {
+		background-color: var(--color-error-5);
+		color: var(--color-error-80);
 	}
 }
 

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
@@ -7,24 +7,16 @@ export const getGetTipaltiPayeeQueryKey = ( agencyId?: number ) => {
 	return [ 'a4a-tipalti-payee', agencyId ];
 };
 
-const showDummyData = true;
-
 export default function useGetTipaltiPayee() {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	const data = useQuery( {
 		queryKey: getGetTipaltiPayeeQueryKey( agencyId ),
 		queryFn: () =>
-			showDummyData
-				? {
-						status: 'ACTIVE',
-						isPayable: false,
-						statusReason: 'Tax forms not provided, No payment method selected',
-				  }
-				: wpcom.req.get( {
-						apiNamespace: 'wpcom/v2',
-						path: `agency/${ agencyId }/tipalti-payee`,
-				  } ),
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/tipalti`,
+			} ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export const getGetTipaltiPayeeQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-tipalti-payee', agencyId ];
+};
+
+const showDummyData = true;
+
+export default function useGetTipaltiPayee() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const data = useQuery( {
+		queryKey: getGetTipaltiPayeeQueryKey( agencyId ),
+		queryFn: () =>
+			showDummyData
+				? {
+						status: 'ACTIVE',
+						isPayable: false,
+						statusReason: 'Tax forms not provided, No payment method selected',
+				  }
+				: wpcom.req.get( {
+						apiNamespace: 'wpcom/v2',
+						path: `agency/${ agencyId }/tipalti-payee`,
+				  } ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+
+	return data;
+}

--- a/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
@@ -40,11 +40,17 @@ export const getAccountStatus = (
 				statusType: 'error',
 				status: translate( 'Suspended' ),
 			};
-		case 'BLOCKED_BY_TIPALTI':
 		case 'Blocked':
 			return {
 				statusType: 'error',
 				status: translate( 'Blocked' ),
+				statusReason: translate( 'Your account is blocked' ),
+			};
+		case 'Closed':
+			return {
+				statusType: 'error',
+				status: translate( 'Closed' ),
+				statusReason: translate( 'Your account is closed' ),
 			};
 		default:
 			return null;

--- a/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
@@ -1,0 +1,44 @@
+export const getAccountStatus = (
+	data: {
+		status: string;
+		isPayable: boolean;
+		statusReason: string;
+	} | null,
+	translate: ( key: string ) => string
+): {
+	statusType: 'success' | 'warning' | 'error';
+	status: string;
+	statusReason?: string;
+} | null => {
+	if ( ! data ) {
+		return null;
+	}
+	const { status, isPayable, statusReason } = data;
+	switch ( status ) {
+		case 'ACTIVE':
+			if ( ! isPayable ) {
+				return {
+					statusType: 'warning',
+					status: translate( 'Not Payable' ),
+					statusReason,
+				};
+			}
+			return {
+				statusType: 'success',
+				status: translate( 'Confirmed' ),
+			};
+		case 'SUSPENDED':
+			return {
+				statusType: 'error',
+				status: translate( 'Suspended' ),
+			};
+		case 'BLOCKED_BY_TIPALTI':
+		case 'BLOCKED':
+			return {
+				statusType: 'error',
+				status: translate( 'Blocked' ),
+			};
+		default:
+			return null;
+	}
+};

--- a/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
@@ -35,13 +35,13 @@ export const getAccountStatus = (
 				statusType: 'success',
 				status: translate( 'Confirmed' ),
 			};
-		case 'SUSPENDED':
+		case 'Suspended':
 			return {
 				statusType: 'error',
 				status: translate( 'Suspended' ),
 			};
 		case 'BLOCKED_BY_TIPALTI':
-		case 'BLOCKED':
+		case 'Blocked':
 			return {
 				statusType: 'error',
 				status: translate( 'Blocked' ),

--- a/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
@@ -1,8 +1,8 @@
 export const getAccountStatus = (
 	data: {
-		status: string;
-		isPayable: boolean;
-		statusReason: string;
+		Status: string;
+		IsPayable: boolean;
+		PayableReason: string[];
 	} | null,
 	translate: ( key: string ) => string
 ): {
@@ -13,14 +13,22 @@ export const getAccountStatus = (
 	if ( ! data ) {
 		return null;
 	}
-	const { status, isPayable, statusReason } = data;
-	switch ( status ) {
-		case 'ACTIVE':
-			if ( ! isPayable ) {
+	const { Status, IsPayable, PayableReason } = data;
+	switch ( Status ) {
+		case 'Active':
+			if ( ! IsPayable ) {
 				return {
 					statusType: 'warning',
 					status: translate( 'Not Payable' ),
-					statusReason,
+					statusReason: PayableReason?.map( ( reason ) => {
+						if ( reason === 'No PM' ) {
+							return translate( 'Bank details are missing' );
+						}
+						if ( reason === 'Tax' ) {
+							return translate( 'Tax form is missing' );
+						}
+						return reason;
+					} ).join( ', ' ),
 				};
 			}
 			return {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -9,11 +9,14 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_REFERRALS_BANK_DETAILS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../common/step-section';
 import StepSectionItem from '../../common/step-section-item';
+import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
+import { getAccountStatus } from '../../lib/get-account-status';
 import tipaltiLogo from '../../lib/tipalti-logo';
 
 import './style.scss';
@@ -28,10 +31,11 @@ export default function ReferralsOverview() {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );
 	}, [ dispatch ] );
 
-	const hasPayeeAccount = false; // FIXME: Replace with actual check
-	const showStatus = true; // FIXME: Replace with actual check
-	const statusType = 'warning'; // FIXME: Replace with actual check
-	const status = 'Pending'; // FIXME: Replace with actual check
+	const { data, isFetching } = useGetTipaltiPayee();
+
+	const accountStatus = getAccountStatus( data, translate );
+
+	const hasPayeeAccount = !! accountStatus?.status;
 
 	return (
 		<Layout
@@ -53,62 +57,77 @@ export default function ReferralsOverview() {
 					{ translate( 'Receive up to 30% revenue share on Automattic product referrals.' ) }
 				</div>
 				<div className="referrals-overview__section-container">
-					<StepSection heading={ translate( 'Set up your commission payments' ) } stepCount={ 1 }>
-						<StepSectionItem
-							icon={ tipaltiLogo }
-							heading={ translate( 'Set up payment details in Tipalti' ) }
-							description={ translate(
-								'Get paid seamlessly by adding your bank details and tax forms to Tipalti, our trusted and secure platform for commission payments.'
-							) }
-							buttonProps={ {
-								children: hasPayeeAccount
-									? translate( 'Edit my bank details' )
-									: translate( 'Get started with secure payments' ),
-								href: A4A_REFERRALS_BANK_DETAILS_LINK,
-								onClick: onAddBankDetailsClick,
-								primary: ! hasPayeeAccount,
-								compact: true,
-							} }
-							statusProps={
-								showStatus
-									? {
-											children: status,
-											type: statusType,
-									  }
-									: undefined
-							}
-						/>
-						<StepSectionItem
-							icon={ plugins }
-							heading={ translate( 'Install the A4A plugin to verify your referrals' ) }
-							description={ translate(
-								'Install the A4A plugin on your clients’ sites to verify your referrals accurately and ensure easy tracking of Automattic product purchases.'
-							) }
-							buttonProps={ {
-								children: translate( 'Download plugin to verify my referrals' ),
-								compact: true,
-							} }
-						/>
-					</StepSection>
-					<StepSection
-						heading={ translate( 'Earn commissions from your referrals' ) }
-						stepCount={ 2 }
-					>
-						<StepSectionItem
-							icon={ payment }
-							heading={ translate( 'Encourage your clients to purchase Automattic products' ) }
-							description={ translate(
-								'We offer commissions for each purchase of Automattic products by your clients, including Woo, Jetpack, and hosting from either Pressable or WordPress.com.'
-							) }
-						/>
-						<StepSectionItem
-							icon={ percent }
-							heading={ translate( 'Receive commissions on client purchases' ) }
-							description={ translate(
-								'Every 60 days, we will review your clients’ purchases and pay you a commission based on them.'
-							) }
-						/>
-					</StepSection>
+					{ isFetching ? (
+						<>
+							<TextPlaceholder />
+							<TextPlaceholder />
+							<TextPlaceholder />
+							<TextPlaceholder />
+						</>
+					) : (
+						<>
+							<StepSection
+								heading={ translate( 'Set up your commission payments' ) }
+								stepCount={ 1 }
+							>
+								<StepSectionItem
+									icon={ tipaltiLogo }
+									heading={ translate( 'Set up payment details in Tipalti' ) }
+									description={ translate(
+										'Get paid seamlessly by adding your bank details and tax forms to Tipalti, our trusted and secure platform for commission payments.'
+									) }
+									buttonProps={ {
+										children: hasPayeeAccount
+											? translate( 'Edit my bank details' )
+											: translate( 'Get started with secure payments' ),
+										href: A4A_REFERRALS_BANK_DETAILS_LINK,
+										onClick: onAddBankDetailsClick,
+										primary: ! hasPayeeAccount,
+										compact: true,
+									} }
+									statusProps={
+										accountStatus
+											? {
+													children: accountStatus?.status,
+													type: accountStatus?.statusType,
+													tooltip: accountStatus?.statusReason,
+											  }
+											: undefined
+									}
+								/>
+								<StepSectionItem
+									icon={ plugins }
+									heading={ translate( 'Install the A4A plugin to verify your referrals' ) }
+									description={ translate(
+										'Install the A4A plugin on your clients’ sites to verify your referrals accurately and ensure easy tracking of Automattic product purchases.'
+									) }
+									buttonProps={ {
+										children: translate( 'Download plugin to verify my referrals' ),
+										compact: true,
+									} }
+								/>
+							</StepSection>
+							<StepSection
+								heading={ translate( 'Earn commissions from your referrals' ) }
+								stepCount={ 2 }
+							>
+								<StepSectionItem
+									icon={ payment }
+									heading={ translate( 'Encourage your clients to purchase Automattic products' ) }
+									description={ translate(
+										'We offer commissions for each purchase of Automattic products by your clients, including Woo, Jetpack, and hosting from either Pressable or WordPress.com.'
+									) }
+								/>
+								<StepSectionItem
+									icon={ percent }
+									heading={ translate( 'Receive commissions on client purchases' ) }
+									description={ translate(
+										'Every 60 days, we will review your clients’ purchases and pay you a commission based on them.'
+									) }
+								/>
+							</StepSection>
+						</>
+					) }
 				</div>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -14,3 +14,7 @@
 .referrals-layout .a4a-layout__body-wrapper {
 	max-width: 900px;
 }
+
+.referrals-overview__section-container .a4a-text-placeholder {
+	height: 80px;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/327

## Proposed Changes

This PR implements the account status API endpoint

## Testing Instructions

1) Open the A4A live link.
2) Make sure you are sandboxed.
3) Go to the Referrals page (/referrals) 
4) Verify that the status badge (e.g., Active, etc.) matches the status of your Tipalti account
5) If you don't have account yet, visit the `/referrals/bank-details` (or click "Referrals in the sidebar and then "Get started with secure payments")
6) Now visit the Referrals page (/referrals) and verify that the status shows Active because your Tipalti account will be created behind the scenes when you access the iframe.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?