### PR TITLE
Untangling: show collapsed sidebar on GSV pages

### DIFF
--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -8,7 +8,7 @@ import { withCurrentRoute } from 'calypso/components/route';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import SidebarMenuItem from 'calypso/layout/global-sidebar/menu-items/menu-item';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getShouldShowCollapsedGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
+import { getShouldShowGlobalSiteSidebar } from 'calypso/state/global-sidebar/selectors';
 import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
@@ -27,7 +27,7 @@ class SidebarNotifications extends Component {
 		isNotificationsOpen: PropTypes.bool,
 		hasUnseenNotifications: PropTypes.bool,
 		tooltip: TranslatableString,
-		shouldShowCollapsedGlobalSidebar: PropTypes.bool,
+		shouldShowGlobalSiteSidebar: PropTypes.bool,
 	};
 
 	notificationLink = createRef();
@@ -137,9 +137,7 @@ class SidebarNotifications extends Component {
 					className={ classes }
 					ref={ this.notificationLink }
 					key={ this.state.animationState }
-					tooltipPlacement={
-						this.props.shouldShowCollapsedGlobalSidebar ? 'bottom-left' : 'bottom'
-					}
+					tooltipPlacement={ this.props.shouldShowGlobalSiteSidebar ? 'bottom-left' : 'bottom' }
 				/>
 				<div className="sidebar-notifications__panel" ref={ this.notificationPanel }>
 					<AsyncLoad
@@ -160,7 +158,7 @@ const mapStateToProps = ( state, { currentSection } ) => {
 	const sectionGroup = currentSection?.group ?? null;
 	const sectionName = currentSection?.name ?? null;
 	const siteId = getSelectedSiteId( state );
-	const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
+	const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
 		state,
 		siteId,
 		sectionGroup,
@@ -169,7 +167,7 @@ const mapStateToProps = ( state, { currentSection } ) => {
 	return {
 		isNotificationsOpen: isNotificationsOpen( state ),
 		hasUnseenNotifications: hasUnseenNotifications( state ),
-		shouldShowCollapsedGlobalSidebar,
+		shouldShowGlobalSiteSidebar,
 	};
 };
 const mapDispatchToProps = {

--- a/client/layout/global-sidebar/menu-items/search/index.jsx
+++ b/client/layout/global-sidebar/menu-items/search/index.jsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
 import { useDispatch } from 'calypso/state';
 import { openCommandPalette } from 'calypso/state/command-palette/actions';
-import { getShouldShowCollapsedGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
+import { getShouldShowGlobalSiteSidebar } from 'calypso/state/global-sidebar/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarMenuItem from '../menu-item';
 
@@ -16,8 +16,8 @@ export const SidebarSearch = ( { tooltip, onClick } ) => {
 	};
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const { currentSection } = useCurrentRoute();
-	const shouldShowCollapsedGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowCollapsedGlobalSidebar(
+	const shouldShowGlobalSiteSidebar = useSelector( ( state ) => {
+		return getShouldShowGlobalSiteSidebar(
 			state,
 			selectedSiteId,
 			currentSection?.group,
@@ -33,7 +33,7 @@ export const SidebarSearch = ( { tooltip, onClick } ) => {
 				} ) }
 				tooltip={ tooltip }
 				icon={ <Icon icon={ search } size={ 28 } /> }
-				tooltipPlacement={ shouldShowCollapsedGlobalSidebar ? 'bottom-left' : 'bottom' }
+				tooltipPlacement={ shouldShowGlobalSiteSidebar ? 'bottom-left' : 'bottom' }
 			/>
 		</>
 	);

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -425,11 +425,6 @@ $brand-text: "SF Pro Text", $sans;
 		}
 
 		.sidebar__body {
-			.sidebar__menu-link {
-				.theme-default & {
-					margin: 0;
-				}
-			}
 			.sidebar__menu-link-text {
 				display: none;
 			}

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -425,6 +425,11 @@ $brand-text: "SF Pro Text", $sans;
 		}
 
 		.sidebar__body {
+			.sidebar__menu-link {
+				.theme-default & {
+					margin: 0;
+				}
+			}
 			.sidebar__menu-link-text {
 				display: none;
 			}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -41,8 +41,8 @@ import { closeCommandPalette } from 'calypso/state/command-palette/actions';
 import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
-	getShouldShowCollapsedGlobalSidebar,
 	getShouldShowGlobalSidebar,
+	getShouldShowGlobalSiteSidebar,
 	getShouldShowUnifiedSiteSidebar,
 } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
@@ -454,7 +454,7 @@ export default withCurrentRoute(
 				sectionGroup,
 				sectionName
 			);
-			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
+			const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
 				state,
 				siteId,
 				sectionGroup,
@@ -543,7 +543,7 @@ export default withCurrentRoute(
 				userAllowedToHelpCenter,
 				currentRoute,
 				isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
-				isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
+				isGlobalSidebarCollapsed: shouldShowGlobalSiteSidebar && ! sidebarIsHidden,
 				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
 				currentRoutePattern: getCurrentRoutePattern( state ) ?? '',
 				userCapabilities: state.currentUser.capabilities,

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -6,10 +6,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
 import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-only-fallback-menu';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
-import {
-	getShouldShowCollapsedGlobalSidebar,
-	getShouldShowGlobalSidebar,
-} from 'calypso/state/global-sidebar/selectors';
+import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { canAnySiteHavePlugins } from 'calypso/state/selectors/can-any-site-have-plugins';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -41,14 +38,6 @@ const useSiteMenuItems = () => {
 	const { currentSection } = useCurrentRoute();
 	const shouldShowGlobalSidebar = useSelector( ( state ) => {
 		return getShouldShowGlobalSidebar(
-			state,
-			selectedSiteId,
-			currentSection?.group,
-			currentSection?.name
-		);
-	} );
-	const shouldShowCollapsedGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowCollapsedGlobalSidebar(
 			state,
 			selectedSiteId,
 			currentSection?.group,
@@ -122,7 +111,7 @@ const useSiteMenuItems = () => {
 		} );
 	}, [ isJetpack, menuItems, siteDomain, translate ] );
 
-	if ( shouldShowGlobalSidebar || shouldShowCollapsedGlobalSidebar ) {
+	if ( shouldShowGlobalSidebar ) {
 		return globalSidebarMenu();
 	}
 

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -20,33 +20,6 @@ function shouldShowGlobalSiteViewSection( siteId: number, sectionName: string ) 
 	);
 }
 
-export const getShouldShowGlobalSidebar = (
-	_: AppState,
-	siteId: number,
-	sectionGroup: string,
-	sectionName: string
-) => {
-	return (
-		sectionGroup === 'me' ||
-		sectionGroup === 'reader' ||
-		sectionGroup === 'sites-dashboard' ||
-		( sectionGroup === 'sites' &&
-			( ! siteId || shouldShowGlobalSiteViewSection( siteId, sectionName ) ) )
-	);
-};
-
-export const getShouldShowCollapsedGlobalSidebar = (
-	state: AppState,
-	siteId: number,
-	sectionGroup: string,
-	sectionName: string // eslint-disable-line @typescript-eslint/no-unused-vars
-) => {
-	// Global sidebar should be collapsed when in sites dashboard and a site is selected.
-	return (
-		isEnabled( 'layout/dotcom-nav-redesign-v2' ) && sectionGroup === 'sites-dashboard' && siteId
-	);
-};
-
 export const getShouldShowGlobalSiteSidebar = (
 	state: AppState,
 	siteId: number,
@@ -57,6 +30,21 @@ export const getShouldShowGlobalSiteSidebar = (
 		isGlobalSiteViewEnabled( state, siteId ) &&
 		sectionGroup === 'sites' &&
 		shouldShowGlobalSiteViewSection( siteId, sectionName )
+	);
+};
+
+export const getShouldShowGlobalSidebar = (
+	state: AppState,
+	siteId: number,
+	sectionGroup: string,
+	sectionName: string
+) => {
+	return (
+		sectionGroup === 'me' ||
+		sectionGroup === 'reader' ||
+		sectionGroup === 'sites-dashboard' ||
+		( sectionGroup === 'sites' && ! siteId ) ||
+		getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName )
 	);
 };
 


### PR DESCRIPTION
## Proposed Changes

This PR collapses the global sidebar when we are in the supported GSV hosting pages:

|`/hosting-overview/`|`/hosting-config/`|`/github-deployments/`|
|-|-|-|
|<img width="1073" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/e8929b07-c13a-4466-b1f5-649225a8e084">|<img width="1072" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/5ca22ab8-62fe-4f84-b7b5-330c5ba88da7">|<img width="1076" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/2d1d9e05-5fb1-4c9e-a765-a2e9edda7d65">|

Related: https://github.com/Automattic/wp-calypso/pull/89735#discussion_r1577147135

## Testing Instructions

1. Go to the following pages on Atomic EARLY classic view sites and verify you see the collapsed sidebar as above screenshots:
   * `<live URL>/hosting-overview/<siteSlug>?flags=layout/dotcom-nav-redesign-v2`
   * `<live URL>/hosting-config/<siteSlug>?flags=layout/dotcom-nav-redesign-v2`
   * `<live URL>/github-deployments/<siteSlug>?flags=layout/dotcom-nav-redesign-v2`

### Regression tests

1. Go to the following pages on Atomic EARLY classic view sites and verify you see the pages on their old locations:
   * `<live URL>/hosting-config/<siteSlug>`
   * `<live URL>/github-deployments/<siteSlug>`
1. Go to the following pages on Atomic classic view sites (NON-EARLY) and verify you see the pages on their old locations:
   * `<live URL>/hosting-config/<siteSlug>?flags=layout/dotcom-nav-redesign-v2`
   * `<live URL>/github-deployments/<siteSlug>?flags=layout/dotcom-nav-redesign-v2`
1. Go to the above pages on Atomic Default view sites and verify you see the pages on their old locations.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?