### PR TITLE
Nav redesign: click selected site on mount

### DIFF
--- a/client/sites-dashboard-v2/hooks/use-initialize-dataviews-selected-item.ts
+++ b/client/sites-dashboard-v2/hooks/use-initialize-dataviews-selected-item.ts
@@ -1,0 +1,30 @@
+import { SiteDetails } from '@automattic/data-stores';
+import { useEffect, useRef } from 'react';
+
+// The @wordpress/dataviews's DataViews component does not accept an initial selected item.
+// Therefore, when a page is first loaded, the currently selected site won't be rendered as active.
+// As a workaround, until that component allows passing an initial selected item,
+// we manually click the selected site so that it is rendered as active.
+export function useInitializeDataViewsSelectedItem( {
+	selectedSite,
+	paginatedSites,
+}: {
+	selectedSite?: SiteDetails | null;
+	paginatedSites: any;
+} ) {
+	const initialized = useRef( false );
+
+	useEffect( () => {
+		if ( initialized.current || ! selectedSite ) {
+			return;
+		}
+		for ( const site of document.querySelectorAll( 'button.sites-dataviews__site' ) ) {
+			const slug = site.querySelector( '.sites-dataviews__site-url span' );
+			if ( selectedSite.slug === slug?.innerHTML ) {
+				( site as HTMLElement ).click?.();
+				initialized.current = true;
+				break;
+			}
+		}
+	}, [ selectedSite, paginatedSites ] );
+}

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -33,6 +33,7 @@ import {
 	useShowSiteTransferredNotice,
 } from 'calypso/sites-dashboard/components/sites-dashboard';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
+import { useInitializeDataViewsSelectedItem } from './hooks/use-initialize-dataviews-selected-item';
 import { useSyncSelectedSite } from './hooks/use-sync-selected-site';
 import { useSyncSelectedSiteFeature } from './hooks/use-sync-selected-site-feature';
 import { DOTCOM_OVERVIEW, FEATURE_TO_ROUTE_MAP } from './site-preview-pane/constants';
@@ -183,6 +184,8 @@ const SitesDashboardV2 = ( {
 		( dataViewsState.page - 1 ) * dataViewsState.perPage,
 		dataViewsState.page * dataViewsState.perPage
 	);
+
+	useInitializeDataViewsSelectedItem( { selectedSite, paginatedSites } );
 
 	// Update URL with view control params on change.
 	useEffect( () => {


### PR DESCRIPTION
This is a best-effort intermediate solution for:

- https://github.com/Automattic/dotcom-forge/issues/6782

## Proposed Changes

The `@wordpress/dataviews`'s `DataViews`, used to render the site list, initializes the selection as empty ([code](https://github.com/WordPress/gutenberg/blob/6a0527abc3cb9fbf1133a36ec7a9e9f85f06d82a/packages/dataviews/src/dataviews.js#L46)) and there is no way to pass an initial selection to it or to change the selection programmatically. This is why the selected site is not highlighted as active initially.

This PR proposes a workaround to trigger HTML click on the row element of the selected site so that has the correct active state.

## Testing Instructions

1. Go to `<Calypso live URL>/sites`.
2. Click on a site.
3. After the flyout animation, verify that the selected is now highlighted.
4. Refresh the page, verify that the selected site is still highlighted.
5. Click another site, verify that the newly selected site is highlighted correctly.

## Credit

Props to @candy02058912 's https://github.com/Automattic/wp-calypso/pull/90028 that inspires this PR.

## Note

Notice that while the flyout animation is ongoing, the selected site is STILL NOT highlighted. This is a bug in the `dataviews` package, which is resolved when bumped to the latest version (see https://github.com/Automattic/wp-calypso/pull/89739).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?