### PR TITLE
Site Migration: Stores the flow name to allow redirecting the users back to the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -248,7 +248,7 @@ const siteMigration: Flow = {
 						if ( siteSlug ) {
 							// Remove the in_site_migration_flow option at the end of the flow.
 							await saveSiteSettings( siteSlug, {
-								in_site_migration_flow: false,
+								in_site_migration_flow: '',
 							} );
 						}
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -279,7 +279,7 @@ const siteMigration: Flow = {
 						if ( siteSlug ) {
 							// Set the in_site_migration_flow option if the user needs to be verified.
 							await saveSiteSettings( siteSlug, {
-								in_site_migration_flow: true,
+								in_site_migration_flow: flowName,
 							} );
 						}
 						return navigate( STEPS.VERIFY_EMAIL.slug );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

More details: p1714141864540179-slack-C0Q664T29

## Proposed Changes

* Stores the flow name to allow redirecting users back the correct migration flow after the email verification.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso.live or apply this PR to your local environment
* Use an unverified user
* Navigate to the `/start` and start creating a new site.
* Once you reach the Goals step, select the `Import existing content or website`
* Continue to the flow once you reach the `site-migration-upgrade-plan` step and with the console open click on "Try 7 days for free"
* Ensure the `/settings` endpoint was called and contains the following data:
```
{
    in_site_migration_flow: 'site-migration'
}
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?