### PR TITLE
exploration - use site sort component for dashboard headers.

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/site-sort/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/site-sort/index.tsx
@@ -18,6 +18,8 @@ const SORT_DIRECTION_DESC = 'desc';
 // Mapping the columns to the site data keys
 const SITE_COLUMN_KEY_MAP: { [ key: string ]: string } = {
 	site: 'url',
+	'last-publish': 'last-publish',
+	name: 'site',
 };
 
 export default function SiteSort( {
@@ -25,13 +27,21 @@ export default function SiteSort( {
 	isLargeScreen,
 	children,
 	isSortable,
+	viewStateByProp,
+	setViewStateByProp,
 }: {
 	columnKey: string;
 	isLargeScreen?: boolean;
 	children?: React.ReactNode;
 	isSortable?: boolean;
+	viewStateByProp?: object;
+	setViewStateByProp?: Function;
 } ) {
-	const { dataViewsState, setDataViewsState } = useContext( SitesDashboardContext );
+	const { dataViewsState: dataViewStateByContext, setDataViewsState: setDataViewStateByContext } =
+		useContext( SitesDashboardContext );
+
+	const dataViewsState = viewStateByProp || dataViewStateByContext;
+	const setDataViewsState = setViewStateByProp || setDataViewStateByContext;
 
 	const { field, direction } = dataViewsState.sort;
 

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -3,6 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import SiteSort from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/site-sort';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
@@ -66,13 +67,24 @@ const DotcomSitesDataViews = ( {
 		() => [
 			{
 				id: 'site',
-				header: <span>{ __( 'Site' ) }</span>,
+				header: (
+					<SiteSort
+						isSortable={ true }
+						columnKey="name"
+						viewStateByProp={ dataViewsState }
+						setViewStateByProp={ setDataViewsState }
+					>
+						<span className="sites-dataview__site-header sites-dataview__site-header--sort">
+							{ __( 'Site' ) }
+						</span>
+					</SiteSort>
+				),
 				getValue: ( { item }: { item: SiteInfo } ) => item.URL,
 				render: ( { item }: { item: SiteInfo } ) => {
 					return <SiteField site={ item } openSitePreviewPane={ openSitePreviewPane } />;
 				},
 				enableHiding: false,
-				enableSorting: true,
+				enableSorting: false,
 			},
 			{
 				id: 'plan',
@@ -95,11 +107,23 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'last-publish',
-				header: <span>{ __( 'Last Publish' ) }</span>,
+				// header: <span>{ __( 'Last Publish' ) }</span>,
+				header: (
+					<SiteSort
+						isSortable={ true }
+						columnKey="last-publish"
+						viewStateByProp={ dataViewsState }
+						setViewStateByProp={ setDataViewsState }
+					>
+						<span className="sites-dataview__site-header sites-dataview__site-header--sort">
+							{ __( 'Last Publish' ) }
+						</span>
+					</SiteSort>
+				),
 				render: ( { item }: { item: SiteInfo } ) =>
 					item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
 				enableHiding: false,
-				enableSorting: true,
+				enableSorting: false,
 			},
 			{
 				id: 'stats',
@@ -128,7 +152,7 @@ const DotcomSitesDataViews = ( {
 				enableSorting: true,
 			},
 		],
-		[ __, openSitePreviewPane, userId ]
+		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState ]
 	);
 
 	// Create the itemData packet state


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to an option presented in slack p1714123451300799/1714077270.866299-slack-C06DN6QQVAQ

## Proposed Changes

Technically:
* This was hacking to explore how we might use the "SiteSort" component. We may want to explore having a similar context provider and not passing through conditional props instead. There are also unresolved TS issues.

Design wise:
* This replaces the headings of the columns we can sort by with buttons that will trigger the sorting by stepping through ascending, descending, and default for that column. (avoiding the awkward nested ascending/descending popup)
* A side effect of this is that these items need to have sorting disabled in the gutenberg component meaning they are no longer available in the site view sort settings in the top right.
* We currently have other items like "magic" sort in there (our dotcom name for "last interacted with date" that we brought over from the old dashboard) which we don't currently show columns for. 
![Screenshot 2024-04-26 at 3 19 27 PM](https://github.com/Automattic/wp-calypso/assets/28742426/eb3e18fe-3a00-45dd-a2d1-21c2a4a86faf)
* It is currently a bit odd that we can only sort the visible columns in this PR by the headings and not find them in that list that is exposed by the magic sort.
* I think it depends on what we want design wise. Maybe we can get rid of 'magic' sort and go a route using these components. Maybe we want to add "last interacted with" as a column in some way and use this component for it as well? 🤔 

![site-sort-component-preview](https://github.com/Automattic/wp-calypso/assets/28742426/97385cc4-2ba1-46b3-a077-76a7295ab8a6)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch and test the sites dashboard with flag `sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Click on the "Site" and "last published" headings to sort by those columns. Notice there is no ascending/descending popup and that clicking a second time switches the direction.
* Note the oddity provided by still allowing to sort by a hidden column "magic" in the top right views settings, and that we can no longer sort by "site" or "last published" here.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?