### PR TITLE
Atomic sites: Prevent installing Jetpack plugins with overlapping features.

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -51,7 +51,6 @@ const incompatiblePlugins = new Set( [
 	'backup-wd',
 	'backupwordpress',
 	'backwpup',
-	'jetpack-backup',
 	'wp-db-backup',
 
 	// caching

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -11,6 +11,7 @@ import { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { marketplacePlanToAdd, getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
+import useAtomicSiteHasEquivalentFeatureToPluginItem from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
@@ -100,6 +101,12 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 	const { isPreinstalledPremiumPlugin, preinstalledPremiumPluginProduct } =
 		usePreinstalledPremiumPlugin( plugin.slug );
 
+	// Atomic sites already include features such as Jetpack backup, scan, videopress, publicize, and search. So
+	// therefore we should prevent users from installing these standalone plugin equivalents.
+	const atomicSiteHasEquivalentFeatureToPluginItem = useAtomicSiteHasEquivalentFeatureToPluginItem(
+		plugin.slug
+	);
+
 	const productsList = useSelector( getProductsList );
 
 	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
@@ -113,6 +120,8 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 		buttonText = translate( 'Upgrade your plan' );
 	} else if ( shouldUpgrade ) {
 		buttonText = translate( 'Upgrade and activate' );
+	} else if ( atomicSiteHasEquivalentFeatureToPluginItem ) {
+		buttonText = translate( 'Included with your plan' );
 	}
 
 	return (
@@ -198,7 +207,10 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 					} );
 				} }
 				disabled={
-					( isJetpackSelfHosted && isMarketplaceProduct ) || isSiteConnected === false || disabled
+					( isJetpackSelfHosted && isMarketplaceProduct ) ||
+					isSiteConnected === false ||
+					atomicSiteHasEquivalentFeatureToPluginItem ||
+					disabled
 				}
 			>
 				{ buttonText }

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -11,7 +11,7 @@ import { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { marketplacePlanToAdd, getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
-import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
+import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -11,7 +11,7 @@ import { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { marketplacePlanToAdd, getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
-import useAtomicSiteHasEquivalentFeatureToPluginItem from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
+import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
@@ -103,7 +103,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 
 	// Atomic sites already include features such as Jetpack backup, scan, videopress, publicize, and search. So
 	// therefore we should prevent users from installing these standalone plugin equivalents.
-	const atomicSiteHasEquivalentFeatureToPluginItem = useAtomicSiteHasEquivalentFeatureToPluginItem(
+	const atomicSiteHasEquivalentFeatureToPlugin = useAtomicSiteHasEquivalentFeatureToPlugin(
 		plugin.slug
 	);
 
@@ -120,7 +120,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 		buttonText = translate( 'Upgrade your plan' );
 	} else if ( shouldUpgrade ) {
 		buttonText = translate( 'Upgrade and activate' );
-	} else if ( atomicSiteHasEquivalentFeatureToPluginItem ) {
+	} else if ( atomicSiteHasEquivalentFeatureToPlugin ) {
 		buttonText = translate( 'Included with your plan' );
 	}
 
@@ -209,7 +209,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 				disabled={
 					( isJetpackSelfHosted && isMarketplaceProduct ) ||
 					isSiteConnected === false ||
-					atomicSiteHasEquivalentFeatureToPluginItem ||
+					atomicSiteHasEquivalentFeatureToPlugin ||
 					disabled
 				}
 			>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -407,7 +407,9 @@ function PrimaryButton( {
 	const isMarketplaceProduct = useSelector( ( state ) =>
 		isMarketplaceProductSelector( state, plugin.slug )
 	);
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isDisabledForWpcomStaging = isWpcomStaging && isMarketplaceProduct;
+	const isIncompatibleForAtomic = isAtomic && 'vaultpress' === plugin.slug;
 
 	const onClick = useCallback( () => {
 		dispatch(
@@ -452,7 +454,12 @@ function PrimaryButton( {
 		<CTAButton
 			plugin={ plugin }
 			hasEligibilityMessages={ hasEligibilityMessages }
-			disabled={ incompatiblePlugin || userCantManageTheSite || isDisabledForWpcomStaging }
+			disabled={
+				incompatiblePlugin ||
+				userCantManageTheSite ||
+				isDisabledForWpcomStaging ||
+				isIncompatibleForAtomic
+			}
 		/>
 	);
 }

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
+import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import useAtomicSiteHasEquivalentFeatureToPluginItem from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -39,6 +40,12 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		isPreinstalledPremiumPluginPaidInstalled,
 	} = usePreinstalledPremiumPlugin( plugin.slug );
 
+	// Atomic sites already include features such as Jetpack backup, scan, videopress, publicize, and search. So
+	// therefore we should prevent users from installing these standalone plugin equivalents.
+	const atomicSiteHasEquivalentFeatureToPluginItem = useAtomicSiteHasEquivalentFeatureToPluginItem(
+		plugin.slug
+	);
+
 	const managedPluginMessage = (
 		<span className="plugin-details-cta__preinstalled">
 			{ translate( '%s is automatically managed for you.', { args: plugin.name } ) }
@@ -63,6 +70,18 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 				</PluginPrice>
 			</div>
 		</>
+	);
+
+	const includedWithAtomicPlanButton = (
+		<div className="plugin-details-cta__install">
+			<Button
+				className="plugin-details-cta__install-button"
+				href={ `/checkout/${ selectedSiteSlug }/${ preinstalledPremiumPluginProduct }` }
+				disabled
+			>
+				{ translate( 'Included with your plan' ) }
+			</Button>
+		</div>
 	);
 
 	const startForFreeButton = (
@@ -99,6 +118,10 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 			/>
 		</div>
 	);
+
+	if ( atomicSiteHasEquivalentFeatureToPluginItem ) {
+		return includedWithAtomicPlanButton;
+	}
 
 	if ( isPreinstalledPremiumPluginPaidInstalled ) {
 		return managedPluginMessage;

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import useAtomicSiteHasEquivalentFeatureToPluginItem from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
+import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -42,7 +42,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 
 	// Atomic sites already include features such as Jetpack backup, scan, videopress, publicize, and search. So
 	// therefore we should prevent users from installing these standalone plugin equivalents.
-	const atomicSiteHasEquivalentFeatureToPluginItem = useAtomicSiteHasEquivalentFeatureToPluginItem(
+	const atomicSiteHasEquivalentFeatureToPlugin = useAtomicSiteHasEquivalentFeatureToPlugin(
 		plugin.slug
 	);
 
@@ -115,7 +115,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		</div>
 	);
 
-	if ( atomicSiteHasEquivalentFeatureToPluginItem ) {
+	if ( atomicSiteHasEquivalentFeatureToPlugin ) {
 		return includedWithAtomicPlanButton;
 	}
 

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -74,11 +74,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 
 	const includedWithAtomicPlanButton = (
 		<div className="plugin-details-cta__install">
-			<Button
-				className="plugin-details-cta__install-button"
-				href={ `/checkout/${ selectedSiteSlug }/${ preinstalledPremiumPluginProduct }` }
-				disabled
-			>
+			<Button className="plugin-details-cta__install-button" disabled>
 				{ translate( 'Included with your plan' ) }
 			</Button>
 		</div>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -149,6 +149,14 @@ function PluginDetails( props ) {
 		isSaasProductSelector( state, props.pluginSlug )
 	);
 
+	const isIncompatiblePlugin = useMemo( () => {
+		return ! isCompatiblePlugin( props.pluginSlug ) && ! isJetpackSelfHosted;
+	}, [ isJetpackSelfHosted, props.pluginSlug ] );
+
+	const isIncompatibleBackupPlugin = useMemo( () => {
+		return 'vaultpress' === props.pluginSlug && ! isJetpackSelfHosted;
+	}, [ isJetpackSelfHosted, props.pluginSlug ] );
+
 	// Fetch WPorg plugin data if needed
 	useEffect( () => {
 		if ( isProductListFetched && ! isMarketplaceProduct && ! isWporgPluginFetched ) {
@@ -424,7 +432,7 @@ function PluginDetails( props ) {
 					<div className="plugin-details__content">
 						{ ! showPlaceholder && (
 							<div className="plugin-details__body">
-								{ ! isJetpackSelfHosted && ! isCompatiblePlugin( props.pluginSlug ) && (
+								{ ! isJetpackSelfHosted && isIncompatiblePlugin && ! isIncompatibleBackupPlugin && (
 									<Notice
 										text={ translate(
 											'Incompatible plugin: This plugin is not supported on WordPress.com.'
@@ -436,6 +444,20 @@ function PluginDetails( props ) {
 											href={ localizeUrl( 'https://wordpress.com/support/incompatible-plugins/' ) }
 										>
 											{ translate( 'More info' ) }
+										</NoticeAction>
+									</Notice>
+								) }
+
+								{ isIncompatibleBackupPlugin && (
+									<Notice
+										text={ translate(
+											'Incompatible plugin: You site plan already includes Jetpack VaultPress Backup.'
+										) }
+										status="is-warning"
+										showDismiss={ false }
+									>
+										<NoticeAction href={ `/backup/${ selectedSite.slug }` }>
+											{ translate( 'View backups' ) }
 										</NoticeAction>
 									</Notice>
 								) }

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -334,6 +334,7 @@ function InstalledInOrPricing( {
 			installedText = translate( 'Installed on %d site', 'Installed on %d sites', {
 				args: [ sitesWithPlugin.length ],
 				count: sitesWithPlugin.length,
+				comment: '%d is the number of sites the user has the plugin installed on.',
 			} );
 		}
 		if ( atomicSiteHasEquivalentFeatureToPluginItem ) {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -14,7 +14,7 @@ import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
-import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
+import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin';
 import { useLocalizedPlugins, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,4 +1,5 @@
 import { WPCOM_FEATURES_INSTALL_PLUGINS } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
 import { Badge, Gridicon } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { Icon, info } from '@wordpress/icons';
@@ -13,6 +14,7 @@ import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
+import useAtomicSiteHasEquivalentFeatureToPluginItem from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
 import { useLocalizedPlugins, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
@@ -117,14 +119,28 @@ const PluginsBrowserListElement = ( props ) => {
 		return ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.slug );
 	}, [ isJetpack, site, plugin ] );
 
+	// Atomic sites already include features such as Jetpack backup, scan, videopress, publicize, and search. So
+	// therefore we should prevent users from installing these standalone plugin equivalents.
+	const atomicSiteHasEquivalentFeatureToPluginItem = useAtomicSiteHasEquivalentFeatureToPluginItem(
+		plugin.slug
+	);
+
 	const isPluginInstalledOnSite = useMemo(
 		() =>
 			selectedSite?.ID &&
 			( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) ||
 				isWpcomPreinstalled ||
-				isPreinstalledPremiumPluginUpgraded ),
-		[ selectedSite?.ID, sitesWithPlugin, isWpcomPreinstalled, isPreinstalledPremiumPluginUpgraded ]
+				isPreinstalledPremiumPluginUpgraded ||
+				atomicSiteHasEquivalentFeatureToPluginItem ),
+		[
+			selectedSite?.ID,
+			sitesWithPlugin,
+			isWpcomPreinstalled,
+			isPreinstalledPremiumPluginUpgraded,
+			atomicSiteHasEquivalentFeatureToPluginItem,
+		]
 	);
+
 	const isUntestedVersion = useMemo( () => {
 		const wpVersion = selectedSite?.options?.software_version;
 		const pluginTestedVersion = plugin?.tested;
@@ -141,9 +157,13 @@ const PluginsBrowserListElement = ( props ) => {
 			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
 	);
 
-	const isPluginIncompatible = useMemo( () => {
+	const isIncompatiblePlugin = useMemo( () => {
 		return ! isCompatiblePlugin( plugin.slug ) && ! jetpackNonAtomic;
-	} );
+	}, [ jetpackNonAtomic, plugin.slug ] );
+
+	const isIncompatibleBackupPlugin = useMemo( () => {
+		return 'vaultpress' === plugin.slug && ! jetpackNonAtomic;
+	}, [ jetpackNonAtomic, plugin.slug ] );
 
 	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite?.ID ) );
 
@@ -157,13 +177,19 @@ const PluginsBrowserListElement = ( props ) => {
 	}
 
 	const classNames = classnames( 'plugins-browser-item', variant, {
-		incompatible: isPluginIncompatible,
+		incompatible: isIncompatiblePlugin || isIncompatibleBackupPlugin,
 	} );
 
-	const onClick = ( e ) => {
+	const onClickIncompatiblePlugin = ( e ) => {
 		e.preventDefault();
 		e.stopPropagation();
 		window.location.href = localizeUrl( 'https://wordpress.com/support/incompatible-plugins/' );
+	};
+
+	const onClickIncompatibleBackup = ( e ) => {
+		e.preventDefault();
+		e.stopPropagation();
+		page( `/backup/${ site }` );
 	};
 
 	return (
@@ -194,15 +220,26 @@ const PluginsBrowserListElement = ( props ) => {
 						</span>
 					</div>
 				) }
-				{ isPluginIncompatible && (
+				{ isIncompatiblePlugin && ! isIncompatibleBackupPlugin && (
 					<span
 						role="link"
 						tabIndex="-1"
-						onClick={ onClick }
-						onKeyPress={ onClick }
+						onClick={ onClickIncompatiblePlugin }
+						onKeyPress={ onClickIncompatiblePlugin }
 						className="plugins-browser-item__incompatible"
 					>
 						{ translate( 'Why is this plugin not compatible with WordPress.com?' ) }
+					</span>
+				) }
+				{ isIncompatibleBackupPlugin && (
+					<span
+						role="link"
+						tabIndex="-1"
+						onClick={ onClickIncompatibleBackup }
+						onKeyPress={ onClickIncompatibleBackup }
+						className="plugins-browser-item__incompatible"
+					>
+						{ translate( 'Your site plan already includes Jetpack VaultPress Backup.' ) }
 					</span>
 				) }
 				<div className="plugins-browser-item__footer">
@@ -210,6 +247,9 @@ const PluginsBrowserListElement = ( props ) => {
 						<InstalledInOrPricing
 							sitesWithPlugin={ sitesWithPlugin }
 							isWpcomPreinstalled={ isWpcomPreinstalled }
+							atomicSiteHasEquivalentFeatureToPluginItem={
+								atomicSiteHasEquivalentFeatureToPluginItem
+							}
 							plugin={ plugin }
 							shouldUpgrade={ shouldUpgrade }
 							canInstallPlugins={ canInstallPlugins }
@@ -252,6 +292,7 @@ const PluginsBrowserListElement = ( props ) => {
 function InstalledInOrPricing( {
 	sitesWithPlugin,
 	isWpcomPreinstalled,
+	atomicSiteHasEquivalentFeatureToPluginItem,
 	plugin,
 	shouldUpgrade,
 	canInstallPlugins,
@@ -267,25 +308,43 @@ function InstalledInOrPricing( {
 		getPluginOnSites( state, [ selectedSiteId ], softwareSlug )
 	)?.active;
 	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( plugin.slug );
-	const active = isWpcomPreinstalled || isPluginActive;
+
+	const active =
+		isWpcomPreinstalled || isPluginActive || atomicSiteHasEquivalentFeatureToPluginItem;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isSaasProduct = useSelector( ( state ) => isSaasProductSelector( state, plugin.slug ) );
 
-	if ( isPreinstalledPremiumPlugin ) {
+	// is plugin item an already active feature on the site?
+	// is atomicSite and is plugin one of the keys of atomicFeaturesIncludedInPluginsMap?
+	// return does the site have the feature?
+
+	if ( isPreinstalledPremiumPlugin && ! atomicSiteHasEquivalentFeatureToPluginItem ) {
 		return <PreinstalledPremiumPluginBrowserItemPricing plugin={ plugin } />;
 	}
 
-	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
+	if (
+		( sitesWithPlugin && sitesWithPlugin.length > 0 ) ||
+		isWpcomPreinstalled ||
+		atomicSiteHasEquivalentFeatureToPluginItem
+	) {
+		let installedText = '';
+		if ( isWpcomPreinstalled || currentSites?.length === 1 ) {
+			installedText = translate( 'Installed' );
+		} else {
+			installedText = translate( 'Installed on %d site', 'Installed on %d sites', {
+				args: [ sitesWithPlugin.length ],
+				count: sitesWithPlugin.length,
+			} );
+		}
+		if ( atomicSiteHasEquivalentFeatureToPluginItem ) {
+			installedText = translate( 'Included with your plan' );
+		}
+
 		return (
 			<div className="plugins-browser-item__installed-and-active-container">
 				<div className="plugins-browser-item__installed ">
 					<Gridicon icon="checkmark" className="checkmark" size={ 12 } />
-					{ isWpcomPreinstalled || currentSites?.length === 1
-						? translate( 'Installed' )
-						: translate( 'Installed on %d site', 'Installed on %d sites', {
-								args: [ sitesWithPlugin.length ],
-								count: sitesWithPlugin.length,
-						  } ) }
+					{ installedText }
 				</div>
 				{ selectedSiteId && (
 					<div className="plugins-browser-item__active">

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -14,7 +14,7 @@ import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
-import useAtomicSiteHasEquivalentFeatureToPluginItem from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
+import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item';
 import { useLocalizedPlugins, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
@@ -121,7 +121,7 @@ const PluginsBrowserListElement = ( props ) => {
 
 	// Atomic sites already include features such as Jetpack backup, scan, videopress, publicize, and search. So
 	// therefore we should prevent users from installing these standalone plugin equivalents.
-	const atomicSiteHasEquivalentFeatureToPluginItem = useAtomicSiteHasEquivalentFeatureToPluginItem(
+	const atomicSiteHasEquivalentFeatureToPlugin = useAtomicSiteHasEquivalentFeatureToPlugin(
 		plugin.slug
 	);
 
@@ -131,13 +131,13 @@ const PluginsBrowserListElement = ( props ) => {
 			( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) ||
 				isWpcomPreinstalled ||
 				isPreinstalledPremiumPluginUpgraded ||
-				atomicSiteHasEquivalentFeatureToPluginItem ),
+				atomicSiteHasEquivalentFeatureToPlugin ),
 		[
 			selectedSite?.ID,
 			sitesWithPlugin,
 			isWpcomPreinstalled,
 			isPreinstalledPremiumPluginUpgraded,
-			atomicSiteHasEquivalentFeatureToPluginItem,
+			atomicSiteHasEquivalentFeatureToPlugin,
 		]
 	);
 
@@ -247,9 +247,7 @@ const PluginsBrowserListElement = ( props ) => {
 						<InstalledInOrPricing
 							sitesWithPlugin={ sitesWithPlugin }
 							isWpcomPreinstalled={ isWpcomPreinstalled }
-							atomicSiteHasEquivalentFeatureToPluginItem={
-								atomicSiteHasEquivalentFeatureToPluginItem
-							}
+							atomicSiteHasEquivalentFeatureToPlugin={ atomicSiteHasEquivalentFeatureToPlugin }
 							plugin={ plugin }
 							shouldUpgrade={ shouldUpgrade }
 							canInstallPlugins={ canInstallPlugins }
@@ -292,7 +290,7 @@ const PluginsBrowserListElement = ( props ) => {
 function InstalledInOrPricing( {
 	sitesWithPlugin,
 	isWpcomPreinstalled,
-	atomicSiteHasEquivalentFeatureToPluginItem,
+	atomicSiteHasEquivalentFeatureToPlugin,
 	plugin,
 	shouldUpgrade,
 	canInstallPlugins,
@@ -309,8 +307,7 @@ function InstalledInOrPricing( {
 	)?.active;
 	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( plugin.slug );
 
-	const active =
-		isWpcomPreinstalled || isPluginActive || atomicSiteHasEquivalentFeatureToPluginItem;
+	const active = isWpcomPreinstalled || isPluginActive || atomicSiteHasEquivalentFeatureToPlugin;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isSaasProduct = useSelector( ( state ) => isSaasProductSelector( state, plugin.slug ) );
 
@@ -318,14 +315,14 @@ function InstalledInOrPricing( {
 	// is atomicSite and is plugin one of the keys of atomicFeaturesIncludedInPluginsMap?
 	// return does the site have the feature?
 
-	if ( isPreinstalledPremiumPlugin && ! atomicSiteHasEquivalentFeatureToPluginItem ) {
+	if ( isPreinstalledPremiumPlugin && ! atomicSiteHasEquivalentFeatureToPlugin ) {
 		return <PreinstalledPremiumPluginBrowserItemPricing plugin={ plugin } />;
 	}
 
 	if (
 		( sitesWithPlugin && sitesWithPlugin.length > 0 ) ||
 		isWpcomPreinstalled ||
-		atomicSiteHasEquivalentFeatureToPluginItem
+		atomicSiteHasEquivalentFeatureToPlugin
 	) {
 		let installedText = '';
 		if ( isWpcomPreinstalled || currentSites?.length === 1 ) {
@@ -337,7 +334,7 @@ function InstalledInOrPricing( {
 				comment: '%d is the number of sites the user has the plugin installed on.',
 			} );
 		}
-		if ( atomicSiteHasEquivalentFeatureToPluginItem ) {
+		if ( atomicSiteHasEquivalentFeatureToPlugin ) {
 			installedText = translate( 'Included with your plan' );
 		}
 

--- a/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item/index.ts
+++ b/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item/index.ts
@@ -18,7 +18,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
  * @param   {string}  pluginSlug - The slug of the plugin to check.
  * @returns {boolean} True if the plugin is equivalent to any of the Atomic site features.
  */
-export default function useAtomicSiteHasEquivalentFeatureToPluginItem( pluginSlug: string ) {
+export default function useAtomicSiteHasEquivalentFeatureToPlugin( pluginSlug: string ) {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSiteId ) );
 

--- a/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item/index.ts
+++ b/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item/index.ts
@@ -1,0 +1,43 @@
+import {
+	WPCOM_FEATURES_REAL_TIME_BACKUPS,
+	WPCOM_FEATURES_SCAN,
+	WPCOM_FEATURES_VIDEOPRESS,
+	FEATURE_REPUBLICIZE,
+	WPCOM_FEATURES_CLASSIC_SEARCH,
+} from '@automattic/calypso-products';
+import { useSelector } from 'react-redux';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+/**
+ * Checks if a plugin is equivalent to already included features of an Atomic site.
+ * For example, Atomic sites aleady include features such as Jetpack Backup, scan, videopress,
+ * publicize, and search. This hook returns whether the plugin given is equivalent to any of those
+ * included features.
+ * @param   {string}  pluginSlug - The slug of the plugin to check.
+ * @returns {boolean} True if the plugin is equivalent to any of the Atomic site features.
+ */
+export default function useAtomicSiteHasEquivalentFeatureToPluginItem( pluginSlug: string ) {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSiteId ) );
+
+	const atomicFeaturesIncludedInPluginsMap = {
+		'jetpack-backup': WPCOM_FEATURES_REAL_TIME_BACKUPS,
+		'jetpack-protect': WPCOM_FEATURES_SCAN,
+		'jetpack-videopress': WPCOM_FEATURES_VIDEOPRESS,
+		'jetpack-social': FEATURE_REPUBLICIZE,
+		'jetpack-search': WPCOM_FEATURES_CLASSIC_SEARCH,
+	};
+	const featureEquivalentToPluginItem =
+		( isAtomic &&
+			pluginSlug in atomicFeaturesIncludedInPluginsMap &&
+			atomicFeaturesIncludedInPluginsMap[
+				pluginSlug as keyof typeof atomicFeaturesIncludedInPluginsMap
+			] ) ||
+		'';
+
+	return useSelector( ( state ) =>
+		siteHasFeature( state, selectedSiteId, featureEquivalentToPluginItem )
+	);
+}

--- a/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item/index.ts
+++ b/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin-item/index.ts
@@ -31,7 +31,6 @@ export default function useAtomicSiteHasEquivalentFeatureToPluginItem( pluginSlu
 	};
 	const featureEquivalentToPluginItem =
 		( isAtomic &&
-			pluginSlug in atomicFeaturesIncludedInPluginsMap &&
 			atomicFeaturesIncludedInPluginsMap[
 				pluginSlug as keyof typeof atomicFeaturesIncludedInPluginsMap
 			] ) ||

--- a/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin/index.ts
+++ b/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin/index.ts
@@ -29,7 +29,7 @@ export default function useAtomicSiteHasEquivalentFeatureToPlugin( pluginSlug: s
 		'jetpack-social': FEATURE_REPUBLICIZE,
 		'jetpack-search': WPCOM_FEATURES_CLASSIC_SEARCH,
 	};
-	const featureEquivalentToPluginItem =
+	const featureEquivalentToPlugin =
 		( isAtomic &&
 			atomicFeaturesIncludedInPluginsMap[
 				pluginSlug as keyof typeof atomicFeaturesIncludedInPluginsMap
@@ -37,6 +37,6 @@ export default function useAtomicSiteHasEquivalentFeatureToPlugin( pluginSlug: s
 		'';
 
 	return useSelector( ( state ) =>
-		siteHasFeature( state, selectedSiteId, featureEquivalentToPluginItem )
+		siteHasFeature( state, selectedSiteId, featureEquivalentToPlugin )
 	);
 }


### PR DESCRIPTION
Atomic sites include pre-installed features that are already active on an atomic site (such as Jetpack Backup, Scan/Protect, VideoPress, Publicize/Social, and Search). This PR updates the plugins list page to show these overlapping plugins as "Active" and "Included with your plan", preventing users from installing these overlapping plugins on their Atomic site.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to: p9F6qB-e2m-p2
Github task: https://github.com/Automattic/jetpack-marketing/issues/499

## Proposed Changes

For Atomic sites:
- Disable the "VaultPress Backup" plugin (The depreciated one) and instead of displaying the link, "Why is this plugin not compatible with wordpress.com?", we show a link, "Your site plan already includes Jetpack VaultPress Backup", pointing to the Backups page.
- For Jetpack plugins that overlap with Atomic site pre-activated features, we display them as "Included with your plan" and "Active". (See screenshot below)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a WoA Developer Blog:  (In Mission Control, goto `/atomic/wpcom-dev-blogs/`), if you don't already have one. 
    - Make sure it is a true Atomic (Automatic Transfer) site: Read, "How does a site become Atomic?": PCYsg-m19-p2
- Spin up this branch or use the _Calypso Live (direct link)_ below.
- Go to the Plugins page: (Calypso) `/plugins/{YOUR ATOMIC SITE SLUG}`
- In the plugins search bar, search for "Jetpack".
- See all the Jetpack plugins.. 
- First verify that the "VaultPress Backup" plugin (The depreciated one) is disabled, and shows, "Your site plan already includes Jetpack VaultPress Backup".
- Next verify that Jetpack Protect, Jetpack Social, Jetpack VideoPress, Jetpack Backup, and Jetpack Search are all showing as "Included with your plan" and "Active" (See screenshot)
- Click into each plugin detail page and verify that the CTA shows as "Included with your plan" and is disabled.


#### Screenshots

![Screen Shot 2024-04-26 at 02 13 30](https://github.com/Automattic/wp-calypso/assets/11078128/bf179273-53ff-484d-914f-a8d41a0cae36)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?