### PR TITLE
Checkout: Refactor CartFreeUserPlanUpsell to fetch its own data

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -8,7 +8,6 @@ import { Button } from '@automattic/components';
 import { StoreProductSlug, useProducts } from '@automattic/data-stores/src/products-list';
 import formatCurrency from '@automattic/format-currency';
 import {
-	type ResponseCart,
 	type MinimalRequestCartProduct,
 	type ResponseCartProduct,
 	useShoppingCart,
@@ -38,18 +37,17 @@ const isRegistrationOrTransfer = ( item: ResponseCartProduct ) => {
 };
 
 function UpgradeText( {
-	cart,
 	planPrice,
 	planName,
+	firstDomain,
 }: {
-	cart: ResponseCart;
 	planPrice: number;
 	planName: string;
+	firstDomain: ResponseCartProduct;
 } ) {
 	const translate = useTranslate();
-	const firstDomain = cart.products.find( isRegistrationOrTransfer );
 
-	if ( firstDomain && planPrice > firstDomain.item_subtotal_integer ) {
+	if ( planPrice > firstDomain.item_subtotal_integer ) {
 		const extraToPay = planPrice - firstDomain.item_subtotal_integer;
 		return translate(
 			'Pay an {{strong}}extra %(extraToPay)s{{/strong}} for our %(planName)s plan, and get access to all its features, plus the first year of your domain for free.',
@@ -68,7 +66,7 @@ function UpgradeText( {
 		);
 	}
 
-	if ( firstDomain && planPrice < firstDomain.item_subtotal_integer ) {
+	if ( planPrice < firstDomain.item_subtotal_integer ) {
 		const savings = firstDomain.item_subtotal_integer - planPrice;
 		return translate(
 			'{{strong}}Save %(savings)s{{/strong}} when you purchase a WordPress.com %(planName)s plan instead — your domain comes free for a year.',
@@ -87,6 +85,7 @@ function UpgradeText( {
 		);
 	}
 
+	// The plan price and domain price are equal.
 	return translate(
 		'Purchase our %(planName)s plan at {{strong}}no extra cost{{/strong}}, and get access to all its features, plus the first year of your domain for free.',
 		{
@@ -125,6 +124,7 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 	const dispatch = useDispatch();
 	const upsellProductSlug = PLAN_PERSONAL;
 	const upsellPlan = getPlan( upsellProductSlug );
+	const firstDomainInCart = responseCart.products.find( isRegistrationOrTransfer );
 
 	const translate = useTranslate();
 
@@ -143,7 +143,7 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 	if ( hasPaidPlan || hasPlanInCart ) {
 		return null;
 	}
-	if ( ! isRegisteringOrTransferringDomain ) {
+	if ( ! isRegisteringOrTransferringDomain || ! firstDomainInCart ) {
 		return null;
 	}
 
@@ -165,9 +165,9 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 			<div className="cart__upsell-body">
 				<p>
 					<UpgradeText
-						cart={ responseCart }
 						planPrice={ planPrice }
 						planName={ String( planName ) }
+						firstDomain={ firstDomainInCart }
 					/>
 				</p>
 				<Button onClick={ addPlanToCart }>{ translate( 'Add to Cart' ) }</Button>

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -56,7 +56,10 @@ function UpgradeText( {
 			'Pay an {{strong}}extra %(extraToPay)s{{/strong}} for our %(planName)s plan, and get access to all its features, plus the first year of your domain for free.',
 			{
 				args: {
-					extraToPay: formatCurrency( extraToPay, firstDomain.currency ),
+					extraToPay: formatCurrency( extraToPay, firstDomain.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ),
 					planName,
 				},
 				components: {
@@ -73,7 +76,10 @@ function UpgradeText( {
 			{
 				args: {
 					planName,
-					savings: formatCurrency( savings, firstDomain.currency ),
+					savings: formatCurrency( savings, firstDomain.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ),
 				},
 				components: {
 					strong: <strong />,

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -40,15 +40,14 @@ const isRegistrationOrTransfer = ( item: ResponseCartProduct ) => {
 function UpgradeText( {
 	cart,
 	planPrice,
-	upsellPlan,
+	planName,
 }: {
 	cart: ResponseCart;
 	planPrice: number;
-	upsellPlan: ReturnType< typeof getPlan >;
+	planName: string;
 } ) {
 	const translate = useTranslate();
 	const firstDomain = cart.products.find( isRegistrationOrTransfer );
-	const planName = upsellPlan?.getTitle() ?? '';
 
 	if ( firstDomain && planPrice > firstDomain.item_subtotal_integer ) {
 		const extraToPay = planPrice - firstDomain.item_subtotal_integer;
@@ -130,6 +129,7 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 	const translate = useTranslate();
 
 	const planPrice = useGetPriceForProduct( upsellProductSlug );
+	const planName = upsellPlan?.getTitle();
 
 	if ( ! selectedSite?.ID ) {
 		return null;
@@ -137,7 +137,7 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 	if ( isCartPendingUpdate || isLoadingCart ) {
 		return null;
 	}
-	if ( ! planPrice ) {
+	if ( ! planPrice || ! planName ) {
 		return null;
 	}
 	if ( hasPaidPlan || hasPlanInCart ) {
@@ -164,7 +164,11 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 			/>
 			<div className="cart__upsell-body">
 				<p>
-					<UpgradeText cart={ responseCart } planPrice={ planPrice } upsellPlan={ upsellPlan } />
+					<UpgradeText
+						cart={ responseCart }
+						planPrice={ planPrice }
+						planName={ String( planName ) }
+					/>
 				</p>
 				<Button onClick={ addPlanToCart }>{ translate( 'Add to Cart' ) }</Button>
 			</div>

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -6,9 +6,14 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { localize, useTranslate } from 'i18n-calypso';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import {
+	type ResponseCart,
+	type MinimalRequestCartProduct,
+	type ResponseCartProduct,
+	useShoppingCart,
+} from '@automattic/shopping-cart';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
@@ -18,96 +23,57 @@ import {
 	planItem,
 } from 'calypso/lib/cart-values/cart-items';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
+import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { isRequestingPlans } from 'calypso/state/plans/selectors';
-import { getPlanPrice } from 'calypso/state/products-list/selectors';
-import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
-import { CalypsoDispatch } from 'calypso/state/types';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { SiteDetails } from '@automattic/data-stores';
-import type {
-	ResponseCart,
-	MinimalRequestCartProduct,
-	ResponseCartProduct,
-} from '@automattic/shopping-cart';
-import type { AppState } from 'calypso/types';
+import useCartKey from '../use-cart-key';
 
 export interface CartFreeUserPlanUpsellProps {
-	cart: Pick< ResponseCart, 'products' >;
-	isCartPendingUpdate?: boolean;
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
-	upsellPlan?: ReturnType< typeof getPlan >;
 }
 
-interface CartFreeUserPlanUpsellHocProps {
-	selectedSite?: SiteDetails | null;
-	hasPaidPlan?: boolean;
-	hasPlanInCart?: boolean;
-	isPlansListFetching?: boolean;
-	isRegisteringOrTransferringDomain?: boolean;
-	isSitePlansListFetching?: boolean;
-	planPrice: number | false | null | undefined;
-	showPlanUpsell?: boolean;
-	translate: ReturnType< typeof useTranslate >;
-	clickUpsellAddToCart: () => void;
-}
+const isRegistrationOrTransfer = ( item: ResponseCartProduct ) => {
+	return isDomainRegistration( item ) || isDomainTransfer( item );
+};
 
-class CartFreeUserPlanUpsell extends Component<
-	CartFreeUserPlanUpsellProps & CartFreeUserPlanUpsellHocProps
-> {
-	isLoading() {
-		const { isCartPendingUpdate: isLoadingCart } = this.props;
-		const isLoadingPlans = this.props.isPlansListFetching;
-		const isLoadingSitePlans = this.props.isSitePlansListFetching;
-		return isLoadingCart || isLoadingPlans || isLoadingSitePlans;
-	}
+function UpgradeText( {
+	cart,
+	planPrice,
+	upsellPlan,
+}: {
+	cart: ResponseCart;
+	planPrice: number;
+	upsellPlan: ReturnType< typeof getPlan >;
+} ) {
+	const translate = useTranslate();
+	const firstDomain = cart.products.find( isRegistrationOrTransfer );
+	const planName = upsellPlan?.getTitle() ?? '';
 
-	isRegistrationOrTransfer = ( item: ResponseCartProduct ) => {
-		return isDomainRegistration( item ) || isDomainTransfer( item );
-	};
-
-	getUpgradeText() {
-		const { cart, planPrice, translate, upsellPlan } = this.props;
-		const firstDomain = cart.products.find( this.isRegistrationOrTransfer );
-		const planName = upsellPlan?.getTitle() ?? '';
-
-		if ( planPrice && firstDomain && planPrice > firstDomain.cost ) {
-			const extraToPay = planPrice - firstDomain.cost;
-			return translate(
-				'Pay an {{strong}}extra %(extraToPay)s{{/strong}} for our %(planName)s plan, and get access to all its ' +
-					'features, plus the first year of your domain for free.',
-				{
-					args: {
-						extraToPay: formatCurrency( extraToPay, firstDomain.currency ),
-						planName,
-					},
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		} else if ( planPrice && firstDomain && planPrice < firstDomain.cost ) {
-			const savings = firstDomain.cost - planPrice;
-			return translate(
-				'{{strong}}Save %(savings)s{{/strong}} when you purchase a WordPress.com %(planName)s plan ' +
-					'instead — your domain comes free for a year.',
-				{
-					args: {
-						planName,
-						savings: formatCurrency( savings, firstDomain.currency ),
-					},
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		}
-
+	if ( planPrice && firstDomain && planPrice > firstDomain.cost ) {
+		const extraToPay = planPrice - firstDomain.cost;
 		return translate(
-			'Purchase our %(planName)s plan at {{strong}}no extra cost{{/strong}}, and get access to all its ' +
+			'Pay an {{strong}}extra %(extraToPay)s{{/strong}} for our %(planName)s plan, and get access to all its ' +
 				'features, plus the first year of your domain for free.',
 			{
-				args: { planName },
+				args: {
+					extraToPay: formatCurrency( extraToPay, firstDomain.currency ),
+					planName,
+				},
+				components: {
+					strong: <strong />,
+				},
+			}
+		);
+	} else if ( planPrice && firstDomain && planPrice < firstDomain.cost ) {
+		const savings = firstDomain.cost - planPrice;
+		return translate(
+			'{{strong}}Save %(savings)s{{/strong}} when you purchase a WordPress.com %(planName)s plan ' +
+				'instead — your domain comes free for a year.',
+			{
+				args: {
+					planName,
+					savings: formatCurrency( savings, firstDomain.currency ),
+				},
 				components: {
 					strong: <strong />,
 				},
@@ -115,18 +81,43 @@ class CartFreeUserPlanUpsell extends Component<
 		);
 	}
 
-	shouldRender() {
-		if ( this.isLoading() ) {
+	return translate(
+		'Purchase our %(planName)s plan at {{strong}}no extra cost{{/strong}}, and get access to all its ' +
+			'features, plus the first year of your domain for free.',
+		{
+			args: { planName },
+			components: {
+				strong: <strong />,
+			},
+		}
+	);
+}
+
+export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserPlanUpsellProps ) {
+	const cartKey = useCartKey();
+	const {
+		responseCart,
+		isLoading: isLoadingCart,
+		isPendingUpdate: isCartPendingUpdate,
+	} = useShoppingCart( cartKey );
+	const selectedSite = useSelector( getSelectedSite );
+	const isRegisteringOrTransferringDomain =
+		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );
+	const showPlanUpsell = !! selectedSite?.ID;
+	const hasPaidPlan = siteHasPaidPlan( selectedSite );
+	const hasPlanInCart = hasPlan( responseCart );
+	const dispatch = useDispatch();
+	const upsellPlan = getPlan( PLAN_PERSONAL );
+
+	const translate = useTranslate();
+
+	// FIXME
+	const planPrice = 0;
+
+	const shouldRender = ( () => {
+		if ( isCartPendingUpdate || isLoadingCart ) {
 			return false;
 		}
-
-		const {
-			hasPaidPlan,
-			hasPlanInCart,
-			isRegisteringOrTransferringDomain,
-			selectedSite,
-			showPlanUpsell,
-		} = this.props;
 
 		return (
 			isRegisteringOrTransferringDomain &&
@@ -135,68 +126,34 @@ class CartFreeUserPlanUpsell extends Component<
 			! hasPaidPlan &&
 			! hasPlanInCart
 		);
-	}
+	} )();
 
-	addPlanToCart = () => {
+	const addPlanToCart = () => {
 		const planCartItem = planItem( PLAN_PERSONAL );
 
 		if ( planCartItem ) {
-			this.props.addItemToCart( planCartItem );
-			this.props.clickUpsellAddToCart();
+			addItemToCart( planCartItem );
+			dispatch( recordTracksEvent( 'calypso_non_dwpo_checkout_plan_upsell_add_to_cart', {} ) );
 		}
 	};
 
-	render() {
-		if ( ! this.shouldRender() ) {
-			return null;
-		}
-
-		const { translate } = this.props;
-
-		return (
-			<div className="cart__upsell-wrapper">
-				<SectionHeader
-					className="cart__header cart__upsell-header"
-					label={ translate( 'Upgrade and save' ) }
-				/>
-				<div className="cart__upsell-body">
-					<p>{ this.getUpgradeText() }</p>
-					<Button onClick={ this.addPlanToCart }>{ translate( 'Add to Cart' ) }</Button>
-				</div>
-				<TrackComponentView eventName="calypso_non_dwpo_checkout_plan_upsell_impression" />
-			</div>
-		);
+	if ( ! shouldRender ) {
+		return null;
 	}
+
+	return (
+		<div className="cart__upsell-wrapper">
+			<SectionHeader
+				className="cart__header cart__upsell-header"
+				label={ translate( 'Upgrade and save' ) }
+			/>
+			<div className="cart__upsell-body">
+				<p>
+					<UpgradeText cart={ responseCart } planPrice={ planPrice } upsellPlan={ upsellPlan } />
+				</p>
+				<Button onClick={ addPlanToCart }>{ translate( 'Add to Cart' ) }</Button>
+			</div>
+			<TrackComponentView eventName="calypso_non_dwpo_checkout_plan_upsell_impression" />
+		</div>
+	);
 }
-
-const mapStateToProps = ( state: AppState, { cart }: CartFreeUserPlanUpsellProps ) => {
-	const selectedSite = getSelectedSite( state );
-	const selectedSiteId = selectedSite ? selectedSite.ID : null;
-	const isPlansListFetching = isRequestingPlans( state );
-	const upsellPlan = getPlan( PLAN_PERSONAL );
-
-	return {
-		hasPaidPlan: siteHasPaidPlan( selectedSite ),
-		hasPlanInCart: hasPlan( cart ),
-		isPlansListFetching,
-		isRegisteringOrTransferringDomain: hasDomainRegistration( cart ) || hasTransferProduct( cart ),
-		isSitePlansListFetching: isRequestingSitePlans( state ),
-		planPrice:
-			! isPlansListFetching &&
-			selectedSiteId &&
-			upsellPlan &&
-			getPlanPrice( state, selectedSiteId, upsellPlan, false ),
-		selectedSite,
-		showPlanUpsell: !! selectedSiteId,
-		upsellPlan,
-	};
-};
-
-const mapDispatchToProps = ( dispatch: CalypsoDispatch ) => {
-	return {
-		clickUpsellAddToCart: () =>
-			dispatch( recordTracksEvent( 'calypso_non_dwpo_checkout_plan_upsell_add_to_cart', {} ) ),
-	};
-};
-
-export default connect( mapStateToProps, mapDispatchToProps )( localize( CartFreeUserPlanUpsell ) );

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -224,22 +224,20 @@ const getPresalesChatKey = ( responseCart: ObjectWithProducts ) => {
 
 /* Include a condition for your use case here if you want to show a specific nudge in the checkout sidebar */
 function CheckoutSidebarNudge( {
-	responseCart,
 	siteId,
 	formStatus,
 	changeSelection,
 	addItemToCart,
-	isCartPendingUpdate,
 	areThereDomainProductsInCart,
 }: {
-	responseCart: ResponseCart;
 	siteId: number | undefined;
 	formStatus: FormStatus;
 	changeSelection: OnChangeItemVariant;
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
-	isCartPendingUpdate: boolean;
 	areThereDomainProductsInCart: boolean;
 } ) {
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const isWcMobile = isWcMobileApp();
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
@@ -292,7 +290,6 @@ function CheckoutSidebarNudge( {
 				<SecondaryCartPromotions
 					responseCart={ responseCart }
 					addItemToCart={ addItemToCart }
-					isCartPendingUpdate={ isCartPendingUpdate }
 					isPurchaseRenewal={ isPurchaseRenewal }
 				/>
 			) }
@@ -563,12 +560,10 @@ export default function CheckoutMainContent( {
 
 								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
 								<CheckoutSidebarNudge
-									responseCart={ responseCart }
 									siteId={ siteId }
 									formStatus={ formStatus }
 									changeSelection={ changeSelection }
 									addItemToCart={ addItemToCart }
-									isCartPendingUpdate={ isCartPendingUpdate }
 									areThereDomainProductsInCart={ areThereDomainProductsInCart }
 								/>
 							</CheckoutSummaryBody>

--- a/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
@@ -70,10 +70,9 @@ const UpsellWrapper = styled.div< DivProps >`
 const SecondaryCartPromotions: FunctionComponent< Props > = ( {
 	responseCart,
 	addItemToCart,
-	isCartPendingUpdate,
 	isPurchaseRenewal,
 } ) => {
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) as number );
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	if (
 		config.isEnabled( 'upgrades/upcoming-renewals-notices' ) &&
@@ -89,11 +88,7 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( {
 
 	return (
 		<UpsellWrapper>
-			<CartFreeUserPlanUpsell
-				cart={ responseCart }
-				addItemToCart={ addItemToCart }
-				isCartPendingUpdate={ isCartPendingUpdate }
-			/>
+			<CartFreeUserPlanUpsell addItemToCart={ addItemToCart } />
 		</UpsellWrapper>
 	);
 };

--- a/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import styled from '@emotion/styled';
+import { styled } from '@automattic/wpcom-checkout';
 import { FunctionComponent } from 'react';
 import CartFreeUserPlanUpsell from 'calypso/my-sites/checkout/cart/cart-free-user-plan-upsell';
 import UpcomingRenewalsReminder from 'calypso/my-sites/checkout/cart/upcoming-renewals-reminder';
@@ -15,10 +15,7 @@ interface Props {
 	isPurchaseRenewal?: boolean;
 }
 
-type DivProps = {
-	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-};
-const UpsellWrapper = styled.div< DivProps >`
+const UpsellWrapper = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 
 	.cart__upsell-wrapper {

--- a/client/my-sites/checkout/src/components/test/lib/fixtures.ts
+++ b/client/my-sites/checkout/src/components/test/lib/fixtures.ts
@@ -1,8 +1,9 @@
-import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import moment from 'moment';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
-export const responseCartWithRenewal: Pick< ResponseCart, 'products' > = {
+export const responseCartWithRenewal: ResponseCart = {
+	...getEmptyResponseCart(),
 	products: [
 		{
 			...getEmptyResponseCartProduct(),

--- a/client/my-sites/checkout/src/components/test/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/test/secondary-cart-promotions.tsx
@@ -4,12 +4,21 @@
 
 import config from '@automattic/calypso-config';
 import { checkoutTheme } from '@automattic/composite-checkout';
+import { RawAPIProductsList, StoreProductSlug } from '@automattic/data-stores/src/products-list';
+import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
-import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
+import { WpcomRequestParams } from 'wpcom-proxy-request';
+import {
+	mockGetCartEndpointWith,
+	mockSetCartEndpointWith,
+} from 'calypso/my-sites/checkout/src/test/util';
 import SecondaryCartPromotions from '../secondary-cart-promotions';
 import { responseCartWithRenewal, storeData } from './lib/fixtures';
 
@@ -20,9 +29,59 @@ jest.mock( '@automattic/calypso-config', () => {
 	return mock;
 } );
 
-describe( 'SecondaryCartPromotions', () => {
-	const store = applyMiddleware( thunk )( createStore )( storeData );
+const mockProductsEndpointResponse: RawAPIProductsList = {
+	'personal-bundle': {
+		available: true,
+		combined_cost_display: '10',
+		cost: 10,
+		cost_smallest_unit: 1000,
+		currency_code: 'USD',
+		description: 'Personal',
+		is_domain_registration: false,
+		price_tier_list: [],
+		price_tier_slug: '',
+		price_tier_usage_quantity: null,
+		price_tiers: '',
+		product_id: 1234,
+		product_name: 'Personal',
+		product_slug: 'personal-bundle' as StoreProductSlug,
+		product_type: 'something',
+	},
+};
 
+// The useProducts hook is in an external package that uses
+// `wpcom-proxy-request` directly to fetch data, so using `nock` will not be
+// able to mock its request. Instead we have to mock the module directly.
+jest.mock( 'wpcom-proxy-request', () => async ( data: WpcomRequestParams ) => {
+	switch ( data.path ) {
+		case '/products':
+			return mockProductsEndpointResponse;
+	}
+} );
+
+function TestWrapper( { children, initialCart } ) {
+	const [ reduxStore ] = useState( () => applyMiddleware( thunk )( createStore )( storeData ) );
+	const [ queryClient ] = useState( () => new QueryClient() );
+	const mockSetCartEndpoint = mockSetCartEndpointWith( {
+		currency: initialCart.currency,
+		locale: initialCart.locale,
+	} );
+	const managerClient = createShoppingCartManagerClient( {
+		getCart: mockGetCartEndpointWith( initialCart ),
+		setCart: mockSetCartEndpoint,
+	} );
+	return (
+		<ReduxProvider store={ reduxStore }>
+			<QueryClientProvider client={ queryClient }>
+				<ShoppingCartProvider managerClient={ managerClient }>
+					<ThemeProvider theme={ checkoutTheme }>{ children }</ThemeProvider>
+				</ShoppingCartProvider>
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+}
+
+describe( 'SecondaryCartPromotions', () => {
 	afterEach( () => {
 		mockConfig.isEnabled.mockRestore();
 	} );
@@ -34,47 +93,33 @@ describe( 'SecondaryCartPromotions', () => {
 					( flag ) => flag === 'upgrades/upcoming-renewals-notices'
 				);
 			} );
-			test( 'displays the upcoming renewals reminder', () => {
-				const { queryByText } = render(
-					<ReduxProvider store={ store }>
-						<ThemeProvider theme={ checkoutTheme }>
-							<SecondaryCartPromotions
-								responseCart={ responseCartWithRenewal }
-								addItemToCart={ jest.fn() }
-								isPurchaseRenewal={ true }
-							/>
-						</ThemeProvider>
-					</ReduxProvider>
-				);
-				expect( queryByText( 'Renew your products together' ) ).toBeTruthy();
-				expect( queryByText( 'Renew all' ) ).toBeTruthy();
-			} );
 
-			test( 'does not crash when there is missing data', () => {
-				const { container } = render(
-					<ReduxProvider store={ store }>
-						<ThemeProvider theme={ checkoutTheme }>
-							<SecondaryCartPromotions responseCart={ null } addItemToCart={ jest.fn() } />
-						</ThemeProvider>
-					</ReduxProvider>
+			test( 'displays the upcoming renewals reminder', async () => {
+				render(
+					<TestWrapper initialCart={ responseCartWithRenewal }>
+						<SecondaryCartPromotions
+							responseCart={ responseCartWithRenewal }
+							addItemToCart={ jest.fn() }
+							isPurchaseRenewal={ true }
+						/>
+					</TestWrapper>
 				);
-				expect( container ).toHaveTextContent( '' );
+				expect( await screen.findByText( 'Renew your products together' ) ).toBeInTheDocument();
+				expect( await screen.findByText( 'Renew all' ) ).toBeInTheDocument();
 			} );
 
 			test( 'adds the items to the cart when "Renew all" is clicked', async () => {
 				const mockAddItemToCart = jest.fn();
-				const { queryByText } = render(
-					<ReduxProvider store={ store }>
-						<ThemeProvider theme={ checkoutTheme }>
-							<SecondaryCartPromotions
-								responseCart={ responseCartWithRenewal }
-								addItemToCart={ mockAddItemToCart }
-								isPurchaseRenewal={ true }
-							/>
-						</ThemeProvider>
-					</ReduxProvider>
+				render(
+					<TestWrapper initialCart={ responseCartWithRenewal }>
+						<SecondaryCartPromotions
+							responseCart={ responseCartWithRenewal }
+							addItemToCart={ mockAddItemToCart }
+							isPurchaseRenewal={ true }
+						/>
+					</TestWrapper>
 				);
-				await userEvent.click( queryByText( 'Renew all' ) );
+				await userEvent.click( await screen.findByText( 'Renew all' ) );
 				expect( mockAddItemToCart ).toHaveBeenCalledTimes( 2 );
 				expect( mockAddItemToCart ).toHaveBeenCalledWith(
 					expect.objectContaining( {
@@ -92,52 +137,46 @@ describe( 'SecondaryCartPromotions', () => {
 		} );
 
 		describe( 'when there is a renewal in the cart and the feature flag is disabled', () => {
-			test( 'does not display the upcoming renewals reminder', () => {
-				const { queryByText } = render(
-					<ReduxProvider store={ store }>
-						<ThemeProvider theme={ checkoutTheme }>
-							<SecondaryCartPromotions
-								responseCart={ responseCartWithRenewal }
-								addItemToCart={ jest.fn() }
-							/>
-						</ThemeProvider>
-					</ReduxProvider>
+			test( 'does not display the upcoming renewals reminder', async () => {
+				render(
+					<TestWrapper initialCart={ responseCartWithRenewal }>
+						<SecondaryCartPromotions
+							responseCart={ responseCartWithRenewal }
+							addItemToCart={ jest.fn() }
+						/>
+					</TestWrapper>
 				);
-				expect( queryByText( 'Renew your products together' ) ).toBeNull();
+				await expect( screen.findByText( 'Renew your products together' ) ).toNeverAppear();
 			} );
 		} );
 	} );
 
 	describe( 'CartFreeUserPlanUpsell', () => {
 		describe( 'when there is a domain in the cart for a site without a paid plan', () => {
-			test( 'displays the free user plan upsell component', () => {
-				const { queryByText } = render(
-					<ReduxProvider store={ store }>
-						<ThemeProvider theme={ checkoutTheme }>
-							<SecondaryCartPromotions
-								responseCart={ responseCartWithRenewal }
-								addItemToCart={ jest.fn() }
-							/>
-						</ThemeProvider>
-					</ReduxProvider>
+			test( 'displays the free user plan upsell component', async () => {
+				render(
+					<TestWrapper initialCart={ responseCartWithRenewal }>
+						<SecondaryCartPromotions
+							responseCart={ responseCartWithRenewal }
+							addItemToCart={ jest.fn() }
+						/>
+					</TestWrapper>
 				);
-				expect( queryByText( 'Upgrade and save' ) ).toBeTruthy();
-				expect( queryByText( 'Add to Cart' ) ).toBeTruthy();
+				expect( await screen.findByText( 'Upgrade and save' ) ).toBeInTheDocument();
+				expect( await screen.findByText( 'Add to Cart' ) ).toBeInTheDocument();
 			} );
 
 			test( 'adds the plan to the cart when "Add to Cart" is clicked', async () => {
 				const mockAddItemToCart = jest.fn();
-				const { queryByText } = render(
-					<ReduxProvider store={ store }>
-						<ThemeProvider theme={ checkoutTheme }>
-							<SecondaryCartPromotions
-								responseCart={ responseCartWithRenewal }
-								addItemToCart={ mockAddItemToCart }
-							/>
-						</ThemeProvider>
-					</ReduxProvider>
+				render(
+					<TestWrapper initialCart={ responseCartWithRenewal }>
+						<SecondaryCartPromotions
+							responseCart={ responseCartWithRenewal }
+							addItemToCart={ mockAddItemToCart }
+						/>
+					</TestWrapper>
 				);
-				await userEvent.click( queryByText( 'Add to Cart' ) );
+				await userEvent.click( await screen.findByText( 'Add to Cart' ) );
 				expect( mockAddItemToCart ).toHaveBeenCalledTimes( 1 );
 				expect( mockAddItemToCart ).toHaveBeenCalledWith( {
 					product_slug: 'personal-bundle',

--- a/client/signup/steps/site-picker/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/site-picker-submit.jsx
@@ -5,8 +5,12 @@ import { connect } from 'react-redux';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 
+/**
+ * @param {null|undefined|{plan?: {product_slug: string}}} selectedSite
+ * @returns {boolean}
+ */
 export const siteHasPaidPlan = ( selectedSite ) =>
-	selectedSite && selectedSite.plan && ! isFreePlan( selectedSite.plan.product_slug );
+	Boolean( selectedSite && selectedSite.plan && ! isFreePlan( selectedSite.plan.product_slug ) );
 
 export class SitePickerSubmit extends Component {
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!


### PR DESCRIPTION
The `CartFreeUserPlanUpsell` component renders an upsell to add a plan to the cart when the cart contains only a domain (and the site has no existing plan). However, it requires product data stored in Redux to be able to determine the price to use and what text to display and there are many cases where that Redux data will never be fetched, particularly since https://github.com/Automattic/wp-calypso/pull/87540 was merged. As a result, the component will assume that the data has been fetched but that there is no price for the product and will display incorrect text.

## Proposed Changes

In this PR, we first refactor the component from a class into a functional component to make it easier to reason about and so we can use React hooks; then we change the code that fetches the price to use the `useProducts` hook, which itself uses React Query to fetch and cache the price data it requires. The logic is also changed to display nothing if no price is found or if there is no domain in the cart. This way the component will be responsible for its own data.

Fixes https://github.com/Automattic/wp-calypso/issues/89768

Before             |  After
:-------------------------:|:-------------------------:
<img width="231" alt="Screenshot 2024-04-24 at 4 23 38 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/b6b9bc95-0053-4d35-8580-5cb59e6da725"> | <img width="227" alt="Screenshot 2024-04-24 at 4 23 54 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/35f75b3f-9e3b-4dbe-ab71-5c6b2a558948">

## Testing Instructions

For a site with no plan, add just a domain to your cart and visit checkout using calypso.localhost, then reload the page until you get the notification that the Redux store has been cleared. Verify that the upsell is always displayed with the price included.