### PR TITLE
Sites Dashboard v2: Implement pagination

### DIFF
--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -31,6 +31,7 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import DotcomPreviewPane from './site-preview-pane/dotcom-preview-pane';
 import SitesDashboardHeader from './sites-dashboard-header';
 import DotcomSitesDataViews, { siteStatusGroups } from './sites-dataviews';
+import { getSitesPagination } from './sites-dataviews/utils';
 
 // todo: we are using A4A styles until we extract them as common styles in the ItemsDashboard component
 import './style.scss';
@@ -103,7 +104,10 @@ const SitesDashboardV2 = ( {
 	const filteredSites = useSitesListFiltering( currentStatusGroup, {
 		search: dataViewsState.search,
 	} );
-	// todo: Perform pagination and sorting actions
+
+	// todo: Perform sorting actions
+
+	const paginatedSites = filteredSites.slice( ( page - 1 ) * perPage, page * perPage );
 
 	// Site is selected:
 	useEffect( () => {
@@ -128,6 +132,12 @@ const SitesDashboardV2 = ( {
 		// then redirecting back to the previous path.
 		window.setTimeout( () => updateQueryParams( queryParams ) );
 	}, [ dataViewsState.search, statusSlug, updateQueryParams ] );
+
+	// Update URL with page param on change.
+	useEffect( () => {
+		const queryParams = { page: dataViewsState.page };
+		window.setTimeout( () => updateQueryParams( queryParams ) );
+	}, [ dataViewsState.page, updateQueryParams ] );
 
 	// Manage the closing of the preview pane
 	const closeSitePreviewPane = useCallback( () => {
@@ -166,8 +176,9 @@ const SitesDashboardV2 = ( {
 
 					<DocumentHead title={ __( 'Sites' ) } />
 					<DotcomSitesDataViews
-						sites={ filteredSites }
+						sites={ paginatedSites }
 						isLoading={ isLoading }
+						paginationInfo={ getSitesPagination( filteredSites, perPage ) }
 						dataViewsState={ dataViewsState }
 						setDataViewsState={ setDataViewsState }
 					/>

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -2,11 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
-import {
-	DataViewsColumn,
-	DataViewsState,
-	ItemsDataViewsType,
-} from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
@@ -17,12 +12,18 @@ import SiteField from './dataviews-fields/site-field';
 import { SiteInfo } from './interfaces';
 import { SiteStats } from './sites-site-stats';
 import { SiteStatus } from './sites-site-status';
-import { getSitesPagination } from './utils';
 import type { SiteExcerptData } from '@automattic/sites';
+import type {
+	DataViewsColumn,
+	DataViewsPaginationInfo,
+	DataViewsState,
+	ItemsDataViewsType,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 
 type Props = {
 	sites: SiteExcerptData[];
 	isLoading: boolean;
+	paginationInfo: DataViewsPaginationInfo;
 	dataViewsState: DataViewsState;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 };
@@ -36,7 +37,13 @@ export const siteStatusGroups = [
 	{ value: 6, label: __( 'Deleted' ), slug: 'deleted' },
 ];
 
-const DotcomSitesDataViews = ( { sites, isLoading, dataViewsState, setDataViewsState }: Props ) => {
+const DotcomSitesDataViews = ( {
+	sites,
+	isLoading,
+	paginationInfo,
+	dataViewsState,
+	setDataViewsState,
+}: Props ) => {
 	const { __ } = useI18n();
 	const userId = useSelector( getCurrentUserId );
 
@@ -118,13 +125,13 @@ const DotcomSitesDataViews = ( { sites, isLoading, dataViewsState, setDataViewsS
 	// Create the itemData packet state
 	const [ itemsData, setItemsData ] = useState< ItemsDataViewsType< SiteExcerptData > >( {
 		items: sites,
-		pagination: getSitesPagination( sites, dataViewsState.perPage ),
 		itemFieldId: 'ID',
 		searchLabel: __( 'Search for sites' ),
 		fields,
 		actions: [],
 		setDataViewsState: setDataViewsState,
 		dataViewsState: dataViewsState,
+		pagination: paginationInfo,
 	} );
 
 	// Update the itemData packet
@@ -133,13 +140,13 @@ const DotcomSitesDataViews = ( { sites, isLoading, dataViewsState, setDataViewsS
 			...prevState,
 			items: sites,
 			fields,
-			//actions: actions,
-			pagination: getSitesPagination( sites, dataViewsState.perPage ),
+			// actions: actions,
 			setDataViewsState,
 			dataViewsState,
 			selectedItem: dataViewsState.selectedItem,
+			pagination: paginationInfo,
 		} ) );
-	}, [ fields, dataViewsState, setDataViewsState, sites ] ); // add actions when implemented
+	}, [ fields, dataViewsState, paginationInfo, setDataViewsState, sites ] ); // add actions when implemented
 
 	return <ItemsDataViews data={ itemsData } isLoading={ isLoading } />;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6710

## Proposed Changes

This PR implements pagination in the Sites Dashboard v2. See recording for reference:

https://github.com/Automattic/wp-calypso/assets/797888/133476e4-94f5-45eb-bac2-71f523fc5da0

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites?flags=layout%2Fdotcom-nav-redesign-v2`.
* Ensure that the pagination works as expected.
* Ensure to test pagination with search.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?