### PR TITLE
Untangling: use blue colors for Core Default scheme instead of pink

### DIFF
--- a/packages/calypso-color-schemes/src/calypso-color-schemes.scss
+++ b/packages/calypso-color-schemes/src/calypso-color-schemes.scss
@@ -9,6 +9,7 @@
 @import "shared/color-schemes/coffee";
 @import "shared/color-schemes/contrast";
 @import "shared/color-schemes/ectoplasm";
+@import "shared/color-schemes/fresh";
 @import "shared/color-schemes/light";
 @import "shared/color-schemes/midnight";
 @import "shared/color-schemes/modern";

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_fresh.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_fresh.scss
@@ -1,0 +1,5 @@
+.color-scheme.is-fresh {
+	--color-primary: #2271b1;
+	--color-accent: var(--color-primary);
+	--color-accent-60: #135e96;
+}


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6665

## Proposed Changes

This PR fixes the color scheme in Calypso pages of Atomic classic sites using the Default admin color scheme, to follow Core's scheme.

This fix only applies for Calypso screens. WP Admin screens are handled via https://github.com/Automattic/jetpack/pull/37064.

|Before|After|
|-|-|
|<img width="766" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/c64e3a2a-1a9f-48d4-a2ee-cb944d4e1a57">|<img width="766" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/c1ce5978-5a3a-48b4-8462-f24c53b231dd">|

> [!NOTE]  
> This should not break production because the Default color scheme (with slug = `fresh`) is only available on untangled sites. It is not offered via Calypso's `/me/account`.

## Testing Instructions

1. Prepare an Atomic site.
2. Go to Settings -> Hosting Configuration and change the admin interface style to Classic.
3. Go to the site's `_cli` and run `wp option update wpcom_classic_early_relase 1`.
4. Go to Users -> Profile.
5. Update the admin color scheme to Default.
7. Go to My Home via the Calypso Live URL.
8. Verify that the buttons have the correct blue color (also when hovered).


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?