### PR TITLE
Calypso notifications - ensure 'n' closes the panel.

### DIFF
--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
@@ -54,7 +55,7 @@ class SidebarNotifications extends Component {
 		}
 	}
 
-	checkToggleNotes = ( event, forceToggle ) => {
+	checkToggleNotes = debounce( ( event, forceToggle ) => {
 		const target = event ? event.target : false;
 
 		// Ignore clicks or other events which occur inside of the notification panel.
@@ -69,7 +70,7 @@ class SidebarNotifications extends Component {
 		if ( this.props.isNotificationsOpen || forceToggle === true ) {
 			this.toggleNotesFrame( event );
 		}
-	};
+	}, 100 );
 
 	toggleNotesFrame = ( event ) => {
 		if ( event ) {

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -55,6 +55,8 @@ class SidebarNotifications extends Component {
 		}
 	}
 
+	// This toggle gets called both on the calypso and panel sides.
+	// Throttle it to prevent calls on both sides from conflicting and cancelling each other out.
 	checkToggleNotes = throttle(
 		( event, forceToggle ) => {
 			const target = event ? event.target : false;

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { debounce } from 'lodash';
+import { throttle } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
@@ -55,22 +55,26 @@ class SidebarNotifications extends Component {
 		}
 	}
 
-	checkToggleNotes = debounce( ( event, forceToggle ) => {
-		const target = event ? event.target : false;
+	checkToggleNotes = throttle(
+		( event, forceToggle ) => {
+			const target = event ? event.target : false;
 
-		// Ignore clicks or other events which occur inside of the notification panel.
-		if (
-			target &&
-			( this.notificationLink.current.contains( target ) ||
-				this.notificationPanel.current.contains( target ) )
-		) {
-			return;
-		}
+			// Ignore clicks or other events which occur inside of the notification panel.
+			if (
+				target &&
+				( this.notificationLink.current.contains( target ) ||
+					this.notificationPanel.current.contains( target ) )
+			) {
+				return;
+			}
 
-		if ( this.props.isNotificationsOpen || forceToggle === true ) {
-			this.toggleNotesFrame( event );
-		}
-	}, 100 );
+			if ( this.props.isNotificationsOpen || forceToggle === true ) {
+				this.toggleNotesFrame( event );
+			}
+		},
+		100,
+		{ leading: true, trailing: false }
+	);
 
 	toggleNotesFrame = ( event ) => {
 		if ( event ) {

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -55,10 +55,10 @@ class SidebarNotifications extends Component {
 		}
 	}
 
-	// This toggle gets called both on the calypso and panel sides.
-	// Throttle it to prevent calls on both sides from conflicting and cancelling each other out.
+	// This toggle gets called both on the calypso and panel sides. Throttle it to prevent calls on
+	// both sides from conflicting and cancelling each other out.
 	checkToggleNotes = throttle(
-		( event, forceToggle ) => {
+		( event, forceToggle, forceOpen = false ) => {
 			const target = event ? event.target : false;
 
 			// Ignore clicks or other events which occur inside of the notification panel.
@@ -70,7 +70,12 @@ class SidebarNotifications extends Component {
 				return;
 			}
 
-			if ( this.props.isNotificationsOpen || forceToggle === true ) {
+			// Prevent toggling closed if we are opting to open.
+			if ( forceOpen && this.props.isNotificationsOpen ) {
+				return;
+			}
+
+			if ( this.props.isNotificationsOpen || forceToggle === true || forceOpen === true ) {
 				this.toggleNotesFrame( event );
 			}
 		},

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
@@ -48,7 +49,7 @@ class MasterbarItemNotifications extends Component {
 		}
 	}
 
-	checkToggleNotes = ( event, forceToggle ) => {
+	checkToggleNotes = debounce( ( event, forceToggle ) => {
 		const target = event ? event.target : false;
 
 		// Ignore clicks or other events which occur inside of the notification panel.
@@ -63,7 +64,7 @@ class MasterbarItemNotifications extends Component {
 		if ( this.props.isNotificationsOpen || forceToggle === true ) {
 			this.toggleNotesFrame( event );
 		}
-	};
+	}, 100 );
 
 	toggleNotesFrame = ( event ) => {
 		if ( event ) {

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -52,7 +52,7 @@ class MasterbarItemNotifications extends Component {
 	// This toggle gets called both on the calypso and panel sides. Throttle it to prevent calls on
 	// both sides from conflicting and cancelling each other out.
 	checkToggleNotes = throttle(
-		( event, forceToggle ) => {
+		( event, forceToggle, forceOpen = false ) => {
 			const target = event ? event.target : false;
 
 			// Ignore clicks or other events which occur inside of the notification panel.
@@ -64,7 +64,12 @@ class MasterbarItemNotifications extends Component {
 				return;
 			}
 
-			if ( this.props.isNotificationsOpen || forceToggle === true ) {
+			// Prevent toggling closed if we are opting to open.
+			if ( forceOpen && this.props.isNotificationsOpen ) {
+				return;
+			}
+
+			if ( this.props.isNotificationsOpen || forceToggle === true || forceOpen === true ) {
 				this.toggleNotesFrame( event );
 			}
 		},

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -49,6 +49,8 @@ class MasterbarItemNotifications extends Component {
 		}
 	}
 
+	// This toggle gets called both on the calypso and panel sides. Throttle it to prevent calls on
+	// both sides from conflicting and cancelling each other out.
 	checkToggleNotes = throttle(
 		( event, forceToggle ) => {
 			const target = event ? event.target : false;

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { debounce } from 'lodash';
+import { throttle } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
@@ -49,22 +49,26 @@ class MasterbarItemNotifications extends Component {
 		}
 	}
 
-	checkToggleNotes = debounce( ( event, forceToggle ) => {
-		const target = event ? event.target : false;
+	checkToggleNotes = throttle(
+		( event, forceToggle ) => {
+			const target = event ? event.target : false;
 
-		// Ignore clicks or other events which occur inside of the notification panel.
-		if (
-			target &&
-			( this.notificationLink.current.contains( target ) ||
-				this.notificationPanel.current.contains( target ) )
-		) {
-			return;
-		}
+			// Ignore clicks or other events which occur inside of the notification panel.
+			if (
+				target &&
+				( this.notificationLink.current.contains( target ) ||
+					this.notificationPanel.current.contains( target ) )
+			) {
+				return;
+			}
 
-		if ( this.props.isNotificationsOpen || forceToggle === true ) {
-			this.toggleNotesFrame( event );
-		}
-	}, 100 );
+			if ( this.props.isNotificationsOpen || forceToggle === true ) {
+				this.toggleNotesFrame( event );
+			}
+		},
+		100,
+		{ leading: true, trailing: false }
+	);
 
 	toggleNotesFrame = ( event ) => {
 		if ( event ) {

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -138,10 +138,8 @@ export class Notifications extends Component {
 
 		switch ( event.data.action ) {
 			case 'openPanel':
-				// checktoggle closes panel with no parameters
-				this.props.checkToggle();
-				// ... and toggles when the 2nd parameter is true
-				this.props.checkToggle( null, true );
+				// Ensure panel is opened.
+				this.props.checkToggle( null, true, true );
 				return refreshNotes();
 
 			case 'trackClick':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/6837 

## Proposed Changes

* Throttles the toggle callbacks we use in notifications in calypso, that also get sent through to the notifications panel used. This prevents the toggle function from being called twice with the 'n' key preventing it from closing when expected.
* Updates our service worker message handler to not have to call the toggle back to back to ensure it is open. Instead now calls the toggle once with a `forceOpen` optional param.

Notes
* The calypso control of the notifications panel sets a keybinding to the 'n' key to toggle the panel open/closed.
* The notification panel component/app itself registers the 'n' key as a means to close the panel.
* When the panel is open and a user presses the 'n' key in calypso, this event is first picked up and fired by the panel (closing it) and then fired by the calypso handler (instantly reopening it).
* An alternative approach could be to use `event.stopImmediatePropagation` [from within the notes app here](https://github.com/Automattic/wp-calypso/blob/f12888618597132215700bf0afa51d082ae4245c/apps/notifications/src/panel/templates/index.jsx#L318). But i believe that may have more potential for external conflicts in the standalone implementation used outside calypso.
* One thought was to limit the toggle used on the calypso side to only fire when the panel is closed. However due to the nature of the dual event bindings and connected state it has no effect. (By the time the binding on the calypso side fires, the panel is already technically closed and state reads it as such).
* I think it makes the most sense to throttle our toggle functions in the calypso control side on 100ms, since these are also the same functions passed into the panel component to be fired on close. This will prevent our toggle function from firing twice at the same time and should allow them to work as expected in this context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build.
* Test opening and closing the notifications panel using the 'n' key. 
* Verify it opens and closes as expected on 'n' press throughout calypso (both where the global sidebar is present, and where the calypso masterbar is present.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
