### PR TITLE
Refactor: Extract getStartUrl hook from site migration

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -1,9 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
-import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -11,9 +9,9 @@ import { addQueryArgs } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import { useSiteData } from '../hooks/use-site-data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { useStartUrl } from '../hooks/use-start-url';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
 import { goToCheckout } from '../utils/checkout';
-import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
@@ -48,68 +46,17 @@ const siteMigration: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
+		const startUrl = useStartUrl( FLOW_NAME );
 
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 		const { isOwner } = useIsSiteOwner();
 
-		const flowName = this.name;
-
-		// There is a race condition where useLocale is reporting english,
-		// despite there being a locale in the URL so we need to look it up manually.
-		// We also need to support both query param and path suffix localized urls
-		// depending on where the user is coming from.
-		const useLocaleSlug = useLocale();
-		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
-		const queryLocaleSlug = getLocaleFromQueryParam();
-		const pathLocaleSlug = getLocaleFromPathname();
-		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
-
-		const queryParams = new URLSearchParams( window.location.search );
-		const aff = queryParams.get( 'aff' );
-		const vendorId = queryParams.get( 'vid' );
-
-		const getStartUrl = () => {
-			let hasFlowParams = false;
-			const flowParams = new URLSearchParams();
-			const queryParams = new URLSearchParams();
-
-			if ( vendorId ) {
-				queryParams.set( 'vid', vendorId );
-			}
-
-			if ( aff ) {
-				queryParams.set( 'aff', aff );
-			}
-
-			if ( locale && locale !== 'en' ) {
-				flowParams.set( 'locale', locale );
-				hasFlowParams = true;
-			}
-
-			const redirectTarget =
-				`/setup/${ FLOW_NAME }` +
-				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
-
-			let queryString = `redirect_to=${ redirectTarget }`;
-
-			if ( queryParams.toString() ) {
-				queryString = `${ queryString }&${ queryParams.toString() }`;
-			}
-
-			const logInUrl = getLoginUrl( {
-				variationName: flowName,
-				locale,
-			} );
-
-			return `${ logInUrl }&${ queryString }`;
-		};
-
 		useEffect( () => {
 			if ( ! userIsLoggedIn ) {
-				const logInUrl = getStartUrl();
+				const logInUrl = startUrl;
 				window.location.assign( logInUrl );
 			}
-		}, [] );
+		}, [ startUrl, userIsLoggedIn ] );
 
 		useEffect( () => {
 			if ( isOwner === false ) {

--- a/client/landing/stepper/hooks/test/use-start-url.tsx
+++ b/client/landing/stepper/hooks/test/use-start-url.tsx
@@ -10,7 +10,7 @@ jest.mock( 'calypso/boot/locale', () => ( {
 } ) );
 
 jest.mock( '../../utils/path', () => ( {
-	getLoginUrl: jest.fn().mockReturnValue( '/start/account?variationName=site-migration' ),
+	useLoginUrl: jest.fn().mockReturnValue( '/start/account?variationName=test-flow' ),
 } ) );
 
 describe( 'useStartUrl', () => {
@@ -30,7 +30,7 @@ describe( 'useStartUrl', () => {
 		const { result } = renderHook( () => useStartUrl( 'test-flow' ) );
 
 		expect( result.current ).toBe(
-			'/start/account?variationName=site-migration&redirect_to=/setup/test-flow%3Flocale%3Dfr&vid=456&aff=123'
+			'/start/account?variationName=test-flow&redirect_to=/setup/test-flow%3Flocale%3Dfr&vid=456&aff=123'
 		);
 	} );
 

--- a/client/landing/stepper/hooks/test/use-start-url.tsx
+++ b/client/landing/stepper/hooks/test/use-start-url.tsx
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useStartUrl } from '../use-start-url';
+
+jest.mock( 'calypso/boot/locale', () => ( {
+	getLocaleFromQueryParam: jest.fn().mockReturnValue( 'fr' ),
+	getLocaleFromPathname: jest.fn().mockReturnValue( 'fr' ),
+} ) );
+
+jest.mock( '../../utils/path', () => ( {
+	getLoginUrl: jest.fn().mockReturnValue( 'https://example.com/login' ),
+} ) );
+
+describe( 'useStartUrl', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: {
+				search: '?aff=123&vid=456',
+				replace: jest.fn(), // Ensure this is mocked if used in your code
+				href: '',
+			},
+			writable: true, // Allow this definition to be writable if needed later
+		} );
+	} );
+
+	it( 'should generate the correct start URL', () => {
+		// Use the hook and assert results
+		const { result } = renderHook( () => useStartUrl( 'test-flow' ) );
+
+		expect( result.current ).toBe(
+			'https://example.com/login&redirect_to=/setup/test-flow%3Flocale%3Dfr&vid=456&aff=123'
+		);
+	} );
+
+	afterAll( () => {
+		// Restore the original window.location object after all tests are done
+		jest.restoreAllMocks();
+	} );
+} );

