### PR TITLE
A4A: Add WPCOM Creator plan purchase flow feature flag.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/constants.ts
@@ -2,5 +2,6 @@ export const PRODUCT_FILTER_ALL = '';
 export const PRODUCT_FILTER_PLANS = 'plans';
 export const PRODUCT_FILTER_PRODUCTS = 'products';
 export const PRODUCT_FILTER_PRESSABLE_PLANS = 'pressable-plans';
+export const PRODUCT_FILTER_WPCOM_PLANS = 'wpcom-plans';
 export const PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS = 'woocommerce-extensions';
 export const PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS = 'vaultpress-backup-addons';

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -16,8 +16,9 @@ import {
 	PRODUCT_FILTER_PRODUCTS,
 	PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
 	PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+	PRODUCT_FILTER_WPCOM_PLANS,
 } from '../constants';
-import { isPressableHostingProduct } from '../lib/hosting';
+import { isPressableHostingProduct, isWPCOMHostingProduct } from '../lib/hosting';
 import type { SiteDetails } from '@automattic/data-stores';
 
 // Plans and Products that we can merged into 1 card.
@@ -69,6 +70,12 @@ const getProductsAndPlansByFilter = (
 			return (
 				allProductsAndPlans?.filter( ( { family_slug } ) =>
 					isPressableHostingProduct( family_slug )
+				) || []
+			);
+		case PRODUCT_FILTER_WPCOM_PLANS:
+			return (
+				allProductsAndPlans?.filter( ( { family_slug } ) =>
+					isWPCOMHostingProduct( family_slug )
 				) || []
 			);
 	}
@@ -183,6 +190,10 @@ export default function useProductAndPlans( {
 			),
 			pressablePlans: getProductsAndPlansByFilter(
 				PRODUCT_FILTER_PRESSABLE_PLANS,
+				filteredProductsAndBundles
+			),
+			wpcomPlans: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_WPCOM_PLANS,
 				filteredProductsAndBundles
 			),
 			suggestedProductSlugs,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -30,17 +31,22 @@ export default function HostingList( { selectedSite }: Props ) {
 
 	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
 
-	const { isLoadingProducts, pressablePlans } = useProductAndPlans( {
+	const { isLoadingProducts, pressablePlans, wpcomPlans } = useProductAndPlans( {
 		selectedSite,
 		productSearchQuery,
 	} );
+
+	const isWPCOMOptionEnabled = isEnabled( 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' );
 
 	const cheapestPressablePlan = useMemo(
 		() => ( pressablePlans.length ? getCheapestPlan( pressablePlans ) : null ),
 		[ pressablePlans ]
 	);
 
-	const cheapestWPCOMPlan = null; // FIXME: Need to fetch from API
+	const cheapestWPCOMPlan = useMemo(
+		() => ( isWPCOMOptionEnabled && wpcomPlans.length ? getCheapestPlan( wpcomPlans ) : null ),
+		[ isWPCOMOptionEnabled, wpcomPlans ]
+	);
 
 	const onProductSearch = useCallback(
 		( value: string ) => {

--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -61,3 +61,12 @@ export function getHostingLogo( slug: string ) {
 export function isPressableHostingProduct( keyOrSlug: string ) {
 	return keyOrSlug.startsWith( 'pressable-hosting' ) || keyOrSlug.startsWith( 'jetpack-pressable' );
 }
+
+/**
+ * Determine if current slug is a WPCOM hosting product.
+ * @param {string} slug - Product slug
+ * @returns {boolean} - True if WPCOM hosting product, false if not
+ */
+export function isWPCOMHostingProduct( slug: string ) {
+	return slug.startsWith( 'wpcom-hosting' );
+}

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -29,6 +29,7 @@
 	"oauth_client_id": 95928,
 	"features": {
 		"a8c-for-agencies": true,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"always_use_logout_url": true,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -26,6 +26,7 @@
 	],
 	"features": {
 		"a8c-for-agencies": true,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": false,
 		"oauth": false,
 		"a4a/site-details-pane": true
 	},

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -28,6 +28,7 @@
 	"oauth_client_id": 95932,
 	"features": {
 		"a8c-for-agencies": true,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": false,
 		"oauth": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -28,6 +28,7 @@
 	"oauth_client_id": 95931,
 	"features": {
 		"a8c-for-agencies": true,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": false,
 		"oauth": true,
 		"a4a/site-details-pane": true
 	},


### PR DESCRIPTION
This pull request adds a new feature flag for the WPCOM Creator plan purchase flow. Additionally, I have added logic to load the WPCOM option when the flag is enabled to make testing easier.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/359
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/360

## Proposed Changes

* Add `a8c-for-agencies/wpcom-creator-plan-purchase-flow` feature flag in A4A environment config.
* Updating Hosting page to load WPCOM options when the feature flag is enabled.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/hosting`
* Confirm that you don't see the WPCOM option.
   <img width="1519" alt="Screenshot 2024-04-26 at 6 38 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/bfbb457f-c565-4883-ab9a-a501f0bd6e04">

* Now go to the same link with feature flag enabled `/marketplace/hosting?flags=a8c-for-agencies/wpcom-creator-plan-purchase-flow`
* Confirm that you can see the WPCOM option.
  <img width="1608" alt="Screenshot 2024-04-26 at 6 39 06 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/aa9f5a03-99f2-4d7e-aff6-7746c01705f4">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?