### PR TITLE
Trail Map: implement the plans page subheader

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -1,0 +1,134 @@
+import { Button, Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+
+const Subheader = styled.p`
+	margin: -32px 0 40px 0;
+	color: var( --studio-gray-60 );
+	font-size: 1rem;
+	text-align: center;
+	button.is-borderless {
+		font-weight: 500;
+		color: var( --studio-gray-90 );
+		text-decoration: underline;
+		font-size: 16px;
+		padding: 0;
+	}
+	@media ( max-width: 960px ) {
+		margin-top: -16px;
+	}
+`;
+
+const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
+	const translate = useTranslate();
+	const headerText = translate( 'Upgrade your plan to access this feature and more' );
+	const subHeaderText = (
+		<Button className="plans-features-main__view-all-plans is-link" href={ `/plans/${ siteSlug }` }>
+			{ translate( 'View all plans' ) }
+		</Button>
+	);
+
+	return (
+		<FormattedHeader
+			headerText={ headerText }
+			subHeaderText={ subHeaderText }
+			compactOnMobile
+			isSecondary
+		/>
+	);
+};
+
+const HeaderContainer = styled( Subheader )`
+	display: flex;
+	justify-content: center;
+	font-size: 16px;
+	font-weight: 500;
+	margin-bottom: 0;
+
+	// TODO:
+	// This value is grabbed directly from https://github.com/Automattic/wp-calypso/blob/trunk/packages/plans-grid-next/src/index.tsx#L109
+	// Ideally there should be a shared constant that can be reused from the CSS side.
+	@media ( max-width: 740px ) {
+		flex-direction: column;
+	}
+`;
+
+const PrefixSection = styled.p`
+	// TODO:
+	// The same as above.
+	@media ( max-width: 740px ) {
+		margin-bottom: 4px;
+	}
+`;
+
+const FeatureSection = styled.p`
+	.gridicon.gridicons-checkmark {
+		color: var( --studio-green-50 );
+		vertical-align: middle;
+		margin-left: 12px;
+		margin-right: 4px;
+		padding-bottom: 4px;
+	}
+`;
+
+const PlanBenefitHeader = () => {
+	const translate = useTranslate();
+
+	return (
+		<HeaderContainer>
+			<PrefixSection>{ translate( 'All plans includes:' ) }</PrefixSection>
+			<FeatureSection>
+				{ translate(
+					'{{Checkmark}}{{/Checkmark}}Website Building{{Checkmark}}{{/Checkmark}}Hosting{{Checkmark}}{{/Checkmark}}eCommerce',
+					{
+						components: {
+							Checkmark: <Gridicon icon="checkmark" size={ 18 } />,
+						},
+						comment: 'Checkmark is an icon showing a green check mark.',
+					}
+				) }
+			</FeatureSection>
+		</HeaderContainer>
+	);
+};
+
+// TBD
+// It is actually questionable that we implement a subheader here instead of reusing the header mechanism
+// provided by the signup framework. How could we unify them?
+const PlansPageSubheader = ( {
+	siteSlug,
+	isDisplayingPlansNeededForFeature,
+	deemphasizeFreePlan,
+	showPlanBenefits,
+	onFreePlanCTAClick,
+}: {
+	siteSlug?: string | null;
+	isDisplayingPlansNeededForFeature: boolean;
+	deemphasizeFreePlan?: boolean;
+	showPlanBenefits?: boolean;
+	onFreePlanCTAClick: () => void;
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ deemphasizeFreePlan && (
+				<Subheader>
+					{ translate(
+						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+						{
+							components: {
+								link: <Button onClick={ onFreePlanCTAClick } borderless />,
+							},
+						}
+					) }
+				</Subheader>
+			) }
+			{ ! deemphasizeFreePlan && showPlanBenefits && <PlanBenefitHeader /> }
+			{ isDisplayingPlansNeededForFeature && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
+		</>
+	);
+};
+
+export default PlansPageSubheader;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -45,7 +45,6 @@ import QueryPlans from 'calypso/components/data/query-plans';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
@@ -65,6 +64,7 @@ import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/s
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
+import PlansPageSubheader from './components/plans-page-subheader';
 import useGenerateActionCallback from './hooks/use-action-callback';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
