### PR TITLE
Nav Redesign: Fix the responsive styles

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -412,36 +412,38 @@ $brand-text: "SF Pro Text", $sans;
 	}
 }
 
-.is-global-sidebar-collapsed {
-	.global-sidebar {
-		.sidebar__header,
-		.sidebar__footer {
-			flex-direction: column;
+@media ( min-width: 660px ) {
+	.is-global-sidebar-collapsed {
+		.global-sidebar {
+			.sidebar__header,
+			.sidebar__footer {
+				flex-direction: column;
 
-			.sidebar__footer-profile {
-				padding: 0;
-			}
-		}
-
-		.sidebar__header {
-			span.dotcom {
-				background-position: left;
-				width: 24px;
-				margin-left: 6px;
-
-				.rtl & {
-					background-position: right;
-					margin-right: 6px;
+				.sidebar__footer-profile {
+					padding: 0;
 				}
 			}
-		}
 
-		.sidebar__body {
-			.sidebar__menu-item-parent .sidebar__menu-link {
-				margin: 0 auto;
+			.sidebar__header {
+				span.dotcom {
+					background-position: left;
+					width: 24px;
+					margin-left: 6px;
 
-				> *:not(:first-child) {
-					display: none;
+					.rtl & {
+						background-position: right;
+						margin-right: 6px;
+					}
+				}
+			}
+
+			.sidebar__body {
+				.sidebar__menu-item-parent .sidebar__menu-link {
+					margin: 0 auto;
+
+					> *:not(:first-child) {
+						display: none;
+					}
 				}
 			}
 		}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -102,7 +102,9 @@
 .wpcom-site .is-group-sites.is-global-sidebar-collapsed,
 .wpcom-site .is-group-sites.is-global-sidebar-visible {
 	.layout__content {
-		padding: 16px 16px 16px calc(var(--sidebar-width-max));
+		@include break-medium {
+			padding: 16px 16px 16px calc(var(--sidebar-width-max));
+		}
 	}
 
 	.layout__secondary .global-sidebar {
@@ -124,13 +126,15 @@
 		}
 	}
 	.is-global-sidebar-collapsed {
-		.global-sidebar {
-			.sidebar__body {
-				.sidebar__menu-link {
-					width: fit-content;
+		@media ( min-width: 660px ) {
+			.global-sidebar {
+				.sidebar__body {
+					.sidebar__menu-link {
+						width: fit-content;
 
-					> :first-child {
-						margin-right: 0;
+						> :first-child {
+							margin-right: 0;
+						}
 					}
 				}
 			}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -35,6 +35,18 @@
 	.a4a-layout__header-title {
 		display: block;
 	}
+
+	.item-preview__content {
+		.hosting-overview,
+		.site-monitoring-overview {
+			overflow-y: initial;
+			max-height: initial;
+		}
+	}
+
+	@media (max-width: $break-large) {
+		height: calc(100vh - 32px);
+	}
 }
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -42,7 +42,6 @@
 		.site-monitoring-overview {
 			overflow-y: initial;
 			max-height: initial;
-			padding-bottom: 88px;
 		}
 	}
 
@@ -82,8 +81,6 @@
 	}
 
 	@media (max-width: $break-large) {
-		height: calc(100vh - 120px); /* Matches the offset defined in PR #65520 */
-
 		.section-nav__mobile-header {
 			padding: 13px;
 		}

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -37,14 +37,6 @@
 		padding-block-start: 24px;
 	}
 
-	.item-preview__content {
-		.hosting-overview,
-		.site-monitoring-overview {
-			overflow-y: initial;
-			max-height: initial;
-		}
-	}
-
 	@media (min-width: $break-large) {
 		background: inherit;
 
@@ -81,6 +73,8 @@
 	}
 
 	@media (max-width: $break-large) {
+		height: calc(100vh - 120px); /* Matches the offset defined in PR #65520 */
+
 		.section-nav__mobile-header {
 			padding: 13px;
 		}
@@ -181,7 +175,7 @@
 			display: none;
 		}
 
-		td:nth-child(n+2):nth-child(-n+5) {
+		.dataviews-view-table-wrapper td:nth-child(n+2):nth-child(-n+5) {
 			display: none;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6788

## Proposed Changes

* Fix the responsive styles

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/187a0409-ac0d-465e-b84a-e2dcc741e51b) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/13d860e9-b9aa-462a-bcc5-7c4f904a088d) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ca4a7ae8-5b9f-4b8a-8d5a-8e6176cb44ea) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1c4574eb-9292-4079-b4bf-798b7f898398) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6055b351-af0e-49a8-a06d-ac6c7d782d9e) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/aff13a23-89cb-4179-b0ad-4e8232f3c971) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Opened GSV**

* Go to /sites?flags=layout/dotcom-nav-redesign-v2
* Open the GSV
* Resize the viewport width
* When the sidebar is collapsed, make sure the styles look good 
* When the masterbar is shown and the sidebar becomes full-screen, make sure the styles look good (open & close the sidebar)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?