### PR TITLE
A4A: Update Marketplace's Hosting card design and copies

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/simple-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/simple-list/index.tsx
@@ -1,0 +1,17 @@
+import { Icon, check } from '@wordpress/icons';
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+export default function SimpleList( { items }: { items: ReactNode[] } ) {
+	return (
+		<ul className="simple-list">
+			{ items.map( ( item, index ) => (
+				<li key={ `item-${ index }` }>
+					<Icon className="simple-list-icon" icon={ check } size={ 24 } />
+					{ item }
+				</li>
+			) ) }
+		</ul>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/common/simple-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/simple-list/index.tsx
@@ -9,7 +9,7 @@ export default function SimpleList( { items }: { items: ReactNode[] } ) {
 			{ items.map( ( item, index ) => (
 				<li key={ `item-${ index }` }>
 					<Icon className="simple-list-icon" icon={ check } size={ 24 } />
-					{ item }
+					<div className="simple-list-text">{ item }</div>
 				</li>
 			) ) }
 		</ul>

--- a/client/a8c-for-agencies/sections/marketplace/common/simple-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/simple-list/style.scss
@@ -1,0 +1,21 @@
+.simple-list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+	margin: 0;
+	padding: 0;
+	list-style: none;
+
+	li {
+		font-size: 1rem;
+		line-height: 1.6;
+		font-weight: 400;
+	}
+}
+
+.simple-list-icon {
+	margin-inline-end: 4px;
+	fill: var(--color-primary-40);
+	margin-block-end: -6px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/common/simple-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/simple-list/style.scss
@@ -8,6 +8,8 @@
 	list-style: none;
 
 	li {
+		display: flex;
+		flex-direction: row;
 		font-size: 1rem;
 		line-height: 1.6;
 		font-weight: 400;
@@ -18,4 +20,6 @@
 	margin-inline-end: 4px;
 	fill: var(--color-primary-40);
 	margin-block-end: -6px;
+	min-width: 24px;
+	min-height: 24px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.ts
@@ -9,12 +9,14 @@ import { useMemo } from 'react';
 export default function useHostingDescription( slug: string ): {
 	name: TranslateResult;
 	description: TranslateResult;
+	features: TranslateResult[];
 } {
 	const translate = useTranslate();
 
 	return useMemo( () => {
 		let description = '';
 		let name = '';
+		let features: TranslateResult[] = [];
 
 		switch ( slug ) {
 			case 'pressable-hosting':
@@ -22,18 +24,38 @@ export default function useHostingDescription( slug: string ): {
 				description = translate(
 					'Best for developers and agencies who need advanced hosting controls and management tools.'
 				);
+				features = [
+					translate( 'Optimized for high-traffic WooCommerce stores' ),
+					translate( '100% uptime SLA' ),
+					translate( 'Great for teams with granular permission needs' ),
+					translate( 'Tooling to help you manage sites at scale with one-click config options' ),
+					translate( 'White-label tools for agencies' ),
+					translate(
+						'Partner sales concierge to assist with custom plans and complex purchasing requirements'
+					),
+					translate( 'Multiple support channels: Email, web chat, and Slack.' ),
+					translate( 'Decoupled (headless) support' ),
+				];
 				break;
 			case 'wpcom-hosting':
 				name = translate( 'WordPress.com' );
 				description = translate(
 					'Best for those who want optimized, hassle-free WordPress hosting.'
 				);
+				features = [
+					translate( 'Great for developers with client-managed sites' ),
+					translate( 'Unlimited visits' ),
+					translate( '50GB storage' ),
+					translate( 'Self-service sales' ),
+					translate( 'Local development environment, Studio' ),
+				];
 				break;
 		}
 
 		return {
 			name,
 			description,
+			features,
 		};
 	}, [ slug, translate ] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.ts
@@ -20,13 +20,13 @@ export default function useHostingDescription( slug: string ): {
 			case 'pressable-hosting':
 				name = translate( 'Pressable' );
 				description = translate(
-					'9 custom plans built for agencies that include an intuitive control panel, easy site migration, staging environments, performance tools, and flexible upgrades & downgrades. '
+					'Best for developers and agencies who need advanced hosting controls and management tools.'
 				);
 				break;
 			case 'wpcom-hosting':
 				name = translate( 'WordPress.com' );
 				description = translate(
-					'Unbeatable uptime, unmetered bandwidth, and everything you need to streamline your development process, baked in. Perfect uptime. Fastest WP Bench score. A+ SSL grade.'
+					'Best for those who want optimized, hassle-free WordPress hosting.'
 				);
 				break;
 		}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
@@ -1,5 +1,6 @@
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 
 /**
  * Returns hosting name and description with given product slug.
@@ -25,7 +26,11 @@ export default function useHostingDescription( slug: string ): {
 					'Best for developers and agencies who need advanced hosting controls and management tools.'
 				);
 				features = [
-					translate( 'Optimized for high-traffic WooCommerce stores' ),
+					translate( 'Optimized for high-traffic WooCommerce stores {{img/}}', {
+						components: {
+							img: <WooCommerceLogo size={ 32 } />,
+						},
+					} ),
 					translate( '100% uptime SLA' ),
 					translate( 'Great for teams with granular permission needs' ),
 					translate( 'Tooling to help you manage sites at scale with one-click config options' ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -32,50 +32,59 @@ export default function HostingCard( { plan, pressableOwnership }: Props ) {
 
 	return (
 		<div className="hosting-card">
-			<div className="hosting-card__header">
-				{ getHostingLogo( plan.family_slug ) }
-				{ pressableOwnership && <Badge type="success">{ translate( 'You own this' ) }</Badge> }
-			</div>
-
-			<div className="hosting-card__price">
-				<b className="hosting-card__price-value">
-					{ translate( 'Starting at %(price)s', {
-						args: { price: formatCurrency( Number( plan.amount ), plan.currency ) },
-					} ) }
-				</b>
-				<div className="hosting-card__price-interval">
-					{ plan.price_interval === 'day' && translate( 'USD per plan per day' ) }
-					{ plan.price_interval === 'month' && translate( 'USD per plan per month' ) }
+			<div className="hosting-card__section">
+				<div className="hosting-card__header">
+					{ getHostingLogo( plan.family_slug ) }
+					{ pressableOwnership && <Badge type="success">{ translate( 'You own this' ) }</Badge> }
 				</div>
+
+				<div className="hosting-card__price">
+					<b className="hosting-card__price-value">
+						{ translate( 'Starting at %(price)s', {
+							args: { price: formatCurrency( Number( plan.amount ), plan.currency ) },
+						} ) }
+					</b>
+					<div className="hosting-card__price-interval">
+						{ plan.price_interval === 'day' && translate( 'USD per plan per day' ) }
+						{ plan.price_interval === 'month' && translate( 'USD per plan per month' ) }
+					</div>
+				</div>
+
+				<p className="hosting-card__description">{ description }</p>
+
+				{ ! pressableOwnership ? (
+					<Button
+						className="hosting-card__explore-button"
+						href={ getHostingPageUrl( plan.family_slug ) }
+						onClick={ onExploreClick }
+						primary
+					>
+						{ translate( 'Explore %(hosting)s plans', {
+							args: {
+								hosting: name,
+							},
+							comment: '%(hosting)s is the name of the hosting provider.',
+						} ) }
+					</Button>
+				) : (
+					<Button
+						className="hosting-card__pressable-dashboard-button"
+						target="_blank"
+						rel="norefferer nooppener"
+						href={ pressableUrl }
+					>
+						{ translate( 'Go to Pressable Dashboard' ) }
+						<Icon icon={ external } size={ 18 } />
+					</Button>
+				) }
 			</div>
 
-			<p className="hosting-card__description">{ description }</p>
-
-			{ ! pressableOwnership ? (
-				<Button
-					className="hosting-card__explore-button"
-					href={ getHostingPageUrl( plan.family_slug ) }
-					onClick={ onExploreClick }
-					primary
-				>
-					{ translate( 'Explore %(hosting)s plans', {
-						args: {
-							hosting: name,
-						},
-						comment: '%(hosting)s is the name of the hosting provider.',
-					} ) }
-				</Button>
-			) : (
-				<Button
-					className="hosting-card__pressable-dashboard-button"
-					target="_blank"
-					rel="norefferer nooppener"
-					href={ pressableUrl }
-				>
-					{ translate( 'Go to Pressable Dashboard' ) }
-					<Icon icon={ external } size={ 18 } />
-				</Button>
-			) }
+			<div className="hosting-card__section">
+				<ul className="hosting-card__features">
+					<li>test</li>
+					<li>test</li>
+				</ul>
+			</div>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -42,6 +42,8 @@ export default function HostingCard( { plan, pressableOwnership }: Props ) {
 					{ pressableOwnership && <Badge type="success">{ translate( 'You own this' ) }</Badge> }
 				</div>
 
+				<p className="hosting-card__description">{ description }</p>
+
 				<div className="hosting-card__price">
 					<b className="hosting-card__price-value">
 						{ translate( 'Starting at %(price)s', {
@@ -49,12 +51,12 @@ export default function HostingCard( { plan, pressableOwnership }: Props ) {
 						} ) }
 					</b>
 					<div className="hosting-card__price-interval">
-						{ plan.price_interval === 'day' && translate( 'USD per plan per day' ) }
-						{ plan.price_interval === 'month' && translate( 'USD per plan per month' ) }
+						{ plan.price_interval === 'day' &&
+							translate( 'USD per plan per day, billed annually' ) }
+						{ plan.price_interval === 'month' &&
+							translate( 'USD per plan per month, billed annually' ) }
 					</div>
 				</div>
-
-				<p className="hosting-card__description">{ description }</p>
 
 				{ ! pressableOwnership ? (
 					<Button

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Badge, Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { Icon, external } from '@wordpress/icons';
@@ -5,9 +6,12 @@ import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import SimpleList from '../../common/simple-list';
 import { getHostingLogo, getHostingPageUrl } from '../../lib/hosting';
 import useHostingDescription from '../hooks/use-hosting-description';
+
 import './style.scss';
+
 type Props = {
 	plan: APIProductFamilyProduct;
 	pressableOwnership?: boolean;
@@ -20,7 +24,7 @@ export default function HostingCard( { plan, pressableOwnership }: Props ) {
 	//on how the UX should look in the end
 	const pressableUrl = 'https://my.pressable.com/agency/auth';
 
-	const { name, description } = useHostingDescription( plan.family_slug );
+	const { name, description, features } = useHostingDescription( plan.family_slug );
 
 	const onExploreClick = () => {
 		dispatch(
@@ -79,12 +83,11 @@ export default function HostingCard( { plan, pressableOwnership }: Props ) {
 				) }
 			</div>
 
-			<div className="hosting-card__section">
-				<ul className="hosting-card__features">
-					<li>test</li>
-					<li>test</li>
-				</ul>
-			</div>
+			{ isEnabled( 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' ) && (
+				<div className="hosting-card__section">
+					<SimpleList items={ features } />
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -51,10 +51,8 @@ export default function HostingCard( { plan, pressableOwnership }: Props ) {
 						} ) }
 					</b>
 					<div className="hosting-card__price-interval">
-						{ plan.price_interval === 'day' &&
-							translate( 'USD per plan per day, billed annually' ) }
-						{ plan.price_interval === 'month' &&
-							translate( 'USD per plan per month, billed annually' ) }
+						{ plan.price_interval === 'day' && translate( 'USD per plan per day' ) }
+						{ plan.price_interval === 'month' && translate( 'USD per plan per month' ) }
 					</div>
 				</div>
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -12,7 +12,7 @@
 	align-items: flex-start;
 	gap: 24px;
 
-	&:last-child {
+	&:last-child:not(:first-child) {
 		border-block-start: 1px solid var(--color-neutral-5);
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -30,7 +30,7 @@
 }
 
 .hosting-card__price-value {
-	font-size: 1.5rem;
+	font-size: 1rem;
 	font-weight: 600;
 	line-height: 1.1;
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -7,6 +7,14 @@
 	.button {
 		width: 100%;
 	}
+
+	.woo-logo {
+		margin: 0;
+
+		path {
+			fill: var(--color-woocommerce);
+		}
+	}
 }
 
 .hosting-card__section {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -3,6 +3,10 @@
 	border: 1px solid var(--color-neutral-10);
 	border-radius: 4px;
 	user-select: none;
+
+	.button {
+		width: 100%;
+	}
 }
 
 .hosting-card__section {
@@ -30,9 +34,10 @@
 }
 
 .hosting-card__description {
-	font-size: 0.875rem;
-	line-height: 1.1;
+	font-size: 1rem;
+	line-height: 1.3;
 	font-weight: 400;
+	min-height: 44px;
 	margin: 0;
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -1,13 +1,20 @@
 
 .hosting-card {
-	padding: 1.5rem;
 	border: 1px solid var(--color-neutral-10);
 	border-radius: 4px;
 	user-select: none;
+}
+
+.hosting-card__section {
+	padding: 24px;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
 	gap: 24px;
+
+	&:last-child {
+		border-block-start: 1px solid var(--color-neutral-5);
+	}
 }
 
 .hosting-card__price-value {
@@ -47,4 +54,12 @@
 	svg {
 		margin-inline-start: 6px;
 	}
+}
+
+ul.hosting-card__features {
+	display: flex;
+	flex-direction: column;
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -79,10 +79,11 @@ export default function HostingList( { selectedSite }: Props ) {
 				) }
 				isTwoColumns
 			>
+				{ cheapestWPCOMPlan && <HostingCard plan={ cheapestWPCOMPlan } /> }
+
 				{ cheapestPressablePlan && (
 					<HostingCard plan={ cheapestPressablePlan } pressableOwnership={ hasPressablePlan } />
 				) }
-				{ cheapestWPCOMPlan && <HostingCard plan={ cheapestWPCOMPlan } /> }
 			</ListingSection>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,14 +1,15 @@
 import { Button } from '@automattic/components';
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
-import { Icon, check, external } from '@wordpress/icons';
+import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode, useCallback } from 'react';
+import { useCallback } from 'react';
 import { getProductPricingInfo } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import SimpleList from '../../common/simple-list';
 import getPressablePlan from '../lib/get-pressable-plan';
 import getPressableShortName from '../lib/get-pressable-short-name';
 
@@ -16,23 +17,6 @@ type Props = {
 	selectedPlan: APIProductFamilyProduct | null;
 	onSelectPlan: () => void;
 };
-
-function IncludedList( { items }: { items: ReactNode[] } ) {
-	return (
-		<ul className="pressable-overview-plan-selection__details-card-included-list">
-			{ items.map( ( item, index ) => (
-				<li key={ `included-item-${ index }` }>
-					<Icon
-						className="pressable-overview-plan-selection__details-card-included-list-icon"
-						icon={ check }
-						size={ 24 }
-					/>
-					{ item }
-				</li>
-			) ) }
-		</ul>
-	);
-}
 
 export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Props ) {
 	const translate = useTranslate();
@@ -80,7 +64,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 					) }
 				</div>
 
-				<IncludedList
+				<SimpleList
 					items={ [
 						info?.install
 							? translate(
@@ -146,7 +130,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 					{ translate( 'All plans include:' ) }{ ' ' }
 				</h3>
 
-				<IncludedList
+				<SimpleList
 					items={ [
 						translate( '24/7 WordPress hosting support' ),
 						translate( 'WP Cloud platform' ),

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -74,28 +74,6 @@
 	color: var(--color-neutral-60);
 }
 
-.pressable-overview-plan-selection__details-card-included-list {
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-
-	margin: 0;
-	padding: 0;
-	list-style: none;
-
-	li {
-		font-size: 1rem;
-		line-height: 1.6;
-		font-weight: 400;
-	}
-}
-
-.pressable-overview-plan-selection__details-card-included-list-icon {
-	margin-inline-end: 4px;
-	fill: var(--color-primary-40);
-	margin-block-end: -6px;
-}
-
 .pressable-overview-plan-selection__details-card-cta-button {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
This PR updates the current Hosting card to follow the new design and copies. Note that copies are based on the latest discussion. https://github.com/Automattic/automattic-for-agencies-dev/issues/379

| Before | After |
|--------|--------|
| <img width="1356" alt="Screenshot 2024-04-29 at 7 49 24 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/33384642-8692-482a-8e46-3985da5f8dae"> | <img width="1337" alt="Screenshot 2024-04-29 at 7 49 32 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6019859d-c25b-4656-bbd8-c9c0328063f1"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/361

## Proposed Changes

* Rearranged the Pressable and WPCOM hosting card positions based on the latest discussion.
* Rearranged the description and price info based on the latest discussion.
* Add a feature list to the card. I also added a shared simple list that can be used across the marketplace section.
* Update some copies based on the latest discussion.

## Testing Instructions


* Use the A4A live link below and go to `/marketplace/hosting?flags=a8c-for-agencies/wpcom-creator-plan-purchase-flow`
* Confirm that the card design follows the new design and copies.


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?