### PR TITLE
Nav redesign: fix sorting/filtering mechanism on sites-dashboard-v2

### DIFF
--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -167,19 +167,19 @@ const SitesDashboardV2 = ( {
 		showHidden: true,
 	} );
 
-	// Filter sites list by search query.
-	const filteredSites = useSitesListFiltering( currentStatusGroup, {
-		search: dataViewsState.search,
-	} );
-
 	// Perform sorting actions
-	const sortedSites = useSitesListSorting( filteredSites, {
+	const sortedSites = useSitesListSorting( currentStatusGroup, {
 		sortKey: siteSortingKeys.find( ( key ) => key.dataView === dataViewsState.sort.field )
 			?.sortKey as SitesSortKey,
 		sortOrder: dataViewsState.sort.direction || undefined,
 	} );
 
-	const paginatedSites = sortedSites.slice(
+	// Filter sites list by search query.
+	const filteredSites = useSitesListFiltering( sortedSites, {
+		search: dataViewsState.search,
+	} );
+
+	const paginatedSites = filteredSites.slice(
 		( dataViewsState.page - 1 ) * dataViewsState.perPage,
 		dataViewsState.page * dataViewsState.perPage
 	);


### PR DESCRIPTION
## Proposed Changes

I've been always feeling that searching on `/sites` V1 returns "better" results than V2, so I investigated the code a bit. Here is my finding:

In V1, we do grouping -> sorting -> filtering:

https://github.com/Automattic/wp-calypso/blob/668c5eacb5f8b8d3eacf9f3c0b797331044f1986/packages/sites/src/create-sites-list-component.ts#L115-L117

In V2, we do grouping -> filtering -> sorting

https://github.com/Automattic/wp-calypso/blob/668c5eacb5f8b8d3eacf9f3c0b797331044f1986/client/sites-dashboard-v2/sites-dashboard.tsx#L164-L180

This PR proposes to follow V1's instead. Particularly, if you search for EXACT site name, V1 will always put the site as the first result, while V2 is random. Try it before testing the Calypso URL!

## Testing Instructions

1. Open `<Calypso Live URL>/sites` in one tab
1. Open `<Calypso Live URL>/sites?flags=layout/dotcom-nav-redesign-v2` in another tab
2. Search for site name in both tabs, verify they get consistent results.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)