### PR TITLE
Trail Map: preserve availableForCurrentPlan in feature list

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -835,7 +835,7 @@ const PlansFeaturesMain = ( {
 										useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 										useActionCallback={ useActionCallback }
 										enableFeatureTooltips={ ! trailMapExperiment.result }
-										renderCategorisedFeatures={ trailMapExperiment.result }
+										enableCategorisedFeatures={ trailMapExperiment.result }
 										featureGroupMap={ trailMapExperiment.result ? featureGroupMap : undefined }
 									/>
 								) }

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -40,7 +40,6 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
-		"@automattic/js-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/viewport": "workspace:^",

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -15,7 +15,7 @@ const RenderFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 			allFeaturesList: getFeaturesList(),
 			useCheckPlanAvailabilityForPurchase: () => ( { value_bundle: true } ),
 			storageAddOns: [],
-			includeAllFeatures: props.renderCategorisedFeatures,
+			includeAllFeatures: props.enableCategorisedFeatures,
 		},
 		useGridPlans
 	);
@@ -24,7 +24,7 @@ const RenderFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		<FeaturesGrid
 			{ ...props }
 			gridPlans={ gridPlans || [] }
-			featureGroupMap={ props.renderCategorisedFeatures ? getPlanFeaturesGrouped() : undefined }
+			featureGroupMap={ props.enableCategorisedFeatures ? getPlanFeaturesGrouped() : undefined }
 		/>
 	);
 };
