### PR TITLE
Hide the domains button when sites list is collapsed

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -88,8 +88,18 @@
 			margin-right: 0;
 		}
 
-		.sites-site-thumbnail {
+		.sites-site-thumbnail,
+		.sites-manage-all-domains-button {
 			display: none;
+		}
+
+		.a4a-layout__viewport {
+			width: 360px;
+			justify-content: space-between;
+		}
+
+		.a4a-layout__viewport > div:first-child {
+			width: 100%;
 		}
 
 		.list-tile__leading {

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -123,10 +123,11 @@ const SitesDashboardHeader = () => {
 	return (
 		<PageHeader>
 			<HeaderControls>
-				<ManageAllDomainsButton href="/domains/manage">
+				<ManageAllDomainsButton className="sites-manage-all-domains-button" href="/domains/manage">
 					{ __( 'Manage all domains' ) }
 				</ManageAllDomainsButton>
 				<AddNewSiteSplitButton
+					className="sites-add-new-site-split-button"
 					primary
 					whiteSeparator
 					label={ isMobile ? undefined : __( 'Add new site' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6778

## Proposed Changes

* Hide the domains button when the flyout panel is visible.

Before | After
--|--
<img width="480" alt="Screenshot 2024-04-26 at 4 54 35 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/9cd718b9-f47d-415c-9cb9-06ae02ef17f1">  | <img width="503" alt="Screenshot 2024-04-26 at 4 54 18 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/e1e2ad85-3b45-4c2a-8496-e6bfb0de04c6">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?