### PR TITLE
Congrats: Miscellaneous legacy code removal

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -700,7 +700,14 @@ export class CheckoutThankYou extends Component<
 	};
 
 	productRelatedMessages = () => {
-		const { selectedSite, upgradeIntent, isSimplified, displayMode, receipt } = this.props;
+		const {
+			selectedSite,
+			siteUnlaunchedBeforeUpgrade,
+			upgradeIntent,
+			isSimplified,
+			displayMode,
+			receipt,
+		} = this.props;
 		const purchases = getPurchases( this.props );
 		const failedPurchases = getFailedPurchases( this.props );
 		const hasFailedPurchases = failedPurchases.length > 0;
@@ -711,9 +718,11 @@ export class CheckoutThankYou extends Component<
 			<div>
 				<CheckoutThankYouHeader
 					isDataLoaded={ this.isDataLoaded() }
+					isSimplified={ isSimplified }
 					primaryPurchase={ primaryPurchase }
 					selectedSite={ selectedSite }
 					hasFailedPurchases={ hasFailedPurchases }
+					siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
 					upgradeIntent={ upgradeIntent }
 					primaryCta={ this.primaryCta }
 					displayMode={ displayMode }

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -700,14 +700,7 @@ export class CheckoutThankYou extends Component<
 	};
 
 	productRelatedMessages = () => {
-		const {
-			selectedSite,
-			siteUnlaunchedBeforeUpgrade,
-			upgradeIntent,
-			isSimplified,
-			displayMode,
-			receipt,
-		} = this.props;
+		const { selectedSite, upgradeIntent, isSimplified, displayMode, receipt } = this.props;
 		const purchases = getPurchases( this.props );
 		const failedPurchases = getFailedPurchases( this.props );
 		const hasFailedPurchases = failedPurchases.length > 0;
@@ -718,11 +711,9 @@ export class CheckoutThankYou extends Component<
 			<div>
 				<CheckoutThankYouHeader
 					isDataLoaded={ this.isDataLoaded() }
-					isSimplified={ isSimplified }
 					primaryPurchase={ primaryPurchase }
 					selectedSite={ selectedSite }
 					hasFailedPurchases={ hasFailedPurchases }
-					siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
 					upgradeIntent={ upgradeIntent }
 					primaryCta={ this.primaryCta }
 					displayMode={ displayMode }

--- a/client/my-sites/checkout/checkout-thank-you/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/utils.ts
@@ -16,7 +16,6 @@ import JetpackSearchPluginImage from 'calypso/assets/images/jetpack/jetpack-plug
 import JetpackSocialPluginImage from 'calypso/assets/images/jetpack/jetpack-plugin-image-social.svg';
 import JetpackVideopressPluginImage from 'calypso/assets/images/jetpack/jetpack-plugin-image-videopress.svg';
 import JetpackPluginImage from 'calypso/assets/images/jetpack/licensing-activation-plugin-install.svg';
-import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import type { WithCamelCaseSlug, WithSnakeCaseSlug } from '@automattic/calypso-products';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
@@ -88,13 +87,6 @@ export function getJetpackPluginImage( productSlug: string ): string {
 		JETPACK_PLUGIN_IMAGE_MAP[ productSlug ]
 		? JETPACK_PLUGIN_IMAGE_MAP[ productSlug ]
 		: JetpackPluginImage;
-}
-
-export function getDomainManagementUrl(
-	{ slug }: { slug: string },
-	domain: string | undefined
-): string {
-	return domain ? domainManagementEdit( slug, domain ) : domainManagementList( slug );
 }
 
 export function isBulkDomainTransfer( purchases: ReceiptPurchase[] ): boolean {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6015-gh-Automattic/dotcom-forge

## Proposed Changes

This is hopefully the final pass of legacy thank-you/congrats code removal, and is mainly cleaning up the last few odds and ends:

`getDomainManagementUrl` is no longer in use, so there's no need to keep this util in the codebase

~Two props of `CheckoutThankyouHeader` were made obsolete in #89823, but they hadn't yet been removed from the implementation of that component.~ Handled in #89952 instead

## Testing Instructions

- Confirm `getDomainManagementUrl` is no longer in use elsewhere
- All tests should still pass