### PR TITLE
Sites Dashboard v2: Restructure the flyout panel by using flexbox

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -124,3 +124,50 @@
 		overflow-x: auto;
 	}
 }
+
+// Use flexbox to structure of fly-out panel.
+.wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout:not(.preview-hidden) {
+	.a4a-layout-column__container {
+		display: flex;
+		flex-direction: column;
+		height: calc(100vh - 32px);
+
+		.a4a-layout__top-wrapper {
+			display: flex;
+			margin-bottom: 0;
+			padding: 0;
+
+			.a4a-layout__viewport {
+				display: flex;
+				margin: 0;
+				padding: 16px;
+			}
+
+			.a4a-layout__header {
+				margin: 0;
+			}
+		}
+
+		.sites-overview__content {
+			flex-grow: 1;
+			margin-top: 0;
+			overflow: hidden;
+			padding-bottom: 0 !important;
+		}
+
+		.dataviews-wrapper {
+			display: flex;
+			height: 100%;
+
+			.dataviews-view-list {
+				flex: 1;
+				max-height: none;
+			}
+
+			.dataviews-pagination {
+				margin: 0;
+				position: relative;
+			}
+		}
+	}
+}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -4,6 +4,10 @@
 @import "@wordpress/base-styles/mixins";
 
 // Add new Dotcom specific styles to this file.
+.wpcom-site .layout__primary .main {
+	padding-bottom: 0;
+}
+
 .wpcom-site .a4a-layout-with-columns__container {
 	background: var(--color-sidebar-background);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6741

## Proposed Changes

This PR restructures the layout of the fly-out panel by using flexbox. The benefit of this approach is that the site list fill the remaining space of the panel without explicitly setting a max-height as it's the case in production, allowing the list to change height depending on whether the pagination control is shown or not.

In production: 
![Screenshot 2024-04-26 at 11 29 38 AM](https://github.com/Automattic/wp-calypso/assets/797888/10701e1a-2e2d-4e0e-897f-a41d17b4e109)

PR:
![Screenshot 2024-04-26 at 11 37 14 AM](https://github.com/Automattic/wp-calypso/assets/797888/c32f067f-aa1f-4aa6-8849-17fb9649216f)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Ensure that the fly-out panel's site list takes the entire vertical remaining space available. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?