### PR TITLE
Nav Redesign: Enable flag on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -96,7 +96,7 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign-v2": false,
+		"layout/dotcom-nav-redesign-v2": true,
 		"layout/wpcom-admin-interface": false,
 		"legal-updates-banner": false,
 		"livechat_solution": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to https://github.com/Automattic/wp-calypso/issues/90006

## Proposed Changes

This is part of the Nav Redesign Launch Checklist (https://github.com/Automattic/dotcom-forge/issues/6796)
Enable `layout/dotcom-nav-redesign-v2` on production environment
