### PR TITLE
Added segmentation survey param to account creation call

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -111,6 +111,7 @@ class PasswordlessSignupForm extends Component {
 				} ),
 				anon_id: getTracksAnonymousUserId(),
 				is_dev_account: ref === 'developer-lp',
+				has_segmentation_survey: queryArgs.variationName === 'entrepreneur',
 			} );
 
 			this.createAccountCallback( response );

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -111,7 +111,7 @@ class PasswordlessSignupForm extends Component {
 				} ),
 				anon_id: getTracksAnonymousUserId(),
 				is_dev_account: ref === 'developer-lp',
-				has_segmentation_survey: queryArgs.variationName === 'entrepreneur',
+				extra: { has_segmentation_survey: queryArgs.variationName === 'entrepreneur' },
 			} );
 
 			this.createAccountCallback( response );

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -182,7 +182,7 @@ export const createSiteWithCart = async (
 			lang_id: getLanguage( locale as string )?.value,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
-			has_segmentation_survey: hasSegmentationSurvey,
+			options: { has_segmentation_survey: hasSegmentationSurvey },
 		},
 	} );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/89745

## Proposed Changes

This PR adds the has_segmentation_survey to the account creation API call when we are in the entrepreneur flow.

## Testing Instructions

Test alongside with D146276-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?