### PR TITLE
Nav redesign: Fix flickering thumbnails

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -21,47 +21,47 @@ type Props = {
 	openSitePreviewPane?: ( site: SiteExcerptData ) => void;
 };
 
+const SiteListTile = styled( ListTile )`
+	margin-inline-end: 0;
+
+	${ MEDIA_QUERIES.hideTableRows } {
+		margin-inline-end: 12px;
+	}
+`;
+
+const ListTileLeading = styled( ThumbnailLink )`
+	${ MEDIA_QUERIES.hideTableRows } {
+		margin-inline-end: 12px;
+	}
+`;
+
+const ListTileTitle = styled.div`
+	display: flex;
+	align-items: center;
+	margin-block-end: 8px;
+`;
+
+const ListTileSubtitle = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	font-size: 14px;
+	color: var( --studio-gray-60 ) !important;
+	svg {
+		flex-shrink: 0;
+	}
+
+	&:not( :last-child ) {
+		margin-block-end: 2px;
+	}
+`;
+
 const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const { __ } = useI18n();
 	// todo: This hook is used by the SiteItemThumbnail component below, in a prop showPlaceholder={ ! inView }. It does not work as expected. Fix it.
 	//const { inView } = useInView( { triggerOnce: true } );
-
-	const SiteListTile = styled( ListTile )`
-		margin-inline-end: 0;
-
-		${ MEDIA_QUERIES.hideTableRows } {
-			margin-inline-end: 12px;
-		}
-	`;
-
-	const ListTileLeading = styled( ThumbnailLink )`
-		${ MEDIA_QUERIES.hideTableRows } {
-			margin-inline-end: 12px;
-		}
-	`;
-
-	const ListTileTitle = styled.div`
-		display: flex;
-		align-items: center;
-		margin-block-end: 8px;
-	`;
-
-	const ListTileSubtitle = styled.div`
-		display: flex;
-		align-items: center;
-		gap: 4px;
-		text-overflow: ellipsis;
-		overflow: hidden;
-		font-size: 14px;
-		color: var( --studio-gray-60 ) !important;
-		svg {
-			flex-shrink: 0;
-		}
-
-		&:not( :last-child ) {
-			margin-block-end: 2px;
-		}
-	`;
 
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6702

| Before | After |
| --- | --- |
| https://github.com/Automattic/wp-calypso/assets/402286/13d47e54-0a55-4aeb-8b14-195d1d1aea76 | https://github.com/Automattic/wp-calypso/assets/402286/c0a2b0ab-0ebe-44f4-b751-23421733425c |

## Proposed Changes

Fix flickering images on `/sites` with `layout/dotcom-nav-redesign-v2` flag

## Testing Instructions

* Go to `/sites?flags=layout/dotcom-nav-redesign-v2`
* Site's thumbnails should not flicker.