### PR TITLE
Entrepreneur Signup: Temporarily redirect to Calypso My Home for Entrepreneur signup flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -107,7 +107,10 @@ const entrepreneurFlow: Flow = {
 						);
 
 						// Redirect users to the login page with the 'action=jetpack-sso' parameter to initiate Jetpack SSO login and redirect them to Woo CYS's Design With AI after. This URL, however, is just symbolic because somewhere within Jetpack SSO or some plugin is stripping off the `redirect_to` param. The actual work that is doing the redirection is in wpcomsh/1801.
-						const redirectToWithSSO = `https://${ stagingUrl }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`;
+						let redirectToWithSSO = `https://${ stagingUrl }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`;
+
+						// Temporarily redirect to Calypso My Home until Woo Express 8.9 is deployed.
+						redirectToWithSSO = `/home/${ stagingUrl }`;
 
 						return window.location.assign( redirectToWithSSO );
 					}


### PR DESCRIPTION
Related to #

## Proposed Changes

* Until WooExpress 8.9 is deployed, we'll temporarily redirect to Calypso My Home. This also aligns with the upcoming CfT for Entrepreneur signup.

## Testing Instructions

* Go through the signup flow at `calypso.localhost:3000/setup/entrepreneur/?flags=ecommerce-segmentation-survey`.
* Watch closely. You will land in `/home/yournewsite.wpcomstaging.com`.
  * But until this PR https://github.com/Automattic/wp-calypso/pull/90047 is merged, you will be redirected back to `wc-admin`, which is fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?