### PR TITLE
Site migration: Centralize the plugin activation/installation progress in a single status attribute

### DIFF
--- a/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
+++ b/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
@@ -25,13 +25,15 @@ const getPluginActivationEndpoint = ( siteId: number ) =>
 
 const SITE_ID = 123;
 
-const render = ( { retry = 0 } = {} ) => {
+const render = ( { retry = 0, enabled = true } = {} ) => {
 	const queryClient = new QueryClient();
 
-	queryClient.setDefaultOptions( { queries: { retry } } );
-	const renderResult = renderHook( () => usePluginAutoInstallation( PLUGIN, SITE_ID, { retry } ), {
-		wrapper: Wrapper( queryClient ),
-	} );
+	const renderResult = renderHook(
+		() => usePluginAutoInstallation( PLUGIN, SITE_ID, { retry, enabled } ),
+		{
+			wrapper: Wrapper( queryClient ),
+		}
+	);
 
 	return {
 		...renderResult,
@@ -128,7 +130,7 @@ describe( 'usePluginAutoInstallation', () => {
 		);
 	} );
 
-	it( 'returns completed when all steps are successful', async () => {
+	it( 'returns completed and status success when all steps are successful', async () => {
 		nock( 'https://public-api.wordpress.com:443' )
 			.get( getSitePluginsEndpoint( SITE_ID ) )
 			.once()
@@ -195,5 +197,15 @@ describe( 'usePluginAutoInstallation', () => {
 			},
 			{ timeout: 3000 }
 		);
+	} );
+
+	it( "doesn't start the operation when the enabled is set to false", async () => {
+		const { result } = render( { enabled: false } );
+
+		expect( result.current ).toEqual( {
+			status: 'idle',
+			error: null,
+			completed: false,
+		} );
 	} );
 } );

--- a/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
+++ b/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
@@ -23,10 +23,13 @@ const getPluginInstallationEndpoint = ( siteId: number ) =>
 const getPluginActivationEndpoint = ( siteId: number ) =>
 	`/rest/v1.2/sites/${ siteId }/plugins/migrate-guru%2Fmigrateguru`;
 
-const render = ( { siteId } ) => {
+const SITE_ID = 123;
+
+const render = ( { retry = 0 } = {} ) => {
 	const queryClient = new QueryClient();
 
-	const renderResult = renderHook( () => usePluginAutoInstallation( PLUGIN, siteId ), {
+	queryClient.setDefaultOptions( { queries: { retry } } );
+	const renderResult = renderHook( () => usePluginAutoInstallation( PLUGIN, SITE_ID, { retry } ), {
 		wrapper: Wrapper( queryClient ),
 	} );
 
@@ -38,158 +41,159 @@ const render = ( { siteId } ) => {
 
 describe( 'usePluginAutoInstallation', () => {
 	beforeAll( () => nock.disableNetConnect() );
+	beforeEach( () => nock.cleanAll() );
 
-	it( 'returns the initial status', async () => {
+	it( 'returns success when the plugin is already installed and activated', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.once()
+			.reply( 200, { plugins: [ { ...PLUGIN, active: true } ] } );
+
+		const { result } = render();
+
+		await waitFor( () => {
+			expect( result.current ).toEqual( {
+				status: 'success',
+				error: null,
+				completed: true,
+			} );
+		} );
+	} );
+
+	it( 'returns pending when the the retrying to fetch the plugin list after an error', async () => {
 		const siteId = 123;
-		const { result } = render( { siteId: 123 } );
 
 		nock( 'https://public-api.wordpress.com:443' )
 			.get( getSitePluginsEndpoint( siteId ) )
-			.delay( 100 )
-			.once();
+			.times( 2 )
+			.reply( 500, new Error( 'Error fetching plugins list' ) );
 
-		await waitFor( () => {
-			expect( result.current ).toEqual( {
-				activatingPlugin: 'idle',
-				installingPlugin: 'idle',
-				waitingPluginList: 'pending',
-				error: null,
-				completed: false,
-			} );
-		} );
+		const { result } = render( { retry: 1 } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'pending',
+					error: null,
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
 	} );
 
-	it( 'returns the plugin installingPlugin status', async () => {
-		const siteId = 456;
-
+	it( 'returns pending when is retrying install the plugin', async () => {
 		nock( 'https://public-api.wordpress.com:443' )
-			.get( getSitePluginsEndpoint( siteId ) )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
 			.once()
 			.reply( 200, { plugins: [] } )
-			.post( getPluginInstallationEndpoint( siteId ) )
-			.delay( 100 )
-			.once()
-			.reply( 200 );
+			.post( getPluginInstallationEndpoint( SITE_ID ) )
+			.reply( 500, new Error( 'Error installing plugin' ) );
 
-		const { result } = render( { siteId: 456 } );
+		const { result } = render( { retry: 2 } );
 
-		await waitFor( () => {
-			expect( result.current ).toEqual( {
-				activatingPlugin: 'idle',
-				installingPlugin: 'pending',
-				waitingPluginList: 'success',
-				error: null,
-				completed: false,
-			} );
-		} );
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'pending',
+					error: null,
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
 	} );
 
-	it( 'returns the plugin activatingPlugin status', async () => {
-		const siteId = 111;
+	it( 'returns pending when is retrying to active plugin', async () => {
 		nock( 'https://public-api.wordpress.com:443' )
-			.get( getSitePluginsEndpoint( siteId ) )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
 			.once()
 			.reply( 200, { plugins: [] } )
-			.post( getPluginInstallationEndpoint( siteId ) )
+			.post( getPluginInstallationEndpoint( SITE_ID ) )
 			.reply( 200 )
-			.post( getPluginActivationEndpoint( siteId ) )
-			.delay( 100 )
-			.reply( 200 );
+			.post( getPluginActivationEndpoint( SITE_ID ) )
+			.reply( 500, new Error( 'Error activating plugin' ) );
 
-		const { result } = render( { siteId } );
+		const { result } = render( { retry: 2 } );
 
-		await waitFor( () => {
-			expect( result.current ).toEqual( {
-				activatingPlugin: 'pending',
-				installingPlugin: 'success',
-				waitingPluginList: 'success',
-				error: null,
-				completed: false,
-			} );
-		} );
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'pending',
+					error: null,
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
 	} );
 
-	it( 'returns completed when all requests was completed', async () => {
-		const siteId = 111;
+	it( 'returns completed when all steps are successful', async () => {
 		nock( 'https://public-api.wordpress.com:443' )
-			.get( getSitePluginsEndpoint( siteId ) )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
 			.once()
 			.reply( 200, { plugins: [] } )
-			.post( getPluginInstallationEndpoint( siteId ) )
+			.post( getPluginInstallationEndpoint( SITE_ID ) )
 			.reply( 200 )
-			.post( getPluginActivationEndpoint( siteId ) )
+			.post( getPluginActivationEndpoint( SITE_ID ) )
 			.reply( 200 );
 
-		const { result } = render( { siteId } );
+		const { result } = render( { retry: 2 } );
 
-		await waitFor( () => {
-			expect( result.current ).toEqual( {
-				activatingPlugin: 'success',
-				installingPlugin: 'success',
-				waitingPluginList: 'success',
-				error: null,
-				completed: true,
-			} );
-		} );
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'success',
+					error: null,
+					completed: true,
+				} );
+			},
+			{ timeout: 3000 }
+		);
 	} );
 
-	it( 'returns installingPlugin skipped  when the the plugin installation is not necessary', async () => {
-		const siteId = 111;
+	it( 'returns error after all fetching plugin list retries failed', async () => {
 		nock( 'https://public-api.wordpress.com:443' )
-			.get( getSitePluginsEndpoint( siteId ) )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
 			.once()
-			.reply( 200, { plugins: [ { ...PLUGIN, active: false } ] } );
+			.times( 2 )
+			.reply( 500, new Error( 'Error fetching plugins list' ) );
 
-		const { result } = render( { siteId } );
+		const { result } = render( { retry: 1 } );
 
-		await waitFor( () => {
-			expect( result.current ).toEqual( {
-				installingPlugin: 'skipped',
-				activatingPlugin: 'pending',
-				waitingPluginList: 'success',
-				error: null,
-				completed: false,
-			} );
-		} );
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'error',
+					error: expect.any( Error ),
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
 	} );
 
-	it( 'returns activatingPlugin skipped when the plugin activation is not necessary', async () => {
-		const siteId = 111;
+	it( 'returns error after all fetching plugin installation retries', async () => {
 		nock( 'https://public-api.wordpress.com:443' )
-			.get( getSitePluginsEndpoint( siteId ) )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
 			.once()
-			.reply( 200, { plugins: [ { ...PLUGIN, active: true } ] } );
+			.reply( 200, { plugins: [] } )
+			.post( getPluginInstallationEndpoint( SITE_ID ) )
+			.reply( 200 )
+			.post( getPluginActivationEndpoint( SITE_ID ) )
+			.reply( 500, new Error( 'Error activating plugin' ) );
 
-		const { result } = render( { siteId } );
+		const { result } = render( { retry: 1 } );
 
-		await waitFor( () => {
-			expect( result.current ).toEqual( {
-				installingPlugin: 'skipped',
-				activatingPlugin: 'skipped',
-				waitingPluginList: 'success',
-				error: null,
-				completed: true,
-			} );
-		} );
-	} );
-
-	it( 'returns completed when all steps was skipped or completed with success', async () => {
-		const siteId = 111;
-		nock( 'https://public-api.wordpress.com:443' )
-			.get( getSitePluginsEndpoint( siteId ) )
-			.once()
-			.reply( 200, { plugins: [ { ...PLUGIN, active: true } ] } );
-
-		const { result } = render( { siteId } );
-
-		await waitFor( () => {
-			expect( result.current ).toEqual( {
-				installingPlugin: 'skipped',
-				activatingPlugin: 'skipped',
-				waitingPluginList: 'success',
-				error: null,
-				completed: true,
-			} );
-		} );
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'error',
+					error: expect.any( Error ),
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
 	} );
 } );

--- a/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
+++ b/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
@@ -60,7 +60,7 @@ describe( 'usePluginAutoInstallation', () => {
 		} );
 	} );
 
-	it( 'returns pending when the the retrying to fetch the plugin list after an error', async () => {
+	it( 'returns status "pending" when a retry is required to get the plugin list', async () => {
 		const siteId = 123;
 
 		nock( 'https://public-api.wordpress.com:443' )
@@ -82,7 +82,7 @@ describe( 'usePluginAutoInstallation', () => {
 		);
 	} );
 
-	it( 'returns pending when is retrying install the plugin', async () => {
+	it( 'returns "pending" when a retry is required to install a plugin', async () => {
 		nock( 'https://public-api.wordpress.com:443' )
 			.get( getSitePluginsEndpoint( SITE_ID ) )
 			.once()
@@ -104,7 +104,7 @@ describe( 'usePluginAutoInstallation', () => {
 		);
 	} );
 
-	it( 'returns pending when is retrying to active plugin', async () => {
+	it( 'returns "pending" when a retry is required to active a plugin', async () => {
 		nock( 'https://public-api.wordpress.com:443' )
 			.get( getSitePluginsEndpoint( SITE_ID ) )
 			.once()
@@ -138,7 +138,7 @@ describe( 'usePluginAutoInstallation', () => {
 			.post( getPluginActivationEndpoint( SITE_ID ) )
 			.reply( 200 );
 
-		const { result } = render( { retry: 2 } );
+		const { result } = render( { retry: 0 } );
 
 		await waitFor(
 			() => {

--- a/client/landing/stepper/hooks/use-plugin-auto-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-auto-installation.ts
@@ -19,6 +19,8 @@ interface SiteMigrationStatus {
 	error: Error | null;
 }
 
+type Options = Pick< UseQueryOptions, 'enabled' | 'retry' >;
+
 const fetchPluginsForSite = async ( siteId: number ): Promise< Response > =>
 	wpcom.req.get( `/sites/${ siteId }/plugins?http_envelope=1`, {
 		apiNamespace: 'rest/v1.2',
@@ -39,7 +41,6 @@ const activatePlugin = async ( siteId: number, pluginName: string ) =>
 		},
 	} );
 
-type Options = Pick< UseQueryOptions, 'enabled' | 'retry' >;
 const usePluginStatus = ( pluginSlug: string, siteId?: number, options?: Options ) => {
 	return useQuery( {
 		queryKey: [ 'onboarding-site-plugin-status', siteId, pluginSlug ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of #89760

## Proposed Changes
It is part of #89760 where we need to control a sequence of requests to ensure a site is ready to run the migrate-guru migration. 

I am going to use this feature in further PRs. 

* Centralize the plugin installation and activation task status in a single prop.
* Manage better the overall status progress status

**Context:** 
We are returning each operation's status (fetch plugin list, install plugin, active plugin) separately. It was causing extra complexity to manage a flow that needed to use this hook.  So Instead of returning the status of each request, I am returning the overall status representing if something is still required or not. 

## Testing Instructions
* This hook is still not in use but you can check the automated tests
* Visual inspection is also appreciated. 


