### PR TITLE
Nav Redesign: Add z-index 0 to site launch donut container in sites dashboard

### DIFF
--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -25,6 +25,7 @@ const SiteLaunchDonutContainer = styled.div( {
 	position: 'relative',
 	flexShrink: 0,
 	height: '25px',
+	zIndex: 0,
 } );
 
 const SiteLaunchNagLink = styled.a( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- Add z-index 0 to the site launch donut container so it is behind the pagination when scrolling

|BEFORE|AFTER|
|-|-|
|<img width="1452" alt="Screenshot 2567-04-27 at 03 40 11" src="https://github.com/Automattic/wp-calypso/assets/1881481/76d16c52-73fd-4116-bcc2-fd970f09e710">|<img width="1447" alt="Screenshot 2567-04-27 at 03 40 03" src="https://github.com/Automattic/wp-calypso/assets/1881481/dbd9a782-37a0-48ff-a04b-6ae40dab3deb">|

https://github.com/Automattic/wp-calypso/assets/1881481/4503df47-6644-424b-9b57-e72c0f2fa962


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access /`sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Make sure you have a site not launched that shows the link to the "Launch checklist". 
* Scroll the list until the icon is behind the pagination

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?