### PR TITLE
A4A: Update the Marketplace > Hosting page design

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
@@ -55,6 +55,12 @@ export default function useHostingDescription( slug: string ): {
 					translate( 'Local development environment, Studio' ),
 				];
 				break;
+			case 'vip':
+				name = translate( 'VIP' );
+				description = translate(
+					'Deliver unmatched performance with the highest security standards on our enterprise content platform.'
+				);
+				features = [];
 		}
 
 		return {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -1,8 +1,22 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Badge, Button } from '@automattic/components';
+import {
+	Badge,
+	BloombergLogo,
+	Button,
+	CNNLogo,
+	CondenastLogo,
+	DisneyLogo,
+	FacebookLogo,
+	Gridicon,
+	SalesforceLogo,
+	SlackLogo,
+	TimeLogo,
+} from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { Icon, external } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -15,9 +29,10 @@ import './style.scss';
 type Props = {
 	plan: APIProductFamilyProduct;
 	pressableOwnership?: boolean;
+	className?: string;
 };
 
-export default function HostingCard( { plan, pressableOwnership }: Props ) {
+export default function HostingCard( { plan, pressableOwnership, className }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	//FIXME: We want to unify and refactor this logic, once we decide
@@ -26,67 +41,131 @@ export default function HostingCard( { plan, pressableOwnership }: Props ) {
 
 	const { name, description, features } = useHostingDescription( plan.family_slug );
 
-	const onExploreClick = () => {
+	const onExploreClick = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_marketplace_hosting_overview_explore_plan_click', {
 				hosting: plan.family_slug,
 			} )
 		);
-	};
+	}, [ dispatch, plan.family_slug ] );
+
+	const onVipDemoClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_marketplace_hosting_overview_request_vip_demo_click' ) );
+	}, [ dispatch ] );
+
+	const priceStartingAt = useMemo< string >( () => {
+		// If the amount is not a number, we assume it's a string that should be displayed as is.
+		if ( plan.amount && isNaN( Number( plan.amount ) ) ) {
+			return plan.amount;
+		}
+
+		return formatCurrency( Number( plan.amount ), plan.currency );
+	}, [ plan.amount, plan.currency ] );
+
+	const priceIntervalDescription = useMemo< string >( () => {
+		if ( plan.price_interval === 'day' ) {
+			return translate( 'USD per plan per day' );
+		}
+
+		if ( plan.price_interval === 'month' ) {
+			return translate( 'USD per plan per month' );
+		}
+
+		return translate( 'USD' );
+	}, [ plan.price_interval, translate ] );
+
+	const exploreButton = useMemo( () => {
+		if ( pressableOwnership ) {
+			return (
+				<Button
+					className="hosting-card__pressable-dashboard-button"
+					target="_blank"
+					rel="norefferer nooppener"
+					href={ pressableUrl }
+				>
+					{ translate( 'Go to Pressable Dashboard' ) }
+					<Icon icon={ external } size={ 18 } />
+				</Button>
+			);
+		}
+
+		if ( plan.family_slug === 'vip' ) {
+			return (
+				<Button
+					href={ getHostingPageUrl( plan.family_slug ) }
+					target="_blank"
+					onClick={ onVipDemoClick }
+					primary
+				>
+					<span className="hosting-card__explore-button-content">
+						{ translate( 'Request a Demo' ) }
+						<Gridicon icon="external" />
+					</span>
+				</Button>
+			);
+		}
+
+		return (
+			<Button
+				className="hosting-card__explore-button"
+				href={ getHostingPageUrl( plan.family_slug ) }
+				onClick={ onExploreClick }
+				primary
+			>
+				{ translate( 'Explore %(hosting)s plans', {
+					args: {
+						hosting: name,
+					},
+					comment: '%(hosting)s is the name of the hosting provider.',
+				} ) }
+			</Button>
+		);
+	}, [ name, onExploreClick, onVipDemoClick, plan.family_slug, pressableOwnership, translate ] );
 
 	return (
-		<div className="hosting-card">
+		<div className={ classNames( 'hosting-card', className ) }>
 			<div className="hosting-card__section">
 				<div className="hosting-card__header">
 					{ getHostingLogo( plan.family_slug ) }
 					{ pressableOwnership && <Badge type="success">{ translate( 'You own this' ) }</Badge> }
 				</div>
 
-				<p className="hosting-card__description">{ description }</p>
-
 				<div className="hosting-card__price">
 					<b className="hosting-card__price-value">
-						{ translate( 'Starting at %(price)s', {
-							args: { price: formatCurrency( Number( plan.amount ), plan.currency ) },
+						{ translate( 'Starting at %(priceStartingAt)s', {
+							args: { priceStartingAt },
 						} ) }
 					</b>
-					<div className="hosting-card__price-interval">
-						{ plan.price_interval === 'day' && translate( 'USD per plan per day' ) }
-						{ plan.price_interval === 'month' && translate( 'USD per plan per month' ) }
-					</div>
+					<div className="hosting-card__price-interval">{ priceIntervalDescription }</div>
 				</div>
 
-				{ ! pressableOwnership ? (
-					<Button
-						className="hosting-card__explore-button"
-						href={ getHostingPageUrl( plan.family_slug ) }
-						onClick={ onExploreClick }
-						primary
-					>
-						{ translate( 'Explore %(hosting)s plans', {
-							args: {
-								hosting: name,
-							},
-							comment: '%(hosting)s is the name of the hosting provider.',
-						} ) }
-					</Button>
-				) : (
-					<Button
-						className="hosting-card__pressable-dashboard-button"
-						target="_blank"
-						rel="norefferer nooppener"
-						href={ pressableUrl }
-					>
-						{ translate( 'Go to Pressable Dashboard' ) }
-						<Icon icon={ external } size={ 18 } />
-					</Button>
-				) }
+				<p className="hosting-card__description">{ description }</p>
+
+				{ exploreButton }
 			</div>
 
 			{ isEnabled( 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' ) && (
-				<div className="hosting-card__section">
-					<SimpleList items={ features } />
-				</div>
+				<>
+					{ features.length > 0 && (
+						<div className="hosting-card__section">
+							<SimpleList items={ features } />
+						</div>
+					) }
+					{ plan.family_slug === 'vip' && (
+						<div className="hosting-card__section">
+							<div className="hosting-card__logos">
+								<TimeLogo />
+								<SlackLogo />
+								<DisneyLogo />
+								<CNNLogo />
+								<SalesforceLogo />
+								<FacebookLogo />
+								<CondenastLogo />
+								<BloombergLogo />
+							</div>
+						</div>
+					) }
+				</>
 			) }
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -30,23 +30,27 @@
 }
 
 .hosting-card__price-value {
-	font-size: 1rem;
+	display: block;
+	font-size: 1.5rem;
 	font-weight: 600;
-	line-height: 1.1;
+	line-height: 1;
+	margin-bottom: 6px;
 }
 
 .hosting-card__price-interval {
-	font-size: 0.75rem;
+	font-size: 0.875rem;
 	line-height: 1.1;
 	font-weight: 400;
+	color: var(--studio-gray-60, #50575e);
 }
 
 .hosting-card__description {
 	font-size: 1rem;
 	line-height: 1.3;
 	font-weight: 400;
-	min-height: 44px;
+	min-height: 62px;
 	margin: 0;
+	color: var(--studio-gray-80, #2c3338);
 }
 
 .hosting-card__header {
@@ -54,12 +58,29 @@
 	justify-content: space-between;
 	align-items: center;
 	width: 100%;
+	font-size: 1.5rem;
+	font-weight: 600;
+	line-height: 28px;
 
 	.badge {
 		display: flex;
 		background-color: #b8e6bf;
 		color: #00450c;
 
+	}
+}
+
+.button .hosting-card__explore-button-content {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+
+	.gridicon {
+		width: 16px;
+		height: 16px;
+		top: 0;
+		margin-top: 0;
 	}
 }
 
@@ -75,4 +96,18 @@ ul.hosting-card__features {
 	list-style-type: none;
 	margin: 0;
 	padding: 0;
+}
+
+.hosting-card__logos {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 16px;
+	max-width: 300px;
+	margin: 0 auto;
+
+	svg {
+		flex-basis: 88px;
+		height: 48px;
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -50,6 +50,20 @@ export default function HostingList( { selectedSite }: Props ) {
 		[ isWPCOMOptionEnabled, wpcomPlans ]
 	);
 
+	const vipPlan = useMemo(
+		() => ( {
+			amount: '$25k',
+			currency: 'USD',
+			family_slug: 'vip',
+			name: translate( 'WordPress VIP' ),
+			slug: 'vip',
+			price_interval: '',
+			supported_bundles: [],
+			product_id: 0,
+		} ),
+		[ translate ]
+	);
+
 	const onProductSearch = useCallback(
 		( value: string ) => {
 			setProductSearchQuery( value );
@@ -86,11 +100,12 @@ export default function HostingList( { selectedSite }: Props ) {
 				{ cheapestPressablePlan && (
 					<HostingCard plan={ cheapestPressablePlan } pressableOwnership={ hasPressablePlan } />
 				) }
-			</ListingSection>
 
+				<HostingCard plan={ vipPlan } className="hosting-list__vip-card" />
+			</ListingSection>
 			<Card className="hosting-list__features">
 				<h3 className="hosting-list__features-heading">
-					{ translate( 'Pressable & WordPress.com include:' ) }
+					{ translate( 'Included with WordPress.com and Pressable plans' ) }
 				</h3>
 				<SimpleList
 					className="hosting-list__features-list"
@@ -99,14 +114,14 @@ export default function HostingList( { selectedSite }: Props ) {
 						<li>{ translate( 'Global CDN with 28+ locations' ) }</li>,
 						<li>{ translate( 'Automated datacenter failover' ) }</li>,
 						<li>{ translate( 'Free managed migrations' ) }</li>,
-						<li>{ translate( 'Jetpack Protect' ) }</li>,
+						<li>{ translate( 'Automated malware and security scanning via Jetpack' ) }</li>,
 						<li>{ translate( 'Plugin update manager' ) }</li>,
 						<li>{ translate( '24/7 expert support' ) }</li>,
 						<li>{ translate( 'Free staging sites with sync tools' ) }</li>,
 						<li>{ translate( 'SFTP/SSH, WP-CLI, Git tools' ) }</li>,
 						<li>{ translate( '10 PHP workers with auto-scaling' ) }</li>,
 						<li>{ translate( 'Resource isolation across every site' ) }</li>,
-						<li>{ translate( 'Jetpack real-time backups' ) }</li>,
+						<li>{ translate( 'Real-time cloud backups via Jetpack' ) }</li>,
 					] }
 				/>
 			</Card>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -101,30 +101,34 @@ export default function HostingList( { selectedSite }: Props ) {
 					<HostingCard plan={ cheapestPressablePlan } pressableOwnership={ hasPressablePlan } />
 				) }
 
-				<HostingCard plan={ vipPlan } className="hosting-list__vip-card" />
+				{ isWPCOMOptionEnabled && (
+					<HostingCard plan={ vipPlan } className="hosting-list__vip-card" />
+				) }
 			</ListingSection>
-			<Card className="hosting-list__features">
-				<h3 className="hosting-list__features-heading">
-					{ translate( 'Included with WordPress.com and Pressable plans' ) }
-				</h3>
-				<SimpleList
-					className="hosting-list__features-list"
-					items={ [
-						<li>{ translate( 'Global edge caching' ) }</li>,
-						<li>{ translate( 'Global CDN with 28+ locations' ) }</li>,
-						<li>{ translate( 'Automated datacenter failover' ) }</li>,
-						<li>{ translate( 'Free managed migrations' ) }</li>,
-						<li>{ translate( 'Automated malware and security scanning via Jetpack' ) }</li>,
-						<li>{ translate( 'Plugin update manager' ) }</li>,
-						<li>{ translate( '24/7 expert support' ) }</li>,
-						<li>{ translate( 'Free staging sites with sync tools' ) }</li>,
-						<li>{ translate( 'SFTP/SSH, WP-CLI, Git tools' ) }</li>,
-						<li>{ translate( '10 PHP workers with auto-scaling' ) }</li>,
-						<li>{ translate( 'Resource isolation across every site' ) }</li>,
-						<li>{ translate( 'Real-time cloud backups via Jetpack' ) }</li>,
-					] }
-				/>
-			</Card>
+			{ isWPCOMOptionEnabled && (
+				<Card className="hosting-list__features">
+					<h3 className="hosting-list__features-heading">
+						{ translate( 'Included with WordPress.com and Pressable plans' ) }
+					</h3>
+					<SimpleList
+						className="hosting-list__features-list"
+						items={ [
+							<li>{ translate( 'Global edge caching' ) }</li>,
+							<li>{ translate( 'Global CDN with 28+ locations' ) }</li>,
+							<li>{ translate( 'Automated datacenter failover' ) }</li>,
+							<li>{ translate( 'Free managed migrations' ) }</li>,
+							<li>{ translate( 'Automated malware and security scanning via Jetpack' ) }</li>,
+							<li>{ translate( 'Plugin update manager' ) }</li>,
+							<li>{ translate( '24/7 expert support' ) }</li>,
+							<li>{ translate( 'Free staging sites with sync tools' ) }</li>,
+							<li>{ translate( 'SFTP/SSH, WP-CLI, Git tools' ) }</li>,
+							<li>{ translate( '10 PHP workers with auto-scaling' ) }</li>,
+							<li>{ translate( 'Resource isolation across every site' ) }</li>,
+							<li>{ translate( 'Real-time cloud backups via Jetpack' ) }</li>,
+						] }
+					/>
+				</Card>
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
@@ -1,3 +1,10 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.hosting-list {
+	justify-content: flex-start;
+}
+
 .hosting-list__placeholder {
 	@include placeholder( --color-neutral-10 );
 	height: 43px;
@@ -15,6 +22,11 @@
 	border: 1px solid var(--color-neutral-10);
 	box-shadow: none;
 	border-radius: 4px;
+	margin: 0;
+
+	@include break-wide {
+		width: calc(66.666% - 6px);
+	}
 }
 
 .hosting-list__features-heading {
@@ -24,4 +36,14 @@
 .hosting-list__features-list {
 	display: block;
 	column-count: 2;
+}
+
+.hosting-list__vip-card {
+	background-color: var(--color-neutral-0, #f6f7f7);
+}
+
+.wordpress-vip-logo {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -1,3 +1,5 @@
+import { VIPLogo } from '@automattic/components';
+import { translate } from 'i18n-calypso';
 import {
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
@@ -32,6 +34,8 @@ export function getHostingPageUrl( slug: string ) {
 			return A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK;
 		case 'wpcom-hosting':
 			return A4A_MARKETPLACE_HOSTING_WPCOM_LINK;
+		case 'vip':
+			return 'https://wpvip.com/contact/';
 	}
 
 	return A4A_MARKETPLACE_HOSTING_LINK;
@@ -48,6 +52,13 @@ export function getHostingLogo( slug: string ) {
 			return <img src={ PressableLogo } alt="" />;
 		case 'wpcom-hosting':
 			return <img src={ WPCOMLogo } alt="" />;
+		case 'vip':
+			return (
+				<div className="wordpress-vip-logo">
+					<VIPLogo height={ 30 } width={ 67 } />
+					{ translate( '(Enterprise)' ) }
+				</div>
+			);
 	}
 
 	return null;

--- a/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
@@ -47,6 +47,6 @@ p.listing-section-description {
 
 .listing-section.is-two-columns .listing-section-content {
 	@include break-wide {
-		grid-template-columns: repeat(2, 1fr);
+		grid-template-columns: repeat(3, 1fr);
 	}
 }

--- a/packages/components/src/logos/bloomberg-logo/index.tsx
+++ b/packages/components/src/logos/bloomberg-logo/index.tsx
@@ -1,5 +1,12 @@
 const BloombergLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
-	<svg xmlns="http://www.w3.org/2000/svg" width={ 69 } height={ 27 } fill="none" { ...props }>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width={ 69 }
+		height={ 27 }
+		viewBox="0 0 69 27"
+		fill="none"
+		{ ...props }
+	>
 		<title>WordPress VIP client logo for Bloomberg</title>
 		<mask
 			id="bloomberg-logo-a"

--- a/packages/components/src/logos/cnn-logo/index.tsx
+++ b/packages/components/src/logos/cnn-logo/index.tsx
@@ -1,5 +1,12 @@
 const CNNLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
-	<svg xmlns="http://www.w3.org/2000/svg" width={ 40 } height={ 27 } fill="none" { ...props }>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width={ 40 }
+		height={ 27 }
+		fill="none"
+		viewBox="0 0 40 27"
+		{ ...props }
+	>
 		<title>WordPress VIP client logo for CNN</title>
 		<path
 			fill="#50575E"

--- a/packages/components/src/logos/condenast-logo/index.tsx
+++ b/packages/components/src/logos/condenast-logo/index.tsx
@@ -1,5 +1,12 @@
 const CondenastLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
-	<svg xmlns="http://www.w3.org/2000/svg" width={ 84 } height={ 27 } fill="none" { ...props }>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width={ 84 }
+		height={ 27 }
+		viewBox="0 0 84 27"
+		fill="none"
+		{ ...props }
+	>
 		<title>WordPress VIP client logo for Conde Nast</title>
 		<path
 			fill="#50575E"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/379

## Proposed Changes

* Adds a card for WordPress.com VIP to the Marketplace / Hosting page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/marketplace/hosting` and review the updated screen.
  * Review copy against https://github.com/Automattic/automattic-for-agencies-dev/issues/379#issuecomment-2082256553
  * Review design against 1UpoqS1KkCtLXVX68TbMSM-fi

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1221" alt="Screenshot 2024-04-29 at 6 00 21 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/930cf1d1-11d5-4bc4-a4c9-676d3c1d64b3">


