### PR TITLE
Link tk_ai anonymous ids cross-domain (Jetpack checkout flow)

### DIFF
--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -1,3 +1,4 @@
+import { getCurrentUser, getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import {
 	PRODUCT_JETPACK_SEARCH,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
@@ -40,6 +41,11 @@ export function buildCheckoutURL(
 		// user is in Jetpack Cloud.
 		if ( ! urlQueryArgs.source ) {
 			urlQueryArgs.source = 'jetpack-plans';
+		}
+
+		if ( ! urlQueryArgs._tkl && ! getCurrentUser() && getTracksAnonymousUserId() ) {
+			// If the user is not logged in, going to the checkout page will override current tk_ai - we need to pass it through URL to link it to the new one.
+			urlQueryArgs._tkl = getTracksAnonymousUserId();
 		}
 
 		// This URL is used when clicking the back button in the checkout screen to redirect users

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -150,6 +150,12 @@ export function initializeAnalytics(
 		identifyUser( currentUser );
 	}
 
+	const tracksLinkerId = getUrlParameter( '_tkl' );
+	if ( tracksLinkerId && tracksLinkerId !== getTracksAnonymousUserId() ) {
+		// Link tk_ai anonymous ids if _tkl parameter is present in URL and ids between pages are different (e.g. cross-domain)
+		signalUserFromAnotherProduct( 'anon', tracksLinkerId );
+	}
+
 	// Tracks blocked?
 	debug( 'checkForBlockedTracks' );
 	return checkForBlockedTracks();


### PR DESCRIPTION
## Proposed Changes

Currently, checkout flow tracking for anonymous users is broken - we lose track of anonymous id that has been created on jetpack.com, as we don't pass it to wordpress.com (where we generate another one). That way, our conversion rate insights might be inadequate.

## Testing Instructions

* Enter Jetpack Cloud Live link (in incognito tab)
* Get `tk_ai` cookie value from there
* Enter Calypso Live link (in incognito tab)
* Using your Calypso Live domain, open `<Calypso Live>/checkout/jetpack/jetpack_ai_yearly?_tkl=<tk_ai>`
* Using Tracks Vigilante, notice `_aliasUserGeneral` event, similar to this one:
![CleanShot 2024-04-26 at 11 34 36@2x](https://github.com/Automattic/wp-calypso/assets/8419292/b77809d5-dea8-4745-8321-e5e66adfeeb3)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?