### PR TITLE
Untangling: correctly show global sidebar width pt 2

### DIFF
--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -11,15 +11,10 @@ const GLOBAL_SITE_VIEW_SECTION_NAMES: string[] = [
 	'github-deployments',
 ];
 
-function shouldShowGlobalSiteViewSection(
-	siteId: number,
-	sectionGroup: string,
-	sectionName: string
-) {
+function shouldShowGlobalSiteViewSection( siteId: number, sectionName: string ) {
 	return (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
 		!! siteId &&
-		sectionGroup === 'sites' &&
 		GLOBAL_SITE_VIEW_SECTION_NAMES.includes( sectionName )
 	);
 }
@@ -34,8 +29,8 @@ export const getShouldShowGlobalSidebar = (
 		sectionGroup === 'me' ||
 		sectionGroup === 'reader' ||
 		sectionGroup === 'sites-dashboard' ||
-		( sectionGroup === 'sites' && ! siteId ) ||
-		shouldShowGlobalSiteViewSection( siteId, sectionGroup, sectionName )
+		( sectionGroup === 'sites' &&
+			( ! siteId || shouldShowGlobalSiteViewSection( siteId, sectionName ) ) )
 	);
 };
 
@@ -58,9 +53,9 @@ export const getShouldShowGlobalSiteSidebar = (
 	sectionName: string
 ) => {
 	return (
-		!! siteId &&
 		isGlobalSiteViewEnabled( state, siteId ) &&
-		shouldShowGlobalSiteViewSection( siteId, sectionGroup, sectionName )
+		sectionGroup === 'sites' &&
+		shouldShowGlobalSiteViewSection( siteId, sectionName )
 	);
 };
 
@@ -71,8 +66,8 @@ export const getShouldShowUnifiedSiteSidebar = (
 	sectionName: string
 ) => {
 	return (
-		!! siteId &&
 		isGlobalSiteViewEnabled( state, siteId ) &&
-		! shouldShowGlobalSiteViewSection( siteId, sectionGroup, sectionName )
+		sectionGroup === 'sites' &&
+		! shouldShowGlobalSiteViewSection( siteId, sectionName )
 	);
 };


### PR DESCRIPTION
## Proposed Changes

The previous PR (https://github.com/Automattic/wp-calypso/pull/89829) did not fix the issue, so this is another attempt that should actually fix the issue.

## Testing Instructions

### Test you can reproduce the issue

1. In production, go to any Atomic early classic site's wp-admin
1. Go to Hosting -> Configuration
1. Then click the All Sites button on the top bar
1. You will see the reduced width in the global sidebar
1. Click the Domains menu item and the sidebar width is back to normal

### Test the issue is fixed

1. Go to `<live URL>/hosting-config/<siteSlug>` (same site as above)
2. Go to `<live URL>/sites`
3. Verify you see the correct global sidebar width
4. Go to `<live URL>/home/<siteSlug>` of any non-classic sites and verify you don't see the untangled (nav unification narrow width) sidebars.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?