### PR TITLE
Automattic for Agencies: Implement WPCOM hosting header section

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/index.tsx
@@ -1,0 +1,19 @@
+import { getHostingLogo } from '../../lib/hosting';
+
+import './style.scss';
+
+interface HostingOverviewProps {
+	slug: string;
+	title: string;
+	subtitle: string;
+}
+
+export default function HostingOverview( { slug, title, subtitle }: HostingOverviewProps ) {
+	return (
+		<section className="hosting-overview__banner">
+			<div className="hosting-overview__banner-logo">{ getHostingLogo( slug ) }</div>
+			<h1 className="hosting-overview__banner-title">{ title }</h1>
+			<h2 className="hosting-overview__banner-subtitle">{ subtitle }</h2>
+		</section>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/style.scss
@@ -1,0 +1,49 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.hosting-overview .a4a-layout__body-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 64px;
+	margin-block-start: 48px;
+	margin-block-end: 64px;
+}
+
+.hosting-overview__banner {
+	margin: 0 auto;
+	text-align: center;
+}
+
+.hosting-overview__banner-logo {
+	margin-block-end: 32px;
+}
+
+.hosting-overview__banner-title {
+	font-size: 2.25rem;
+	font-weight: 600;
+	line-height: 1.1;
+	margin-block-end: 8px;
+}
+
+.hosting-overview__banner-subtitle {
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.1;
+}
+
+.hosting-overview__footer {
+	text-align: center;
+}
+
+.hosting-overview__learn-more-link {
+	border-radius: 4px;
+	font-weight: 600;
+	font-size: 0.875rem;
+	min-height: 40px;
+}
+
+.a4a-layout__header-breadcrumb {
+	@include breakpoint-deprecated( "<660px" ) {
+		display: none;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -20,11 +20,12 @@ import {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import HostingOverview from '../common/hosting-overview';
 import useShoppingCart from '../hooks/use-shopping-cart';
-import { getHostingLogo } from '../lib/hosting';
 import ShoppingCart, { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
 import PressableOverviewFeatures from './footer';
 import PressableOverviewPlanSelection from './plan-selection';
+
 import './style.scss';
 
 export default function PressableOverview() {
@@ -93,20 +94,11 @@ export default function PressableOverview() {
 			</LayoutTop>
 
 			<LayoutBody>
-				<section className="pressable-overview__banner">
-					<div className="pressable-overview__banner-logo">
-						{ getHostingLogo( 'pressable-hosting' ) }
-					</div>
-
-					<h1 className="pressable-overview__banner-title">
-						{ translate( 'Managed WordPress Hosting' ) }
-					</h1>
-
-					<h2 className="pressable-overview__banner-subtitle">
-						{ translate( 'Scalable plans to help you grow your business.' ) }
-					</h2>
-				</section>
-
+				<HostingOverview
+					slug="pressable-hosting"
+					title={ translate( 'Managed WordPress Hosting' ) }
+					subtitle={ translate( 'Scalable plans to help you grow your business.' ) }
+				/>
 				<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
 
 				<section className="pressable-overview__banner">

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -13,8 +13,11 @@ import {
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import HostingOverview from '../common/hosting-overview';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
+
+import './style.scss';
 
 export default function WpcomOverview() {
 	const translate = useTranslate();
@@ -60,7 +63,15 @@ export default function WpcomOverview() {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>WordPress.com hosting here</LayoutBody>
+			<LayoutBody>
+				<HostingOverview
+					slug="wpcom-hosting"
+					title={ translate( 'Powerful WordPress Hosting' ) }
+					subtitle={ translate(
+						'When you build and host your sites with WordPress.com, everything’s integrated, secure, and scalable.'
+					) }
+				/>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.pressable-overview .a4a-layout__body-wrapper {
+.wpcom-overview .a4a-layout__body-wrapper {
 	display: flex;
 	flex-direction: column;
 	gap: 64px;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/366

## Proposed Changes

This PR implements the WPCOM hosting header section includes the:

- Refactoring the header section into a new component and reusing it for Pressable & WPCOM hosting

## Testing Instructions

1) Open the A4A live link.
2) Visit /marketplace/hosting/pressable > Verify nothing is broken here by comparing it with the staging version.
3) Visit /marketplace/hosting/wpcom > Verify the header section is visible as shown below:

<img width="1138" alt="Screenshot 2024-04-29 at 2 02 22 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1b47b7b2-8a63-414d-8c4e-9466b964d9c2">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?