### PR TITLE
Nav Redesign: Update Search box styles

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
@@ -8,4 +10,41 @@
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {
 	background: var(--studio-white);
+}
+
+/*
+	Styles for actions (search, filters)
+*/
+.dataviews-filters__view-actions {
+	align-items: center;
+
+	.components-search-control {
+		@media (min-width: 1014px) {
+			min-width: 390px;
+		}
+	}
+
+	.components-search-control .components-input-control__container {
+		width: 100%;
+		height: 44px;
+		flex: 1 1 auto;
+		flex-direction: row-reverse;
+		align-items: center;
+		// places search above filters
+		z-index: 1;
+		border-radius: 2px;
+		border: 1px solid var(--studio-gray-10);
+		background-color: var(--color-surface, $white);
+
+		.components-input-control__input {
+			padding-left: 0;
+			font-size: $font-body;
+		}
+
+		// search icon
+		.components-input-control__suffix {
+			padding-inline-start: 11px;
+			color: var(--studio-gray-30);
+		}
+	}
 }

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -10,6 +10,19 @@
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {
 	background: var(--studio-white);
+
+	.a4a-layout__top-wrapper {
+		border-block-end: 0;
+
+		@media (min-width: $break-medium) {
+			border-block-end: 1px solid var(--studio-gray-0);
+			margin-bottom: 24px;
+		}
+	}
+
+	.dataviews-filters__view-actions {
+		border-bottom: 0;
+	}
 }
 
 /*
@@ -19,7 +32,7 @@
 	align-items: center;
 
 	.components-search-control {
-		@media (min-width: 1014px) {
+		@media (min-width: $break-large) {
 			min-width: 390px;
 		}
 	}

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -126,7 +126,7 @@ const DotcomSitesDataViews = ( {
 	const [ itemsData, setItemsData ] = useState< ItemsDataViewsType< SiteExcerptData > >( {
 		items: sites,
 		itemFieldId: 'ID',
-		searchLabel: __( 'Search for sites' ),
+		searchLabel: __( 'Search by name or domain…' ),
 		fields,
 		actions: [],
 		setDataViewsState: setDataViewsState,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
Fx linked issue.
-->

Fix https://github.com/Automattic/dotcom-forge/issues/6707

## Proposed Changes

This PR updates search box styles. https://github.com/Automattic/dotcom-forge/issues/6707

| before | after |
|--------|--------|
| <img width="1434" alt="Screenshot 2024-04-25 at 15 39 37" src="https://github.com/Automattic/wp-calypso/assets/5287479/9b0e9984-1341-41d1-b729-35d6837e26eb"> | <img width="1411" alt="Screen Shot 2024-04-25 at 1 09 59 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/23abff16-90ec-42a2-a94c-61c0558e9078"> |


Please note that this PR focuses on the search box and does not update the filter and sort actions (c.f., previous insight about sorting: p1712824490424629/1712699780.220079-slack-C06DN6QQVAQ **-> Update**: https://github.com/Automattic/wp-calypso/pull/89918). IMO, since a4a is [utilizing](https://github.com/Automattic/wp-calypso/blob/3f20d3141ffdfc929b1d4e709aca02eb673f495a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx#L84) the [DataView component from Gutenberg](https://wordpress.github.io/gutenberg/?path=/docs/dataviews-dataviews--docs), I believe we stay close to the original UI. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare an Atomin site with Classic View 
* Go to the site's `_cli` and run `wp option update wpcom_classic_early_relase 1`.
* Go to `/sites/?flags=layout/dotcom-nav-redesign-v2&page=1`
* See the updated search box

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?