### PR TITLE
A4A: Add the WPCOM plan card. 

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/simple-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/simple-list/index.tsx
@@ -1,0 +1,17 @@
+import { Icon, check } from '@wordpress/icons';
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+export default function SimpleList( { items }: { items: ReactNode[] } ) {
+	return (
+		<ul className="simple-list">
+			{ items.map( ( item, index ) => (
+				<li key={ `item-${ index }` }>
+					<Icon className="simple-list-icon" icon={ check } size={ 24 } />
+					<div className="simple-list-text">{ item }</div>
+				</li>
+			) ) }
+		</ul>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/common/simple-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/simple-list/style.scss
@@ -1,0 +1,25 @@
+.simple-list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+	margin: 0;
+	padding: 0;
+	list-style: none;
+
+	li {
+		display: flex;
+		flex-direction: row;
+		font-size: 1rem;
+		line-height: 1.6;
+		font-weight: 400;
+	}
+}
+
+.simple-list-icon {
+	margin-inline-end: 4px;
+	fill: var(--color-primary-40);
+	margin-block-end: -6px;
+	min-width: 24px;
+	min-height: 24px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -10,7 +10,7 @@ type Props = {
 		value: number;
 		label: string;
 	};
-	onSelectCount: ( count: { value: number; label: string } ) => void;
+	onSelectCount: ( value: number ) => void;
 };
 
 export default function WPCOMBulkSelector( { selectedCount, onSelectCount }: Props ) {
@@ -24,10 +24,7 @@ export default function WPCOMBulkSelector( { selectedCount, onSelectCount }: Pro
 					count: option.value,
 				} )
 			);
