### PR TITLE
Add new dotcom-styles.scss file

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -1,0 +1,1 @@
+// Add new Dotcom specific fly-out panel styles to this file

--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -34,6 +34,9 @@ import DotcomSitesDataViews from './sites-dataviews';
 // todo: we are using A4A styles until we extract them as common styles in the ItemsDashboard component
 import './style.scss';
 
+// Add Dotcom specific styles
+import './dotcom-style.scss';
+
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
 	updateQueryParams?: ( params: SitesDashboardQueryParams ) => void;


### PR DESCRIPTION
## Description

I asked @cleacos how we should deal with Dotcom specific styles and this was his recommendation:

> I think the best way and safe, for keeping thing tidy until we finish all the style decoupling work, is to create a dotcom-style.scss at the client/sites-dashboard-v2 folder and load it from the SitesDashboardV2 component along with the current style.scss file.