### PR TITLE
Try: PTM experiment and plans grid syncing

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -1,7 +1,6 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 
 const Subheader = styled.p`
@@ -40,18 +39,47 @@ const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) 
 	);
 };
 
+const PlanBenefitHeader = () => {
+	const Container = styled.div`
+		margin: -32px 0 40px 0;
+		text-align: center;
+
+		@media ( max-width: 960px ) {
+			margin-top: -16px;
+		}
+	`;
+
+	const translate = useTranslate();
+
+	return (
+		<Container>
+			<p>{ translate( 'All plans includes:' ) }</p>
+			<p>
+				{ translate(
+					'{{Checkmark}}{{/Checkmark}}Website Building {{Checkmark}}{{/Checkmark}}Hosting {{Checkmark}}{{/Checkmark}}eCommerce',
+					{
+						components: {
+							Checkmark: <Gridicon icon="checkmark" size={ 24 } />,
+						},
+					}
+				) }
+			</p>
+		</Container>
+	);
+};
+
 const PlansPageSubheader = ( {
 	siteSlug,
 	isDisplayingPlansNeededForFeature,
 	deemphasizeFreePlan,
+	showPlanBenefits,
 	onClickFreePlanCTA,
-	content,
 }: {
 	siteSlug?: string | null;
 	isDisplayingPlansNeededForFeature: boolean;
 	deemphasizeFreePlan?: boolean;
+	showPlanBenefits?: boolean;
 	onClickFreePlanCTA: () => void;
-	content?: ReactNode;
 } ) => {
 	const translate = useTranslate();
 
@@ -69,7 +97,7 @@ const PlansPageSubheader = ( {
 					) }
 				</Subheader>
 			) }
-			{ ! deemphasizeFreePlan && content && <Subheader>{ content }</Subheader> }
+			{ ! deemphasizeFreePlan && showPlanBenefits && <PlanBenefitHeader /> }
 			{ isDisplayingPlansNeededForFeature && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
 		</>
 	);

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 
 const Subheader = styled.p`
-	margin: -32px 0 0 0;
+	margin: -32px 0 40px 0;
 	color: var( --studio-gray-60 );
 	font-size: 1rem;
 	text-align: center;
@@ -44,6 +44,7 @@ const HeaderContainer = styled( Subheader )`
 	justify-content: center;
 	font-size: 16px;
 	font-weight: 500;
+	margin-bottom: 0;
 
 	@media ( max-width: 740px ) {
 		flex-direction: column;

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -40,31 +40,49 @@ const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) 
 };
 
 const PlanBenefitHeader = () => {
-	const Container = styled.div`
+	const HeaderContainer = styled.div`
+		display: flex;
+		justify-content: center;
 		margin: -32px 0 40px 0;
 		text-align: center;
+		color: var( --studio-gray-60 );
+		font-size: 16px;
+		line-height: 20px;
+		font-weight: 500;
 
 		@media ( max-width: 960px ) {
 			margin-top: -16px;
 		}
 	`;
 
