### PR TITLE
Sites Dashboard v2: Set item preview panel close button to be aligned to the top

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -6,6 +6,10 @@
 		.item-preview__header-title-summary {
 			word-wrap: anywhere;
 		}
+
+		.item-preview__close-preview {
+			align-self: flex-start;
+		}
 	}
 
 	@media ( min-width: $break-large ) {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -202,6 +202,16 @@
 				}
 			}
 		}
+
+		.item-preview__header-content .item-preview__close-preview {
+			height: 16px;
+			padding-left: 0;
+			padding-right: 0;
+
+			@include break-medium {
+				height: 32px;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6772

## Proposed Changes

This PR changes the vertical alignment of the close button to be to the top, and other small CSS improvements.

| Before | After |
| --- | --- |
| ![Screenshot 2024-04-29 at 4 46 22 PM](https://github.com/Automattic/wp-calypso/assets/797888/ff2940f3-a70f-44b2-b717-8467d1da6225) |  ![Screenshot 2024-04-29 at 4 46 34 PM](https://github.com/Automattic/wp-calypso/assets/797888/e9095ac2-42d8-4c3a-a571-95340abc1f12) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites?flags=layout%2Fdotcom-nav-redesign-v2`
* Ensure that the UI is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?