### PR TITLE
Fix GSV RTL issues

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -429,6 +429,12 @@ $brand-text: "SF Pro Text", $sans;
 				width: 24px;
 				margin-left: 6px;
 			}
+			.rtl & {
+				span.dotcom {
+					background-position: right;
+					margin-right: 6px;
+				}
+			}
 		}
 
 		.sidebar__body {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -428,9 +428,8 @@ $brand-text: "SF Pro Text", $sans;
 				background-position: left;
 				width: 24px;
 				margin-left: 6px;
-			}
-			.rtl & {
-				span.dotcom {
+
+				.rtl & {
 					background-position: right;
 					margin-right: 6px;
 				}

--- a/client/sites-dashboard-v2/controller.tsx
+++ b/client/sites-dashboard-v2/controller.tsx
@@ -64,10 +64,13 @@ export function sitesDashboard( context: Context, next: () => void ) {
 				min-height: 100vh;
 				padding: 16px 16px 16px calc( var( --sidebar-width-max ) );
 			}
-
 			.layout__secondary .global-sidebar {
 				border: none;
 			}
+		}
+
+		body.is-group-sites-dashboard.rtl .layout__content {
+			padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
 		}
 
 		.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {

--- a/client/sites-dashboard-v2/controller.tsx
+++ b/client/sites-dashboard-v2/controller.tsx
@@ -64,6 +64,7 @@ export function sitesDashboard( context: Context, next: () => void ) {
 				min-height: 100vh;
 				padding: 16px 16px 16px calc( var( --sidebar-width-max ) );
 			}
+
 			.layout__secondary .global-sidebar {
 				border: none;
 			}

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -65,10 +65,18 @@ const AddNewSiteSplitButton = styled( SplitButton )< { isMobile: boolean } >`
 	.split-button__main {
 		border-radius: 4px 0 0 4px;
 		-webkit-font-smoothing: antialiased;
+
+		.rtl & {
+			border-radius: 0 4px 4px 0;
+		}
 	}
 
 	.split-button__toggle {
 		border-radius: ${ ( { isMobile } ) => ( isMobile ? '4px' : '0 4px 4px 0' ) };
+
+		.rtl & {
+			border-radius: ${ ( { isMobile } ) => ( isMobile ? '4px' : '4px 0 0 4px' ) };
+		}
 	}
 
 	.sites-dashboard__layout:not( .preview-hidden ) & {
@@ -86,6 +94,11 @@ const AddNewSiteSplitButton = styled( SplitButton )< { isMobile: boolean } >`
 const DownloadIcon = styled( Icon )`
 	margin-right: 8px;
 	vertical-align: bottom;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
 `;
 
 const popoverHoverStyles = css`

--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
@@ -30,6 +30,7 @@ const DeletedStatus = styled.div`
 	flex-direction: column;
 	align-items: center;
 	padding-left: 8px;
+
 	span {
 		color: var( --color-error );
 	}

--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
@@ -29,7 +29,6 @@ const DeletedStatus = styled.div`
 	display: inline-flex;
 	flex-direction: column;
 	align-items: center;
-
 	span {
 		color: var( --color-error );
 	}

--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
@@ -29,7 +29,6 @@ const DeletedStatus = styled.div`
 	display: inline-flex;
 	flex-direction: column;
 	align-items: center;
-	padding-left: 8px;
 
 	span {
 		color: var( --color-error );

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -151,6 +151,11 @@ const ManageAllDomainsButton = styled( Button )`
 const DownloadIcon = styled( Icon )`
 	margin-right: 8px;
 	vertical-align: bottom;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
 `;
 
 const popoverHoverStyles = css`

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -60,6 +60,10 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 			}
 		}
 
+		body.is-group-sites-dashboard.rtl .layout__content {
+			padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
+		}
+
 		.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {
 			height: calc( 100vh - 32px );
 			padding-bottom: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6811

## Proposed Changes

* This PR fixes several RTL styling issues in GSV v1 and v2

In GSV v1 aka: /sites
Before | After
--|--
<img width="1969" alt="regular-sites-before" src="https://github.com/Automattic/wp-calypso/assets/140841/1c8315af-942c-4105-9ca3-615606d5eadb">  | <img width="1965" alt="regular-sites-after" src="https://github.com/Automattic/wp-calypso/assets/140841/e10b00a8-1845-4e74-b86a-40653205879b">

In GSV v2 aka: /sites?flags=layout%2Fdotcom-nav-redesign-v2
Before | After
--|--
<img width="1550" alt="before" src="https://github.com/Automattic/wp-calypso/assets/140841/eefebe51-ba22-41a2-98cd-d63264e1367c"> | <img width="1548" alt="after" src="https://github.com/Automattic/wp-calypso/assets/140841/91dcd5f7-8e6f-4d1d-887e-2e04e3cb20cb">

Logo in GSV v2 Panel Visible aka: /sites?flags=layout%2Fdotcom-nav-redesign-v2

Before | After
--|--
<img width="1545" alt="logo-before" src="https://github.com/Automattic/wp-calypso/assets/140841/64831c53-3b4c-4952-9611-a12b5fb02be7">  |  <img width="1542" alt="logo-after" src="https://github.com/Automattic/wp-calypso/assets/140841/522cf446-4412-4808-bfae-2009187978ff">

In GSV v2 the "Delete Section" I removed the padding for both LTR and RTL
Before | After
--|--
<img width="1546" alt="delete-before" src="https://github.com/Automattic/wp-calypso/assets/140841/09050f4d-21c6-4901-b1c4-fb1a323d51db">  | <img width="1552" alt="delete-after" src="https://github.com/Automattic/wp-calypso/assets/140841/0e87bc98-a2fb-4c8f-8c7f-874bab4d4985">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this PR
- Set your profile language to a RTL language
- View both /sites and /sites?flags=layout%2Fdotcom-nav-redesign-v2 and observe the changes above where made and it looks good.
- Set your profile language to a LTR language
- View both /sites and /sites?flags=layout%2Fdotcom-nav-redesign-v2 and observe that the changes above did not create any regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?