### PR TITLE
Add panels to global sites dashboard

### DIFF
--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -1,6 +1,11 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .hosting-overview {
+	margin: 0;
+	padding: 0;
+	overflow-y: auto;
+	max-height: calc(100vh - 300px);
+
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	grid-template-rows: auto auto;

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -1,5 +1,14 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 
+.preview-pane__content {
+	.hosting {
+		margin: 0;
+		padding: 0;
+		overflow-y: auto;
+		max-height: calc(100vh - 300px);
+	}
+}
+
 .hosting {
 	/* Rely on the standard spacing for the underlying elements. */
 	.feature-example {

--- a/client/site-monitoring/components/site-monitoring-overview.tsx
+++ b/client/site-monitoring/components/site-monitoring-overview.tsx
@@ -1,6 +1,8 @@
 import { FC } from 'react';
 import { MetricsTab } from 'calypso/my-sites/site-monitoring/metrics-tab';
 
+import '../style.scss';
+
 const SiteMonitoringOverview: FC = () => {
 	return (
 		<div className="site-monitoring-overview">

--- a/client/site-monitoring/style.scss
+++ b/client/site-monitoring/style.scss
@@ -1,0 +1,16 @@
+.site-monitoring-overview {
+	margin: 0;
+	padding: 0;
+	overflow-y: auto;
+	max-height: calc(100vh - 300px);
+
+	.site-monitoring__pie-charts {
+		flex-direction: column;
+	}
+
+	@media (min-width: 1600px) {
+		.site-monitoring__pie-charts {
+			flex-direction: row;
+		}
+	}
+}

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -6,13 +6,15 @@ import ItemPreviewPane, {
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
 import HostingOverview from 'calypso/hosting-overview/components/hosting-overview';
+import { GitHubDeployments } from 'calypso/my-sites/github-deployments/deployments';
+import Hosting from 'calypso/my-sites/hosting/main';
+import SiteMonitoringOverview from 'calypso/site-monitoring/components/site-monitoring-overview';
 import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
 	DOTCOM_MONITORING,
 	DOTCOM_GITHUB_DEPLOYMENTS,
 } from './constants';
-import PreviewPaneSample from './preview-pane-sample';
 
 import './style.scss';
 
@@ -54,7 +56,7 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<PreviewPaneSample site={ site } tabName="Monitoring" />
+				<SiteMonitoringOverview />
 			),
 			createFeaturePreview(
 				DOTCOM_GITHUB_DEPLOYMENTS,
@@ -62,7 +64,7 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<PreviewPaneSample site={ site } tabName="GitHub Deployments" />
+				<GitHubDeployments />
 			),
 			createFeaturePreview(
 				DOTCOM_HOSTING_CONFIG,
@@ -70,7 +72,7 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<PreviewPaneSample site={ site } tabName="Hosting Config" />
+				<Hosting />
 			),
 		],
 		[ selectedSiteFeature, setSelectedSiteFeature, site ]


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6712

This adds the following panels to the global site view dashboard

* Monitoring
* GitHub Deployments
* Hosting Config

The panels are accessible through tabs in the flyout panel on the new sites dashboard

<img width="1353" alt="Screenshot 2024-04-24 at 17 33 36" src="https://github.com/Automattic/wp-calypso/assets/5560595/9a79778e-3892-49ca-bd90-a88680c8471f">

## Testing Instructions

* Go to http://calypso.localhost:3000/sites?flags=layout/dotcom-nav-redesign-v2
* Click on the tabs and confirm panels load as expected
