### PR TITLE
Enable command palette in horizon environment

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -164,7 +164,7 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/command-palette": false
+		"yolo/command-palette": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6840

Command palette isn't working on horizon.wordpress.com. I suspect it is because the feature is disabled on horizon config. This PR enables that feature on horizon config.

## Testing instructions

Not sure how to test this.