### PR TITLE
nav redesign: fix background panel colors

### DIFF
--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -1,6 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+:root {
+	--color-light-backdrop: var(--studio-white);
+}
 .main.a4a-layout.sites-dashboard {
 	padding-block-start: 0;
 

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -70,7 +70,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 		// Update body margin to account for the sidebar width
 		@media only screen and ( min-width: 782px ) {
 			div.layout.is-global-sidebar-visible {
-				.layout__primary main {
+				.layout__primary > main {
 					background: var( --color-surface );
 					border-radius: 8px;
 					box-shadow: 0px 0px 17.4px 0px rgba( 0, 0, 0, 0.05 );


### PR DESCRIPTION
Fix 6750-gh-Automattic/dotcom-forge

add missing color variable and limit specificity of a selector to make the background color white 


### Testing instructions 

sites with nav redesign v2 enabled `/sites/?flags=layout/dotcom-nav-redesign-v2`
see 6750-gh-Automattic/dotcom-forge