### PR TITLE
Trail Map: Hide unsupported features in the comparison grid on mobile

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -716,7 +716,6 @@ const PlansFeaturesMain = ( {
 		siteId,
 		gridPlansForFeaturesGrid?.map( ( gridPlan ) => gridPlan.planSlug )
 	);
-	const hideUnsupportedFeatures = !! trailMapExperiment.result;
 
 	const onFreePlanCTAClick = useActionCallback( { planSlug: PLAN_FREE } );
 
@@ -925,9 +924,9 @@ const PlansFeaturesMain = ( {
 													useCheckPlanAvailabilityForPurchase={
 														useCheckPlanAvailabilityForPurchase
 													}
-													hideUnsupportedFeatures={ hideUnsupportedFeatures }
 													enableFeatureTooltips={ ! isTrailMapCopy }
 													featureGroupMap={ featureGroupMap }
+													hideUnsupportedFeatures={ isTrailMapStructure }
 												/>
 											) }
 											<ComparisonGridToggle

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -716,6 +716,7 @@ const PlansFeaturesMain = ( {
 		siteId,
 		gridPlansForFeaturesGrid?.map( ( gridPlan ) => gridPlan.planSlug )
 	);
+	const hideUnsupportedFeatures = !! trailMapExperiment.result;
 
 	const onFreePlanCTAClick = useActionCallback( { planSlug: PLAN_FREE } );
 
@@ -924,6 +925,7 @@ const PlansFeaturesMain = ( {
 													useCheckPlanAvailabilityForPurchase={
 														useCheckPlanAvailabilityForPurchase
 													}
+													hideUnsupportedFeatures={ hideUnsupportedFeatures }
 													enableFeatureTooltips={ ! isTrailMapCopy }
 													featureGroupMap={ featureGroupMap }
 												/>

--- a/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
@@ -1,4 +1,4 @@
-import { getFeaturesList } from '@automattic/calypso-products';
+import { getFeaturesList, getPlanFeaturesGrouped } from '@automattic/calypso-products';
 import { Meta, StoryObj } from '@storybook/react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { ComparisonGrid, ComparisonGridExternalProps, useGridPlansForComparisonGrid } from '../..';
@@ -19,7 +19,13 @@ const RenderComparisonGrid = ( props: ComparisonGridExternalProps ) => {
 		useGridPlans
 	);
 
-	return <ComparisonGrid { ...props } gridPlans={ gridPlans || [] } />;
+	return (
+		<ComparisonGrid
+			{ ...props }
+			gridPlans={ gridPlans || [] }
+			featureGroupMap={ getPlanFeaturesGrouped() }
+		/>
+	);
 };
 
 const meta: Meta< typeof ComparisonGrid > = {
@@ -59,3 +65,10 @@ export const StartFlow: Story = {
 };
 
 StartFlow.storyName = '/start';
+
+export const HideUnsupportedFeaturesOnMobile: Story = {
+	args: {
+		...StartFlow.args,
+		hideUnsupportedFeatures: true,
+	},
+};

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -621,6 +621,8 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 			'popular-plan-parent-class': gridPlan.highlightLabel,
 			'has-feature': hasFeature,
 			'has-conditional-feature': hasConditionalFeature,
+			'hide-unsupported-feature':
+				hideUnsupportedFeatures && ! hasFeature && ! hasConditionalFeature,
 			'title-is-subtitle': 'live-chat-support' === featureSlug,
 			'is-left-of-highlight': highlightAdjacencyMatrix[ planSlug ]?.leftOfHighlight,
 			'is-right-of-highlight': highlightAdjacencyMatrix[ planSlug ]?.rightOfHighlight,
@@ -681,22 +683,16 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 									{ feature.getIcon() as React.ReactNode }
 								</span>
 							) }
-
 							<Plans2023Tooltip
 								text={ enableFeatureTooltips ? feature?.getDescription?.() : undefined }
 								setActiveTooltipId={ setActiveTooltipId }
 								activeTooltipId={ activeTooltipId }
 								id={ `${ planSlug }-${ featureSlug }` }
 							>
-								{ hideUnsupportedFeatures && ! hasFeature && ! hasConditionalFeature ? (
-									<></>
-								) : (
-									<span className="plan-comparison-grid__plan-title">
-										{ feature?.getAlternativeTitle?.() || feature?.getTitle() }
-									</span>
-								) }
+								<span className="plan-comparison-grid__plan-title">
+									{ feature?.getAlternativeTitle?.() || feature?.getTitle() }
+								</span>
 							</Plans2023Tooltip>
-
 							{ feature?.getCompareTitle && (
 								<span className="plan-comparison-grid__plan-subtitle">
 									{ feature.getCompareTitle() }

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -577,7 +577,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	setActiveTooltipId,
 	onStorageAddOnClick,
 } ) => {
-	const { gridPlansIndex, enableFeatureTooltips } = usePlansGridContext();
+	const { gridPlansIndex, enableFeatureTooltips, hideUnsupportedFeatures } = usePlansGridContext();
 	const gridPlan = gridPlansIndex[ planSlug ];
 	const translate = useTranslate();
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
@@ -681,16 +681,22 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 									{ feature.getIcon() as React.ReactNode }
 								</span>
 							) }
+
 							<Plans2023Tooltip
 								text={ enableFeatureTooltips ? feature?.getDescription?.() : undefined }
 								setActiveTooltipId={ setActiveTooltipId }
 								activeTooltipId={ activeTooltipId }
 								id={ `${ planSlug }-${ featureSlug }` }
 							>
-								<span className="plan-comparison-grid__plan-title">
-									{ feature?.getAlternativeTitle?.() || feature?.getTitle() }
-								</span>
+								{ hideUnsupportedFeatures && ! hasFeature && ! hasConditionalFeature ? (
+									<></>
+								) : (
+									<span className="plan-comparison-grid__plan-title">
+										{ feature?.getAlternativeTitle?.() || feature?.getTitle() }
+									</span>
+								) }
 							</Plans2023Tooltip>
+
 							{ feature?.getCompareTitle && (
 								<span className="plan-comparison-grid__plan-subtitle">
 									{ feature.getCompareTitle() }

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -15,7 +15,6 @@ interface PlansGridContext {
 		recordTracksEvent?: GridContextProps[ 'recordTracksEvent' ];
 	};
 	coupon?: string;
-	hideUnsupportedFeatures?: boolean;
 	enableFeatureTooltips?: boolean;
 	/**
 	 * `enableCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)
@@ -27,6 +26,7 @@ interface PlansGridContext {
 	 * This is necessary for Comparison Grid and optional for Features Grid (i.e. applicable when `enableCategorisedFeatures` is set).
 	 */
 	featureGroupMap: Partial< FeatureGroupMap >;
+	hideUnsupportedFeatures?: boolean;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -41,10 +41,10 @@ const PlansGridContextProvider = ( {
 	siteId,
 	children,
 	coupon,
-	hideUnsupportedFeatures,
 	enableFeatureTooltips,
 	enableCategorisedFeatures,
 	featureGroupMap,
+	hideUnsupportedFeatures,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -64,10 +64,10 @@ const PlansGridContextProvider = ( {
 				allFeaturesList,
 				helpers: { useCheckPlanAvailabilityForPurchase, useActionCallback, recordTracksEvent },
 				coupon,
-				hideUnsupportedFeatures,
 				enableFeatureTooltips,
 				enableCategorisedFeatures,
 				featureGroupMap,
+				hideUnsupportedFeatures,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -15,6 +15,7 @@ interface PlansGridContext {
 		recordTracksEvent?: GridContextProps[ 'recordTracksEvent' ];
 	};
 	coupon?: string;
+	hideUnsupportedFeatures?: boolean;
 	enableFeatureTooltips?: boolean;
 	/**
 	 * `enableCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)
@@ -40,6 +41,7 @@ const PlansGridContextProvider = ( {
 	siteId,
 	children,
 	coupon,
+	hideUnsupportedFeatures,
 	enableFeatureTooltips,
 	enableCategorisedFeatures,
 	featureGroupMap,
@@ -62,6 +64,7 @@ const PlansGridContextProvider = ( {
 				allFeaturesList,
 				helpers: { useCheckPlanAvailabilityForPurchase, useActionCallback, recordTracksEvent },
 				coupon,
+				hideUnsupportedFeatures,
 				enableFeatureTooltips,
 				enableCategorisedFeatures,
 				featureGroupMap,

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -36,6 +36,7 @@ const WrappedComparisonGrid = ( {
 	stickyRowOffset,
 	coupon,
 	className,
+	hideUnsupportedFeatures,
 	enableFeatureTooltips,
 	featureGroupMap,
 	...otherProps
@@ -72,6 +73,7 @@ const WrappedComparisonGrid = ( {
 				recordTracksEvent={ recordTracksEvent }
 				allFeaturesList={ allFeaturesList }
 				coupon={ coupon }
+				hideUnsupportedFeatures={ hideUnsupportedFeatures }
 				enableFeatureTooltips={ enableFeatureTooltips }
 				featureGroupMap={ featureGroupMap }
 			>

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -73,9 +73,9 @@ const WrappedComparisonGrid = ( {
 				recordTracksEvent={ recordTracksEvent }
 				allFeaturesList={ allFeaturesList }
 				coupon={ coupon }
-				hideUnsupportedFeatures={ hideUnsupportedFeatures }
 				enableFeatureTooltips={ enableFeatureTooltips }
 				featureGroupMap={ featureGroupMap }
+				hideUnsupportedFeatures={ hideUnsupportedFeatures }
 			>
 				<ComparisonGrid
 					intervalType={ intervalType }

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -962,6 +962,13 @@ $mobile-card-max-width: 440px;
 			.plan-comparison-grid__plan-subtitle {
 				text-decoration: line-through;
 			}
+
+			&.hide-unsupported-feature {
+				.plan-comparison-grid__plan-title,
+				.plan-comparison-grid__plan-subtitle {
+					display: none;
+				}
+			}
 		}
 
 		@include plans-grid-medium-large {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -157,7 +157,6 @@ export type GridContextProps = {
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
 	children: React.ReactNode;
 	coupon?: string;
-	hideUnsupportedFeatures?: boolean;
 	enableFeatureTooltips?: boolean;
 	/**
 	 * `enableCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)
@@ -169,6 +168,7 @@ export type GridContextProps = {
 	 * This is necessary for Comparison Grid and optional for Features Grid (i.e. applicable when `enableCategorisedFeatures` is set).
 	 */
 	featureGroupMap: Partial< FeatureGroupMap >;
+	hideUnsupportedFeatures?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit<

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -157,6 +157,7 @@ export type GridContextProps = {
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
 	children: React.ReactNode;
 	coupon?: string;
+	hideUnsupportedFeatures?: boolean;
 	enableFeatureTooltips?: boolean;
 	/**
 	 * `enableCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)


### PR DESCRIPTION
Related to #89787

## Proposed Changes

When the flag `onboarding/trail-map-feature-grid` is enabled on mobile, hide unsupported features in the comparison grid rather than displaying them with ~strikethrough~ formatting. This is controlled by a new optional context prop `hideUnsupportedFeatures`.

| Before | After |
| -- | -- |
|![CleanShot 2024-05-01 at 16 53 53@2x](https://github.com/Automattic/wp-calypso/assets/69198925/dc9a2a11-0741-45db-a788-76f1ff16f739)|![CleanShot 2024-05-01 at 16 54 01@2x](https://github.com/Automattic/wp-calypso/assets/69198925/a2fa8068-a8c2-4ce1-b384-8f26819be2c5)|

## Testing Instructions

Approach 1:

1. Run storybook: `yarn workspace @automattic/plans-grid-next storybook`
2. View the story in: `ComparisonGrid > Hide Unsupported Features On Mobile`
    - Naming not ideal -- we'll need to come up with a better naming pattern for these experiment-based stories
4. Switch to the mobile layout in Storybook (see screenshot below)
5. Toggle the `hideUnsupportedFeatures` prop (see screenshot below)
    - When `true` any unsupported features should be hidden
    - When `false` any unsupported features should be visible with ~strikethrough~ formatting

![CleanShot 2024-05-01 at 17 08 33@2x](https://github.com/Automattic/wp-calypso/assets/69198925/f88aac04-1680-4cb9-89b4-9dfe835f5340)


Approach 2:

1. Go to `/start/plans?flags=onboarding/trail-map-feature-grid`
2. Open the comparison grid
3. On mobile, any unsupported features should be hidden
4. On desktop, any unsupported features should match production ie. with a dash/hyphen (screenshot below)
6. Check that the grid matches production when the `?flags=onboarding/trail-map-feature-grid` is not used

![CleanShot 2024-05-01 at 17 11 18@2x](https://github.com/Automattic/wp-calypso/assets/69198925/de0ddcd2-3d71-4565-92bc-ad89fc7af3e3)





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?