### PR TITLE
Nav Redesign - Add focus style to flyout header links

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -50,6 +50,7 @@
 
 						&:focus {
 							box-shadow: none;
+							outline: thin dotted;
 						}
 					}
 				}


### PR DESCRIPTION
Fixes issue https://github.com/Automattic/dotcom-forge/issues/6791

Adds focus style like below;

<img width="549" alt="Screenshot 2024-04-29 at 11 38 54" src="https://github.com/Automattic/wp-calypso/assets/5560595/cf890077-ab53-4953-b3b1-fee91ea0b39f">
<img width="587" alt="Screenshot 2024-04-29 at 11 38 27" src="https://github.com/Automattic/wp-calypso/assets/5560595/bb55129b-ffb3-415f-b4a9-7a36b965b712">

## Testing Instructions

* Go to `https://container-confident-kirch.calypso.live/sites?flags=layout/dotcom-nav-redesign-v2`
* Click on a site and confirm that when links are tabbed to, they have an outline to let the user know that link is focused.

