### PR TITLE
Scheduled Updates Multisite: Handle errors through context

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/context/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/context/index.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, ReactNode, useState } from 'react';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { SiteSlug } from 'calypso/types';
+import type { Dispatch, SetStateAction } from 'react';
+
+export type MultisitePluginUpdateManagerErrors = {
+	siteSlug: SiteSlug;
+	error: string;
+	site?: SiteDetails | null;
+}[];
+
+interface MultisitePluginUpdateManagerContextProps {
+	errors: MultisitePluginUpdateManagerErrors;
+	setErrors: Dispatch< SetStateAction< MultisitePluginUpdateManagerErrors > >;
+}
+
+const MultisitePluginUpdateManagerContext =
+	createContext< MultisitePluginUpdateManagerContextProps >( {
+		errors: [],
+		setErrors: () => {},
+	} );
+
+const MultisitePluginUpdateManagerContextProvider = ( { children }: { children: ReactNode } ) => {
+	const [ errors, setErrors ] = useState< MultisitePluginUpdateManagerErrors >( [] );
+
+	return (
+		<MultisitePluginUpdateManagerContext.Provider value={ { errors, setErrors } }>
+			{ children }
+		</MultisitePluginUpdateManagerContext.Provider>
+	);
+};
+
+export { MultisitePluginUpdateManagerContext, MultisitePluginUpdateManagerContextProvider };

--- a/client/blocks/plugins-scheduled-updates-multisite/hooks/use-errors.ts
+++ b/client/blocks/plugins-scheduled-updates-multisite/hooks/use-errors.ts
@@ -1,0 +1,21 @@
+import { useContext } from 'react';
+import { useSelector } from 'calypso/state';
+import getSites from 'calypso/state/selectors/get-sites';
+import { SiteSlug } from 'calypso/types';
+import { MultisitePluginUpdateManagerContext } from '../context';
+
+export const useErrors = () => {
+	const { errors, setErrors } = useContext( MultisitePluginUpdateManagerContext );
+	const sites = useSelector( getSites );
+
+	const addError = ( siteSlug: SiteSlug, error: string ) => {
+		const site = sites.find( ( site ) => site?.slug === siteSlug );
+		setErrors( ( prevErrors ) => [ ...( prevErrors || [] ), { siteSlug, error, site } ] );
+	};
+
+	const clearErrors = () => {
+		setErrors( [] );
+	};
+
+	return { errors, addError, clearErrors };
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,3 +1,4 @@
+import { MultisitePluginUpdateManagerContextProvider } from 'calypso/blocks/plugins-scheduled-updates-multisite/context';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleList } from './schedule-list';
 
