### PR TITLE
Sites Dashboard v2: Update styles for GSV

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -37,6 +37,7 @@ export default function ItemPreviewPane( {
 	className,
 	itemData,
 	addTourDetails,
+	itemPreviewPaneHeaderExtraProps,
 }: PreviewPaneProps ) {
 	const [ navRef, setNavRef ] = useState< HTMLElement | null >( null );
 
@@ -79,7 +80,11 @@ export default function ItemPreviewPane( {
 
 	return (
 		<div className={ classNames( 'item-preview__pane', className ) }>
-			<ItemPreviewPaneHeader closeItemPreviewPane={ closeItemPreviewPane } itemData={ itemData } />
+			<ItemPreviewPaneHeader
+				closeItemPreviewPane={ closeItemPreviewPane }
+				itemData={ itemData }
+				extraProps={ itemPreviewPaneHeaderExtraProps }
+			/>
 			<div ref={ setNavRef }>
 				<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
 					{ navItems && navItems.length > 0 ? (

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -5,7 +5,7 @@ import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import SiteFavicon from '../../site-favicon';
-import { ItemData } from '../types';
+import { ItemData, ItemPreviewPaneHeaderExtraProps } from '../types';
 
 import './style.scss';
 
@@ -15,12 +15,14 @@ interface Props {
 	closeItemPreviewPane?: () => void;
 	itemData: ItemData;
 	className?: string;
+	extraProps?: ItemPreviewPaneHeaderExtraProps;
 }
 
 export default function ItemPreviewPaneHeader( {
 	itemData,
 	closeItemPreviewPane,
 	className,
+	extraProps,
 }: Props ) {
 	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
 	const size = isLargerThan960px ? 64 : 50;
@@ -45,8 +47,22 @@ export default function ItemPreviewPaneHeader( {
 							target="_blank"
 						>
 							<span>{ itemData.subtitle }</span>
-							<Icon className="sidebar-v2__external-icon" icon={ external } size={ ICON_SIZE } />
+							<Icon
+								className="sidebar-v2__external-icon"
+								icon={ external }
+								size={ extraProps?.externalIconSize || ICON_SIZE }
+							/>
 						</Button>
+						{ itemData.adminUrl && (
+							<Button
+								variant="link"
+								className="item-preview__header-summary-link"
+								href={ `${ itemData.adminUrl }` }
+								target="_blank"
+							>
+								<span>{ translate( 'WP Admin' ) }</span>
+							</Button>
+						) }
 					</div>
 				</div>
 				<Button

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -25,6 +25,7 @@ export interface ItemData {
 	color?: string;
 	blogId?: number;
 	isDotcomSite?: boolean;
+	adminUrl?: string;
 }
 
 export interface PreviewPaneProps {
@@ -36,4 +37,9 @@ export interface PreviewPaneProps {
 	isSmallScreen?: boolean;
 	hasError?: boolean;
 	addTourDetails?: { id: string; tourId: TourId };
+	itemPreviewPaneHeaderExtraProps?: ItemPreviewPaneHeaderExtraProps;
+}
+
+export interface ItemPreviewPaneHeaderExtraProps {
+	externalIconSize?: number;
 }

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -117,4 +117,24 @@
 		box-sizing: border-box;
 		overflow-x: auto;
 	}
+	.item-preview__header {
+		.site-favicon .site-icon {
+			box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+		}
+		.item-preview__header-title {
+			font-family: Recoleta, sans-serif;
+		}
+		.item-preview__header-content .item-preview__header-title-summary .item-preview__header-summary {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.5rem;
+			.item-preview__header-summary-link {
+				color: var(--studio-gray-70, #3c434a);
+				text-decoration: none;
+				&:hover {
+					color: var(--color-accent, #3858e9);
+				}
+			}
+		}
+	}
 }

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -104,6 +104,7 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 		url: site.URL,
 		blogId: site.ID,
 		isDotcomSite: site.is_wpcom_atomic || site.is_wpcom_staging_site,
+		adminUrl: site.options?.admin_url || `${ site.URL }/wp-admin`,
 	};
 
 	return (
@@ -111,6 +112,9 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 			itemData={ itemData }
 			closeItemPreviewPane={ closeSitePreviewPane }
 			features={ features }
+			itemPreviewPaneHeaderExtraProps={ {
+				externalIconSize: 16,
+			} }
 		/>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6714
Fixes https://github.com/Automattic/dotcom-forge/issues/6754

## Proposed Changes

-  Update header font styles
-  Update link styles (color and size)
-  Adjust site icon size
-  Add box-shadow to site icon

Figma: PZtnZ1nHhnBrsuXDoMJHPD-fi-446_63469

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/fbce9ba7-d0eb-4086-95c9-fecaa345d1b5">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/b096212d-52a2-4ca2-82a5-a0805ec71db3">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites?flags=layout/dotcom-nav-redesign-v2
* Make sure the styles are aligned with Figma
* Test on mobile to see if there's anything weird

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?