### PR TITLE
Global Sidebar: Improve styles when collapsed

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -176,8 +176,14 @@ $brand-text: "SF Pro Text", $sans;
 		}
 
 		.sidebar__menu-link {
-			&.svg_all-sites {
-				margin: -2px 6px -2px -2px;
+			.sidebar__menu-icon {
+				&.dashicons-admin-site-alt3 {
+					margin-right: 10px;
+				}
+				&.svg_all-sites,
+				&.sidebar_svg-reader {
+					margin-left: -2px;
+				}
 			}
 		}
 	}
@@ -427,15 +433,10 @@ $brand-text: "SF Pro Text", $sans;
 
 		.sidebar__body {
 			.sidebar__menu-item-parent .sidebar__menu-link {
-				margin: 0;
-			}
-			.sidebar__menu-link-text {
-				display: none;
-			}
-			.sidebar__menu-icon {
-				margin-left: 4px;
-				&.svg_all-sites {
-					margin-left: 2px;
+				margin: 0 auto;
+
+				> *:not(:first-child) {
+					display: none;
 				}
 			}
 		}

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -28,9 +28,9 @@ export default function globalSidebarMenu() {
 				<svg
 					className="sidebar__menu-icon sidebar_svg-reader"
 					fill="none"
-					height="20"
+					height="24"
 					viewBox="4 4 24 24"
-					width="20"
+					width="24"
 					xmlns="http://www.w3.org/2000/svg"
 				>
 					<clipPath id="readerIconSidebarFooter">

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -89,11 +89,12 @@
 	.is-global-sidebar-collapsed {
 		.global-sidebar {
 			.sidebar__body {
-				.sidebar__menu-link-text {
-					transition: all 0.1s ease-in-out;
-					transition-delay: 0.2s;
-					opacity: 0;
-					display: block !important;
+				.sidebar__menu-link {
+					width: fit-content;
+
+					> :first-child {
+						margin-right: 0;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6787

## Proposed Changes

* Improve styles of the sidebar when collapsed

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/097e6b2d-720f-4a63-95ec-6add83871f45) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/aaf51943-3904-4706-8d48-939677e3f706) |
| ![Screenshot 2024-04-29 at 3 19 40 PM](https://github.com/Automattic/wp-calypso/assets/13596067/397fb269-e444-46ff-aa2f-cfdad78be876) | ![Screenshot 2024-04-29 at 3 20 42 PM](https://github.com/Automattic/wp-calypso/assets/13596067/1424ecdc-bf9c-4034-a6b8-3f12e4d32080) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites?flags=layout/dotcom-nav-redesign-v2
* Open & Close the GSV
* Make sure the styles of the sidebar look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?