### PR TITLE
Site Migration: Don't headstart the new migration-signup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -14,7 +14,7 @@ import {
 	isFreeFlow,
 	isLinkInBioFlow,
 	isMigrationFlow,
-	isSiteMigrationSignupFlow,
+	isMigrationSignupFlow,
 	isStartWritingFlow,
 	isWooExpressFlow,
 	isEntrepreneurFlow,
@@ -166,7 +166,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		! isStartWritingFlow( flow ) &&
 		! isNewHostedSiteCreationFlow( flow ) &&
 		! isSiteAssemblerFlow( flow ) &&
-		! isSiteMigrationSignupFlow( flow );
+		! isMigrationSignupFlow( flow );
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -14,6 +14,7 @@ import {
 	isFreeFlow,
 	isLinkInBioFlow,
 	isMigrationFlow,
+	isSiteMigrationSignupFlow,
 	isStartWritingFlow,
 	isWooExpressFlow,
 	isEntrepreneurFlow,
@@ -164,7 +165,8 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 	const useThemeHeadstart =
 		! isStartWritingFlow( flow ) &&
 		! isNewHostedSiteCreationFlow( flow ) &&
-		! isSiteAssemblerFlow( flow );
+		! isSiteAssemblerFlow( flow ) &&
+		! isSiteMigrationSignupFlow( flow );
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -1,4 +1,5 @@
 import { useLocale } from '@automattic/i18n-utils';
+import { MIGRATION_SIGNUP_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
@@ -16,7 +17,7 @@ import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 
-const FLOW_NAME = 'migration-signup';
+const FLOW_NAME = MIGRATION_SIGNUP_FLOW;
 
 const migrationSignup: Flow = {
 	name: FLOW_NAME,

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -14,6 +14,7 @@ import {
 	GOOGLE_TRANSFER,
 	REBLOGGING_FLOW,
 	SITE_MIGRATION_FLOW,
+	MIGRATION_SIGNUP_FLOW,
 	ENTREPRENEUR_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
@@ -137,7 +138,7 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	[ REBLOGGING_FLOW ]: () =>
 		import( /* webpackChunkName: "reblogging-flow" */ '../declarative-flow/reblogging' ),
 
-	'migration-signup': () =>
+	[ MIGRATION_SIGNUP_FLOW ]: () =>
 		import( /* webpackChunkName: "migration-signup" */ '../declarative-flow/migration-signup' ),
 };
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -129,7 +129,7 @@ export const isNewSiteMigrationFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ SITE_MIGRATION_FLOW ].includes( flowName ) );
 };
 
-export const isSiteMigrationSignupFlow = ( flowName: string | null ) => {
+export const isMigrationSignupFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ MIGRATION_SIGNUP_FLOW ].includes( flowName ) );
 };
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -24,6 +24,7 @@ export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 export const MIGRATION_FLOW = 'import-focused';
 export const SITE_MIGRATION_FLOW = 'site-migration';
+export const MIGRATION_SIGNUP_FLOW = 'migration-signup';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
@@ -126,6 +127,10 @@ export const isWooExpressFlow = ( flowName: string | null ) => {
 
 export const isNewSiteMigrationFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ SITE_MIGRATION_FLOW ].includes( flowName ) );
+};
+
+export const isSiteMigrationSignupFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ MIGRATION_SIGNUP_FLOW ].includes( flowName ) );
 };
 
 export const isBuildFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This does a little cleanup by adding a new constant for the migration-signup flow name as well as a function for checking for the flow.

Then we use that new function to skip headstarting sites created with the migration-signup flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection and tests passing should be fine.
* But you can also visit `/setup/migration-signup` and make sure the flow behaves correctly and you end up on the Migration Instructions step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?