### PR TITLE
Segmentation Survey: Submit skip as answer key for skipped questions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -39,6 +39,29 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 		[ answers, setAnswers ]
 	);
 
+	const clearAnswersOnComplete = useCallback(
+		( currentQuestion: Question ) => {
+			if ( questions?.[ questions.length - 1 ].key === currentQuestion.key ) {
+				clearAnswers();
+			}
+		},
+		[ clearAnswers, questions ]
+	);
+
+	const onSkipQuestion = useCallback(
+		( currentQuestion: Question ) => {
+			setAnswers( { ...answers, [ currentQuestion.key ]: [] } );
+
+			mutate( {
+				questionKey: currentQuestion.key,
+				answerKeys: [ 'skip' ],
+			} );
+
+			clearAnswersOnComplete( currentQuestion );
+		},
+		[ answers, clearAnswersOnComplete, mutate, setAnswers ]
+	);
+
 	const onSubmitQuestion = useCallback(
 		( currentQuestion: Question ) => {
 			if ( isPending ) {
@@ -52,14 +75,12 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 				},
 				{
 					onSuccess: () => {
-						if ( questions?.[ questions.length - 1 ].key === currentQuestion.key ) {
-							clearAnswers();
-						}
+						clearAnswersOnComplete( currentQuestion );
 					},
 				}
 			);
 		},
-		[ answers, clearAnswers, isPending, mutate, questions ]
+		[ answers, clearAnswersOnComplete, isPending, mutate ]
 	);
 
 	if ( ! config.isEnabled( 'ecommerce-segmentation-survey' ) ) {
@@ -70,6 +91,7 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 		<Main className="segmentation-survey-step">
 			<SegmentationSurveyProvider
 				navigation={ navigation }
+				onSkipQuestion={ onSkipQuestion }
 				onSubmitQuestion={ onSubmitQuestion }
 				surveyKey={ SURVEY_KEY }
 				questions={ questions }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/provider.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/provider.tsx
@@ -8,6 +8,7 @@ import type { NavigationControls } from '../../types';
 type SegmentationSurveyProviderType = {
 	children: React.ReactNode;
 	navigation: NavigationControls;
+	onSkipQuestion: ( currentQuestion: Question ) => void;
 	onSubmitQuestion: ( currentQuestion: Question ) => void;
 	surveyKey: string;
 	questions?: Question[];
@@ -17,6 +18,7 @@ type SegmentationSurveyProviderType = {
 const SegmentationSurveyProvider = ( {
 	children,
 	navigation,
+	onSkipQuestion,
 	onSubmitQuestion,
 	surveyKey,
 	questions,
@@ -75,13 +77,17 @@ const SegmentationSurveyProvider = ( {
 	}, [ answers, currentQuestion, nextPage, onSubmitQuestion, surveyKey ] );
 
 	const skip = useCallback( () => {
-		nextPage();
+		if ( currentQuestion ) {
+			onSkipQuestion( currentQuestion );
 
-		recordTracksEvent( 'calypso_segmentation_survey_skip', {
-			survey_key: surveyKey,
-			question_key: currentQuestion?.key,
-		} );
-	}, [ currentQuestion?.key, nextPage, surveyKey ] );
+			recordTracksEvent( 'calypso_segmentation_survey_skip', {
+				survey_key: surveyKey,
+				question_key: currentQuestion.key,
+			} );
+		}
+
+		nextPage();
+	}, [ currentQuestion, nextPage, onSkipQuestion, surveyKey ] );
 
 	return (
 		<SurveyContext.Provider


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89851

## Proposed Changes

* Submit `skip` as answer key for skipped questions

## Testing Instructions

* Apply this PR to your local
* Test together with D146660-code
* Open the Network tab
* Go to http://calypso.localhost:3000/setup/entrepreneur/start?flags=ecommerce-segmentation-survey
* Select an option and skip the first question
* Check if the `skip` answer key was sent instead of the selected option
* Go back to the first question and verify if the selection was cleaned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?