### PR TITLE
Remove Yoast banner in Stats for Simple Classic

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -13,7 +13,7 @@ import { useHasNeverPublishedPost } from 'calypso/data/stats/use-has-never-publi
 import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MiniCarouselBlock from './mini-carousel-block';
 import { isBlockDismissed } from './selectors';
@@ -46,6 +46,9 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const jetpackNonAtomic = useSelector(
 		( state ) => isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId )
 	);
+	const isSimpleClassic = useSelector( ( state ) =>
+		getSiteOption( state, selectedSiteId, 'is_wpcom_simple' )
+	);
 
 	const currentPlanSlug = useSelector( ( state ) =>
 		getCurrentPlan( state, selectedSiteId )
@@ -75,7 +78,9 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
 	const showYoastPromo =
-		! useSelector( isBlockDismissed( EVENT_YOAST_PROMO_DISMISS ) ) && ! jetpackNonAtomic;
+		! useSelector( isBlockDismissed( EVENT_YOAST_PROMO_DISMISS ) ) &&
+		! jetpackNonAtomic &&
+		! isSimpleClassic;
 
 	const showGoogleAnalyticsPromo =
 		! useSelector( isBlockDismissed( EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS ) ) &&


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6355

## Proposed Changes

* Remove the Yoast Banner for Simple Classic for the same behavior as Jetpack Stats self-hosted

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/34cb953d-fb29-4ed5-8332-81ebe31a796b">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/ce008c00-ce52-4a40-96f9-9c7a910a574d">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the same in Simple Classic

## How to set Simple Classic
To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```
1. Checkout to this branch
2. Go to apps/odyssey-stats
3. Run `NODE_ENV=production yarn dev --sync`
4. Sandbox `widgets.wp.com`
5. Go to `/wp-admin/admin.php?page=stats`
6. The banner should be gone
7. Check Calypso/Self-hosted/Atomic

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?