### PR TITLE
A4A: Remove the Standard Licenses tab and badge in the Licenses overview page.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -237,11 +237,7 @@ export default function LicensePreview( {
 				) }
 
 				<div className="license-preview__badge-container">
-					{ isParentLicense
-						? bundleCountContent
-						: LicenseType.Standard === licenseType && (
-								<Badge type="success">{ translate( 'Standard license' ) }</Badge>
-						  ) }
+					{ isParentLicense && bundleCountContent }
 				</div>
 
 				<div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -164,7 +164,7 @@ export default function LicensePreview( {
 						<>
 							<div className="license-preview__product-small">{ product }</div>
 							{ domain }
-							{ isPressableLicense && (
+							{ isPressableLicense && ! revokedAt && (
 								<a
 									className="license-preview__product-pressable-link"
 									target="_blank"
@@ -241,7 +241,7 @@ export default function LicensePreview( {
 				</div>
 
 				<div>
-					{ isParentLicense && (
+					{ isParentLicense && ! revokedAt && (
 						<LicenseBundleDropDown
 							product={ product }
 							licenseKey={ licenseKey }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-state-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-state-filter/index.tsx
@@ -32,10 +32,6 @@ function LicenseStateFilter( { data }: { data: Record< LicenseFilter, number > }
 			key: LicenseFilter.Revoked,
 			label: translate( 'Revoked' ),
 		},
-		{
-			key: LicenseFilter.Standard,
-			label: translate( 'Standard licenses' ),
-		},
 	].map( ( navItem ) => ( {
 		...navItem,
 		count: data?.[ navItem.key ] || 0,


### PR DESCRIPTION
This PR removes any reference or copies that use the term Standard Licenses as this is no longer relevant in the A4A context.

| Before | After |
|--------|--------|
| <img width="715" alt="Screenshot 2024-04-24 at 8 22 43 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ef41382e-410e-4a90-bd7c-1ff6b6842225"> | <img width="657" alt="Screenshot 2024-04-24 at 8 24 52 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/720056d6-c68c-40a5-8977-2c8688b4dfa4"> |
| <img width="1529" alt="Screenshot 2024-04-24 at 8 23 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d256f7bc-409c-47e2-9cc1-660d688efd73"> | <img width="1520" alt="Screenshot 2024-04-24 at 8 25 18 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9c58af17-34de-47aa-ab27-ca08da57ed17"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/349

## Proposed Changes

* Remove the 'Standard Licenses' tab and badges in the Licenses overview page.
* **Additional fix with few buttons appearing while the license is already revoked. It's not part of the main issue but is tiny enough to be squeezed into this PR.** 
   <img width="246" alt="Screenshot 2024-04-24 at 8 30 09 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6cd1724e-2396-4eca-9fff-cdb7a4dd1363">  <img width="229" alt="Screenshot 2024-04-24 at 8 31 47 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d8a6f082-c8eb-444e-abbd-268e520e5e4b">




## Testing Instructions

* Use the live link below and go to `/purchases/licenses` page.
* Confirm that the Standard Licenses tab is no longer visible.
* Confirm that the Standard License badge is no longer visible for standard licenses. (e.g., Bought Jetpack licenses, not from Jetpack licensing API).


**Additional Fix**
* Under the revoke tab, make sure the following issues are fixed.
     * Revoked Pressable plan should not show the 'Managed in Pressable' button.
     * Revoked Bundle licenses should not show the 'More action' icon. 


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?