### PR TITLE
Sites dashboard v2 - implement sorting.

### DIFF
--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -1,4 +1,8 @@
-import { useSitesListFiltering, useSitesListGrouping } from '@automattic/sites';
+import {
+	useSitesListFiltering,
+	useSitesListGrouping,
+	useSitesListSorting,
+} from '@automattic/sites';
 import { GroupableSiteLaunchStatuses } from '@automattic/sites/src/use-sites-list-grouping';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
@@ -84,6 +88,7 @@ const SitesDashboardV2 = ( {
 		page,
 		perPage,
 		search: search ?? '',
+		hiddenFields: [ 'magic' ],
 		filters:
 			status === 'all'
 				? []
@@ -117,8 +122,22 @@ const SitesDashboardV2 = ( {
 	} );
 
 	// todo: Perform sorting actions
+	const sortKeyMap = {
+		site: 'alphabetically',
+		magic: 'lastInteractedWith',
+		'last-publish': 'updatedAt',
+	};
 
-	const paginatedSites = filteredSites.slice(
+	const sortedSites = useSitesListSorting( filteredSites, {
+		sortKey: ( sortKeyMap[ dataViewsState.sort.field as keyof typeof sortKeyMap ] || '' ) as
+			| 'alphabetically'
+			| 'lastInteractedWith'
+			| 'updatedAt'
+			| undefined,
+		sortOrder: dataViewsState.sort.direction || undefined,
+	} );
+
+	const paginatedSites = sortedSites.slice(
 		( dataViewsState.page - 1 ) * dataViewsState.perPage,
 		dataViewsState.page * dataViewsState.perPage
 	);

--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -178,6 +178,17 @@ const SitesDashboardV2 = ( {
 		window.setTimeout( () => updateQueryParams( queryParams ) );
 	}, [ dataViewsState.search, dataViewsState.perPage, statusSlug, updateQueryParams ] );
 
+	// Update site sorting preference on change
+	useEffect( () => {
+		if ( dataViewsState.sort.field ) {
+			onSitesSortingChange( {
+				sortKey: siteSortingKeys.find( ( key ) => key.dataView === dataViewsState.sort.field )
+					?.sortKey as SitesSortKey,
+				sortOrder: dataViewsState.sort.direction || 'asc',
+			} );
+		}
+	}, [ dataViewsState.sort, onSitesSortingChange ] );
+
 	// Manage the closing of the preview pane
 	const closeSitePreviewPane = useCallback( () => {
 		if ( dataViewsState.selectedItem ) {

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -72,7 +72,7 @@ const DotcomSitesDataViews = ( {
 					return <SiteField site={ item } openSitePreviewPane={ openSitePreviewPane } />;
 				},
 				enableHiding: false,
-				enableSorting: false,
+				enableSorting: true,
 			},
 			{
 				id: 'plan',
@@ -99,7 +99,7 @@ const DotcomSitesDataViews = ( {
 				render: ( { item }: { item: SiteInfo } ) =>
 					item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
 				enableHiding: false,
-				enableSorting: false,
+				enableSorting: true,
 			},
 			{
 				id: 'stats',
@@ -121,6 +121,13 @@ const DotcomSitesDataViews = ( {
 				),
 				enableHiding: false,
 				enableSorting: false,
+			},
+			{
+				id: 'magic',
+				header: __( 'Magic' ),
+				render: () => <></>,
+				enableHiding: false,
+				enableSorting: true,
 			},
 		],
 		[ __, openSitePreviewPane, userId ]

--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -8,6 +8,9 @@ import {
 	stringifySitesSorting,
 	parseSitesSorting,
 	useSitesSorting,
+	ALPHABETICAL_SORTING,
+	MAGIC_SORTING,
+	LAST_PUBLISHED_SORTING,
 } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { SMALL_MEDIA_QUERY } from '../utils';
 
@@ -42,31 +45,26 @@ export const SitesSortingDropdown = ( {
 
 	const choices = [
 		{
-			value: stringifySitesSorting( {
-				sortKey: 'alphabetically',
-				sortOrder: 'asc',
-			} ),
+			...ALPHABETICAL_SORTING,
+			value: stringifySitesSorting( ALPHABETICAL_SORTING ),
 			label: __( 'Name' ),
 		},
 		{
-			value: stringifySitesSorting( {
-				sortKey: 'lastInteractedWith',
-				sortOrder: 'desc',
-			} ),
+			...MAGIC_SORTING,
+			value: stringifySitesSorting( MAGIC_SORTING ),
 			/* translators: name of sorting mode where the details about how best to sort sites are left up to the software */
 			label: __( 'Magic' ),
 		},
 		{
-			value: stringifySitesSorting( {
-				sortKey: 'updatedAt',
-				sortOrder: 'desc',
-			} ),
+			...LAST_PUBLISHED_SORTING,
+			value: stringifySitesSorting( LAST_PUBLISHED_SORTING ),
 			label: __( 'Last published' ),
 		},
 	];
 
 	const currentSortingValue = stringifySitesSorting( sitesSorting );
-	const currentSortingLabel = choices.find( ( { value } ) => value === currentSortingValue )?.label;
+	const currentSortingLabel = choices.find( ( { sortKey } ) => sortKey === sitesSorting.sortKey )
+		?.label;
 
 	if ( currentSortingLabel === undefined ) {
 		throw new Error( `invalid sort value ${ sitesSorting }` );

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -7,13 +7,18 @@ const SEPARATOR = '-' as const;
 
 type SitesSorting = `${ SitesSortKey }${ typeof SEPARATOR }${ SitesSortOrder }`;
 
-const ALPHABETICAL_SORTING = {
+export const ALPHABETICAL_SORTING = {
 	sortKey: 'alphabetically',
 	sortOrder: 'asc',
 } as const;
 
-const MAGIC_SORTING = {
+export const MAGIC_SORTING = {
 	sortKey: 'lastInteractedWith',
+	sortOrder: 'desc',
+} as const;
+
+export const LAST_PUBLISHED_SORTING = {
+	sortKey: 'updatedAt',
 	sortOrder: 'desc',
 } as const;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to another follow up implementing control functionalities from  https://github.com/Automattic/wp-calypso/pull/89698

## Proposed Changes

* Adds sorting on the new dashboard for site name, last published, and "magic" sort (last interacted with). These are the sorting mechanisms we currently support on the old sites dashboard.
* Leverages the `useSiteSorting` hook that saves the sorting preference for users.
* Updates the sites sorting dropdown to check sorting label by key instead of full stringified value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit the sites dashboard with feature flag `?flags=layout/dotcom-nav-redesign-v2`
* Try sorting on sites, last published, and magic. Both sites and last published are sortable by their column headers as well as the view options in the top right. Magic is only accessible in the view options on the top right.
![Screenshot 2024-04-25 at 3 45 05 PM](https://github.com/Automattic/wp-calypso/assets/28742426/e644de32-5519-406a-9e47-89c7cdc930ff)
![Screenshot 2024-04-25 at 3 45 20 PM](https://github.com/Automattic/wp-calypso/assets/28742426/5d96bbe5-57a5-4ee5-b1bc-1700b56e3ab9)
* Test this along with searching, filtering, and pagination.
* Reload the page, verify that the last sorting option you had selected is used.
* Smoke test along with the old sites dashboard with no feature flag.


## Pre-merge Checklist



<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
