### PR TITLE
A4A: Add the 'Create new site' button on the 'Need Setup' page.

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-create-wpcom-site.ts
+++ b/client/a8c-for-agencies/data/sites/use-create-wpcom-site.ts
@@ -1,0 +1,40 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export interface APIError {}
+
+export interface CreateSiteParams {
+	id: number;
+}
+
+interface APIResponse {
+	success: boolean;
+}
+
+function createWPCOMSiteMutation(
+	params: CreateSiteParams,
+	agencyId?: number
+): Promise< APIResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to assign a license' );
+	}
+
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/sites/${ params.id }/provision`,
+		body: params,
+	} );
+}
+
+export default function useCreateWPCOMSiteMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, CreateSiteParams, TContext >
+): UseMutationResult< APIResponse, APIError, CreateSiteParams, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIResponse, APIError, CreateSiteParams, TContext >( {
+		...options,
+		mutationFn: ( args ) => createWPCOMSiteMutation( args, agencyId ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/create-site-button.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/create-site-button.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@automattic/components';
+import { Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+type Props = {
+	provisioning?: boolean;
+	onActivate?: () => void;
+};
+
+export default function CreateSiteButton( { provisioning, onActivate }: Props ) {
+	const translate = useTranslate();
+
+	if ( provisioning ) {
+		return (
+			<div className="plan-field__loader">
+				<Spinner /> { translate( 'Creating site' ) }...
+			</div>
+		);
+	}
+
+	return (
+		<Button className="plan-field__button" onClick={ onActivate } plain>
+			{ translate( 'Create new site' ) }
+		</Button>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -23,10 +23,11 @@ export default function NeedSetup() {
 
 	const { mutate: createWPCOMSite, isPending: isCreatingSite } = useCreateWPCOMSiteMutation();
 
-	const availableSites = data.filter(
-		( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
-			features.wpcom_atomic.state === 'pending'
-	);
+	const availableSites =
+		data?.filter(
+			( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
+				features.wpcom_atomic.state === 'pending'
+		) ?? [];
 
 	const availablePlans: AvailablePlans[] = availableSites.length
 		? [
@@ -40,7 +41,7 @@ export default function NeedSetup() {
 
 	const isProvisioning =
 		isCreatingSite ||
-		data.find(
+		data?.find(
 			( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
 				features.wpcom_atomic.state === 'provisioning'
 		);

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -19,12 +19,12 @@ export default function NeedSetup() {
 
 	const title = translate( 'Sites' );
 
-	const { data, isFetching } = useFetchPendingSites();
+	const { data: pendingSites, isFetching, refetch: refetchPendingSites } = useFetchPendingSites();
 
 	const { mutate: createWPCOMSite, isPending: isCreatingSite } = useCreateWPCOMSiteMutation();
 
 	const availableSites =
-		data?.filter(
+		pendingSites?.filter(
 			( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
 				features.wpcom_atomic.state === 'pending'
 		) ?? [];
@@ -41,7 +41,7 @@ export default function NeedSetup() {
 
 	const isProvisioning =
 		isCreatingSite ||
-		data?.find(
+		pendingSites?.find(
 			( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
 				features.wpcom_atomic.state === 'provisioning'
 		);
@@ -53,11 +53,12 @@ export default function NeedSetup() {
 				{
 					onSuccess: () => {
 						// refetch pending sites
+						refetchPendingSites();
 					},
 				}
 			);
 		},
-		[ createWPCOMSite ]
+		[ createWPCOMSite, refetchPendingSites ]
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -8,6 +8,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import SitesHeaderActions from '../sites-header-actions';
 import { AvailablePlans } from './plan-field';
@@ -19,6 +20,8 @@ export default function NeedSetup() {
 	const title = translate( 'Sites' );
 
 	const { data, isFetching } = useFetchPendingSites();
+
+	const { mutate: createWPCOMSite, isPending: isCreatingSite } = useCreateWPCOMSiteMutation();
 
 	const availableSites = data.filter(
 		( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
@@ -35,14 +38,26 @@ export default function NeedSetup() {
 		  ]
 		: [];
 
-	const isProvisioning = data.find(
-		( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
-			features.wpcom_atomic.state === 'provisioning'
-	);
+	const isProvisioning =
+		isCreatingSite ||
+		data.find(
+			( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
+				features.wpcom_atomic.state === 'provisioning'
+		);
 
-	const onCreateSite = useCallback( () => {
-		// FIXME: Implement this
-	}, [] );
+	const onCreateSite = useCallback(
+		( id: number ) => {
+			createWPCOMSite(
+				{ id },
+				{
+					onSuccess: () => {
+						// refetch pending sites
+					},
+				}
+			);
+		},
+		[ createWPCOMSite ]
+	);
 
 	return (
 		<Layout className="sites-dashboard sites-dashboard__layout preview-hidden" wide title={ title }>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
@@ -9,6 +10,7 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import SitesHeaderActions from '../sites-header-actions';
+import { AvailablePlans } from './plan-field';
 import NeedSetupTable from './table';
 
 export default function NeedSetup() {
@@ -18,19 +20,29 @@ export default function NeedSetup() {
 
 	const { data, isFetching } = useFetchPendingSites();
 
-	const totalAvailableSites = data.filter(
+	const availableSites = data.filter(
 		( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
 			features.wpcom_atomic.state === 'pending'
-	).length;
+	);
 
-	const availablePlans = totalAvailableSites
+	const availablePlans: AvailablePlans[] = availableSites.length
 		? [
 				{
 					name: translate( 'WordPress.com Creator' ),
-					available: totalAvailableSites,
+					available: availableSites.length as number,
+					ids: availableSites.map( ( { id }: { id: number } ) => id ),
 				},
 		  ]
 		: [];
+
+	const isProvisioning = data.find(
+		( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
+			features.wpcom_atomic.state === 'provisioning'
+	);
+
+	const onCreateSite = useCallback( () => {
+		// FIXME: Implement this
+	}, [] );
 
 	return (
 		<Layout className="sites-dashboard sites-dashboard__layout preview-hidden" wide title={ title }>
@@ -45,7 +57,12 @@ export default function NeedSetup() {
 					</LayoutHeader>
 				</LayoutTop>
 
-				<NeedSetupTable availablePlans={ availablePlans } isLoading={ isFetching } />
+				<NeedSetupTable
+					availablePlans={ availablePlans }
+					isLoading={ isFetching }
+					provisioning={ isProvisioning }
+					onCreateSite={ onCreateSite }
+				/>
 			</LayoutColumn>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/plan-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/plan-field.tsx
@@ -1,12 +1,19 @@
 import { useTranslate } from 'i18n-calypso';
 import wpcomIcon from 'calypso/assets/images/icons/wordpress-logo.svg';
+import CreateSiteButton from './create-site-button';
 
 export type AvailablePlans = {
 	name: string;
 	available: number;
+	ids: number[];
 };
 
-export default function PlanField( { name, available }: AvailablePlans ) {
+type Props = AvailablePlans & {
+	provisioning?: boolean;
+	onCreateSite: ( id: number ) => void;
+};
+
+export default function PlanField( { name, available, ids, provisioning, onCreateSite }: Props ) {
 	const translate = useTranslate();
 
 	return (
@@ -27,6 +34,11 @@ export default function PlanField( { name, available }: AvailablePlans ) {
 					} ) }
 				</div>
 			</div>
+
+			<CreateSiteButton
+				provisioning={ provisioning }
+				onActivate={ () => onCreateSite( ids[ 0 ] ) }
+			/>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -2,6 +2,8 @@
 	display: flex;
 	flex-direction: row;
 	gap: 12px;
+
+	align-items: center;
 }
 
 .plan-field__icon {
@@ -32,3 +34,26 @@
 	font-weight: 400;
 	color: var(--color-neutral-50);
 }
+
+.plan-field__button {
+	padding: 8px 16px;
+	text-decoration: underline;
+	font-size: rem(13px);
+	font-weight: 400;
+	cursor: pointer;
+}
+
+.plan-field__loader {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+	align-items: center;
+	padding: 8px 16px;
+	font-size: rem(13px);
+	font-weight: 400;
+
+	.components-spinner {
+		margin: 0;
+	}
+}
+

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/table.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/table.tsx
@@ -11,9 +11,16 @@ import './style.scss';
 type Props = {
 	availablePlans: AvailablePlans[];
 	isLoading?: boolean;
+	provisioning?: boolean;
+	onCreateSite: ( id: number ) => void;
 };
 
-export default function NeedSetupTable( { availablePlans, isLoading }: Props ) {
+export default function NeedSetupTable( {
+	availablePlans,
+	isLoading,
+	provisioning,
+	onCreateSite,
+}: Props ) {
 	const translate = useTranslate();
 
 	const fields = [
@@ -30,7 +37,9 @@ export default function NeedSetupTable( { availablePlans, isLoading }: Props ) {
 					return <TextPlaceholder />;
 				}
 
-				return <PlanField { ...item } />;
+				return (
+					<PlanField { ...item } provisioning={ provisioning } onCreateSite={ onCreateSite } />
+				);
 			},
 			enableHiding: false,
 			enableSorting: false,


### PR DESCRIPTION
This implements the **'Create new site'** button in the Need Setup section.

<img width="318" alt="Screenshot 2024-04-30 at 11 13 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9641ba06-4bf3-488f-8fe7-5a4b2de1fe28">
<img width="288" alt="Screenshot 2024-04-30 at 11 14 08 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6ede7c0c-d2ad-4025-b125-51ff1796e9c2">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/377
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/378
Depends on https://github.com/Automattic/wp-calypso/pull/90093

## Proposed Changes

* Add Create WPCOM Site mutation.
* Update the Site table in the Need Setup section to render a 'Create new site' button.
* Add loading indicator when provisioning a site.

## Testing Instructions

* Before testing, make sure you purchase a WPCOM plan first in /marketplace/hosting/wpcom
* Use the A4A live link and go to `/sites/need-setup`.
* Confirm that you see the 'Create new site' button.
* Click the button and confirm a loading indicator shows up.

**Note that there is some performance issue with the provisioning endpoint that will be fixed. See Slack discussion for context:** 
p1714488150284989/1714417851.445469-slack-C06JY8QL0TU

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?