### PR TITLE
Nav Redesign v2: fix sites pagination footer

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -18,7 +18,8 @@
 	margin-bottom: 1rem;
 	padding: 12px 16px 12px 16px;
 	position: fixed;
-	width: calc(100% - 64px);
+	box-sizing: border-box;
+	width: 100%;
 
 	.components-input-control__backdrop {
 		border-color: var(--Gray-Gray-5, #dcdcde);
@@ -28,8 +29,12 @@
 		padding: 0 5px;
 	}
 
-	@include breakpoint-deprecated( ">660px" ) {
-		width: calc(100% - ( var(--sidebar-width-max) + 48px));
+	@media only screen and ( min-width: 600px ) {
+		width: calc(100% - 48px);
+	}
+
+	@media only screen and ( min-width: 782px ) {
+		width: calc(100% - ( var(--sidebar-width-max) + 16px));
 	}
 
 	@include breakpoint-deprecated( ">1400px" ) {

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -18,8 +18,7 @@
 	margin-bottom: 1rem;
 	padding: 12px 16px 12px 16px;
 	position: fixed;
-	box-sizing: border-box;
-	width: 100%;
+	width: calc(100% - 64px);
 
 	.components-input-control__backdrop {
 		border-color: var(--Gray-Gray-5, #dcdcde);
@@ -29,12 +28,8 @@
 		padding: 0 5px;
 	}
 
-	@media only screen and ( min-width: 600px ) {
-		width: calc(100% - 48px);
-	}
-
-	@media only screen and ( min-width: 782px ) {
-		width: calc(100% - ( var(--sidebar-width-max) + 16px));
+	@include breakpoint-deprecated( ">660px" ) {
+		width: calc(100% - ( var(--sidebar-width-max) + 48px));
 	}
 
 	@include breakpoint-deprecated( ">1400px" ) {

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -1098,6 +1098,19 @@
 	}
 }
 
+.dataviews-pagination {
+	box-sizing: border-box;
+	width: 100%;
+
+	@media only screen and ( min-width: 600px ) {
+		width: calc(100% - 48px);
+	}
+
+	@media only screen and ( min-width: 782px ) {
+		width: calc(100% - ( var(--sidebar-width-max) + 16px));
+	}
+}
+
 /* See wp-calypso/client/layout/style.scss for the original style - this is removed on sites dashboard to enable pagination to display properly. */
 .layout__primary .preview-hidden {
 	@include breakpoint-deprecated( ">960px" ) {


### PR DESCRIPTION
WIP: this needs to be tested with A4A

Fixes the footer on the /sites page on mobile and tablet screens

**Before**
<img width="600" alt="Screenshot 2024-04-29 at 4 23 21 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/47f6101d-fc9b-4704-80bd-b899a2a95c7e">

**After**
<img width="600" alt="Screenshot 2024-04-29 at 4 23 32 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/8ff68eff-bfad-4f24-bc80-398dce008314">

### Test instructions