### PR TITLE
Nav Redesign - fix search style

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -102,6 +102,10 @@
 			padding-left: 0;
 			font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			color: var(--studio-gray-40);
+
+			&::placeholder {
+				color: var(--studio-gray-40);
+			}
 		}
 
 		// Search icon

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -100,13 +100,14 @@
 
 		.components-input-control__input {
 			padding-left: 0;
-			font-size: $font-body;
+			font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			color: var(--studio-gray-40);
 		}
 
 		// Search icon
 		.components-input-control__suffix {
 			padding-inline-start: 11px;
-			color: var(--studio-gray-30);
+			color: var(--studio-black);
 		}
 	}
 }

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -2,15 +2,12 @@ import Search from '@automattic/search';
 import styled from '@emotion/styled';
 import { MEDIA_QUERIES } from '../utils';
 
-//The font should be 13px and --studio-gray-40. The icons should use --studio-black.
 export const SitesSearch = styled( Search )( {
 	'--color-surface': 'var( --studio-white )',
 
 	maxHeight: '42px',
 	overflow: 'hidden',
 	border: '1px solid #c3c4c7',
-	color: 'var( --studio-gray-40 )',
-	fontSize: '13px',
 
 	[ MEDIA_QUERIES.mediumOrLarger ]: {
 		flex: '0 1 390px !important',

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -2,12 +2,15 @@ import Search from '@automattic/search';
 import styled from '@emotion/styled';
 import { MEDIA_QUERIES } from '../utils';
 
+//The font should be 13px and --studio-gray-40. The icons should use --studio-black.
 export const SitesSearch = styled( Search )( {
 	'--color-surface': 'var( --studio-white )',
 
 	maxHeight: '42px',
 	overflow: 'hidden',
 	border: '1px solid #c3c4c7',
+	color: 'var( --studio-gray-40 )',
+	fontSize: '13px',
 
 	[ MEDIA_QUERIES.mediumOrLarger ]: {
 		flex: '0 1 390px !important',


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6849

Updates search input styles;
* Icon color is now  `--studio-black`
* Font color is now `--studio-gray-40`
* Font size is now `13px`

## Before

<img width="392" alt="Screenshot 2024-04-30 at 15 43 25" src="https://github.com/Automattic/wp-calypso/assets/5560595/96760f68-0940-46fa-b408-06b15b891212">
<img width="381" alt="Screenshot 2024-04-30 at 15 43 15" src="https://github.com/Automattic/wp-calypso/assets/5560595/c57569fb-648b-4919-9903-5583cd5d96f1">

## After

<img width="389" alt="Screenshot 2024-04-30 at 15 43 01" src="https://github.com/Automattic/wp-calypso/assets/5560595/91170eb2-6b29-413c-9642-6acc4395344f">
<img width="377" alt="Screenshot 2024-04-30 at 15 42 51" src="https://github.com/Automattic/wp-calypso/assets/5560595/8d8adfaa-6642-4fe1-be52-2abca3828e58">

## Testing Instructions

* Apply patch and confirm styles look like above
