### PR TITLE
Nav Redesign: Update the style for the collapsed site list

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -25,9 +25,7 @@
 	}
 }
 
-/*
-	Styles for actions (search, filters)
-*/
+// Styles for actions (search, filters)
 .dataviews-filters__view-actions {
 	align-items: center;
 
@@ -43,7 +41,7 @@
 		flex: 1 1 auto;
 		flex-direction: row-reverse;
 		align-items: center;
-		// places search above filters
+		// Places search above filters
 		z-index: 1;
 		border-radius: 2px;
 		border: 1px solid var(--studio-gray-10);
@@ -54,7 +52,7 @@
 			font-size: $font-body;
 		}
 
-		// search icon
+		// Search icon
 		.components-input-control__suffix {
 			padding-inline-start: 11px;
 			color: var(--studio-gray-30);
@@ -62,14 +60,13 @@
 	}
 }
 
-/*
-	Styles collapsed site list
-*/
+// Styles collapsed site list
 .wpcom-site {
 	.sites-dashboard.preview-hidden {
 		.sites-site-thumbnail {
 			display: flex;
 		}
+
 		.sites-site-favicon {
 			display: none;
 		}
@@ -80,22 +77,33 @@
 			display: flex;
 			margin-right: 0;
 		}
+
 		.sites-site-thumbnail {
 			display: none;
 		}
+
 		.list-tile__leading {
 			margin-right: 12px;
 		}
-		.dataviews-filters__view-actions .components-search-control {
-			min-width: initial;
+
+		.dataviews-filters__view-actions {
+			align-items: center;
+			display: flex;
+
+			.components-search-control {
+				min-width: initial;
+			}
 		}
+
 		ul.dataviews-view-list {
 			.components-h-stack {
 				gap: 0;
 			}
+
 			li {
 				border-bottom: 1px solid #f1f1f1 !important;
 			}
+
 			li.is-selected {
 				background-color: #f7faff;
 			}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -61,3 +61,44 @@
 		}
 	}
 }
+
+/*
+	Styles collapsed site list
+*/
+.wpcom-site {
+	.sites-dashboard.preview-hidden {
+		.sites-site-thumbnail {
+			display: flex;
+		}
+		.sites-site-favicon {
+			display: none;
+		}
+	}
+
+	.sites-dashboard:not(.preview-hidden) {
+		.sites-site-favicon {
+			display: flex;
+			margin-right: 0;
+		}
+		.sites-site-thumbnail {
+			display: none;
+		}
+		.list-tile__leading {
+			margin-right: 12px;
+		}
+		.dataviews-filters__view-actions .components-search-control {
+			min-width: initial;
+		}
+		ul.dataviews-view-list {
+			.components-h-stack {
+				gap: 0;
+			}
+			li {
+				border-bottom: 1px solid #f1f1f1 !important;
+			}
+			li.is-selected {
+				background-color: #f7faff;
+			}
+		}
+	}
+}

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
 //import { useInView } from 'react-intersection-observer';
+import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
 import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import SitesP2Badge from 'calypso/sites-dashboard/components/sites-p2-badge';
 import { SiteItemThumbnail } from 'calypso/sites-dashboard/components/sites-site-item-thumbnail';
@@ -23,10 +24,11 @@ type Props = {
 
 const SiteListTile = styled( ListTile )`
 	margin-inline-end: 0;
-	max-width: 340px;
+	width: 295px;
 
 	.preview-hidden & {
 		max-width: 500px;
+		width: 100%;
 	}
 
 	${ MEDIA_QUERIES.hideTableRows } {
@@ -43,7 +45,6 @@ const ListTileLeading = styled( ThumbnailLink )`
 const ListTileTitle = styled.div`
 	display: flex;
 	align-items: center;
-	margin-block-end: 8px;
 `;
 
 const ListTileSubtitle = styled.div`
@@ -85,14 +86,24 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	};
 
 	return (
-		<Button onClick={ onSiteClick } borderless={ true }>
+		<Button css={ { gap: 'none' } } onClick={ onSiteClick } borderless={ true }>
 			<SiteListTile
 				contentClassName={ css`
 					min-width: 0;
 				` }
 				leading={
 					<ListTileLeading title={ title }>
-						<SiteItemThumbnail displayMode="list" showPlaceholder={ false } site={ site } />
+						<SiteItemThumbnail
+							className="sites-site-thumbnail"
+							displayMode="list"
+							showPlaceholder={ false }
+							site={ site }
+						/>
+						<SiteFavicon
+							className="sites-site-favicon"
+							blogId={ site.ID }
+							isDotcomSite={ site.is_wpcom_atomic }
+						/>
 					</ListTileLeading>
 				}
 				title={

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -86,7 +86,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	};
 
 	return (
-		<Button css={ { gap: 'none' } } onClick={ onSiteClick } borderless={ true }>
+		<Button onClick={ onSiteClick } borderless={ true }>
 			<SiteListTile
 				contentClassName={ css`
 					min-width: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/6742
- https://github.com/Automattic/dotcom-forge/issues/6743
- https://github.com/Automattic/dotcom-forge/issues/6749

## Proposed Changes

* This PR styles the collapsed site list to get it closer to the Figma.
* It does **not** fix the mobile view.
* It does **not** fix an issue where the first site you select, the background is not highlighted. This is due to the .is-selected class not being properly applied to the li element. Recommend fixing that in a followup PR.

Before | After
--|--
<img width="1594" alt="Screenshot 2024-04-25 at 6 18 27 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/526da450-a7b8-46b1-87f0-3d27b3b24227">  | <img width="1599" alt="Screenshot 2024-04-25 at 6 16 45 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/ae153da3-a4ac-4611-8b67-88ccee70a8d9">





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this PR.
- Go to /sites?flags=layout%2Fdotcom-nav-redesign-v2
- Observe the Sites title is closer to the Figma PZtnZ1nHhnBrsuXDoMJHPD-fi-394%3A97553
- Double check these style updates won't bleed-over somewhere else.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?