### PR TITLE
A4A: New Signup Flow - Add tracks event to redirects

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-form/hooks/use-handle-wpcom-redirect.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/hooks/use-handle-wpcom-redirect.tsx
@@ -3,6 +3,7 @@ import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useCallback } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { AgencyDetailsPayload } from '../../agency-details-form/types';
 
@@ -29,6 +30,7 @@ export function useHandleWPCOMRedirect() {
 				} ).toString();
 
 				let wpcomRedirectUrl = undefined;
+				let tracksEventName = undefined;
 
 				if ( isNewUser ) {
 					wpcomRedirectUrl = new URL(
@@ -40,6 +42,7 @@ export function useHandleWPCOMRedirect() {
 						oauth2_redirect: authUrl.toString(),
 						email_address: payload.email ?? '',
 					} ).toString();
+					tracksEventName = 'calypso_a4a_create_agency_redirect_to_wpcom_signup';
 				} else {
 					wpcomRedirectUrl = new URL( localizeUrl( config( 'wpcom_login_url' ), userLocale ) );
 					wpcomRedirectUrl.search = new URLSearchParams( {
@@ -47,7 +50,28 @@ export function useHandleWPCOMRedirect() {
 						redirect_to: authUrl.toString(),
 						email_address: payload.email ?? '',
 					} ).toString();
+					tracksEventName = 'calypso_a4a_create_agency_redirect_to_wpcom_login';
 				}
+
+				dispatch(
+					recordTracksEvent( tracksEventName, {
+						email: payload.email,
+						first_name: payload.firstName,
+						last_name: payload.lastName,
+						name: payload.agencyName,
+						business_url: payload.agencyUrl,
+						managed_sites: payload.managedSites,
+						services_offered: ( payload.servicesOffered || [] ).join( ',' ),
+						products_offered: ( payload.productsOffered || [] ).join( ',' ),
+						city: payload.city,
+						line1: payload.line1,
+						line2: payload.line2,
+						country: payload.country,
+						postal_code: payload.postalCode,
+						state: payload.state,
+						referer: payload.referer,
+					} )
+				);
 
 				window.location.href = wpcomRedirectUrl.toString();
 			} catch ( error ) {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/358

## Proposed Changes

* This PR adds tracks events to our redirects.

## Testing Instructions

* Run `yarn start-a8c-for-agencies`
* Complete a signup flow and a login flow in our new signup flow for logged out users.
  * Existing WPCOM email flow:
    * Make sure you are logged out of WPCOM (using a private browser window helps here)
    * Go to the signup page (http://agencies.localhost:3000/signup)
    * Fill in the form using an existing WPCOM email
      * Verify that you are redirected to the WPCOM login page
      * Log in and authorize A4A
      * Verify that after authorization you are redirected to /signup/resume and your form is displayed as a JSON string on   * the page
  * Non-existing WPCOM email flow:
    * Fill in the form using a non-existing WPCOM email
      * Verify that you are redirected to the WPCOM signup page
      * Create a new account and authorize A4A
      * Verify that after authorization you are redirected to /signup/resume and your form is displayed as a JSON string on the page

For the existing flow, verify that we have the tracks events `calypso_a4a_create_agency_redirect_to_wpcom_login` and `calypso_a4a_create_agency_finish_submit`.
![image](https://github.com/Automattic/wp-calypso/assets/37049295/cac1ed6b-030f-452b-aade-43b4b93d6c81)

![image](https://github.com/Automattic/wp-calypso/assets/37049295/84dce994-085a-40b5-8c42-d96bf11f91c4)


For the non-existing flow, verify that we have the tracks events `calypso_a4a_create_agency_redirect_to_wpcom_signup` and `calypso_a4a_create_agency_finish_submit`.
![image](https://github.com/Automattic/wp-calypso/assets/37049295/4a206a5f-2d6a-45a7-b021-045187fc1613)

![image](https://github.com/Automattic/wp-calypso/assets/37049295/deabb7d3-31c8-4e06-9ef2-22a33ba500cc)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?