### PR TITLE
Global Sidebar: Fix the icon when collapsed

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -425,6 +425,9 @@ $brand-text: "SF Pro Text", $sans;
 		}
 
 		.sidebar__body {
+			.sidebar__menu-item-parent .sidebar__menu-link {
+				margin: 0;
+			}
 			.sidebar__menu-link-text {
 				display: none;
 			}

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -401,6 +401,7 @@ $brand-text: "SF Pro Text", $sans;
 
 		.sidebar__body {
 			padding-top: 0;
+			overflow-y: hidden;
 		}
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -376,6 +376,7 @@ $font-size: rem(14px);
 
 	.global-sidebar .sidebar {
 		background-color: var(--color-sidebar-background);
+		padding-bottom: 0;
 
 		.sidebar__menu-link {
 			line-height: 15px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6762

## Proposed Changes

* Fix the icons are misaligned on the collapsed global sidebar

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3e67f38f-9476-4df6-89ba-ab31fe778181) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a1b2b8cb-3719-4d07-848e-6f62b84da303) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site to open GSV
* Make sure the icons on the collapsed sidebar look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?