### PR TITLE
Hosting Overview: Update quick actions card header text

### DIFF
--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -36,7 +36,7 @@ const QuickActionsCard: FC = () => {
 	return (
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
 			<div className="hosting-overview__card-header">
-				<h3 className="hosting-overview__card-title">{ translate( 'Quick actions' ) }</h3>
+				<h3 className="hosting-overview__card-title">{ translate( 'WP Admin links' ) }</h3>
 			</div>
 
 			<ul className="hosting-overview__actions-list">

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -1,4 +1,5 @@
 import { Button, Card } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { chevronRightSmall, Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -29,6 +30,7 @@ const Action: FC< ActionProps > = ( { icon, href, text } ) => {
 };
 
 const QuickActionsCard: FC = () => {
+	const hasEnTranslation = useHasEnTranslation();
 	const site = useSelector( getSelectedSite );
 	const editorUrl = useSelector( ( state ) => ( site?.ID ? getEditorUrl( state, site.ID ) : '#' ) );
 	const translate = useTranslate();
@@ -36,7 +38,11 @@ const QuickActionsCard: FC = () => {
 	return (
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
 			<div className="hosting-overview__card-header">
-				<h3 className="hosting-overview__card-title">{ translate( 'WP Admin links' ) }</h3>
+				<h3 className="hosting-overview__card-title">
+					{ hasEnTranslation( 'WP Admin links' )
+						? translate( 'WP Admin links' )
+						: translate( 'Quick actions' ) }
+				</h3>
 			</div>
 
 			<ul className="hosting-overview__actions-list">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6780

## Proposed Changes

This PR updates the header text from "Quick actions" to "WP Admin links"

| Before | After |
| --- | --- |
| ![Screenshot 2024-04-29 at 7 44 09 AM](https://github.com/Automattic/wp-calypso/assets/797888/298e69f2-1499-45a8-9fa5-121dd11984ee) | ![Screenshot 2024-04-29 at 7 42 29 AM](https://github.com/Automattic/wp-calypso/assets/797888/0d3fbe21-2cae-4335-acb7-8d8af7ca1d2e) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/hosting/:site?flags=layout%2Fdotcom-nav-redesign-v2`.
* Ensure that the text is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?