### PR TITLE
Fix sites being duplicated on `/sites` page.

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -46,7 +46,7 @@ export const useSiteExcerptsQuery = (
 
 			if ( site_visibility === 'deleted' ) {
 				sites.forEach( ( site ) => {
-					site.is_deleted = true;
+					site.is_deleted = site.site_owner === undefined;
 				} );
 			}
 

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -47,7 +47,12 @@ export const useSiteExcerptsQuery = (
 			let sites = data?.sites.map( computeFields( data?.sites ) ) || [];
 
 			if ( site_visibility === 'deleted' ) {
+				// If we got the site data from Redux store (see `initialData` below),
+				// then we can't rely on the `site_visibility` parameter to know
+				// whether the site is deleted or not. We use the `site_owner` field
+				// to infer the `is_deleted` status.
 				sites = sites.filter( ( site ) => site.site_owner === undefined );
+
 				sites.forEach( ( site ) => {
 					site.is_deleted = true;
 				} );

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -10,8 +10,10 @@ import type { SiteExcerptData, SiteExcerptNetworkData } from '@automattic/sites'
 
 export const USE_SITE_EXCERPTS_QUERY_KEY = 'sites-dashboard-sites-data';
 
+export type SiteVisibility = 'all' | 'deleted';
+
 const fetchSites = (
-	site_visibility = 'all',
+	site_visibility: SiteVisibility = 'all',
 	siteFilter = config< string[] >( 'site_filter' )
 ): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	return wpcom.me().sites( {
@@ -28,7 +30,7 @@ const fetchSites = (
 export const useSiteExcerptsQuery = (
 	fetchFilter?: string[],
 	sitesFilterFn?: ( site: SiteExcerptData ) => boolean,
-	site_visibility = 'all'
+	site_visibility: SiteVisibility = 'all'
 ) => {
 	const store = useStore();
 
@@ -42,11 +44,12 @@ export const useSiteExcerptsQuery = (
 		],
 		queryFn: () => fetchSites( site_visibility, fetchFilter ),
 		select: ( data ) => {
-			const sites = data?.sites.map( computeFields( data?.sites ) ) || [];
+			let sites = data?.sites.map( computeFields( data?.sites ) ) || [];
 
 			if ( site_visibility === 'deleted' ) {
+				sites = sites.filter( ( site ) => site.site_owner === undefined );
 				sites.forEach( ( site ) => {
-					site.is_deleted = site.site_owner === undefined;
+					site.is_deleted = true;
 				} );
 			}
 

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -184,7 +184,7 @@ export function SitesDashboard( {
 
 	const { data: deletedSites = [] } = useSiteExcerptsQuery(
 		[],
-		( site ) => ! site.options?.is_domain_only && !! site?.is_deleted,
+		( site ) => ! site.options?.is_domain_only,
 		'deleted'
 	);
 

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -184,7 +184,7 @@ export function SitesDashboard( {
 
 	const { data: deletedSites = [] } = useSiteExcerptsQuery(
 		[],
-		( site ) => ! site.options?.is_domain_only,
+		( site ) => ! site.options?.is_domain_only && !! site?.is_deleted,
 		'deleted'
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/89825

## Proposed Changes
The issue being encountered is that on the sites page the `useSiteExcerptsQuery` hook is being used twice, to get all sites and also deleted sites which are then concatenated. What happens is that there are cases where `initialData` is used to fetch sites from the redux store as a result the same data is fetched twice, the second time they are flagged as deleted sites then concatenated to the live sites causing duplications.

This PR uses the `site_owner` field to determine if a site was deleted instead of always setting it to true when the  `site_visibility = deleted`. Deleted sites do not have an owner

* Use site_owner to flag deleted sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
This is not reproducible on all sites so we have to use a user that's having the issue.
* In MC go to Tools > support user
* Set user to `mrsenff` and environment to `calypso.localhost`
* Click all sites and you will see sites are duplicated
* checkout branch
* do the same steps and click all sites and see sites are no longer duplicated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)