### PR TITLE
Assistance migration modal: Add tracking events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/migration-assistance-modal/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/migration-assistance-modal/index.tsx
@@ -7,7 +7,7 @@ import './style.scss';
 
 const EVENT_NAMES = {
 	accepted: 'calypso_migration_assistance_modal_deal_accepted',
-	declined: 'calypso_migration_assistance_modal_no_thanks_or_closed',
+	declined: 'calypso_migration_assistance_modal_deal_declined',
 };
 
 interface MigrationAssistanceModalProps {

--- a/client/landing/stepper/declarative-flow/internals/components/migration-assistance-modal/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/migration-assistance-modal/index.tsx
@@ -1,7 +1,14 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
 import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
 import { setMigrationAssistanceAccepted } from 'calypso/blocks/importer/wordpress/utils';
 import './style.scss';
+
+const EVENT_NAMES = {
+	accepted: 'calypso_migration_assistance_modal_deal_accepted',
+	declined: 'calypso_migration_assistance_modal_no_thanks_or_closed',
+};
+
 interface MigrationAssistanceModalProps {
 	navigateBack: ( () => void ) | undefined;
 	migrateFrom: string | null;
@@ -13,8 +20,22 @@ export const MigrationAssistanceModal: React.FunctionComponent< MigrationAssista
 	const translate = useTranslate();
 	const importSiteHostName = props.migrateFrom || translate( 'your site' );
 
+	const logEvent = ( acceptedDeal: boolean = false ) => {
+		const eventName = acceptedDeal ? EVENT_NAMES.accepted : EVENT_NAMES.declined;
+		recordTracksEvent( eventName, {
+			user_site: importSiteHostName,
+		} );
+	};
+
+	const navigateBackOrCloseModal = () => {
+		logEvent();
+		props.navigateBack?.();
+	};
+
 	const acceptMigrationAssistance = () => {
+		const acceptedDeal = true;
 		setMigrationAssistanceAccepted();
+		logEvent( acceptedDeal );
 		props.onConfirm?.();
 	};
 
@@ -24,7 +45,7 @@ export const MigrationAssistanceModal: React.FunctionComponent< MigrationAssista
 			title={ translate( 'Migration sounds daunting? It shouldn’t be!' ) }
 			confirmText={ translate( 'Take the deal' ) }
 			cancelText={ translate( 'No, thanks' ) }
-			onClose={ props.navigateBack }
+			onClose={ navigateBackOrCloseModal }
 			onConfirm={ acceptMigrationAssistance }
 		>
 			<p>

--- a/client/landing/stepper/declarative-flow/internals/components/migration-assistance-modal/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/migration-assistance-modal/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
 import { setMigrationAssistanceAccepted } from 'calypso/blocks/importer/wordpress/utils';
@@ -38,6 +39,12 @@ export const MigrationAssistanceModal: React.FunctionComponent< MigrationAssista
 		logEvent( acceptedDeal );
 		props.onConfirm?.();
 	};
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_migration_assistance_modal_loaded', {
+			user_site: importSiteHostName,
+		} );
+	}, [ importSiteHostName ] );
 
 	return (
 		<ConfirmModal


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add tracking events on migration modal when accepting or declining the deal

According to this pcmemI-2sX-p2 great post, I have mapped some flows using this step and furthermore should show the modal when navigating back, they are:

- site-setup
- site-migration-flow
- import-hosted-sites
- import-flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->




* Pull and run this branch or use live link
* Navigate to the flows, adapting the URL with live link or calypso.localhost.
* Make sure to add the feature flag in the URL to be able to see the modal when navigating back `flags=migration_assistance_modal`
* After accepting the deal and redirected to the checkout page, check using tracks vigilante PCYsg-T9m-p2
if `calypso_migration_assistance_modal_deal_accepted` was logged.

* If the user clicks on 'No, thanks' button or close the modal, it should point the user to the previous step and log `calypso_migration_assistance_modal_deal_declined`

* When the modal loads, `calypso_migration_assistance_modal_loaded`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?