### PR TITLE
A4A: Implement the WPCOM creator plan purchase flow.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -1,5 +1,6 @@
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import { useTranslate } from 'i18n-calypso';
+import wpcomIcon from 'calypso/assets/images/icons/wordpress-logo.svg';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import { useLicenseLightboxData } from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/hooks/use-license-lightbox-data';
 import getProductIcon from 'calypso/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon';
@@ -36,6 +37,22 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 				count: presablePlan.install,
 				comment:
 					'The `install`, `visits` & `storage` are the count of WordPress installs, visits per month, and storage per month in the plan description.',
+			}
+		);
+	}
+
+	if ( product.family_slug === 'wpcom-hosting' ) {
+		productIcon = wpcomIcon;
+		productTitle = product.name;
+		productDescription = translate(
+			'Plan with %(install)d managed WordPress install, with 50GB of storage each.',
+			'Plan with %(install)d managed WordPress installs, with 50GB of storage each.',
+			{
+				args: {
+					install: product.quantity,
+				},
+				count: product.quantity,
+				comment: 'The `install` are the count of WordPress installs.',
 			}
 		);
 	}

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -41,7 +41,8 @@ export default function useShoppingCart() {
 					return (
 						product.slug === slug &&
 						( quantity === 1 ||
-							product.supported_bundles.map( ( bundle ) => bundle.quantity ).includes( quantity ) )
+							product.supported_bundles.map( ( bundle ) => bundle.quantity ).includes( quantity ) ||
+							product.family_slug === 'wpcom-hosting' )
 					);
 				} );
 

