### PR TITLE
Nav Redesign: fix sites table padding

### DIFF
--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -139,7 +139,7 @@
 
 		.dataviews-view-table tr th:first-child,
 		.dataviews-view-table tr td:first-child {
-			padding: 8px 24px 8px 8px;
+			padding: 8px 24px 8px 16px;
 		}
 		.dataviews-view-table tr td:last-child {
 			padding: 0;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -80,6 +80,12 @@ const Column = styled.td< { tabletHidden?: boolean; deletedSite?: boolean } >`
 		${ ( props ) => props.deletedSite && 'width: 80%;' };
 	}
 
+	${ MEDIA_QUERIES.mediumOrSmaller } {
+		&:first-child {
+			padding-inline-start: 12px;
+		}
+	}
+
 	.stats-sparkline__bar {
 		fill: var( --studio-gray-60 );
 	}
@@ -393,7 +399,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					</>
 				) }
 			</StatsColumnStyled>
-			<Column style={ site.is_deleted ? { display: 'none' } : { width: '24px' } }>
+			<Column style={ site.is_deleted ? { display: 'none' } : { width: '36px' } }>
 				{ inView && <SitesEllipsisMenu site={ site } /> }
 			</Column>
 		</Row>

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -154,7 +154,7 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 							<JetpackLogo size={ 16 } /> <span>{ __( 'Stats' ) }</span>
 						</StatsThInner>
 					</StatsTh>
-					<th style={ { width: '24px' } }></th>
+					<th style={ { width: '36px' } }></th>
 				</Row>
 			</THead>
 			<tbody>


### PR DESCRIPTION
tidy up padding on the /sites table to fix 6785-gh-Automattic/dotcom-forge


<img width="590" alt="Screenshot 2024-04-29 at 7 31 02 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/8cd1caa9-e0e0-4a82-9288-69e491d982e3">

I think that it is not worth removing the grey border from 600px-780px because this is a generic layout thing that applies to other pages, and there seems to be plenty of space on the page:


I am fixing the pagination footer in 6779-gh-Automattic/dotcom-forge

And it looks like the header is being tidied up in https://github.com/Automattic/wp-calypso/pull/90016

### Testing instructions: 
test `/sites` page on mobile and desktop, with and without `?flags=layout/dotcom-nav-redesign-v2` enabled