### PR TITLE
Nav redesign: update quick actions card to have wp-admin links

### DIFF
--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -8,6 +8,9 @@ import { useSelector } from 'react-redux';
 import { WriteIcon } from 'calypso/layout/masterbar/write-icon';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url';
+import getStatsUrl from 'calypso/state/selectors/get-stats-url';
+import getThemeInstallUrl from 'calypso/state/selectors/get-theme-install-url';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 interface ActionProps {
@@ -51,17 +54,17 @@ const QuickActionsCard: FC = () => {
 					icon={
 						<SidebarCustomIcon icon="dashicons-admin-appearance hosting-overview__dashicon" />
 					}
-					href={ `/themes/${ site?.slug }` }
+					href={ getThemeInstallUrl( state, site?.ID ) }
 					text={ translate( 'Change theme' ) }
 				/>
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-admin-plugins hosting-overview__dashicon" /> }
-					href={ `/plugins/${ site?.slug }` }
+					href={ getPluginInstallUrl( state, site?.ID ) }
 					text={ translate( 'Install plugins' ) }
 				/>
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-chart-bar hosting-overview__dashicon" /> }
-					href={ `/stats/${ site?.slug }` }
+					href={ getStatsUrl( state, site?.ID ) }
 					text={ translate( 'See Jetpack Stats' ) }
 				/>
 			</ul>

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -35,7 +35,12 @@ const Action: FC< ActionProps > = ( { icon, href, text } ) => {
 const QuickActionsCard: FC = () => {
 	const hasEnTranslation = useHasEnTranslation();
 	const site = useSelector( getSelectedSite );
-	const editorUrl = useSelector( ( state ) => ( site?.ID ? getEditorUrl( state, site.ID ) : '#' ) );
+	const { editorUrl, themeInstallUrl, pluginInstallUrl, statsUrl } = useSelector( ( state ) => ( {
+		editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
+		themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
+		pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
+		statsUrl: getStatsUrl( state, site?.ID ) ?? '',
+	} ) );
 	const translate = useTranslate();
 
 	return (
@@ -54,17 +59,17 @@ const QuickActionsCard: FC = () => {
 					icon={
 						<SidebarCustomIcon icon="dashicons-admin-appearance hosting-overview__dashicon" />
 					}
-					href={ getThemeInstallUrl( state, site?.ID ) }
+					href={ themeInstallUrl }
 					text={ translate( 'Change theme' ) }
 				/>
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-admin-plugins hosting-overview__dashicon" /> }
-					href={ getPluginInstallUrl( state, site?.ID ) }
+					href={ pluginInstallUrl }
 					text={ translate( 'Install plugins' ) }
 				/>
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-chart-bar hosting-overview__dashicon" /> }
-					href={ getStatsUrl( state, site?.ID ) }
+					href={ statsUrl }
 					text={ translate( 'See Jetpack Stats' ) }
 				/>
 			</ul>

--- a/client/state/selectors/get-plugin-install-url.ts
+++ b/client/state/selectors/get-plugin-install-url.ts
@@ -1,0 +1,10 @@
+import { getSiteAdminUrl, getSiteSlug, usesWPAdminInterface } from '../sites/selectors';
+
+export default function getPluginInstallUrl( state: AppState, siteId?: number | null ) {
+	if ( ! usesWPAdminInterface( state, siteId ) ) {
+		const siteSlug = getSiteSlug( state, siteId );
+		return `/plugins/${ siteSlug }`;
+	}
+
+	return getSiteAdminUrl( state, siteId, 'plugin-install.php' );
+}

--- a/client/state/selectors/get-plugin-install-url.ts
+++ b/client/state/selectors/get-plugin-install-url.ts
@@ -1,7 +1,8 @@
-import { getSiteAdminUrl, getSiteSlug, usesWPAdminInterface } from '../sites/selectors';
+import { getSiteAdminUrl, getSiteSlug, isAdminInterfaceWPAdmin } from '../sites/selectors';
+import type { AppState } from 'calypso/types';
 
 export default function getPluginInstallUrl( state: AppState, siteId?: number | null ) {
-	if ( ! usesWPAdminInterface( state, siteId ) ) {
+	if ( ! isAdminInterfaceWPAdmin( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
 		return `/plugins/${ siteSlug }`;
 	}

--- a/client/state/selectors/get-stats-url.ts
+++ b/client/state/selectors/get-stats-url.ts
@@ -1,7 +1,8 @@
-import { getSiteAdminUrl, getSiteSlug, usesWPAdminInterface } from '../sites/selectors';
+import { getSiteAdminUrl, getSiteSlug, isAdminInterfaceWPAdmin } from '../sites/selectors';
+import type { AppState } from 'calypso/types';
 
 export default function getStatsUrl( state: AppState, siteId?: number | null ) {
-	if ( ! usesWPAdminInterface( state, siteId ) ) {
+	if ( ! isAdminInterfaceWPAdmin( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
 		return `/stats/${ siteSlug }`;
 	}

--- a/client/state/selectors/get-stats-url.ts
+++ b/client/state/selectors/get-stats-url.ts
@@ -1,0 +1,10 @@
+import { getSiteAdminUrl, getSiteSlug, usesWPAdminInterface } from '../sites/selectors';
+
+export default function getStatsUrl( state: AppState, siteId?: number | null ) {
+	if ( ! usesWPAdminInterface( state, siteId ) ) {
+		const siteSlug = getSiteSlug( state, siteId );
+		return `/stats/${ siteSlug }`;
+	}
+
+	return getSiteAdminUrl( state, siteId, 'admin.php?page=stats' );
+}

--- a/client/state/selectors/get-theme-install-url.ts
+++ b/client/state/selectors/get-theme-install-url.ts
@@ -1,7 +1,8 @@
-import { getSiteAdminUrl, getSiteSlug, usesWPAdminInterface } from '../sites/selectors';
+import { getSiteAdminUrl, getSiteSlug, isAdminInterfaceWPAdmin } from '../sites/selectors';
+import type { AppState } from 'calypso/types';
 
 export default function getThemeInstallUrl( state: AppState, siteId?: number | null ) {
-	if ( ! usesWPAdminInterface( state, siteId ) ) {
+	if ( ! isAdminInterfaceWPAdmin( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
 		return `/themes/${ siteSlug }`;
 	}

--- a/client/state/selectors/get-theme-install-url.ts
+++ b/client/state/selectors/get-theme-install-url.ts
@@ -1,0 +1,10 @@
+import { getSiteAdminUrl, getSiteSlug, usesWPAdminInterface } from '../sites/selectors';
+
+export default function getThemeInstallUrl( state: AppState, siteId?: number | null ) {
+	if ( ! usesWPAdminInterface( state, siteId ) ) {
+		const siteSlug = getSiteSlug( state, siteId );
+		return `/themes/${ siteSlug }`;
+	}
+
+	return getSiteAdminUrl( state, siteId, 'theme-install.php' );
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -43,6 +43,7 @@ export { default as hasJetpackActivePlugins } from './has-jetpack-active-plugins
 export { default as hasJetpackSiteCustomDomain } from './has-jetpack-site-custom-domain';
 export { default as hasSiteProduct } from './has-site-product';
 export { default as hasStaticFrontPage } from './has-static-front-page';
+export { default as usesWPAdminInterface } from './uses-wp-admin-interface';
 export { default as isBackupPluginActive } from './is-backup-plugin-active';
 export { default as isCurrentPlanPaid } from './is-current-plan-paid';
 export { default as isCurrentSitePlan } from './is-current-site-plan';

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -43,7 +43,7 @@ export { default as hasJetpackActivePlugins } from './has-jetpack-active-plugins
 export { default as hasJetpackSiteCustomDomain } from './has-jetpack-site-custom-domain';
 export { default as hasSiteProduct } from './has-site-product';
 export { default as hasStaticFrontPage } from './has-static-front-page';
-export { default as usesWPAdminInterface } from './uses-wp-admin-interface';
+export { default as isAdminInterfaceWPAdmin } from './is-admin-interface-wp-admin';
 export { default as isBackupPluginActive } from './is-backup-plugin-active';
 export { default as isCurrentPlanPaid } from './is-current-plan-paid';
 export { default as isCurrentSitePlan } from './is-current-site-plan';

--- a/client/state/sites/selectors/is-admin-interface-wp-admin.ts
+++ b/client/state/sites/selectors/is-admin-interface-wp-admin.ts
@@ -1,6 +1,6 @@
 import getSiteOption from './get-site-option';
 import type { AppState } from 'calypso/types';
 
-export default function usesWPAdminInterface( state: AppState, siteId?: number | null ) {
+export default function isAdminInterfaceWPAdmin( state: AppState, siteId?: number | null ) {
 	return getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
 }

--- a/client/state/sites/selectors/uses-wp-admin-interface.ts
+++ b/client/state/sites/selectors/uses-wp-admin-interface.ts
@@ -1,0 +1,6 @@
+import getSiteOption from './get-site-option';
+import type { AppState } from 'calypso/types';
+
+export default function usesWPAdminInterface( state: AppState, siteId?: number | null ) {
+	return getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
+}


### PR DESCRIPTION
## Proposed Changes

This PR updates the quick action links to have wp-admin links if the admin interface is set to classic:

<img width="664" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/6f2824dc-5787-42d7-956d-9fe4c996ec95">

|Item|Default Style|Classic Style|
|-|-|-|
|Change theme|`/themes`|`wp-admin/theme-install.php`|
|Install plugins|`/plugins`|`wp-admin/plugin-install.php`
|See Jetpack Stats|`/stats`|`wp-admin/admin.php?page=stats`


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Prepare an Atomic site.
2. Set Settings -> Hosting Configuration -> Admin interface style to Default.
3. Go to `<Calypso Live URL>/hosting/:siteSlug` and verify the links as shown above.
2. Set Settings -> Hosting Configuration -> Admin interface style to Classic.
3. Go to `<Calypso Live URL>/hosting/:siteSlug` and verify the links as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?