### PR TITLE
Scheduled Updates: multisite query 

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,11 +1,17 @@
 import { ScheduleCreate } from './schedule-create';
+import { ScheduleList } from './schedule-list';
 
 import './styles.scss';
 
 type Props = {
 	onNavBack?: () => void;
+	context: 'create' | 'edit' | 'list';
 };
 
-export const PluginsScheduledUpdatesMultisite = ( { onNavBack }: Props ) => {
-	return <ScheduleCreate onNavBack={ onNavBack } />;
+export const PluginsScheduledUpdatesMultisite = ( { context, onNavBack }: Props ) => {
+	switch ( context ) {
+		case 'create':
+			return <ScheduleCreate onNavBack={ onNavBack } />;
+	}
+	return <ScheduleList />;
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -1,7 +1,7 @@
-import { useUpdateSchedulesQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { useMultisiteUpdateSchedulesQuery } from 'calypso/data/plugins/use-update-schedules-query';
 
 export const ScheduleList = () => {
-	const { data } = useUpdateSchedulesQuery( true );
+	const { data } = useMultisiteUpdateSchedulesQuery( true );
 
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -1,0 +1,12 @@
+import { useUpdateSchedulesQuery } from 'calypso/data/plugins/use-update-schedules-query';
+
+export const ScheduleList = () => {
+	const { data } = useUpdateSchedulesQuery( true );
+
+	return (
+		<div className="plugins-update-manager plugins-update-manager-multisite">
+			<h1 className="wp-brand-font">List schedules</h1>
+			<pre>{ JSON.stringify( data, null, 4 ) }</pre>
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -1,7 +1,7 @@
-import { useMultisiteUpdateSchedulesQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 
 export const ScheduleList = () => {
-	const { data } = useMultisiteUpdateSchedulesQuery( true );
+	const { data } = useMultisiteUpdateScheduleQuery( true );
 
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -34,6 +34,7 @@ export type MultisiteSchedulesUpdates = Omit<
 	ScheduleUpdates,
 	'last_run_status' | 'last_run_timestamp'
 > & {
+	schedule_id: string;
 	sites: MultisiteSiteDetails[];
 };
 
@@ -108,7 +109,13 @@ export const useMultisiteUpdateScheduleQuery = (
 					const { timestamp, schedule, args, interval, last_run_timestamp, last_run_status } =
 						data.sites[ site_id ][ scheduleId ];
 
-					const existingSchedule = result.find( ( item ) => item.id === scheduleId );
+					const existingSchedule = result.find(
+						( item ) =>
+							item.id === scheduleId &&
+							item.timestamp === timestamp &&
+							item.schedule === schedule &&
+							item.interval === interval
+					);
 
 					const site = retrieveSite( parseInt( site_id, 10 ) ) as SiteDetails;
 					if ( existingSchedule ) {
@@ -119,7 +126,8 @@ export const useMultisiteUpdateScheduleQuery = (
 						} );
 					} else {
 						result.push( {
-							id: scheduleId,
+							id: `${ scheduleId }-${ schedule }-${ interval }-${ timestamp }`,
+							schedule_id: scheduleId,
 							timestamp,
 							schedule,
 							args,

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -111,7 +111,7 @@ export const useMultisiteUpdateScheduleQuery = (
 
 					const existingSchedule = result.find(
 						( item ) =>
-							item.id === scheduleId &&
+							item.schedule_id === scheduleId &&
 							item.timestamp === timestamp &&
 							item.schedule === schedule &&
 							item.interval === interval

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -77,7 +77,7 @@ export const useUpdateScheduleQuery = (
 	} );
 };
 
-export const useMultisiteUpdateSchedulesQuery = (
+export const useMultisiteUpdateScheduleQuery = (
 	isEligibleForFeature: boolean,
 	queryOptions = {}
 ): UseQueryResult< MultisiteSchedulesUpdates[] > => {
@@ -91,7 +91,7 @@ export const useMultisiteUpdateSchedulesQuery = (
 	);
 
 	return useQuery< MultisiteSchedulesUpdatesResponse, Error, MultisiteSchedulesUpdates[] >( {
-		queryKey: [ 'schedules-updates' ],
+		queryKey: [ 'multisite-schedules-update' ],
 		queryFn: () =>
 			wpcomRequest< MultisiteSchedulesUpdatesResponse >( {
 				path: `/hosting/update-schedules`,

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -1,6 +1,18 @@
+import { SiteDetails } from '@automattic/data-stores';
 import { useQuery, UseQueryResult, type QueryObserverOptions } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
+import { useSelector } from 'calypso/state';
+import { getSite } from 'calypso/state/sites/selectors';
 import type { SiteSlug } from 'calypso/types';
+
+type LastRunStatus =
+	| 'in-progress'
+	| 'success'
+	| 'failure'
+	| 'failure-and-rollback'
+	| 'failure-and-rollback-fail'
+	| null;
 
 export type ScheduleUpdates = {
 	id: string;
@@ -9,14 +21,21 @@ export type ScheduleUpdates = {
 	timestamp: number;
 	schedule: 'weekly' | 'daily';
 	args: string[];
-	last_run_status:
-		| 'in-progress'
-		| 'success'
-		| 'failure'
-		| 'failure-and-rollback'
-		| 'failure-and-rollback-fail'
-		| null;
+	last_run_status: LastRunStatus;
 	last_run_timestamp: number | null;
+};
+
+type SiteStatus = SiteDetails & {
+	last_run_status: LastRunStatus;
+	last_run_timestamp: number | null;
+};
+
+export type SchedulesUpdates = Omit< ScheduleUpdates, 'last_run_status' | 'last_run_timestamp' > & {
+	sites: SiteStatus[];
+};
+
+type SchedulesUpdatesResponse = {
+	sites: { [ site_id: string ]: { [ scheduleId: string ]: ScheduleUpdates } };
 };
 
 export const useUpdateScheduleQuery = (
@@ -50,6 +69,72 @@ export const useUpdateScheduleQuery = (
 		enabled: !! siteSlug && isEligibleForFeature,
 		retry: false,
 		select,
+		refetchOnWindowFocus: false,
+		...queryOptions,
+	} );
+};
+
+export const useUpdateSchedulesQuery = (
+	isEligibleForFeature: boolean,
+	queryOptions = {}
+): UseQueryResult< SchedulesUpdates[] > => {
+	const state = useSelector( ( state ) => state );
+
+	const retrieveSite = useCallback(
+		( siteId: number ) => {
+			return getSite( state, siteId );
+		},
+		[ state ]
+	);
+
+	return useQuery< SchedulesUpdatesResponse, Error, SchedulesUpdates[] >( {
+		queryKey: [ 'schedules-updates' ],
+		queryFn: () =>
+			wpcomRequest< SchedulesUpdatesResponse >( {
+				path: `/hosting/update-schedules`,
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+			} ),
+		enabled: isEligibleForFeature,
+		retry: false,
+		select: ( data ) => {
+			const result: SchedulesUpdates[] = [];
+
+			for ( const site_id in data.sites ) {
+				for ( const scheduleId in data.sites[ site_id ] ) {
+					const { timestamp, schedule, args, interval, last_run_timestamp, last_run_status } =
+						data.sites[ site_id ][ scheduleId ];
+
+					const existingSchedule = result.find( ( item ) => item.id === scheduleId );
+
+					const site = retrieveSite( parseInt( site_id, 10 ) ) as SiteDetails;
+					if ( existingSchedule ) {
+						existingSchedule.sites.push( {
+							...site,
+							last_run_status,
+							last_run_timestamp,
+						} );
+					} else {
+						result.push( {
+							id: scheduleId,
+							timestamp,
+							schedule,
+							args,
+							interval,
+							sites: [
+								{
+									...site,
+									last_run_status,
+									last_run_timestamp,
+								},
+							],
+						} );
+					}
+				}
+			}
+
+			return result;
+		},
 		refetchOnWindowFocus: false,
 		...queryOptions,
 	} );

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -25,16 +25,19 @@ export type ScheduleUpdates = {
 	last_run_timestamp: number | null;
 };
 
-type SiteStatus = SiteDetails & {
+type MultisiteSiteDetails = SiteDetails & {
 	last_run_status: LastRunStatus;
 	last_run_timestamp: number | null;
 };
 
-export type SchedulesUpdates = Omit< ScheduleUpdates, 'last_run_status' | 'last_run_timestamp' > & {
-	sites: SiteStatus[];
+export type MultisiteSchedulesUpdates = Omit<
+	ScheduleUpdates,
+	'last_run_status' | 'last_run_timestamp'
+> & {
+	sites: MultisiteSiteDetails[];
 };
 
-type SchedulesUpdatesResponse = {
+type MultisiteSchedulesUpdatesResponse = {
 	sites: { [ site_id: string ]: { [ scheduleId: string ]: ScheduleUpdates } };
 };
 
@@ -74,10 +77,10 @@ export const useUpdateScheduleQuery = (
 	} );
 };
 
-export const useUpdateSchedulesQuery = (
+export const useMultisiteUpdateSchedulesQuery = (
 	isEligibleForFeature: boolean,
 	queryOptions = {}
-): UseQueryResult< SchedulesUpdates[] > => {
+): UseQueryResult< MultisiteSchedulesUpdates[] > => {
 	const state = useSelector( ( state ) => state );
 
 	const retrieveSite = useCallback(
@@ -87,10 +90,10 @@ export const useUpdateSchedulesQuery = (
 		[ state ]
 	);
 
-	return useQuery< SchedulesUpdatesResponse, Error, SchedulesUpdates[] >( {
+	return useQuery< MultisiteSchedulesUpdatesResponse, Error, MultisiteSchedulesUpdates[] >( {
 		queryKey: [ 'schedules-updates' ],
 		queryFn: () =>
-			wpcomRequest< SchedulesUpdatesResponse >( {
+			wpcomRequest< MultisiteSchedulesUpdatesResponse >( {
 				path: `/hosting/update-schedules`,
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
@@ -98,7 +101,7 @@ export const useUpdateSchedulesQuery = (
 		enabled: isEligibleForFeature,
 		retry: false,
 		select: ( data ) => {
-			const result: SchedulesUpdates[] = [];
+			const result: MultisiteSchedulesUpdates[] = [];
 
 			for ( const site_id in data.sites ) {
 				for ( const scheduleId in data.sites[ site_id ] ) {

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -185,15 +185,23 @@ export function scheduledUpdatesMultisite( context, next ) {
 		case 'create':
 			context.primary = createElement( PluginsScheduledUpdatesMultisite, {
 				onNavBack: goToScheduledUpdatesList,
+				context: 'create',
 			} );
 			break;
 
 		case 'edit':
-			context.primary = `Edit multisite scheduled updates ${ context.params.schedule_id }`;
+			context.primary = createElement( PluginsScheduledUpdatesMultisite, {
+				onNavBack: goToScheduledUpdatesList,
+				scheduleId: context.params.scheduleId,
+				context: 'edit',
+			} );
 			break;
 
 		default:
-			context.primary = 'List of multisite scheduled updates';
+			context.primary = createElement( PluginsScheduledUpdatesMultisite, {
+				onNavBack: goToScheduledUpdatesList,
+				context: 'list',
+			} );
 			break;
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89734

## Proposed Changes

- Implements `useMultisiteUpdateSchedulesQuery`

This query fetches `/hosting/update-schedules` and transforms this into a format ready to be consumed by the list.

````
schedule_id:
    interval
    args (plugins)
    schedule
    sites[]:
     last_run_status
     last_run_timestamp
     ...siteDetails
````

- It also sets up the routing for list/create/update in a similar way as single site scheduled updates.      


![CleanShot 2024-04-24 at 13 43 26@2x](https://github.com/Automattic/wp-calypso/assets/528287/a69ccbc3-d5b1-4d3b-8781-6529d077221e)

## Testing Instructions

- Apply this PR
- Make sure you have two WoA sites, both running Jetpack & jetpack-mu-wpcom bleeding edge
- Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/create` and create a schedule for both sites
- If everything goes well (check the console / network tab) you should be redirected to the list and see the raw output of the query.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?