### PR TITLE
Segmentation Survey: Added padding to survey bottom

### DIFF
--- a/client/components/survey-container/components/style.scss
+++ b/client/components/survey-container/components/style.scss
@@ -48,6 +48,7 @@ $blueberry-focus-color: #abc0f5;
 		flex-direction: column;
 		align-items: start;
 		gap: 44px;
+		padding-bottom: 40px;
 	}
 
 	&__continue-button.components-button.is-primary {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/90116

## Proposed Changes

This PR adds a bit of padding to the bottom of the segmentation survey.

<img width="895" alt="Screenshot 2024-04-30 at 18 04 39" src="https://github.com/Automattic/wp-calypso/assets/3832570/a9ad7f04-9e58-43eb-bb31-9200172baa2c">


## Testing Instructions

- Apply this PR and start the application.
- Go to http://calypso.localhost:3000/setup/entrepreneur/start?flags=ecommerce-segmentation-survey
- Change the height of the browser so it's smaller than the height of the survey.
- Scroll to bottom.
- There should be some space between the button and the bottom of the viewport, as shown in the image above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?