### PR TITLE
Untangling: Show sections in the site dashboard fly-out panel

### DIFF
--- a/client/hosting-overview/controller.tsx
+++ b/client/hosting-overview/controller.tsx
@@ -5,38 +5,43 @@ import HostingActivate from 'calypso/my-sites/hosting/hosting-activate';
 import Hosting from 'calypso/my-sites/hosting/main';
 import MySitesNavigation from 'calypso/my-sites/navigation';
 import SitesDashboardV2 from 'calypso/sites-dashboard-v2';
-import { DOTCOM_HOSTING_CONFIG } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import {
+	DOTCOM_HOSTING_CONFIG,
+	DOTCOM_OVERVIEW,
+} from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
 import { isGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function hostingOverview( context: PageJSContext, next: () => void ) {
-	context.secondary = <MySitesNavigation path={ context.path } />;
-	context.primary = <HostingOverview />;
-	next();
-}
-
-export function hostingConfiguration( context: PageJSContext, next: () => void ) {
-	context.secondary = <MySitesNavigation path={ context.path } />;
+function shouldShowInSitesFlyoutPanel( context: PageJSContext, feature: string ) {
 	const state = context.store.getState();
 	const selectedSiteId = getSelectedSiteId( state );
+
 	// Show the hosting configuration page in the preview pane from the sites dashboard.
 	if (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
 		isGlobalSiteViewEnabled( state, selectedSiteId )
 	) {
 		const selectedSite = getSelectedSite( state );
-		context.primary = (
+		return (
 			// Sites Dashboard V2 - Dotcom Nav Redesign V2
 			<SitesDashboardV2
 				queryParams={ {} }
 				selectedSite={ selectedSite }
-				selectedFeature={ DOTCOM_HOSTING_CONFIG }
+				selectedFeature={ feature }
 			/>
 		);
-		next();
 	}
+}
 
-	context.primary = (
+export function hostingOverview( context: PageJSContext, next: () => void ) {
+	context.secondary = <MySitesNavigation path={ context.path } />;
+	context.primary = shouldShowInSitesFlyoutPanel( context, DOTCOM_OVERVIEW ) ?? <HostingOverview />;
+	next();
+}
+
+export function hostingConfiguration( context: PageJSContext, next: () => void ) {
+	context.secondary = <MySitesNavigation path={ context.path } />;
+	context.primary = shouldShowInSitesFlyoutPanel( context, DOTCOM_HOSTING_CONFIG ) ?? (
 		<div className="hosting-configuration">
 			<Hosting />
 		</div>
@@ -46,7 +51,7 @@ export function hostingConfiguration( context: PageJSContext, next: () => void )
 
 export function hostingActivate( context: PageJSContext, next: () => void ) {
 	context.secondary = <MySitesNavigation path={ context.path } />;
-	context.primary = (
+	context.primary = shouldShowInSitesFlyoutPanel( context, DOTCOM_HOSTING_CONFIG ) ?? (
 		<div className="hosting-configuration">
 			<HostingActivate />
 		</div>

--- a/client/hosting-overview/controller.tsx
+++ b/client/hosting-overview/controller.tsx
@@ -1,8 +1,13 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Context as PageJSContext } from '@automattic/calypso-router';
 import HostingOverview from 'calypso/hosting-overview/components/hosting-overview';
 import HostingActivate from 'calypso/my-sites/hosting/hosting-activate';
 import Hosting from 'calypso/my-sites/hosting/main';
 import MySitesNavigation from 'calypso/my-sites/navigation';
+import SitesDashboardV2 from 'calypso/sites-dashboard-v2';
+import { DOTCOM_HOSTING_CONFIG } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import { isGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function hostingOverview( context: PageJSContext, next: () => void ) {
 	context.secondary = <MySitesNavigation path={ context.path } />;
@@ -12,6 +17,25 @@ export function hostingOverview( context: PageJSContext, next: () => void ) {
 
 export function hostingConfiguration( context: PageJSContext, next: () => void ) {
 	context.secondary = <MySitesNavigation path={ context.path } />;
+	const state = context.store.getState();
+	const selectedSiteId = getSelectedSiteId( state );
+	// Show the hosting configuration page in the preview pane from the sites dashboard.
+	if (
+		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
+		isGlobalSiteViewEnabled( state, selectedSiteId )
+	) {
+		const selectedSite = getSelectedSite( state );
+		context.primary = (
+			// Sites Dashboard V2 - Dotcom Nav Redesign V2
+			<SitesDashboardV2
+				queryParams={ {} }
+				selectedSite={ selectedSite }
+				selectedFeature={ DOTCOM_HOSTING_CONFIG }
+			/>
+		);
+		next();
+	}
+
 	context.primary = (
 		<div className="hosting-configuration">
 			<Hosting />

--- a/client/site-monitoring/controller.tsx
+++ b/client/site-monitoring/controller.tsx
@@ -1,13 +1,45 @@
+import { isEnabled } from '@automattic/calypso-config';
 import MySitesNavigation from 'calypso/my-sites/navigation';
+import SitesDashboardV2 from 'calypso/sites-dashboard-v2';
+import {
+	DOTCOM_MONITORING,
+	DOTCOM_PHP_LOGS,
+	DOTCOM_SERVER_LOGS,
+} from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import { isGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SiteMonitoringPhpLogs from './components/php-logs';
 import SiteMonitoringServerLogs from './components/server-logs';
 import SiteMonitoringOverview from './components/site-monitoring-overview';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
+function shouldShowInSitesFlyoutPanel( context: PageJSContext, feature: string ) {
+	const state = context.store.getState();
+	const selectedSiteId = getSelectedSiteId( state );
+
+	// Show the hosting configuration page in the preview pane from the sites dashboard.
+	if (
+		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
+		isGlobalSiteViewEnabled( state, selectedSiteId )
+	) {
+		const selectedSite = getSelectedSite( state );
+		return (
+			// Sites Dashboard V2 - Dotcom Nav Redesign V2
+			<SitesDashboardV2
+				queryParams={ {} }
+				selectedSite={ selectedSite }
+				selectedFeature={ feature }
+			/>
+		);
+	}
+}
+
 export function siteMonitoringOverview( context: PageJSContext, next: () => void ) {
 	context.secondary = <MySitesNavigation path={ context.path } />;
 
-	context.primary = <SiteMonitoringOverview />;
+	context.primary = shouldShowInSitesFlyoutPanel( context, DOTCOM_MONITORING ) ?? (
+		<SiteMonitoringOverview />
+	);
 
 	next();
 }
@@ -15,7 +47,9 @@ export function siteMonitoringOverview( context: PageJSContext, next: () => void
 export function siteMonitoringPhpLogs( context: PageJSContext, next: () => void ) {
 	context.secondary = <MySitesNavigation path={ context.path } />;
 
-	context.primary = <SiteMonitoringPhpLogs />;
+	context.primary = shouldShowInSitesFlyoutPanel( context, DOTCOM_PHP_LOGS ) ?? (
+		<SiteMonitoringPhpLogs />
+	);
 
 	next();
 }
@@ -23,7 +57,9 @@ export function siteMonitoringPhpLogs( context: PageJSContext, next: () => void 
 export function siteMonitoringServerLogs( context: PageJSContext, next: () => void ) {
 	context.secondary = <MySitesNavigation path={ context.path } />;
 
-	context.primary = <SiteMonitoringServerLogs />;
+	context.primary = shouldShowInSitesFlyoutPanel( context, DOTCOM_SERVER_LOGS ) ?? (
+		<SiteMonitoringServerLogs />
+	);
 
 	next();
 }

--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -32,6 +32,7 @@ import DotcomPreviewPane from './site-preview-pane/dotcom-preview-pane';
 import SitesDashboardHeader from './sites-dashboard-header';
 import DotcomSitesDataViews, { siteStatusGroups } from './sites-dataviews';
 import { getSitesPagination } from './sites-dataviews/utils';
+import type { SiteExcerptData } from '@automattic/sites';
 
 // todo: we are using A4A styles until we extract them as common styles in the ItemsDashboard component
 import './style.scss';
@@ -41,6 +42,8 @@ import './dotcom-style.scss';
 
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
+	selectedSite?: SiteExcerptData | null | undefined;
+	selectedFeature?: string;
 	updateQueryParams?: ( params: SitesDashboardQueryParams ) => void;
 }
 
@@ -58,6 +61,8 @@ const SitesDashboardV2 = ( {
 		status = DEFAULT_STATUS_GROUP,
 	},
 	updateQueryParams = handleQueryParamChange,
+	selectedSite,
+	selectedFeature,
 }: SitesDashboardProps ) => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
@@ -84,6 +89,7 @@ const SitesDashboardV2 = ( {
 		page,
 		perPage,
 		search: search ?? '',
+		selectedItem: selectedSite,
 		filters:
 			status === 'all'
 				? []
@@ -199,6 +205,7 @@ const SitesDashboardV2 = ( {
 					<DotcomPreviewPane
 						site={ dataViewsState.selectedItem }
 						closeSitePreviewPane={ closeSitePreviewPane }
+						selectedFeature={ selectedFeature }
 					/>
 				</LayoutColumn>
 			) }

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -25,14 +25,21 @@ import './style.scss';
 type Props = {
 	site: SiteExcerptData;
 	closeSitePreviewPane: () => void;
+	selectedFeature?: string;
 };
 
-const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
+const DotcomPreviewPane = ( { site, closeSitePreviewPane, selectedFeature }: Props ) => {
 	const { __ } = useI18n();
 
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState< string | undefined >(
 		'dotcom-overview'
 	);
+
+	useEffect( () => {
+		if ( selectedFeature ) {
+			setSelectedSiteFeature( selectedFeature );
+		}
+	}, [ selectedFeature ] );
 
 	useEffect( () => {
 		if ( selectedSiteFeature === undefined ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6748

## Proposed Changes

Following sections should ALWAYS see the site selector fly-out panel for early users.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/56d45822-0381-4919-909f-33ca27827bf4) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/f59f786c-6381-4bb8-aae3-4661d3505bb6) |

#### Sections

- [x] Overview (Pulls from /hosting-overview/{SITE-URL}
- [x] Hosting Config (/hosting-config/{SITE-URL})
- [x] Monitoring (/site-monitoring/{SITE-URL})
- [x] PHP Logs (/site-monitoring/{SITE-URL}/php)
- [x] Server Logs (/site-monitoring/{SITE-URL}/web)
- [x] GitHub Deployments (/github-deployments/{SITE-URL})

## To Do
- Clean the code
- Clicking on a site breaks the design and does not update the URL.

## Testing Instructions

* With an early interface site and using `?flags=layout/dotcom-nav-redesign-v2`
* Go to `/hosting-config/:siteSlug?flags=layout/dotcom-nav-redesign-v2` (or other sections mentioned above)
* You should see the Sites dashboard and the section in the fly-out panel.
* Make sure non-classic early sites are affected.

### Make a site classic early.
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```

