### PR TITLE
Sites Dashboard v2: Ensure that the children of dataviews use the full width

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -227,6 +227,10 @@
 			display: flex;
 			height: 100%;
 
+			> * {
+				flex-grow: 1;
+			}
+
 			.dataviews-view-list {
 				flex: 1;
 				max-height: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6783

## Proposed Changes

This PR ensures that the child nodes for the dataviews container element use the full width.

With pagination, which has an explicit width of 368px.
![Screenshot 2024-04-29 at 11 31 00 AM](https://github.com/Automattic/wp-calypso/assets/797888/6674164c-0c88-4b08-ae5c-85bb60a14853)

Without pagination.
![Screenshot 2024-04-29 at 11 31 23 AM](https://github.com/Automattic/wp-calypso/assets/797888/d1fa3ef0-ebc9-470c-88a5-86afa34f6eb7)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Ensure that the collapsed dataviews panel uses the full width even with search, filter, and grouping.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?