### PR TITLE
Automattic for Agencies: Fix checkout navigation from product upsell card

### DIFF
--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -6,6 +6,7 @@ import {
 	isJetpackScanSlug,
 	isJetpackSearchSlug,
 } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ReactNode, useMemo, useState } from 'react';
@@ -95,20 +96,23 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 
 	if ( hasJetpackPartnerAccess ) {
 		const manageProductSlug = nonManageProductSlug.replace( '_yearly', '' ).replace( /_/g, '-' );
-		const productPurchaseLink = isA4AEnabled
-			? `${ A4A_MARKETPLACE_CHECKOUT_LINK }?product_slug=${ manageProductSlug }&source=sitesdashboard&site_id=${ siteId }`
-			: '#';
 		manageProduct = products?.find( ( product ) => product.slug === manageProductSlug );
 		isFetchingPrices = isFetchingManagePrices || !! isFetchingNonManagePrices;
 		if ( manageProduct ) {
 			aboveButtonText = null;
 			billingTerm = TERM_MONTHLY;
-			ctaButtonURL = productPurchaseLink;
+			ctaButtonURL = '#';
 			currencyCode = manageProduct.currency;
 			originalPrice = parseFloat( manageProduct.amount );
 			onCtaButtonClickInternal = () => {
-				setShowLightbox( true );
 				onCtaButtonClick();
+				if ( isA4AEnabled ) {
+					page.redirect(
+						`${ A4A_MARKETPLACE_CHECKOUT_LINK }?product_slug=${ manageProductSlug }&source=sitesdashboard&site_id=${ siteId }`
+					);
+					return;
+				}
+				setShowLightbox( true );
 			};
 		}
 	} else {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/316

## Proposed Changes

This PR fixes the checkout navigation from the product upsell card for A4A.

## Testing Instructions

1) Open the A4A live link.
2) Visit Sites (/sites) page > Click on any site where Backup or Scan isn't added ever > Go to Backup or Scan tab > Click on the add product CTA > Verify that you are redirected to the checkout page with the product shown clearly.
3) Repeat step 2 multiple times and verify that it always takes you to the checkout page with the product added. 

<img width="1141" alt="Screenshot 2024-04-24 at 1 03 58 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0695cf26-0dab-4f6d-b5c4-609b3ac732a1">

4) Also, now click the Jetpack Cloud live link > Go to site details page of the same site > Click on Backup/Scan > Click the add product CTA > Verify that you can now see the popup as shown below:

<img width="1124" alt="Screenshot 2024-04-24 at 1 06 25 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2bc8feef-df15-466f-bd23-ac941ae69f46">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?