### PR TITLE
Update disk quota error message while transfering to atomic

### DIFF
--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -36,7 +36,7 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 			{ ! displayUpgradeLink && (
 				<span>
 					{ translate(
-						' To active Hosting Features, you can either {{a}}upgrade to additional storage{{/a}} or {{b}}delete media files{{/b}} until you have less than 95% space usage.',
+						'You can either {{a}}buy additional storage{{/a}} or {{b}}delete media files{{/b}} until you have less than 95% space usage.',
 						{
 							components: {
 								a: <a href={ `/add-ons/${ siteSlug }` } />,

--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -1,4 +1,6 @@
 import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
+import { englishLocales, useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import PlanStorage from 'calypso/blocks/plan-storage';
 import { useSelector } from 'calypso/state';
@@ -17,10 +19,21 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 
 	const planHasTopStorageSpace = isBusinessPlan( sitePlanSlug ) || isEcommercePlan( sitePlanSlug );
 	const displayUpgradeLink = canUserUpgrade && ! planHasTopStorageSpace;
+	const locale = useLocale();
+	const { hasTranslation } = useI18n();
+	const errorMessage =
+		englishLocales.includes( locale ) ||
+		hasTranslation(
+			'Your site does not have enough storage space. To complete this operation, you need to use less than 95% of the space.'
+		)
+			? translate(
+					'Your site does not have enough storage space. To complete this operation, you need to use less than 95% of the space.'
+			  )
+			: translate( 'Your site does not have enough available storage space.' );
 
 	return (
 		<div>
-			{ translate( 'Your site does not have enough available storage space.' ) }
+			{ errorMessage }
 			<div className="eligibility-warnings__plan-storage-wrapper">
 				<PlanStorage siteId={ selectedSiteId }>{ null }</PlanStorage>
 			</div>

--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -1,6 +1,4 @@
 import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
-import { englishLocales, useLocale } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import PlanStorage from 'calypso/blocks/plan-storage';
 import { useSelector } from 'calypso/state';
@@ -19,21 +17,10 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 
 	const planHasTopStorageSpace = isBusinessPlan( sitePlanSlug ) || isEcommercePlan( sitePlanSlug );
 	const displayUpgradeLink = canUserUpgrade && ! planHasTopStorageSpace;
-	const locale = useLocale();
-	const { hasTranslation } = useI18n();
-	const errorMessage =
-		englishLocales.includes( locale ) ||
-		hasTranslation(
-			'Your site does not have enough storage space. To complete this operation, you need to use less than 95% of the space.'
-		)
-			? translate(
-					'Your site does not have enough storage space. To complete this operation, you need to use less than 95% of the space.'
-			  )
-			: translate( 'Your site does not have enough available storage space.' );
 
 	return (
 		<div>
-			{ errorMessage }
+			{ translate( 'Your site does not have enough available storage space.' ) }
 			<div className="eligibility-warnings__plan-storage-wrapper">
 				<PlanStorage siteId={ selectedSiteId }>{ null }</PlanStorage>
 			</div>
@@ -46,7 +33,19 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 						},
 					}
 				) }
-			{ ! displayUpgradeLink && translate( 'Please contact our support team for help.' ) }
+			{ ! displayUpgradeLink && (
+				<span>
+					{ translate(
+						' To active Hosting Features, you can either {{a}}upgrade to additional storage{{/a}} or {{b}}delete media files{{/b}} until you have less than 95% space usage.',
+						{
+							components: {
+								a: <a href={ `/add-ons/${ siteSlug }` } />,
+								b: <a href={ `/media/${ siteSlug }` } />,
+							},
+						}
+					) }
+				</span>
+			) }
 		</div>
 	);
 };

--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -1,4 +1,5 @@
 import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import PlanStorage from 'calypso/blocks/plan-storage';
 import { useSelector } from 'calypso/state';
@@ -40,7 +41,15 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 						{
 							components: {
 								a: <a href={ `/add-ons/${ siteSlug }` } />,
-								b: <a href={ `/media/${ siteSlug }` } />,
+								b: (
+									<a
+										target="_blank"
+										href={ localizeUrl(
+											'https://wordpress.com/support/media/#delete-files-from-media'
+										) }
+										rel="noreferrer"
+									/>
+								),
 							},
 						}
 					) }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -176,6 +176,7 @@
 
 .eligibility-warnings__action a,
 .eligibility-warnings__hold-action a {
+	text-wrap: nowrap;
 	.gridicons-help-outline {
 		color: var(--color-neutral-light);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1714397294805299-slack-C03TY6J1A

## Proposed Changes

* We're adding the 95% limit threshold as a warning.

**When can purchase a plan upgrade**:

| Before | After (style fix) |
|--------|--------|
| <img width="700" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/d5739380-fcaf-48f0-b45f-174bf0e2423b"> | <img width="697" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/49c680cd-5a1b-4742-9454-08cc510610ce"> |


**When it's already upgraded**:

| Before | After (copy fix) |
|--------|--------|
|<img width="696" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/c82defb5-480a-4522-8368-1bd6d31394ae"> | <img width="697" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/d57d4e5d-b542-479b-b4ab-db6f856f90a0">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?