### PR TITLE
Nav Redesign: Fix for dataviews scrolling container

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -181,9 +181,7 @@
 	}
 }
 
-.wpcom-site .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {
-	.div.is-group-sites-dashboard:not(.has-no-masterbar) & {
-		// With masterbar
-		max-height: calc(100vh - 347px); /* 347px is the size of all the height above and below the dataviews-view-table-wrapper */
-	}
+.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {
+	// With masterbar
+	max-height: calc(100vh - 347px); /* 347px is the size of all the height above and below the dataviews-view-table-wrapper */
 }

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -26,6 +26,11 @@
 
 	.dataviews-filters__view-actions {
 		border-bottom: 0;
+		align-items: center;
+	}
+
+	.a4a-layout__header {
+		flex-wrap: nowrap;
 	}
 }
 
@@ -33,7 +38,7 @@
 .dataviews-filters__view-actions {
 	.components-search-control {
 		@include break-large {
-			min-width: 390px;
+			min-width: 337px;
 		}
 	}
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -180,3 +180,10 @@
 		}
 	}
 }
+
+.wpcom-site .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {
+	.div.is-group-sites-dashboard:not(.has-no-masterbar) & {
+		// With masterbar
+		max-height: calc(100vh - 347px); /* 347px is the size of all the height above and below the dataviews-view-table-wrapper */
+	}
+}

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -77,4 +77,8 @@
 
 .main.sites-dashboard.sites-dashboard__layout:has(.dataviews-pagination) {
 	height: calc(100vh - 70px);
+
+	.dataviews-view-table {
+		margin: 0;
+	}
 }

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -209,7 +209,7 @@
 		.dataviews-view-table-wrapper {
 			overflow-y: auto;
 			// Without masterbar
-			max-height: calc(100vh - 261px); /* 261px is the size of all the height above and below the dataviews-view-table-wrapper */
+			max-height: calc(100vh - 285px); /* 285px is the size of all the height above and below the dataviews-view-table-wrapper */
 
 			div.is-group-sites-dashboard:not(.has-no-masterbar) & {
 				// With masterbar

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -265,7 +265,7 @@
 
 			.is-hiding-navigation .dataviews-view-table-wrapper {
 				overflow-y: auto;
-				max-height: calc(100vh - 253px); /* 253px is the size of all content above the dataview in table style, which includes our CTA elements, the pagination bottom bar, and an additional 10px margin. */
+				max-height: calc(100vh - 277px); /* 277px is the size of all content above the dataview in table style, which includes our CTA elements, the pagination bottom bar, and an additional 10px margin. */
 			}
 		}
 

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -213,7 +213,7 @@
 
 			div.is-group-sites-dashboard:not(.has-no-masterbar) & {
 				// With masterbar
-				max-height: calc(100vh - 321px); /* 321px is the size of all the height above and below the dataviews-view-table-wrapper */
+				max-height: calc(100vh - 347px); /* 347px is the size of all the height above and below the dataviews-view-table-wrapper */
 			}
 
 			table {

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -235,6 +235,12 @@
 		}
 	}
 
+	@media (max-width: 600px) {
+		.dataviews-view-table-wrapper {
+			max-height: calc(100vh - 323px); /* 323px is the size of all the height above and below the dataviews-view-table-wrapper */
+		}
+	}
+
 	@media (max-width: $break-wide) {
 		&.sites-dashboard__layout:not(.preview-hidden) {
 			flex-direction: column;

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -92,6 +92,10 @@
 			.sites-overview {
 				overflow: hidden;
 
+				.a4a-layout__viewport {
+					padding-inline: 16px;
+				}
+
 				.sites-overview__page-title-container {
 					display: flex;
 				}
@@ -204,7 +208,13 @@
 
 		.dataviews-view-table-wrapper {
 			overflow-y: auto;
-			max-height: calc(100vh - 326px); /* 326px is the size of all the height above and below the dataview, from the edges of the screen, plus 10px offset from the padding. Currently below 9px + 309 above */
+			// Without masterbar
+			max-height: calc(100vh - 261px); /* 261px is the size of all the height above and below the dataviews-view-table-wrapper */
+
+			div.is-group-sites-dashboard:not(.has-no-masterbar) & {
+				// With masterbar
+				max-height: calc(100vh - 321px); /* 321px is the size of all the height above and below the dataviews-view-table-wrapper */
+			}
 
 			table {
 				width: 100%;
@@ -255,7 +265,7 @@
 
 			.is-hiding-navigation .dataviews-view-table-wrapper {
 				overflow-y: auto;
-				max-height: calc(100vh - 260px); /* 260px is the size of all content above the dataview in table style, which includes our CTA elements, the pagination bottom bar, and an additional 10px margin. */
+				max-height: calc(100vh - 253px); /* 253px is the size of all content above the dataview in table style, which includes our CTA elements, the pagination bottom bar, and an additional 10px margin. */
 			}
 		}
 

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -211,11 +211,6 @@
 			// Without masterbar
 			max-height: calc(100vh - 285px); /* 285px is the size of all the height above and below the dataviews-view-table-wrapper */
 
-			div.is-group-sites-dashboard:not(.has-no-masterbar) & {
-				// With masterbar
-				max-height: calc(100vh - 347px); /* 347px is the size of all the height above and below the dataviews-view-table-wrapper */
-			}
-
 			table {
 				width: 100%;
 				max-width: 100vw;

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -69,6 +69,13 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 			box-shadow: none;
 		}
 
+		div.is-group-sites-dashboard:not( .has-no-masterbar ) {
+			.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {
+				// Fix for scrollbars when global-sidebar is not visible because masterbar is visible
+				height: calc( 100vh - 95px );
+			}
+		}
+
 		// Update body margin to account for the sidebar width
 		@media only screen and ( min-width: 782px ) {
 			div.layout.is-global-sidebar-visible {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the  linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6745 https://github.com/Automattic/wp-calypso/pull/89939

|BEFORE|AFTER|
|-|-|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/9c3c356b-0a10-4cdf-ae8c-86a7bcfa3939">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/36806e34-aecc-4ec5-8451-6b39f053b044">|


## Proposed Changes

* Avoid the header "Sites" from wrapping on all viewports as that affects the height of the dataviews and because it looks better on the right IMO cc: @davemart-in 
* Reduce the horizontal padding of the container of the header "Sites" in small breakpoints  
* Reduce the width of the search input so it doesn't push down the button "Reset filters" in small breakpoints

These changes fix the following issues:
 - the dataviews scroll container `.dataviews-view-table-wrapper` fits the available height completely in all breakpoints
 - avoid the container `.sites-dashboard__layout` from being scrollable

> [!Note]
> I aligned the "View Options" icon button to the center but that doesn't work well on the smallest breakpoint. Also,  "Reset filters" button drops down. I will create an issue for that to get a design. cc: @davemart-in 

> [!Warning]
> I would expect that `is-global-sidebar-visible` is not applied when the sidebar collapses in small breakpoints. Let's consider fixing that in a follow-up PR. I have used `.has-no-masterbar` as a workaround because it is applied when the sidebar is visible. I'll create an issue for this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Scroll the list of sites to verify the last item touches the bottom of the scrolling area
* Place the cursor on the header and try to scroll it to verify another scrollbar does not appear
* Repeat the test in small breakpoints
* Open a site detail to verify the scroll and UI works and looks as expected
* Test these changes on A4A too  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?