+	const PrefixSection = styled.p``;
+
+	const FeatureSection = styled.p`
+		.gridicons-checkmark {
+			color: var( --studio-green-50 );
+			vertical-align: middle;
+			margin-left: 12px;
+			margin-right: 4px;
+			padding-bottom: 4px;
+		}
+	`;
+
 	const translate = useTranslate();
 
 	return (
-		<Container>
-			<p>{ translate( 'All plans includes:' ) }</p>
-			<p>
+		<HeaderContainer>
+			<PrefixSection>{ translate( 'All plans includes:' ) }</PrefixSection>
+			<FeatureSection>
 				{ translate(
-					'{{Checkmark}}{{/Checkmark}}Website Building {{Checkmark}}{{/Checkmark}}Hosting {{Checkmark}}{{/Checkmark}}eCommerce',
+					'{{Checkmark}}{{/Checkmark}}Website Building{{Checkmark}}{{/Checkmark}}Hosting{{Checkmark}}{{/Checkmark}}eCommerce',
 					{
 						components: {
-							Checkmark: <Gridicon icon="checkmark" size={ 24 } />,
+							Checkmark: <Gridicon icon="checkmark" size={ 18 } />,
 						},
 					}
 				) }
-			</p>
-		</Container>
+			</FeatureSection>
+		</HeaderContainer>
 	);
 };
 

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -1,0 +1,74 @@
+import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+
+const FreePlanSubHeader = styled.p`
+	margin: -32px 0 40px 0;
+	color: var( --studio-gray-60 );
+	font-size: 1rem;
+	text-align: center;
+	button.is-borderless {
+		font-weight: 500;
+		color: var( --studio-gray-90 );
+		text-decoration: underline;
+		font-size: 16px;
+		padding: 0;
+	}
+	@media ( max-width: 960px ) {
+		margin-top: -16px;
+	}
+`;
+
+const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
+	const translate = useTranslate();
+	const headerText = translate( 'Upgrade your plan to access this feature and more' );
+	const subHeaderText = (
+		<Button className="plans-features-main__view-all-plans is-link" href={ `/plans/${ siteSlug }` }>
+			{ translate( 'View all plans' ) }
+		</Button>
+	);
+
+	return (
+		<FormattedHeader
+			headerText={ headerText }
+			subHeaderText={ subHeaderText }
+			compactOnMobile
+			isSecondary
+		/>
+	);
+};
+
+const PlansPageSubheader = ( {
+	siteSlug,
+	isDisplayingPlansNeededForFeature,
+	deemphasizeFreePlan,
+	onClickFreePlanCTA,
+}: {
+	siteSlug?: string | null;
+	isDisplayingPlansNeededForFeature: boolean;
+	deemphasizeFreePlan?: boolean;
+	onClickFreePlanCTA: () => void;
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ deemphasizeFreePlan && (
+				<FreePlanSubHeader>
+					{ translate(
+						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+						{
+							components: {
+								link: <Button onClick={ onClickFreePlanCTA } borderless />,
+							},
+						}
+					) }
+				</FreePlanSubHeader>
+			) }
+			{ isDisplayingPlansNeededForFeature && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
+		</>
+	);
+};
+
+export default PlansPageSubheader;

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -46,12 +46,17 @@ const HeaderContainer = styled( Subheader )`
 	font-weight: 500;
 	margin-bottom: 0;
 
+	// TODO:
+	// This value is grabbed directly from https://github.com/Automattic/wp-calypso/blob/trunk/packages/plans-grid-next/src/index.tsx#L109
+	// Ideally there should be a shared constant that can be reused from the CSS side.
 	@media ( max-width: 740px ) {
 		flex-direction: column;
 	}
 `;
 
 const PrefixSection = styled.p`
+	// TODO:
+	// The same as above.
 	@media ( max-width: 740px ) {
 		margin-bottom: 4px;
 	}

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -63,7 +63,7 @@ const PrefixSection = styled.p`
 `;
 
 const FeatureSection = styled.p`
