### PR TITLE
Hosting Overview: Fix `Need more storage` link

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -125,7 +125,7 @@ const PlanCard: FC = () => {
 						<Button
 							className="hosting-overview__link-button"
 							plain
-							href={ `/plans/${ site?.slug }` }
+							href={ `/add-ons/${ site?.slug }` }
 						>
 							{ translate( 'Need more storage?' ) }
 						</Button>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6869

## Proposed Changes

* Target `/add-ons/{site.slug}` instead of `/plans/{site.slug}`

## Testing Instructions

* Open the live preview
* Go to `/sites?flags=layout/dotcom-nav-redesign-v2`
* Click on a site to open the global site view
* On the Overview tab, click on `Need more storage?`

![Screenshot from 2024-04-30 17-49-35](https://github.com/Automattic/wp-calypso/assets/8511199/e5d2732a-0601-46a2-a8a6-2cb883275512)

* Check that the link takes you to `/add-ons/{site.slug}`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?