### PR TITLE
Ensure we track whether the upgrade-plan component hides the trial

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, PLAN_BUSINESS, PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
@@ -11,7 +12,6 @@ import useAddHostingTrialMutation, {
 } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
 import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import UpgradePlanDetails from './upgrade-plan-details';
 
@@ -91,7 +91,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 			migration_trial_hidden: hideFreeMigrationTrial ? 'true' : 'false',
 		};
 
-		dispatch( recordTracksEvent( 'calypso_site_migration_upgrade_plan_screen', allEventProps ) );
+		recordTracksEvent( 'calypso_site_migration_upgrade_plan_screen', allEventProps );
 	}, [ migrationTrialEligibility, hideFreeMigrationTrial ] );
 
 	const renderCTAs = () => {

--- a/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import React, { type ComponentPropsWithoutRef } from 'react';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { UpgradePlan } from '../index';
+
+// Stub out UpgradePlanDetails because it has much more complex dependencies, and only provides a wrapper around the content from this component.
+jest.mock( '../upgrade-plan-details', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+// This is effectively a custom passthrough as jest.spyOn() doesn't seem to work well
+// with the recordTracksEvent import.
+jest.mock( 'calypso/state/analytics/actions', () => {
+	const originalActions = jest.requireActual( 'calypso/state/analytics/actions' );
+
+	return {
+		__esModule: true,
+		...originalActions,
+		recordTracksEvent: jest
+			.fn()
+			.mockImplementation( ( ...args ) => originalActions.recordTracksEvent( ...args ) ),
+	};
+} );
+
+function renderUpgradePlanComponent( props: ComponentPropsWithoutRef< typeof UpgradePlan > ) {
+	const queryClient = new QueryClient();
+
+	return renderWithProvider(
+		<QueryClientProvider client={ queryClient }>
+			<UpgradePlan { ...props } />
+		</QueryClientProvider>,
+		{
+			initialState: {},
+			reducers: {},
+		}
+	);
+}
+
+const DEFAULT_SITE_ID = 123;
+const DEFAULT_SITE_SLUG = 'test-example.wordpress.com';
+
+const DEFAULT_SITE_CAPABILITIES = {
+	activate_plugins: true,
+	activate_wordads: true,
+	delete_others_posts: true,
+	delete_posts: true,
+	delete_users: true,
+	edit_others_pages: true,
+	edit_others_posts: true,
+	edit_pages: true,
+	edit_posts: true,
+	edit_theme_options: true,
+	edit_users: true,
+	list_users: true,
+	manage_categories: true,
+	manage_options: true,
+	moderate_comments: true,
+	own_site: true,
+	promote_users: true,
+	publish_posts: true,
+	remove_users: true,
+	upload_files: true,
+	view_hosting: true,
+	view_stats: true,
+};
+
+function getUpgradePlanProps(
+	customProps: Partial< ComponentPropsWithoutRef< typeof UpgradePlan > > = {}
+): ComponentPropsWithoutRef< typeof UpgradePlan > {
+	const defaultProps: ComponentPropsWithoutRef< typeof UpgradePlan > = {
+		site: {
+			ID: DEFAULT_SITE_ID,
+			URL: 'https://test-example.wordpress.com',
+			capabilities: DEFAULT_SITE_CAPABILITIES,
+			description: 'test site',
+			domain: 'test-example.wordpress.com',
+			jetpack: false,
+			launch_status: 'launched',
+			locale: 'en',
+			logo: { id: 'logo', sizes: [ '100x100' ], url: 'https://test-example.wordpress.com/logo' },
+			name: 'Test Site',
+			slug: DEFAULT_SITE_SLUG,
+			title: 'Test Site',
+		},
+		isBusy: false,
+		ctaText: '',
+		navigateToVerifyEmailStep: () => {},
+		onCtaClick: () => {},
+	};
+
+	return {
+		...defaultProps,
+		...customProps,
+	};
+}
+
+const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
+
+const API_RESPONSE_ELIGIBLE = {
+	eligible: true,
+};
+
+const API_RESPONSE_INELIGIBLE_UNVERIFIED_EMAIL = {
+	eligible: true,
+	error_code: 'email-unverified',
+};
+
+describe( 'UpgradePlan', () => {
+	beforeAll( () => nock.disableNetConnect() );
+
+	it( 'should render the default Continue CTA and trigger onCtaClick when no CTA is supplied', async () => {
+		const mockOnCtaClick = jest.fn();
+
+		renderUpgradePlanComponent( getUpgradePlanProps( { onCtaClick: mockOnCtaClick } ) );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		await waitFor( () => expect( mockOnCtaClick ).toHaveBeenCalled() );
+	} );
+
+	it( 'should render a custom CTA admd triggerOnCtaClick when ctaText is supplied', async () => {
+		const mockOnCtaClick = jest.fn();
+
+		renderUpgradePlanComponent(
+			getUpgradePlanProps( { ctaText: 'My Custom CTA', onCtaClick: mockOnCtaClick } )
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: /My Custom CTA/ } ) );
+
+		await waitFor( () => expect( mockOnCtaClick ).toHaveBeenCalled() );
+	} );
+
+	it( 'should correctly trigger a Tracks event without custom event properties', async () => {
+		nock.cleanAll();
+		mockApi()
+			.persist()
+			.get(
+				`/wpcom/v2/sites/${ DEFAULT_SITE_ID }/hosting/trial/check-eligibility/${ PLAN_MIGRATION_TRIAL_MONTHLY }`
+			)
+			.reply( 200, API_RESPONSE_ELIGIBLE );
+
+		renderUpgradePlanComponent( getUpgradePlanProps() );
+
+		await waitFor( () => {
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_site_migration_upgrade_plan_screen',
+				{ migration_trial_hidden: 'false' }
+			);
+		} );
+	} );
+
+	it( 'should correctly trigger a Tracks event with custom event properties', async () => {
+		nock.cleanAll();
+		mockApi()
+			.persist()
+			.get(
+				`/wpcom/v2/sites/${ DEFAULT_SITE_ID }/hosting/trial/check-eligibility/${ PLAN_MIGRATION_TRIAL_MONTHLY }`
+			)
+			.reply( 200, API_RESPONSE_ELIGIBLE );
+
+		const customEventProps = {
+			custom_number: 123,
+			custom_string: 'test',
+		};
+		renderUpgradePlanComponent( getUpgradePlanProps( { trackingEventsProps: customEventProps } ) );
+
+		await waitFor( () => {
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_site_migration_upgrade_plan_screen',
+				{ migration_trial_hidden: 'false', ...customEventProps }
+			);
+		} );
+	} );
+
+	it( 'should correctly trigger a Tracks event that flags the trial as hidden', async () => {
+		nock.cleanAll();
+		mockApi()
+			.persist()
+			.get(
+				`/wpcom/v2/sites/${ DEFAULT_SITE_ID }/hosting/trial/check-eligibility/${ PLAN_MIGRATION_TRIAL_MONTHLY }`
+			)
+			.reply( 200, API_RESPONSE_INELIGIBLE_UNVERIFIED_EMAIL );
+
+		renderUpgradePlanComponent(
+			getUpgradePlanProps( { hideFreeMigrationTrialForNonVerifiedEmail: true } )
+		);
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'button', { name: /Try 7 days for free/ } ) ).toBeNull();
+			expect( screen.getByRole( 'button', { name: /Continue/ } ) ).toBeInTheDocument();
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_site_migration_upgrade_plan_screen',
+				{ migration_trial_hidden: 'true' }
+			);
+		} );
+	} );
+} );

