### PR TITLE
Nav redesign: Fix the header styles on mobile

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -124,7 +124,7 @@ html,
 
 	@include breakpoint-deprecated( "<1280px" ) {
 		flex-wrap: wrap;
-		row-gap: 16px;
+		gap: 16px;
 
 		> * + * {
 			margin-inline-start: 0;

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -12,6 +12,31 @@
 	background: var(--color-sidebar-background);
 }
 
+.wpcom-site .main.a4a-layout.sites-dashboard {
+	.a4a-layout__top-wrapper,
+	.a4a-layout__body {
+		> * {
+			padding-inline: 8px;
+
+			@include breakpoint-deprecated( ">660px" ) {
+				padding-inline: 8px;
+			}
+
+			@include breakpoint-deprecated( ">960px" ) {
+				padding-inline: 64px;
+			}
+		}
+	}
+
+	.a4a-layout__header-main {
+		display: block;
+	}
+
+	.a4a-layout__header-title {
+		display: block;
+	}
+}
+
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {
 	background: var(--studio-white);
 

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -13,21 +13,9 @@ import { useSitesDashboardImportSiteUrl } from 'calypso/sites-dashboard/hooks/us
 import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 
 const MAX_PAGE_WIDTH = '1224px';
-const pagePadding = {
-	[ MEDIA_QUERIES.mediumOrSmaller ]: {
-		paddingInlineStart: '16px',
-		paddingInlineEnd: '16px',
-	},
-};
 
 const PageHeader = styled.div( {
-	...pagePadding,
-
 	backgroundColor: 'var( --studio-white )',
-
-	[ MEDIA_QUERIES.mediumOrSmaller ]: {
-		padding: '16px',
-	},
 } );
 
 const HeaderControls = styled.div( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6770

## Proposed Changes

* Fix the header styles on the mobile

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/47e83517-c509-4cfd-8572-5b3e2d775de6) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/90fbf72d-6db5-409f-b72c-5a1f720acfbc) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Adjust the viewport width
* Make sure the header styles look good
* Open GSV
* Adjust the viewport width
* Make sure the header styles look good as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?