--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -22,6 +22,17 @@ export function getCheapestPlan( plans: APIProductFamilyProduct[] ) {
 }
 
 /**
+ * Get the WPCOM Creator plan from a list of plans
+ * @param {APIProductFamilyProduct[]} plans - List of plans
+ * @returns {APIProductFamilyProduct} - WPCOM Creator plan
+ */
+export function getWPCOMCreatorPlan( plans: APIProductFamilyProduct[] ) {
+	return plans.find( ( plan: APIProductFamilyProduct ) => {
+		return plan.slug === 'wpcom-hosting-business';
+	} );
+}
+
+/**
  * Get the URL for a hosting provider
  * @param {string} slug - Hosting provider slug
  * @returns {string} - Hosting provider URL

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -31,7 +31,7 @@ import HostingOverview from '../common/hosting-overview';
 import HostingOverviewFeatures from '../common/hosting-overview-features';
 import useProductAndPlans from '../hooks/use-product-and-plans';
 import useShoppingCart from '../hooks/use-shopping-cart';
-import { getCheapestPlan } from '../lib/hosting';
+import { getWPCOMCreatorPlan } from '../lib/hosting';
 import ShoppingCart from '../shopping-cart';
 import WPCOMBulkSelector from './bulk-selection';
 import wpcomBulkOptions from './lib/wpcom-bulk-options';
@@ -55,7 +55,8 @@ export default function WpcomOverview() {
 
 	const { wpcomPlans } = useProductAndPlans( {} );
 
-	const cheapestWPCOMPlan = getCheapestPlan( wpcomPlans );
+	const creatorPlan = getWPCOMCreatorPlan( wpcomPlans );
+
 	const onclickMoreInfo = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_wpcom_view_all_features_click' )
@@ -113,11 +114,13 @@ export default function WpcomOverview() {
 				/>
 				<WPCOMBulkSelector selectedCount={ selectedCount } onSelectCount={ onSelectCount } />
 
-				<WPCOMPlanCard
-					plan={ cheapestWPCOMPlan }
-					quantity={ selectedCount.value }
-					discount={ selectedCount.discount }
-				/>
+				{ creatorPlan && (
+					<WPCOMPlanCard
+						plan={ creatorPlan }
+						quantity={ selectedCount.value }
+						discount={ selectedCount.discount }
+					/>
+				) }
 
 				<HostingOverview
 					title={ translate( 'Powerful development & platform tools' ) }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -24,15 +24,17 @@ import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingOverview from '../common/hosting-overview';
 import HostingOverviewFeatures from '../common/hosting-overview-features';
 import useProductAndPlans from '../hooks/use-product-and-plans';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { getWPCOMCreatorPlan } from '../lib/hosting';
-import ShoppingCart from '../shopping-cart';
+import ShoppingCart, { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
 import WPCOMBulkSelector from './bulk-selection';
 import wpcomBulkOptions from './lib/wpcom-bulk-options';
 import WPCOMPlanCard from './wpcom-card';
@@ -43,7 +45,7 @@ export default function WpcomOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { selectedCartItems, onRemoveCartItem } = useShoppingCart();
+	const { selectedCartItems, onRemoveCartItem, setSelectedCartItems } = useShoppingCart();
 
 	const [ selectedCount, setSelectedCount ] = useState( wpcomBulkOptions[ 0 ] );
 
@@ -62,6 +64,21 @@ export default function WpcomOverview() {
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_wpcom_view_all_features_click' )
 		);
 	}, [ dispatch ] );
+
+	const onAddToCart = useCallback(
+		( plan: APIProductFamilyProduct, quantity: number ) => {
+			if ( plan ) {
+				// We will need to remove first any existing Pressable plan in the cart as we do not allow multiple Pressable plans to be purchase.
+				const items = selectedCartItems?.filter(
+					( cartItem ) => cartItem.family_slug !== 'wpcom-hosting'
+				);
+
+				setSelectedCartItems( [ ...items, { ...plan, quantity } ] );
+				page( A4A_MARKETPLACE_PRODUCTS_LINK + CART_URL_HASH_FRAGMENT );
+			}
+		},
+		[ selectedCartItems, setSelectedCartItems ]
+	);
 
 	const WPCOM_PRICING_PAGE_LINK = 'https://wordpress.com/pricing/';
 
@@ -119,6 +136,7 @@ export default function WpcomOverview() {
 						plan={ creatorPlan }
 						quantity={ selectedCount.value }
 						discount={ selectedCount.discount }
+						onSelect={ onAddToCart }
 					/>
 				) }
 

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -11,9 +11,10 @@ type Props = {
 	plan: APIProductFamilyProduct;
 	quantity: number;
 	discount: number;
+	onSelect: ( plan: APIProductFamilyProduct, quantity: number ) => void;
 };
 
-export default function WPCOMPlanCard( { plan, quantity, discount }: Props ) {
+export default function WPCOMPlanCard( { plan, quantity, discount, onSelect }: Props ) {
 	const translate = useTranslate();
 
 	const originalPrice = Number( plan.amount ) * quantity;
@@ -54,7 +55,7 @@ export default function WPCOMPlanCard( { plan, quantity, discount }: Props ) {
 					</div>
 				</div>
 
-				<Button primary>
+				<Button primary onClick={ () => onSelect( plan, quantity ) }>
 					{ quantity > 1
 						? translate( 'Add %(quantity)s %(planName)s sites to cart', {
 								args: {


### PR DESCRIPTION
This PR implements the checkout handler so we can purchase a WPCOM plan from the marketplace.

<img width="1606" alt="Screenshot 2024-04-30 at 2 31 00 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7299cb25-761c-4151-975b-4f0108292e9f">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/372

## Proposed Changes

* Implement an **add-to-cart** handler in the WPCOM hosting page.
* Implement WPCOM plan item render logic on the Checkout page.
* Fix the issue with ShoppingCart not being able to support the WPCOM plan with a quantity of more than 1.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/hosting/wpcom`.
* Select any volume and click the **'Add to cart'** CTA button.
  <img width="477" alt="Screenshot 2024-04-30 at 2 30 24 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d14c659b-a4c2-4d28-9f9f-5159e6789db5">

* Then select the **checkout** button when the cart is displayed.
  <img width="531" alt="Screenshot 2024-04-30 at 2 30 12 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7ee34de0-47e6-4bc1-8342-208b2e47f9ae">

* On the checkout page, confirm you can see the WPCOM plan in the item list.
* Proceed to purchase and confirm the UI submit the cart. (**Note that the WPCOM plan bulk purchase doesn't work at the moment, as mentioned in Slack**: p1714457648795839/1714417851.445469-slack-C06JY8QL0TU )
## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?