### PR TITLE
Nav Redesign - update action link hover styles

### DIFF
--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -216,23 +216,6 @@ a.hosting-overview__link-button {
 	margin: 0;
 }
 
-.hosting-overview__action {
-	border-bottom: 1px solid var(--color-border-secondary);
-	padding: var(--grid-unit-15, 12px) 0;
-
-	svg {
-		color: var(--studio-gray-30);
-		margin-right: 8px;
-		width: 20px;
-		height: 20px;
-	}
-
-
-	&:last-child {
-		border-bottom: none;
-	}
-}
-
 .hosting-overview__action-button {
 	display: flex;
 	justify-content: space-between;
@@ -242,8 +225,8 @@ a.hosting-overview__link-button {
 	line-height: 20px;
 	letter-spacing: -0.15px;
 
-	&:hover,
 	&:visited,
+	&:hover,
 	&:active,
 	&:focus {
 		color: var(--studio-gray-100);
@@ -258,6 +241,39 @@ a.hosting-overview__link-button {
 	.hosting-overview__dashicon {
 		color: var(--studio-gray-30);
 		margin-right: 8px;
+	}
+}
+
+.hosting-overview__action {
+	border-bottom: 1px solid var(--gutenberg-gray-100, #f0f0f0);
+	padding: var(--grid-unit-15, 12px) 0;
+
+	svg {
+		color: var(--studio-gray-30);
+		margin-right: 8px;
+		width: 20px;
+		height: 20px;
+	}
+
+	&:last-child {
+		border-bottom: none;
+	}
+
+	&:hover {
+		color: var(--color-primary-60);
+		svg {
+			color: var(--color-primary-60);
+			fill: var(--color-primary-60);
+		}
+
+		.hosting-overview__action-button,
+		.hosting-overview__action-text,
+		.hosting-overview__dashicon {
+			color: var(--color-primary-60);
+			svg {
+				color: var(--color-primary-60);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6825

Adds blueberry blue hover colors to action links on hosting overview action links.

https://github.com/Automattic/wp-calypso/assets/5560595/1fedc62d-259d-46f0-adaf-23061021e31a

## Testing Instructions

* Go to calypso live `/sites?flags=layout/dotcom-nav-redesign-v2`
* Click on a site
* Confirm action links in overview panel are working like in video above.