### PR TITLE
A4A: Fix the issue with the Volume pricing selector not working when the URL has a hash fragment.

### DIFF
--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -26,5 +26,5 @@ export const requireAccessContext: Callback = ( context, next ) => {
 	}
 
 	const args = getQueryArgs( window.location.href );
-	page.redirect( addQueryArgs( A4A_LANDING_LINK, { ...args, return: pathname + hash + search } ) );
+	page.redirect( addQueryArgs( A4A_LANDING_LINK, { ...args, return: pathname + search + hash } ) );
 };

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -12,6 +12,7 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { useSelector } from 'calypso/state';
 import getSites from 'calypso/state/selectors/get-sites';
 import { ShoppingCartContext } from '../context';
@@ -28,6 +29,8 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 
 	const { selectedCartItems, setSelectedCartItems, onRemoveCartItem } = useShoppingCart();
 
+	const { isLoading } = useProductsQuery();
+
 	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
 
 	const sites = useSelector( getSites );
@@ -42,7 +45,7 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 	}, [ siteId, sites ] );
 
 	useEffect( () => {
-		if ( window.location.hash ) {
+		if ( window.location.hash && ! isLoading ) {
 			const target = window.location.hash.replace( '#', '' );
 			const element = document.getElementById( target );
 
@@ -53,7 +56,7 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 				} );
 			}
 		}
-	}, [] );
+	}, [ isLoading ] );
 
 	return (
 		<Layout

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-product-bundle-size.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-product-bundle-size.tsx
@@ -43,15 +43,18 @@ export function useProductBundleSize( isPublicFacing = false ) {
 				return;
 			}
 
+			// We need to make sure that we  add query parameters after the #, otherwise it will not be parsed correctly.
+			const hrefWithoutHash = window.location.origin + window.location.pathname;
+
 			const queryArgs =
 				size === 1
-					? removeQueryArgs( window.location.href, BUNDLE_SIZE_PARAM_KEY )
-					: addQueryArgs( window.location.href, {
+					? removeQueryArgs( hrefWithoutHash, BUNDLE_SIZE_PARAM_KEY )
+					: addQueryArgs( hrefWithoutHash, {
 							...getQueryArgs( window.location.href ),
 							[ BUNDLE_SIZE_PARAM_KEY ]: `${ size }`,
 					  } );
 
-			window.history.pushState( null, '', queryArgs );
+			window.history.pushState( null, '', queryArgs + window.location.hash ); // Insert back the hash to retain it.
 
 			setSelectedSize( size );
 		},


### PR DESCRIPTION
This issue relates to the Volume pricing selector in the Marketplace products section. When a hash (#) fragment is present in the URL, there is a tendency for the selector to stop working properly and be unresponsive with clicks.  This is because the component uses `getQueryArgs` to extract the current bundle size query parameter, but `getQueryArgs` cannot parse any strings after the # symbol in the URL to extract values.

To address this problem, we need to ensure that the URL is constructed correctly when we select a bundle size from the volume pricing selector. This PR fixes the issue by implementing the necessary changes.

Related to https://github.com/Automattic/wp-calypso/pull/89797

| Incorrect URL construction | Correct ✅  |
|--------|--------|
| `/marketplace/products#woocommerce-extensions?bundle_size=10` |`/marketplace/products?bundle_size=10#woocommerce-extensions` | 


## Proposed Changes

* Update `useProductBundleSize` hook to insert `bundle_size` before hash fragment parameter.

## Testing Instructions

* Use the A4A live link below and go to the `/overview` page.
* Scroll down to the products section and select the **View all Woocommerce products** or the **View all Jetpack products** button. This will redirect you to the Marketplace with a hash fragment (e.g. `#woocommerce-extensions`)
* In the Marketplace, select any bundle size in the Volume pricing selector.
* Confirm that it works properly.
   <img width="489" alt="Screenshot 2024-04-24 at 7 40 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/186c2fa0-8959-4cd7-97d7-26546db47026">



## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?