### PR TITLE
Nav redesign: long site titles are truncated

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -23,6 +23,11 @@ type Props = {
 
 const SiteListTile = styled( ListTile )`
 	margin-inline-end: 0;
+	max-width: 340px;
+
+	.preview-hidden & {
+		max-width: 500px;
+	}
 
 	${ MEDIA_QUERIES.hideTableRows } {
 		margin-inline-end: 12px;
@@ -92,7 +97,9 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 				}
 				title={
 					<ListTileTitle>
-						<SiteName title={ title }>{ site.title }</SiteName>
+						<SiteName title={ title }>
+							<Truncated>{ site.title }</Truncated>
+						</SiteName>
 						{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 						{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
 						{ isTrialSitePlan && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6703

## Proposed Changes

* Truncates the site title.
* Uses different max-widths when the preview panel is open vs closed.
* This PR does not consider mobile view.

Before | After
--|--
<img width="1747" alt="Screenshot 2024-04-24 at 4 47 14 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/c89450cd-c483-46d5-9d69-b38d7c7920aa"> |  <img width="1747" alt="Screenshot 2024-04-24 at 4 46 28 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/8e292f3a-ead6-4af9-b200-b5cf9434578c">

Before | After
--|--
<img width="1751" alt="Screenshot 2024-04-24 at 4 47 31 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/0dae7d26-6bc1-4f77-a033-6e361a364c25">  | <img width="1751" alt="Screenshot 2024-04-24 at 4 46 39 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/4dd5478c-6501-4197-97b6-5ba954ea32dd">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR.
* Either create a site with a super long title or update the code to add an extra string to the end of site.title.
* Go to /sites?flags=layout%2Fdotcom-nav-redesign-v2
* Open and Close the preview panel and observe the site title length is appropriate.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?