### PR TITLE
Nav Redesign - add focus to stats when link focused

### DIFF
--- a/client/blocks/stats-sparkline/style.scss
+++ b/client/blocks/stats-sparkline/style.scss
@@ -6,3 +6,11 @@
 .stats-sparkline__bar {
 	fill: var(--color-stats-sparkline);
 }
+
+a:focus {
+	.stats-sparkline {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+		border-radius: 2px;
+		margin-left: 2px;
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6789

The missing focus was due to the stats sparkline not highlighting the focus when focused.

This PR adds styles to handle that and adds some spacing to avoid issue with current dashboard.

**New Dashboad**
<img width="1548" alt="Screenshot 2024-04-29 at 19 07 39" src="https://github.com/Automattic/wp-calypso/assets/5560595/70b3aa7e-601f-4c6c-a180-cea09d9d6ece">

**Current Dashboard**
<img width="1583" alt="Screenshot 2024-04-29 at 19 08 13" src="https://github.com/Automattic/wp-calypso/assets/5560595/bda76667-c7e4-4baf-9443-6db0520395c0">

## Testing Instructions

* Tab through the links/buttons on calypso.live/sites dashboard and confirm no missing focus in the sites rows table.
