### PR TITLE
Happy block: Update the /plan API request to include a query param

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -2,6 +2,7 @@ import { calculateMonthlyPriceForPlan, getPlan, Plan } from '@automattic/calypso
 import formatCurrency from '@automattic/format-currency';
 import { useEffect, useState } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest from 'wpcom-proxy-request';
 import config from '../config';
 import { ApiPricingPlan } from '../types.js';
@@ -56,9 +57,13 @@ const usePricingPlans = () => {
 		const fetchPlans = async () => {
 			setIsLoading( true );
 			setError( null );
+			const url = addQueryArgs( '/plans', {
+				locale: config.locale,
+				eligible_request_for_experiment: true,
+			} );
 			try {
 				const data: ApiPricingPlan[] = await wpcomRequest( {
-					path: '/plans?locale=' + config.locale,
+					path: url,
 					apiVersion: '1.5',
 				} );
 				setPlans( parsePlans( data ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* This is related to the changes made for the plan name change experiment discussed in pcNC1U-18h-p2. The change made here is related to the changes made in D146266-code. A new flag is added to the /plans endpoint to identify requests originating from support pages. This flag will be help identify in the backend if  the request is eligible for the plan name change experiment. Users who access the support pages logged-out will be assigned to the experiment. Logged-in eligible users will also be assigned due to the changes made in https://github.com/Automattic/wp-calypso/pull/84016.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run yarn dev --sync in apps/happy-blocks to sync code to your sandbox (might need to follow the[ instructions](https://github.com/Automattic/wp-calypso/blob/trunk/apps/happy-blocks/README.md#development-environment) and/or the Calypso Apps field guide to get it to work)

* Sandbox wordpress.com and en.support.wordpress.com
* Visit https://en.support.wordpress.com/support/domains/register-domain/. Handle any certificate errors that appear for the assets
* Verify the network request for the `/plans` endpoint and verify that the `locale` and `eligible_request_for_experiment` query params are sent in the payload.
