### PR TITLE
Scheduled Updates Multisite: Implement cache clearing

### DIFF
--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -86,43 +86,12 @@ export function useBatchCreateUpdateScheduleMutation( siteSlugs: SiteSlug[], que
 
 			return results;
 		},
-		onMutate: ( params: CreateRequestParams ) => {
-			const prevSchedulesMap = new Map< SiteSlug, ScheduleUpdates[] >();
-
-			siteSlugs.forEach( ( siteSlug ) => {
-				const prevSchedules: ScheduleUpdates[] =
-					queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
-
-				prevSchedulesMap.set( siteSlug, prevSchedules );
-
-				const newSchedules = [
-					...prevSchedules,
-					{
-						id: 'temp-id',
-						args: params.plugins,
-						timestamp: params.schedule.timestamp,
-						schedule: params.schedule.interval,
-						interval: params.schedule.timestamp,
-					},
-				];
-
-				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], newSchedules );
-			} );
-			return { prevSchedulesMap };
-		},
-		onError: ( err, params, context ) => {
-			context?.prevSchedulesMap.forEach( ( prevSchedules, siteSlug ) => {
-				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], prevSchedules );
-			} );
-		},
 		onSettled: () => {
-			// TODO optimistic update for 'multisite-schedules-update'
-			// in onSettled we know which sites were successful and which failed
+			queryClient.removeQueries( { queryKey: [ 'multisite-schedules-update' ] } );
 
 			siteSlugs.forEach( ( siteSlug ) => {
-				queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
+				queryClient.removeQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
 			} );
-			queryClient.invalidateQueries( { queryKey: [ 'multisite-schedules-update' ] } );
 		},
 		...queryOptions,
 	} );
@@ -213,62 +182,19 @@ export function useBatchEditUpdateScheduleMutation( siteSlugs: SiteSlug[], query
 							} );
 							return { siteSlug, response };
 						} catch ( error ) {
-							throw { siteSlug, error };
+							return { siteSlug, error };
 						}
 					} )
 				);
 
-			// check if any of the requests failed
-			const failedRequests = results.filter( ( result ) => result.error );
-			if ( failedRequests.length ) {
-				throw failedRequests;
-			}
-		},
-		onMutate: ( props ) => {
-			const id = props.id;
-			const params = props.params as CreateRequestParams;
-
-			const prevSchedulesMap = new Map< SiteSlug, ScheduleUpdates[] >();
-
-			siteSlugs.forEach( ( siteSlug ) => {
-				const prevSchedules: ScheduleUpdates[] =
-					queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
-				const scheduleIndex = prevSchedules.findIndex( ( x ) => x.id === id );
-
-				prevSchedulesMap.set( siteSlug, prevSchedules );
-
-				// Replace schedule with new data without mutating the original array
-				const newSchedules = [
-					...prevSchedules.slice( 0, scheduleIndex ),
-					{
-						...prevSchedules[ scheduleIndex ],
-						args: params.plugins,
-						timestamp: params.schedule.timestamp,
-						schedule: params.schedule.interval,
-						interval: params.schedule.timestamp,
-					},
-					...prevSchedules.slice( scheduleIndex + 1 ),
-				];
-
-				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], newSchedules );
-			} );
-			// TODO optimistic update for 'multisite-schedules-update'
-
-			return { prevSchedulesMap };
-		},
-		onError: ( err, props, context ) => {
-			context?.prevSchedulesMap.forEach( ( prevSchedules, siteSlug ) => {
-				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], prevSchedules );
-			} );
+			return results;
 		},
 		onSettled: () => {
-			// TODO optimistic update for 'multisite-schedules-update'
-			// in onSettled we know which sites were successful and which failed
+			queryClient.removeQueries( { queryKey: [ 'multisite-schedules-update' ] } );
 
 			siteSlugs.forEach( ( siteSlug ) => {
-				queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
+				queryClient.removeQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
 			} );
-			queryClient.invalidateQueries( { queryKey: [ 'multisite-schedules-update' ] } );
 		},
 		...queryOptions,
 	} );
@@ -335,32 +261,11 @@ export function useBatchDeleteUpdateScheduleMutation( siteSlugs: SiteSlug[], que
 				throw failedRequests;
 			}
 		},
-		onMutate: ( id ) => {
-			const prevSchedulesMap = new Map< SiteSlug, ScheduleUpdates[] >();
-
-			siteSlugs.forEach( ( siteSlug ) => {
-				const prevSchedules: ScheduleUpdates[] =
-					queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
-				const schedules = prevSchedules.filter( ( x ) => x.id !== id );
-
-				prevSchedulesMap.set( siteSlug, prevSchedules );
-				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], schedules );
-			} );
-
-			return { prevSchedulesMap };
-		},
-		onError: ( err, id, context ) => {
-			context?.prevSchedulesMap.forEach( ( prevSchedules, siteSlug ) => {
-				queryClient.setQueryData( [ 'schedule-updates', siteSlug ], prevSchedules );
-			} );
-		},
 		onSettled: () => {
-			// TODO optimistic update for 'multisite-schedules-update'
-			// in onSettled we know which sites were successful and which failed
+			queryClient.removeQueries( { queryKey: [ 'multisite-schedules-update' ] } );
 
-			queryClient.invalidateQueries( { queryKey: [ 'multisite-schedules-update' ] } );
 			siteSlugs.forEach( ( siteSlug ) => {
-				queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
+				queryClient.removeQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
 			} );
 		},
 		...queryOptions,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

I initially wanted to use optimistic updates, but after researching them, I realized it was not worth the hassle in this case. The retrieval query is just reading an option, so it's already lightning-fast.

Trying to update the cache optimistically would be a lot of work, and there's potential for things to get out of sync or break. I've decided the best approach is to clear the query cache after a mutation and refetch the data from the server. We'll still have a snappy user experience and won't have to worry about any weird inconsistencies.

* Clears the cache after a mutation

## Testing Instructions

1. Apply this PR
2. Go to http://calypso.localhost:3000/plugins/scheduled-updates
3. Create new schedule
4. You should see the loading indicator

(The same should happen for deletes)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?