### PR TITLE
Add-Ons: Pass the locale parameter for fetching products

### DIFF
--- a/packages/data-stores/src/products-list/queries/use-products.ts
+++ b/packages/data-stores/src/products-list/queries/use-products.ts
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import * as ProductsList from '../../products-list';
@@ -18,15 +19,16 @@ function useProducts(
 ): UseQueryResult< ProductsIndex > {
 	const queryKeys = useQueryKeysFactory();
 	const product_slugs = productSlugs?.join( ',' ) ?? null;
+	const locale = useLocale();
 
 	return useQuery( {
-		queryKey: [ ...queryKeys.products(), product_slugs ],
+		queryKey: [ ...queryKeys.products(), product_slugs, locale ],
 		queryFn: async (): Promise< ProductsIndex > => {
 			const apiProducts: RawAPIProductsList = await wpcomRequest( {
 				path: `/products`,
 				apiVersion: '1.1',
 				...( product_slugs
-					? { query: new URLSearchParams( { product_slugs: product_slugs } ).toString() }
+					? { query: new URLSearchParams( { product_slugs, locale } ).toString() }
 					: {} ),
 			} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 776-gh-Automattic/i18n-issues

## Proposed Changes

* Pass the `locale` parameter to the products query to fetch the product properties in the user locale.

**Before:**
![3TbTdpK00N8tNG33](https://github.com/Automattic/wp-calypso/assets/2722412/5ce9e838-b11a-4821-8a31-7353deaf9c1d)

**After:**
![jV8DVj3kiP5nI5Uu](https://github.com/Automattic/wp-calypso/assets/2722412/031c8329-6584-46bf-a91e-aa23308c8a24)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI to a Mag-16 language.
* Navigate to `/add-ons/` and select a site.
* Confirm products fetched from the API are in the user locale.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
