### PR TITLE
nav redesign: tidy up border radius on new sites page

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -400,7 +400,7 @@ $font-size: rem(14px);
 		.sidebar__menu.is-togglable .sidebar__heading {
 			padding: 12px 10px;
 			margin: 0 12px;
-			border-radius: 2px;
+			border-radius: 4px;
 		}
 
 		.sidebar__expandable-content .sidebar__menu-link {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -82,7 +82,7 @@
 		align-items: center;
 		// Places search above filters
 		z-index: 1;
-		border-radius: 2px;
+		border-radius: 4px;
 		border: 1px solid var(--studio-gray-10);
 		background-color: var(--color-surface, $white);
 


### PR DESCRIPTION
Just bump up the border radius to 4px to match the other controls on the v2 sites page

<img width="1481" alt="Screenshot 2024-04-30 at 1 37 53 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/3d7ce698-7f86-4af4-ac55-39359f0ddd3a">
Note that when the panel is open we still have 2px for some controls, I'm trying to work out if we want to change the other controls across all of calypso or just on this page


### Testing instructions


go to `/sites?flags=+layout/dotcom-nav-redesign-v2`
Border radiuses on controls on the page should all be 4px.
