### PR TITLE
Sites Dashboard v2: Improve preview pane tabs scrolling behavior

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -25,7 +25,7 @@
 	}
 }
 
-// Styles for actions (search, filters)
+// Styles for actions (search, filters).
 .dataviews-filters__view-actions {
 	align-items: center;
 
@@ -60,7 +60,7 @@
 	}
 }
 
-// Styles collapsed site list
+// Styles collapsed site list.
 .wpcom-site {
 	.sites-dashboard.preview-hidden {
 		.sites-site-thumbnail {
@@ -108,5 +108,13 @@
 				background-color: #f7faff;
 			}
 		}
+	}
+}
+
+// Styles for site preview pane.
+.wpcom-site .site-preview-pane {
+	.section-nav-tabs__list {
+		box-sizing: border-box;
+		overflow-x: auto;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6744

## Proposed Changes

This PR improves the preview pane tabs scrolling so that it only scrolls when overflown.


https://github.com/Automattic/wp-calypso/assets/797888/7c590878-ac13-4d94-8684-453cf0485b54



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Ensure that the scrolling only works on the tabs content overflow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?