### PR TITLE
Trail map: Optionalise feature tooltips

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -860,6 +860,7 @@ const PlansFeaturesMain = ( {
 										stickyRowOffset={ masterbarHeight }
 										useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 										useActionCallback={ useActionCallback }
+										renderFeatureTooltips={ ! trailMapExperiment.result }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && (
@@ -935,6 +936,7 @@ const PlansFeaturesMain = ( {
 													useCheckPlanAvailabilityForPurchase={
 														useCheckPlanAvailabilityForPurchase
 													}
+													renderFeatureTooltips={ ! trailMapExperiment.result }
 												/>
 											) }
 											<ComparisonGridToggle

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -860,7 +860,7 @@ const PlansFeaturesMain = ( {
 										stickyRowOffset={ masterbarHeight }
 										useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 										useActionCallback={ useActionCallback }
-										renderFeatureTooltips={ ! trailMapExperiment.result }
+										enableFeatureTooltips={ ! trailMapExperiment.result }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && (
@@ -936,7 +936,7 @@ const PlansFeaturesMain = ( {
 													useCheckPlanAvailabilityForPurchase={
 														useCheckPlanAvailabilityForPurchase
 													}
-													renderFeatureTooltips={ ! trailMapExperiment.result }
+													enableFeatureTooltips={ ! trailMapExperiment.result }
 												/>
 											) }
 											<ComparisonGridToggle

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -579,7 +579,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	setActiveTooltipId,
 	onStorageAddOnClick,
 } ) => {
-	const { gridPlansIndex } = usePlansGridContext();
+	const { gridPlansIndex, renderFeatureTooltips } = usePlansGridContext();
 	const gridPlan = gridPlansIndex[ planSlug ];
 	const translate = useTranslate();
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
@@ -658,7 +658,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 							{ planPaymentTransactionFees ? (
 								<>
 									<Plans2023Tooltip
-										text={ feature?.getDescription?.() }
+										text={ renderFeatureTooltips ? feature?.getDescription?.() : undefined }
 										setActiveTooltipId={ setActiveTooltipId }
 										activeTooltipId={ activeTooltipId }
 										id={ `${ planSlug }-${ featureSlug }` }
@@ -684,7 +684,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 								</span>
 							) }
 							<Plans2023Tooltip
-								text={ feature?.getDescription?.() }
+								text={ renderFeatureTooltips ? feature?.getDescription?.() : undefined }
 								setActiveTooltipId={ setActiveTooltipId }
 								activeTooltipId={ activeTooltipId }
 								id={ `${ planSlug }-${ featureSlug }` }
@@ -759,6 +759,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	const hasWooExpressPlans = visibleGridPlans.some( ( { planSlug } ) =>
 		isWooExpressPlan( planSlug )
 	);
+	const { renderFeatureTooltips } = usePlansGridContext();
 
 	return (
 		<Row
@@ -773,7 +774,11 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 			>
 				{ isStorageFeature ? (
 					<Plans2023Tooltip
-						text={ translate( 'Space to store your photos, media, and more.' ) }
+						text={
+							renderFeatureTooltips
+								? translate( 'Space to store your photos, media, and more.' )
+								: undefined
+						}
 						setActiveTooltipId={ setActiveTooltipId }
 						activeTooltipId={ activeTooltipId }
 						id={ tooltipId }
@@ -785,9 +790,13 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 						{ feature && (
 							<>
 								<Plans2023Tooltip
-									text={ feature.getDescription?.( {
-										planSlug: hasWooExpressPlans ? PLAN_WOOEXPRESS_MEDIUM_MONTHLY : undefined,
-									} ) }
+									text={
+										renderFeatureTooltips
+											? feature.getDescription?.( {
+													planSlug: hasWooExpressPlans ? PLAN_WOOEXPRESS_MEDIUM_MONTHLY : undefined,
+											  } )
+											: undefined
+									}
 									setActiveTooltipId={ setActiveTooltipId }
 									activeTooltipId={ activeTooltipId }
 									id={ tooltipId }

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -579,7 +579,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	setActiveTooltipId,
 	onStorageAddOnClick,
 } ) => {
-	const { gridPlansIndex, renderFeatureTooltips } = usePlansGridContext();
+	const { gridPlansIndex, enableFeatureTooltips } = usePlansGridContext();
 	const gridPlan = gridPlansIndex[ planSlug ];
 	const translate = useTranslate();
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
@@ -658,7 +658,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 							{ planPaymentTransactionFees ? (
 								<>
 									<Plans2023Tooltip
-										text={ renderFeatureTooltips ? feature?.getDescription?.() : undefined }
+										text={ enableFeatureTooltips ? feature?.getDescription?.() : undefined }
 										setActiveTooltipId={ setActiveTooltipId }
 										activeTooltipId={ activeTooltipId }
 										id={ `${ planSlug }-${ featureSlug }` }
@@ -684,7 +684,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 								</span>
 							) }
 							<Plans2023Tooltip
-								text={ renderFeatureTooltips ? feature?.getDescription?.() : undefined }
+								text={ enableFeatureTooltips ? feature?.getDescription?.() : undefined }
 								setActiveTooltipId={ setActiveTooltipId }
 								activeTooltipId={ activeTooltipId }
 								id={ `${ planSlug }-${ featureSlug }` }
@@ -759,7 +759,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	const hasWooExpressPlans = visibleGridPlans.some( ( { planSlug } ) =>
 		isWooExpressPlan( planSlug )
 	);
-	const { renderFeatureTooltips } = usePlansGridContext();
+	const { enableFeatureTooltips } = usePlansGridContext();
 
 	return (
 		<Row
@@ -775,7 +775,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 				{ isStorageFeature ? (
 					<Plans2023Tooltip
 						text={
-							renderFeatureTooltips
+							enableFeatureTooltips
 								? translate( 'Space to store your photos, media, and more.' )
 								: undefined
 						}
@@ -791,7 +791,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 							<>
 								<Plans2023Tooltip
 									text={
-										renderFeatureTooltips
+										enableFeatureTooltips
 											? feature.getDescription?.( {
 													planSlug: hasWooExpressPlans ? PLAN_WOOEXPRESS_MEDIUM_MONTHLY : undefined,
 											  } )

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -72,7 +72,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	setActiveTooltipId,
 } ) => {
 	const translate = useTranslate();
-	const { renderFeatureTooltips } = usePlansGridContext();
+	const { enableFeatureTooltips } = usePlansGridContext();
 
 	return (
 		<>
@@ -116,7 +116,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 									{ isFreePlanAndCustomDomainFeature ? (
 										<Plans2023Tooltip
 											text={
-												renderFeatureTooltips
+												enableFeatureTooltips
 													? translate( '%s is not included', {
 															args: [ paidDomainName as string ],
 															comment: '%s is a domain name.',
@@ -137,7 +137,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 									) : (
 										<Plans2023Tooltip
 											text={
-												renderFeatureTooltips
+												enableFeatureTooltips
 													? currentFeature.getDescription?.( { planSlug } )
 													: undefined
 											}

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { Dispatch, SetStateAction } from 'react';
+import { usePlansGridContext } from '../grid-context';
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { TransformedFeatureObject, DataResponse } from '../types';
@@ -71,6 +72,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	setActiveTooltipId,
 } ) => {
 	const translate = useTranslate();
+	const { renderFeatureTooltips } = usePlansGridContext();
 
 	return (
 		<>
@@ -113,10 +115,14 @@ const PlanFeatures2023GridFeatures: React.FC< {
 								<span className={ itemTitleClasses }>
 									{ isFreePlanAndCustomDomainFeature ? (
 										<Plans2023Tooltip
-											text={ translate( '%s is not included', {
-												args: [ paidDomainName as string ],
-												comment: '%s is a domain name.',
-											} ) }
+											text={
+												renderFeatureTooltips
+													? translate( '%s is not included', {
+															args: [ paidDomainName as string ],
+															comment: '%s is a domain name.',
+													  } )
+													: undefined
+											}
 											activeTooltipId={ activeTooltipId }
 											setActiveTooltipId={ setActiveTooltipId }
 											id={ key }
@@ -130,7 +136,11 @@ const PlanFeatures2023GridFeatures: React.FC< {
 										</Plans2023Tooltip>
 									) : (
 										<Plans2023Tooltip
-											text={ currentFeature.getDescription?.( { planSlug } ) }
+											text={
+												renderFeatureTooltips
+													? currentFeature.getDescription?.( { planSlug } )
+													: undefined
+											}
 											activeTooltipId={ activeTooltipId }
 											setActiveTooltipId={ setActiveTooltipId }
 											id={ key }

--- a/packages/plans-grid-next/src/components/plans-2023-tooltip.tsx
+++ b/packages/plans-grid-next/src/components/plans-2023-tooltip.tsx
@@ -25,22 +25,27 @@ const StyledTooltip = styled( Tooltip )`
 	}
 `;
 
-export const Plans2023Tooltip = ( {
-	showOnMobile = true,
-	...props
-}: PropsWithChildren< {
+export type Plans2023TooltipProps = PropsWithChildren< {
 	text?: TranslateResult;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	activeTooltipId: string;
 	id: string;
 	showOnMobile?: boolean;
-} > ) => {
-	const { activeTooltipId, setActiveTooltipId, id } = props;
+} >;
+
+export const Plans2023Tooltip = ( {
+	showOnMobile = true,
+	activeTooltipId,
+	setActiveTooltipId,
+	id,
+	text,
+	children,
+}: Plans2023TooltipProps ) => {
 	const tooltipRef = useRef< HTMLDivElement >( null );
 	const isTouch = hasTouch();
 
-	if ( ! props.text ) {
-		return <>{ props.children }</>;
+	if ( ! text ) {
+		return <>{ children }</>;
 	}
 
 	const getMobileActiveTooltip = () => {
@@ -62,9 +67,9 @@ export const Plans2023Tooltip = ( {
 				onMouseEnter={ () => ! isTouch && setActiveTooltipId( id ) }
 				onMouseLeave={ () => ! isTouch && setActiveTooltipId( '' ) }
 				onTouchStart={ () => isTouch && setActiveTooltipId( getMobileActiveTooltip() ) }
-				id={ props.id }
+				id={ id }
 			>
-				{ props.children }
+				{ children }
 			</HoverAreaContainer>
 			<StyledTooltip
 				isVisible={ isVisible }
@@ -73,7 +78,7 @@ export const Plans2023Tooltip = ( {
 				hideArrow
 				showOnMobile={ showOnMobile }
 			>
-				{ props.text }
+				{ text }
 			</StyledTooltip>
 		</>
 	);

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -15,7 +15,7 @@ interface PlansGridContext {
 		recordTracksEvent?: GridContextProps[ 'recordTracksEvent' ];
 	};
 	coupon?: string;
-	renderFeatureTooltips?: boolean;
+	enableFeatureTooltips?: boolean;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -30,7 +30,7 @@ const PlansGridContextProvider = ( {
 	siteId,
 	children,
 	coupon,
-	renderFeatureTooltips,
+	enableFeatureTooltips,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -50,7 +50,7 @@ const PlansGridContextProvider = ( {
 				allFeaturesList,
 				helpers: { useCheckPlanAvailabilityForPurchase, useActionCallback, recordTracksEvent },
 				coupon,
-				renderFeatureTooltips,
+				enableFeatureTooltips,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -15,6 +15,7 @@ interface PlansGridContext {
 		recordTracksEvent?: GridContextProps[ 'recordTracksEvent' ];
 	};
 	coupon?: string;
+	renderFeatureTooltips?: boolean;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -29,6 +30,7 @@ const PlansGridContextProvider = ( {
 	siteId,
 	children,
 	coupon,
+	renderFeatureTooltips,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -48,6 +50,7 @@ const PlansGridContextProvider = ( {
 				allFeaturesList,
 				helpers: { useCheckPlanAvailabilityForPurchase, useActionCallback, recordTracksEvent },
 				coupon,
+				renderFeatureTooltips,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -36,6 +36,7 @@ const WrappedComparisonGrid = ( {
 	stickyRowOffset,
 	coupon,
 	className,
+	renderFeatureTooltips,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
@@ -70,6 +71,7 @@ const WrappedComparisonGrid = ( {
 				recordTracksEvent={ recordTracksEvent }
 				allFeaturesList={ allFeaturesList }
 				coupon={ coupon }
+				renderFeatureTooltips={ renderFeatureTooltips }
 			>
 				<ComparisonGrid
 					intervalType={ intervalType }
@@ -102,6 +104,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		coupon,
 		isInAdmin,
 		className,
+		renderFeatureTooltips,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
@@ -131,6 +134,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				useActionCallback={ useActionCallback }
 				recordTracksEvent={ recordTracksEvent }
 				allFeaturesList={ allFeaturesList }
+				renderFeatureTooltips={ renderFeatureTooltips }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -36,7 +36,7 @@ const WrappedComparisonGrid = ( {
 	stickyRowOffset,
 	coupon,
 	className,
-	renderFeatureTooltips,
+	enableFeatureTooltips,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
@@ -71,7 +71,7 @@ const WrappedComparisonGrid = ( {
 				recordTracksEvent={ recordTracksEvent }
 				allFeaturesList={ allFeaturesList }
 				coupon={ coupon }
-				renderFeatureTooltips={ renderFeatureTooltips }
+				enableFeatureTooltips={ enableFeatureTooltips }
 			>
 				<ComparisonGrid
 					intervalType={ intervalType }
@@ -104,7 +104,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		coupon,
 		isInAdmin,
 		className,
-		renderFeatureTooltips,
+		enableFeatureTooltips,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
@@ -134,7 +134,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				useActionCallback={ useActionCallback }
 				recordTracksEvent={ recordTracksEvent }
 				allFeaturesList={ allFeaturesList }
-				renderFeatureTooltips={ renderFeatureTooltips }
+				enableFeatureTooltips={ enableFeatureTooltips }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -156,6 +156,7 @@ export type GridContextProps = {
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
 	children: React.ReactNode;
 	coupon?: string;
+	renderFeatureTooltips?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit< GridContextProps, 'children' > &

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -156,7 +156,7 @@ export type GridContextProps = {
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
 	children: React.ReactNode;
 	coupon?: string;
-	renderFeatureTooltips?: boolean;
+	enableFeatureTooltips?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit< GridContextProps, 'children' > &


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/89682
Based on https://github.com/Automattic/wp-calypso/pull/89800

## Proposed Changes

- Makes the feature tooltips in Features Grid and Comparison Grid optional
- Introduces `renderFeatureTooltips` optional context prop for controlling this
- Other tooltips (e.g. for plan logos) continue to work irrespective

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans?flags=onboarding/trail-map-feature-grid` and onfirm feature tooltips are no longer rendering (for the features that have them)
* Disable the flag (`/start/plans?flags=-onboarding/trail-map-feature-grid`) and confirm tooltips work as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?