-	.gridicons-checkmark {
+	.gridicon.gridicons-checkmark {
 		color: var( --studio-green-50 );
 		vertical-align: middle;
 		margin-left: 12px;

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -93,6 +93,9 @@ const PlanBenefitHeader = () => {
 	);
 };
 
+// TBD
+// It is actually questionable that we implement a subheader here instead of reusing the header mechanism
+// provided by the signup framework. How could we unify them?
 const PlansPageSubheader = ( {
 	siteSlug,
 	isDisplayingPlansNeededForFeature,

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -43,21 +43,26 @@ const PlanBenefitHeader = () => {
 	const HeaderContainer = styled.div`
 		display: flex;
 		justify-content: center;
-		margin: -32px 0 40px 0;
+		margin: -32px 0 0 0;
 		text-align: center;
 		color: var( --studio-gray-60 );
 		font-size: 16px;
-		line-height: 20px;
 		font-weight: 500;
 
 		@media ( max-width: 960px ) {
 			margin-top: -16px;
+			flex-direction: column;
 		}
 	`;
 
-	const PrefixSection = styled.p``;
+	const PrefixSection = styled.p`
+		line-height: 20px;
+		margin-bottom: 4px;
+	`;
 
 	const FeatureSection = styled.p`
+		line-height: 24px;
+
 		.gridicons-checkmark {
 			color: var( --studio-green-50 );
 			vertical-align: middle;

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 
-const FreePlanSubHeader = styled.p`
+const Subheader = styled.p`
 	margin: -32px 0 40px 0;
 	color: var( --studio-gray-60 );
 	font-size: 1rem;
@@ -44,18 +45,20 @@ const PlansPageSubheader = ( {
 	isDisplayingPlansNeededForFeature,
 	deemphasizeFreePlan,
 	onClickFreePlanCTA,
+	content,
 }: {
 	siteSlug?: string | null;
 	isDisplayingPlansNeededForFeature: boolean;
 	deemphasizeFreePlan?: boolean;
 	onClickFreePlanCTA: () => void;
+	content?: ReactNode;
 } ) => {
 	const translate = useTranslate();
 
 	return (
 		<>
 			{ deemphasizeFreePlan && (
-				<FreePlanSubHeader>
+				<Subheader>
 					{ translate(
 						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
 						{
@@ -64,8 +67,9 @@ const PlansPageSubheader = ( {
 							},
 						}
 					) }
-				</FreePlanSubHeader>
+				</Subheader>
 			) }
+			{ ! deemphasizeFreePlan && content && <Subheader>{ content }</Subheader> }
 			{ isDisplayingPlansNeededForFeature && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
 		</>
 	);

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -79,6 +79,7 @@ const PlanBenefitHeader = () => {
 						components: {
 							Checkmark: <Gridicon icon="checkmark" size={ 18 } />,
 						},
+						comment: 'Checkmark is an icon showing a green check mark.',
 					}
 				) }
 			</FeatureSection>

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 
 const Subheader = styled.p`
-	margin: -32px 0 40px 0;
+	margin: -32px 0 0 0;
 	color: var( --studio-gray-60 );
 	font-size: 1rem;
 	text-align: center;
@@ -39,41 +39,34 @@ const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) 
 	);
 };
 
+const HeaderContainer = styled( Subheader )`
+	display: flex;
+	justify-content: center;
+	font-size: 16px;
+	font-weight: 500;
+
+	@media ( max-width: 740px ) {
+		flex-direction: column;
+	}
+`;
+
+const PrefixSection = styled.p`
+	@media ( max-width: 740px ) {
+		margin-bottom: 4px;
+	}
+`;
+
+const FeatureSection = styled.p`
+	.gridicons-checkmark {
+		color: var( --studio-green-50 );
+		vertical-align: middle;
+		margin-left: 12px;
+		margin-right: 4px;
+		padding-bottom: 4px;
+	}
+`;
+
 const PlanBenefitHeader = () => {
-	const HeaderContainer = styled.div`
-		display: flex;
-		justify-content: center;
-		margin: -32px 0 0 0;
-		text-align: center;
-		color: var( --studio-gray-60 );
-		font-size: 16px;
-		font-weight: 500;
-
-		@media ( max-width: 960px ) {
-			margin-top: -16px;
-		}
-
-		@media ( max-width: 740px ) {
-			flex-direction: column;
-		}
-	`;
-
-	const PrefixSection = styled.p`
-		@media ( max-width: 740px ) {
-			margin-bottom: 4px;
-		}
-	`;
-
-	const FeatureSection = styled.p`
-		.gridicons-checkmark {
-			color: var( --studio-green-50 );
-			vertical-align: middle;
-			margin-left: 12px;
-			margin-right: 4px;
-			padding-bottom: 4px;
-		}
-	`;
-
 	const translate = useTranslate();
 
 	return (

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -51,18 +51,20 @@ const PlanBenefitHeader = () => {
 
 		@media ( max-width: 960px ) {
 			margin-top: -16px;
+		}
+
+		@media ( max-width: 740px ) {
 			flex-direction: column;
 		}
 	`;
 
 	const PrefixSection = styled.p`
-		line-height: 20px;
-		margin-bottom: 4px;
+		@media ( max-width: 740px ) {
+			margin-bottom: 4px;
+		}
 	`;
 
 	const FeatureSection = styled.p`
-		line-height: 24px;
-
 		.gridicons-checkmark {
 			color: var( --studio-green-50 );
 			vertical-align: middle;

--- a/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
+++ b/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
@@ -1,0 +1,15 @@
+import config from '@automattic/calypso-config';
+import type { DataResponse } from '@automattic/plans-grid-next';
+
+interface Props {
+	flowName?: string | null;
+}
+
+function useExperimentForTrailMap( { flowName }: Props ): DataResponse< boolean > {
+	return {
+		isLoading: false,
+		result: config.isEnabled( 'onboarding/trail-map-feature-grid' ) && flowName === 'onboarding',
+	};
+}
+
+export default useExperimentForTrailMap;

--- a/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
+++ b/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
@@ -1,14 +1,33 @@
 import config from '@automattic/calypso-config';
+import { useExperiment } from 'calypso/lib/explat';
 import type { DataResponse } from '@automattic/plans-grid-next';
 
 interface Props {
 	flowName?: string | null;
+	isDesktop?: boolean;
 }
 
-function useExperimentForTrailMap( { flowName }: Props ): DataResponse< boolean > {
+function useExperimentForTrailMap( { flowName, isDesktop }: Props ): DataResponse< boolean > {
+	const [ isLoadingDesktop, desktopExperimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_plans_offerings_copy_desktop',
+		{
+			isEligible: flowName === 'onboarding' && isDesktop,
+		}
+	);
+
+	const [ isLoadingMobile, mobileExperimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_plans_offerings_copy_mobile',
+		{
+			isEligible: flowName === 'onboarding' && ! isDesktop,
+		}
+	);
+
 	return {
-		isLoading: false,
-		result: config.isEnabled( 'onboarding/trail-map-feature-grid' ) && flowName === 'onboarding',
+		isLoading: isLoadingDesktop || isLoadingMobile,
+		result:
+			config.isEnabled( 'onboarding/trail-map-feature-grid' ) ||
+			desktopExperimentAssignment?.variationName === 'treatment' ||
+			mobileExperimentAssignment?.variationName === 'treatment',
 	};
 }
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -75,6 +75,7 @@ import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useDeemphasizeFreePlan from './hooks/use-deemphasize-free-plan';
+import useExperimentForTrailMap from './hooks/use-experiment-for-trail-map';
 import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-intervals';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
@@ -759,6 +760,8 @@ const PlansFeaturesMain = ( {
 		gridPlansForFeaturesGrid?.map( ( gridPlan ) => gridPlan.planSlug )
 	);
 
+	const trailMapExperiment = useExperimentForTrailMap( { flowName } );
+
 	return (
 		<>
 			<div
@@ -869,7 +872,7 @@ const PlansFeaturesMain = ( {
 										isLaunchPage={ isLaunchPage }
 										onStorageAddOnClick={ handleStorageAddOnClick }
 										onUpgradeClick={ handleUpgradeClick }
-										paidDomainName={ paidDomainName }
+										paidDomainName={ trailMapExperiment.result ? undefined : paidDomainName }
 										planActionOverrides={ planActionOverrides }
 										planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 										recordTracksEvent={ recordTracksEvent }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -786,6 +786,10 @@ const PlansFeaturesMain = ( {
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
 					onClickFreePlanCTA={ () => handleUpgradeClick() }
+					content={
+						trailMapExperiment.result &&
+						translate( 'All plans included: Website Building Hosting eCommerce' )
+					}
 				/>
 
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -780,8 +780,6 @@ const PlansFeaturesMain = ( {
 							} ) }
 					/>
 				) }
-				// TBD // It is actually questionable that we implement a subheader here instead of reusing
-				the header mechanism // provided by the signup framework. How could we unify them?
 				<PlansPageSubheader
 					siteSlug={ siteSlug }
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -780,7 +780,8 @@ const PlansFeaturesMain = ( {
 							} ) }
 					/>
 				) }
-
+				// TBD // It is actually questionable that we implement a subheader here instead of reusing
+				the header mechanism // provided by the signup framework. How could we unify them?
 				<PlansPageSubheader
 					siteSlug={ siteSlug }
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
@@ -788,7 +789,6 @@ const PlansFeaturesMain = ( {
 					onClickFreePlanCTA={ () => handleUpgradeClick() }
 					showPlanBenefits={ isInSignup && trailMapExperiment.result }
 				/>
-
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (
 					<>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -786,7 +786,7 @@ const PlansFeaturesMain = ( {
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
 					onClickFreePlanCTA={ () => handleUpgradeClick() }
-					showPlanBenefits={ true }
+					showPlanBenefits={ trailMapExperiment.result }
 				/>
 
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -786,10 +786,7 @@ const PlansFeaturesMain = ( {
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
 					onClickFreePlanCTA={ () => handleUpgradeClick() }
-					content={
-						trailMapExperiment.result &&
-						translate( 'All plans included: Website Building Hosting eCommerce' )
-					}
+					showPlanBenefits={ true }
 				/>
 
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -27,6 +27,7 @@ import {
 	useGridPlansForComparisonGrid,
 	useGridPlanForSpotlight,
 } from '@automattic/plans-grid-next';
+import { isDesktop } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
@@ -60,7 +61,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
-import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { getCurrentUserName, getCurrentUserMeta } from 'calypso/state/current-user/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -724,7 +725,13 @@ const PlansFeaturesMain = ( {
 		gridPlansForFeaturesGrid?.map( ( gridPlan ) => gridPlan.planSlug )
 	);
 
-	const trailMapExperiment = useExperimentForTrailMap( { flowName } );
+	const trailMapExperiment = useExperimentForTrailMap( {
+		flowName,
+		isDesktop: isDesktop(),
+	} );
+
+	const isTrailMap =
+		useSelector( getCurrentUserMeta )[ 'use_trail_map_features_grid' ] || trailMapExperiment.result;
 
 	return (
 		<>
@@ -785,7 +792,7 @@ const PlansFeaturesMain = ( {
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
 					onClickFreePlanCTA={ () => handleUpgradeClick() }
-					showPlanBenefits={ isInSignup && trailMapExperiment.result }
+					showPlanBenefits={ isInSignup && isTrailMap }
 				/>
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (
@@ -830,7 +837,7 @@ const PlansFeaturesMain = ( {
 										isLaunchPage={ isLaunchPage }
 										onStorageAddOnClick={ handleStorageAddOnClick }
 										onUpgradeClick={ handleUpgradeClick }
-										paidDomainName={ trailMapExperiment.result ? undefined : paidDomainName }
+										paidDomainName={ isTrailMap ? undefined : paidDomainName }
 										planActionOverrides={ planActionOverrides }
 										planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 										recordTracksEvent={ recordTracksEvent }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -786,7 +786,7 @@ const PlansFeaturesMain = ( {
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
 					onClickFreePlanCTA={ () => handleUpgradeClick() }
-					showPlanBenefits={ trailMapExperiment.result }
+					showPlanBenefits={ isInSignup && trailMapExperiment.result }
 				/>
 
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -48,7 +48,6 @@ import QueryPlans from 'calypso/components/data/query-plans';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -72,6 +71,7 @@ import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/s
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
+import PlansPageSubheader from './components/plans-page-subheader';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useDeemphasizeFreePlan from './hooks/use-deemphasize-free-plan';
@@ -91,23 +91,6 @@ import type {
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
-
-const FreePlanSubHeader = styled.p`
-	margin: -32px 0 40px 0;
-	color: var( --studio-gray-60 );
-	font-size: 1rem;
-	text-align: center;
-	button.is-borderless {
-		font-weight: 500;
-		color: var( --studio-gray-90 );
-		text-decoration: underline;
-		font-size: 16px;
-		padding: 0;
-	}
-	@media ( max-width: 960px ) {
-		margin-top: -16px;
-	}
-`;
 
 const PlanComparisonHeader = styled.h1`
 	.plans .step-container .step-container__content &&,
@@ -198,25 +181,6 @@ export interface PlansFeaturesMainProps {
 	 */
 	deemphasizeFreePlan?: boolean;
 }
-
-const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
-	const translate = useTranslate();
-	const headerText = translate( 'Upgrade your plan to access this feature and more' );
-	const subHeaderText = (
-		<Button className="plans-features-main__view-all-plans is-link" href={ `/plans/${ siteSlug }` }>
-			{ translate( 'View all plans' ) }
-		</Button>
-	);
-
-	return (
-		<FormattedHeader
-			headerText={ headerText }
-			subHeaderText={ subHeaderText }
-			compactOnMobile
-			isSecondary
-		/>
-	);
-};
 
 const PlansFeaturesMain = ( {
 	paidDomainName,
@@ -816,19 +780,14 @@ const PlansFeaturesMain = ( {
 							} ) }
 					/>
 				) }
-				{ deemphasizeFreePlan && (
-					<FreePlanSubHeader>
-						{ translate(
-							`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
-							{
-								components: {
-									link: <Button onClick={ () => handleUpgradeClick() } borderless />,
-								},
-							}
-						) }
-					</FreePlanSubHeader>
-				) }
-				{ isDisplayingPlansNeededForFeature && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
+
+				<PlansPageSubheader
+					siteSlug={ siteSlug }
+					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
+					deemphasizeFreePlan={ deemphasizeFreePlan }
+					onClickFreePlanCTA={ () => handleUpgradeClick() }
+				/>
+
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (
 					<>

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -155,3 +155,10 @@ export function getCurrentUserLasagnaJwt( state ) {
  * @returns {boolean} Whether the current user is bootstrapped
  */
 export const isCurrentUserBootstrapped = createCurrentUserSelector( 'bootstrapped', false );
+
+/**
+ * Returns the meta object of the current user
+ *  @param {Object} state Global state tree
+ *  @returns {Object} The meta object of the current user
+ */
+export const getCurrentUserMeta = createCurrentUserSelector( 'meta', {} );

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -91,7 +91,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				const isHighlightedFeature = selectedFeature
 					? currentFeature.getSlug() === selectedFeature
 					: currentFeature?.isHighlighted ||
-					  currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN ||
+					  ( currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN && paidDomainName ) ||
 					  ! currentFeature.availableForCurrentPlan;
 
 				const divClasses = classNames( '', getPlanClass( planSlug ), {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89685 and #89689

## Proposed Changes

WIP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
