### PR TITLE
Nav Redesign: Fix the tabs separator border disappears when scrolling

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
@@ -6,6 +6,8 @@
 		clip-path: inset(0 -1px -1px -1px);
 		box-shadow: 0 0 0 1px var(--color-accent-0), 0 1px 2px var(--color-neutral-0);
 		margin: 0;
+		position: relative;
+		z-index: 1;
 
 		.section-nav-tab__link {
 			color: #000;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89939#pullrequestreview-2024411925

## Proposed Changes

* Add `z-index: 1` to make sure the border is over the content when scrolling

|BEFOER|AFTER|
|-|-|
|<img width="800" alt="Screenshot 2567-04-26 at 23 31 17" src="https://github.com/Automattic/wp-calypso/assets/1881481/73654ae1-692b-41ce-ad0e-0a9b7ae3eec3">|<img width="779" alt="Screenshot 2567-04-26 at 23 31 49" src="https://github.com/Automattic/wp-calypso/assets/1881481/ae0295ec-a5e0-4c45-87c9-540c5e1f7953">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Open a site detail and scroll down until the very bottom
* Verify the tabs separator border never disapears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?