### PR TITLE
Store source domain in identify step and fix steps in migration-signup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -5,10 +5,13 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
+import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import SiteMigrationIdentify from '..';
 import { UrlData } from '../../../../../../../blocks/import/types';
 import { StepProps } from '../../../types';
 import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site-slug' );
 
 const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
 
@@ -35,12 +38,16 @@ const API_RESPONSE_WITH_OTHER_PLATFORM: UrlData = {
 	},
 };
 
+const MOCK_WORDPRESS_SITE_SLUG = 'test-example.wordpress.com';
+
 const getInput = () => screen.getByLabelText( /Enter your site address/ );
 
 describe( 'SiteMigrationIdentify', () => {
 	beforeAll( () => nock.disableNetConnect() );
 
-	it( 'continues the flow when the platform is wordpress', async () => {
+	it( 'continues the flow and saves the migration domain when the platform is wordpress', async () => {
+		useSiteSlug.mockReturnValue( MOCK_WORDPRESS_SITE_SLUG );
+
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 
@@ -49,13 +56,28 @@ describe( 'SiteMigrationIdentify', () => {
 			.query( { site_url: 'https://example.com' } )
 			.reply( 200, API_RESPONSE_WORDPRESS_PLATFORM );
 
+		const saveSettingsMock = mockApi()
+			.post(
+				`/rest/v1.4/sites/${ MOCK_WORDPRESS_SITE_SLUG }/settings`,
+				JSON.stringify( { migration_source_site_domain: API_RESPONSE_WORDPRESS_PLATFORM.url } )
+			)
+			.reply( 200, {
+				updated: { migration_source_site_domain: API_RESPONSE_WORDPRESS_PLATFORM.url },
+			} );
+
 		await userEvent.type( getInput(), 'https://example.com' );
 
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
-		await waitFor( () =>
-			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { platform: 'wordpress' } ) )
-		);
+		await waitFor( () => {
+			expect( submit ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					platform: 'wordpress',
+					from: API_RESPONSE_WORDPRESS_PLATFORM.url,
+				} )
+			);
+			expect( saveSettingsMock.isDone() ).toBeTruthy();
+		} );
 	} );
 
 	it( 'continues the flow when the platform is unknown', async () => {

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -221,8 +221,14 @@ const migrationSignup: Flow = {
 				}
 
 				case STEPS.PROCESSING.slug: {
-					// If we just created the site, go to the upgrade plan step.
+					// If we just created the site, either go to the upgrade plan step, or the site identification step.
 					if ( providedDependencies?.siteId && providedDependencies?.siteSlug ) {
+						if ( ! fromQueryParam ) {
+							return navigate(
+								addQueryArgs( { siteId, siteSlug }, STEPS.SITE_MIGRATION_IDENTIFY.slug )
+							);
+						}
+
 						return navigate(
 							addQueryArgs(
 								{ siteId, siteSlug, from: fromQueryParam },

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -173,12 +173,6 @@ const siteMigration: Flow = {
 						action: SiteMigrationIdentifyAction;
 					};
 
-					if ( siteSlug ) {
-						await saveSiteSettings( siteSlug, {
-							migration_source_site_domain: from,
-						} );
-					}
-
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
 						return exitFlow(
 							addQueryArgs(

--- a/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
@@ -83,7 +83,7 @@ describe( 'Migration Signup Flow', () => {
 			} );
 		} );
 
-		it( 'redirects the user to the site-migration-upgrade-plan step from the processing step', () => {
+		it( 'redirects the user to the site-migration-identify step from the processing step', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
 
 			runUseStepNavigationSubmit( {
@@ -96,7 +96,25 @@ describe( 'Migration Signup Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com`,
+				path: `/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }?siteSlug=example.wordpress.com`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects the user to the site-migration-upgrade-plan step from the processing step when we have a from', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.PROCESSING.slug,
+				currentURL: `/setup/${ STEPS.PROCESSING.slug }?siteSlug=&from=https%3A%2F%2Fexample.com%2F`,
+				dependencies: {
+					siteSlug: 'example.wordpress.com',
+					siteId: 123,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fexample.com%2F`,
 				state: {
 					hideFreeMigrationTrialForNonVerifiedEmail: true,
 				},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/89866
* https://github.com/Automattic/wp-calypso/issues/89649

## Proposed Changes

This PR tackles two related issues:
* The PR ensures that we show users the `site-migration-identify` step in the `migration-signup` flow
* The PR moves the logic for saving the source domain into the `site-migration-identify` step so it can be done across migration flows

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Navigate to `/setup/migration-signup` while logged in -- ensure you have your browser's network tab open
* Verify that after the site is created, you're redirected to the `site-migration-identify` step
* Enter the URL for a valid WordPress site, and click Continue
* Verify that you see a `POST` API call to `/rest/v1.4/site/:siteSlug/settings` that specifies the `migration_source_site_domain` value, and that it matches the domain you entered before
* Create a new site via `/start` and work through the flow until you get to the goal selection screen
* Select the `Import existing content or website` option and click on Continue
* You should be taken to the site identify step in `/setup/site-migration`
* Enter a valid WordPress site in the input field, ensure your browser network tab is open, and click Continue
* Verify that you see a `POST` API call to `/rest/v1.4/site/:siteSlug/settings` that specifies the `migration_source_site_domain` value, and that it matches the domain you entered before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
