### PR TITLE
Remove some irrelevant copy/pasted code from site-migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
@@ -41,7 +41,6 @@ const siteMigration: Flow = {
 	},
 	useAssertConditions(): AssertConditionResult {
 		const { siteSlug, siteId } = useSiteData();
-		const { setProfilerData } = useDispatch( ONBOARD_STORE );
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
@@ -63,20 +62,8 @@ const siteMigration: Flow = {
 		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
 
 		const queryParams = new URLSearchParams( window.location.search );
-		const profilerData = queryParams.get( 'profilerdata' );
 		const aff = queryParams.get( 'aff' );
 		const vendorId = queryParams.get( 'vid' );
-
-		if ( profilerData ) {
-			try {
-				const decodedProfilerData = JSON.parse(
-					decodeURIComponent( escape( window.atob( profilerData ) ) )
-				);
-
-				setProfilerData( decodedProfilerData );
-				// Ignore any bad/invalid data and prevent it from causing downstream issues.
-			} catch {}
-		}
 
 		const getStartUrl = () => {
 			let hasFlowParams = false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* While working on the new `migration-signup` flow, I noticed what looks like some copy/pasted code in the `site-migration` flow that was intended for/from the Woo Express flow. This PR removes that code.

## Testing Instructions

* Run this branch locally or via Calypso.live
* Work through the steps to create a new site via `/start`, and when you get to the goal selection screen, choose to import your existing site/content
* Work through the `site-migration` flow to verify that everything works

You can also check that we don't have any uses of the related `getProfilerData` selector -- AFAICT, the only usage of the selector is in the `assign-trial-plan` step:

https://github.com/Automattic/wp-calypso/blob/1f163b62a2ebfe7dee45bdbeb23aa12a9fd54c1f/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx#L24-L26

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
