### PR TITLE
Sites Dashboard: Add margin top to the Command Palette banner

### DIFF
--- a/client/sites-dashboard/components/hosting-command-palette-banner.tsx
+++ b/client/sites-dashboard/components/hosting-command-palette-banner.tsx
@@ -18,6 +18,7 @@ import DismissibleCard from 'calypso/blocks/dismissible-card';
 const HostingCommandPaletteBannerRoot = styled.div( {
 	'&:not(:empty)': {
 		marginBottom: 25,
+		marginTop: 25,
 	},
 	'.hosting-command-palette-banner': {
 		background: 'linear-gradient(270deg, #E9EFF5 12.03%, rgba(233, 239, 245, 0) 40.39%)',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds margin-top to the Command Palette since the screen now has a wrapper frame.

| Before | After |
| --- | --- |
| ![Screenshot 2024-04-26 at 4 57 35 PM](https://github.com/Automattic/wp-calypso/assets/797888/b37fb40e-55e7-49d5-814a-b156974fa0bc)| ![Screenshot 2024-04-26 at 4 57 23 PM](https://github.com/Automattic/wp-calypso/assets/797888/9986163c-93b0-41da-b049-cff36ac45f82)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the banner is updated as shown above.
* You can enable the banner via the environment badge > preferences, and look for `dismissible-card-hosting-command-palette-banner-display`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?