### PR TITLE
Nav Redesign - add focus to close preview icon

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -4,6 +4,7 @@ import { useMediaQuery } from '@wordpress/compose';
 import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
+import { useEffect, useRef } from 'react';
 import SiteFavicon from '../../site-favicon';
 import { ItemData, ItemPreviewPaneHeaderExtraProps } from '../types';
 
@@ -26,6 +27,15 @@ export default function ItemPreviewPaneHeader( {
 }: Props ) {
 	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
 	const size = isLargerThan960px ? 64 : 50;
+
+	const focusRef = useRef< HTMLInputElement >( null );
+
+	// Use useEffect to set the focus when the component mounts
+	useEffect( () => {
+		if ( focusRef.current ) {
+			focusRef.current.focus();
+		}
+	}, [] );
 
 	return (
 		<div className={ classNames( 'item-preview__header', className ) }>
@@ -69,6 +79,7 @@ export default function ItemPreviewPaneHeader( {
 					onClick={ closeItemPreviewPane }
 					className="item-preview__close-preview"
 					aria-label={ translate( 'Close Preview' ) }
+					ref={ focusRef }
 				>
 					<Gridicon icon="cross" size={ ICON_SIZE } />
 				</Button>


### PR DESCRIPTION
Fixes issue https://github.com/Automattic/dotcom-forge/issues/6790

This auto focuses the close preview icon when a site is selected from the sites page;

https://github.com/Automattic/wp-calypso/assets/5560595/f8f07de1-005c-466e-827d-7353c392bb21

## Testing Instructions

* Go to calypso.live sites page - `/sites?flags=layout/dotcom-nav-redesign-v2`
* Tab to a site and when the preview pane loads, the close preview icon should be focused

## Notes

The close icon appears to flicker when focused - looking into why that happens.