### PR TITLE
Site Migration: Update site-migration-upgrade-plan tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -29,6 +29,11 @@ jest.mock( 'calypso/data/hosting/use-add-hosting-trial-mutation' );
 
 const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
 
+interface TrialEligibilityResponse {
+	eligible: boolean;
+	error_code: string;
+}
+
 const API_RESPONSE_EMAIL_VERIFIED = {
 	eligible: true,
 	error_code: 'email-verified',
@@ -39,7 +44,7 @@ const API_RESPONSE_EMAIL_UNVERIFIED = {
 	error_code: 'email-unverified',
 };
 
-const mockTrialEligibilityAPI = ( payload: any ) => {
+const mockTrialEligibilityAPI = ( payload: TrialEligibilityResponse ) => {
 	mockApi()
 		.get( `/wpcom/v2/sites/site-id/hosting/trial/check-eligibility/${ planSlug }` )
 		.reply( 200, payload );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -1,19 +1,21 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import React from 'react';
 import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
-import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import plansReducer from 'calypso/state/plans/reducer';
 import SiteMigrationUpgradePlan from '../';
 import { StepProps } from '../../../types';
 import { mockStepProps, renderStep } from '../../test/helpers';
 
+const planSlug = PLAN_MIGRATION_TRIAL_MONTHLY;
+
 jest.mock( 'calypso/landing/stepper/hooks/use-site' );
-jest.mock( 'calypso/data/plans/use-check-eligibility-migration-trial-plan' );
 jest.mock( 'calypso/data/hosting/use-add-hosting-trial-mutation' );
 
 ( useSite as jest.Mock ).mockReturnValue( {
@@ -21,13 +23,27 @@ jest.mock( 'calypso/data/hosting/use-add-hosting-trial-mutation' );
 	URL: 'https://site-url.wordpress.com',
 } );
 
-( useCheckEligibilityMigrationTrialPlan as jest.Mock ).mockReturnValue( {
-	data: { eligible: true },
-} );
-
 ( useAddHostingTrialMutation as jest.Mock ).mockImplementation( ( { onSuccess } ) => ( {
 	addHostingTrial: () => onSuccess(),
 } ) );
+
+const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
+
+const API_RESPONSE_EMAIL_VERIFIED = {
+	eligible: true,
+	error_code: 'email-verified',
+};
+
+const API_RESPONSE_EMAIL_UNVERIFIED = {
+	eligible: false,
+	error_code: 'email-unverified',
+};
+
+const mockTrialEligibilityAPI = ( payload: any ) => {
+	mockApi()
+		.get( `/wpcom/v2/sites/site-id/hosting/trial/check-eligibility/${ planSlug }` )
+		.reply( 200, payload );
+};
 
 describe( 'SiteMigrationUpgradePlan', () => {
 	const render = ( props?: Partial< StepProps > ) => {
@@ -38,6 +54,11 @@ describe( 'SiteMigrationUpgradePlan', () => {
 			},
 		} );
 	};
+
+	beforeAll( () => {
+		nock.disableNetConnect();
+		mockTrialEligibilityAPI( API_RESPONSE_EMAIL_VERIFIED );
+	} );
 
 	it( 'selects annual plan as default', async () => {
 		const navigation = { submit: jest.fn() };
@@ -78,14 +99,40 @@ describe( 'SiteMigrationUpgradePlan', () => {
 	} );
 
 	it( 'selects free trial', async () => {
+		mockTrialEligibilityAPI( API_RESPONSE_EMAIL_VERIFIED );
 		const navigation = { submit: jest.fn() };
 		render( { navigation } );
 
-		await userEvent.click( screen.getByRole( 'button', { name: /Try 7 days for free/ } ) );
-		await userEvent.click( screen.getByRole( 'button', { name: /Upgrade and migrate/ } ) );
+		await waitFor( async () => {
+			await userEvent.click( screen.getByRole( 'button', { name: /Try 7 days for free/ } ) );
 
-		expect( navigation.submit ).toHaveBeenCalledWith( {
-			freeTrialSelected: true,
+			expect( navigation.submit ).toHaveBeenCalledWith( {
+				freeTrialSelected: true,
+			} );
+		} );
+	} );
+
+	it( 'show the trial plan for verified users', async () => {
+		nock.cleanAll();
+		mockTrialEligibilityAPI( API_RESPONSE_EMAIL_VERIFIED );
+
+		render( { data: { hideFreeMigrationTrialForNonVerifiedEmail: true } } );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'button', { name: /Try 7 days for free/ } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'hides the trial plan for unverified users', async () => {
+		nock.cleanAll();
+		mockTrialEligibilityAPI( API_RESPONSE_EMAIL_UNVERIFIED );
+
+		render( { data: { hideFreeMigrationTrialForNonVerifiedEmail: true } } );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByRole( 'button', { name: /Try 7 days for free/ } )
+			).not.toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This updates the site-migration-upgrade plan tests to mock the check-eligibility API call instead of the `useCheckEligibilityMigrationTrialPlan` hook and also adds tests to make sure the Trial plan button is hidden for non-verified users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify tests pass
```
yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?