### PR TITLE
Segmentation Survey: Record skip event when submitting with no answers and other minor fixes 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -41,14 +41,19 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 
 	const onSubmitQuestion = useCallback(
 		( currentQuestion: Question ) => {
-			mutate( {
-				questionKey: currentQuestion.key,
-				answerKeys: answers[ currentQuestion.key ] || [],
-			} );
-
-			if ( questions?.[ questions.length - 1 ].key === currentQuestion.key ) {
-				clearAnswers();
-			}
+			mutate(
+				{
+					questionKey: currentQuestion.key,
+					answerKeys: answers[ currentQuestion.key ] || [],
+				},
+				{
+					onSuccess: () => {
+						if ( questions?.[ questions.length - 1 ].key === currentQuestion.key ) {
+							clearAnswers();
+						}
+					},
+				}
+			);
 		},
 		[ answers, clearAnswers, mutate, questions ]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -28,7 +28,7 @@ const SegmentationSurveyDocumentHead = () => {
 
 const SegmentationSurveyStep: Step = ( { navigation } ) => {
 	const { data: questions } = useSurveyStructureQuery( { surveyKey: SURVEY_KEY } );
-	const { mutate } = useSaveAnswersMutation( { surveyKey: SURVEY_KEY } );
+	const { mutate, isPending } = useSaveAnswersMutation( { surveyKey: SURVEY_KEY } );
 	const { answers, setAnswers, clearAnswers } = useCachedAnswers( SURVEY_KEY );
 
 	const onChangeAnswer = useCallback(
@@ -41,6 +41,10 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 
 	const onSubmitQuestion = useCallback(
 		( currentQuestion: Question ) => {
+			if ( isPending ) {
+				return;
+			}
+
 			mutate(
 				{
 					questionKey: currentQuestion.key,
@@ -55,7 +59,7 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 				}
 			);
 		},
-		[ answers, clearAnswers, mutate, questions ]
+		[ answers, clearAnswers, isPending, mutate, questions ]
 	);
 
 	if ( ! config.isEnabled( 'ecommerce-segmentation-survey' ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/provider.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/provider.tsx
@@ -57,11 +57,18 @@ const SegmentationSurveyProvider = ( {
 		if ( currentQuestion ) {
 			onSubmitQuestion( currentQuestion );
 
-			recordTracksEvent( 'calypso_segmentation_survey_continue', {
-				survey_key: surveyKey,
-				question_key: currentQuestion.key,
-				answer_keys: answers?.[ currentQuestion.key ].join( ',' ) || '',
-			} );
+			if ( answers?.[ currentQuestion.key ] ) {
+				recordTracksEvent( 'calypso_segmentation_survey_continue', {
+					survey_key: surveyKey,
+					question_key: currentQuestion.key,
+					answer_keys: answers?.[ currentQuestion.key ].join( ',' ) || '',
+				} );
+			} else {
+				recordTracksEvent( 'calypso_segmentation_survey_skip', {
+					survey_key: surveyKey,
+					question_key: currentQuestion.key,
+				} );
+			}
 		}
 
 		nextPage();


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89852
Closes https://github.com/Automattic/wp-calypso/issues/89853
Closes https://github.com/Automattic/wp-calypso/issues/89855

## Proposed Changes

* Record skip event on Tracks when clicking continue with empty answers
* Clear local storage answers only after the request succeeded
* Do not call mutation when save is in progress to avoid multiple submissions

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur/start?flags=ecommerce-segmentation-survey
* Open the Network tab
* Click continue without selecting any option
* Check if the Tracks request has the skip event
* Add a log to the `clearAnswers();` call on `client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx`
* Answer one question and click Continue
* Check if the localStorage is cleaned after the request succeeds

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?