### PR TITLE
Hosting Overview: Adjust price style

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -60,13 +60,20 @@ const PlanCard: FC = () => {
 								height="32px"
 							/>
 						) : (
-							<PlanPrice
-								className="hosting-overview__plan-price"
-								currencyCode={ planData?.currencyCode }
-								displayPerMonthNotation
-								isSmallestUnit
-								rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
-							/>
+							<div className="hosting-overview__plan-price-wrapper">
+								<PlanPrice
+									className="hosting-overview__plan-price"
+									currencyCode={ planData?.currencyCode }
+									isSmallestUnit
+									rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
+								/>
+								<span className="hosting-overview__plan-price-term">
+									{ translate( '/mo', {
+										comment:
+											'/mo is short for per month, referring to the monthly price of a site plan',
+									} ) }
+								</span>
+							</div>
 						) }
 						{ isLoading ? (
 							<LoadingPlaceholder
@@ -76,21 +83,24 @@ const PlanCard: FC = () => {
 							/>
 						) : (
 							<div className="hosting-overview__plan-info">
-								{ translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
-									args: {
-										rawPrice: formatCurrency(
-											pricing?.[ planSlug ].originalPrice.full ?? 0,
-											planData?.currencyCode ?? '',
-											{
-												stripZeros: true,
-												isSmallestUnit: true,
-											}
-										),
-									},
-									components: {
-										span: <span />,
-									},
-								} ) }
+								{ translate(
+									'per month, {{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.',
+									{
+										args: {
+											rawPrice: formatCurrency(
+												pricing?.[ planSlug ].originalPrice.full ?? 0,
+												planData?.currencyCode ?? '',
+												{
+													stripZeros: true,
+													isSmallestUnit: true,
+												}
+											),
+										},
+										components: {
+											span: <span />,
+										},
+									}
+								) }
 							</div>
 						) }
 						{ isLoading ? (

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -83,24 +83,21 @@ const PlanCard: FC = () => {
 							/>
 						) : (
 							<div className="hosting-overview__plan-info">
-								{ translate(
-									'per month, {{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.',
-									{
-										args: {
-											rawPrice: formatCurrency(
-												pricing?.[ planSlug ].originalPrice.full ?? 0,
-												planData?.currencyCode ?? '',
-												{
-													stripZeros: true,
-													isSmallestUnit: true,
-												}
-											),
-										},
-										components: {
-											span: <span />,
-										},
-									}
-								) }
+								{ translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
+									args: {
+										rawPrice: formatCurrency(
+											pricing?.[ planSlug ].originalPrice.full ?? 0,
+											planData?.currencyCode ?? '',
+											{
+												stripZeros: true,
+												isSmallestUnit: true,
+											}
+										),
+									},
+									components: {
+										span: <span />,
+									},
+								} ) }
 							</div>
 						) }
 						{ isLoading ? (

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
 
 .hosting-overview {
@@ -54,6 +55,10 @@
 	margin-bottom: 8px;
 }
 
+.hosting-overview .hosting-overview__plan-price {
+	align-items: center;
+}
+
 .hosting-overview__plan-card-title {
 	flex: 1;
 }
@@ -72,6 +77,23 @@
 .hosting-overview__plan-price .plan-price__term {
 	color: var(--studio-gray-100);
 	font-family: "SF Pro", $sans;
+}
+
+@media ( max-width: $break-xlarge ) {
+	.hosting-overview__plan-card-title,
+	.hosting-overview__plan-price,
+	.hosting-overview__plan-price .plan-price__currency-symbol,
+	.hosting-overview__plan-price .plan-price__integer,
+	.hosting-overview__plan-price .plan-price__fraction {
+		font-family: "SF Pro", $sans;
+		font-size: rem(18px); //typography-exception
+		line-height: 26px;
+	}
+
+	.hosting-overview__plan-price .plan-price__term {
+		font-size: rem(9px);
+		line-height: 9px;
+	}
 }
 
 a.hosting-overview__link-button {

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -78,7 +78,6 @@ a.hosting-overview__link-button {
 	color: var(--Primary-Blue, #007cba);
 	font-family: "SF Pro Text", $sans;
 	font-size: $font-body-extra-small;
-	font-style: normal;
 	line-height: 16px;
 	text-decoration-line: underline;
 }
@@ -101,7 +100,6 @@ a.hosting-overview__link-button {
 	font-feature-settings: "clig" off, "liga" off;
 	font-family: "SF Pro Display", $sans;
 	font-size: $font-title-small;
-	font-style: normal;
 	font-weight: 500;
 	line-height: 26px;
 	letter-spacing: 0.38px;
@@ -111,7 +109,6 @@ a.hosting-overview__link-button {
 	color: var(--studio-gray-80);
 	font-family: "SF Pro Text", $sans;
 	font-size: $font-body-extra-small;
-	font-style: normal;
 	line-height: 16px;
 	margin-bottom: 4px;
 }
@@ -131,7 +128,6 @@ a.hosting-overview__link-button {
 	color: var(--studio-gray-80, #2c3338);
 	font-family: "SF Pro Text", $sans;
 	font-size: $font-body-extra-small;
-	font-style: normal;
 	line-height: 16px;
 	margin-top: 30px;
 }
@@ -200,7 +196,6 @@ a.hosting-overview__link-button {
 	color: var(--studio-gray-100);
 	font-family: "SF Pro Text", $sans;
 	font-size: $font-body-small;
-	font-style: normal;
 	line-height: 20px;
 	letter-spacing: -0.15px;
 

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -80,9 +80,19 @@
 	line-height: 32px;
 }
 
+.hosting-overview__plan-price .plan-price__integer {
+	margin-right: 0;
+}
+
+.hosting-overview__plan-price .plan-price__fraction {
+	font-weight: 400;
+}
+
 .hosting-overview__plan-price .plan-price__term {
 	color: var(--studio-gray-100);
 	font-family: "SF Pro", $sans;
+	font-size: $font-body-extra-small;
+	line-height: 12px;
 }
 
 @media ( max-width: $break-xlarge ) {

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -48,7 +48,7 @@
 }
 
 .hosting-overview__plan-card-header,
-.hosting-overview__plan-price,
+.hosting-overview .hosting-overview__plan-price,
 .hosting-overview__plan-price-loading-placeholder {
 	display: flex;
 	margin-bottom: 8px;
@@ -148,7 +148,7 @@ a.hosting-overview__link-button {
 }
 
 @media ( max-width: $break-xlarge ) {
-	.hosting-overview__plan-price,
+	.hosting-overview .hosting-overview__plan-price,
 	.hosting-overview__plan-price-loading-placeholder {
 		margin-bottom: 4px;
 	}

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -54,15 +54,24 @@
 	margin-bottom: 8px;
 }
 
-.hosting-overview__plan-card-title,
-.hosting-overview__plan-price {
-	color: var(--studio-gray-100);
+.hosting-overview__plan-card-title {
 	flex: 1;
-	font-feature-settings: "clig" off, "liga" off;
+}
+
+.hosting-overview__plan-card-title,
+.hosting-overview__plan-price,
+.hosting-overview__plan-price .plan-price__currency-symbol,
+.hosting-overview__plan-price .plan-price__integer,
+.hosting-overview__plan-price .plan-price__fraction {
+	color: var(--studio-gray-100);
 	font-family: "SF Pro", $sans;
 	font-size: rem(28px); //typography-exception
-	font-style: normal;
 	line-height: 32px;
+}
+
+.hosting-overview__plan-price .plan-price__term {
+	color: var(--studio-gray-100);
+	font-family: "SF Pro", $sans;
 }
 
 a.hosting-overview__link-button {
@@ -97,7 +106,6 @@ a.hosting-overview__link-button {
 	line-height: 26px;
 	letter-spacing: 0.38px;
 }
-
 
 .hosting-overview__plan-info {
 	color: var(--studio-gray-80);

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -49,20 +49,25 @@
 }
 
 .hosting-overview__plan-card-header,
-.hosting-overview .hosting-overview__plan-price,
+.hosting-overview .hosting-overview__plan-price-wrapper,
 .hosting-overview__plan-price-loading-placeholder {
 	display: flex;
 	margin-bottom: 8px;
+}
+
+.hosting-overview .hosting-overview__plan-price {
+	display: flex;
+	align-items: center;
+}
+
+.hosting-overview__plan-price-wrapper {
+	align-items: center;
 }
 
 @media ( max-width: $break-xlarge ) {
 	.hosting-overview__plan-card-header {
 		margin-bottom: 4px;
 	}
-}
-
-.hosting-overview .hosting-overview__plan-price {
-	align-items: center;
 }
 
 .hosting-overview__plan-card-title {
@@ -73,7 +78,8 @@
 .hosting-overview__plan-price,
 .hosting-overview__plan-price .plan-price__currency-symbol,
 .hosting-overview__plan-price .plan-price__integer,
-.hosting-overview__plan-price .plan-price__fraction {
+.hosting-overview__plan-price .plan-price__fraction,
+.hosting-overview__plan-price-term {
 	color: var(--studio-gray-100);
 	font-family: "SF Pro", $sans;
 	font-size: rem(28px); //typography-exception
@@ -88,13 +94,6 @@
 	font-weight: 400;
 }
 
-.hosting-overview__plan-price .plan-price__term {
-	color: var(--studio-gray-100);
-	font-family: "SF Pro", $sans;
-	font-size: $font-body-extra-small;
-	line-height: 12px;
-}
-
 @media ( max-width: $break-xlarge ) {
 	.hosting-overview__plan-card-title {
 		font-size: $font-size-header-small;
@@ -105,15 +104,12 @@
 	.hosting-overview__plan-price,
 	.hosting-overview__plan-price .plan-price__currency-symbol,
 	.hosting-overview__plan-price .plan-price__integer,
-	.hosting-overview__plan-price .plan-price__fraction {
+	.hosting-overview__plan-price .plan-price__fraction,
+	.hosting-overview__plan-price-term {
 		font-size: rem(18px); //typography-exception
 		line-height: 26px;
 	}
 
-	.hosting-overview__plan-price .plan-price__term {
-		font-size: rem(9px);
-		line-height: 9px;
-	}
 }
 
 a.hosting-overview__link-button {
@@ -190,7 +186,7 @@ a.hosting-overview__link-button {
 }
 
 @media ( max-width: $break-xlarge ) {
-	.hosting-overview .hosting-overview__plan-price,
+	.hosting-overview .hosting-overview__plan-price-wrapper,
 	.hosting-overview__plan-price-loading-placeholder {
 		margin-bottom: 4px;
 	}

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -55,6 +55,12 @@
 	margin-bottom: 8px;
 }
 
+@media ( max-width: $break-xlarge ) {
+	.hosting-overview__plan-card-header {
+		margin-bottom: 4px;
+	}
+}
+
 .hosting-overview .hosting-overview__plan-price {
 	align-items: center;
 }
@@ -80,12 +86,16 @@
 }
 
 @media ( max-width: $break-xlarge ) {
-	.hosting-overview__plan-card-title,
+	.hosting-overview__plan-card-title {
+		font-size: $font-size-header-small;
+		font-weight: 500;
+		line-height: 26px;
+	}
+
 	.hosting-overview__plan-price,
 	.hosting-overview__plan-price .plan-price__currency-symbol,
 	.hosting-overview__plan-price .plan-price__integer,
 	.hosting-overview__plan-price .plan-price__fraction {
-		font-family: "SF Pro", $sans;
 		font-size: rem(18px); //typography-exception
 		line-height: 26px;
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6384

## Proposed Changes

* This PR adjusts the price styles to make sure it doesn't look misaligned, which happened erratically, as can be seen on this comment: https://github.com/Automattic/wp-calypso/pull/89476#issuecomment-2059177300

## Testing Instructions

* Open the live preview
* Go to `/hosting-overview`
* Check that the plan price card matches the desktop (PZtnZ1nHhnBrsuXDoMJHPD-fi-446%3A153354) and mobile (IQgFHqGiN0eXkPn7Qkth4s-fi-6%3A8860) designs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?