### PR TITLE
A4A: hide wpcom masterbar from signup page

### DIFF
--- a/client/a8c-for-agencies/sections/signup/controller.tsx
+++ b/client/a8c-for-agencies/sections/signup/controller.tsx
@@ -1,7 +1,9 @@
 import { type Callback } from '@automattic/calypso-router';
+import { hideMasterbar } from 'calypso/state/ui/actions';
 import AgencySignUp from './primary/agency-signup';
 
 export const signUpContext: Callback = ( context, next ) => {
+	context.store.dispatch( hideMasterbar() );
 	context.primary = <AgencySignUp />;
 	next();
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-genesis/issues/331

## Proposed Changes

This PR removes WPCOM masterbar from the signup page of A4A.

**This is removed:**
<img width="1726" alt="Screenshot 2024-04-24 at 10 03 16 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/4ebc2ee3-acef-4404-b7b1-43f96f247832">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- While logged out from wpcom, navigate to `/signup` page and verify that there's no masterbar present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?