-			onSelectCount( {
-				value: option.value as number,
-				label: option.label,
-			} );
+			onSelectCount( option.value as number );
 		},
 		[ dispatch, onSelectCount ]
 	);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -15,10 +15,13 @@ import {
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import HostingOverview from '../common/hosting-overview';
+import useProductAndPlans from '../hooks/use-product-and-plans';
 import useShoppingCart from '../hooks/use-shopping-cart';
+import { getCheapestPlan } from '../lib/hosting';
 import ShoppingCart from '../shopping-cart';
 import WPCOMBulkSelector from './bulk-selection';
 import wpcomBulkOptions from './lib/wpcom-bulk-options';
+import WPCOMPlanCard from './wpcom-card';
 
 import './style.scss';
 
@@ -28,6 +31,16 @@ export default function WpcomOverview() {
 	const { selectedCartItems, onRemoveCartItem } = useShoppingCart();
 
 	const [ selectedCount, setSelectedCount ] = useState( wpcomBulkOptions[ 0 ] );
+
+	const onSelectCount = ( count: number ) => {
+		setSelectedCount(
+			wpcomBulkOptions.find( ( option ) => option.value === count ) ?? wpcomBulkOptions[ 0 ]
+		);
+	};
+
+	const { wpcomPlans } = useProductAndPlans( {} );
+
+	const cheapestWPCOMPlan = getCheapestPlan( wpcomPlans );
 
 	return (
 		<Layout
@@ -76,7 +89,13 @@ export default function WpcomOverview() {
 						'When you build and host your sites with WordPress.com, everything’s integrated, secure, and scalable.'
 					) }
 				/>
-				<WPCOMBulkSelector selectedCount={ selectedCount } onSelectCount={ setSelectedCount } />
+				<WPCOMBulkSelector selectedCount={ selectedCount } onSelectCount={ onSelectCount } />
+
+				<WPCOMPlanCard
+					plan={ cheapestWPCOMPlan }
+					quantity={ selectedCount.value }
+					discount={ selectedCount.discount }
+				/>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -3,36 +3,43 @@ const wpcomBulkOptions = [
 	{
 		value: 1,
 		label: '1',
+		discount: 0,
 	},
 	{
 		value: 3,
 		label: '3',
 		sub: '4%',
+		discount: 0.04,
 	},
 	{
 		value: 5,
 		label: '5',
 		sub: '8%',
+		discount: 0.08,
 	},
 	{
 		value: 10,
 		label: '10',
 		sub: '20%',
+		discount: 0.2,
 	},
 	{
 		value: 20,
 		label: '20',
 		sub: '40%',
+		discount: 0.4,
 	},
 	{
 		value: 50,
 		label: '50',
 		sub: '70%',
+		discount: 0.7,
 	},
 	{
 		value: 100,
 		label: '100',
 		sub: '80%',
+		discount: 0.8,
 	},
 ];
 

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts
@@ -1,0 +1,42 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function useWPCOMPlanDescription( slug: string ) {
+	const translate = useTranslate();
+
+	let name = slug;
+	let features1: string[] = [];
+	let features2: string[] = [];
+
+	// FIXME: Need to have correct slug. Right now we use whatever we have.
+	if ( slug === 'wpcom-hosting-business' ) {
+		name = translate( 'Creator' );
+		features1 = [
+			translate( '50GB of storage' ),
+			translate( 'Unrestricted bandwidth' ),
+			translate( 'Global CDN with 28+ locations' ),
+			translate( 'Install your own plugins & themes' ),
+			translate( 'Global edge caching' ),
+			translate( 'High-burst capacity' ),
+			translate( 'Web Application Firewall' ),
+			translate( 'High-frequency CPUs' ),
+			translate( 'Automated datacenter failover' ),
+		];
+
+		features2 = [
+			translate( 'Expert live chat & email support' ),
+			translate( 'DDOS mitigation' ),
+			translate( 'Free staging environment' ),
+			translate( 'Isolated site infrastructure' ),
+			translate( 'Managed malware protection' ),
+			translate( 'SFTP/SSH, WP-CLI, Git tools' ),
+			translate( 'Extremely fast DNS with SSL' ),
+			translate( 'Centralized site management' ),
+		];
+	}
+
+	return {
+		name,
+		features1,
+		features2,
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, JetpackLogo } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -77,7 +77,16 @@ export default function WPCOMPlanCard( { plan, quantity, discount }: Props ) {
 					{ features2.length && <SimpleList items={ features2 } /> }
 				</div>
 			</div>
-			<div className="wpcom-plan-card__section"></div>
+			<div className="wpcom-plan-card__section">
+				<h2 className="wpcom-plan-card__title">
+					<JetpackLogo size={ 20 } /> { translate( 'Premium Jetpack features included' ) }{ ' ' }
+				</h2>
+
+				<div className="wpcom-plan-card__features is-jetpack">
+					{ features1.length && <SimpleList items={ features1 } /> }
+					{ features2.length && <SimpleList items={ features2 } /> }
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -1,0 +1,83 @@
+import { Button } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import SimpleList from '../../common/simple-list';
+import useWPCOMPlanDescription from './hooks/use-wpcom-plan-description';
+
+import './style.scss';
+
+type Props = {
+	plan: APIProductFamilyProduct;
+	quantity: number;
+	discount: number;
+};
+
+export default function WPCOMPlanCard( { plan, quantity, discount }: Props ) {
+	const translate = useTranslate();
+
+	const originalPrice = Number( plan.amount ) * quantity;
+	const actualPrice = originalPrice - originalPrice * discount;
+
+	const { name, features1, features2 } = useWPCOMPlanDescription( plan.slug );
+
+	return (
+		<div className="wpcom-plan-card">
+			<div className="wpcom-plan-card__section is-main">
+				<div className="wpcom-plan-card__header">
+					<h2 className="wpcom-plan-card__title">{ name }</h2>
+
+					<div className="wpcom-plan-card__price">
+						<b className="wpcom-plan-card__price-actual-value">
+							{ formatCurrency( actualPrice, plan.currency ) }
+						</b>
+						{ !! discount && (
+							<>
+								<b className="wpcom-plan-card__price-original-value">
+									{ formatCurrency( originalPrice, plan.currency ) }
+								</b>
+
+								<span className="wpcom-plan-card__price-discount">
+									{ translate( 'You save %(discount)s%', {
+										args: {
+											discount: discount * 100,
+										},
+										comment: '%(discount)s is the discount percentage.',
+									} ) }
+								</span>
+							</>
+						) }
+						<div className="wpcom-plan-card__price-interval">
+							{ plan.price_interval === 'day' && translate( 'USD per plan per day' ) }
+							{ plan.price_interval === 'month' && translate( 'USD per plan per month' ) }
+						</div>
+					</div>
+				</div>
+
+				<Button primary>
+					{ quantity > 1
+						? translate( 'Add %(quantity)s %(planName)s sites to cart', {
+								args: {
+									quantity,
+									planName: name,
+								},
+								comment:
+									'%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
+						  } )
+						: translate( 'Add %(planName)s to cart', {
+								args: {
+									planName: name,
+								},
+								comment: '%(planName)s is the name of the plan.',
+						  } ) }
+				</Button>
+
+				<div className="wpcom-plan-card__features">
+					{ features1.length && <SimpleList items={ features1 } /> }
+					{ features2.length && <SimpleList items={ features2 } /> }
+				</div>
+			</div>
+			<div className="wpcom-plan-card__section"></div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .wpcom-plan-card {
 	border: 1px solid var(--color-neutral-5);
 	border-radius: 4px;
@@ -60,8 +63,12 @@
 .wpcom-plan-card__features {
 	width: 100%;
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: 1fr;
 	gap: 48px;
+
+	@include break-large {
+		grid-template-columns: 1fr 1fr;
+	}
 }
 
 .wpcom-plan-card__features.is-jetpack .simple-list-icon {

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/style.scss
@@ -22,9 +22,12 @@
 }
 
 .wpcom-plan-card__title {
-	font-size: 1rem;
-	font-weight: 500;
+	font-size: 1.125rem; // stylelint-disable-line
+	font-weight: 510; // stylelint-disable-line
 	line-height: 1.5;
+	display: flex;
+	align-items: center;
+	gap: 10px;
 }
 
 .wpcom-plan-card__price-actual-value {
@@ -59,4 +62,8 @@
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	gap: 48px;
+}
+
+.wpcom-plan-card__features.is-jetpack .simple-list-icon {
+	fill: var(--color-jetpack);
 }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/style.scss
@@ -1,0 +1,62 @@
+.wpcom-plan-card {
+	border: 1px solid var(--color-neutral-5);
+	border-radius: 4px;
+	margin: 0;
+	padding: 0;
+}
+
+.wpcom-plan-card__section {
+	padding: 48px;
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+	align-items: flex-start;
+
+	&.is-main {
+		background: var(--color-neutral-0);
+	}
+
+	&:last-child {
+		border-block-start: 1px solid var(--color-neutral-5);
+	}
+}
+
+.wpcom-plan-card__title {
+	font-size: 1rem;
+	font-weight: 500;
+	line-height: 1.5;
+}
+
+.wpcom-plan-card__price-actual-value {
+	color: var(--color-black);
+	font-size: 2rem;
+	font-weight: 600;
+	line-height: 1;
+}
+
+.wpcom-plan-card__price-original-value {
+	display: inline-block;
+	color: var(--color-neutral-80);
+	font-size: 1.5rem;
+	font-weight: 400;
+	line-height: 1;
+	text-decoration: line-through;
+	margin-inline: 8px;
+}
+
+.wpcom-plan-card__price-discount {
+	color: var(--color-success);
+}
+
+.wpcom-plan-card__price-interval {
+	font-size: 0.75rem;
+	line-height: 1.1;
+	font-weight: 400;
+}
+
+.wpcom-plan-card__features {
+	width: 100%;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 48px;
+}


### PR DESCRIPTION
This PR implements the WPCOM plan card on the WPCOM hosting page.
<img width="1132" alt="Screenshot 2024-04-29 at 9 41 47 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7f1faf82-a961-452f-8d3b-3556038f2f99">

Depends on https://github.com/Automattic/wp-calypso/pull/90029
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/365

## Proposed Changes

* Add WPCOM Plan card component that can be reused later with different plan.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/hosting/wpcom`
* Confirm that the Creator plan card is visible.
* Change the volume
* Confirm that the Creator plan also reflects the discounted amount.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?