### PR TITLE
Entrepreneur expired trial page.

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
+import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useMemo, useState } from 'react';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -124,6 +125,9 @@ const ECommerceTrialExpired = (): JSX.Element => {
 					/>
 				) }
 				{ isEntrepreneurTrial && <EntrepreneurPlan hideTrialIncluded /> }
+				{ ! isWooExpressTrial && ! isEntrepreneurTrial && (
+					<Spinner className="ecommerce-trial-expired__spinner" />
+				) }
 
 				<div className="ecommerce-trial-expired__footer">
 					<Button href={ exportUrl }>

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -5,6 +5,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useMemo, useState } from 'react';
 import QueryPlans from 'calypso/components/data/query-plans';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -13,9 +14,10 @@ import { WooExpressPlans } from 'calypso/my-sites/plans/ecommerce-trial/wooexpre
 import { useSelector } from 'calypso/state';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 import useOneDollarOfferTrack from '../../hooks/use-onedollar-offer-track';
+import { EntrepreneurPlan } from '../entrepreneur-plan/entrepreneur-plan';
 
 const ECommerceTrialExpired = (): JSX.Element => {
 	const translate = useTranslate();
@@ -24,6 +26,7 @@ const ECommerceTrialExpired = (): JSX.Element => {
 	const siteSlug = selectedSite?.slug ?? null;
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+	const purchase = useSelector( getSelectedPurchase );
 
 	const nonECommerceTrialPurchases = useMemo(
 		() =>
@@ -73,10 +76,15 @@ const ECommerceTrialExpired = (): JSX.Element => {
 		[ page, recordTracksEvent, settingsDeleteSiteUrl ]
 	);
 
+	const isWooExpressTrial = purchase?.isWooExpressTrial;
+	const isEntrepreneurTrial = purchase?.isWooExpressTrial === false;
+
 	return (
 		<>
 			<QueryPlans />
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+			{ siteId && <QuerySitePlans siteId={ siteId } /> }
+
 			<BodySectionCssClass bodyClass={ [ 'is-expired-ecommerce-trial-plan' ] } />
 			<Main wideLayout>
 				<PageViewTracker
@@ -104,15 +112,18 @@ const ECommerceTrialExpired = (): JSX.Element => {
 						) }
 					</div>
 				</div>
-				<WooExpressPlans
-					interval={ interval }
-					monthlyControlProps={ monthlyControlProps }
-					siteId={ siteId ?? 0 }
-					siteSlug={ siteSlug ?? '' }
-					triggerTracksEvent={ triggerPlansGridTracksEvent }
-					yearlyControlProps={ yearlyControlProps }
-					showIntervalToggle={ true }
-				/>
+				{ isWooExpressTrial && (
+					<WooExpressPlans
+						interval={ interval }
+						monthlyControlProps={ monthlyControlProps }
+						siteId={ siteId ?? 0 }
+						siteSlug={ siteSlug ?? '' }
+						triggerTracksEvent={ triggerPlansGridTracksEvent }
+						yearlyControlProps={ yearlyControlProps }
+						showIntervalToggle={ true }
+					/>
+				) }
+				{ isEntrepreneurTrial && <EntrepreneurPlan hideTrialIncluded /> }
 
 				<div className="ecommerce-trial-expired__footer">
 					<Button href={ exportUrl }>

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -46,6 +46,12 @@ body.is-section-plans.is-expired-ecommerce-trial-plan {
 		}
 	}
 
+	.ecommerce-trial-expired__spinner {
+		width: 100%;
+		height: 64px;
+		margin: 64px auto;
+	}
+
 	.ecommerce-trial-expired__footer {
 		border-top: 1px solid var(--color-border-subtle);
 		display: flex;

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
@@ -29,7 +29,7 @@ interface PlanPriceType {
 	slug: string;
 	price?: number;
 	montlyPrice?: number;
-	subText: ReactNode;
+	subText?: ReactNode;
 	discount?: number;
 	discountText?: ReactNode;
 }
@@ -47,19 +47,19 @@ const useEntrepreneurPlanPrices = () => {
 	const baseMontlyPrice =
 		getPlanRawPrice( state, rawPlans[ PLAN_ECOMMERCE_MONTHLY ].getProductId(), false ) || 0;
 
-	const planPrices = {
+	const planPrices: Record< PlanKeys, PlanPriceType > = {
 		PLAN_ECOMMERCE: {
 			term: translate( 'Pay yearly' ),
 			slug: PLAN_ECOMMERCE,
-		} as PlanPriceType,
+		},
 		PLAN_ECOMMERCE_2_YEARS: {
 			term: translate( 'Pay every 2 years' ),
 			slug: PLAN_ECOMMERCE_2_YEARS,
-		} as PlanPriceType,
+		},
 		PLAN_ECOMMERCE_3_YEARS: {
 			term: translate( 'Pay every 3 years' ),
 			slug: PLAN_ECOMMERCE_3_YEARS,
-		} as PlanPriceType,
+		},
 		PLAN_ECOMMERCE_MONTHLY: {
 			term: translate( 'Pay monthly' ),
 			slug: PLAN_ECOMMERCE_MONTHLY,
@@ -69,7 +69,7 @@ const useEntrepreneurPlanPrices = () => {
 				args: { rawPrice: baseMontlyPrice },
 				comment: 'Excl. Taxes is short for excluding taxes',
 			} ),
-		} as PlanPriceType,
+		},
 	};
 	const keys = Object.keys( planPrices ) as PlanKeys[];
 	keys.forEach( ( key ) => {

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/style.scss
@@ -25,6 +25,7 @@
 	display: flex;
 	align-items: center;
 	margin-bottom: 20px;
+	margin-top: 64px;
 	@media ( max-width: $break-large ) {
 		display: block;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6345

## Proposed Changes

Updates the expired trial page to fit Entrepreneur trial.

## Testing Instructions
For testing this you will need an **Entrepreneur trial** account:
p1712672819187649-slack-C02TCEHP3HA

You will also need a **Woo Express trial** to check that we didn't break the original experience
https://woocommerce.com/start/

Even if your trial is not expired, you can force Calypso to render ir by directly typping the following url:
`http://calypso.localhost:3000/plans/my-plan/trial-expired/{your-site-here}`

### Testing your **Entrepreneur trial** site
![image](https://github.com/Automattic/wp-calypso/assets/33497086/adc3f012-6b9a-4998-a045-8567d524fcb1)
- It should look likes the image above.
- Click on the complete purchase button.
- You should be redirected to checkout page targeting the **Entrepreneur** plan and the 1U$ offer should **not** be offered.

###  Testing your **Woo Express trial** site (regression)
![image](https://github.com/Automattic/wp-calypso/assets/33497086/554cadc8-7d07-442e-b8f0-efefd5dcad26)
- It should look likes the image above.
- Click on the complete purchase button.
- You should be redirected to checkout page targeting the **Woo Express** plan and the 1U$ offer should be offered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?