### PR TITLE
Nav Redesign: Remove unnecessary padding from the site panel

### DIFF
--- a/client/sites-dashboard-v2/site-preview-pane/style.scss
+++ b/client/sites-dashboard-v2/site-preview-pane/style.scss
@@ -1,3 +1,7 @@
 .item-preview__content {
-	padding: 32px;
+	padding: 0 32px;
+	> div {
+		// Apply padding-top to the content so that the padding is scrolled together
+		padding: 32px 0;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89934

## Proposed Changes

This PR removes unnecessary padding from the site panel. 

before

https://github.com/Automattic/wp-calypso/assets/5287479/c42b663f-9f96-4069-84e6-701f09fa4449

after

https://github.com/Automattic/wp-calypso/assets/5287479/d68d1a9b-8f65-4923-94f0-533b6fdc70ed


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare an Atomin site with Classic View 
* Go to the site's `_cli` and run `wp option update wpcom_classic_early_relase 1`.
* Go to `/sites/?flags=layout/dotcom-nav-redesign-v2&page=1`
* Click any of your site
* See the updated panel style

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?