### PR TITLE
Sites dashboard v2 - update pagination to handle perPage

### DIFF
--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -139,7 +139,6 @@ const SitesDashboardV2 = ( {
 		const queryParams = {
 			search: dataViewsState.search?.trim(),
 			status: statusSlug === DEFAULT_STATUS_GROUP ? undefined : statusSlug,
-			page: dataViewsState.page === 1 ? undefined : dataViewsState.page,
 			'per-page': dataViewsState.perPage === DEFAULT_PER_PAGE ? undefined : dataViewsState.perPage,
 		};
 
@@ -147,13 +146,7 @@ const SitesDashboardV2 = ( {
 		// updateQueryParams call to the back of the stack to avoid it getting the incorrect URL and
 		// then redirecting back to the previous path.
 		window.setTimeout( () => updateQueryParams( queryParams ) );
-	}, [
-		dataViewsState.search,
-		dataViewsState.page,
-		dataViewsState.perPage,
-		statusSlug,
-		updateQueryParams,
-	] );
+	}, [ dataViewsState.search, dataViewsState.perPage, statusSlug, updateQueryParams ] );
 
 	// Manage the closing of the preview pane
 	const closeSitePreviewPane = useCallback( () => {

--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -44,10 +44,19 @@ interface SitesDashboardProps {
 	updateQueryParams?: ( params: SitesDashboardQueryParams ) => void;
 }
 
+const DEFAULT_PER_PAGE = 96;
+const DEFAULT_STATUS_GROUP = 'all';
+
 const SitesDashboardV2 = ( {
 	// Note - control params (eg. search, page, perPage, status...) are currently meant for
 	// initializing the dataViewsState. Further calculations should reference the dataViewsState.
-	queryParams: { page = 1, perPage = 96, search, newSiteID, status = 'all' },
+	queryParams: {
+		page = 1,
+		perPage = DEFAULT_PER_PAGE,
+		search,
+		newSiteID,
+		status = DEFAULT_STATUS_GROUP,
+	},
 	updateQueryParams = handleQueryParamChange,
 }: SitesDashboardProps ) => {
 	const { __ } = useI18n();
@@ -129,9 +138,9 @@ const SitesDashboardV2 = ( {
 	useEffect( () => {
 		const queryParams = {
 			search: dataViewsState.search?.trim(),
-			status: statusSlug === 'all' ? undefined : statusSlug,
+			status: statusSlug === DEFAULT_STATUS_GROUP ? undefined : statusSlug,
 			page: dataViewsState.page === 1 ? undefined : dataViewsState.page,
-			'per-page': dataViewsState.perPage === 96 ? undefined : dataViewsState.perPage,
+			'per-page': dataViewsState.perPage === DEFAULT_PER_PAGE ? undefined : dataViewsState.perPage,
 		};
 
 		// There is a chance that the URL is not up to date when it mounts, so bump the

--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -45,6 +45,8 @@ interface SitesDashboardProps {
 }
 
 const SitesDashboardV2 = ( {
+	// Note - control params (eg. search, page, perPage, status...) are currently meant for
+	// initializing the dataViewsState. Further calculations should reference the dataViewsState.
 	queryParams: { page = 1, perPage = 96, search, newSiteID, status = 'all' },
 	updateQueryParams = handleQueryParamChange,
 }: SitesDashboardProps ) => {
@@ -107,7 +109,10 @@ const SitesDashboardV2 = ( {
 
 	// todo: Perform sorting actions
 
-	const paginatedSites = filteredSites.slice( ( page - 1 ) * perPage, page * perPage );
+	const paginatedSites = filteredSites.slice(
+		( dataViewsState.page - 1 ) * dataViewsState.perPage,
+		dataViewsState.page * dataViewsState.perPage
+	);
 
 	// Site is selected:
 	useEffect( () => {
@@ -120,24 +125,26 @@ const SitesDashboardV2 = ( {
 		}
 	}, [ dataViewsState.selectedItem ] );
 
-	// Update URL with search param on change
+	// Update URL with view control params on change.
 	useEffect( () => {
 		const queryParams = {
 			search: dataViewsState.search?.trim(),
 			status: statusSlug === 'all' ? undefined : statusSlug,
+			page: dataViewsState.page === 1 ? undefined : dataViewsState.page,
+			'per-page': dataViewsState.perPage === 96 ? undefined : dataViewsState.perPage,
 		};
 
 		// There is a chance that the URL is not up to date when it mounts, so bump the
 		// updateQueryParams call to the back of the stack to avoid it getting the incorrect URL and
 		// then redirecting back to the previous path.
 		window.setTimeout( () => updateQueryParams( queryParams ) );
-	}, [ dataViewsState.search, statusSlug, updateQueryParams ] );
-
-	// Update URL with page param on change.
-	useEffect( () => {
-		const queryParams = { page: dataViewsState.page };
-		window.setTimeout( () => updateQueryParams( queryParams ) );
-	}, [ dataViewsState.page, updateQueryParams ] );
+	}, [
+		dataViewsState.search,
+		dataViewsState.page,
+		dataViewsState.perPage,
+		statusSlug,
+		updateQueryParams,
+	] );
 
 	// Manage the closing of the preview pane
 	const closeSitePreviewPane = useCallback( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to follow up on # https://github.com/Automattic/wp-calypso/pull/89882 

## Proposed Changes

* Updates the pagination to use the perPage setting.
* Uses the dataViewsState values of pagination for pagination calculations instead of the url Params.
* Updates the page url param to only show up if it is a value other than 1.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit the sites dashboard with flag enabled `/sites?flags=layout%2Fdotcom-nav-r
* Update the 'perPage' setting dropdown in the top right of the list (view options)
![Screenshot 2024-04-25 at 8 45 41 AM](https://github.com/Automattic/wp-calypso/assets/28742426/0a2d1c7e-a127-4721-aab7-cac334d635aa)
edesign-v2`
* Verify the list is then paginated WRT the perPage setting, and that pagination still works as expected.
* Verify a 'per-page' value is added to the URL if anything other than the default (currently 96)
* Reload the page and verify the per page value preserved in the URL is respected when the list is loaded.
* * Note - there is a previous known issue that the 'page' value always resets to 1 on reload.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
