### PR TITLE
Stats: Gate the Devices module on Odyssey Stats with API proxy version

### DIFF
--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -51,7 +51,10 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			// UTM stats are only available for Jetpack sites for now.
 			isSiteJetpackNotAtomic &&
 			version_greater_than_or_equal( statsAdminVersion, '0.17.0-alpha', isOdysseyStats ),
-		supportsDevicesStats: config.isEnabled( 'stats/devices' ) && isSiteJetpackNotAtomic,
+		supportsDevicesStats:
+			config.isEnabled( 'stats/devices' ) &&
+			isSiteJetpackNotAtomic &&
+			version_greater_than_or_equal( statsAdminVersion, '0.19.0-alpha', isOdysseyStats ),
 		supportsOnDemandCommercialClassification: version_greater_than_or_equal(
 			statsAdminVersion,
 			'0.18.0-alpha',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Gate the Devices module on Odyssey Stats with API proxy of Jetpack version `0.19.0-alpha`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Jetpack with the latest trunk.
* Spin this change up on Odyssey Stats: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/path-to-jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to `/wp-admin/admin.php?page=stats#!/stats/day/:site?page=stats&flags=stats/devices`.
* Ensure the Devices module works well.
* Ensure the module is not displaying on Jetpack before version `0.19.0-alpha`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?