### PR TITLE
Entrepreneur trial plan page: Address some comments on original PR.

### DIFF
--- a/client/my-sites/plans/components/upgrade-button/style.scss
+++ b/client/my-sites/plans/components/upgrade-button/style.scss
@@ -1,4 +1,4 @@
-.trial-current-plan__trial-card-cta {
+.plans-upgrade-button__button {
 	&.blue {
 		background-color: var(--studio-blue-60);
 		color: var(--studio-blue-0);

--- a/client/my-sites/plans/components/upgrade-button/upgrade-button.tsx
+++ b/client/my-sites/plans/components/upgrade-button/upgrade-button.tsx
@@ -11,12 +11,12 @@ interface UpgradeButtonProps {
 const UpgradeButton = ( { goToCheckoutWithPlan, isEntrepreneurTrial }: UpgradeButtonProps ) => {
 	const translate = useTranslate();
 	const label = isEntrepreneurTrial
-		? translate( 'Add payment method' )
+		? translate( 'Complete your plan purchase' )
 		: translate( 'Upgrade now' );
 
 	return (
 		<Button
-			className={ classNames( 'trial-current-plan__trial-card-cta', {
+			className={ classNames( 'plans-upgrade-button__button', {
 				[ 'blue' ]: isEntrepreneurTrial,
 			} ) }
 			primary

--- a/client/my-sites/plans/current-plan/trials/use-go-to-checkout-with-plan.tsx
+++ b/client/my-sites/plans/current-plan/trials/use-go-to-checkout-with-plan.tsx
@@ -37,7 +37,7 @@ const useGoToCheckoutWithPlan = () => {
 	useOneDollarOfferTrack( selectedSite?.ID, 'plans' );
 
 	/**
-	 * Redirects to the checkout page with Plan on cart.
+	 * Redirects to the checkout page with Plan in cart.
 	 * @param ctaPosition - The position of the CTA that triggered the redirect.
 	 */
 	const goToCheckoutWithPlan = ( ctaPosition: string ) => {

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.jsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.jsx
@@ -146,7 +146,7 @@ export function EntrepreneurPlan() {
 						<h3 className="entrepreneur-trial-plan__plan-title">{ translate( 'Entrepreneur' ) }</h3>
 						<p className="card-text">
 							{ translate(
-								"Secure the full benefits of the Entrepreneur Plan. Purchase today and maximize your store's potential!"
+								"Secure the full benefits of the Entrepreneur plan. Purchase today and maximize your store's potential!"
 							) }
 						</p>
 					</div>

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.jsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.jsx
@@ -146,7 +146,7 @@ export function EntrepreneurPlan() {
 						<h3 className="entrepreneur-trial-plan__plan-title">{ translate( 'Entrepreneur' ) }</h3>
 						<p className="card-text">
 							{ translate(
-								"Continue enjoying the full benefits of Entrepreneur plan, simply add your payment method and maximize your store's potential."
+								"Secure the full benefits of the Entrepreneur Plan. Purchase today and maximize your store's potential!"
 							) }
 						</p>
 					</div>

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -52,7 +52,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 						isEntrepreneurTrial ? (
 							<UpgradeButton
 								goToCheckoutWithPlan={ goToCheckoutWithPlan }
-								isEntrepreneurTrial={ isWooExpressTrial }
+								isEntrepreneurTrial={ isEntrepreneurTrial }
 							/>
 						) : null
 					}

--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -84,12 +84,14 @@ export default function useBannerSubtitle(
 				);
 			} else {
 				entrepreneurTrialSubtitle = translate(
-					'Your free trial will end in %(daysLeft)d day. Add payment method by %(expirationdate)s to continue selling your products and access all the power.',
+					'Your free trial ends in %(daysLeft)d day. Complete the plan purchase by %(expirationdate)s o keep selling and unlock all features!',
+					'Your free trial ends in %(daysLeft)d days. Complete the plan purchase by %(expirationdate)s o keep selling and unlock all features!',
 					{
 						args: {
 							daysLeft: trialDaysLeftToDisplay,
 							expirationdate: readableExpirationDate as string,
 						},
+						count: trialDaysLeftToDisplay,
 						comment:
 							'%daysLeft is the number of days left in the trial, %expirationdate is the date the trial ends',
 					}

--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -80,12 +80,13 @@ export default function useBannerSubtitle(
 						args: {
 							expirationdate: readableExpirationDate as string,
 						},
+						comment: '%expirationdate is the date the trial ends',
 					}
 				);
 			} else {
 				entrepreneurTrialSubtitle = translate(
-					'Your free trial ends in %(daysLeft)d day. Complete the plan purchase by %(expirationdate)s o keep selling and unlock all features!',
-					'Your free trial ends in %(daysLeft)d days. Complete the plan purchase by %(expirationdate)s o keep selling and unlock all features!',
+					'Your free trial ends in %(daysLeft)d day. Complete the plan purchase by %(expirationdate)s to keep selling and unlock all features!',
+					'Your free trial ends in %(daysLeft)d days. Complete the plan purchase by %(expirationdate)s to keep selling and unlock all features!',
 					{
 						args: {
 							daysLeft: trialDaysLeftToDisplay,


### PR DESCRIPTION
## Proposed Changes

This PR should address the last rounds of comments of the previews PR:
https://github.com/Automattic/wp-calypso/pull/89575

It also update some copies according to p1713968451134459/1713529322.545209-slack-C06RQ4EQ7V2

## Testing Instructions

Check if the comments on original PR were addressed.
Repeat the testing steps of the original PR just to ensure all works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?