### PR TITLE
Self-service site restore: remove second sites query for deleted sites

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -44,20 +44,7 @@ export const useSiteExcerptsQuery = (
 		],
 		queryFn: () => fetchSites( site_visibility, fetchFilter ),
 		select: ( data ) => {
-			let sites = data?.sites.map( computeFields( data?.sites ) ) || [];
-
-			if ( site_visibility === 'deleted' ) {
-				// If we got the site data from Redux store (see `initialData` below),
-				// then we can't rely on the `site_visibility` parameter to know
-				// whether the site is deleted or not. We use the `site_owner` field
-				// to infer the `is_deleted` status.
-				sites = sites.filter( ( site ) => site.site_owner === undefined );
-
-				sites.forEach( ( site ) => {
-					site.is_deleted = true;
-				} );
-			}
-
+			const sites = data?.sites.map( computeFields( data?.sites ) ) || [];
 			return sitesFilterFn ? sites.filter( sitesFilterFn ) : sites;
 		},
 		initialData: () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -28,7 +28,10 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	const [ isUnAuthorized, setIsUnAuthorized ] = useState( false );
 	const urlQueryParams = useQuery();
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
-	const { data: sites } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
+	const { data: sites } = useSiteExcerptsQuery(
+		SITE_PICKER_FILTER_CONFIG,
+		( site ) => ! site.is_deleted
+	);
 	const { data: sourceSiteMigrationStatus, isError: isErrorSourceSiteMigrationStatus } =
 		useSourceMigrationStatusQuery( sourceSiteSlug );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -42,7 +42,7 @@ const SitePicker = function SitePicker( props: Props ) {
 	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
 		SITE_PICKER_FILTER_CONFIG,
-		( site ) => ! site.is_wpcom_staging_site
+		( site ) => ! site.is_wpcom_staging_site && ! site.is_deleted
 	);
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
@@ -56,6 +56,16 @@ describe( 'SitePicker', () => {
 						product_slug: 'free_plan',
 					},
 				},
+				3: {
+					// should not be shown
+					ID: 3,
+					name: 'A deleted site',
+					URL: 'deleted.wordpress.com',
+					is_deleted: true,
+					plan: {
+						product_slug: 'free_plan',
+					},
+				},
 			},
 			domains: {
 				items: {

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -83,18 +83,10 @@ const SitesDashboardV2 = ( {
 
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
 
-	const { data: liveSites = [], isLoading } = useSiteExcerptsQuery(
+	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
 		[],
 		( site ) => ! site.options?.is_domain_only
 	);
-
-	const { data: deletedSites = [] } = useSiteExcerptsQuery(
-		[],
-		( site ) => ! site.options?.is_domain_only,
-		'deleted'
-	);
-
-	const allSites = liveSites.concat( deletedSites );
 
 	useShowSiteCreationNotice( allSites, newSiteID );
 	useShowSiteTransferredNotice();

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -182,7 +182,7 @@ export function SitesDashboard( {
 		ref: 'topbar',
 	} );
 	const { __, _n } = useI18n();
-	const { data: liveSites = [], isLoading } = useSiteExcerptsQuery(
+	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
 		[],
 		( site ) => ! site.options?.is_domain_only
 	);
@@ -203,8 +203,6 @@ export function SitesDashboard( {
 	} );
 
 	const isMobile = useMobileBreakpoint();
-
-	const allSites = liveSites.concat( deletedSites );
 
 	useShowSiteCreationNotice( allSites, newSiteID );
 	useShowSiteTransferredNotice();

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -187,12 +187,6 @@ export function SitesDashboard( {
 		( site ) => ! site.options?.is_domain_only
 	);
 
-	const { data: deletedSites = [] } = useSiteExcerptsQuery(
-		[],
-		( site ) => ! site.options?.is_domain_only,
-		'deleted'
-	);
-
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const elementRef = useRef( window );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89997#issuecomment-2082053495

## Proposed Changes

* Don't do a separate query for deleted sites and merge them with active sites when the user requests "all". Instead, update the backend to return deleted sites with all sites (see D147075-code)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have some deleted sites that are visible on the trunk when filtering to the status "deleted". Note the slugs.  
* Apply D147075-code
* Apply patch https://github.com/Automattic/jetpack/pull/37142 to your sandbox
* Test this on Calypso Live or local branch
* You can find your deleted sites when filtering to "all" now because of D147075-code
* You can also filter to "deleted" and see only your deleted sites
* You should not see deleted sites on the `/setup/migrate-hosted-site` and `/setup/import-focused` flows. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?