### PR TITLE
Global Sidebar: Update search icon tooltip text

### DIFF
--- a/client/layout/global-sidebar/header.tsx
+++ b/client/layout/global-sidebar/header.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -8,8 +9,14 @@ import SidebarNotifications from './menu-items/notifications';
 import { SidebarSearch } from './menu-items/search';
 
 export const GlobalSidebarHeader = () => {
+	const hasEnTranslation = useHasEnTranslation();
 	const translate = useTranslate();
+
+	const isMac = window?.navigator.userAgent && window.navigator.userAgent.indexOf( 'Mac' ) > -1;
+	const searchShortcut = isMac ? '⌘ + K' : 'Ctrl + K';
+
 	const sectionName = useSelector( getSectionName );
+
 	return (
 		<div className="sidebar__header">
 			<SkipNavigation
@@ -30,7 +37,11 @@ export const GlobalSidebarHeader = () => {
 			) }
 			<span className="gap"></span>
 			<SidebarSearch
-				tooltip={ translate( 'Jump to…' ) }
+				tooltip={
+					hasEnTranslation( 'Search (%(shortcut)s)' )
+						? translate( 'Search (%(shortcut)s)', { args: { shortcut: searchShortcut } } )
+						: translate( 'Jump to…' )
+				}
 				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.SEARCH_CLICK ) }
 			/>
 			<SidebarNotifications


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6823

## Proposed Changes

This PR updates the tooltip text from "Jump to..." to "Search (shortcut)" as proposed in https://github.com/Automattic/dotcom-forge/issues/6823.

| Before | After | 
| --- | --- |
| ![Screenshot 2024-04-30 at 3 32 32 PM](https://github.com/Automattic/wp-calypso/assets/797888/27b11c6f-57d0-4787-a538-b9b18908a471) | ![Screenshot 2024-04-30 at 3 32 22 PM](https://github.com/Automattic/wp-calypso/assets/797888/d66cdf3b-1c5a-41c7-9fc1-7754bfaf6d1f)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the search icon tooltip is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?