### PR TITLE
Sites Dashboard v2: Change the default per page to 50

### DIFF
--- a/client/sites-dashboard-v2/index.tsx
+++ b/client/sites-dashboard-v2/index.tsx
@@ -56,7 +56,7 @@ const siteSortingKeys = [
 	{ dataView: 'last-publish', sortKey: 'updatedAt' },
 ];
 
-const DEFAULT_PER_PAGE = 96;
+const DEFAULT_PER_PAGE = 50;
 const DEFAULT_STATUS_GROUP = 'all';
 
 const SitesDashboardV2 = ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR changes the default per page value from 96 to 50. As discussed in p1714092792535229-slack-C06DN6QQVAQ, the value was originally 96 to better support 2 and 3 column rows (see https://github.com/Automattic/wp-calypso/pull/67690). 

However, Sites Dashboard v2 currently only supports list view, so there is no need for the value to be 96. Instead, this PR proposed the new default value to be 50, which is the same value as A4A.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Ensure that the default per page value is 50.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?