### PR TITLE
Scheduled updates: Add path async validation before adding to the list of paths

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -11,7 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect } from 'react';
 import { useScheduledUpdatesVerifyPathQuery } from 'calypso/data/plugins/use-scheduled-updates-verify-path-query';
 import { useSelector } from 'calypso/state';
-import getSiteId from '../../state/sites/selectors/get-site-id';
+import getSiteId from 'calypso/state/sites/selectors/get-site-id';
 import { MAX_SELECTABLE_PATHS } from './config';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { prepareRelativePath, validatePath } from './schedule-form.helper';

--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -5,10 +5,13 @@ import {
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
-import { check, plus, closeSmall } from '@wordpress/icons';
+import { check, plus, closeSmall, rotateRight } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import { useScheduledUpdatesVerifyPathQuery } from 'calypso/data/plugins/use-scheduled-updates-verify-path-query';
+import { useSelector } from 'calypso/state';
+import getSiteId from '../../state/sites/selectors/get-site-id';
 import { MAX_SELECTABLE_PATHS } from './config';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { prepareRelativePath, validatePath } from './schedule-form.helper';
@@ -20,11 +23,37 @@ interface Props {
 export function ScheduleFormPaths( props: Props ) {
 	const translate = useTranslate();
 	const siteSlug = useSiteSlug();
+	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
 	const { paths: initPaths = [], borderWrapper = true } = props;
 
 	const [ paths, setPaths ] = useState( initPaths );
 	const [ newPath, setNewPath ] = useState( '' );
 	const [ newPathError, setNewPathError ] = useState( '' );
+	const [ newPathSubmitted, setNewPathSubmitted ] = useState( false );
+	const { data: verificationData, isFetching: isVerifying } = useScheduledUpdatesVerifyPathQuery(
+		siteId as number,
+		newPath,
+		{
+			enabled: newPathSubmitted && !! newPath && !! siteId,
+		}
+	);
+	const pathAvailable = verificationData?.available;
+
+	/**
+	 * Callbacks
+	 */
+	const resetFormState = useCallback( () => {
+		setNewPath( '' );
+		setNewPathError( '' );
+		setNewPathSubmitted( false );
+	}, [] );
+
+	const addPath = useCallback( () => {
+		if ( newPathSubmitted && ! newPathError && pathAvailable ) {
+			setPaths( [ ...paths, newPath ] );
+			resetFormState();
+		}
+	}, [ newPath, paths, newPathSubmitted, newPathError, pathAvailable ] );
 
 	const removePath = useCallback(
 		( index: number ) => {
@@ -34,16 +63,16 @@ export function ScheduleFormPaths( props: Props ) {
 	);
 
 	const onNewPathSubmit = useCallback( () => {
-		const pathError = validatePath( newPath, paths );
-		setNewPathError( pathError );
+		const validationErrors = validatePath( newPath, paths );
+		! validationErrors && setNewPathSubmitted( true );
+		setNewPathError( validationErrors );
+	}, [ newPath, paths, newPathError ] );
 
-		if ( pathError ) {
-			return;
-		}
-
-		setPaths( [ ...paths, newPath ] );
-		setNewPath( '' );
-	}, [ newPath, paths ] );
+	/**
+	 * Effects
+	 */
+	useEffect( addPath, [ addPath ] );
+	useEffect( () => setNewPathSubmitted( false ), [ newPath ] );
 
 	return (
 		<div className="form-field form-field--paths">
@@ -116,7 +145,9 @@ export function ScheduleFormPaths( props: Props ) {
 							</FlexItem>
 							<FlexItem>
 								<Button
-									icon={ plus }
+									className={ classnames( { 'is-verifying': isVerifying } ) }
+									icon={ isVerifying ? rotateRight : plus }
+									disabled={ isVerifying }
 									variant="secondary"
 									onClick={ onNewPathSubmit }
 									__next40pxDefaultSize

--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -30,13 +30,13 @@ export function ScheduleFormPaths( props: Props ) {
 	const [ newPath, setNewPath ] = useState( '' );
 	const [ newPathError, setNewPathError ] = useState( '' );
 	const [ newPathSubmitted, setNewPathSubmitted ] = useState( false );
-	const { data: verificationData, isFetching: isVerifying } = useScheduledUpdatesVerifyPathQuery(
-		siteId as number,
-		newPath,
-		{
-			enabled: newPathSubmitted && !! newPath && !! siteId,
-		}
-	);
+	const {
+		data: verificationData,
+		isFetching: isVerifying,
+		isFetched: isVerified,
+	} = useScheduledUpdatesVerifyPathQuery( siteId as number, newPath, {
+		enabled: newPathSubmitted && !! newPath && !! siteId,
+	} );
 	const pathAvailable = verificationData?.available;
 
 	/**
@@ -62,6 +62,12 @@ export function ScheduleFormPaths( props: Props ) {
 		[ paths ]
 	);
 
+	const handleAsyncValidationError = useCallback( () => {
+		if ( newPathSubmitted && isVerified && ! pathAvailable ) {
+			setNewPathError( translate( 'This path is not available.' ) );
+		}
+	}, [ newPathSubmitted, isVerified, pathAvailable ] );
+
 	const onNewPathSubmit = useCallback( () => {
 		const validationErrors = validatePath( newPath, paths );
 		! validationErrors && setNewPathSubmitted( true );
@@ -72,6 +78,7 @@ export function ScheduleFormPaths( props: Props ) {
 	 * Effects
 	 */
 	useEffect( addPath, [ addPath ] );
+	useEffect( handleAsyncValidationError, [ handleAsyncValidationError ] );
 	useEffect( () => setNewPathSubmitted( false ), [ newPath ] );
 
 	return (

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -238,5 +238,11 @@
 			color: var(--studio-gray-50);
 			background: var(--studio-gray-0);
 		}
+
+		button.is-verifying {
+			svg {
+				animation: scheduled-updates-rotate 2s linear infinite;
+			}
+		}
 	}
 }

--- a/client/data/plugins/use-scheduled-updates-verify-path-query.ts
+++ b/client/data/plugins/use-scheduled-updates-verify-path-query.ts
@@ -1,0 +1,21 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+export const useScheduledUpdatesVerifyPathQuery = (
+	siteId: number,
+	path: string,
+	queryOptions = {}
+): UseQueryResult< { available: boolean } > => {
+	return useQuery( {
+		queryKey: [ 'verify-path', siteId, path ],
+		queryFn: () =>
+			wpcomRequest( {
+				path: `/sites/${ siteId }/scheduled-updates/verify-path-status?path=${ path }`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			} ),
+		enabled: !! siteId && !! path,
+		retry: false,
+		...queryOptions,
+	} );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89677

## Proposed Changes

* Created hook for the path async verification
* Adjusted the form for a new async validation

## Testing Instructions

* Go to `/plugins/scheduled-updates/create/bogdannikolic10.wpcomstaging.com`
* Paste or type a new path
* Check if it's an async check (see animated icon button)

![Screen Capture on 2024-04-25 at 19-12-01](https://github.com/Automattic/wp-calypso/assets/1241413/c73f2e22-bb2e-4252-a214-38d3cea16180)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?