### PR TITLE
Added segmentation survey param to site creation call

### DIFF
--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -170,6 +170,8 @@ export const createSiteWithCart = async (
 	// }
 
 	const locale = getLocaleSlug();
+	const hasSegmentationSurvey: boolean =
+		newSiteParams[ 'options' ][ 'site_creation_flow' ] === 'entrepreneur';
 	const siteCreationResponse: NewSiteSuccessResponse = await wpcomRequest( {
 		path: '/sites/new',
 		apiVersion: '1.1',
@@ -180,6 +182,7 @@ export const createSiteWithCart = async (
 			lang_id: getLanguage( locale as string )?.value,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
+			has_segmentation_survey: hasSegmentationSurvey,
 		},
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/89745

**Note:** test with D146276-code

## Proposed Changes

For the backend to know if we should link segmentation survey answers with the newly created user_id or blog_id, we need to send a new parameter as part of the `sites/new` endpoint call: `has_segmentation_survey`.

## Testing Instructions

- Follow the testing instructions in D146276-code , as we have to test this changes with the changes in that patch together.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?