### PR TITLE
Site monitoring: Fix for missing tabs

### DIFF
--- a/client/site-monitoring/index.tsx
+++ b/client/site-monitoring/index.tsx
@@ -1,7 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { siteSelection, sites } from 'calypso/my-sites/controller';
-import { redirectHomeIfIneligible } from 'calypso/my-sites/site-monitoring/controller';
+import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
+import { redirectHomeIfIneligible, siteMetrics } from 'calypso/my-sites/site-monitoring/controller';
 import {
 	siteMonitoringOverview,
 	siteMonitoringPhpLogs,
@@ -10,30 +11,43 @@ import {
 
 export default function () {
 	page( '/site-monitoring', siteSelection, sites, makeLayout, clientRender );
-	page(
-		'/site-monitoring/:site',
-		siteSelection,
-		redirectHomeIfIneligible,
-		siteMonitoringOverview,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/site-monitoring/:site/php',
-		siteSelection,
-		redirectHomeIfIneligible,
-		siteMonitoringPhpLogs,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/site-monitoring/:site/web',
-		siteSelection,
-		redirectHomeIfIneligible,
-		siteMonitoringServerLogs,
-		makeLayout,
-		clientRender
-	);
+
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		page(
+			'/site-monitoring/:site',
+			siteSelection,
+			redirectHomeIfIneligible,
+			siteMonitoringOverview,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/site-monitoring/:site/php',
+			siteSelection,
+			redirectHomeIfIneligible,
+			siteMonitoringPhpLogs,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/site-monitoring/:site/web',
+			siteSelection,
+			redirectHomeIfIneligible,
+			siteMonitoringServerLogs,
+			makeLayout,
+			clientRender
+		);
+	} else {
+		page(
+			'/site-monitoring/:siteId/:tab(php|web)?',
+			siteSelection,
+			redirectHomeIfIneligible,
+			navigation,
+			siteMetrics,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	// Legacy redirect for Site Logs.
 	const redirectSiteLogsToMonitoring: Callback = ( context ) => {


### PR DESCRIPTION
This fixes issue https://github.com/Automattic/wp-calypso/issues/89844

Reported on slack here - p1713954017317509-slack-C03TY6J1A

There was a regression added with https://github.com/Automattic/wp-calypso/pull/89741 where the tabs (below) were not rendered on the metrics page.

<img width="649" alt="Screenshot 2024-04-24 at 12 31 47" src="https://github.com/Automattic/wp-calypso/assets/5560595/19c2f34b-7040-4930-995a-790fe026fa5f">

This PR will render this page as normal (with the tabs) when the feature flag (`?flags=layout/dotcom-nav-redesign-v2`) is not enabled. 

When the feature flag is enabled, we will want to render each page individually as they will be render this way in the new sites dashboard flyout panels.

## Before

<img width="1367" alt="Screenshot 2024-04-24 at 12 37 52" src="https://github.com/Automattic/wp-calypso/assets/5560595/c224f872-f3ed-41a2-8d05-77e381ac75a7">

## After

<img width="1370" alt="Screenshot 2024-04-24 at 12 38 08" src="https://github.com/Automattic/wp-calypso/assets/5560595/64ce9482-4f4b-447c-8111-e1bcc5d63bf0">

### Testing instructions

* Apply PR and confirm that you can see the tabs and they work as expected when you go to `/site-monitoring/{atomic-site}`
* Confirm that the tabs are not rendered and the global sidebar is rendered when the query param `?flags=layout/dotcom-nav-redesign-v2` is added to URL.