### PR TITLE
Akismet checkout: Enable coupon field in checkout.

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -730,7 +730,7 @@ export default function CheckoutMainContent( {
 							return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
 						} }
 					/>
-					{ ! isAkismetCheckout() && ! shouldUseCheckoutV2 && (
+					{ ! shouldUseCheckoutV2 && (
 						<CouponFieldArea
 							isCouponFieldVisible={ isCouponFieldVisible }
 							setCouponFieldVisible={ setCouponFieldVisible }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -8,7 +8,6 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses, hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
-import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { hasDIFMProduct, hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
@@ -233,7 +232,7 @@ export default function WPCheckoutOrderReview( {
 					/>
 				</WPOrderReviewSection>
 
-				{ ! isAkismetCheckout() && shouldUseCheckoutV2 && (
+				{ shouldUseCheckoutV2 && (
 					<CouponFieldArea
 						isCouponFieldVisible={ isCouponFieldVisible }
 						setCouponFieldVisible={ setCouponFieldVisible }


### PR DESCRIPTION
Akismet checkout previously was not showing the coupon field, restricting the ability to enter a coupon code for Akismet products.

This PR enables the coupon field in Akismet checkout.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
#### Screenshots

BEFORE | AFTER
--- | ---
![Screen Shot 2024-04-24 at 14 01 08](https://github.com/Automattic/wp-calypso/assets/11078128/57870455-7ebd-49b0-923c-de1a184ca053) | ![Screen Shot 2024-04-24 at 14 03 21](https://github.com/Automattic/wp-calypso/assets/11078128/6a31f13c-b90a-4854-ad9c-09590f6b8ed6)





## Testing Instructions

- Checkout and run this branch locally, or click the _Calypso Live (direct link)_ below.
- Go to checkout with any Akismet product, i.e.- `/checkout/akismet/ak_pro5h_yearly:-q-1`
- Verify that you can see the "Have a coupon?" link just below Step 2,  _Payment Method_ section in checkout (See screenshot)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
- [ ] 