### PR TITLE
Scheduled updates: Connect health check paths with the endpoint

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -18,13 +18,14 @@ import { prepareRelativePath, validatePath } from './schedule-form.helper';
 
 interface Props {
 	paths?: string[];
+	onChange?: ( value: string[] ) => void;
 	borderWrapper?: boolean;
 }
 export function ScheduleFormPaths( props: Props ) {
 	const translate = useTranslate();
 	const siteSlug = useSiteSlug();
 	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
-	const { paths: initPaths = [], borderWrapper = true } = props;
+	const { paths: initPaths = [], onChange, borderWrapper = true } = props;
 
 	const [ paths, setPaths ] = useState( initPaths );
 	const [ newPath, setNewPath ] = useState( '' );
@@ -80,6 +81,7 @@ export function ScheduleFormPaths( props: Props ) {
 	useEffect( addPath, [ addPath ] );
 	useEffect( handleAsyncValidationError, [ handleAsyncValidationError ] );
 	useEffect( () => setNewPathSubmitted( false ), [ newPath ] );
+	useEffect( () => onChange?.( paths ), [ paths ] );
 
 	return (
 		<div className="form-field form-field--paths">

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -46,6 +46,10 @@ export const ScheduleForm = ( props: Props ) => {
 	const [ timestamp, setTimestamp ] = useState< number >(
 		scheduleForEdit ? scheduleForEdit?.timestamp * 1000 : Date.now()
 	);
+	const [ healthCheckPaths, setHealthCheckPaths ] = useState< string[] >(
+		scheduleForEdit?.health_check_paths || []
+	);
+
 	const scheduledTimeSlots = schedules.map( ( schedule ) => ( {
 		timestamp: schedule.timestamp,
 		frequency: schedule.schedule,
@@ -90,6 +94,7 @@ export const ScheduleForm = ( props: Props ) => {
 				timestamp,
 				interval: frequency,
 			},
+			health_check_paths: healthCheckPaths,
 		};
 
 		if ( formValid ) {
@@ -161,7 +166,11 @@ export const ScheduleForm = ( props: Props ) => {
 			{ isEnabled( 'plugins/multisite-scheduled-updates' ) && (
 				<>
 					<Text>{ translate( 'Step 3' ) }</Text>
-					<ScheduleFormPaths borderWrapper={ false } />
+					<ScheduleFormPaths
+						paths={ healthCheckPaths }
+						borderWrapper={ false }
+						onChange={ setHealthCheckPaths }
+					/>
 				</>
 			) }
 		</form>

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -93,8 +93,8 @@ export const ScheduleForm = ( props: Props ) => {
 			schedule: {
 				timestamp,
 				interval: frequency,
+				health_check_paths: healthCheckPaths,
 			},
-			health_check_paths: healthCheckPaths,
 		};
 
 		if ( formValid ) {

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -23,6 +23,7 @@ export type ScheduleUpdates = {
 	args: string[];
 	last_run_status: LastRunStatus;
 	last_run_timestamp: number | null;
+	health_check_paths?: string[];
 };
 
 type MultisiteSiteDetails = SiteDetails & {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89677

## Proposed Changes

* Connect health check paths with the endpoint

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure that the Atomic site uses the Jetpack Beta tester bleeding edge versions

* Go to `/plugins/scheduled-updates/create/{SITE_SLUG}?flags=plugins/multisite-scheduled-updates`
* Create a schedule with defined custom paths
* Check if it is properly saved

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?