### PR TITLE
Nav Redesign: Hide Remove filters on non-large screens

### DIFF
--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -141,6 +141,9 @@
 		.components-button.is-compact.has-icon:not(.has-text).dataviews-filters-button {
 			min-width: 40px;
 		}
+		.components-button.is-compact.is-tertiary:not(.dataviews-filters-button) {
+			display: none;
+		}
 
 		.components-button.is-compact.is-tertiary {
 			margin-right: 8px;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6880

## Proposed Changes

Hide `Remove filters` on non-large screens to avoid unaligned icons.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/a75f8325-7da4-44e5-8403-c6a9921a1d25) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/ec5c84e9-b879-47c8-b448-a3545017080e) |


## Testing Instructions

* Go to `/sites` with a small screen
* Icons should looks aligned