### PR TITLE
Plans 2023: Fix missing refund messaging in features grid billing timeframe

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -156,6 +156,7 @@ type TabletViewProps = {
 	planUpgradeCreditsApplicable?: number | null;
 	renderedGridPlans: GridPlan[];
 	selectedFeature?: string;
+	showRefundPeriod?: boolean;
 	showUpgradeableStorage: boolean;
 	stickyRowOffset: number;
 };
@@ -164,7 +165,6 @@ const TabletView = ( {
 	currentSitePlanSlug,
 	generatedWPComSubdomain,
 	gridPlanForSpotlight,
-	renderedGridPlans,
 	hideUnavailableFeatures,
 	intervalType,
 	isCustomDomainAllowedOnFreePlan,
@@ -174,7 +174,9 @@ const TabletView = ( {
 	paidDomainName,
 	planActionOverrides,
 	planUpgradeCreditsApplicable,
+	renderedGridPlans,
 	selectedFeature,
+	showRefundPeriod,
 	showUpgradeableStorage,
 	stickyRowOffset,
 }: TabletViewProps ) => {
@@ -198,6 +200,7 @@ const TabletView = ( {
 		planActionOverrides,
 		planUpgradeCreditsApplicable,
 		selectedFeature,
+		showRefundPeriod,
 		showUpgradeableStorage,
 		stickyRowOffset,
 	};
@@ -217,23 +220,24 @@ const TabletView = ( {
 };
 
 const FeaturesGrid = ( {
-	gridPlans,
-	gridPlanForSpotlight,
-	stickyRowOffset,
-	isInSignup,
-	planUpgradeCreditsApplicable,
 	currentSitePlanSlug,
-	isLaunchPage,
-	planActionOverrides,
-	intervalType,
-	onStorageAddOnClick,
-	showUpgradeableStorage,
-	paidDomainName,
-	hideUnavailableFeatures,
-	selectedFeature,
 	generatedWPComSubdomain,
-	isCustomDomainAllowedOnFreePlan,
+	gridPlanForSpotlight,
+	gridPlans,
 	gridSize,
+	hideUnavailableFeatures,
+	intervalType,
+	isCustomDomainAllowedOnFreePlan,
+	isInSignup,
+	isLaunchPage,
+	onStorageAddOnClick,
+	paidDomainName,
+	planActionOverrides,
+	planUpgradeCreditsApplicable,
+	selectedFeature,
+	showRefundPeriod,
+	showUpgradeableStorage,
+	stickyRowOffset,
 }: FeaturesGridProps ) => {
 	const spotlightPlanProps = {
 		currentSitePlanSlug,
@@ -251,10 +255,11 @@ const FeaturesGrid = ( {
 	const planFeaturesProps = {
 		...spotlightPlanProps,
 		generatedWPComSubdomain,
-		renderedGridPlans: gridPlans,
 		hideUnavailableFeatures,
 		isCustomDomainAllowedOnFreePlan,
 		paidDomainName,
+		renderedGridPlans: gridPlans,
+		showRefundPeriod,
 	};
 
 	return (

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -28,6 +28,7 @@ type TableProps = {
 	planUpgradeCreditsApplicable?: number | null;
 	renderedGridPlans: GridPlan[];
 	selectedFeature?: string;
+	showRefundPeriod?: boolean;
 	showUpgradeableStorage: boolean;
 	stickyRowOffset: number;
 	options?: {
@@ -50,6 +51,7 @@ const Table = ( {
 	planUpgradeCreditsApplicable,
 	renderedGridPlans,
 	selectedFeature,
+	showRefundPeriod,
 	showUpgradeableStorage,
 	stickyRowOffset,
 }: TableProps ) => {
@@ -109,6 +111,7 @@ const Table = ( {
 				<tr>
 					<BillingTimeframes
 						renderedGridPlans={ gridPlansWithoutSpotlight }
+						showRefundPeriod={ showRefundPeriod }
 						options={ { isTableCell: true } }
 					/>
 				</tr>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89945 and  https://github.com/Automattic/wp-calypso/pull/82690#discussion_r1577581885

## Proposed Changes

* The `showRefundPeriod` prop wasn't being passed into the features grid `BillingTimeframes` component
* It was, presumably, removed during some rebase or refactoring effort
* From what I could tell, the comparison grid was unaffected

I didn't spend too much time investigating when or where the `showRefundPeriod` was removed since it's clear that it was mistakenly omitted from props. I can, however, take a closer look if folks feel that it's necessary.

## Screenshots
### Before
<img width="733" alt="Screenshot 2024-04-29 at 10 04 51 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/2f845f59-695c-486b-aff7-49916ef04c22">

### After
<img width="785" alt="Screenshot 2024-04-29 at 10 04 41 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/550c8238-efd9-42df-b9cf-c325c34b8d99">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/setup/new-hosted-site`
* Verify that the billing timeframe now displays refund period messaging "Refundable within 14 days. No questions asked."

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?