### PR TITLE
Nav Redesign: drop the early access gating

### DIFF
--- a/client/state/sites/selectors/is-global-site-view-enabled.ts
+++ b/client/state/sites/selectors/is-global-site-view-enabled.ts
@@ -10,7 +10,6 @@ import type { AppState } from 'calypso/types';
 export default function isGlobalSiteViewEnabled( state: AppState, siteId: number | null ) {
 	const isAdminInterfaceWPAdmin =
 		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
-	const isClassicEarlyRelease = !! getSiteOption( state, siteId, 'wpcom_classic_early_release' );
 
-	return isAdminInterfaceWPAdmin && isClassicEarlyRelease;
+	return isAdminInterfaceWPAdmin;
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6793

## Proposed Changes

As part of the Nav Redesign Launch Checklist (https://github.com/Automattic/dotcom-forge/issues/6796), we drop the `wpcom_classic_early_release` gating.

## Testing Instructions

* Check all Nav redesign features on sites without `wpcom_classic_early_release` and with `wp-admin` interface selected
