### PR TITLE
Take 2: "Starter" to "Beginner" plan name change 

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -57,7 +57,7 @@ export const ProviderWrappedLayout = ( {
 	useEffect( () => {
 		if ( ! isLoading ) {
 			setPlansListExperiment(
-				'wpcom_plan_name_change_starter_to_beginner',
+				'wpcom_plan_name_change_starter_to_beginner_v2',
 				experimentAssignment?.variationName
 			);
 		}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -51,7 +51,7 @@ export const ProviderWrappedLayout = ( {
 	const userLoggedIn = isUserLoggedIn( state );
 
 	const [ isLoading, experimentAssignment ] = useExperiment(
-		'wpcom_plan_name_change_starter_to_beginner'
+		'wpcom_plan_name_change_starter_to_beginner_v2'
 	);
 
 	useEffect( () => {

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { setPlansListExperiment } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import {
 	getLanguage,
@@ -7,6 +8,7 @@ import {
 } from '@automattic/i18n-utils';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import EmptyContent from 'calypso/components/empty-content';
@@ -14,6 +16,7 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { useExperiment } from 'calypso/lib/explat';
 import { createAccountUrl, login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -46,6 +49,19 @@ export const ProviderWrappedLayout = ( {
 } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
+
+	const [ isLoading, experimentAssignment ] = useExperiment(
+		'wpcom_plan_name_change_starter_to_beginner'
+	);
+
+	useEffect( () => {
+		if ( ! isLoading ) {
+			setPlansListExperiment(
+				'wpcom_plan_name_change_starter_to_beginner',
+				experimentAssignment?.variationName
+			);
+		}
+	}, [ isLoading, experimentAssignment?.variationName ] );
 
 	const layout = userLoggedIn ? (
 		<Layout primary={ primary } secondary={ secondary } />

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -25,6 +25,7 @@ export const requestPlans = ( action ) =>
 			path: '/plans',
 			query: {
 				coupon_code: action.coupon,
+				test: 'niranjan',
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -25,7 +25,6 @@ export const requestPlans = ( action ) =>
 			path: '/plans',
 			query: {
 				coupon_code: action.coupon,
-				test: 'niranjan',
 			},
 		},
 		action

--- a/packages/calypso-products/src/plans.tsx
+++ b/packages/calypso-products/src/plans.tsx
@@ -1,4 +1,5 @@
 import i18n from 'i18n-calypso';
+import { getPlansListExperiment } from './experiments';
 
 /**
  * Extracted functions to avoid Calypso apps from depending on the PLANS_LIST object.
@@ -6,8 +7,11 @@ import i18n from 'i18n-calypso';
  */
 
 export const getPlanPersonalTitle = () =>
-	// translators: Starter is a plan name
-	i18n.translate( 'Starter' );
+	getPlansListExperiment( 'wpcom_plan_name_change_starter_to_beginner_v2' ) === 'treatment'
+		? // translators: Beginner is a plan name
+		  i18n.translate( 'Beginner' )
+		: // translators: Starter is a plan name
+		  i18n.translate( 'Starter' );
 
 export const getPlanPremiumTitle = () =>
 	// translators: Explorer is a plan name

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -26,6 +26,7 @@ function usePlans( {
 	const params = new URLSearchParams();
 	coupon && params.append( 'coupon_code', coupon );
 	params.append( 'locale', locale );
+	params.append( 'eligible_request_for_experiment', 'true' );
 
 	return useQuery( {
 		queryKey: queryKeys.plans( coupon ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Re-launch of the plan name change experiment originally implemented in https://github.com/Automattic/wp-calypso/pull/89535.
* This also adds the `eligible_request_for_experiment` param to the v1.5/plans endpoint so that the backend can assign assignments to requests coming from the logged-out /themes page (implemented in D146266-code). 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Follow the test instructions in D146266-code.
