### PR TITLE
Entrepreneur Plan: Use Calypso My Home based on the right Entrepreneur plans (non-woo plans).

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -12,6 +12,7 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
 import {
 	isSiteOnWooExpressEcommerceTrial,
+	isSiteOnWooExpress,
 	getCurrentPlan,
 } from 'calypso/state/sites/plans/selectors';
 import { canCurrentUserUseCustomerHome, getSiteUrl } from 'calypso/state/sites/selectors';
@@ -94,8 +95,10 @@ export async function maybeRedirect( context, next ) {
 				const currentPlan = getCurrentPlan( refetchedState, siteId );
 				const purchase = getByPurchaseId( refetchedState, currentPlan?.id );
 
+				const isWooExpressPlatform =
+					isSiteOnWooExpress( refetchedState, siteId ) || purchase?.isWooExpressTrial;
 				const shouldUseCalypsoMyHome =
-					config.isEnabled( 'entrepreneur-my-home' ) && ! purchase?.isWooExpressTrial;
+					config.isEnabled( 'entrepreneur-my-home' ) && ! isWooExpressPlatform;
 
 				const installedWooCommercePlugin = getPluginOnSite( refetchedState, siteId, 'woocommerce' );
 				const isSSOEnabled = !! isJetpackModuleActive( refetchedState, siteId, 'sso' );

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -45,7 +45,10 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { launchSite } from 'calypso/state/sites/launch/actions';
-import { isSiteOnWooExpressEcommerceTrial } from 'calypso/state/sites/plans/selectors';
+import {
+	isSiteOnWooExpressEcommerceTrial,
+	isRequestingSitePlans as isFetchingSitePlans,
+} from 'calypso/state/sites/plans/selectors';
 import {
 	canCurrentUserUseCustomerHome,
 	getSitePlan,
@@ -108,6 +111,7 @@ const Home = ( {
 	const emailDnsDiagnostics = domainDiagnosticData?.email_dns_records;
 	const [ dismissedEmailDnsDiagnostics, setDismissedEmailDnsDiagnostics ] = useState( false );
 
+	const isRequestingSitePlans = useSelector( isFetchingSitePlans );
 	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );
 	const purchase = useSelector( getSelectedPurchase );
 
@@ -146,14 +150,16 @@ const Home = ( {
 		);
 	}
 
-	// Ecommerce Plan's Home redirects to WooCommerce Home, so we show a placeholder
-	// while doing the redirection.
+	// While fetching all the data, show placeholder.
+	// After fetching all the data:
+	//  - For eCommerce & eCommerce trial, don't show placeholder.
+	//  - For Woo Express Trial, Essential & Performance, show placeholder while redirecting to WooCommerce Home (search for `wc-admin` under customer-home/controller.jsx).
 	if (
 		isSiteWooExpressEcommerceTrial &&
 		( isRequestingSitePlugins || hasWooCommerceInstalled ) &&
 		( fetchingJetpackModules || ssoModuleActive ) &&
 		( config.isEnabled( 'entrepreneur-my-home' )
-			? isRequestingSitePurchases || purchase?.isWooExpressTrial
+			? isRequestingSitePlans || isRequestingSitePurchases || purchase?.isWooExpressTrial
 			: true )
 	) {
 		return <WooCommerceHomePlaceholder />;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from '@automattic/urls';
@@ -36,6 +37,7 @@ import {
 	getPluginOnSite,
 	isRequesting as isRequestingInstalledPlugins,
 } from 'calypso/state/plugins/installed/selectors';
+import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import getRequest from 'calypso/state/selectors/get-request';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
@@ -51,7 +53,11 @@ import {
 	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
 } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedPurchase,
+} from 'calypso/state/ui/selectors';
 import CelebrateLaunchModal from './components/celebrate-launch-modal';
 
 import './style.scss';
@@ -102,6 +108,9 @@ const Home = ( {
 	const emailDnsDiagnostics = domainDiagnosticData?.email_dns_records;
 	const [ dismissedEmailDnsDiagnostics, setDismissedEmailDnsDiagnostics ] = useState( false );
 
+	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );
+	const purchase = useSelector( getSelectedPurchase );
+
 	useEffect( () => {
 		if ( getQueryArgs().celebrateLaunch === 'true' && isSuccess ) {
 			setCelebrateLaunchModalIsOpen( true );
@@ -142,7 +151,10 @@ const Home = ( {
 	if (
 		isSiteWooExpressEcommerceTrial &&
 		( isRequestingSitePlugins || hasWooCommerceInstalled ) &&
-		( fetchingJetpackModules || ssoModuleActive )
+		( fetchingJetpackModules || ssoModuleActive ) &&
+		( config.isEnabled( 'entrepreneur-my-home' )
+			? isRequestingSitePurchases || purchase?.isWooExpressTrial
+			: true )
 	) {
 		return <WooCommerceHomePlaceholder />;
 	}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -47,6 +47,7 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { launchSite } from 'calypso/state/sites/launch/actions';
 import {
 	isSiteOnWooExpressEcommerceTrial,
+	isSiteOnWooExpress,
 	isRequestingSitePlans as isFetchingSitePlans,
 } from 'calypso/state/sites/plans/selectors';
 import {
@@ -75,6 +76,7 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
+	isSiteWooExpress,
 	isSiteWooExpressEcommerceTrial,
 	ssoModuleActive,
 	fetchingJetpackModules,
@@ -159,7 +161,10 @@ const Home = ( {
 		( isRequestingSitePlugins || hasWooCommerceInstalled ) &&
 		( fetchingJetpackModules || ssoModuleActive ) &&
 		( config.isEnabled( 'entrepreneur-my-home' )
-			? isRequestingSitePlans || isRequestingSitePurchases || purchase?.isWooExpressTrial
+			? isRequestingSitePlans ||
+			  isRequestingSitePurchases ||
+			  isSiteWooExpress ||
+			  purchase?.isWooExpressTrial
 			: true )
 	) {
 		return <WooCommerceHomePlaceholder />;
@@ -327,6 +332,7 @@ const mapStateToProps = ( state ) => {
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 		hasWooCommerceInstalled: !! ( installedWooCommercePlugin && installedWooCommercePlugin.active ),
 		isRequestingSitePlugins: isRequestingInstalledPlugins( state, siteId ),
+		isSiteWooExpress: isSiteOnWooExpress( state, siteId ),
 		isSiteWooExpressEcommerceTrial: isSiteOnWooExpressEcommerceTrial( state, siteId ),
 		ssoModuleActive: !! isJetpackModuleActive( state, siteId, 'sso' ),
 		fetchingJetpackModules: !! isFetchingJetpackModules( state, siteId ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6764

## Proposed Changes

* Ensure sites on Entrepreneur Plan (ECommerce Trial & ECommerce, Non-Woo) lands on My Home.

This is currently behind the `entrepreneur-my-home` feature flag so OK to merge without affecting production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/home/yoursitehere.wpcomstaging.com?flags=entrepreneur-my-home`.
* You should land in My Home.
  * The launchpad might be stuck in loading state forever, that's OK.
* Test the above again with the following sites:
  * Site on Ecommerce plan.
  * Site on Ecommerce trial plan manually assigned via store admin (the April one).
  * Site on Woo plans (Trial/Essential/Performance).
    * Site on Woo plan should go to wc-admin.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?