### PR TITLE
Automattic for Agencies: Implement purchase confirmation success message

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
@@ -1,0 +1,66 @@
+import page from '@automattic/calypso-router';
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import useWPCOMPlanDescription from '../../marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description';
+
+export default function PurchaseConfirmationMessage() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const wpcomHostingPurchased = ( getQueryArg( window.location.href, 'wpcom_creator_purchased' ) ??
+		'' ) as string;
+
+	const [ successNotification, setSuccessNotification ] = useState< boolean >( false );
+	const [ hostingPlanSlug, setHostingPlanSlug ] = useState< string >( '' );
+
+	// Set the success notification when a WPCOM hosting plan is purchased and remove the query arg from the URL
+	useEffect( () => {
+		if ( wpcomHostingPurchased ) {
+			setSuccessNotification( true );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_wpcom_hosting_purchased', {
+					hosting_plan: wpcomHostingPurchased,
+				} )
+			);
+			setHostingPlanSlug( wpcomHostingPurchased );
+			page(
+				removeQueryArgs(
+					window.location.pathname + window.location.search,
+					'wpcom_creator_purchased'
+				)
+			);
+		}
+	}, [ dispatch, wpcomHostingPurchased ] );
+
+	const { name } = useWPCOMPlanDescription( hostingPlanSlug );
+
+	return successNotification ? (
+		<NoticeBanner
+			level="success"
+			title={
+				translate( 'Congratulations on your WordPress.com %(name)s purchase!', {
+					args: {
+						name,
+					},
+					comment: '%(name)s is the WPCOM plan name.',
+				} ) as string
+			}
+			onClose={ () => setSuccessNotification( false ) }
+		>
+			{ translate(
+				'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.' +
+					' Any add-ons you’ve purchased will be set up when you create your corresponding WordPress.com %(name)s site.',
+				{
+					args: {
+						name,
+					},
+					comment: '%(name)s is the WPCOM plan name.',
+				}
+			) }
+		</NoticeBanner>
+	) : null;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/375

## Proposed Changes

This PR implements a purchase confirmation success message.

## Testing Instructions

1) Open the A4A live link.
2) Go to client/a8c-for-agencies/sections/sites/controller.tsx > Do the below:

```
import PurchaseConfirmationMessage from './needs-setup-sites/purchase-confirmation-message';
context.primary = (
	<div>
		<PurchaseConfirmationMessage />
	</div>
);
```

2) Visit  /sites/needs-setup?wpcom_creator_purchased=wpcom-hosting-business, and you can see the success message as shown below:

<img width="1657" alt="Screenshot 2024-04-30 at 4 54 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3bbb7813-e8f9-4083-b8cd-8d3c9f3e1806">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?