### PR TITLE
Untangling: show left nav in GH deployment routes when nav redesign is disabled

### DIFF
--- a/client/github-deployments/index.tsx
+++ b/client/github-deployments/index.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { siteSelection, sites } from 'calypso/my-sites/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { redirectHomeIfIneligible } from 'calypso/my-sites/github-deployments/controller';
 import globalSiteLayout from 'calypso/sites-dashboard-v2/global-site-layout';
 import {
@@ -23,6 +23,7 @@ export default function () {
 		'/github-deployments/:site',
 		siteSelection,
 		redirectHomeIfIneligible,
+		navigation,
 		deploymentsList,
 		globalSiteLayout( DOTCOM_GITHUB_DEPLOYMENTS ),
 		makeLayout,
@@ -33,6 +34,7 @@ export default function () {
 		'/github-deployments/:site/create',
 		siteSelection,
 		redirectHomeIfIneligible,
+		navigation,
 		deploymentCreation,
 		globalSiteLayout( DOTCOM_GITHUB_DEPLOYMENTS, DOTCOM_GITHUB_DEPLOYMENTS_CREATE ),
 		makeLayout,
@@ -43,6 +45,7 @@ export default function () {
 		'/github-deployments/:site/manage/:deploymentId',
 		siteSelection,
 		redirectHomeIfIneligible,
+		navigation,
 		deploymentManagement,
 		globalSiteLayout( DOTCOM_GITHUB_DEPLOYMENTS, DOTCOM_GITHUB_DEPLOYMENTS_MANAGE ),
 		makeLayout,
@@ -53,6 +56,7 @@ export default function () {
 		'/github-deployments/:site/logs/:deploymentId',
 		siteSelection,
 		redirectHomeIfIneligible,
+		navigation,
 		deploymentRunLogs,
 		globalSiteLayout( DOTCOM_GITHUB_DEPLOYMENTS, DOTCOM_GITHUB_DEPLOYMENTS_LOGS ),
 		makeLayout,


### PR DESCRIPTION
Related to

- https://github.com/Automattic/wp-calypso/pull/89949#issuecomment-2080214458

## Proposed Changes

This PR re-adds the left sidebar when in GH deployment routes and the `layout/dotcom-nav-redesign-v2` id disabled.

## Testing Instructions

1. Go to `<Calypso URL>/github-deployments/:site`
2. Verify that the left sidebar is shown

<img width="1084" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/d7627fe0-b236-4c13-a35d-30a00c5895e8">

1. Go to `<Calypso URL>/github-deployments/:site?flags=layout/dotcom-nav-redesign-v2`
1. Verify you see the v2 redesign

<img width="1286" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/f4c08fe2-e302-42db-a570-296b77ecef5e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?