### PR TITLE
Newsletter: Add reply-to settings

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
@@ -1,7 +1,10 @@
 import { FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
+import { isJetpackSite as isJetpackSiteSelector } from 'calypso/state/sites/selectors';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 
 type ReplyToSettingProps = {
 	value?: string;
@@ -13,9 +16,14 @@ export const ReplyToSetting = ( {
 	value = 'no-reply',
 	disabled,
 	updateFields,
-	isWPcomSite,
 }: ReplyToSettingProps ) => {
 	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = selectedSite?.ID;
+	const isWPcomSite = useSelector( ( state ) => {
+		return ! isJetpackSiteSelector( state, siteId );
+	} );
+
 	return (
 		<FormFieldset>
 			<FormLabel className="increase-margin-bottom-fix">

--- a/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
@@ -31,7 +31,7 @@ export const ReplyToSetting = ( {
 					checked={ value === 'no-reply' || value === '' }
 					onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'no-reply' } ) }
 					disabled={ disabled }
-					label={ translate( 'Replies are not allowed.' ) }
+					label={ translate( 'Replies are not allowed' ) }
 				/>
 			</FormLabel>
 			{ isWPcomSite && (
@@ -42,7 +42,7 @@ export const ReplyToSetting = ( {
 							value="comment"
 							onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'comment' } ) }
 							disabled={ disabled }
-							label={ translate( 'Replies will be a public comment on the post.' ) }
+							label={ translate( 'Replies will be a public comment on the post' ) }
 						/>
 					</FormLabel>
 				</>
@@ -53,7 +53,7 @@ export const ReplyToSetting = ( {
 					value="author"
 					onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'author' } ) }
 					disabled={ disabled }
-					label={ translate( "Replies will be sent to the post author's email." ) }
+					label={ translate( "Replies will be sent to the post author's email" ) }
 				/>
 			</FormLabel>
 		</FormFieldset>

--- a/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
@@ -1,0 +1,46 @@
+import { FormLabel } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormRadio from 'calypso/components/forms/form-radio';
+
+type ReplyToSettingProps = {
+	value?: string;
+	disabled?: boolean;
+	updateFields?: ( fields: { [ key: string ]: unknown } ) => void;
+};
+
+export const ReplyToSetting = ( {
+	value = 'no-reply',
+	disabled,
+	updateFields,
+}: ReplyToSettingProps ) => {
+	const translate = useTranslate();
+	return (
+		<FormFieldset>
+			<FormLabel className="increase-margin-bottom-fix">
+				{ translate( 'Reply-to settings' ) }
+			</FormLabel>
+			<p>
+				{ translate( 'Choose who receives emails when subscribers reply to your newsletter.' ) }
+			</p>
+			<FormLabel>
+				<FormRadio
+					value="no-reply"
+					checked={ value === 'no-reply' || value === '' }
+					onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'no-reply' } ) }
+					disabled={ disabled }
+					label={ translate( 'Replies are not allowed.' ) }
+				/>
+			</FormLabel>
+			<FormLabel>
+				<FormRadio
+					checked={ value === 'author' }
+					value="author"
+					onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'author' } ) }
+					disabled={ disabled }
+					label={ translate( "Replies will be sent to the post author's email." ) }
+				/>
+			</FormLabel>
+		</FormFieldset>
+	);
+};

