### PR TITLE
Site Migration: Add hook to manage site transfer

### DIFF
--- a/client/landing/stepper/hooks/use-site-migration-transfer/index.ts
+++ b/client/landing/stepper/hooks/use-site-migration-transfer/index.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useSiteTransferMutation } from './mutation';
+import { useSiteTransferStatusQuery } from './query';
+
+/**
+ * Hook to to initiate a site transfer and monitor its progress
+ * @param siteId
+ */
+export const useSiteMigrationTransfer = ( siteId?: number ) => {
+	const [ shouldStartPooling, setShouldStartPooling ] = useState( true );
+	const {
+		mutate: startTransfer,
+		status: startTransferStatus,
+		error: startTransferError,
+	} = useSiteTransferMutation( siteId );
+
+	const { data, error: statusError } = useSiteTransferStatusQuery( siteId, {
+		pooling: shouldStartPooling,
+	} );
+	const { isStarted, status: transferStatus, isTransferring } = data || {};
+
+	useEffect( () => {
+		if ( ! data ) {
+			return;
+		}
+
+		if ( ! isStarted && startTransferStatus === 'idle' ) {
+			setShouldStartPooling( false );
+			startTransfer();
+		}
+	}, [ data, isStarted, startTransfer, startTransferStatus ] );
+
+	useEffect( () => {
+		setShouldStartPooling( !! isTransferring );
+	}, [ isTransferring ] );
+
+	return {
+		status: transferStatus,
+		error: statusError || startTransferError || null,
+	};
+};

