### PR TITLE
Stats: Apply color schemes to the Devices module donut chart

### DIFF
--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -1,15 +1,15 @@
 import { select as d3Select, mouse as d3Mouse } from 'd3-selection';
 import { pie as d3Pie, arc as d3Arc } from 'd3-shape';
 import { localize } from 'i18n-calypso';
-import { throttle, sortBy } from 'lodash';
+import { throttle } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import DataType from './data-type';
+import { sortData } from './legend';
 
 import './style.scss';
 
 const SVG_SIZE = 300;
-const NUM_COLOR_SECTIONS = 3;
 
 // Bottom left position relative to the cursor for the tooltip,
 // which is the tooltip width offset the distance from the right edge to the arrow.
@@ -17,12 +17,7 @@ const TOOLTIP_OFFSET_X = -207;
 const TOOLTIP_OFFSET_Y = 0;
 
 function transformData( data, { donut = false, startAngle = -Math.PI, svgSize = SVG_SIZE } ) {
-	const sortedData = sortBy( data, ( datum ) => datum.value )
-		.reverse()
-		.map( ( datum, index ) => ( {
-			...datum,
-			sectionNum: index % NUM_COLOR_SECTIONS,
-		} ) );
+	const sortedData = sortData( data );
 
 	const arcs = d3Pie()
 		.startAngle( startAngle )

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -6,12 +6,12 @@ import DataType from './data-type';
 
 const NUM_COLOR_SECTIONS = 3;
 
-function transformData( data ) {
+export function sortData( data ) {
 	return sortBy( data, ( datum ) => datum.value )
 		.reverse()
 		.map( ( datum, index ) => ( {
 			...datum,
-			sectionNum: index % NUM_COLOR_SECTIONS,
+			sectionNum: index % ( data.length || NUM_COLOR_SECTIONS ),
 		} ) );
 }
 
@@ -33,7 +33,7 @@ class PieChartLegend extends Component {
 			return {
 				data: nextProps.data,
 				dataTotal: nextProps.data.reduce( ( sum, { value } ) => sum + value, 0 ),
-				transformedData: transformData( nextProps.data ),
+				transformedData: sortData( nextProps.data ),
 			};
 		}
 

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.scss
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.scss
@@ -45,22 +45,21 @@
 		}
 	}
 
-	// TODO: Update corresponding colors based on color schemes.
-	.pie-chart__chart-section-donut-desktop,
-	.pie-chart__legend-sample-donut-desktop {
-		fill: var(--studio-jetpack-green-60);
+	.pie-chart__chart-section-0,
+	.pie-chart__legend-sample-0 {
+		fill: var(--color-primary-70);
 	}
-	.pie-chart__chart-section-donut-mobile,
-	.pie-chart__legend-sample-donut-mobile {
-		fill: #069e08;
+	.pie-chart__chart-section-1,
+	.pie-chart__legend-sample-1 {
+		fill: var(--color-primary-50);
 	}
-	.pie-chart__chart-section-donut-tablet,
-	.pie-chart__legend-sample-donut-tablet {
-		fill: #64ca43;
+	.pie-chart__chart-section-2,
+	.pie-chart__legend-sample-2 {
+		fill: var(--color-primary-30);
 	}
-	.pie-chart__chart-section-donut-others,
-	.pie-chart__legend-sample-donut-others {
-		fill: #d0e6b8;
+	.pie-chart__chart-section-3,
+	.pie-chart__legend-sample-3 {
+		fill: var(--color-primary-10);
 	}
 }
 

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
@@ -27,6 +27,15 @@ type SelectOptionType = {
 	value: string;
 };
 
+interface StatsDevicesChartData {
+	id: string;
+	value: number;
+	icon: string;
+	name: string;
+	descrtipion?: string;
+	className?: string;
+}
+
 interface StatsModuleDevicesProps {
 	path: string;
 	className?: string;
@@ -37,7 +46,9 @@ interface StatsModuleDevicesProps {
 	isLoading?: boolean;
 }
 
-const prepareChartData = ( data: Array< StatsDevicesData > | undefined ) => {
+const prepareChartData = (
+	data: Array< StatsDevicesData > | undefined
+): Array< StatsDevicesChartData > => {
 	if ( ! data ) {
 		return [];
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1HpG7-r9Q-p2#comment-69969

## Proposed Changes

* Apply Calypso color schemes to the donut chart of the Devices module.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Calypso Stats
* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page for a Jetpack site purchased commercial license with the feature flag `?flags=stats/devices`.
* Ensure the donut chart of the Devices module works in line with the design.

<img width="652" alt="截圖 2024-04-26 下午10 56 40" src="https://github.com/Automattic/wp-calypso/assets/6869813/b5c632c3-8b8d-4b0f-af05-acc5ef7be9f2">

#### Odyssey Stats
* Follow the testing instructions in the Jetpack PR: https://github.com/Automattic/jetpack/pull/37098.
* Ensure the donut chart of the Devices module works in line with the design.

<img width="651" alt="截圖 2024-04-26 下午10 56 17" src="https://github.com/Automattic/wp-calypso/assets/6869813/a2337a9e-26fa-443a-b87c-0c86697bf5ff">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?