### PR TITLE
EXPLORATION: Add new hosted site migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
@@ -1,0 +1,409 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useLocale } from '@automattic/i18n-utils';
+import { SiteExcerptData } from '@automattic/sites';
+import { useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { addQueryArgs } from 'calypso/lib/url';
+import wpcom from 'calypso/lib/wp';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import { goToCheckout } from '../utils/checkout';
+import { getLoginUrl } from '../utils/path';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
+import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
+import { AssertConditionState } from './internals/types';
+import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
+import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
+
+const FLOW_NAME = 'hosted-site-migration';
+
+const hostedSiteMigration: Flow = {
+	name: FLOW_NAME,
+	isSignupFlow: false,
+
+	useSteps() {
+		return [
+			STEPS.SITE_MIGRATION_IDENTIFY,
+			STEPS.SITE_PICKER,
+			STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.BUNDLE_TRANSFER,
+			STEPS.SITE_MIGRATION_PLUGIN_INSTALL,
+			STEPS.PROCESSING,
+			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
+			STEPS.VERIFY_EMAIL,
+			STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN,
+			STEPS.SITE_MIGRATION_INSTRUCTIONS,
+			STEPS.SITE_MIGRATION_INSTRUCTIONS_I2,
+			STEPS.ERROR,
+		];
+	},
+	useAssertConditions(): AssertConditionResult {
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+		const { isOwner } = useIsSiteOwner();
+
+		const flowName = this.name;
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
+		const queryParams = new URLSearchParams( window.location.search );
+		const aff = queryParams.get( 'aff' );
+		const vendorId = queryParams.get( 'vid' );
+
+		const getStartUrl = () => {
+			let hasFlowParams = false;
+			const flowParams = new URLSearchParams();
+			const queryParams = new URLSearchParams();
+
+			if ( vendorId ) {
+				queryParams.set( 'vid', vendorId );
+			}
+
+			if ( aff ) {
+				queryParams.set( 'aff', aff );
+			}
+
+			if ( locale && locale !== 'en' ) {
+				flowParams.set( 'locale', locale );
+				hasFlowParams = true;
+			}
+
+			const redirectTarget =
+				`/setup/${ FLOW_NAME }` +
+				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+
+			let queryString = `redirect_to=${ redirectTarget }`;
+
+			if ( queryParams.toString() ) {
+				queryString = `${ queryString }&${ queryParams.toString() }`;
+			}
+
+			const logInUrl = getLoginUrl( {
+				variationName: flowName,
+				locale,
+			} );
+
+			return `${ logInUrl }&${ queryString }`;
+		};
+
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				const logInUrl = getStartUrl();
+				window.location.assign( logInUrl );
+			}
+		}, [] );
+
+		useEffect( () => {
+			if ( isOwner === false ) {
+				window.location.assign( '/start' );
+			}
+		}, [ isOwner ] );
+
+		if ( ! userIsLoggedIn ) {
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'site-migration requires a logged in user',
+			};
+		}
+
+		// if ( ! siteSlug && ! siteId ) {
+		// 	window.location.assign( '/start' );
+		// 	result = {
+		// 		state: AssertConditionState.FAILURE,
+		// 		message: 'site-setup did not provide the site slug or site id it is configured to.',
+		// 	};
+		// }
+
+		return result;
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const intent = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
+			[]
+		);
+		const siteSlugParam = useSiteSlugParam();
+		const urlQueryParams = useQuery();
+		const fromQueryParam = urlQueryParams.get( 'from' );
+		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
+		const siteCount =
+			useSelect( ( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(), [] )
+				?.site_count ?? 0;
+		const exitFlow = ( to: string ) => {
+			window.location.assign( to );
+		};
+
+		const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unknown > ) => {
+			return wpcom.req.post(
+				`/sites/${ siteSlug }/settings`,
+				{
+					apiVersion: '1.4',
+				},
+				{
+					...settings,
+				}
+			);
+		};
+
+		// TODO - We may need to add `...params: string[]` back once we start adding more steps.
+		async function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
+			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
+			const siteId = getSiteIdBySlug( siteSlug );
+
+			switch ( currentStep ) {
+				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
+					const { from, platform, action } = providedDependencies as {
+						from: string;
+						platform: string;
+						action: SiteMigrationIdentifyAction;
+					};
+
+					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
+						return exitFlow(
+							addQueryArgs(
+								{
+									siteId,
+									siteSlug,
+									from,
+									origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+									backToFlow: `/${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+								},
+								'/setup/site-setup/importList'
+							)
+						);
+					}
+
+					if ( ! siteSlugParam ) {
+						if ( siteCount > 0 ) {
+							return navigate( `sitePicker?from=${ encodeURIComponent( from ) }` );
+						}
+
+						if ( from ) {
+							return navigate( 'site-migration-upgrade-plan', {
+								siteId,
+								siteSlug,
+							} );
+							// return navigate( `createSite?from=${ encodeURIComponent( from ) }` );
+						}
+						return navigate( 'error' );
+					}
+					return navigate(
+						addQueryArgs(
+							{ from: from, siteSlug, siteId },
+							STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
+						)
+					);
+				}
+				case 'sitePicker': {
+					switch ( providedDependencies?.action ) {
+						case 'update-query': {
+							const newQueryParams =
+								( providedDependencies?.queryParams as { [ key: string ]: string } ) || {};
+
+							Object.keys( newQueryParams ).forEach( ( key ) => {
+								newQueryParams[ key ]
+									? urlQueryParams.set( key, newQueryParams[ key ] )
+									: urlQueryParams.delete( key );
+							} );
+
+							return navigate( `sitePicker?${ urlQueryParams.toString() }` );
+						}
+						case 'select-site': {
+							const { ID: newSiteId, slug: newSiteSlug } =
+								providedDependencies.site as SiteExcerptData;
+							return navigate(
+								addQueryArgs(
+									{ siteId: newSiteId, siteSlug: newSiteSlug, from: fromQueryParam },
+									STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+								)
+							);
+						}
+						case 'create-site':
+							return navigate(
+								addQueryArgs( { from: fromQueryParam }, STEPS.SITE_CREATION_STEP.slug )
+							);
+					}
+				}
+				case STEPS.SITE_CREATION_STEP.slug: {
+					return navigate(
+						addQueryArgs( { from: fromQueryParam, siteSlug, siteId }, STEPS.PROCESSING.slug )
+					);
+				}
+				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
+					// Switch to the normal Import flow.
+					if ( providedDependencies?.destination === 'import' ) {
+						return exitFlow(
+							addQueryArgs(
+								{
+									siteSlug,
+									siteId,
+									backToFlow: `/${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }`,
+								},
+								'/setup/site-setup/importList'
+							)
+						);
+					}
+
+					// Take the user to the upgrade plan step.
+					if ( providedDependencies?.destination === 'upgrade' ) {
+						// TODO - Once the upgrade plan step is available, we'll want to change this to use the slug constant.
+						return navigate( 'site-migration-upgrade-plan', {
+							siteId,
+							siteSlug,
+						} );
+					}
+
+					// Continue with the migration flow.
+					return navigate( STEPS.BUNDLE_TRANSFER.slug, {
+						siteId,
+						siteSlug,
+					} );
+				}
+
+				case STEPS.BUNDLE_TRANSFER.slug: {
+					if ( isEnabled( 'migration-flow/remove-processing-step' ) ) {
+						return navigate( STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug );
+					}
+					return navigate( STEPS.PROCESSING.slug, { bundleProcessing: true } );
+				}
+
+				case STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug: {
+					return navigate( STEPS.PROCESSING.slug, { pluginInstall: true } );
+				}
+
+				case STEPS.PROCESSING.slug: {
+					// Any process errors go to the error step.
+					if ( providedDependencies?.error ) {
+						return navigate( STEPS.ERROR.slug );
+					}
+
+					if ( providedDependencies?.siteCreated ) {
+						return navigate(
+							addQueryArgs(
+								{ siteId, siteSlug, from: fromQueryParam },
+								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+							)
+						);
+					}
+					// If the plugin was installed successfully, go to the migration instructions.
+					if ( providedDependencies?.pluginInstalled ) {
+						if ( siteSlug ) {
+							// Remove the in_site_migration_flow option at the end of the flow.
+							await saveSiteSettings( siteSlug, {
+								in_site_migration_flow: false,
+							} );
+						}
+
+						return navigate( STEPS.SITE_MIGRATION_INSTRUCTIONS.slug );
+					}
+
+					// Otherwise processing has finished from the BundleTransfer step and we need to install the plugin.
+					return navigate( STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug );
+				}
+
+				case STEPS.VERIFY_EMAIL.slug: {
+					return navigate( STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug );
+				}
+
+				case STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug: {
+					if ( providedDependencies?.error ) {
+						return navigate( STEPS.ERROR.slug );
+					}
+
+					return navigate( STEPS.BUNDLE_TRANSFER.slug, {
+						siteId,
+						siteSlug,
+					} );
+				}
+
+				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
+					if ( providedDependencies?.verifyEmail ) {
+						if ( siteSlug ) {
+							// Set the in_site_migration_flow option if the user needs to be verified.
+							await saveSiteSettings( siteSlug, {
+								in_site_migration_flow: true,
+							} );
+						}
+						return navigate( STEPS.VERIFY_EMAIL.slug );
+					}
+
+					if ( providedDependencies?.goToCheckout ) {
+						const destination = addQueryArgs(
+							{
+								siteSlug,
+								from: fromQueryParam,
+							},
+							`/setup/${ FLOW_NAME }/${ STEPS.BUNDLE_TRANSFER.slug }`
+						);
+						goToCheckout( {
+							flowName: FLOW_NAME,
+							stepName: 'site-migration-upgrade-plan',
+							siteSlug: siteSlug,
+							destination: destination,
+							plan: providedDependencies.plan as string,
+						} );
+						return;
+					}
+					if ( providedDependencies?.freeTrialSelected ) {
+						return navigate( STEPS.BUNDLE_TRANSFER.slug, {
+							siteId,
+							siteSlug,
+						} );
+					}
+				}
+
+				case STEPS.SITE_MIGRATION_INSTRUCTIONS.slug: {
+					return exitFlow( `/home/${ siteSlug }` );
+				}
+			}
+		}
+
+		const goBack = () => {
+			switch ( currentStep ) {
+				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
+					return navigate( STEPS.SITE_MIGRATION_IDENTIFY.slug );
+				}
+				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
+					return exitFlow( `/setup/site-setup/goals?${ urlQueryParams }` );
+				}
+
+				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
+					if ( urlQueryParams.has( 'showModal' ) || ! isEnabled( 'migration_assistance_modal' ) ) {
+						urlQueryParams.delete( 'showModal' );
+						return navigate(
+							`${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?${ urlQueryParams }`
+						);
+					}
+					if ( isEnabled( 'migration_assistance_modal' ) ) {
+						urlQueryParams.set( 'showModal', 'true' );
+					}
+
+					return navigate( `site-migration-upgrade-plan?${ urlQueryParams.toString() }` );
+				}
+			}
+		};
+
+		return { goBack, submit, exitFlow };
+	},
+};
+
+export default hostedSiteMigration;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -170,6 +170,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			return {
 				siteSlug: getSignupCompleteSlug(),
 				goToCheckout: true,
+				siteCreated: true,
 			};
 		}
 
@@ -203,6 +204,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 				siteId: site.siteId,
 				siteSlug: site.siteSlug,
 				goToCheckout: false,
+				siteCreated: true,
 			};
 		}
 
@@ -224,6 +226,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			siteSlug: site?.siteSlug,
 			goToCheckout: Boolean( planCartItem ),
 			hasSetPreselectedTheme: Boolean( preselectedThemeSlug ),
+			siteCreated: true,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -246,6 +246,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-plugin-install' ),
 	},
 
+	SITE_PICKER: {
+		slug: 'sitePicker',
+		asyncComponent: () => import( './steps-repository/site-picker' ),
+	},
+
 	SEGMENTATION_SURVEY: {
 		slug: 'segmentation-survey',
 		asyncComponent: () => import( './steps-repository/segmentation-survey' ),

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -16,6 +16,7 @@ import {
 	SITE_MIGRATION_FLOW,
 	MIGRATION_SIGNUP_FLOW,
 	ENTREPRENEUR_FLOW,
+	HOSTED_SITE_MIGRATION_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -168,4 +169,25 @@ const siteMigrationFlow: Record< string, () => Promise< { default: Flow } > > = 
 	  }
 	: {};
 
-export default { ...availableFlows, ...videoPressTvFlows, ...siteMigrationFlow };
+const hostedSiteMigrationFlow: Record< string, () => Promise< { default: Flow } > > = {
+	[ HOSTED_SITE_MIGRATION_FLOW ]: () =>
+		import(
+			/* webpackChunkName: "hosted-site-migration-flow" */ '../declarative-flow/hosted-site-migration-flow'
+		),
+};
+// const hostedSiteMigrationFlow: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(
+// 	'onboarding/new-migration-flow'
+// )
+// 	? {
+// 			[ SITE_MIGRATION_FLOW ]: () =>
+// 				import(
+// 					/* webpackChunkName: "site-migration-flow" */ '../declarative-flow/site-migration-flow'
+// 				),
+// 	  }
+// 	: {};
+export default {
+	...availableFlows,
+	...videoPressTvFlows,
+	...siteMigrationFlow,
+	...hostedSiteMigrationFlow,
+};

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -24,6 +24,7 @@ export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 export const MIGRATION_FLOW = 'import-focused';
 export const SITE_MIGRATION_FLOW = 'site-migration';
+export const HOSTED_SITE_MIGRATION_FLOW = 'hosted-site-migration';
 export const MIGRATION_SIGNUP_FLOW = 'migration-signup';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

_Discussion on the shaping doc linked in this comment_: p1714410393264509/1714405011.851319-slack-C0Q664T29

This is an opinionated exploratory PR about creating a new version of the hosted site migration flow.

The idea is to create an alternative `/setup/import-hosted-site` that uses Migrate Guru as the underlaying migration tech. This PR adds a variation of the current site migration flow with these basic additions:
* You can navigate to it directly by going to `/setup/hosted-site-migration`.
* You get to pick an existing site to migrate into or create a new one.
* If your source site is not on Wordpress then you are redirected to the import flow (this is not done yet in this PR)
* Once you have a destination site, you are redirected straight to the `upgrade-bundle` screen, I skipped the one giving you the chance to pick between migrate vs import.

**BIG MISSING PIECES**
* Back button handling
* Figure out what Migrate Guru does when you try to migrate into a site with actual content
* Redirection to import flow if the source site is not on Wordpress
* We will need to update this when the new instructions are merged, since the waiting is annoying
* Update to require credit card? https://github.com/Automattic/wp-calypso/pull/89839

**Current state**
This happy path is ready to test:
1. Go to `/setup/import-hosted-site`.
2. Select `create a new site`
3. Select a Free Plan
4. Wait
5. See the instructions screen, including your Migrate Guru key

https://github.com/Automattic/wp-calypso/assets/375980/c87bfe56-51d6-420a-b3af-fece929f04f5



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?