### PR TITLE
Nav Redesign: Adjust the position of the sort icon

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -27,8 +27,6 @@
 
 // Styles for actions (search, filters)
 .dataviews-filters__view-actions {
-	align-items: center;
-
 	.components-search-control {
 		@media (min-width: $break-large) {
 			min-width: 390px;
@@ -57,6 +55,12 @@
 			padding-inline-start: 11px;
 			color: var(--studio-gray-30);
 		}
+	}
+
+	// Sort action icon
+	> .components-button {
+		// Since we changed the original height of the search input, we need to adjust the position of this icon.
+		margin-top: 5px;
 	}
 }
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -14,7 +14,7 @@
 	.a4a-layout__top-wrapper {
 		border-block-end: 0;
 
-		@media (min-width: $break-medium) {
+		@include break-medium {
 			border-block-end: 1px solid var(--studio-gray-0);
 			margin-bottom: 24px;
 		}
@@ -28,7 +28,7 @@
 // Styles for actions (search, filters)
 .dataviews-filters__view-actions {
 	.components-search-control {
-		@media (min-width: $break-large) {
+		@include break-large {
 			min-width: 390px;
 		}
 	}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -56,17 +56,19 @@
 			color: var(--studio-gray-30);
 		}
 	}
-
-	// Sort action icon
-	> .components-button {
-		// Since we changed the original height of the search input, we need to adjust the position of this icon.
-		margin-top: 5px;
-	}
 }
 
 // Styles collapsed site list
 .wpcom-site {
 	.sites-dashboard.preview-hidden {
+		.dataviews-filters__view-actions {
+			// Sort action icon
+			> .components-button:has(.preview-hidden) {
+				// Since we changed the original height of the search input, we need to adjust the position of this icon.
+				margin-top: 5px;
+			}
+		}
+
 		.sites-site-thumbnail {
 			display: flex;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the https://github.com/Automattic/wp-calypso/pull/89887linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89887

## Proposed Changes

Since we changed the original height of the search input, we need to adjust the position of this icon.

| before | after |
|--------|--------|
|<img width="490" alt="Screenshot 2024-04-26 at 11 55 45" src="https://github.com/Automattic/wp-calypso/assets/5287479/861ffc51-5f65-41e3-8c26-7dc0186358d8"> | <img width="492" alt="Screenshot 2024-04-26 at 11 55 50" src="https://github.com/Automattic/wp-calypso/assets/5287479/fce29bbb-23b3-4301-827a-8f9ebd3f218d"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare an Atomin site with Classic View 
* Go to the site's `_cli` and run `wp option update wpcom_classic_early_relase 1`.
* Go to `/sites/?flags=layout/dotcom-nav-redesign-v2&page=1`
* See the updated icon position 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?