@@ -18,15 +19,21 @@ export const PluginsScheduledUpdatesMultisite = ( {
 	onEditSchedule,
 	onShowLogs,
 }: Props ) => {
-	switch ( context ) {
-		case 'create':
-			return <ScheduleCreate onNavBack={ onNavBack } />;
-	}
 	return (
-		<ScheduleList
-			onCreateNewSchedule={ onCreateNewSchedule }
-			onEditSchedule={ onEditSchedule }
-			onShowLogs={ onShowLogs }
-		/>
+		<MultisitePluginUpdateManagerContextProvider>
+			{ ( () => {
+				switch ( context ) {
+					case 'create':
+						return <ScheduleCreate onNavBack={ onNavBack } />;
+				}
+				return (
+					<ScheduleList
+						onCreateNewSchedule={ onCreateNewSchedule }
+						onEditSchedule={ onEditSchedule }
+						onShowLogs={ onShowLogs }
+					/>
+				);
+			} )() }
+		</MultisitePluginUpdateManagerContextProvider>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
@@ -8,7 +8,6 @@ export const ScheduleCreate = ( { onNavBack }: Props ) => {
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
 			<h1 className="wp-brand-font">New schedule</h1>
-
 			<ScheduleForm onNavBack={ onNavBack } />
 		</div>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -8,6 +8,7 @@ import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query
 import { ScheduleFormFrequency } from '../plugins-scheduled-updates/schedule-form-frequency';
 import { ScheduleFormPlugins } from '../plugins-scheduled-updates/schedule-form-plugins';
 import { validateSites, validatePlugins } from '../plugins-scheduled-updates/schedule-form.helper';
+import { useErrors } from './hooks/use-errors';
 import { ScheduleFormSites } from './schedule-form-sites';
 
 type Props = {
@@ -21,6 +22,8 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
 	const [ frequency, setFrequency ] = useState< 'daily' | 'weekly' >( 'daily' );
 	const [ timestamp, setTimestamp ] = useState< number >( Date.now() );
+
+	const { addError, clearErrors } = useErrors();
 
 	const translate = useTranslate();
 
@@ -68,6 +71,10 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 		}
 	}, [ plugins ] );
 
+	useEffect( () => {
+		clearErrors();
+	}, [] );
+
 	const selectedSiteSlugs = sites
 		? sites.filter( ( site ) => selectedSites.includes( site.ID ) ).map( ( site ) => site.slug )
 		: [];
@@ -92,6 +99,11 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 		const successfulSiteSlugs = createResults
 			.filter( ( result ) => ! result.error )
 			.map( ( result ) => result.siteSlug );
+		// Store errors
+		createResults
+			.filter( ( result ) => result.error )
+			.forEach( ( result ) => addError( result.siteSlug, ( result.error as Error ).message ) );
+
 		// Create monitors for sites that have been successfully scheduled
 		createMonitors( successfulSiteSlugs );
 		onNavBack && onNavBack();

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -76,18 +76,6 @@ export const ScheduleList = ( props: Props ) => {
 	const isLoading = isLoadingSchedules;
 	const ScheduleListComponent = isMobile ? null : ScheduleListTable;
 
-	// Be sure to update this with new translations/mappings
-	const translatedErrorsMap: { [ original: string ]: string } = {
-		'Server could not read response.': translate( 'Server could not read response.' ),
-		'Sorry, you can not create more than two schedules at this time.': translate(
-			'Sorry, you can not create more than two schedules at this time.'
-		),
-		'Invalid schedule': translate( 'Invalid schedule' ),
-		'Sorry, you can not create a schedule with the same time as an existing schedule.': translate(
-			'Sorry, you can not create a schedule with the same time as an existing schedule.'
-		),
-	};
-
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
 			<h1 className="wp-brand-font">List schedules</h1>
@@ -110,8 +98,7 @@ export const ScheduleList = ( props: Props ) => {
 					<ul>
 						{ errors.map( ( error, idx ) => (
 							<li key={ `${ error.siteSlug }.${ idx }` }>
-								<strong>{ error.site?.title }: </strong>{ ' ' }
-								{ translatedErrorsMap[ error.error ] || error.error }
+								<strong>{ error.site?.title }: </strong> { error.error }
 							</li>
 						) ) }
 					</ul>

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -6,6 +6,15 @@
 		margin-bottom: 1rem;
 	}
 
+	.components-notice {
+		margin-bottom: 1.25rem;
+		margin-top: 1.25rem;
+
+		ul {
+			margin-top: 1.25rem;
+		}
+	}
+
 	.schedule-form {
 		margin-bottom: 1.25rem;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the oses linked issue.
-->

Closes #https://github.com/Automattic/wp-calypso/issues/89969

## Proposed Changes

* Adds `MultisitePluginUpdateManagerContext` & `MultisitePluginUpdateManagerContextProvider`
* Adds `useErrors` hook, to easily add/clear errors
* Shows the errors on the list

![CleanShot 2024-04-29 at 14 04 32@2x](https://github.com/Automattic/wp-calypso/assets/528287/47377186-3912-4de7-9701-9fbb64a7bb08)

## Testing Instructions

1. Apply this PR
2. Visit http://calypso.localhost:3000/plugins/scheduled-updates
3. Create some duplicate schedules (or more than 2 schedules for the same site)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?