@@ -82,6 +82,6 @@ export const CategorisedFeatures: Story = {
 	args: {
 		...PlansFlow.args,
 		gridPlanForSpotlight: undefined,
-		renderCategorisedFeatures: true,
+		enableCategorisedFeatures: true,
 	},
 };

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -75,11 +75,11 @@ const MobileView = ( {
 	showUpgradeableStorage,
 }: MobileViewProps ) => {
 	const translate = useTranslate();
-	const { renderCategorisedFeatures, featureGroupMap } = usePlansGridContext();
+	const { enableCategorisedFeatures, featureGroupMap } = usePlansGridContext();
 	const featureGroups = useMemo(
 		() =>
-			renderCategorisedFeatures ? ( Object.keys( featureGroupMap ) as FeatureGroupSlug[] ) : [],
-		[ renderCategorisedFeatures, featureGroupMap ]
+			enableCategorisedFeatures ? ( Object.keys( featureGroupMap ) as FeatureGroupSlug[] ) : [],
+		[ enableCategorisedFeatures, featureGroupMap ]
 	);
 
 	return renderedGridPlans
@@ -138,7 +138,7 @@ const MobileView = ( {
 						}
 					>
 						<PartnerLogos renderedGridPlans={ [ gridPlan ] } />
-						{ renderCategorisedFeatures ? (
+						{ enableCategorisedFeatures ? (
 							featureGroups.map( ( featureGroupSlug ) => (
 								<PlanFeaturesList
 									key={ featureGroupSlug }

--- a/packages/plans-grid-next/src/components/features-grid/partner-logos.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/partner-logos.tsx
@@ -21,12 +21,12 @@ type PreviousFeaturesIncludedTitleProps = {
 };
 
 const PartnerLogos = ( { renderedGridPlans, options }: PreviousFeaturesIncludedTitleProps ) => {
-	const { featureGroupMap, renderCategorisedFeatures } = usePlansGridContext();
+	const { featureGroupMap, enableCategorisedFeatures } = usePlansGridContext();
 
 	return renderedGridPlans.map( ( { planSlug, features: { wpcomFeatures, jetpackFeatures } } ) => {
 		const shouldRenderLogos = isWpcomEnterpriseGridPlan( planSlug );
 		const shouldCoverFullColumn =
-			( wpcomFeatures.length === 0 && jetpackFeatures.length === 0 ) || renderCategorisedFeatures;
+			( wpcomFeatures.length === 0 && jetpackFeatures.length === 0 ) || enableCategorisedFeatures;
 		const rowspanProp =
 			options?.isTableCell && shouldRenderLogos
 				? {
@@ -36,7 +36,7 @@ const PartnerLogos = ( { renderedGridPlans, options }: PreviousFeaturesIncludedT
 							 * - the number of feature groups + 2 (1 this row + 1 row of storage) in case of feature categories,
 							 * - otherwise: 4 (1 this row + 1 row of features + 1 row of storage + 1 row for the "everything in ... plus" part)
 							 */
-							rowSpan: renderCategorisedFeatures ? Object.values( featureGroupMap ).length + 2 : 4,
+							rowSpan: enableCategorisedFeatures ? Object.values( featureGroupMap ).length + 2 : 4,
 						} ),
 				  }
 				: {};

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -59,11 +59,11 @@ const Table = ( {
 	stickyRowOffset,
 }: TableProps ) => {
 	const translate = useTranslate();
-	const { renderCategorisedFeatures, featureGroupMap } = usePlansGridContext();
+	const { enableCategorisedFeatures, featureGroupMap } = usePlansGridContext();
 	const featureGroups = useMemo(
 		() =>
-			renderCategorisedFeatures ? ( Object.keys( featureGroupMap ) as FeatureGroupSlug[] ) : [],
-		[ renderCategorisedFeatures, featureGroupMap ]
+			enableCategorisedFeatures ? ( Object.keys( featureGroupMap ) as FeatureGroupSlug[] ) : [],
+		[ enableCategorisedFeatures, featureGroupMap ]
 	);
 	// Do not render the spotlight plan if it exists
 	const gridPlansWithoutSpotlight = useMemo(
@@ -150,7 +150,7 @@ const Table = ( {
 						options={ { isTableCell: true } }
 					/>
 				</tr>
-				{ renderCategorisedFeatures ? (
+				{ enableCategorisedFeatures ? (
 					<>
 						<tr>
 							<PlanStorageOptions

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -17,13 +17,13 @@ interface PlansGridContext {
 	coupon?: string;
 	enableFeatureTooltips?: boolean;
 	/**
-	 * `renderCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)
+	 * `enableCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)
 	 * for rendering features with categories based on available/associated feature group map.
 	 */
-	renderCategorisedFeatures?: boolean;
+	enableCategorisedFeatures?: boolean;
 	/**
 	 * `featureGroupMap` is relevant for rendering features with categories.
-	 * This is necessary for Comparison Grid and optional for Features Grid (i.e. applicable when `renderCategorisedFeatures` is set).
+	 * This is necessary for Comparison Grid and optional for Features Grid (i.e. applicable when `enableCategorisedFeatures` is set).
 	 */
 	featureGroupMap: Partial< FeatureGroupMap >;
 }
@@ -41,7 +41,7 @@ const PlansGridContextProvider = ( {
 	children,
 	coupon,
 	enableFeatureTooltips,
-	renderCategorisedFeatures,
+	enableCategorisedFeatures,
 	featureGroupMap,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
@@ -63,7 +63,7 @@ const PlansGridContextProvider = ( {
 				helpers: { useCheckPlanAvailabilityForPurchase, useActionCallback, recordTracksEvent },
 				coupon,
 				enableFeatureTooltips,
-				renderCategorisedFeatures,
+				enableCategorisedFeatures,
 				featureGroupMap,
 			} }
 		>

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -3,7 +3,6 @@ import {
 	applyTestFiltersToPlansList,
 	isMonthly,
 } from '@automattic/calypso-products';
-import { uniqueBy } from '@automattic/js-utils';
 import { useMemo } from '@wordpress/element';
 import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import useHighlightedFeatures from './use-highlighted-features';
@@ -203,15 +202,23 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 
 				previousPlan = planSlug;
 
+				if ( includeAllFeatures ) {
+					// Add the previous plan features only if it is not present in the current plan features.
+					previousPlanFeatures.wpcomFeatures.forEach( ( feature ) => {
+						if (
+							! wpcomFeaturesTransformed.find(
+								( featureToFind ) => featureToFind.getSlug() === feature.getSlug()
+							)
+						) {
+							wpcomFeaturesTransformed.push( feature );
+						}
+					} );
+				}
+
 				return {
 					...acc,
 					[ planSlug ]: {
-						wpcomFeatures: includeAllFeatures
-							? uniqueBy(
-									[ ...previousPlanFeatures.wpcomFeatures, ...wpcomFeaturesTransformed ],
-									( featureA, featureB ) => featureA.getSlug() === featureB.getSlug()
-							  )
-							: wpcomFeaturesTransformed,
+						wpcomFeatures: wpcomFeaturesTransformed,
 						jetpackFeatures: jetpackFeaturesTransformed,
 						storageOptions:
 							planConstantObj.get2023PricingGridSignupStorageOptions?.(

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -107,7 +107,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		isInAdmin,
 		className,
 		enableFeatureTooltips,
-		renderCategorisedFeatures,
+		enableCategorisedFeatures,
 		featureGroupMap = {},
 	} = props;
 
@@ -139,7 +139,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				recordTracksEvent={ recordTracksEvent }
 				allFeaturesList={ allFeaturesList }
 				enableFeatureTooltips={ enableFeatureTooltips }
-				renderCategorisedFeatures={ renderCategorisedFeatures }
+				enableCategorisedFeatures={ enableCategorisedFeatures }
 				featureGroupMap={ featureGroupMap }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -159,20 +159,20 @@ export type GridContextProps = {
 	coupon?: string;
 	enableFeatureTooltips?: boolean;
 	/**
-	 * `renderCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)
+	 * `enableCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)
 	 * for rendering features with categories based on available/associated feature group map.
 	 */
-	renderCategorisedFeatures?: boolean;
+	enableCategorisedFeatures?: boolean;
 	/**
 	 * `featureGroupMap` is relevant for rendering features with categories.
-	 * This is necessary for Comparison Grid and optional for Features Grid (i.e. applicable when `renderCategorisedFeatures` is set).
+	 * This is necessary for Comparison Grid and optional for Features Grid (i.e. applicable when `enableCategorisedFeatures` is set).
 	 */
 	featureGroupMap: Partial< FeatureGroupMap >;
 };
 
 export type ComparisonGridExternalProps = Omit<
 	GridContextProps,
-	'children' | 'renderCategorisedFeatures'
+	'children' | 'enableCategorisedFeatures'
 > &
 	Omit< ComparisonGridProps, 'onUpgradeClick' | 'gridContainerRef' | 'gridSize' > & {
 		className?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,7 +1552,6 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/format-currency": "workspace:^"
-    "@automattic/js-utils": "workspace:^"
     "@automattic/onboarding": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/viewport": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89682

## Proposed Changes

* In the previous PR (#89650), we added the previous plan features to the current plan features and then used the `uniqueBy` function to filter out unique. This caused the `availableForCurrentPlan` property of the feature to be overwritten by the same feature of the previous plan. Ultimately, this caused the "Free domain for one year" feature to be shown as crossed out even for non-Free plans.
* In this PR, we fix this by adding the features of the previous plan only if it is not present in the current plan feature list, thereby preserving the properties of the current plan's features. See 787afd9b9b9f730974701e32f1665fc4fa1aed9f.
* This commit also includes renaming the `renderCategorisedFeatures` prop to `enableCategorisedFeatures`. This is in a separate commit and changes can be viewed here: 68a083cb62496f9ef17bdb6e15640e54daa4d5c8

![localhost_56543_iframe html_args= id=featuresgrid--categorised-features viewMode=story](https://github.com/Automattic/wp-calypso/assets/5436027/2e6c07d2-7573-4794-83f0-3c0a11bb589d)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Run `yarn workspace @automattic/plans-grid-next storybook`.
* Check the "Categorised Features" story and confirm that the features are rendered according to the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?