### PR TITLE
A4A: add ability to set signup data to local storage

### DIFF
--- a/client/a8c-for-agencies/sections/signup/lib/signup-data-to-local-storage.ts
+++ b/client/a8c-for-agencies/sections/signup/lib/signup-data-to-local-storage.ts
@@ -1,0 +1,27 @@
+import { AgencyDetailsPayload } from '../agency-details-form/types';
+
+const SIGNUP_DATA_KEY = 'a4aSignupFormData';
+
+export function saveSignupDataToLocalStorage( data: AgencyDetailsPayload ) {
+	try {
+		window.localStorage.setItem( SIGNUP_DATA_KEY, JSON.stringify( data ) );
+	} catch ( err ) {
+		return [];
+	}
+}
+
+export function getSignupDataFromLocalStorage(): AgencyDetailsPayload | null {
+	try {
+		return JSON.parse( window.localStorage.getItem( SIGNUP_DATA_KEY ) || 'null' );
+	} catch ( err ) {
+		return null;
+	}
+}
+
+export function clearSignupDataFromLocalStorage(): void {
+	try {
+		window.localStorage.removeItem( SIGNUP_DATA_KEY );
+	} catch ( e ) {
+		return;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/354

## Proposed Changes

Add functionality to store signup data to local storage, when we need to redirect user to wpcom for login. 
Note that redirection itself will be done in the follow up PRs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Logged out, navigate to `/signup` page. 
- Fill the form and hit submit. 
- In console dev tools, check Application-Local Storage and check that the `a4aSignupFormData` is present.
- Test the flow with logged in user. Signup should continue normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?