### PR TITLE
Marketplace: adds hardcoded bazaar plugin.

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -79,3 +79,49 @@ export const ECOMMERCE_BUNDLED_PLUGINS = [
 ];
 
 export const UNLISTED_PLUGINS = [ 'automated-db-schenker-shipping' ];
+
+export const FREE_NON_ORG_PLUGINS = {
+	bazaar: {
+		name: 'Bazaar',
+		slug: 'bazaar',
+		software_slug: 'bazaar',
+		org_slug: null,
+		isMarketplaceProduct: false,
+		isSaasProduct: false,
+		wporg: false,
+		short_description:
+			'Maximize opportunities for both sellers and publishers. Sellers easily list their goods, while publishers effortlessly expand their offerings.',
+		description:
+			'Maximize opportunities for both sellers and publishers. Sellers easily list their goods, while publishers effortlessly expand their offerings.',
+		requirements: { required_primary_domain: null, plugins: [ 'woocommerce' ], themes: [] },
+		variations: null,
+		icon: 'https://ps.w.org/woocommerce/assets/icon-256x256.gif?rev=2869506',
+		banners: {
+			high: 'https://ps.w.org/woocommerce/assets/banner-1544x500.png?rev=3000842',
+		},
+		tags: {
+			plugins: 'Plugins',
+			ecommerce: 'eCommerce',
+			'store-management': 'Store Management',
+		},
+		sections: {
+			description:
+				'Maximize opportunities for both sellers and publishers. Sellers easily list their goods, while publishers effortlessly expand their offerings.',
+			changelog: 'changelog',
+			faq: 'faq',
+			installation: 'installation',
+		},
+		rating: '80',
+		reviews_link: null,
+		author_name: 'Automattic',
+		demo_url: null,
+		documentation_url: null,
+		version: '1.0.0',
+		tested: '6.5.2',
+		last_updated: '2024-04-24',
+		product_video: null,
+		setup_url: null,
+		is_hidden: false,
+		saas_landing_page: null,
+	},
+};

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -76,6 +76,7 @@ import {
 	isRequestingSites as checkRequestingSites,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { FREE_NON_ORG_PLUGINS } from './constants';
 import { MarketplaceFooter } from './education-footer';
 import NoPermissionsError from './no-permissions-error';
 import { usePluginIsMaintained } from './use-plugin-is-maintained';
@@ -97,6 +98,7 @@ function PluginDetails( props ) {
 	const { localizePath } = useLocalizedPlugins();
 
 	// Plugin information.
+	const freeNonOrgPlugin = FREE_NON_ORG_PLUGINS[ props.pluginSlug ];
 	const PREMIUM_SLUG_FIELD = 'plugin.premium_slug';
 	const { data: esPlugin = {} } = useESPlugin( props.pluginSlug, [ PREMIUM_SLUG_FIELD ] );
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );
@@ -151,7 +153,12 @@ function PluginDetails( props ) {
 
 	// Fetch WPorg plugin data if needed
 	useEffect( () => {
-		if ( isProductListFetched && ! isMarketplaceProduct && ! isWporgPluginFetched ) {
+		if (
+			isProductListFetched &&
+			! isMarketplaceProduct &&
+			! isWporgPluginFetched &&
+			! freeNonOrgPlugin
+		) {
 			dispatch( wporgFetchPluginData( props.pluginSlug, translate.localeSlug ) );
 		}
 	}, [
@@ -161,6 +168,7 @@ function PluginDetails( props ) {
 		props.pluginSlug,
 		dispatch,
 		translate.localeSlug,
+		freeNonOrgPlugin,
 	] );
 
 	// Fetch WPcom plugin data if needed
@@ -180,8 +188,9 @@ function PluginDetails( props ) {
 			...esPlugin,
 			...wpcomPlugin,
 			...wporgPlugin,
+			...freeNonOrgPlugin,
 			...plugin,
-			fetched: wpcomPlugin?.fetched || wporgPlugin?.fetched,
+			fetched: wpcomPlugin?.fetched || wporgPlugin?.fetched || freeNonOrgPlugin,
 			isMarketplaceProduct,
 			isSaasProduct,
 		};
@@ -193,11 +202,13 @@ function PluginDetails( props ) {
 		isWpComPluginFetched,
 		isMarketplaceProduct,
 		isSaasProduct,
+		freeNonOrgPlugin,
 	] );
 
 	const existingPlugin = useMemo( () => {
 		if (
 			( ! isMarketplaceProduct &&
+				! freeNonOrgPlugin &&
 				( isWporgPluginFetching || ( ! isWporgPluginFetched && ! wporgPluginError ) ) ) ||
 			( isMarketplaceProduct && ( isWpComPluginFetching || ! isWpComPluginFetched ) )
 		) {
@@ -206,7 +217,6 @@ function PluginDetails( props ) {
 		if ( fullPlugin && fullPlugin.fetched ) {
 			return true;
 		}
-
 		// If the plugin has at least one site then we know it exists
 		const pluginSites = fullPlugin?.sites ? Object.values( fullPlugin.sites ) : [];
 		if ( pluginSites && pluginSites[ 0 ] ) {
@@ -227,6 +237,7 @@ function PluginDetails( props ) {
 		wporgPluginError,
 		fullPlugin,
 		requestingPluginsForSites,
+		freeNonOrgPlugin,
 	] );
 
 	const canPublishReview = useSelector( ( state ) =>
@@ -454,7 +465,7 @@ function PluginDetails( props ) {
 									</Notice>
 								) }
 
-								{ fullPlugin.wporg || isMarketplaceProduct ? (
+								{ fullPlugin.wporg || isMarketplaceProduct || freeNonOrgPlugin ? (
 									<PluginSections plugin={ fullPlugin } isWpcom={ isWpcom } addBanner />
 								) : (
 									<PluginSectionsCustom plugin={ fullPlugin } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6646
Blocked by: plugin should become managed first p9o2xV-4bp-p2

## Proposed Changes

* adds bazaar as a Calypso hardcoded  plugin. 
 
The WP.com Marketplace has a lot of checks ( in wpcom, Calypso,and Elastic ) to avoid showing paid products as free, thus we cannot add it in the usual way through WooCoommerce.com. If the plugin is ever launched in WP.org, we can simply remove the code this PR introduces and will still keep working as expected.

![CleanShot 2024-04-24 at 15 33 25@2x](https://github.com/Automattic/wp-calypso/assets/12430020/6dc3421a-4d82-46fa-b92f-957c67d756ae)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Notes: 

1. data are still not finalised 
2. the plugin cannot yet be installed. Pending to become managed p9o2xV-4bp-p2

* Visit `/plugins/bazaar`
* Make sure all properties display ( eg title, icon, description, sections, etc )
* Make sure the plugin is marked as `Free` and requires a `Creator` plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?