### PR TITLE
Jetpack: Backup: record upsell click event to LogRocket

### DIFF
--- a/client/my-sites/backup/backup-upsell/index.tsx
+++ b/client/my-sites/backup/backup-upsell/index.tsx
@@ -16,6 +16,7 @@ import UpsellProductCard from 'calypso/components/jetpack/upsell-product-card';
 import { UpsellComponentProps } from 'calypso/components/jetpack/upsell-switch';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import { recordLogRocketEvent } from 'calypso/lib/analytics/logrocket';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -69,10 +70,10 @@ const BackupsUpsellBody: FunctionComponent = () => {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const dispatch = useDispatch();
 
-	const onClick = useCallback(
-		() => dispatch( recordTracksEvent( 'calypso_jetpack_backup_upsell_click' ) ),
-		[ dispatch ]
-	);
+	const onClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_upsell_click' ) );
+		recordLogRocketEvent( 'calypso_jetpack_backup_upsell_click' );
+	}, [ dispatch ] );
 
 	return (
 		<>


### PR DESCRIPTION
## Proposed Changes

* Record `calypso_jetpack_backup_upsell_click` event to LogRocket for trial purpose

## Testing Instructions
* Spin up a Jetpack Cloud Live branch and append `?flags=ad-tracking,logrocket` to the URL to enable the feature flags.
* Enable debug logs using the developer console:
  `localStorage.setItem( 'debug', 'calypso:*' );`
* Filter console and network tabs by `logrocket`
* Navigate to the `Backup` with a site with no backup plan and you should see the upsell view to add backups
* Click on `Add Jetpack VaultPress Backup`
  ![CleanShot 2024-04-30 at 18 09 20@2x](https://github.com/Automattic/wp-calypso/assets/1488641/9be29c74-f497-4d36-8a95-093561da79b4)
* You should see a log like this:
   ![CleanShot 2024-04-30 at 18 10 35@2x](https://github.com/Automattic/wp-calypso/assets/1488641/eb8ccc9f-4f19-410f-aa44-1e07fe2fffbc)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?