### PR TITLE
Scheduled Updates: Unlock the health path check feature

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -161,14 +161,13 @@ export const ScheduleForm = ( props: Props ) => {
 					setFieldTouched( { ...fieldTouched, plugins: touched } );
 				} }
 			/>
-			<>
-				<Text>{ translate( 'Step 3' ) }</Text>
-				<ScheduleFormPaths
-					paths={ healthCheckPaths }
-					borderWrapper={ false }
-					onChange={ setHealthCheckPaths }
-				/>
-			</>
+
+			<Text>{ translate( 'Step 3' ) }</Text>
+			<ScheduleFormPaths
+				paths={ healthCheckPaths }
+				borderWrapper={ false }
+				onChange={ setHealthCheckPaths }
+			/>
 		</form>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { __experimentalText as Text } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -162,17 +161,14 @@ export const ScheduleForm = ( props: Props ) => {
 					setFieldTouched( { ...fieldTouched, plugins: touched } );
 				} }
 			/>
-
-			{ isEnabled( 'plugins/multisite-scheduled-updates' ) && (
-				<>
-					<Text>{ translate( 'Step 3' ) }</Text>
-					<ScheduleFormPaths
-						paths={ healthCheckPaths }
-						borderWrapper={ false }
-						onChange={ setHealthCheckPaths }
-					/>
-				</>
-			) }
+			<>
+				<Text>{ translate( 'Step 3' ) }</Text>
+				<ScheduleFormPaths
+					paths={ healthCheckPaths }
+					borderWrapper={ false }
+					onChange={ setHealthCheckPaths }
+				/>
+			</>
 		</form>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6531

## Proposed Changes

* Unlock the health check path feature to all the users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review should be enough, but if you want to double check, apply this PR and make sure the health check path feature shows up correctly when create/edit a schedule.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?