### PR TITLE
Scheduled Updates multisite: Fix state error

### DIFF
--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useSelector } from 'calypso/state';
-import { getSite } from 'calypso/state/sites/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { SiteSlug } from 'calypso/types';
 
@@ -84,14 +84,14 @@ export const useMultisiteUpdateScheduleQuery = (
 	isEligibleForFeature: boolean,
 	queryOptions = {}
 ): UseQueryResult< MultisiteSchedulesUpdates[] > => {
-	const state = useSelector( ( state ) => state );
 	const moment = useLocalizedMoment();
 
+	const sites = useSelector( getSites );
 	const retrieveSite = useCallback(
 		( siteId: number ) => {
-			return getSite( state, siteId );
+			return sites.find( ( site ) => site?.ID === siteId );
 		},
-		[ state ]
+		[ sites ]
 	);
 
 	const generateId = useCallback(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #90014

## Proposed Changes

* Uses getSites selector, to avoid rerendering any time state changes.

## Testing Instructions

- Test for regressions. http://calypso.localhost:3000/plugins/scheduled-updates should load fine, and expanded view should show site titles.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?