### PR TITLE
Site Profiler: Add initial version of Basic metrics

### DIFF
--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -1,0 +1,8 @@
+export const BASIC_METRICS_UNITS: Record< string, string > = {
+	cls: '',
+	fid: 'ms',
+	lcp: 'ms',
+	fcp: 'ms',
+	ttfb: 'ms',
+	inp: 'ms',
+};

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -81,3 +81,12 @@ export interface HostingProviderQueryResponse {
 	domain: string;
 	hosting_provider: HostingProvider;
 }
+
+export interface UrlBasicMetricsQueryResponse {
+	cls: number;
+	fid: number;
+	lcp: number;
+	fcp: number;
+	ttfb: number;
+	inp: number;
+}

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -82,11 +82,15 @@ export interface HostingProviderQueryResponse {
 	hosting_provider: HostingProvider;
 }
 
-export interface UrlBasicMetricsQueryResponse {
+export type BasicMetrics = {
 	cls: number;
 	fid: number;
 	lcp: number;
 	fcp: number;
 	ttfb: number;
 	inp: number;
+};
+export interface UrlBasicMetricsQueryResponse {
+	basic: BasicMetrics;
+	advanced: Record< string, string >;
 }

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { UrlBasicMetricsQueryResponse } from 'calypso/data/site-profiler/types';
+import wp from 'calypso/lib/wp';
+
+export const useUrlBasicMetricsQuery = ( url: string | null ) => {
+	return useQuery( {
+		queryKey: [ 'url-', url ],
+		queryFn: (): Promise< UrlBasicMetricsQueryResponse > =>
+			wp.req.get( {
+				path: '/site-profiler/metrics/basic?url=' + encodeURIComponent( url ?? '' ),
+				apiNamespace: 'wpcom/v2',
+			} ),
+		meta: {
+			persist: false,
+		},
+		enabled: !! url,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};

--- a/client/lib/importer/url-validation.js
+++ b/client/lib/importer/url-validation.js
@@ -8,7 +8,7 @@ export const parseUrl = function ( value = '' ) {
 	return new URL( hasProtocol ? rawUrl : 'https://' + rawUrl );
 };
 
-const hasTld = function ( hostname ) {
+export const hasTld = function ( hostname ) {
 	// Min length of hostname with TLD is 4 characters, e.g. "a.co".
 	const lastDotIndex = hostname.lastIndexOf( '.' );
 	return hostname.length > 3 && lastDotIndex >= 1 && lastDotIndex < hostname.length - 2;

--- a/client/site-profiler/components/basic-metrics.tsx
+++ b/client/site-profiler/components/basic-metrics.tsx
@@ -1,10 +1,11 @@
 import { translate } from 'i18n-calypso';
+import { BASIC_METRICS_UNITS } from 'calypso/data/site-profiler/metrics-dictionaries';
 import type { BasicMetrics } from 'calypso/data/site-profiler/types';
 
 export function BasicMetrics( { basicMetrics }: { basicMetrics: BasicMetrics } ) {
 	return (
 		<div className="basic-metrics">
-			<h3>{ translate( 'Basic Metrics' ) }</h3>
+			<h3>{ translate( 'Basic Performance Metrics' ) }</h3>
 			<ul className="basic-metric-details result-list">
 				{ Object.entries( basicMetrics ).map( ( [ key, value ] ) => {
 					return (
@@ -12,7 +13,9 @@ export function BasicMetrics( { basicMetrics }: { basicMetrics: BasicMetrics } )
 							<div className="name">
 								<a href={ `https://web.dev/articles/${ key }` }>{ key }</a>
 							</div>
-							<div>{ value }</div>
+							<div>
+								{ value } { BASIC_METRICS_UNITS[ key ] }
+							</div>
 						</li>
 					);
 				} ) }

--- a/client/site-profiler/components/basic-metrics.tsx
+++ b/client/site-profiler/components/basic-metrics.tsx
@@ -9,7 +9,7 @@ export function BasicMetrics( { basicMetrics }: { basicMetrics: BasicMetrics } )
 			<ul className="basic-metric-details result-list">
 				{ Object.entries( basicMetrics ).map( ( [ key, value ] ) => {
 					return (
-						<li>
+						<li key={ key }>
 							<div className="name">
 								<a href={ `https://web.dev/articles/${ key }` }>{ key }</a>
 							</div>

--- a/client/site-profiler/components/basic-metrics.tsx
+++ b/client/site-profiler/components/basic-metrics.tsx
@@ -1,7 +1,7 @@
 import { translate } from 'i18n-calypso';
-import type { UrlBasicMetricsQueryResponse } from 'calypso/data/site-profiler/types';
+import type { BasicMetrics } from 'calypso/data/site-profiler/types';
 
-export function BasicMetrics( { basicMetrics }: { basicMetrics: UrlBasicMetricsQueryResponse } ) {
+export function BasicMetrics( { basicMetrics }: { basicMetrics: BasicMetrics } ) {
 	return (
 		<div className="basic-metrics">
 			<h3>{ translate( 'Basic Metrics' ) }</h3>

--- a/client/site-profiler/components/basic-metrics.tsx
+++ b/client/site-profiler/components/basic-metrics.tsx
@@ -1,0 +1,22 @@
+import { translate } from 'i18n-calypso';
+import type { UrlBasicMetricsQueryResponse } from 'calypso/data/site-profiler/types';
+
+export function BasicMetrics( { basicMetrics }: { basicMetrics: UrlBasicMetricsQueryResponse } ) {
+	return (
+		<div className="basic-metrics">
+			<h3>{ translate( 'Basic Metrics' ) }</h3>
+			<ul className="basic-metric-details result-list">
+				{ Object.entries( basicMetrics ).map( ( [ key, value ] ) => {
+					return (
+						<li>
+							<div className="name">
+								<a href={ `https://web.dev/articles/${ key }` }>{ key }</a>
+							</div>
+							<div>{ value }</div>
+						</li>
+					);
+				} ) }
+			</ul>
+		</div>
+	);
+}

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -74,7 +75,11 @@ export default function SiteProfiler( props: Props ) {
 		isFetching: isFetchingBasicMetrics,
 	} = useUrlBasicMetricsQuery( url );
 
-	const showBasicMetrics = basicMetrics && ! isFetchingBasicMetrics && ! errorBasicMetrics;
+	const showBasicMetrics =
+		basicMetrics &&
+		! isFetchingBasicMetrics &&
+		! errorBasicMetrics &&
+		isEnabled( 'site-profiler/metrics' );
 
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
@@ -21,6 +22,8 @@ import HeadingInformation from './heading-information';
 import HostingInformation from './hosting-information';
 import HostingIntro from './hosting-intro';
 import './styles.scss';
+
+const debug = debugFactory( 'apps:site-profiler' );
 
 interface Props {
 	routerDomain?: string;
@@ -77,10 +80,17 @@ export default function SiteProfiler( props: Props ) {
 
 	const showBasicMetrics =
 		basicMetrics &&
-		basicMetrics.basic &&
 		! isFetchingBasicMetrics &&
 		! errorBasicMetrics &&
 		isEnabled( 'site-profiler/metrics' );
+
+	// TODO: Remove this debug statement once we have a better error handling mechanism
+	if ( errorBasicMetrics ) {
+		debug(
+			`Error fetching basic metrics for domain ${ domain }: ${ errorBasicMetrics.message }`,
+			errorBasicMetrics
+		);
+	}
 
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -77,6 +77,7 @@ export default function SiteProfiler( props: Props ) {
 
 	const showBasicMetrics =
 		basicMetrics &&
+		basicMetrics.basic &&
 		! isFetchingBasicMetrics &&
 		! errorBasicMetrics &&
 		isEnabled( 'site-profiler/metrics' );
@@ -140,7 +141,7 @@ export default function SiteProfiler( props: Props ) {
 					) }
 					{ showBasicMetrics && (
 						<LayoutBlockSection>
-							<BasicMetrics basicMetrics={ basicMetrics } />
+							<BasicMetrics basicMetrics={ basicMetrics.basic } />
 						</LayoutBlockSection>
 					) }
 				</LayoutBlock>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -85,7 +85,7 @@ export default function SiteProfiler( props: Props ) {
 		isEnabled( 'site-profiler/metrics' );
 
 	// TODO: Remove this debug statement once we have a better error handling mechanism
-	if ( errorBasicMetrics ) {
+	if ( isEnabled( 'site-profiler/metrics' ) && errorBasicMetrics ) {
 		debug(
 			`Error fetching basic metrics for domain ${ domain }: ${ errorBasicMetrics.message }`,
 			errorBasicMetrics

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -13,6 +13,7 @@ import useScrollToTop from '../hooks/use-scroll-to-top';
 import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
 import { getValidUrl } from '../utils/get-valid-url';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
+import { BasicMetrics } from './basic-metrics';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
 import HeadingInformation from './heading-information';
@@ -134,21 +135,7 @@ export default function SiteProfiler( props: Props ) {
 					) }
 					{ showBasicMetrics && (
 						<LayoutBlockSection>
-							<div className="basic-metrics">
-								<h3>{ translate( 'Basic Metrics' ) }</h3>
-								<ul className="basic-metric-details result-list">
-									{ Object.entries( basicMetrics ).map( ( [ key, value ] ) => {
-										return (
-											<li>
-												<div className="name">
-													<a href={ `https://web.dev/articles/${ key }` }>{ key }</a>
-												</div>
-												<div>{ value }</div>
-											</li>
-										);
-									} ) }
-								</ul>
-							</div>
+							<BasicMetrics basicMetrics={ basicMetrics } />
 						</LayoutBlockSection>
 					) }
 				</LayoutBlock>

--- a/client/site-profiler/utils/get-valid-url.ts
+++ b/client/site-profiler/utils/get-valid-url.ts
@@ -1,0 +1,17 @@
+import { parseUrl, hasTld } from 'calypso/lib/importer/url-validation';
+
+export function getValidUrl( url?: string ) {
+	let parsedUrl;
+	try {
+		parsedUrl = parseUrl( url );
+	} catch ( error ) {
+		return null;
+	}
+
+	// `isURL` considers `http://a` valid, so check for a top level domain name as well.
+	if ( ! parsedUrl || ! hasTld( parsedUrl.hostname ) ) {
+		return null;
+	}
+
+	return parsedUrl.toString();
+}

--- a/config/development.json
+++ b/config/development.json
@@ -201,6 +201,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler": true,
+		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": false,
 		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -129,6 +129,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler": true,
+		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
 		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,

--- a/config/production.json
+++ b/config/production.json
@@ -168,6 +168,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler": true,
+		"site-profiler/metrics": false,
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -164,6 +164,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler": true,
+		"site-profiler/metrics": false,
 		"ssr/prefetch-timebox": true,
 		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,6 +163,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler": true,
+		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
 		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6674

## Proposed Changes

* Add the initial version of the Basic Performance Metrics
* Calls the new `site-profiler/metrics/basic` endpoint and populate the data
* Adds the feature flag `site-profiler/metrics` that will be enabled in `dev`, `wpcalypso` and `horizon`
* Adds a dictionary with the units of the metrics
* Adds a `debug` statement to notify about errors, to enable it run `localStorage.debug = 'apps:site-profiler'` in the developer console

![CleanShot 2024-05-03 at 16 44 49@2x](https://github.com/Automattic/wp-calypso/assets/3519124/5e9eb6f8-5e48-4ce3-8cb8-2ad8338cdde7)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch to your environment and run Calypso locally
* Navigate to the `/site-profiler` URL and enter a site, e.g. `example.com`
* Check that the `Basic Performance Metrics` section is displayed with data about the [Crux API metrics](https://developer.chrome.com/docs/crux/api#metric_value_types)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?