### PR TITLE
Untangling: temporarily hide Hosting menus already in GSV when nav redesign is enabled

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -150,7 +150,25 @@ const useSiteMenuItems = () => {
 		showSiteMonitoring: isAtomic,
 	};
 
-	return menuItemsWithNewsletterSettings ?? buildFallbackResponse( fallbackDataOverrides );
+	const result = menuItemsWithNewsletterSettings ?? buildFallbackResponse( fallbackDataOverrides );
+
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		return result.map( ( menu ) => {
+			if ( Array.isArray( menu.children ) ) {
+				return {
+					...menu,
+					children: menu.children.filter(
+						( menuItem ) =>
+							! [ '/hosting-config/', '/site-monitoring' ].some( ( path ) =>
+								menuItem.url.startsWith( path )
+							)
+					),
+				};
+			}
+			return menu;
+		} );
+	}
+	return result;
 };
 
 export default useSiteMenuItems;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/6549

## Proposed Changes

This PR allows HEs to test the `layout/dotcom-nav-redesign-v2` changes seamlessly from any early-classic Atomic sites, by hiding the Hosting -> Configuration and Hosting -> Monitoring menus which are already in the Global Site View. This works when the nav redesign v2 flag is on.


<img width="289" alt="image" src="https://github.com/Automattic/wpcomsh/assets/1525580/87d81881-5965-4cc2-b3c0-5030896df714">


## Testing Instructions

1. Start with an early classic Atomic site.
2. Open `<Calypso Live URL>/home/<siteSlug>`
3. Verify you still see Hosting -> Configuration and Hosting -> Monitoring.
2. Open `<Calypso Live URL>/home/<siteSlug>?flags=layout/dotcom-nav-redesign-v2`
3. Verify you CANNOT see Hosting -> Configuration and Hosting -> Monitoring.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?