### PR TITLE
Sites Dashboard V2: The Hosting and Monitoring tabs should not have overflow and max-height

### DIFF
--- a/client/sites-dashboard-v2/site-preview-pane/style.scss
+++ b/client/sites-dashboard-v2/site-preview-pane/style.scss
@@ -1,3 +1,10 @@
 .item-preview__content {
 	padding: 32px;
+
+	.hosting-overview,
+	.site-monitoring-overview {
+		overflow-y: unset;
+		max-height: none;
+	}
 }
+


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The Hosting and Monitoring tabs should not have overflow and max-height. The rest of the tabs are okay.

![image](https://github.com/Automattic/wp-calypso/assets/9832440/ec71e136-55ce-482d-9e73-9e13f954c810)

```
max-height: calc(100vh - 300px);
overflow-y: auto;
```

**In these tabs:**

Overview => .hosting-overview
Monitoring => .site-monitoring-overview

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
