### PR TITLE
Automattic for Agencies: Implement Needs Setup section in the Sites sidebar

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -2,6 +2,7 @@ export const A4A_LANDING_LINK = '/landing';
 export const A4A_OVERVIEW_LINK = '/overview';
 export const A4A_SITES_LINK = '/sites';
 export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';
+export const A4A_SITES_LINK_NEEDS_SETUP = '/sites/need-setup';
 export const A4A_SITES_LINK_FAVORITE = '/sites?is_favorite';
 export const A4A_SITES_LINK_WALKTHROUGH_TOUR = `${ A4A_SITES_LINK }?tour=sites-walkthrough`;
 export const A4A_SITES_LINK_ADD_NEW_SITE_TOUR = '/sites?tour=add-new-site';

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -58,3 +58,9 @@ export const sitesContext: Callback = ( context: Context, next ) => {
 	configureSitesContext( context );
 	next();
 };
+
+export const needsSetupContext: Callback = ( context: Context, next ) => {
+	context.primary = <div>Needs Setup</div>; // TODO: Implement Needs Setup
+	context.secondary = <SitesSidebar path={ context.path } />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/index.tsx
@@ -1,10 +1,20 @@
 import page from '@automattic/calypso-router';
+import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { sitesContext } from './controller';
+import { sitesContext, needsSetupContext } from './controller';
 import { FeatureRoutes as loadFeatureRoutes } from './features/routes';
 
 export default function () {
+	// Always keep this route at the top since it's the most specific /sites route
+	page(
+		A4A_SITES_LINK_NEEDS_SETUP,
+		requireAccessContext,
+		needsSetupContext,
+		makeLayout,
+		clientRender
+	);
+
 	// Load specific feature route contexts
 	loadFeatureRoutes( '/sites/:category/:siteUrl' );
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -737,7 +737,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-sites',
-		paths: [ '/sites', 'sites/favorite' ],
+		paths: [ '/sites', 'sites/need-setup' ],
 		module: 'calypso/a8c-for-agencies/sections/sites',
 		group: 'a8c-for-agencies',
 	},


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/373

## Proposed Changes

This PR implements the Needs Setup section in the Sites sidebar

NOTE: The background color of the Needs Setup page will be fixed in another PR.

## Testing Instructions

1) Open the A4A live link.
2) Visit  /sites/needs-setup, and you can see the below page

<img width="1138" alt="Screenshot 2024-04-30 at 10 47 01 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1fffb4b8-a4bc-45cc-92d2-35dcbb42fa0b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?