### PR TITLE
A4A: Add new sites sidebar menu item

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -1,4 +1,4 @@
-import { category, starEmpty, warning } from '@wordpress/icons';
+import { category, starEmpty, warning, tool } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
@@ -6,6 +6,7 @@ import {
 	A4A_SITES_LINK,
 	A4A_SITES_LINK_FAVORITE,
 	A4A_SITES_LINK_NEEDS_ATTENTION,
+	A4A_SITES_LINK_NEEDS_SETUP,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -39,9 +40,21 @@ const useSitesMenuItems = ( path: string ) => {
 					icon: warning,
 					path: A4A_SITES_LINK,
 					link: A4A_SITES_LINK_NEEDS_ATTENTION,
-					title: translate( 'Needs Attention' ),
+					title: translate( 'Needs attention' ),
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Sites / Needs Attention',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: tool,
+					path: A4A_SITES_LINK,
+					link: A4A_SITES_LINK_NEEDS_SETUP,
+					title: translate( 'Needs setup' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Sites / Needs Setup',
 					},
 				},
 				path

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -2,6 +2,7 @@ export const A4A_LANDING_LINK = '/landing';
 export const A4A_OVERVIEW_LINK = '/overview';
 export const A4A_SITES_LINK = '/sites';
 export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';
+export const A4A_SITES_LINK_NEEDS_SETUP = '/sites/need-setup';
 export const A4A_SITES_LINK_FAVORITE = '/sites?is_favorite';
 export const A4A_SITES_LINK_WALKTHROUGH_TOUR = `${ A4A_SITES_LINK }?tour=sites-walkthrough`;
 export const A4A_SITES_LINK_ADD_NEW_SITE_TOUR = '/sites?tour=add-new-site';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/374

## Proposed Changes

This PR adds a new menu item to the sidebar `Needs setup`. The link is currently temporary and logic will be developed in the future.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On the local branch navigate to `/sites`.
- Verify that `Needs setup button` is present

<img width="254" alt="Screenshot 2024-04-29 at 2 24 19 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/4489cd96-0804-424a-9d9f-9f7894a0cb3d">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?