### PR TITLE
Nav Redesign: Remove chevron from sites row

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/actions-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/actions-field.tsx
@@ -1,24 +1,14 @@
-import { Button, Gridicon } from '@automattic/components';
-import * as React from 'react';
 import { SiteActions } from '../sites-site-actions';
 import type { SiteExcerptData } from '@automattic/sites';
 
 type Props = {
 	site: SiteExcerptData;
-	openSitePreviewPane: ( site: SiteExcerptData ) => void;
 };
 
-const ActionsField = ( { site, openSitePreviewPane }: Props ) => {
+const ActionsField = ( { site }: Props ) => {
 	return (
 		<div className="sites-dataviews__actions">
 			<SiteActions site={ site } />
-			<Button
-				onClick={ () => openSitePreviewPane( site ) }
-				className="site-preview__open"
-				borderless
-			>
-				<Gridicon icon="chevron-right" />
-			</Button>
 		</div>
 	);
 };

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -116,9 +116,7 @@ const DotcomSitesDataViews = ( {
 			{
 				id: 'actions',
 				header: <span>{ __( 'Actions' ) }</span>,
-				render: ( { item }: { item: SiteInfo } ) => (
-					<ActionsField site={ item } openSitePreviewPane={ openSitePreviewPane } />
-				),
+				render: ( { item }: { item: SiteInfo } ) => <ActionsField site={ item } />,
 				enableHiding: false,
 				enableSorting: false,
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix https://github.com/Automattic/dotcom-forge/issues/6740

## Proposed Changes

This PR removes the chevron icon from the site's row.

| before | after | Figma|
|--------|--------|---|
| <img width="1065" alt="Screenshot 2024-04-26 at 16 00 20" src="https://github.com/Automattic/wp-calypso/assets/5287479/0bc43c60-7705-4ff2-b9eb-581e926d043e"> | <img width="1059" alt="Screenshot 2024-04-26 at 16 00 28" src="https://github.com/Automattic/wp-calypso/assets/5287479/b6500c5b-0544-424f-8054-ec3b3f6fda7f"> | <img width="771" alt="Screenshot 2024-04-26 at 16 02 40" src="https://github.com/Automattic/wp-calypso/assets/5287479/859fb77e-b59b-428e-83b8-153b4b025cf3"> |



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare an Atomin site with Classic View 
* Go to the site's `_cli` and run `wp option update wpcom_classic_early_relase 1`.
* Go to `/sites/?flags=layout/dotcom-nav-redesign-v2&page=1`
* See the updated site's row

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?