### PR TITLE
A4A: Add features list under hosting cards

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/simple-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/simple-list/index.tsx
@@ -1,11 +1,17 @@
 import { Icon, check } from '@wordpress/icons';
+import classNames from 'classnames';
 import { ReactNode } from 'react';
-
 import './style.scss';
 
-export default function SimpleList( { items }: { items: ReactNode[] } ) {
+export default function SimpleList( {
+	items,
+	className,
+}: {
+	items: ReactNode[];
+	className?: string;
+} ) {
 	return (
-		<ul className="simple-list">
+		<ul className={ classNames( 'simple-list', className ) }>
 			{ items.map( ( item, index ) => (
 				<li key={ `item-${ index }` }>
 					<Icon className="simple-list-icon" icon={ check } size={ 24 } />

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Card } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -6,6 +7,7 @@ import FilterSearch from 'calypso/a8c-for-agencies/components/filter-search';
 import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import SimpleList from '../../common/simple-list';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { getCheapestPlan } from '../../lib/hosting';
 import ListingSection from '../../listing-section';
@@ -85,6 +87,29 @@ export default function HostingList( { selectedSite }: Props ) {
 					<HostingCard plan={ cheapestPressablePlan } pressableOwnership={ hasPressablePlan } />
 				) }
 			</ListingSection>
+
+			<Card className="hosting-list__features">
+				<h3 className="hosting-list__features-heading">
+					{ translate( 'Pressable & WordPress.com include:' ) }
+				</h3>
+				<SimpleList
+					className="hosting-list__features-list"
+					items={ [
+						<li>{ translate( 'Global edge caching' ) }</li>,
+						<li>{ translate( 'Global CDN with 28+ locations' ) }</li>,
+						<li>{ translate( 'Automated datacenter failover' ) }</li>,
+						<li>{ translate( 'Free managed migrations' ) }</li>,
+						<li>{ translate( 'Jetpack Protect' ) }</li>,
+						<li>{ translate( 'Plugin update manager' ) }</li>,
+						<li>{ translate( '24/7 expert support' ) }</li>,
+						<li>{ translate( 'Free staging sites with sync tools' ) }</li>,
+						<li>{ translate( 'SFTP/SSH, WP-CLI, Git tools' ) }</li>,
+						<li>{ translate( '10 PHP workers with auto-scaling' ) }</li>,
+						<li>{ translate( 'Resource isolation across every site' ) }</li>,
+						<li>{ translate( 'Jetpack real-time backups' ) }</li>,
+					] }
+				/>
+			</Card>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
@@ -10,3 +10,18 @@
 	margin: 16px 0 32px;
 	justify-content: space-between;
 }
+
+.hosting-list__features {
+	border: 1px solid var(--color-neutral-10);
+	box-shadow: none;
+	border-radius: 4px;
+}
+
+.hosting-list__features-heading {
+	margin-bottom: 24px;
+}
+
+.hosting-list__features-list {
+	display: block;
+	column-count: 2;
+}

--- a/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .listing-section {
-	margin-block-end: 32px;
+	margin-block-end: 20px;
 	scroll-margin-block-start: 16px;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/363
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/384

## Proposed Changes

* Adds a feature list below the hosting cards.
* Uses some updated layout (stacked header) and title to prepare for the follow-up task https://github.com/Automattic/automattic-for-agencies-dev/issues/384

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/marketplace/hosting` and review the feature list displayed at the bottom of the screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="956" alt="Screenshot 2024-04-29 at 2 11 10 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/42b4ba05-54d6-48cf-8789-7849235c84ff">

