### PR TITLE
Fix warning on /sites due to icon type

### DIFF
--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -66,7 +66,7 @@ export const MySitesSidebarUnifiedItem = ( {
 MySitesSidebarUnifiedItem.propTypes = {
 	badge: PropTypes.string,
 	count: PropTypes.number,
-	icon: PropTypes.string,
+	icon: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 	sectionId: PropTypes.string,
 	slug: PropTypes.string,
 	title: PropTypes.string,


### PR DESCRIPTION
warning in the console due to type mismatch, it appears both types are used here for the sidebar component:

<img width="302" alt="Screenshot 2024-04-26 at 11 14 20 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/c2686e09-f576-4c93-9a7d-73a1a544b4a2">
<img width="691" alt="Screenshot 2024-04-26 at 11 13 14 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/3eccea93-8949-4625-a079-41e2edc177a7">

### Test instructions

Warning should no longer be shown