--- a/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { isJetpackSite as isJetpackSiteSelector } from 'calypso/state/sites/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 
@@ -29,9 +30,6 @@ export const ReplyToSetting = ( {
 			<FormLabel className="increase-margin-bottom-fix">
 				{ translate( 'Reply-to settings' ) }
 			</FormLabel>
-			<p>
-				{ translate( 'Choose who receives emails when subscribers reply to your newsletter.' ) }
-			</p>
 			<FormLabel>
 				<FormRadio
 					value="no-reply"
@@ -63,6 +61,9 @@ export const ReplyToSetting = ( {
 					label={ translate( "Replies will be sent to the post author's email" ) }
 				/>
 			</FormLabel>
+			<FormSettingExplanation>
+				{ translate( 'Choose who receives emails when subscribers reply to your newsletter.' ) }
+			</FormSettingExplanation>
 		</FormFieldset>
 	);
 };

--- a/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
@@ -6,8 +6,7 @@ import FormRadio from 'calypso/components/forms/form-radio';
 type ReplyToSettingProps = {
 	value?: string;
 	disabled?: boolean;
-	updateFields?: ( fields: { [ key: string ]: unknown } ) => void;
-	isWPcomSite?: boolean;
+	updateFields: ( fields: { [ key: string ]: unknown } ) => void;
 };
 
 export const ReplyToSetting = ( {
@@ -29,7 +28,7 @@ export const ReplyToSetting = ( {
 				<FormRadio
 					value="no-reply"
 					checked={ value === 'no-reply' || value === '' }
-					onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'no-reply' } ) }
+					onChange={ () => updateFields( { jetpack_subscriptions_reply_to: 'no-reply' } ) }
 					disabled={ disabled }
 					label={ translate( 'Replies are not allowed' ) }
 				/>
@@ -40,7 +39,7 @@ export const ReplyToSetting = ( {
 						<FormRadio
 							checked={ value === 'comment' }
 							value="comment"
-							onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'comment' } ) }
+							onChange={ () => updateFields( { jetpack_subscriptions_reply_to: 'comment' } ) }
 							disabled={ disabled }
 							label={ translate( 'Replies will be a public comment on the post' ) }
 						/>
@@ -51,7 +50,7 @@ export const ReplyToSetting = ( {
 				<FormRadio
 					checked={ value === 'author' }
 					value="author"
-					onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'author' } ) }
+					onChange={ () => updateFields( { jetpack_subscriptions_reply_to: 'author' } ) }
 					disabled={ disabled }
 					label={ translate( "Replies will be sent to the post author's email" ) }
 				/>

--- a/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
@@ -7,12 +7,14 @@ type ReplyToSettingProps = {
 	value?: string;
 	disabled?: boolean;
 	updateFields?: ( fields: { [ key: string ]: unknown } ) => void;
+	isWPcomSite?: boolean;
 };
 
 export const ReplyToSetting = ( {
 	value = 'no-reply',
 	disabled,
 	updateFields,
+	isWPcomSite,
 }: ReplyToSettingProps ) => {
 	const translate = useTranslate();
 	return (
@@ -32,6 +34,19 @@ export const ReplyToSetting = ( {
 					label={ translate( 'Replies are not allowed.' ) }
 				/>
 			</FormLabel>
+			{ isWPcomSite && (
+				<>
+					<FormLabel>
+						<FormRadio
+							checked={ value === 'comment' }
+							value="comment"
+							onChange={ () => updateFields?.( { jetpack_subscriptions_reply_to: 'comment' } ) }
+							disabled={ disabled }
+							label={ translate( 'Replies will be a public comment on the post.' ) }
+						/>
+					</FormLabel>
+				</>
+			) }
 			<FormLabel>
 				<FormRadio
 					checked={ value === 'author' }

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -16,6 +16,7 @@ import wrapSettingsForm from '../wrap-settings-form';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
+import { ReplyToSetting } from './ReplyToSetting';
 import { SubscribeModalOnCommentSetting } from './SubscribeModalOnCommentSetting';
 import { SubscribeModalSetting } from './SubscribeModalSetting';
 import { SubscribePostEndSetting } from './SubscribePostEndSetting';
@@ -36,6 +37,7 @@ type Fields = {
 	wpcom_newsletter_categories?: number[];
 	wpcom_newsletter_categories_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
+	jetpack_subscriptions_reply_to?: string;
 	sm_enabled?: boolean;
 	jetpack_subscriptions_subscribe_post_end_enabled?: boolean;
 	jetpack_subscriptions_login_navigation_enabled?: boolean;
@@ -53,6 +55,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_newsletter_categories,
 		wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt,
+		jetpack_subscriptions_reply_to,
 		sm_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
 		jetpack_subscriptions_login_navigation_enabled,
@@ -65,6 +68,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_newsletter_categories: wpcom_newsletter_categories || [],
 		wpcom_newsletter_categories_enabled: !! wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
+		jetpack_subscriptions_reply_to: jetpack_subscriptions_reply_to || '',
 		sm_enabled: !! sm_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled:
 			!! jetpack_subscriptions_subscribe_post_end_enabled,
@@ -99,6 +103,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 	const {
 		wpcom_featured_image_in_email,
 		wpcom_subscription_emails_use_excerpt,
+		jetpack_subscriptions_reply_to,
 		subscription_options,
 		sm_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
@@ -197,6 +202,13 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					disabled={ disabled }
 					updateFields={ updateFields }
 					value={ wpcom_subscription_emails_use_excerpt }
+				/>
+			</Card>
+			<Card className="site-settings__card">
+				<ReplyToSetting
+					disabled={ disabled }
+					updateFields={ updateFields }
+					value={ jetpack_subscriptions_reply_to }
 				/>
 			</Card>
 

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -133,6 +133,10 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		return ! isJetpackSite;
 	} );
 
+	const isWPcomSite = useSelector( ( state ) => {
+		return ! isJetpackSiteSelector( state, siteId );
+	} );
+
 	const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;
 	const savedSubscriptionOptions = settings?.subscription_options;
 
@@ -209,6 +213,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					disabled={ disabled }
 					updateFields={ updateFields }
 					value={ jetpack_subscriptions_reply_to }
+					isWPcomSite={ isWPcomSite }
 				/>
 			</Card>
 

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -133,10 +133,6 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		return ! isJetpackSite;
 	} );
 
-	const isWPcomSite = useSelector( ( state ) => {
-		return ! isJetpackSiteSelector( state, siteId );
-	} );
-
 	const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;
 	const savedSubscriptionOptions = settings?.subscription_options;
 
@@ -213,7 +209,6 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					disabled={ disabled }
 					updateFields={ updateFields }
 					value={ jetpack_subscriptions_reply_to }
-					isWPcomSite={ isWPcomSite }
 				/>
 			</Card>
 


### PR DESCRIPTION
This PR is a the equivalent to https://github.com/Automattic/jetpack/pull/37011 on the Jetpack side. 

## Proposed Changes

Add Reply-to settings.

**Jetpack sites**
<img width="713" alt="Screenshot 2024-05-06 at 9 33 49 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/170c3efb-872f-4852-a1c2-69acb70b3e72">


**.com sites**
<img width="726" alt="Screenshot 2024-05-06 at 9 34 15 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/38042cc8-147f-4529-8d65-22269220e3b5">


## Testing Instructions
* Navigate to /settings/newsletter/example.com 
* Apply the setting. Test that it works as expected. 

Test it out for jetpack and .com site. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?