### PR TITLE
Nav Redesign: Enable the feature flag on wpcalypso & fix ETE tests

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -121,7 +121,7 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign-v2": false,
+		"layout/dotcom-nav-redesign-v2": true,
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,

--- a/config/test.json
+++ b/config/test.json
@@ -75,7 +75,7 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign-v2": false,
+		"layout/dotcom-nav-redesign-v2": true,
 		"legal-updates-banner": true,
 		"login/social-first": true,
 		"mailchimp": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -90,7 +90,7 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign-v2": false,
+		"layout/dotcom-nav-redesign-v2": true,
 		"layout/wpcom-admin-interface": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6792

## Proposed Changes

This is part of the Nav Redesign Launch Checklist (https://github.com/Automattic/dotcom-forge/issues/6796)
- [x] Enable the layout/dotcom-nav-redesign-v2 on wpcalypso and test env.
- [ ] Fix E2E tests so that when we want to launch

After :point_up: 
- Enable the flag on production https://github.com/Automattic/wp-calypso/pull/90060
