### PR TITLE
DIFM In Progress: fix translation error-prone string

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -23,6 +23,7 @@ import { useGetWebsiteContentQuery } from 'calypso/state/signup/steps/website-co
 import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { AppState, SiteId, SiteSlug } from 'calypso/types';
+import type { PropsWithChildren } from 'react';
 
 import './difm-lite-in-progress.scss';
 
@@ -36,7 +37,7 @@ type Props = {
 	siteId?: SiteId;
 };
 
-function SupportLink( { siteId }: { siteId?: number } ) {
+function SupportLink( { siteId, children }: PropsWithChildren< { siteId?: number } > ) {
 	const translate = useTranslate();
 	// Create URLSearchParams for send feedback by email command
 	const { setInitialRoute, setShowHelpCenter, setSubject, setSite } =
@@ -61,7 +62,7 @@ function SupportLink( { siteId }: { siteId?: number } ) {
 				setShowHelpCenter( true );
 			} }
 		>
-			{ translate( 'Contact support' ) }
+			{ children }
 		</Button>
 	);
 }
@@ -86,34 +87,34 @@ function WebsiteContentSubmissionPending( { siteId, siteSlug }: Props ) {
 		}
 	}
 
-	const lineTextTranslateOptions = {
-		components: {
-			br: <br />,
-			SupportLink: <SupportLink siteId={ siteId } />,
-		},
-	};
-
 	const lineText = contentSubmissionDueDate
 		? translate(
-				'Click the button below to provide the content we need to build your site by %(contentSubmissionDueDate)s.{{br}}{{/br}}' +
-					'{{SupportLink}}{{/SupportLink}} if you have any questions.',
+				'Click the button below to provide the content we need to build your site by %(contentSubmissionDueDate)s.',
 				{
-					...lineTextTranslateOptions,
 					args: {
 						contentSubmissionDueDate: moment( contentSubmissionDueDate ).format( 'MMMM Do, YYYY' ),
 					},
 				}
 		  )
-		: translate(
-				'Click the button below to provide the content we need to build your site.{{br}}{{/br}}' +
-					'{{SupportLink}}{{/SupportLink}} if you have any questions.',
-				lineTextTranslateOptions
-		  );
+		: translate( 'Click the button below to provide the content we need to build your site.' );
 
 	return (
 		<EmptyContent
 			title={ translate( 'Website content not submitted' ) }
-			line={ <h3 className="empty-content__line">{ lineText }</h3> }
+			line={
+				<h3 className="empty-content__line">
+					{ lineText }
+					<br />
+					{ translate(
+						'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
+						{
+							components: {
+								SupportLink: <SupportLink siteId={ siteId } />,
+							},
+						}
+					) }
+				</h3>
+			}
 			action={ translate( 'Provide website content' ) }
 			actionURL={ `/start/site-content-collection/website-content?siteSlug=${ siteSlug }` }
 			illustration={ WebsiteContentRequiredIllustration }
@@ -148,14 +149,18 @@ function WebsiteContentSubmitted( { primaryDomain, siteSlug, siteId }: Props ) {
 			line={
 				<h3 className="empty-content__line">
 					{ translate(
-						"We are currently building your site and will send you an email when it's ready, within %d business days.{{br}}{{/br}}" +
-							'{{SupportLink}}{{/SupportLink}} if you have any questions.',
+						"We are currently building your site and will send you an email when it's ready, within %d business days.",
+						{
+							args: [ 4 ],
+						}
+					) }
+					<br />
+					{ translate(
+						'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
 						{
 							components: {
-								br: <br />,
 								SupportLink: <SupportLink siteId={ siteId } />,
 							},
-							args: [ 4 ],
 						}
 					) }
 				</h3>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2958

## Proposed Changes

* In the TR locale, one of the translated strings(https://translate.wordpress.com/projects/wpcom/tr/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=853631&filters%5Btranslation_id%5D=16200004) contains text within opening an closing `br` tags (`<br>some text</br>`). This causes the page to throw an error.
* The string was structured in an ambiguous way and did not contain any translation comment, so it is easy to see why it was translated like this.
* In this PR, I have separated out the `<br/>` tags from the strings to be translated and also moved the `Contact support` text inside the main string instead of the `<SupportLink>` component so that it reads better and is easier to translate.

### Screenshots
<img width="931" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/87f3dea3-eb12-4a05-9558-25ee1ee79da9">
<img width="859" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/418c8af9-0ec2-4682-a263-22f244fa78a2">
<img width="783" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/66c63756-8b70-4699-bd4f-646416e61500">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and complete purchase.
* After purchase, go to `/home/<site slug>` and confirm that the page is shown according to the screenshots above.
* Submit the content form, go to `/home/<site slug>` and confirm that the page is shown according to the screenshots above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?