### PR TITLE
nav redesign v2: fix scrollbars

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -143,8 +143,9 @@ body.command-palette-modal-open {
 // Add extra bottom padding for smaller screens to prevent
 // floating inline help from overlapping content.
 .layout__primary .main {
+	// The height is set to 100% in /sites page so we want to ensure that padding doesn't take us over 100% total height.
+	box-sizing: border-box;
 	padding-bottom: 88px;
-
 	@include breakpoint-deprecated( ">1400px" ) {
 		padding-bottom: 0;
 	}

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -37,6 +37,15 @@
 		padding-block-start: 24px;
 	}
 
+	.item-preview__content {
+		.hosting-overview,
+		.site-monitoring-overview {
+			overflow-y: initial;
+			max-height: initial;
+			padding-bottom: 88px;
+		}
+	}
+
 	@media (min-width: $break-large) {
 		background: inherit;
 

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -55,7 +55,6 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 				// Add border around everything
 				overflow: hidden;
 				min-height: 100vh;
-				height: 100vh;
 				padding: 16px 16px 16px calc( var( --sidebar-width-max ) );
 			}
 

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -55,6 +55,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 				// Add border around everything
 				overflow: hidden;
 				min-height: 100vh;
+				height: 100vh;
 				padding: 16px 16px 16px calc( var( --sidebar-width-max ) );
 			}
 
@@ -65,6 +66,8 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 
 		.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {
 			height: calc( 100vh - 32px );
+			padding-bottom: 0;
+			box-shadow: none;
 		}
 
 		// Update body margin to account for the sidebar width


### PR DESCRIPTION
Fix the multiple layers of scrollbars on the /sites page when a tab is open.


6745-gh-Automattic/dotcom-forge
<img width="1069" alt="Screenshot 2024-04-26 at 4 53 23 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/0b755e46-0da2-402a-8be2-601dbc459603">


### Testing instructions

Test with `?flags=layout/dotcom-nav-redesign-v2` both on and off. (Especially with it OFF to make sure this doesn't cause any regressions)

One change potentially could affect other pages using `.layout__primary .main` so double check some other pages such as /read and /home

Test mobile, tablet, wide desktop etc.

Note, there is currently a known issue on mobile where a second scrollbar is shown. Other scrollbars should be fixed.:

<img width="502" alt="Screenshot 2024-04-26 at 5 08 31 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/0fbbc509-9db1-417a-8ec2-a391f756e4e4">

