### PR TITLE
Sites Dashboard V2 - add search functionality

### DIFF
--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -37,7 +37,7 @@ import './style.scss';
 
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
-	updateQueryParams: ( params: SitesDashboardQueryParams ) => void;
+	updateQueryParams?: ( params: SitesDashboardQueryParams ) => void;
 }
 
 const SitesDashboardV2 = ( {

--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -84,26 +84,19 @@ const SitesDashboardV2 = ( {
 		}
 	}, [ dataViewsState.selectedItem ] );
 
-	const setQueryParams = useCallback(
-		( queryParams: SitesDashboardQueryParams ) => {
-			// There is a chance that the URL is not up to date when it mounts, so delay
-			// the updateQueryParams call to avoid it getting the incorrect URL and then
-			// redirecting back to the previous path.
-			if ( window.location.pathname.startsWith( `/${ section?.group }` ) ) {
-				updateQueryParams( queryParams );
-			} else {
-				window.setTimeout( () => updateQueryParams( queryParams ) );
-			}
-		},
-		[ updateQueryParams, section?.group ]
-	);
-
 	// Update URL with search param on change
 	useEffect( () => {
 		const queryParams = { search: dataViewsState.search?.trim() };
 
-		setQueryParams( queryParams );
-	}, [ dataViewsState.search, setQueryParams ] );
+		// There is a chance that the URL is not up to date when it mounts, so delay
+		// the updateQueryParams call to avoid it getting the incorrect URL and then
+		// redirecting back to the previous path.
+		if ( window.location.pathname.startsWith( `/${ section?.group }` ) ) {
+			updateQueryParams( queryParams );
+		} else {
+			window.setTimeout( () => updateQueryParams( queryParams ) );
+		}
+	}, [ dataViewsState.search, updateQueryParams, section?.group ] );
 
 	// Search, filtering, pagination and sorting sites:
 	useEffect( () => {

--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -25,9 +25,8 @@ import {
 	useShowSiteCreationNotice,
 	useShowSiteTransferredNotice,
 } from 'calypso/sites-dashboard/components/sites-dashboard';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { getSection } from 'calypso/state/ui/selectors';
 import DotcomPreviewPane from './site-preview-pane/dotcom-preview-pane';
 import SitesDashboardHeader from './sites-dashboard-header';
 import DotcomSitesDataViews from './sites-dataviews';
@@ -46,7 +45,6 @@ const SitesDashboardV2 = ( {
 }: SitesDashboardProps ) => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
-	const section = useSelector( getSection );
 
 	const { data: liveSites = [], isLoading } = useSiteExcerptsQuery(
 		[],
@@ -88,15 +86,11 @@ const SitesDashboardV2 = ( {
 	useEffect( () => {
 		const queryParams = { search: dataViewsState.search?.trim() };
 
-		// There is a chance that the URL is not up to date when it mounts, so delay
-		// the updateQueryParams call to avoid it getting the incorrect URL and then
-		// redirecting back to the previous path.
-		if ( window.location.pathname.startsWith( `/${ section?.group }` ) ) {
-			updateQueryParams( queryParams );
-		} else {
-			window.setTimeout( () => updateQueryParams( queryParams ) );
-		}
-	}, [ dataViewsState.search, updateQueryParams, section?.group ] );
+		// There is a chance that the URL is not up to date when it mounts, so bump the
+		// updateQueryParams call to the back of the stack to avoid it getting the incorrect URL and
+		// then redirecting back to the previous path.
+		window.setTimeout( () => updateQueryParams( queryParams ) );
+	}, [ dataViewsState.search, updateQueryParams ] );
 
 	// Search, filtering, pagination and sorting sites:
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to connecting functionality on top of # https://github.com/Automattic/wp-calypso/pull/89698

## Proposed Changes

* Adds search functionality to the new sites dashboard.
* NOTE - functionalities for filtering, sorting, pagination, etc. are not yet setup and scoped for follow up PRs.

BEFORE
![Screenshot 2024-04-24 at 10 52 49 AM](https://github.com/Automattic/wp-calypso/assets/28742426/d0519ef1-cf1b-43db-bca6-b21f2f49f347)

AFTER
![Screenshot 2024-04-24 at 10 51 56 AM](https://github.com/Automattic/wp-calypso/assets/28742426/eebacc72-5dff-42cc-a311-4390e0515a88)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso.
* Visit the sites dashboard `*/sites` with the feature flag `?flags=layout/dotcom-nav-redesign-v2` added to the url.
* Type in the search input, verify the sites list filters according to the search. Verify the search query is updated in the url.
* Reload the page, verify the sites list initializes filtered given the previous search query that was preserved in the url.
* Smoke test the dashboard without the feature flag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
