### PR TITLE
Fix the Free plan CTA in the site launching flow

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-action-callback.ts
@@ -150,10 +150,11 @@ function useGenerateActionCallback( {
 				return;
 			}
 
-			/* 2. Send user to either manage add-ons or manage plan in case of current plan selection */
+			/* 2. In the logged-in plans dashboard, send user to either manage add-ons or manage plan in case of current plan selection */
 			if (
 				sitePlanSlug &&
 				currentPlan?.productSlug === planSlug &&
+				! flowName &&
 				intent !== 'plans-p2' &&
 				intent !== 'plans-blog-onboarding'
 			) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes the Free plan CTA action in the site launching flow. Currently, the 2nd case of `useGenerateActionCallback()`  should only take effects in the logged-in /plans. However, it will be reached by the site launching flow. This PR attemtps to mitigate the issue by checking `! flowName`. It's not quite satisfying, but should be a good enough interim fix.

Production:

https://github.com/Automattic/wp-calypso/assets/1842898/1ccb7fcd-5187-4d66-9def-5bfca9e0587c

This PR:

https://github.com/Automattic/wp-calypso/assets/1842898/0715fd54-5c5f-42b7-968b-4009ec91c4c0


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that launcing the site from the site launching flow accessed from /settings is working again.
* Make sure that other CTA actions work as expected. i.e.
    * Upgrade from the logged-in /plans
    * Puchase a plan from /start/plans
    * Manage the current plan from the logged-in /plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