--- a/client/landing/stepper/hooks/test/use-start-url.tsx
+++ b/client/landing/stepper/hooks/test/use-start-url.tsx
@@ -10,7 +10,7 @@ jest.mock( 'calypso/boot/locale', () => ( {
 } ) );
 
 jest.mock( '../../utils/path', () => ( {
-	getLoginUrl: jest.fn().mockReturnValue( 'https://example.com/login' ),
+	getLoginUrl: jest.fn().mockReturnValue( '/start/account?variationName=site-migration' ),
 } ) );
 
 describe( 'useStartUrl', () => {
@@ -30,7 +30,7 @@ describe( 'useStartUrl', () => {
 		const { result } = renderHook( () => useStartUrl( 'test-flow' ) );
 
 		expect( result.current ).toBe(
-			'https://example.com/login&redirect_to=/setup/test-flow%3Flocale%3Dfr&vid=456&aff=123'
+			'/start/account?variationName=site-migration&redirect_to=/setup/test-flow%3Flocale%3Dfr&vid=456&aff=123'
 		);
 	} );
 

--- a/client/landing/stepper/hooks/use-start-url.ts
+++ b/client/landing/stepper/hooks/use-start-url.ts
@@ -1,0 +1,49 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { getLocaleFromPathname, getLocaleFromQueryParam } from 'calypso/boot/locale';
+import { getLoginUrl } from '../utils/path';
+
+export const useStartUrl = ( flowName: string ) => {
+	const useLocaleSlug = useLocale();
+	// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+	const queryLocaleSlug = getLocaleFromQueryParam();
+	const pathLocaleSlug = getLocaleFromPathname();
+	const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
+	const currentQueryParams = new URLSearchParams( window.location.search );
+	const aff = currentQueryParams.get( 'aff' );
+	const vendorId = currentQueryParams.get( 'vid' );
+
+	let hasFlowParams = false;
+	const flowParams = new URLSearchParams();
+	const queryParams = new URLSearchParams();
+
+	if ( vendorId ) {
+		queryParams.set( 'vid', vendorId );
+	}
+
+	if ( aff ) {
+		queryParams.set( 'aff', aff );
+	}
+
+	if ( locale && locale !== 'en' ) {
+		flowParams.set( 'locale', locale );
+		hasFlowParams = true;
+	}
+
+	const redirectTarget =
+		`/setup/${ flowName }` +
+		( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+
+	let queryString = `redirect_to=${ redirectTarget }`;
+
+	if ( queryParams.toString() ) {
+		queryString = `${ queryString }&${ queryParams.toString() }`;
+	}
+
+	const logInUrl = getLoginUrl( {
+		variationName: flowName,
+		locale,
+	} );
+
+	return `${ logInUrl }&${ queryString }`;
+};

--- a/client/landing/stepper/hooks/use-start-url.ts
+++ b/client/landing/stepper/hooks/use-start-url.ts
@@ -1,13 +1,8 @@
-import { useLocale } from '@automattic/i18n-utils';
-import { getLocaleFromPathname, getLocaleFromQueryParam } from 'calypso/boot/locale';
-import { getLoginUrl } from '../utils/path';
+import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
+import { useLoginUrl } from '../utils/path';
 
 export const useStartUrl = ( flowName: string ) => {
-	const useLocaleSlug = useLocale();
-	// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
-	const queryLocaleSlug = getLocaleFromQueryParam();
-	const pathLocaleSlug = getLocaleFromPathname();
-	const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+	const locale = useFlowLocale();
 
 	const currentQueryParams = new URLSearchParams( window.location.search );
 	const aff = currentQueryParams.get( 'aff' );
@@ -40,9 +35,8 @@ export const useStartUrl = ( flowName: string ) => {
 		queryString = `${ queryString }&${ queryParams.toString() }`;
 	}
 
-	const logInUrl = getLoginUrl( {
+	const logInUrl = useLoginUrl( {
 		variationName: flowName,
-		locale,
 	} );
 
 	return `${ logInUrl }&${ queryString }`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

As I was making experimentation for the site-hosted-migration flow I found this getStartUrl method in the way. It was making the code harder to read.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go through the site-migration flow exercising this hook. To do this go to `/setup/site-migration` while logged out and see that you are redirected. 

Also check the test passes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?