### PR TITLE
Update localizeURL function to support /learn

### DIFF
--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -10,6 +10,7 @@ export const localesWithBlog: Locale[] = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br'
 export const localesWithGoBlog: Locale[] = [ 'en', 'pt-br', 'de', 'es', 'fr', 'it' ];
 export const localesWithPrivacyPolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 export const localesWithCookiePolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
+export const localesWithLearn: Locale[] = [ 'en', 'es' ];
 
 export const localesForPricePlans: Locale[] = [
 	'ar',

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -8,6 +8,7 @@ import {
 	localesWithPrivacyPolicy,
 	localesWithCookiePolicy,
 	localesToSubdomains,
+	localesWithLearn,
 	supportSiteLocales,
 	forumLocales,
 	magnificentNonEnLocales,
@@ -169,6 +170,9 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	},
 	'wordpress.com/start/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+	},
+	'wordpress.com/learn/': ( url: URL, localeSlug: Locale ) => {
+		return suffixLocalizedUrlPath( localesWithLearn )( url, localeSlug );
 	},
 	'wordpress.com/plans/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		// if logged in, or url.pathname contains characters after `/plans/`, don't rewrite

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -430,6 +430,26 @@ describe( '#localizeUrl', () => {
 		);
 	} );
 
+	test( 'learn', () => {
+		expect( localizeUrl( 'https://wordpress.com/learn/', 'en', true ) ).toEqual(
+			'https://wordpress.com/learn/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/learn/', 'en', false ) ).toEqual(
+			'https://wordpress.com/learn/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/learn/', 'pl', true ) ).toEqual(
+			'https://wordpress.com/learn/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/learn/', 'pl', false ) ).toEqual(
+			'https://wordpress.com/learn/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/learn/', 'es', true ) ).toEqual(
+			'https://wordpress.com/learn/es/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/learn/', 'es', false ) ).toEqual(
+			'https://wordpress.com/learn/es/'
+		);
+	} );
 	test( 'tos', () => {
 		expect( localizeUrl( 'https://wordpress.com/tos/', 'en' ) ).toEqual(
 			'https://wordpress.com/tos/'


### PR DESCRIPTION
- Support 'es' locale at the moment

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#758

## Proposed Changes

When the `wordpress.com/learn` is in the `localizeUrl` function, it automatically transforms to the `wordpress.com/[locale]/learn`. We need to hard code in an exception for Spanish, which should redirect to wordpress.com/learn/es (as opposed to wordpress.com/es/learn), and exclude all other locales from being processed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Execute `yarn test-packages -- test/localize-url.js`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?