### PR TITLE
Odyssey Stats: Fill up purchases with site products

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -9,6 +9,8 @@ import { getSiteProducts } from 'calypso/state/sites/selectors';
 
 export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number | null } ) {
 	const reduxDispatch = useDispatch();
+	// Site products are in the site object loaded before anything is rendered.
+	// The selector returns a new object everytime, so we can depend on it in useEffect.
 	const purchasedProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
 
 	useEffect( () => {

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -10,7 +10,7 @@ import { getSiteProducts } from 'calypso/state/sites/selectors';
 export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number | null } ) {
 	const reduxDispatch = useDispatch();
 	// Site products are in the site object loaded before anything is rendered.
-	// The selector returns a new object everytime, so we can depend on it in useEffect.
+	// The selector returns a new object everytime, so we can not depend on it in useEffect.
 	const purchasedProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
 
 	useEffect( () => {

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -1,97 +1,34 @@
 /**
  * This is a Odyssey implementation of 'calypso/components/data/query-site-purchases'.
  */
-import { APIError } from '@automattic/data-stores';
-import { useQuery } from '@tanstack/react-query';
-import { isError } from 'lodash';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import wpcom from 'calypso/lib/wp';
-import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
-import {
-	PURCHASES_SITE_FETCH,
-	PURCHASES_SITE_FETCH_COMPLETED,
-	PURCHASES_SITE_FETCH_FAILED,
-} from 'calypso/state/action-types';
-import { getApiNamespace, getApiPath } from '../lib/get-api';
-
-async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
-	if ( ! siteId ) {
-		return;
-	}
-
-	return wpcom.req
-		.get( {
-			path: getApiPath( '/site/purchases', { siteId } ),
-			apiNamespace: getApiNamespace(),
-		} )
-		.then( ( res: { data: string } ) => JSON.parse( res.data ) )
-		.catch( ( error: APIError ) => error );
-}
-/**
- * Update site products in the Redux store by fetching purchases via API for Odyssey Stats.
- */
-
-const useOdysseyQuerySitePurchases = ( siteId: number | null ) => {
-	return useQuery( {
-		...getDefaultQueryParams(),
-		queryKey: [ 'odyssey-stats', 'site-purchases', siteId ],
-		queryFn: () => queryOdysseyQuerySitePurchases( siteId ),
-		staleTime: 10 * 1000,
-		// If the module is not active, we don't want to retry the query.
-		retry: false,
-	} );
-};
+import { useSelector } from 'calypso/state';
+import { PURCHASES_SITE_FETCH_COMPLETED } from 'calypso/state/action-types';
+import { getSiteProducts } from 'calypso/state/sites/selectors';
 
 export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number | null } ) {
-	const {
-		data: purchases,
-		isFetching,
-		isError: hasOtherErrors,
-	} = useOdysseyQuerySitePurchases( siteId );
 	const reduxDispatch = useDispatch();
+	const purchasedProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
 
 	useEffect( () => {
-		// Dispatch evet marking as requesting
 		reduxDispatch( {
-			type: PURCHASES_SITE_FETCH,
+			type: PURCHASES_SITE_FETCH_COMPLETED,
 			siteId,
+			purchases:
+				purchasedProducts?.map( ( product, index ) => ( {
+					ID: index,
+					product_id: product.productId,
+					product_slug: product.productSlug,
+					product_name: product.productName,
+					expired: product.expired,
+					expiry_status: product.expired ? 'expired' : 'active',
+					active: ! product.expired,
+					blog_id: siteId,
+					product_type: 'jetpack',
+				} ) ) ?? [],
 		} );
-
-		if ( isFetching ) {
-			return;
-		}
-
-		if ( isError( purchases ) || hasOtherErrors ) {
-			if ( ( purchases as APIError ).status !== 403 ) {
-				// Dispatch to the Purchases reducer for error status
-				reduxDispatch( {
-					type: PURCHASES_SITE_FETCH_FAILED,
-					error: 'purchase_fetch_failed',
-				} );
-			} else {
-				// TODO: Remove this after fixing the API permission issue from Jetpack.
-				reduxDispatch( {
-					type: PURCHASES_SITE_FETCH_COMPLETED,
-					siteId,
-					purchases: [
-						{
-							expiry_status: 'active',
-							product_slug: 'jetpack_stats_pwyw_yearly',
-							blog_id: siteId,
-						},
-					],
-				} );
-			}
-		} else {
-			// Dispatch to the Purchases reducer for consistent requesting status
-			reduxDispatch( {
-				type: PURCHASES_SITE_FETCH_COMPLETED,
-				siteId,
-				purchases: purchases,
-			} );
-		}
-	}, [ purchases, isFetching, reduxDispatch, hasOtherErrors, siteId ] );
+	}, [ reduxDispatch, siteId ] );
 
 	return null;
 }


### PR DESCRIPTION
Related to #89464

## Proposed Changes

This is a follow-up PR for #89464. The PR utilize site products within the site endpoint for Odyssey Stats to stops depending on `jetpack/v4/purchases` which is only available for admin users.

The reason we are not using site products for all sites is that only Jetpack sites have the property at the moment.

## Testing Instructions

* Open `/wp-admin/admin.php?page=stats#!/stats/day/:site` for a non-admin user
* Ensure when the site has free/pwyw, user sees UTM upsell
* Ensure when the site has commercial, user could use all the stats
* Enuser user sees upgrade banners when no subscription and not dismissed before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?