### PR TITLE
Untangling: fix avatar position on top masterbar on untangled sites.

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1033,6 +1033,10 @@ a.masterbar__quick-language-switcher {
 		padding: 0 7px;
 	}
 
+	.masterbar__item-me {
+		gap: 0;
+	}
+
 	.masterbar__item-all-sites {
 		gap: 2px;
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes the position of the user avatar icon on untangled sites, a regression found from https://github.com/Automattic/wp-calypso/pull/89201.

|Before|After|
|-|-|
|<img width="128" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/ac03db9f-c46c-4dec-9fb0-1328e5a8117f">|<img width="128" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/ea73e31a-9bff-47e8-bcb1-b1084ac5d7ff">|


## Testing Instructions

1. Prepare an Atomic site.
2. Go to Settings -> Hosting Configuration and change the admin interface style to Classic.
3. Go to the site's `_cli` and run `wp option update wpcom_classic_early_relase 1`.
4. Go to Hosting -> My Home.
5. Verify the position of the user avatar as screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?