### PR TITLE
Patterns: Set Page layout count unit to 'layouts' instead of 'patterns'

### DIFF
--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -52,20 +52,15 @@ function CategoryGalleryItem( { category, patternTypeFilter }: CategoryGalleryIt
 		};
 	}, [ category, renderedPattern?.html ] );
 
-	const patternCount =
-		patternTypeFilter === PatternTypeFilter.PAGES
-			? category.pagePatternCount
-			: category.regularPatternCount;
-
 	const patternCountText =
 		patternTypeFilter === PatternTypeFilter.REGULAR
 			? translate( '%(count)d pattern', '%(count)d patterns', {
-					count: patternCount,
-					args: { count: patternCount },
+					count: category.regularPatternCount,
+					args: { count: category.regularPatternCount },
 			  } )
 			: translate( '%(count)d layout', '%(count)d layouts', {
-					count: patternCount,
-					args: { count: patternCount },
+					count: category.pagePatternCount,
+					args: { count: category.pagePatternCount },
 			  } );
 
 	return (

--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -57,6 +57,17 @@ function CategoryGalleryItem( { category, patternTypeFilter }: CategoryGalleryIt
 			? category.pagePatternCount
 			: category.regularPatternCount;
 
+	const patternCountText =
+		patternTypeFilter === PatternTypeFilter.REGULAR
+			? translate( '%(count)d pattern', '%(count)d patterns', {
+					count: patternCount,
+					args: { count: patternCount },
+			  } )
+			: translate( '%(count)d layout', '%(count)d layouts', {
+					count: patternCount,
+					args: { count: patternCount },
+			  } );
+
 	return (
 		<LocalizedLink
 			className="patterns-category-gallery__item"
@@ -83,12 +94,7 @@ function CategoryGalleryItem( { category, patternTypeFilter }: CategoryGalleryIt
 			</div>
 
 			<div className="patterns-category-gallery__item-name">{ category.label }</div>
-			<div className="patterns-category-gallery__item-count">
-				{ translate( '%(count)d pattern', '%(count)d patterns', {
-					count: patternCount,
-					args: { count: patternCount },
-				} ) }
-			</div>
+			<div className="patterns-category-gallery__item-count">{ patternCountText }</div>
 		</LocalizedLink>
 	);
 }

--- a/client/my-sites/patterns/components/category-gallery/server.tsx
+++ b/client/my-sites/patterns/components/category-gallery/server.tsx
@@ -25,21 +25,16 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 				} ) }
 			>
 				{ categories?.map( ( category ) => {
-					const patternCount =
-						patternTypeFilter === PatternTypeFilter.PAGES
-							? category.pagePatternCount
-							: category.regularPatternCount;
 					const patternCountText =
 						patternTypeFilter === PatternTypeFilter.REGULAR
 							? translate( '%(count)d pattern', '%(count)d patterns', {
-									count: patternCount,
-									args: { count: patternCount },
+									count: category.regularPatternCount,
+									args: { count: category.regularPatternCount },
 							  } )
 							: translate( '%(count)d layout', '%(count)d layouts', {
-									count: patternCount,
-									args: { count: patternCount },
+									count: category.pagePatternCount,
+									args: { count: category.pagePatternCount },
 							  } );
-
 					return (
 						<LocalizedLink
 							className="patterns-category-gallery__item"

--- a/client/my-sites/patterns/components/category-gallery/server.tsx
+++ b/client/my-sites/patterns/components/category-gallery/server.tsx
@@ -29,6 +29,16 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 						patternTypeFilter === PatternTypeFilter.PAGES
 							? category.pagePatternCount
 							: category.regularPatternCount;
+					const patternCountText =
+						patternTypeFilter === PatternTypeFilter.REGULAR
+							? translate( '%(count)d pattern', '%(count)d patterns', {
+									count: patternCount,
+									args: { count: patternCount },
+							  } )
+							: translate( '%(count)d layout', '%(count)d layouts', {
+									count: patternCount,
+									args: { count: patternCount },
+							  } );
 
 					return (
 						<LocalizedLink
@@ -57,12 +67,7 @@ export const CategoryGalleryServer: CategoryGalleryFC = ( {
 							</div>
 
 							<div className="patterns-category-gallery__item-name">{ category.label }</div>
-							<div className="patterns-category-gallery__item-count">
-								{ translate( '%(count)d pattern', '%(count)d patterns', {
-									count: patternCount,
-									args: { count: patternCount },
-								} ) }
-							</div>
+							<div className="patterns-category-gallery__item-count">{ patternCountText }</div>
 						</LocalizedLink>
 					);
 				} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6567-gh-Automattic/dotcom-forge

## Proposed Changes

Ensure that on the main/"All Categories" page, the listing of page layout category counts

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td>
<img width="1285" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13856531/d87f4f11-f733-49f5-b130-b93b8fea8162">
</td>
 <td>
<img width="1287" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13856531/cd74d53e-1de6-45d5-ad9b-74ec0dd9264b">
</td>
</table>

## Wee bit of context/history
Discussion on pattern/layout naming:
- pdtkmj-2wZ-p2#comment-4735
- p1714098544021309/1714075674.412029-slack-C06ELHR6L9J

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Load up `/patterns`
- Scroll down to the page layouts section
- Behold the glory with which it now lays "layout/layouts" instead of "pattern/patterns"