### PR TITLE
A4A: Minor Marketplace product section UI improvements.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
@@ -46,17 +46,6 @@
 	box-shadow: inset 0 0 0 1px var(--color-surface), 0 0 0 var(--wp-admin-border-width-focus) var(--color-accent);
 }
 
-button.product-card__select-button {
-	border-radius: 4px;
-	padding: 7px 12px;
-	font-size: 0.75rem;
-	font-weight: 600;
-	line-height: 1.1;
-	max-height: 36px;
-	min-width: 82px;
-	max-width: 82px;
-}
-
 @mixin product-card-block__details {
 	flex-wrap: wrap;
 	align-items: flex-start;
@@ -91,23 +80,36 @@ button.product-card__select-button {
 }
 
 .product-card__main {
-	display: flex;
+	display: block;
 	width: 100%;
-	justify-content: space-between;
-	gap: 0.5rem;
 
-	@include breakpoint-deprecated( "<660px" ) {
-		display: block;
-
-		.product-card__select-button {
-			margin-block-start: 0.5rem;
-			width: 100%;
-			justify-content: center;
-			text-align: center;
-			font-size: 1rem;
-		}
+	@include breakpoint-deprecated( ">660px" ) {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.5rem;
 	}
 }
+
+.product-card__select-button {
+	display: block;
+	margin-block-start: 0.5rem;
+	max-width: 100%;
+	width: 100%;
+	justify-content: center;
+	text-align: center;
+	font-size: 1rem;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		padding: 7px 12px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		line-height: 1.1;
+		max-height: 36px;
+		min-width: 82px;
+		max-width: 82px;
+	}
+}
+
 
 .product-card__heading {
 	display: flex;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
@@ -11,6 +11,11 @@
 			cursor: not-allowed;
 		}
 	}
+
+	// Override discount text color with success color
+	.product-price-with-discount__price .product-price-with-discount__price-discount {
+		color: var(--color-success);
+	}
 }
 
 .product-card__inner {


### PR DESCRIPTION
This PR fixes a few inconsistencies in the Marketplace products section UI, improving user experience and UI quality.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/341
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/346

## Proposed Changes

* Make the Product card's discount price color green to match the Volume pricing discount text color.

  | Before | After |
  |--------|--------|
  | <img width="515" alt="Screenshot 2024-04-24 at 3 33 09 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c0e49f31-96e7-4dd7-a429-2cb59f99f452"> | <img width="508" alt="Screenshot 2024-04-24 at 3 33 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7226cded-add1-42b7-a52a-2b5154bbb481"> |

* Improve how Product card CTA is rendered when in mobile view.

  | Before | After |
  |--------|--------|
  | <img width="324" alt="Screenshot 2024-04-24 at 3 36 12 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0a40fe76-c2d6-4e81-864d-fa28c910e333"> | <img width="326" alt="Screenshot 2024-04-24 at 3 35 58 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/1d4072d8-58b7-41e0-8c63-6cf6f8ef514c"> | 


## Testing Instructions


* Use the A4A live link below and go to the `/marketplace/products` page.
* Confirm that the components described above are working as expected.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?