### PR TITLE
Hide the Monitoring, PHP Logs, and Server Logs tabs for non-atomic sites

### DIFF
--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -43,6 +43,8 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 		};
 	}, [] );
 
+	const isDotcomSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
+
 	// Dotcom tabs: Overview, Monitoring, GitHub Deployments, Hosting Config
 	const features = useMemo(
 		() => [
@@ -65,7 +67,7 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 			createFeaturePreview(
 				DOTCOM_MONITORING,
 				__( 'Monitoring' ),
-				true,
+				isDotcomSite,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				<SiteMonitoringOverview />
@@ -73,7 +75,7 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 			createFeaturePreview(
 				DOTCOM_PHP_LOGS,
 				__( 'PHP Logs' ),
-				true,
+				isDotcomSite,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				<SiteMonitoringPhpLogs />
@@ -81,7 +83,7 @@ const DotcomPreviewPane = ( { site, closeSitePreviewPane }: Props ) => {
 			createFeaturePreview(
 				DOTCOM_SERVER_LOGS,
 				__( 'Server Logs' ),
-				true,
+				isDotcomSite,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				<SiteMonitoringServerLogs />


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6760

## Proposed Changes

This PR hides the Monitoring, PHP Logs, and Server Logs tabs for non-atomic sites.

**Dotcom - Atomic Site:**

<img width="1243" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/6ee028f5-7235-4ff3-b132-e73ec58e59e0">

**Others**

<img width="1241" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/bb8c699d-492d-4547-9f55-4f4023b23a48">


## Testing Instructions

- Check the code
- Apply this change
- Behind this feature flag: `?flags=layout%2Fdotcom-nav-redesign-v2`
- Go to `/sites`
- Select an Atomic site, it will open the Preview Pane and you will see all the tabs
- Select a non Atomic, you will only see 3 tabs: Overview | Hosting Config | Github Deployments

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
