### PR TITLE
Added migration source setting

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -185,9 +185,11 @@ const siteMigration: Flow = {
 						action: SiteMigrationIdentifyAction;
 					};
 
-					await saveSiteSettings( siteSlug, {
-						migration_source_site_domain: from,
-					} );
+					if ( siteSlug ) {
+						await saveSiteSettings( siteSlug, {
+							migration_source_site_domain: from,
+						} );
+					}
 
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
 						return exitFlow(

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -200,6 +200,10 @@ const siteMigration: Flow = {
 						);
 					}
 
+					await saveSiteSettings( siteSlug, {
+						migration_source_site_domain: from,
+					} );
+
 					return navigate(
 						addQueryArgs(
 							{ from: from, siteSlug, siteId },

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -185,7 +185,7 @@ const siteMigration: Flow = {
 						action: SiteMigrationIdentifyAction;
 					};
 
-					saveSiteSettings( siteSlug, {
+					await saveSiteSettings( siteSlug, {
 						migration_source_site_domain: from,
 					} );
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -185,6 +185,10 @@ const siteMigration: Flow = {
 						action: SiteMigrationIdentifyAction;
 					};
 
+					saveSiteSettings( siteSlug, {
+						migration_source_site_domain: from,
+					} );
+
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
 						return exitFlow(
 							addQueryArgs(
@@ -199,10 +203,6 @@ const siteMigration: Flow = {
 							)
 						);
 					}
-
-					await saveSiteSettings( siteSlug, {
-						migration_source_site_domain: from,
-					} );
 
 					return navigate(
 						addQueryArgs(

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -89,7 +89,7 @@ describe( 'Site Migration Flow', () => {
 	} );
 
 	describe( 'navigation', () => {
-		it( 'redirects the user to the migrate or import page when the platform is wordpress', () => {
+		it( 'redirects the user to the migrate or import page when the platform is wordpress', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
@@ -101,13 +101,15 @@ describe( 'Site Migration Flow', () => {
 				},
 			} );
 
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?from=https%3A%2F%2Fsite-to-be-migrated.com&siteSlug=example.wordpress.com`,
-				state: null,
+			await waitFor( () => {
+				expect( getFlowLocation() ).toEqual( {
+					path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?from=https%3A%2F%2Fsite-to-be-migrated.com&siteSlug=example.wordpress.com`,
+					state: null,
+				} );
 			} );
 		} );
 
-		it( 'redirects the user to the import content flow when was not possible to indentify the platform', () => {
+		it( 'redirects the user to the import content flow when was not possible to indentify the platform', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
@@ -118,20 +120,22 @@ describe( 'Site Migration Flow', () => {
 				},
 			} );
 
-			expect( window.location.assign ).toHaveBeenCalledWith(
-				addQueryArgs(
-					{
-						siteSlug: 'example.wordpress.com',
-						from: 'https://example-to-be-migrated.com',
-						origin: 'site-migration-identify',
-						backToFlow: '/site-migration/site-migration-identify',
-					},
-					'/setup/site-setup/importList'
-				)
-			);
+			await waitFor( () => {
+				expect( window.location.assign ).toHaveBeenCalledWith(
+					addQueryArgs(
+						{
+							siteSlug: 'example.wordpress.com',
+							from: 'https://example-to-be-migrated.com',
+							origin: 'site-migration-identify',
+							backToFlow: '/site-migration/site-migration-identify',
+						},
+						'/setup/site-setup/importList'
+					)
+				);
+			} );
 		} );
 
-		it( 'redirects the user to the import content flow when the user skip the plaform identification', () => {
+		it( 'redirects the user to the import content flow when the user skip the plaform identification', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
@@ -140,16 +144,18 @@ describe( 'Site Migration Flow', () => {
 				},
 			} );
 
-			expect( window.location.assign ).toHaveBeenCalledWith(
-				addQueryArgs(
-					{
-						siteSlug: 'example.wordpress.com',
-						origin: 'site-migration-identify',
-						backToFlow: '/site-migration/site-migration-identify',
-					},
-					'/setup/site-setup/importList'
-				)
-			);
+			await waitFor( () => {
+				expect( window.location.assign ).toHaveBeenCalledWith(
+					addQueryArgs(
+						{
+							siteSlug: 'example.wordpress.com',
+							origin: 'site-migration-identify',
+							backToFlow: '/site-migration/site-migration-identify',
+						},
+						'/setup/site-setup/importList'
+					)
+				);
+			} );
 		} );
 
 		it( 'migrate redirects from the import-from page to bundleTransfer step', () => {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/89649
Related to https://github.com/Automattic/wp-calypso/issues/89897

## Proposed Changes

With this PR, a new setting, `migration_source_site_domain`, is saved once the domain is picked for importing.

## Testing Instructions

- Apply https://github.com/Automattic/jetpack/pull/37060 on your sandbox and sandbox the public-api.
- Go to the import site flow (/start, pick the import option)
- Follow the instructions until the site-migration-identify step
- Enter a valid URL and click continue
- In the https://developer.wordpress.com/docs/api/console/, do a GET query to `/rest/v1.4/site/:siteId/settings`
- Scroll through the settings property of the response until you find `migration_source_site_domain`
- It should be the same URL you entered

Obs.: This PR may be merged before jetpack's without problems since the option is just going to be ignored until then.