### PR TITLE
Trail Map: add styling for feature group headings

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -139,17 +139,23 @@ const MobileView = ( {
 					>
 						<PartnerLogos renderedGridPlans={ [ gridPlan ] } />
 						{ enableCategorisedFeatures ? (
-							featureGroups.map( ( featureGroupSlug ) => (
-								<PlanFeaturesList
-									key={ featureGroupSlug }
-									renderedGridPlans={ [ gridPlan ] }
-									selectedFeature={ selectedFeature }
-									paidDomainName={ paidDomainName }
-									hideUnavailableFeatures={ hideUnavailableFeatures }
-									generatedWPComSubdomain={ generatedWPComSubdomain }
-									isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-									featureGroupSlug={ featureGroupSlug }
-								/>
+							featureGroups.map( ( featureGroupSlug, featureGroupIndex ) => (
+								<div
+									className={ classNames( 'plans-grid-next-features-grid__feature-group-row', {
+										'is-first-feature-group': featureGroupIndex === 0,
+									} ) }
+								>
+									<PlanFeaturesList
+										key={ featureGroupSlug }
+										renderedGridPlans={ [ gridPlan ] }
+										selectedFeature={ selectedFeature }
+										paidDomainName={ paidDomainName }
+										hideUnavailableFeatures={ hideUnavailableFeatures }
+										generatedWPComSubdomain={ generatedWPComSubdomain }
+										isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+										featureGroupSlug={ featureGroupSlug }
+									/>
+								</div>
 							) )
 						) : (
 							<>

--- a/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
@@ -65,14 +65,18 @@ const PlanFeaturesList = ( {
 			);
 
 			if ( featureGroup && ! filteredWpcomFeatures.length ) {
-				// Render a placeholder to keep the grid aligned
-				return (
-					<PlanDivOrTdContainer
-						key={ `${ planSlug }-${ mapIndex }` }
-						isTableCell={ options?.isTableCell }
-						className="plan-features-2023-grid__table-item"
-					/>
-				);
+				if ( options?.isTableCell ) {
+					// Render a placeholder to keep the grid aligned
+					return (
+						<PlanDivOrTdContainer
+							key={ `${ planSlug }-${ mapIndex }` }
+							isTableCell={ options?.isTableCell }
+							className="plan-features-2023-grid__table-item"
+						/>
+					);
+				}
+				// No placeholder required if the element is not a part of the table.
+				return;
 			}
 
 			return (

--- a/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
@@ -70,7 +70,7 @@ const PlanFeaturesList = ( {
 					return (
 						<PlanDivOrTdContainer
 							key={ `${ planSlug }-${ mapIndex }` }
-							isTableCell={ options?.isTableCell }
+							isTableCell
 							className="plan-features-2023-grid__table-item"
 						/>
 					);

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -161,8 +161,13 @@ const Table = ( {
 								showUpgradeableStorage={ showUpgradeableStorage }
 							/>
 						</tr>
-						{ featureGroups.map( ( featureGroupSlug ) => (
-							<tr key={ featureGroupSlug }>
+						{ featureGroups.map( ( featureGroupSlug, featureGroupIndex ) => (
+							<tr
+								className={ classNames( 'plans-grid-next-features-grid__feature-group-row', {
+									'is-first-feature-group': featureGroupIndex === 0,
+								} ) }
+								key={ featureGroupSlug }
+							>
 								<PlanFeaturesList
 									renderedGridPlans={ gridPlansWithoutSpotlight }
 									options={ { isTableCell: true } }

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -353,6 +353,13 @@ $mobile-card-max-width: 440px;
 
 .plans-grid-next-features-grid__feature-group-title {
 	font-weight: 600;
+	color: var(--studio-gray-80);
+}
+
+.plans-grid-next-features-grid__feature-group-row {
+	&:not(.is-first-feature-group) > .plan-features-2023-grid__table-item {
+		padding-top: 32px;
+	}
 }
 
 .plan-features-2023-grid__item-info {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89682

## Proposed Changes

* Adds styling for feature group headings when categorized features are rendered.

![localhost_56214_iframe html_id=featuresgrid--categorised-features viewMode=story](https://github.com/Automattic/wp-calypso/assets/5436027/65a5edcc-051b-4eb3-82ed-6cedb8a77f4f)

![localhost_56214_iframe html_id=featuresgrid--categorised-features viewMode=story (1)](https://github.com/Automattic/wp-calypso/assets/5436027/bae6cc49-ec66-41a0-b5ac-80729ea353aa)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Run `yarn workspace @automattic/plans-grid-next storybook`.
* Check the "Categorised Features" story and confirm that the features are rendered according to the screenshot.
* Check desktop, tablet and mobile screen sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?