### PR TITLE
Automattic for Agencies: Implement API for WPCOM hosting discount

### DIFF
--- a/client/a8c-for-agencies/data/marketplace/use-products-query.ts
+++ b/client/a8c-for-agencies/data/marketplace/use-products-query.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import getProductsRaw from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-products-raw';
 import selectAlphabeticallySortedProductOptions from 'calypso/jetpack-cloud/sections/partner-portal/lib/select-alphabetically-sorted-product-options';
 import wpcom from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -64,7 +65,8 @@ export function usePublicProductsQuery(): UseQueryResult< APIProductFamilyProduc
 }
 
 export default function useProductsQuery(
-	isPublicFacing = false
+	isPublicFacing = false,
+	includeRawData = false
 ): UseQueryResult< APIProductFamilyProduct[], unknown > {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -73,7 +75,7 @@ export default function useProductsQuery(
 	const query = useQuery( {
 		queryKey: [ 'a4a', 'marketplace', 'products', isPublicFacing, agencyId ],
 		queryFn: () => queryProducts( isPublicFacing, agencyId ),
-		select: selectAlphabeticallySortedProductOptions,
+		select: includeRawData ? getProductsRaw : selectAlphabeticallySortedProductOptions,
 		enabled: isPublicFacing || !! agencyId,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -26,6 +26,7 @@ import {
 	A4A_MARKETPLACE_LINK,
 	A4A_MARKETPLACE_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { Option } from 'calypso/a8c-for-agencies/components/slider';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -41,18 +42,22 @@ import WPCOMPlanCard from './wpcom-card';
 
 import './style.scss';
 
+type TierProps = Option & {
+	discount: number;
+};
+
 export default function WpcomOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const { selectedCartItems, onRemoveCartItem, setSelectedCartItems } = useShoppingCart();
 
-	const [ selectedCount, setSelectedCount ] = useState( wpcomBulkOptions[ 0 ] );
+	const options = wpcomBulkOptions( [] );
 
-	const onSelectCount = ( count: number ) => {
-		setSelectedCount(
-			wpcomBulkOptions.find( ( option ) => option.value === count ) ?? wpcomBulkOptions[ 0 ]
-		);
+	const [ selectedTier, setSelectedTier ] = useState< TierProps >( options[ 0 ] );
+
+	const onSelectTier = ( tier: TierProps ) => {
+		setSelectedTier( tier );
 	};
 
 	const { wpcomPlans } = useProductAndPlans( {} );
@@ -129,13 +134,13 @@ export default function WpcomOverview() {
 						'When you build and host your sites with WordPress.com, everything’s integrated, secure, and scalable.'
 					) }
 				/>
-				<WPCOMBulkSelector selectedCount={ selectedCount } onSelectCount={ onSelectCount } />
+				<WPCOMBulkSelector selectedTier={ selectedTier } onSelectTier={ onSelectTier } />
 
 				{ creatorPlan && (
 					<WPCOMPlanCard
 						plan={ creatorPlan }
-						quantity={ selectedCount.value }
-						discount={ selectedCount.discount }
+						quantity={ selectedTier.value as number }
+						discount={selectedTier.discount }
 						onSelect={ onAddToCart }
 					/>
 				) }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -140,7 +140,7 @@ export default function WpcomOverview() {
 					<WPCOMPlanCard
 						plan={ creatorPlan }
 						quantity={ selectedTier.value as number }
-						discount={selectedTier.discount }
+						discount={ selectedTier.discount }
 						onSelect={ onAddToCart }
 					/>
 				) }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -1,7 +1,7 @@
 const wpcomBulkOptions = (
 	discountOptions?: {
 		quantity: number;
-		discount_percent: number;
+		discount: number;
 	}[]
 ) => {
 	if ( ! discountOptions || discountOptions.length === 0 ) {
@@ -16,8 +16,8 @@ const wpcomBulkOptions = (
 	return discountOptions.map( ( option ) => ( {
 		value: option.quantity || 1,
 		label: option.quantity ? `${ option.quantity }` : '1',
-		sub: option.discount_percent ? `${ option.discount_percent }%` : '',
-		discount: option.discount_percent ? option.discount_percent / 100 : 0,
+		sub: option.discount ? `${ option.discount * 100 }%` : '',
+		discount: option.discount ? option.discount : 0,
 	} ) );
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -1,46 +1,24 @@
-// FIXME we should fetch the discount bracket from a proper source when ready.
-const wpcomBulkOptions = [
-	{
-		value: 1,
-		label: '1',
-		discount: 0,
-	},
-	{
-		value: 3,
-		label: '3',
-		sub: '4%',
-		discount: 0.04,
-	},
-	{
-		value: 5,
-		label: '5',
-		sub: '8%',
-		discount: 0.08,
-	},
-	{
-		value: 10,
-		label: '10',
-		sub: '20%',
-		discount: 0.2,
-	},
-	{
-		value: 20,
-		label: '20',
-		sub: '40%',
-		discount: 0.4,
-	},
-	{
-		value: 50,
-		label: '50',
-		sub: '70%',
-		discount: 0.7,
-	},
-	{
-		value: 100,
-		label: '100',
-		sub: '80%',
-		discount: 0.8,
-	},
-];
+const wpcomBulkOptions = (
+	discountOptions?: {
+		quantity: number;
+		discount_percent: number;
+	}[]
+) => {
+	if ( ! discountOptions || discountOptions.length === 0 ) {
+		return [
+			{
+				value: 1,
+				label: '1',
+				discount: 0,
+			},
+		];
+	}
+	return discountOptions.map( ( option ) => ( {
+		value: option.quantity || 1,
+		label: option.quantity ? `${ option.quantity }` : '1',
+		sub: option.discount_percent ? `${ option.discount_percent }%` : '',
+		discount: option.discount_percent ? option.discount_percent / 100 : 0,
+	} ) );
+};
 
 export default wpcomBulkOptions;

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-products-raw.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-products-raw.ts
@@ -1,0 +1,5 @@
+import { APIProductFamily } from 'calypso/state/partner-portal/types';
+
+export default function getProductsRaw( products: APIProductFamily[] ) {
+	return products as any;
+}

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -115,6 +115,12 @@ export interface APIProductFamily {
 	name: string;
 	slug: string;
 	products: APIProductFamilyProduct[];
+	discounts?: {
+		tiers: {
+			quantity: number;
+			discount_percent: number;
+		}[];
+	};
 }
 
 export interface APIError {

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -118,7 +118,7 @@ export interface APIProductFamily {
 	discounts?: {
 		tiers: {
 			quantity: number;
-			discount_percent: number;
+			discount: number;
 		}[];
 	};
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/388

## Proposed Changes

This PR implements an API endpoint for WPCOM hosting discount

## Testing Instructions

1) Open the A4A live link.
2) Apply D146966-code
3) Visit /marketplace/hosting/wpcom > Verify that the slider on this page looks like below:

<img width="906" alt="Screenshot 2024-04-30 at 2 17 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e77ed94c-ebe3-425d-8b01-385d93fe1430">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?