### PR TITLE
Nav Redesign: Add frame around all sites content

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -98,7 +98,7 @@
 }
 
 .main.sites-dashboard.sites-dashboard__layout:has(.dataviews-pagination) {
-	height: calc(100vh - 70px) !important;
+	height: calc(100vh - 70px);
 }
 
 .dataviews-pagination {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -381,7 +381,6 @@ body.is-mobile-app-view {
 // This is done since most has-no-masterbar section have their own padding set already that we don't want to overwrite
 .layout.has-no-masterbar.is-group-me,
 .layout.has-no-masterbar.is-group-sites,
-.layout.has-no-masterbar.is-group-sites-dashboard,
 .layout.has-no-masterbar.is-section-reader {
 	--masterbar-height: 0;
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -1,1 +1,7 @@
 // Add new Dotcom specific fly-out panel styles to this file
+.wpcom-site .a4a-layout-with-columns__container {
+	background: var(--color-sidebar-background);
+}
+.wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {
+	background: var(--studio-white);
+}

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -74,6 +74,7 @@ const HeaderControls = styled.div( {
 	maxWidth: MAX_PAGE_WIDTH,
 	marginBlock: 0,
 	marginInline: 'auto',
+	paddingTop: '32px',
 	display: 'flex',
 	flexDirection: 'row',
 	alignItems: 'flex-start',

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -49,25 +49,28 @@ export function sanitizeQueryParameters( context: PageJSContext, next: () => voi
 export function sitesDashboard( context: PageJSContext, next: () => void ) {
 	const sitesDashboardGlobalStyles = css`
 		body.is-group-sites-dashboard {
-			background: #ffffff;
+			background: var( --studio-gray-0 );
 
 			.layout__content {
-				// The page header background extends all the way to the edge of the screen
-				@media only screen and ( min-width: 782px ) {
-					padding-inline: 0;
-				}
+				// Add border around everything
+				overflow: hidden;
+				min-height: 100vh;
+				padding: 16px 16px 16px calc( var( --sidebar-width-max ) );
+			}
 
-				// Prevents the status dropdown from being clipped when the page content
-				// isn't tall enough
-				overflow: inherit;
+			.layout__secondary .global-sidebar {
+				border: none;
 			}
 		}
 
 		// Update body margin to account for the sidebar width
 		@media only screen and ( min-width: 782px ) {
 			div.layout.is-global-sidebar-visible {
-				.layout__primary {
-					margin-inline-start: var( --sidebar-width-max );
+				.layout__primary main {
+					background: var( --color-surface );
+					border-radius: 8px;
+					height: calc( 100vh - 32px );
+					overflow: auto;
 				}
 			}
 		}

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -73,6 +73,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 				.layout__primary main {
 					background: var( --color-surface );
 					border-radius: 8px;
+					box-shadow: 0px 0px 17.4px 0px rgba( 0, 0, 0, 0.05 );
 					height: calc( 100vh - 32px );
 					overflow: auto;
 				}

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -63,6 +63,10 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 			}
 		}
 
+		.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {
+			height: calc( 100vh - 32px );
+		}
+
 		// Update body margin to account for the sidebar width
 		@media only screen and ( min-width: 782px ) {
 			div.layout.is-global-sidebar-visible {


### PR DESCRIPTION
## Description

For Nav Redesign i2 we want to get the all sites management screen looking as close to A4A as possible. This PR attempts to add a border around the all sites content.

Note: You need to add the following feature flag to see the new sites functionality: `/sites/?flags=layout/dotcom-nav-redesign-v2`

## Before

![before](https://github.com/Automattic/wp-calypso/assets/5634774/c0615c8c-eb3c-4551-bed3-881137a82053)

## After

![after](https://github.com/Automattic/wp-calypso/assets/5634774/dd94ad34-4ba6-404a-a67d-af1f011f53df)

## Testing instructions

- Load this PR
- Head to /sites/?flags=layout/dotcom-nav-redesign-v2