### PR TITLE
A4A: Add the WPCOM Hosting standard feature list.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/index.tsx
@@ -1,0 +1,28 @@
+import { Icon } from '@wordpress/icons';
+
+import './style.scss';
+
+type Props = {
+	items: {
+		icon: JSX.Element;
+		title: string;
+		description: string;
+	}[];
+};
+
+export default function HostingOverviewFeatures( { items }: Props ) {
+	return (
+		<div className="hosting-overview-features">
+			{ items.map( ( { icon, title, description } ) => (
+				<div className="hosting-overview-features__item" key={ title }>
+					<Icon className="hosting-overview-features__item-icon" icon={ icon } size={ 48 } />
+
+					<div className="hosting-overview-features__item-content">
+						<div className="hosting-overview-features__item-title">{ title }</div>
+						<div className="hosting-overview-features__item-description">{ description }</div>
+					</div>
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.pressable-overview-features {
+.hosting-overview-features {
 	display: grid;
 	grid-template-columns: 1fr;
 	column-gap: 48px;
@@ -12,7 +12,7 @@
 	}
 }
 
-.pressable-overview-features__item {
+.hosting-overview-features__item {
 	display: flex;
 	flex-direction: row;
 	gap: 32px;
@@ -20,24 +20,24 @@
 
 }
 
-.pressable-overview-features__item-icon {
+.hosting-overview-features__item-icon {
 	min-width: 48px;
 	height: 48px;
 	fill: var(--color-primary-40);
 }
 
-.pressable-overview-features__item-content {
+.hosting-overview-features__item-content {
 	flex-grow: 1;
 }
 
-.pressable-overview-features__item-title {
+.hosting-overview-features__item-title {
 	font-size: rem(18px);
 	line-height: 1.4;
 	font-weight: 500;
 	margin-block-end: 8px;
 }
 
-.pressable-overview-features__item-description {
+.hosting-overview-features__item-description {
 	font-size: 1rem;
 	line-height: 1.6;
 	font-weight: 400;

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/index.tsx
@@ -3,7 +3,7 @@ import { getHostingLogo } from '../../lib/hosting';
 import './style.scss';
 
 interface HostingOverviewProps {
-	slug: string;
+	slug?: string;
 	title: string;
 	subtitle: string;
 }
@@ -11,7 +11,7 @@ interface HostingOverviewProps {
 export default function HostingOverview( { slug, title, subtitle }: HostingOverviewProps ) {
 	return (
 		<section className="hosting-overview__banner">
-			<div className="hosting-overview__banner-logo">{ getHostingLogo( slug ) }</div>
+			{ slug && <div className="hosting-overview__banner-logo">{ getHostingLogo( slug ) }</div> }
 			<h1 className="hosting-overview__banner-title">{ title }</h1>
 			<h2 className="hosting-overview__banner-subtitle">{ subtitle }</h2>
 		</section>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/footer/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/footer/index.tsx
@@ -1,99 +1,56 @@
-import { Icon, blockMeta, info, layout, levelUp, shuffle, tip } from '@wordpress/icons';
+import { blockMeta, info, layout, levelUp, shuffle, tip } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-
-import './style.scss';
+import HostingOverviewFeatures from '../../common/hosting-overview-features';
 
 export default function PressableOverviewFeatures() {
 	const translate = useTranslate();
 
 	return (
-		<>
-			<div className="pressable-overview-features">
-				<div className="pressable-overview-features__item">
-					<Icon className="pressable-overview-features__item-icon" icon={ layout } size={ 48 } />
-
-					<div className="pressable-overview-features__item-content">
-						<div className="pressable-overview-features__item-title">
-							{ translate( 'Intuitive Control Panel' ) }
-						</div>
-						<div className="pressable-overview-features__item-description">
-							{ translate(
-								`Although it's won awards for being so easy to use, our interface is a powerhouse that delivers for even the most technical of users.`
-							) }
-						</div>
-					</div>
-				</div>
-
-				<div className="pressable-overview-features__item">
-					<Icon className="pressable-overview-features__item-icon" icon={ info } size={ 48 } />
-					<div className="pressable-overview-features__item-content">
-						<div className="pressable-overview-features__item-title">
-							{ translate( '24/7 Expert Support' ) }
-						</div>
-						<div className="pressable-overview-features__item-description">
-							{ translate(
-								'When you win, we win. That’s why our team of WordPress professionals is always available to help.'
-							) }
-						</div>
-					</div>
-				</div>
-
-				<div className="pressable-overview-features__item">
-					<Icon className="pressable-overview-features__item-icon" icon={ blockMeta } size={ 48 } />
-					<div className="pressable-overview-features__item-content">
-						<div className="pressable-overview-features__item-title">
-							{ translate( 'Easy Migrations' ) }
-						</div>
-						<div className="pressable-overview-features__item-description">
-							{ translate(
-								`We'll migrate your sites for free or you can use our powerful plugin to do it yourself - we're here to help.`
-							) }
-						</div>
-					</div>
-				</div>
-
-				<div className="pressable-overview-features__item">
-					<Icon className="pressable-overview-features__item-icon" icon={ levelUp } size={ 48 } />
-					<div className="pressable-overview-features__item-content">
-						<div className="pressable-overview-features__item-title">
-							{ translate( '30-Day Money-Back Guarantee' ) }
-						</div>
-						<div className="pressable-overview-features__item-description">
-							{ translate(
-								'We’re so sure you’ll be satisfied with Pressable that we offer you the world’s best WordPress hosting with no-strings-attached.'
-							) }
-						</div>
-					</div>
-				</div>
-
-				<div className="pressable-overview-features__item">
-					<Icon className="pressable-overview-features__item-icon" icon={ shuffle } size={ 48 } />
-					<div className="pressable-overview-features__item-content">
-						<div className="pressable-overview-features__item-title">
-							{ translate( 'Flexible Upgrades & Downgrades' ) }
-						</div>
-						<div className="pressable-overview-features__item-description">
-							{ translate(
-								'Need to make a change? No problem. Our plans are flexible, so they grow with your business.'
-							) }
-						</div>
-					</div>
-				</div>
-
-				<div className="pressable-overview-features__item">
-					<Icon className="pressable-overview-features__item-icon" icon={ tip } size={ 48 } />
-					<div className="pressable-overview-features__item-content">
-						<div className="pressable-overview-features__item-title">
-							{ translate( '100% Uptime Guarantee' ) }
-						</div>
-						<div className="pressable-overview-features__item-description">
-							{ translate(
-								'You need reliability - we promise it. Our cloud-based architecture ensures success by making your site available all day, every day.'
-							) }
-						</div>
-					</div>
-				</div>
-			</div>
-		</>
+		<HostingOverviewFeatures
+			items={ [
+				{
+					icon: layout,
+					title: translate( 'Intuitive Control Panel' ),
+					description: translate(
+						`Although it's won awards for being so easy to use, our interface is a powerhouse that delivers for even the most technical of users.`
+					),
+				},
+				{
+					icon: info,
+					title: translate( '24/7 Expert Support' ),
+					description: translate(
+						'When you win, we win. That’s why our team of WordPress professionals is always available to help.'
+					),
+				},
+				{
+					icon: blockMeta,
+					title: translate( 'Easy Migrations' ),
+					description: translate(
+						`We'll migrate your sites for free or you can use our powerful plugin to do it yourself - we're here to help.`
+					),
+				},
+				{
+					icon: levelUp,
+					title: translate( '30-Day Money-Back Guarantee' ),
+					description: translate(
+						'We’re so sure you’ll be satisfied with Pressable that we offer you the world’s best WordPress hosting with no-strings-attached.'
+					),
+				},
+				{
+					icon: shuffle,
+					title: translate( 'Flexible Upgrades & Downgrades' ),
+					description: translate(
+						'Need to make a change? No problem. Our plans are flexible, so they grow with your business.'
+					),
+				},
+				{
+					icon: tip,
+					title: translate( '100% Uptime Guarantee' ),
+					description: translate(
+						'You need reliability - we promise it. Our cloud-based architecture ensures success by making your site available all day, every day.'
+					),
+				},
+			] }
+		/>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -101,15 +101,10 @@ export default function PressableOverview() {
 				/>
 				<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
 
-				<section className="pressable-overview__banner">
-					<h1 className="pressable-overview__banner-title">
-						{ translate( 'The Pressable Promise' ) }
-					</h1>
-
-					<h2 className="pressable-overview__banner-subtitle">
-						{ translate( 'Flexible plans that are designed to grow with your business.' ) }
-					</h2>
-				</section>
+				<HostingOverview
+					title={ translate( 'The Pressable Promise' ) }
+					subtitle={ translate( 'Flexible plans that are designed to grow with your business.' ) }
+				/>
 
 				<PressableOverviewFeatures />
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/style.scss
@@ -14,3 +14,7 @@
 		display: none;
 	}
 }
+
+.pressable-overview__footer {
+	text-align: center;
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { blockMeta, code, desktop, globe, login, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -15,6 +16,7 @@ import {
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import HostingOverview from '../common/hosting-overview';
+import HostingOverviewFeatures from '../common/hosting-overview-features';
 import useProductAndPlans from '../hooks/use-product-and-plans';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { getCheapestPlan } from '../lib/hosting';
@@ -100,6 +102,53 @@ export default function WpcomOverview() {
 				<HostingOverview
 					title={ translate( 'Powerful development & platform tools' ) }
 					subtitle={ translate( 'Build for developers, by developers' ) }
+				/>
+
+				<HostingOverviewFeatures
+					items={ [
+						{
+							icon: code,
+							title: translate( 'WPI-CLI' ),
+							description: translate(
+								`Run WP-CLI commands to manage users, plugins, themes, site settings, and more.`
+							),
+						},
+						{
+							icon: login,
+							title: translate( 'SSH/SFTP' ),
+							description: translate(
+								'Effortlessly transfer files to and from your site using SFTP and SSH on WordPress.com.'
+							),
+						},
+						{
+							icon: reusableBlock,
+							title: translate( 'Staging sites' ),
+							description: translate(
+								`Test changes on a WordPress.com staging site first, so you can identify and fix any vulnerabilities before they impact your live site.`
+							),
+						},
+						{
+							icon: desktop,
+							title: translate( 'Local development environment' ),
+							description: translate(
+								'Build fast, ship faster with Studio by WordPress.com, a new local development environment.'
+							),
+						},
+						{
+							icon: globe,
+							title: translate( 'Domain management' ),
+							description: translate(
+								'Everything you need to manage your domains—from registration, transfer, and mapping to DNS configuration, email forwarding, and privacy.'
+							),
+						},
+						{
+							icon: blockMeta,
+							title: translate( 'Easy site migration' ),
+							description: translate(
+								'Import and take any WordPress site further with our developer-first tools and secure, lightning-fast platform.'
+							),
+						},
+					] }
 				/>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -96,6 +96,11 @@ export default function WpcomOverview() {
 					quantity={ selectedCount.value }
 					discount={ selectedCount.discount }
 				/>
+
+				<HostingOverview
+					title={ translate( 'Powerful development & platform tools' ) }
+					subtitle={ translate( 'Build for developers, by developers' ) }
+				/>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -1,7 +1,17 @@
 import page from '@automattic/calypso-router';
-import { blockMeta, code, desktop, globe, login, reusableBlock } from '@wordpress/icons';
+import { Button } from '@automattic/components';
+import {
+	Icon,
+	blockMeta,
+	code,
+	desktop,
+	globe,
+	login,
+	reusableBlock,
+	external,
+} from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -15,6 +25,8 @@ import {
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HostingOverview from '../common/hosting-overview';
 import HostingOverviewFeatures from '../common/hosting-overview-features';
 import useProductAndPlans from '../hooks/use-product-and-plans';
@@ -29,6 +41,7 @@ import './style.scss';
 
 export default function WpcomOverview() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const { selectedCartItems, onRemoveCartItem } = useShoppingCart();
 
@@ -43,6 +56,13 @@ export default function WpcomOverview() {
 	const { wpcomPlans } = useProductAndPlans( {} );
 
 	const cheapestWPCOMPlan = getCheapestPlan( wpcomPlans );
+	const onclickMoreInfo = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_hosting_wpcom_view_all_features_click' )
+		);
+	}, [ dispatch ] );
+
+	const WPCOM_PRICING_PAGE_LINK = 'https://wordpress.com/pricing/';
 
 	return (
 		<Layout
@@ -150,6 +170,18 @@ export default function WpcomOverview() {
 						},
 					] }
 				/>
+
+				<section className="pressable-overview__footer">
+					<Button
+						className="pressable-overview__learn-more-link"
+						href={ WPCOM_PRICING_PAGE_LINK }
+						onClick={ onclickMoreInfo }
+						target="_blank"
+					>
+						{ translate( 'View all WordPress.com features' ) }
+						<Icon icon={ external } size={ 18 } />
+					</Button>
+				</section>
 			</LayoutBody>
 		</Layout>
 	);


### PR DESCRIPTION
Add WPCOM Hosting features list.

<img width="1353" alt="Screenshot 2024-04-29 at 10 30 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9a424b9f-3abe-41b3-bcca-3f4d5f2d5c9b">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/371

## Proposed Changes

* Convert the Existing Pressable feature list component to a reusable one.
* Reuse the same component to build the WPCOM Hosting feature list.
* Additional: Fix broken content in the Pressable page.


## Testing Instructions

* Use the A4A live link and go to `/marketplace/hosting/wpcom`
* Confirm that the standard feature list is visible at the bottom of the page.
* Now go to `/marketplace/hosting/pressable`.
* Confirm that the Feature list is no longer broken.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?