### PR TITLE
Marketplace Themes: Use URL redirection instead of cartManager

### DIFF
--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -10,7 +10,6 @@ import page from '@automattic/calypso-router';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import 'calypso/state/themes/init';
 import { marketplaceThemeProduct } from 'calypso/lib/cart-values/cart-items';
-import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
@@ -103,15 +102,10 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 		}
 
 		dispatch( isLoadingCart( true ) );
-		const cartKey = await cartManagerClient.getCartKeyForSiteSlug( siteSlug );
-		cartManagerClient
-			.forCartKey( cartKey )
-			.actions.addProductsToCart( cartItems )
-			.then( () => {
-				page( `/checkout/${ siteSlug }` );
-			} )
-			.finally( () => {
-				dispatch( isLoadingCart( false ) );
-			} );
+		return page(
+			`/checkout/${ siteSlug }/${ cartItems
+				.map( ( item ) => item.product_slug ?? '' )
+				.join( ',' ) }`
+		);
 	};
 }


### PR DESCRIPTION


Fixes https://github.com/Automattic/dotcom-forge/issues/6118

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?