### PR TITLE
Fix: Collapse sidebar when site is selected

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -42,7 +42,6 @@ import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/c
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getShouldShowGlobalSidebar,
-	getShouldShowGlobalSiteSidebar,
 	getShouldShowUnifiedSiteSidebar,
 } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
@@ -454,12 +453,6 @@ export default withCurrentRoute(
 				sectionGroup,
 				sectionName
 			);
-			const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,
 				siteId,
@@ -543,7 +536,7 @@ export default withCurrentRoute(
 				userAllowedToHelpCenter,
 				currentRoute,
 				isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
-				isGlobalSidebarCollapsed: shouldShowGlobalSiteSidebar && ! sidebarIsHidden,
+				isGlobalSidebarCollapsed: shouldShowGlobalSidebar && siteId && ! sidebarIsHidden,
 				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
 				currentRoutePattern: getCurrentRoutePattern( state ) ?? '',
 				userCapabilities: state.currentUser.capabilities,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -42,6 +42,7 @@ import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/c
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getShouldShowGlobalSidebar,
+	getShouldShowGlobalSiteSidebar,
 	getShouldShowUnifiedSiteSidebar,
 	getShouldShowCollapsedGlobalSidebar,
 } from 'calypso/state/global-sidebar/selectors';
@@ -454,6 +455,12 @@ export default withCurrentRoute(
 				sectionGroup,
 				sectionName
 			);
+			const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 				siteId,
 				sectionGroup
@@ -541,7 +548,8 @@ export default withCurrentRoute(
 				userAllowedToHelpCenter,
 				currentRoute,
 				isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
-				isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
+				isGlobalSidebarCollapsed:
+					( shouldShowGlobalSiteSidebar || shouldShowCollapsedGlobalSidebar ) && ! sidebarIsHidden,
 				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
 				currentRoutePattern: getCurrentRoutePattern( state ) ?? '',
 				userCapabilities: state.currentUser.capabilities,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -43,6 +43,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getShouldShowGlobalSidebar,
 	getShouldShowUnifiedSiteSidebar,
+	getShouldShowCollapsedGlobalSidebar,
 } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -453,6 +454,10 @@ export default withCurrentRoute(
 				sectionGroup,
 				sectionName
 			);
+			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
+				siteId,
+				sectionGroup
+			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,
 				siteId,
@@ -536,7 +541,7 @@ export default withCurrentRoute(
 				userAllowedToHelpCenter,
 				currentRoute,
 				isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
-				isGlobalSidebarCollapsed: shouldShowGlobalSidebar && siteId && ! sidebarIsHidden,
+				isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
 				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
 				currentRoutePattern: getCurrentRoutePattern( state ) ?? '',
 				userCapabilities: state.currentUser.capabilities,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -41,10 +41,9 @@ import { closeCommandPalette } from 'calypso/state/command-palette/actions';
 import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
-	getShouldShowGlobalSidebar,
-	getShouldShowGlobalSiteSidebar,
-	getShouldShowUnifiedSiteSidebar,
 	getShouldShowCollapsedGlobalSidebar,
+	getShouldShowGlobalSidebar,
+	getShouldShowUnifiedSiteSidebar,
 } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -455,15 +454,11 @@ export default withCurrentRoute(
 				sectionGroup,
 				sectionName
 			);
-			const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
+			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 				state,
 				siteId,
 				sectionGroup,
 				sectionName
-			);
-			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
-				siteId,
-				sectionGroup
 			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,
@@ -548,8 +543,7 @@ export default withCurrentRoute(
 				userAllowedToHelpCenter,
 				currentRoute,
 				isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
-				isGlobalSidebarCollapsed:
-					( shouldShowGlobalSiteSidebar || shouldShowCollapsedGlobalSidebar ) && ! sidebarIsHidden,
+				isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
 				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
 				currentRoutePattern: getCurrentRoutePattern( state ) ?? '',
 				userCapabilities: state.currentUser.capabilities,

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -33,6 +33,13 @@ export const getShouldShowGlobalSiteSidebar = (
 	);
 };
 
+export const getShouldShowCollapsedGlobalSidebar = ( siteId: number, sectionGroup: string ) => {
+	// Global sidebar should be collapsed when in sites dashboard and a site is selected.
+	return (
+		isEnabled( 'layout/dotcom-nav-redesign-v2' ) && sectionGroup === 'sites-dashboard' && siteId
+	);
+};
+
 export const getShouldShowGlobalSidebar = (
 	state: AppState,
 	siteId: number,

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -33,13 +33,6 @@ export const getShouldShowGlobalSiteSidebar = (
 	);
 };
 
-export const getShouldShowCollapsedGlobalSidebar = ( siteId: number, sectionGroup: string ) => {
-	// Global sidebar should be collapsed when in sites dashboard and a site is selected.
-	return (
-		isEnabled( 'layout/dotcom-nav-redesign-v2' ) && sectionGroup === 'sites-dashboard' && siteId
-	);
-};
-
 export const getShouldShowGlobalSidebar = (
 	state: AppState,
 	siteId: number,
@@ -53,6 +46,18 @@ export const getShouldShowGlobalSidebar = (
 		( sectionGroup === 'sites' && ! siteId ) ||
 		getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName )
 	);
+};
+
+export const getShouldShowCollapsedGlobalSidebar = (
+	state: AppState,
+	siteId: number,
+	sectionGroup: string,
+	sectionName: string
+) => {
+	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
+	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
+
+	return isEnabled( 'layout/dotcom-nav-redesign-v2' ) && ( siteSelected || siteLoaded );
 };
 
 export const getShouldShowUnifiedSiteSidebar = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6704

## Proposed Changes

Sidebar must collapse when a site is selected and preview pane is open

#### TO DO
- [ ] Close the overview when clicking on `All sites` when a site has the overview open.

## Testing Instructions

* Go to `/sites?flags=layout/dotcom-nav-redesign-v2`
* Click on a site.
* The sidebar should collapse when the site details panel is shown.

