### PR TITLE
Sites Dashboard v2: Use fixed color for the header text color

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -27,6 +27,13 @@
 	.dataviews-filters__view-actions {
 		border-bottom: 0;
 	}
+
+	table.dataviews-view-table thead .dataviews-view-table__row th {
+		span,
+		.dataviews-view-table-header-button {
+			color: inherit;
+		}
+	}
 }
 
 // Styles for actions (search, filters).


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6775

## Proposed Changes

This PR ensure that the header text color is always gray, instead of being dependent on the active color scheme.

| Before | After |
| --- | --- |
| ![Screenshot 2024-04-29 at 2 49 12 PM](https://github.com/Automattic/wp-calypso/assets/797888/345038b8-0dd1-45be-80d9-cbf211043510) | ![Screenshot 2024-04-29 at 2 48 51 PM](https://github.com/Automattic/wp-calypso/assets/797888/7a6827ad-a586-4151-afa3-90502d34500c) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Ensure that the header text color is fixed gray as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?