### PR TITLE
Pattern Library: Fix view toggle in search mode

### DIFF
--- a/client/my-sites/patterns/components/toggle/style.scss
+++ b/client/my-sites/patterns/components/toggle/style.scss
@@ -26,16 +26,20 @@
 	white-space: nowrap;
 	width: 100%;
 
+	@media ( max-width: $break-medium ) {
+		height: 36px;
+	}
+
+	&:hover {
+		color: inherit;
+	}
+
 	&.is-active {
 		color: #fff;
 	}
 
 	path {
 		fill: currentColor;
-	}
-
-	@media ( max-width: $break-medium ) {
-		height: 36px;
 	}
 }
 

--- a/client/my-sites/patterns/components/view-toggle/index.tsx
+++ b/client/my-sites/patterns/components/view-toggle/index.tsx
@@ -6,9 +6,29 @@ import {
 } from 'calypso/my-sites/patterns/components/toggle';
 import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
-import { PatternView } from 'calypso/my-sites/patterns/types';
+import { PatternTypeFilter, PatternView } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
+
+// On the client, the URL query string may contain a search term. If so, we want to preserve that
+function getViewToggleUrlPath(
+	category: string,
+	patternTypeFilter: PatternTypeFilter,
+	isGridView: boolean
+): string {
+	if ( typeof window !== 'undefined' ) {
+		const url = new URL( window.location.href );
+		url.searchParams.delete( 'grid' );
+
+		if ( isGridView ) {
+			url.searchParams.set( 'grid', '1' );
+		}
+
+		return url.toString();
+	}
+
+	return getCategoryUrlPath( category, patternTypeFilter, false, isGridView );
+}
 
 type ViewToggleProps = {
 	onChange?( value: PatternView ): void;
@@ -37,7 +57,7 @@ export function ViewToggle( { onChange }: ViewToggleProps ) {
 		>
 			<PatternLibraryToggleOption
 				aria-label={ listViewLabel }
-				href={ getCategoryUrlPath( category, patternTypeFilter, false, false ) }
+				href={ getViewToggleUrlPath( category, patternTypeFilter, false ) }
 				tooltipText={ listViewLabel }
 				value="list"
 			>
@@ -46,7 +66,7 @@ export function ViewToggle( { onChange }: ViewToggleProps ) {
 
 			<PatternLibraryToggleOption
 				aria-label={ gridViewLabel }
-				href={ getCategoryUrlPath( category, patternTypeFilter, false, true ) }
+				href={ getViewToggleUrlPath( category, patternTypeFilter, true ) }
 				tooltipText={ gridViewLabel }
 				value="grid"
 			>

--- a/client/my-sites/patterns/components/view-toggle/index.tsx
+++ b/client/my-sites/patterns/components/view-toggle/index.tsx
@@ -5,29 +5,30 @@ import {
 	PatternLibraryToggleOption,
 } from 'calypso/my-sites/patterns/components/toggle';
 import { usePatternsContext } from 'calypso/my-sites/patterns/context';
+import { QUERY_PARAM_SEARCH } from 'calypso/my-sites/patterns/lib/filter-patterns-by-term';
 import { getCategoryUrlPath } from 'calypso/my-sites/patterns/paths';
 import { PatternTypeFilter, PatternView } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
 
-// On the client, the URL query string may contain a search term. If so, we want to preserve that
 function getViewToggleUrlPath(
 	category: string,
 	patternTypeFilter: PatternTypeFilter,
-	isGridView: boolean
+	isGridView: boolean,
+	searchTerm: string
 ): string {
-	if ( typeof window !== 'undefined' ) {
-		const url = new URL( window.location.href );
-		url.searchParams.delete( 'grid' );
+	const path = getCategoryUrlPath( category, patternTypeFilter, false );
+	const params = new URLSearchParams();
 
-		if ( isGridView ) {
-			url.searchParams.set( 'grid', '1' );
-		}
-
-		return url.toString();
+	if ( isGridView ) {
+		params.set( 'grid', '1' );
 	}
 
-	return getCategoryUrlPath( category, patternTypeFilter, false, isGridView );
+	if ( searchTerm ) {
+		params.set( QUERY_PARAM_SEARCH, searchTerm );
+	}
+
+	return params.size ? `${ path }?${ params }` : path;
 }
 
 type ViewToggleProps = {
@@ -36,7 +37,7 @@ type ViewToggleProps = {
 
 export function ViewToggle( { onChange }: ViewToggleProps ) {
 	const translate = useTranslate();
-	const { category, isGridView, patternTypeFilter } = usePatternsContext();
+	const { category, isGridView, patternTypeFilter, searchTerm } = usePatternsContext();
 	const currentView = isGridView ? 'grid' : 'list';
 
 	const listViewLabel = translate( 'List view', {
@@ -57,7 +58,7 @@ export function ViewToggle( { onChange }: ViewToggleProps ) {
 		>
 			<PatternLibraryToggleOption
 				aria-label={ listViewLabel }
-				href={ getViewToggleUrlPath( category, patternTypeFilter, false ) }
+				href={ getViewToggleUrlPath( category, patternTypeFilter, false, searchTerm ) }
 				tooltipText={ listViewLabel }
 				value="list"
 			>
@@ -66,7 +67,7 @@ export function ViewToggle( { onChange }: ViewToggleProps ) {
 
 			<PatternLibraryToggleOption
 				aria-label={ gridViewLabel }
-				href={ getViewToggleUrlPath( category, patternTypeFilter, true ) }
+				href={ getViewToggleUrlPath( category, patternTypeFilter, true, searchTerm ) }
 				tooltipText={ gridViewLabel }
 				value="grid"
 			>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6810

## Proposed Changes

This PR fixes a regression introduced in #89729 where the view switcher (`List view / Grid view`) stopped working in search mode.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to patterns
2. Search for e.g. `contact`
3. Ensure that the view switcher works as expected
4. Navigate to a category
5. Without searching for anything, ensure that the view switcher works as expected
6. Search for something
7. Ensure that the view switcher works as expected
