### PR TITLE
Global Sidebar: Keep the Sites icon selected when GSV opens

### DIFF
--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -32,7 +32,10 @@ export const MySitesSidebarUnifiedBody = ( { path, children, onMenuItemClick } )
 		<>
 			{ menuItems &&
 				menuItems.map( ( item, i ) => {
-					const isSelected = item?.url && itemLinkMatches( item.url, path );
+					const isSelected =
+						( item?.url && itemLinkMatches( item.url, path ) ) ||
+						// Keep the Sites icon selected when there is a selected site.
+						( item.slug === 'sites' && site );
 
 					if ( 'current-site' === item?.type ) {
 						return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6832

## Proposed Changes

* Keep the Sites icon selected when there is a selected site

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/fc2dea61-6e3e-4c98-b26c-d2e9f77dab5a) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/c67efd79-957b-48bf-8f7b-4ec1bf36dad9) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site
* Make sure the Sites icon keeps selected on the collapsed sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?