### PR TITLE
Checkout: Add Free Assisted Migration label on checkout 

### DIFF
--- a/client/blocks/importer/wordpress/utils.js
+++ b/client/blocks/importer/wordpress/utils.js
@@ -1,6 +1,10 @@
 export const SESSION_STORAGE_IS_MIGRATE_FROM_WP = 'is_migrate_from_wp';
 export const SESSION_STORAGE_MIGRATION_STATUS = 'migration_status';
 
+/**
+ * Ignore fatals when trying to access window.sessionStorage so that we do not
+ * see them logged in Sentry. Please don't use this for anything else.
+ */
 function ignoreFatalsForSessionStorage( callback ) {
 	try {
 		return callback();

--- a/client/blocks/importer/wordpress/utils.js
+++ b/client/blocks/importer/wordpress/utils.js
@@ -1,6 +1,15 @@
 export const SESSION_STORAGE_IS_MIGRATE_FROM_WP = 'is_migrate_from_wp';
 export const SESSION_STORAGE_MIGRATION_STATUS = 'migration_status';
 
+function ignoreFatalsForSessionStorage( callback ) {
+	try {
+		return callback();
+	} catch {
+		// Do nothing.
+		return undefined;
+	}
+}
+
 export const storeMigrateSource = () => {
 	window.sessionStorage.setItem( SESSION_STORAGE_IS_MIGRATE_FROM_WP, 'true' );
 };
@@ -23,4 +32,10 @@ export const clearMigrationStatus = () => {
 
 export const retrieveMigrationStatus = () => {
 	return window.sessionStorage.getItem( SESSION_STORAGE_MIGRATION_STATUS );
+};
+
+export const getAcceptedAssistedFreeMigration = () => {
+	return ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.getItem( 'wpcom_import_migration_assistance_accepted' )
+	);
 };

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -26,6 +26,7 @@ import {
 import { Gridicon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/format-currency';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import {
 	isNewsletterOrLinkInBioFlow,
 	isAnyHostingFlow,
@@ -42,6 +43,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+import { hasTranslation } from '@wordpress/i18n';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
@@ -478,6 +480,7 @@ export function CheckoutSummaryFeaturesList( props: {
 	const hasSingleProduct = responseCart.products.length === 1;
 
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const hasNoAdsAddOn = responseCart.products.some( ( product ) => isNoAds( product ) );
 
@@ -486,10 +489,13 @@ export function CheckoutSummaryFeaturesList( props: {
 	);
 
 	const hasFreeMigrationAssistance = getAcceptedAssistedFreeMigration();
+	const hasFreeMigrationAssistanceTranslation =
+		( isEnglishLocale || hasTranslation( 'Assisted free site migration' ) ) ??
+		translate( 'Assisted free site migration' );
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
-			{ hasFreeMigrationAssistance && (
+			{ hasFreeMigrationAssistance && hasFreeMigrationAssistanceTranslation && (
 				<CheckoutSummaryFeaturesListItem>
 					<WPCheckoutCheckIcon id="features-list-support-free-migration-assistance" />
 					{ translate( 'Assisted free site migration' ) }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -45,6 +45,7 @@ import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
+import { getAcceptedAssistedFreeMigration } from 'calypso/blocks/importer/wordpress/utils';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -484,8 +485,16 @@ export function CheckoutSummaryFeaturesList( props: {
 		isDomainTransfer( product )
 	);
 
+	const hasFreeMigrationAssistance = getAcceptedAssistedFreeMigration();
+
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
+			{ hasFreeMigrationAssistance && (
+				<CheckoutSummaryFeaturesListItem>
+					<WPCheckoutCheckIcon id="features-list-support-free-migration-assistance" />
+					{ translate( 'Assisted free site migration' ) }
+				</CheckoutSummaryFeaturesListItem>
+			) }
 			{ hasDomainsInCart &&
 				domains.map( ( domain ) => {
 					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.uuid } />;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdDR7T-1uw-p2#comment-1892

## Proposed Changes

* Displays `Assisted free site migration` label on checkout screen, if the user confirms the upgrade deal in the migration assistance modal on the migration upgrade plan step.

![CleanShot 2024-04-25 at 12 02 40@2x](https://github.com/Automattic/wp-calypso/assets/10482592/e8f899db-f3fe-4c35-a292-48ea75ef5345)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to migration flow upgrade plan screen: 
```
/setup/site-migration/site-migration-upgrade-plan?from={SITE_TO_IMPORT_URL}&siteSlug={FREE_SITE_SLUG}&flags=migration_assistance_modal
```
* Open the browser dev tools and set this session storage value: 
```
sessionStorage?.setItem( 'wpcom_import_migration_assistance_accepted', true );
```
* Click the `Upgrade and migrate` button the upgrade plan screen.
* Confirm the `Assisted free site migration` label appears on the checkout screen.
* Navigate to the previous page and remove the session storage value:
```
sessionStorage?.removeItem( 'wpcom_import_migration_assistance_accepted' );
```
* Confirm the label does not appear on the checkout screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?