### PR TITLE
Stats: Adding Device module analytics events

### DIFF
--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -40,7 +40,7 @@ export const STAT_TYPE_VISITS = 'statsVisits';
 export const STAT_TYPE_TAGS_LIST = 'tagsList';
 export const STAT_TYPE_USERS_LIST = 'usersList';
 export const STAT_TYPE_WPCOM_PLUGINS_LIST = 'wpcomPluginsList';
-export const STATS_TYPE_DEVICE_STATS = 'statsDeviceStats';
+export const STATS_TYPE_DEVICE_STATS = 'stats_devices_module';
 
 // stats feature are for more granular control, string value is based on component name
 export const STATS_FEATURE_DATE_CONTROL = 'StatsDateControl';
@@ -63,8 +63,6 @@ export const STATS_FEATURE_SUMMARY_LINKS_YEAR = 'StatsModuleSummaryLinks/year';
 export const STATS_FEATURE_SUMMARY_LINKS_ALL = 'StatsModuleSummaryLinks/all';
 // UTM Stats which is already in use, so didn't align with the naming convertion.
 export const STATS_FEATURE_UTM_STATS = 'stats_utm';
-
-export const STATS_FEATURES_DEVICES_EVENT_NAME = 'stats_devices_module';
 
 // other
 export const STATS_DO_YOU_LOVE_JETPACK_STATS_NOTICE = 'DoYouLoveJetpackStatsNotice';

--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -64,5 +64,7 @@ export const STATS_FEATURE_SUMMARY_LINKS_ALL = 'StatsModuleSummaryLinks/all';
 // UTM Stats which is already in use, so didn't align with the naming convertion.
 export const STATS_FEATURE_UTM_STATS = 'stats_utm';
 
+export const STATS_FEATURES_DEVICES_EVENT_NAME = 'stats_devices_module';
+
 // other
 export const STATS_DO_YOU_LOVE_JETPACK_STATS_NOTICE = 'DoYouLoveJetpackStatsNotice';

--- a/client/my-sites/stats/stats-module-devices/index.tsx
+++ b/client/my-sites/stats/stats-module-devices/index.tsx
@@ -23,7 +23,6 @@ const StatsModuleDevicesWrapper: React.FC< StatsModuleDevicesWrapperProps > = ( 
 	period,
 	postId,
 	query,
-	// summary,
 	className,
 } ) => {
 	const { devices: devicesStrings } = statsStrings();

--- a/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-devices.tsx
@@ -1,3 +1,5 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -12,8 +14,6 @@ import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import statsStrings from '../stats-strings';
 
-// import '../stats-module/style.scss';
-// import '../stats-list/style.scss';
 import './stats-module-devices.scss';
 
 const OPTION_KEYS = {
@@ -88,39 +88,44 @@ const prepareChartData = (
 const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 	path,
 	className,
-	// period, // we will need period once the API endpoint is done
 	isLoading,
 	query,
 } ) => {
 	const { devices: devicesStrings } = statsStrings();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const translate = useTranslate();
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	const optionLabels = {
 		[ OPTION_KEYS.SIZE ]: {
 			selectLabel: translate( 'Size' ),
 			headerLabel: translate( 'Visitors share per screen size' ),
+			analyticsId: 'screensize',
 		},
 		[ OPTION_KEYS.BROWSER ]: {
 			selectLabel: translate( 'Browser' ),
 			headerLabel: translate( 'Browser' ),
+			analyticsId: 'browser',
 		},
 		[ OPTION_KEYS.OS ]: {
 			selectLabel: translate( 'OS' ),
 			headerLabel: translate( 'Operating System' ),
+			analyticsId: 'os',
 		},
 	};
 
 	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SIZE );
-
 	const { isFetching, data } = useModuleDevicesQuery( siteId, selectedOption, query );
-
 	const showLoader = isLoading || isFetching;
 
 	const changeViewButton = ( selection: SelectOptionType ) => {
 		const filter = selection.value;
 
-		// TODO: add analytics events
+		// publish an event
+		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+		recordTracksEvent( `${ event_from }_devices_module_menu_clicked`, {
+			button: optionLabels[ filter ]?.analyticsId ?? filter,
+		} );
 
 		setSelectedOption( filter );
 	};

--- a/client/my-sites/stats/stats-module-devices/stats-module-upgrade-overlay.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-upgrade-overlay.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
-import { STATS_FEATURES_DEVICES_EVENT_NAME } from '../constants';
+import { STATS_TYPE_DEVICE_STATS } from '../constants';
 import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
 import StatsListCard from '../stats-list/stats-list-card';
 
@@ -64,7 +64,7 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 				<StatsCardUpsellJetpack
 					className="stats-module__upsell"
 					siteId={ siteId }
-					statType={ STATS_FEATURES_DEVICES_EVENT_NAME }
+					statType={ STATS_TYPE_DEVICE_STATS }
 				/>
 			}
 		/>

--- a/client/my-sites/stats/stats-module-devices/stats-module-upgrade-overlay.tsx
+++ b/client/my-sites/stats/stats-module-devices/stats-module-upgrade-overlay.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
-import { STATS_TYPE_DEVICE_STATS } from '../constants';
+import { STATS_FEATURES_DEVICES_EVENT_NAME } from '../constants';
 import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
 import StatsListCard from '../stats-list/stats-list-card';
 
@@ -64,10 +64,10 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 				<StatsCardUpsellJetpack
 					className="stats-module__upsell"
 					siteId={ siteId }
-					statType={ STATS_TYPE_DEVICE_STATS }
+					statType={ STATS_FEATURES_DEVICES_EVENT_NAME }
 				/>
 			}
-		></StatsListCard>
+		/>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89307

## Proposed Changes

* adding analytics events for the Device module menu

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch and apply `stats/devices` feature flag
* click on different Device module menu and check if an analytics event is triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?