### PR TITLE
Automattic for Agencies: Implement A4A WPCOM hosting slider

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -40,12 +40,14 @@ export default function PlanSelectionFilter( { selectedPlan, plans, onSelectPlan
 	const onSelectOption = useCallback(
 		( option: Option ) => {
 			const plan = plans.find( ( plan ) => plan.slug === option.value ) ?? null;
-			recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_select_plan', {
-				slug: plan?.slug,
-			} );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_select_plan', {
+					slug: plan?.slug,
+				} )
+			);
 			onSelectPlan( plan );
 		},
-		[ onSelectPlan, plans ]
+		[ dispatch, onSelectPlan, plans ]
 	);
 
 	const selectedOption = options.findIndex(

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -38,15 +38,13 @@ export default function WPCOMBulkSelector( { selectedCount, onSelectCount }: Pro
 
 	return (
 		<div className="bulk-selection">
-			<div>
-				<A4ASlider
-					label={ translate( 'Total sites' ) }
-					sub={ translate( 'Total discount' ) }
-					value={ selectedOption }
-					onChange={ onSelectOption }
-					options={ wpcomBulkOptions }
-				/>
-			</div>
+			<A4ASlider
+				label={ translate( 'Total sites' ) }
+				sub={ translate( 'Total discount' ) }
+				value={ selectedOption }
+				onChange={ onSelectOption }
+				options={ wpcomBulkOptions }
+			/>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -1,0 +1,52 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import wpcomBulkOptions from './lib/wpcom-bulk-options';
+
+type Props = {
+	selectedCount: {
+		value: number;
+		label: string;
+	};
+	onSelectCount: ( count: { value: number; label: string } ) => void;
+};
+
+export default function WPCOMBulkSelector( { selectedCount, onSelectCount }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onSelectOption = useCallback(
+		( option: Option ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_hosting_wpcom_select_count', {
+					count: option.value,
+				} )
+			);
+			onSelectCount( {
+				value: option.value as number,
+				label: option.label,
+			} );
+		},
+		[ dispatch, onSelectCount ]
+	);
+
+	const selectedOption = wpcomBulkOptions.findIndex(
+		( { value } ) => value === ( selectedCount ? selectedCount.value : null )
+	);
+
+	return (
+		<div className="bulk-selection">
+			<div>
+				<A4ASlider
+					label={ translate( 'Total sites' ) }
+					sub={ translate( 'Total discount' ) }
+					value={ selectedOption }
+					onChange={ onSelectOption }
+					options={ wpcomBulkOptions }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -16,6 +17,8 @@ import {
 import HostingOverview from '../common/hosting-overview';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
+import WPCOMBulkSelector from './bulk-selection';
+import wpcomBulkOptions from './lib/wpcom-bulk-options';
 
 import './style.scss';
 
@@ -23,6 +26,8 @@ export default function WpcomOverview() {
 	const translate = useTranslate();
 
 	const { selectedCartItems, onRemoveCartItem } = useShoppingCart();
+
+	const [ selectedCount, setSelectedCount ] = useState( wpcomBulkOptions[ 0 ] );
 
 	return (
 		<Layout
@@ -71,6 +76,7 @@ export default function WpcomOverview() {
 						'When you build and host your sites with WordPress.com, everything’s integrated, secure, and scalable.'
 					) }
 				/>
+				<WPCOMBulkSelector selectedCount={ selectedCount } onSelectCount={ setSelectedCount } />
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -1,3 +1,4 @@
+// FIXME we should fetch the discount bracket from a proper source when ready.
 const wpcomBulkOptions = [
 	{
 		value: 1,

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -1,0 +1,38 @@
+const wpcomBulkOptions = [
+	{
+		value: 1,
+		label: '1',
+	},
+	{
+		value: 3,
+		label: '3',
+		sub: '4%',
+	},
+	{
+		value: 5,
+		label: '5',
+		sub: '8%',
+	},
+	{
+		value: 10,
+		label: '10',
+		sub: '20%',
+	},
+	{
+		value: 20,
+		label: '20',
+		sub: '40%',
+	},
+	{
+		value: 50,
+		label: '50',
+		sub: '70%',
+	},
+	{
+		value: 100,
+		label: '100',
+		sub: '80%',
+	},
+];
+
+export default wpcomBulkOptions;

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
@@ -7,6 +7,15 @@
 	gap: 64px;
 	margin-block-start: 48px;
 	margin-block-end: 64px;
+
+	.bulk-selection {
+		width: 100%;
+
+		@include break-large {
+			width: 800px;
+			margin-inline: auto;
+		}
+	}
 }
 
 .a4a-layout__header-breadcrumb {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/364

## Proposed Changes

This PR implements the WPCOM hosting bulk selection slider

NOTE: Since this is a slider with specific number of sites, I think it makes sense to keep the count to 100 instead of 100+

## Testing Instructions

1) Open the A4A live link.
2) Visit /marketplace/hosting/wpcom > Verify the bulk selection slider is visible as shown below & works as expected(changing the total sites).

<img width="1138" alt="Screenshot 2024-04-29 at 5 00 34 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8092e43b-fa23-4a76-9a05-cbec178c3531">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?