--- a/client/landing/stepper/hooks/use-site-migration-transfer/index.ts
+++ b/client/landing/stepper/hooks/use-site-migration-transfer/index.ts
@@ -3,7 +3,7 @@ import { useSiteTransferMutation } from './mutation';
 import { useSiteTransferStatusQuery } from './query';
 
 /**
- * Hook to to initiate a site transfer and monitor its progress
+ * Hook to initiate a site transfer and monitor its progress
  */
 export const useSiteMigrationTransfer = ( siteId?: number ) => {
 	const {

--- a/client/landing/stepper/hooks/use-site-migration-transfer/mutation.ts
+++ b/client/landing/stepper/hooks/use-site-migration-transfer/mutation.ts
@@ -1,0 +1,49 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { TransferStates } from 'calypso/state/automated-transfer/constants';
+import { getSiteTransferStatusQueryKey } from './query';
+
+interface InitiateAtomicTransferResponse {
+	status: TransferStates;
+	atomic_transfer_id: string;
+}
+
+const startTransfer = ( siteId: number ): Promise< InitiateAtomicTransferResponse > =>
+	wpcom.req.post( {
+		path: `/sites/${ siteId }/atomic/transfers`,
+		apiNamespace: 'wpcom/v2',
+		body: {
+			context: 'unknown',
+			transfer_intent: 'migrate',
+		},
+	} );
+
+/**
+ *  Mutation hook to initiate a site transfer
+ */
+export const useSiteTransferMutation = ( siteId?: number ) => {
+	const query = useQueryClient();
+
+	const mutation = () =>
+		siteId ? startTransfer( siteId ) : Promise.reject( new Error( 'siteId is required' ) );
+
+	const refreshSiteStatus = () => {
+		query.setQueryData( getSiteTransferStatusQueryKey( siteId! ), { status: 'active' } );
+		// query.refetchQueries( { queryKey: getSiteTransferStatusQueryKey( siteId! ), exact: true } );
+		query.invalidateQueries( { queryKey: getSiteTransferStatusQueryKey( siteId! ) } );
+	};
+
+	return useMutation( {
+		mutationKey: [ 'sites', siteId, 'atomic', 'transfers' ],
+		mutationFn: mutation,
+		onSuccess: refreshSiteStatus,
+		onSettled: ( data, error ) => {
+			recordTracksEvent( 'calypso_site_transfer_started', {
+				site_id: siteId,
+				status: !! error || 'success',
+				atomic_transfer_id: data?.atomic_transfer_id,
+			} );
+		},
+	} );
+};

--- a/client/landing/stepper/hooks/use-site-migration-transfer/mutation.ts
+++ b/client/landing/stepper/hooks/use-site-migration-transfer/mutation.ts
@@ -28,10 +28,9 @@ export const useSiteTransferMutation = ( siteId?: number ) => {
 	const mutation = () =>
 		siteId ? startTransfer( siteId ) : Promise.reject( new Error( 'siteId is required' ) );
 
-	const refreshSiteStatus = () => {
-		query.setQueryData( getSiteTransferStatusQueryKey( siteId! ), { status: 'active' } );
-		// query.refetchQueries( { queryKey: getSiteTransferStatusQueryKey( siteId! ), exact: true } );
-		query.invalidateQueries( { queryKey: getSiteTransferStatusQueryKey( siteId! ) } );
+	const refreshSiteStatus = ( data: InitiateAtomicTransferResponse ) => {
+		query.setQueryData( getSiteTransferStatusQueryKey( siteId! ), data );
+		query.refetchQueries( { queryKey: getSiteTransferStatusQueryKey( siteId! ), exact: true } );
 	};
 
 	return useMutation( {

--- a/client/landing/stepper/hooks/use-site-migration-transfer/query.ts
+++ b/client/landing/stepper/hooks/use-site-migration-transfer/query.ts
@@ -1,0 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { transferStates, type TransferStates } from 'calypso/state/automated-transfer/constants';
+
+// The endpoint returns HTTP status 200 with a JSON body with status 404 when the transfer was not initiated.
+const TransferNotFoundStatus = 404 as const;
+type TransferState = TransferStates | typeof TransferNotFoundStatus;
+
+type TransferStatusResponse = {
+	status: TransferState;
+	code?: string;
+};
+
+const fetchStatus = ( siteId: number ): Promise< TransferStatusResponse > => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/atomic/transfers/latest`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+const endStates: TransferState[] = [
+	transferStates.NONE,
+	transferStates.COMPLETE,
+	transferStates.COMPLETED,
+	transferStates.FAILURE,
+	transferStates.ERROR,
+	transferStates.REVERTED,
+	TransferNotFoundStatus,
+];
+
+const isTransferring = ( status: TransferState ) => {
+	return ! endStates.includes( status );
+};
+
+export function getSiteTransferStatusQueryKey( siteId: number ) {
+	return [ 'sites', siteId, 'atomic', 'transfers', 'latest' ];
+}
+
+// const shouldContinuePooling = ( status: TransferStates | 404 | undefined ) => {
+// 	if ( ! status || status === 404 ) {
+// 		return false;
+// 	}
+
+// 	return isTransferring( status );
+// };
+
+interface useSiteTransferStatusQueryOptions {
+	pooling: boolean;
+}
+export const useSiteTransferStatusQuery = (
+	siteId: number | undefined,
+	options?: useSiteTransferStatusQueryOptions
+) => {
+	const { pooling = true } = options || {};
+
+	return useQuery( {
+		queryKey: getSiteTransferStatusQueryKey( siteId! ),
+		queryFn: () => fetchStatus( siteId! ),
+		select: ( data ) => {
+			return {
+				isTransferring: data?.status ? isTransferring( data.status as TransferStates ) : false,
+				isStarted: data?.code !== 'no_transfer_record',
+				isComplete: data?.status === transferStates.COMPLETE,
+				status: data.status,
+				error: null,
+			};
+		},
+
+		refetchInterval: 2000,
+		enabled: !! siteId && pooling,
+	} );
+};

--- a/client/landing/stepper/hooks/use-site-migration-transfer/test/use-site-transfer-status.tsx
+++ b/client/landing/stepper/hooks/use-site-migration-transfer/test/use-site-transfer-status.tsx
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { useSiteMigrationTransfer } from '../';
+import { transferStates } from '../../../../../state/automated-transfer/constants';
+
+const Wrapper =
+	( queryClient: QueryClient ) =>
+	( { children } ) => {
+		return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+	};
+
+const render = ( { siteId } ) => {
+	const queryClient = new QueryClient();
+
+	const renderResult = renderHook( () => useSiteMigrationTransfer( siteId ), {
+		wrapper: Wrapper( queryClient ),
+	} );
+
+	return {
+		...renderResult,
+		queryClient,
+	};
+};
+
+const TRANSFER_NOT_INITIATED_PAYLOAD = () => ( {
+	code: 'no_transfer_record',
+	message: 'Transfer record not found for blog `232256476`',
+	data: {
+		status: 404,
+	},
+} );
+
+const TRANSFER_PROVISIONED_PAYLOAD = ( siteId: number ) => ( {
+	atomic_transfer_id: '1254451',
+	blog_id: siteId,
+	status: 'provisioned',
+	created_at: '2024-04-24 08:32:07',
+	is_stuck: false,
+	is_stuck_reset: false,
+	in_lossless_revert: false,
+} );
+
+const TRANSFER_COMPLETED_PAYLOAD = ( siteId: number ) => ( {
+	atomic_transfer_id: '1254451',
+	blog_id: siteId,
+	status: 'completed',
+	created_at: '2024-04-24 08:32:07',
+	is_stuck: false,
+	is_stuck_reset: false,
+	in_lossless_revert: false,
+} );
+
+const TRANSFER_ACTIVE_PAYLOAD = ( siteId: number ) => ( {
+	atomic_transfer_id: 1253811,
+	blog_id: siteId,
+	status: 'active',
+	created_at: '2024-04-23 16:21:01',
+	is_stuck: false,
+	is_stuck_reset: false,
+	in_lossless_revert: false,
+} );
+
+jest.useFakeTimers( { advanceTimers: 500 } );
+
+describe( 'useSiteMigrationTransfer', () => {
+	beforeAll( () => nock.disableNetConnect() );
+
+	it( 'returns the latest transfer status', async () => {
+		const siteId = 123;
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, TRANSFER_COMPLETED_PAYLOAD );
+
+		const { result } = render( { siteId } );
+
+		await waitFor( () => {
+			expect( result.current ).toEqual( {
+				status: transferStates.COMPLETED,
+				error: null,
+			} );
+		} );
+	} );
+
+	it( 'starts the transfer process if it is not transferring', async () => {
+		const siteId = 123;
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, TRANSFER_NOT_INITIATED_PAYLOAD );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( `/wpcom/v2/sites/123/atomic/transfers`, {
+				context: 'unknown',
+				transfer_intent: 'migrate',
+			} )
+			.once()
+			.reply( 200, TRANSFER_ACTIVE_PAYLOAD( siteId ) );
+
+		const { result } = render( { siteId } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: transferStates.ACTIVE,
+					error: null,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'starts to pool the status after start a new flow', async () => {
+		const siteId = 4444;
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, TRANSFER_NOT_INITIATED_PAYLOAD() );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( `/wpcom/v2/sites/${ siteId }/atomic/transfers`, {
+				context: 'unknown',
+				transfer_intent: 'migrate',
+			} )
+			.once()
+			.reply( 200, TRANSFER_ACTIVE_PAYLOAD( siteId ) );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, TRANSFER_COMPLETED_PAYLOAD( siteId ) );
+
+		const { result } = render( { siteId } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: transferStates.COMPLETED,
+					error: null,
+				} );
+			},
+			{ timeout: 9000 }
+		);
+	} );
+
+	it( 'stops to pool when the transfer is completed', async () => {
+		const siteId = 555;
+
+		const scope = nock( 'https://public-api.wordpress.com:443' );
+		scope
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, TRANSFER_ACTIVE_PAYLOAD );
+
+		scope
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, TRANSFER_PROVISIONED_PAYLOAD( siteId ) );
+
+		scope
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, TRANSFER_COMPLETED_PAYLOAD( siteId ) );
+
+		const { result } = render( { siteId } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: transferStates.COMPLETED,
+					error: null,
+				} );
+			},
+			{ timeout: 9000 }
+		);
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89760

## Proposed Changes

* Introduce a hook that runs the described above
* Introduce automated tests to cover the main scenarios. 
 <img width="370" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/7cd863d9-e130-4161-87d8-389353878526">


### Expected FLOW
* Fetch the transfer status using/atomic/transfers/latest?_envelope=1
    - If the status is `"code": "no_transfer_record"` stop the pooling
    - Start a new transfer 
   -  Start pooling again the status until it returns 'completed' 
   -  Stop the pooling when the transfer is completed. 






Usage: 

```jsx
const { completed: isTransferCompleted, isTransferring } = useSiteMigrationTransfer( siteId );

if ( isTransferring ) {
  return (<>
    <h1>Transferring your site...</h1>
    <p>Please check the requests on the developer tools</p>
  </>);
}

if ( isTransferCompleted ) {
    submit?.();
}

```

> [!NOTE]
> It is only handling the atomic transfer, the plugin installation was implemented on #89805, and both will be used together to manage the full site migration. 

## Testing Instructions
* Visual inspection is important, please check if the names make sense. 
* To see the code running, please follow the steps:
* Open the file `client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx`  and replace only the `BundleTransfer` component definition with this:

````jsx
const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
	const { submit } = navigation;
	const site = useSite();
	const siteId = site?.ID;
	const { completed: isTransferCompleted, isTransferring } = useSiteMigrationTransfer( siteId );

	if ( i sTransferring ) {
		return (<>
				<h1>Transferring your site...</h1>
				<p>Please check the requests on the developer tools</p>
			</>);
	}

	if ( isTransferCompleted ) {
		submit?.();
	}

	return null;
};
````

* Start the `/start/` flow
* Select a free plan
* Follow the steps until you reach the step 'bundleTrasnfer`
* Open the developer tools and check the requests happening
* You should be redirected to the plugin installation step and then the site instructions step.
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?