### PR TITLE
Sites Dashboard v2: Fix header padding

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -2,26 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 // Add new Dotcom specific styles to this file.
-.wpcom-site .main.sites-dashboard__layout {
-	.a4a-layout__header {
-		margin: auto;
-
-		@include break-medium {
-			margin: 0 auto 16px auto;
-		}
-
-		@include break-large {
-			margin: 0 auto 24px auto;
-		}
-	}
-}
-
-.wpcom-site .main.sites-dashboard__layout.preview-hidden {
-	.a4a-layout__top-wrapper {
-		padding-block-start: 0;
-	}
-}
-
 .wpcom-site .a4a-layout-with-columns__container {
 	background: var(--color-sidebar-background);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes a header padding issue by reverting styles changes introduced in https://github.com/Automattic/wp-calypso/pull/89880.

Before:
<img width="1027" alt="Screenshot 2024-04-25 at 5 15 51 PM" src="https://github.com/Automattic/wp-calypso/assets/797888/30582d6b-5329-46a6-9314-9c6177492afa">

After:
<img width="826" alt="Screenshot 2024-04-25 at 5 18 44 PM" src="https://github.com/Automattic/wp-calypso/assets/797888/c38073e2-1439-4a30-a965-f95780da7b1d">


## Testing Instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites?flags=layout%2Fdotcom-nav-redesign-v2`.
* Ensure that the header padding is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?