### PR TITLE
Staging Sites: Localize options within the Staging Sync Card component

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -39,52 +39,6 @@ function useIsFailedSyncError( error: string | null | undefined ) {
 	return STAGING_SYNC_FAILED_ERROR_CODES.includes( error );
 }
 
-const synchronizationOptions: CheckboxOptionItem[] = [
-	{
-		name: 'sqls',
-		label: 'Site database (SQL)',
-		subTitle: translate(
-			'Overwrite the database, including any posts, pages, products, or orders.'
-		),
-		checked: false,
-		isDangerous: true,
-	},
-	{
-		name: 'themes',
-		label: translate( 'Theme files and directories' ),
-		checked: false,
-		isDangerous: false,
-	},
-	{
-		name: 'plugins',
-		label: translate( 'Plugin files and directories' ),
-		checked: false,
-		isDangerous: false,
-	},
-	{
-		name: 'uploads',
-		label: translate( 'Media uploads' ),
-		subTitle: translate(
-			'You must also select ‘Site database’ for the files to appear in the Media Library.'
-		),
-		checked: false,
-		isDangerous: false,
-	},
-	{
-		name: 'contents',
-		label: translate( 'wp-content files and directories' ),
-		subTitle: translate( 'Apart from themes, plugins, and uploads.' ),
-		checked: false,
-		isDangerous: false,
-	},
-	{
-		name: 'roots',
-		label: translate( 'Additional web root files and directories' ),
-		checked: false,
-		isDangerous: false,
-	},
-];
-
 const StagingSyncCardBody = styled.div( {
 	display: 'flex',
 	'&&&': {
@@ -196,6 +150,54 @@ const StagingToProductionSync = ( {
 } ) => {
 	const [ typedSiteName, setTypedSiteName ] = useState( '' );
 	const translate = useTranslate();
+	const synchronizationOptions: CheckboxOptionItem[] = useMemo(
+		() => [
+			{
+				name: 'sqls',
+				label: 'Site database (SQL)',
+				subTitle: translate(
+					'Overwrite the database, including any posts, pages, products, or orders.'
+				),
+				checked: false,
+				isDangerous: true,
+			},
+			{
+				name: 'themes',
+				label: translate( 'Theme files and directories' ),
+				checked: false,
+				isDangerous: false,
+			},
+			{
+				name: 'plugins',
+				label: translate( 'Plugin files and directories' ),
+				checked: false,
+				isDangerous: false,
+			},
+			{
+				name: 'uploads',
+				label: translate( 'Media uploads' ),
+				subTitle: translate(
+					'You must also select ‘Site database’ for the files to appear in the Media Library.'
+				),
+				checked: false,
+				isDangerous: false,
+			},
+			{
+				name: 'contents',
+				label: translate( 'wp-content files and directories' ),
+				subTitle: translate( 'Apart from themes, plugins, and uploads.' ),
+				checked: false,
+				isDangerous: false,
+			},
+			{
+				name: 'roots',
+				label: translate( 'Additional web root files and directories' ),
+				checked: false,
+				isDangerous: false,
+			},
+		],
+		[ translate ]
+	);
 	return (
 		<>
 			{ showSyncPanel && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 778-gh-Automattic/i18n-issues

## Proposed Changes

Using a static `translate` calls could result in executing the function before the translation data is loaded to the `i18n-calypso` instance, due to loading the translation data asynchronously. To avoid that, it's recommended to use the `useTranslate` hook or wrap the component that renders the strings with the `localize` HOC, so that the component re-renders when the translation data is updated.

* Move the definition of `synchronizationOptions` inside the component and use the `useTranslate` hook to translate the options, so that the array of options can be recomputed if/when the i18n locale data changes (i.e. when the async chunks are loaded).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Navigate to `/hosting-config` and select a site.
* Under "Choose synchronization direction:", select "Staging to production" and confirm the options are translated as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