--- a/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
@@ -130,7 +130,6 @@ describe( 'UpgradePlan', () => {
 	it( 'should trigger a Tracks event without custom event properties', async () => {
 		nock.cleanAll();
 		mockApi()
-			.persist()
 			.get(
 				`/wpcom/v2/sites/${ DEFAULT_SITE_ID }/hosting/trial/check-eligibility/${ PLAN_MIGRATION_TRIAL_MONTHLY }`
 			)
@@ -149,7 +148,6 @@ describe( 'UpgradePlan', () => {
 	it( 'should trigger a Tracks event with custom event properties', async () => {
 		nock.cleanAll();
 		mockApi()
-			.persist()
 			.get(
 				`/wpcom/v2/sites/${ DEFAULT_SITE_ID }/hosting/trial/check-eligibility/${ PLAN_MIGRATION_TRIAL_MONTHLY }`
 			)
@@ -172,7 +170,6 @@ describe( 'UpgradePlan', () => {
 	it( 'should trigger a Tracks event that flags the trial as hidden', async () => {
 		nock.cleanAll();
 		mockApi()
-			.persist()
 			.get(
 				`/wpcom/v2/sites/${ DEFAULT_SITE_ID }/hosting/trial/check-eligibility/${ PLAN_MIGRATION_TRIAL_MONTHLY }`
 			)

--- a/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
@@ -127,7 +127,7 @@ describe( 'UpgradePlan', () => {
 		await waitFor( () => expect( mockOnCtaClick ).toHaveBeenCalled() );
 	} );
 
-	it( 'should correctly trigger a Tracks event without custom event properties', async () => {
+	it( 'should trigger a Tracks event without custom event properties', async () => {
 		nock.cleanAll();
 		mockApi()
 			.persist()
@@ -146,7 +146,7 @@ describe( 'UpgradePlan', () => {
 		} );
 	} );
 
-	it( 'should correctly trigger a Tracks event with custom event properties', async () => {
+	it( 'should trigger a Tracks event with custom event properties', async () => {
 		nock.cleanAll();
 		mockApi()
 			.persist()
@@ -169,7 +169,7 @@ describe( 'UpgradePlan', () => {
 		} );
 	} );
 
-	it( 'should correctly trigger a Tracks event that flags the trial as hidden', async () => {
+	it( 'should trigger a Tracks event that flags the trial as hidden', async () => {
 		nock.cleanAll();
 		mockApi()
 			.persist()

--- a/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
@@ -1,13 +1,13 @@
 /**
  * @jest-environment jsdom
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React, { type ComponentPropsWithoutRef } from 'react';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { UpgradePlan } from '../index';
 
@@ -17,19 +17,7 @@ jest.mock( '../upgrade-plan-details', () => ( {
 	default: ( { children } ) => <div>{ children }</div>,
 } ) );
 
-// This is effectively a custom passthrough as jest.spyOn() doesn't seem to work well
-// with the recordTracksEvent import.
-jest.mock( 'calypso/state/analytics/actions', () => {
-	const originalActions = jest.requireActual( 'calypso/state/analytics/actions' );
-
-	return {
-		__esModule: true,
-		...originalActions,
-		recordTracksEvent: jest
-			.fn()
-			.mockImplementation( ( ...args ) => originalActions.recordTracksEvent( ...args ) ),
-	};
-} );
+jest.mock( '@automattic/calypso-analytics' );
 
 function renderUpgradePlanComponent( props: ComponentPropsWithoutRef< typeof UpgradePlan > ) {
 	const queryClient = new QueryClient();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR ensures that we track whether the `UpgradePlan` component hides the migration trial via the `migration_trial_hidden` event prop, which may be `'true'` or `'false'`.
  - The PR also adds some unit tests to the component

## Testing Instructions

_I haven't tested this yet!_

* Work through the `migration-signup` flow, and ensure that you can see Tracks events that get logged
* When the plan upgrade component is shown, verify that we log a `calypso_site_migration_upgrade_plan_screen` Tracks event, and the event includes a `migration_trial_hidden` event prop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
