### PR TITLE
Checkout Modal: Add cancel_to by parameter

### DIFF
--- a/client/landing/stepper/utils/checkout.ts
+++ b/client/landing/stepper/utils/checkout.ts
@@ -41,9 +41,11 @@ export const goToCheckout = ( {
 
 	const products = [ ...( plan ? [ plan ] : [] ), ...extraProducts ];
 	const hasProducts = products.length > 0;
-
 	if ( hasProducts && ! forceRedirection ) {
-		openCheckoutModal( products, { redirect_to: destination } );
+		openCheckoutModal( products, {
+			redirect_to: destination,
+			cancel_to: cancelDestination || relativeCurrentPath,
+		} );
 	} else {
 		// If no products are provided, we might have added plan to the cart so we just go to the checkout page directly.
 		// If the flag forceRedirection is true, we also go to the checkout page via redirection.

--- a/client/landing/stepper/utils/checkout.ts
+++ b/client/landing/stepper/utils/checkout.ts
@@ -41,6 +41,7 @@ export const goToCheckout = ( {
 
 	const products = [ ...( plan ? [ plan ] : [] ), ...extraProducts ];
 	const hasProducts = products.length > 0;
+
 	if ( hasProducts && ! forceRedirection ) {
 		openCheckoutModal( products, {
 			redirect_to: destination,

--- a/client/my-sites/checkout/modal/utils.ts
+++ b/client/my-sites/checkout/modal/utils.ts
@@ -8,7 +8,11 @@ export const openCheckoutModal = (
 ) => {
 	const relativeCurrentPath = window.location.href.replace( window.location.origin, '' );
 	const path = addQueryArgs(
-		{ ...searchParams, [ KEY_PRODUCTS ]: products.join( ',' ), cancel_to: relativeCurrentPath },
+		{
+			...searchParams,
+			[ KEY_PRODUCTS ]: products.join( ',' ),
+			cancel_to: searchParams.cancel_to || relativeCurrentPath,
+		},
 		relativeCurrentPath
 	);
 


### PR DESCRIPTION
## Proposed Changes

The `openCheckoutModal` currently overrides the `cancel_to` parameter with `window.location.href`.
This PR lets you use your `cancel_to` url if you pass it in the `searchParams`.

It will be useful in our PR https://github.com/Automattic/wp-calypso/pull/89917, where we need to remove a query parameter when going back (cancel) from the checkout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live link
* Try to use the checkout and then going back. It should continue to work.
* Do a regression test and try to complete a checkout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?