@@ -85,23 +85,6 @@ import type {
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
-
-const FreePlanSubHeader = styled.p`
-	margin: -32px 0 40px 0;
-	color: var( --studio-gray-60 );
-	font-size: 1rem;
-	text-align: center;
-	button.is-borderless {
-		font-weight: 500;
-		color: var( --studio-gray-90 );
-		text-decoration: underline;
-		font-size: 16px;
-		padding: 0;
-	}
-	@media ( max-width: 960px ) {
-		margin-top: -16px;
-	}
-`;
 
 const PlanComparisonHeader = styled.h1`
 	.plans .step-container .step-container__content &&,
@@ -192,25 +175,6 @@ export interface PlansFeaturesMainProps {
 	 */
 	deemphasizeFreePlan?: boolean;
 }
-
-const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
-	const translate = useTranslate();
-	const headerText = translate( 'Upgrade your plan to access this feature and more' );
-	const subHeaderText = (
-		<Button className="plans-features-main__view-all-plans is-link" href={ `/plans/${ siteSlug }` }>
-			{ translate( 'View all plans' ) }
-		</Button>
-	);
-
-	return (
-		<FormattedHeader
-			headerText={ headerText }
-			subHeaderText={ subHeaderText }
-			compactOnMobile
-			isSecondary
-		/>
-	);
-};
 
 const PlansFeaturesMain = ( {
 	paidDomainName,
@@ -793,19 +757,13 @@ const PlansFeaturesMain = ( {
 							} ) }
 					/>
 				) }
-				{ deemphasizeFreePlan && (
-					<FreePlanSubHeader>
-						{ translate(
-							`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
-							{
-								components: {
-									link: <Button onClick={ onFreePlanCTAClick } borderless />,
-								},
-							}
-						) }
-					</FreePlanSubHeader>
-				) }
-				{ isDisplayingPlansNeededForFeature && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
+				<PlansPageSubheader
+					siteSlug={ siteSlug }
+					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
+					deemphasizeFreePlan={ deemphasizeFreePlan }
+					onFreePlanCTAClick={ onFreePlanCTAClick }
+					showPlanBenefits={ isInSignup && trailMapExperiment.result }
+				/>
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (
 					<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89788, based on #89800 

## Proposed Changes

This PR implements the Trail Map version of the plans page subheader:

Desktop:
<img width="1146" alt="CleanShot 2024-04-26 at 10 51 50@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/ae56f7a4-cac7-4ba8-8b43-53d62b9886b2">

Mobile:
<img width="590" alt="CleanShot 2024-04-26 at 10 52 43@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/f918536f-28f9-4f25-b8e1-be49790fded5">

When the Free plan is deemphasized, the subheader will be replaced by the same Free plan CTA header:

<img width="1063" alt="CleanShot 2024-04-26 at 10 53 53@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/d5d21513-6207-4e7f-8d76-f88ddf390414">

The design can be found in Uzd0AYiDAV4eFq1V35T9Ef-fi-673_7146. Note that we are not aiming at pixel-perfect implementation here since it will be an experiment. We can first get the structure correct, and then iterate on the details when the time budget allows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the feature flag by appending `?flags=onboarding/trail-map-feature-grid`
* Go to `/start/plans` and confirm that the new subheader shows correctly, on both destkop & mobile.
* The new subheader shouldn't show in the logged-in `/plans` and any other signup flows.
* Hard-code `deemphasizeFreePlan` as true here: https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plans-features-main/index.tsx#L405, and confirm that the Free plan CTA subheader shows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
