### PR TITLE
Scheduled Updates: Update PLUGIN_SITE_HEALTH_CHECK_FAILURE log

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-logs.helper.ts
+++ b/client/blocks/plugins-scheduled-updates/schedule-logs.helper.ts
@@ -1,8 +1,9 @@
 import { translate } from 'i18n-calypso';
 import type { CorePlugin } from 'calypso/data/plugins/types';
 import type { ScheduleLog } from 'calypso/data/plugins/use-update-schedule-logs-query';
+import type { SiteSlug } from 'calypso/types';
 
-export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[] ) => {
+export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[], siteSlug: SiteSlug ) => {
 	const pluginName =
 		plugins.find( ( p ) => p.plugin === log.context?.plugin_name )?.name ||
 		log.context?.plugin_name;
@@ -39,6 +40,14 @@ export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[] ) => {
 		case 'PLUGIN_SITE_HEALTH_CHECK_SUCCESS':
 			return translate( 'Site health check completed' );
 		case 'PLUGIN_SITE_HEALTH_CHECK_FAILURE':
+			if ( log.context?.path ) {
+				const path = log.context?.path === '/' ? '' : log.context?.path;
+				return translate( 'Site health check failed on %(path)s', {
+					args: {
+						path: siteSlug + path,
+					},
+				} );
+			}
 			return translate( 'Site health check failed' );
 	}
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-logs.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-logs.tsx
@@ -129,7 +129,7 @@ export const ScheduleLogs = ( props: Props ) => {
 									? `${ dateFormat } ${ timeFormat }`
 									: timeFormat
 							}
-							detail={ getLogDetails( log, plugins ) }
+							detail={ getLogDetails( log, plugins, siteSlug ) }
 							icon={ getLogIcon( log ) }
 							iconBackground={ getLogIconStatus( log ) }
 							className={ shouldIndentTimelineEvent( log ) ? 'indent' : '' }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89903

## Proposed Changes

* Add path to the logs for PLUGIN_SITE_HEALTH_CHECK_FAILURE

**Before**

![Screen Shot 2024-04-25 at 11 01 17 PM](https://github.com/Automattic/wp-calypso/assets/4074459/1059b5db-cf48-4eb2-a634-e46e2aac0413)

**After**
![Screen Shot 2024-04-25 at 10 14 19 PM](https://github.com/Automattic/wp-calypso/assets/4074459/1d0d1e49-0c7e-4cb6-8a61-247fc61b5da9)  



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR needs to be tested with D146591-code, follow the instructions and generate the logs first.
* If it's the root `/` path, it'll be removed and show site_slug only, otherwise it'll be site_slug + recorded path.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?