### PR TITLE
A4A: add wpcom hosting bulk selector

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -13,6 +13,7 @@ html,
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
 	overflow: hidden;
 	height: calc(100vh - 32px);
+	padding-block-end: 0;
 
 	header.current-section {
 		margin: 0;

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -21,8 +21,8 @@ const useSitesMenuItems = ( path: string ) => {
 	const { data } = useFetchPendingSites();
 	const totalAvailableSites =
 		data?.filter(
-			( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
-				features.wpcom_atomic.state === 'pending'
+			( { features }: { features: { wpcom_atomic: { state: string; license_key: string } } } ) =>
+				features.wpcom_atomic.state === 'pending' && !! features.wpcom_atomic.license_key
 		).length || 0;
 	const shouldAddNeedsSetup = isWPCOMPurchaseOptionEnabled && totalAvailableSites > 0;
 

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -1,11 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
+import { Option } from 'calypso/a8c-for-agencies/components/slider';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamily } from 'calypso/state/partner-portal/types';
 import wpcomBulkOptions from './lib/wpcom-bulk-options';
+import A4AWPCOMSlider from './wpcom-slider';
 
 type TierProps = Option & {
 	discount: number;
@@ -31,13 +32,13 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier }: Props
 	const options = wpcomBulkOptions( wpcomProducts?.discounts?.tiers );
 
 	const onSelectOption = useCallback(
-		( option: Option ) => {
+		( option: number ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_marketplace_hosting_wpcom_select_count', {
-					count: option.value,
+					count: option,
 				} )
 			);
-			const foundTier = options.find( ( { value } ) => value === option.value );
+			const foundTier = options.find( ( { value } ) => value === option );
 			if ( foundTier ) {
 				onSelectTier( foundTier );
 			}
@@ -51,7 +52,7 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier }: Props
 
 	return (
 		<div className="bulk-selection">
-			<A4ASlider
+			<A4AWPCOMSlider
 				label={ translate( 'Total sites' ) }
 				sub={ translate( 'Total discount' ) }
 				value={ selectedOption }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -1,3 +1,4 @@
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { Option } from 'calypso/a8c-for-agencies/components/slider';
@@ -15,6 +16,7 @@ type TierProps = Option & {
 type Props = {
 	selectedTier: TierProps;
 	onSelectTier: ( value: TierProps ) => void;
+	ownedPlans: number;
 };
 
 const calculateTier = ( options: TierProps[], value: number ) => {
@@ -34,7 +36,7 @@ const calculateTier = ( options: TierProps[], value: number ) => {
 	};
 };
 
-export default function WPCOMBulkSelector( { selectedTier, onSelectTier }: Props ) {
+export default function WPCOMBulkSelector( { selectedTier, onSelectTier, ownedPlans }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -67,6 +69,29 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier }: Props
 
 	return (
 		<div className="bulk-selection">
+			{ ownedPlans && (
+				<div className="bulk-selection__owned-plan">
+					<Icon icon={ info } size={ 24 } />
+
+					<span>
+						{ translate(
+							'You own {{b}}%(count)s Creator plan{{/b}}',
+							'You own {{b}}%(count)s Creator plans{{/b}}',
+							{
+								args: {
+									count: ownedPlans,
+								},
+								components: {
+									b: <strong />,
+								},
+								count: ownedPlans,
+								comment: '%(count)s is the number of Creator plans owned by the user',
+							}
+						) }
+					</span>
+				</div>
+			) }
+
 			<A4AWPCOMSlider
 				label={ translate( 'Total sites' ) }
 				sub={ translate( 'Total discount' ) }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -17,6 +17,23 @@ type Props = {
 	onSelectTier: ( value: TierProps ) => void;
 };
 
+const calculateTier = ( options: TierProps[], value: number ) => {
+	let tier = options[ 0 ];
+
+	for ( const option of options ) {
+		if ( Number( option.value ) > value ) {
+			break;
+		}
+
+		tier = option;
+	}
+
+	return {
+		...tier,
+		value,
+	};
+};
+
 export default function WPCOMBulkSelector( { selectedTier, onSelectTier }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -38,10 +55,8 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier }: Props
 					count: option,
 				} )
 			);
-			const foundTier = options.find( ( { value } ) => value === option );
-			if ( foundTier ) {
-				onSelectTier( foundTier );
-			}
+
+			onSelectTier( calculateTier( options, option ) );
 		},
 		[ dispatch, onSelectTier, options ]
 	);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -49,7 +49,7 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier, ownedPl
 
 	return (
 		<div className="bulk-selection">
-			{ ownedPlans && (
+			{ !! ownedPlans && (
 				<div className="bulk-selection__owned-plan">
 					<Icon icon={ info } size={ 24 } />
 

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -26,7 +26,6 @@ import {
 	A4A_MARKETPLACE_LINK,
 	A4A_MARKETPLACE_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { Option } from 'calypso/a8c-for-agencies/components/slider';
 import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -39,13 +38,10 @@ import { getWPCOMCreatorPlan } from '../lib/hosting';
 import ShoppingCart, { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
 import WPCOMBulkSelector from './bulk-selection';
 import wpcomBulkOptions from './lib/wpcom-bulk-options';
+import { DiscountTier } from './lib/wpcom-bulk-values-utils';
 import WPCOMPlanCard from './wpcom-card';
 
 import './style.scss';
-
-type TierProps = Option & {
-	discount: number;
-};
 
 export default function WpcomOverview() {
 	const translate = useTranslate();
@@ -57,9 +53,9 @@ export default function WpcomOverview() {
 
 	const options = wpcomBulkOptions( [] );
 
-	const [ selectedTier, setSelectedTier ] = useState< TierProps >( options[ 0 ] );
+	const [ selectedTier, setSelectedTier ] = useState< DiscountTier >( options[ 0 ] );
 
-	const onSelectTier = ( tier: TierProps ) => {
+	const onSelectTier = ( tier: DiscountTier ) => {
 		setSelectedTier( tier );
 	};
 
@@ -154,7 +150,7 @@ export default function WpcomOverview() {
 				{ creatorPlan && (
 					<WPCOMPlanCard
 						plan={ creatorPlan }
-						quantity={ selectedTier.value as number }
+						quantity={ ( selectedTier.value as number ) - ownedPlans } // We only calculate the difference between the selected tier and the owned plans
 						discount={ selectedTier.discount }
 						onSelect={ onAddToCart }
 					/>

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -1,7 +1,7 @@
 const wpcomBulkOptions = (
 	discountOptions?: {
 		quantity: number;
-		discount: number;
+		discount_percent: number;
 	}[]
 ) => {
 	if ( ! discountOptions || discountOptions.length === 0 ) {
@@ -16,8 +16,8 @@ const wpcomBulkOptions = (
 	return discountOptions.map( ( option ) => ( {
 		value: option.quantity || 1,
 		label: option.quantity ? `${ option.quantity }` : '1',
-		sub: option.discount ? `${ option.discount * 100 }%` : '',
-		discount: option.discount ? option.discount : 0,
+		sub: option.discount_percent ? `${ option.discount_percent * 100 }%` : '',
+		discount: option.discount_percent ? option.discount_percent : 0,
 	} ) );
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils.ts
@@ -1,5 +1,4 @@
 import { Option } from '../wpcom-slider';
-import wpcomBulkOptions from './wpcom-bulk-options';
 
 type SliderOption = {
 	minAbsolute: number;
@@ -43,21 +42,4 @@ export const valueToSliderPos = ( value: number, options: SliderOption[] ) => {
 	const { minAbsolute, maxAbsolute, minValue, maxValue } = foundOption;
 	const normalizedValue = ( value - minValue ) / ( maxValue - minValue );
 	return Math.floor( minAbsolute + normalizedValue * ( maxAbsolute - minAbsolute ) );
-};
-
-export const countToOption = ( count: number ) => {
-	for ( let i = 1; i < wpcomBulkOptions.length; i++ ) {
-		if ( count < wpcomBulkOptions[ i ].value ) {
-			return {
-				value: count,
-				label: count.toString(),
-				discount: wpcomBulkOptions[ i - 1 ].discount,
-				sub: wpcomBulkOptions[ i - 1 ].sub,
-			};
-		}
-	}
-	if ( count >= 100 ) {
-		return wpcomBulkOptions[ wpcomBulkOptions.length - 1 ];
-	}
-	return wpcomBulkOptions[ 0 ];
 };

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils.ts
@@ -1,0 +1,63 @@
+import { Option } from '../wpcom-slider';
+import wpcomBulkOptions from './wpcom-bulk-options';
+
+type SliderOption = {
+	minAbsolute: number;
+	maxAbsolute: number;
+	minValue: number;
+	maxValue: number;
+};
+
+export const mapOptionsToSliderOptions = ( options: Option[], total: number ) => {
+	return options.map( ( _, index ) => {
+		const minAbsolute = ( total * index ) / ( options.length - 1 );
+		const maxAbsolute = ( total * ( index + 1 ) ) / ( options.length - 1 );
+		const minValue = options[ index ].value as number;
+		const maxValue = (
+			options[ index + 1 ] ? options[ index + 1 ].value : options[ index ].value
+		) as number;
+
+		return { minAbsolute, maxAbsolute, minValue, maxValue };
+	} );
+};
+
+export const sliderPosToValue = ( sliderPos: number, options: SliderOption[] ) => {
+	const foundOption = options.find(
+		( option ) => sliderPos >= option.minAbsolute && sliderPos <= option.maxAbsolute
+	);
+	if ( ! foundOption ) {
+		return 1;
+	}
+	const { minAbsolute, maxAbsolute, minValue, maxValue } = foundOption;
+	const normalizedOption = ( sliderPos - minAbsolute ) / ( maxAbsolute - minAbsolute );
+	return Math.floor( minValue + normalizedOption * ( maxValue - minValue ) );
+};
+
+export const valueToSliderPos = ( value: number, options: SliderOption[] ) => {
+	const foundOption = options.find(
+		( option ) => value >= option.minValue && value <= option.maxValue
+	);
+	if ( ! foundOption ) {
+		return 1;
+	}
+	const { minAbsolute, maxAbsolute, minValue, maxValue } = foundOption;
+	const normalizedValue = ( value - minValue ) / ( maxValue - minValue );
+	return Math.floor( minAbsolute + normalizedValue * ( maxAbsolute - minAbsolute ) );
+};
+
+export const countToOption = ( count: number ) => {
+	for ( let i = 1; i < wpcomBulkOptions.length; i++ ) {
+		if ( count < wpcomBulkOptions[ i ].value ) {
+			return {
+				value: count,
+				label: count.toString(),
+				discount: wpcomBulkOptions[ i - 1 ].discount,
+				sub: wpcomBulkOptions[ i - 1 ].sub,
+			};
+		}
+	}
+	if ( count >= 100 ) {
+		return wpcomBulkOptions[ wpcomBulkOptions.length - 1 ];
+	}
+	return wpcomBulkOptions[ 0 ];
+};

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils.ts
@@ -44,3 +44,24 @@ export const valueToSliderPos = ( value: number, options: SliderOption[] ) => {
 	const normalizedValue = ( value - minValue ) / ( maxValue - minValue );
 	return Math.floor( minAbsolute + normalizedValue * ( maxAbsolute - minAbsolute ) );
 };
+
+export type DiscountTier = Option & {
+	discount: number;
+};
+
+export const calculateTier = ( options: DiscountTier[], value: number ) => {
+	let tier = options[ 0 ];
+
+	for ( const option of options ) {
+		if ( Number( option.value ) > value ) {
+			break;
+		}
+
+		tier = option;
+	}
+
+	return {
+		...tier,
+		value,
+	};
+};

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils.ts
@@ -37,8 +37,9 @@ export const valueToSliderPos = ( value: number, options: SliderOption[] ) => {
 		( option ) => value >= option.minValue && value <= option.maxValue
 	);
 	if ( ! foundOption ) {
-		return 1;
+		return value === 0 ? 1 : options[ options.length - 1 ].maxAbsolute;
 	}
+
 	const { minAbsolute, maxAbsolute, minValue, maxValue } = foundOption;
 	const normalizedValue = ( value - minValue ) / ( maxValue - minValue );
 	return Math.floor( minAbsolute + normalizedValue * ( maxAbsolute - minAbsolute ) );

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
@@ -23,3 +23,17 @@
 		display: none;
 	}
 }
+
+.bulk-selection {
+	text-align: center;
+}
+
+.bulk-selection__owned-plan {
+	display: inline-flex;
+	flex-direction: row;
+	gap: 16px;
+
+	background-color: var(--color-neutral-0);
+	padding: 8px 16px;
+	margin: 0 auto 32px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -49,8 +49,8 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect }: P
 							</>
 						) }
 						<div className="wpcom-plan-card__price-interval">
-							{ plan.price_interval === 'day' && translate( 'USD per plan per day' ) }
-							{ plan.price_interval === 'month' && translate( 'USD per plan per month' ) }
+							{ plan.price_interval === 'day' && translate( 'USD per site per day' ) }
+							{ plan.price_interval === 'month' && translate( 'USD per site per month' ) }
 						</div>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -92,7 +92,10 @@ export default function A4AWPCOMSlider( {
 								} }
 							>
 								<div className="a4a-slider__marker-line"></div>
-								<div className="a4a-slider__marker-label">{ option.label }</div>
+								<div className="a4a-slider__marker-label">
+									{ option.label }
+									{ index === options.length - 1 && '+' }
+								</div>
 								{ option.sub && <div className="a4a-slider__marker-sub">{ option.sub }</div> }
 							</div>
 						);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -79,7 +79,7 @@ export default function A4AWPCOMSlider( {
 
 	const ratio = valueToSliderPos( minimum, mappedOptions ) / total;
 
-	const thumbSize = 14;
+	const thumbSize = -14;
 	const sliderWidth = rangeRef.current?.offsetWidth ?? 1;
 	const disabledAreaWidth =
 		minimum >= mappedOptions[ mappedOptions.length - 1 ].maxValue

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -1,0 +1,110 @@
+import classNames from 'classnames';
+import { useMemo, useState } from 'react';
+import {
+	mapOptionsToSliderOptions,
+	sliderPosToValue,
+	valueToSliderPos,
+} from '../lib/wpcom-bulk-values-utils';
+import './style.scss';
+
+export type Option = {
+	label: string;
+	value: number | string | null;
+	sub?: string;
+};
+
+type Props = {
+	className?: string;
+	options: Option[];
+	onChange?: ( value: number ) => void;
+	value: number;
+	label?: string;
+	sub?: string;
+};
+
+export default function A4AWPCOMSlider( {
+	className,
+	options,
+	onChange,
+	value,
+	label,
+	sub,
+}: Props ) {
+	const total = 204;
+	const mappedOptions = useMemo(
+		() => mapOptionsToSliderOptions( options, total ),
+		[ options, total ]
+	);
+	const [ currentValue, setCurrentValue ] = useState( value || 1 );
+	const [ currentSliderPos, setCurrentSliderPos ] = useState(
+		valueToSliderPos( value, mappedOptions )
+	);
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const onSliderChange = ( event: any ) => {
+		const sliderPos = Number.parseInt( event.target.value );
+		const selected = sliderPosToValue( sliderPos, mappedOptions );
+		onChange?.( selected );
+		setCurrentValue( selected );
+		setCurrentSliderPos( sliderPos );
+	};
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const onNumberInputChange = ( event: any ) => {
+		const value = Number.parseInt( event.target.value ) || 1;
+		onChange?.( value );
+		setCurrentValue( value );
+		setCurrentSliderPos( valueToSliderPos( value, mappedOptions ) );
+	};
+
+	return (
+		<div className={ classNames( 'a4a-slider', className ) }>
+			{ label && (
+				<div className="a4a-slider__label-container">
+					<div className="a4a-slider__label">{ label }</div>
+					<div className="a4a-slider__sub">{ sub }</div>
+				</div>
+			) }
+
+			<div className="a4a-slider__input">
+				<input
+					type="range"
+					min="0"
+					max={ total.toString() }
+					onChange={ onSliderChange }
+					value={ currentSliderPos }
+					step="1"
+				/>
+
+				<div className="a4a-slider__marker-container">
+					{ options.map( ( option, index ) => {
+						return (
+							<div
+								className="a4a-slider__marker"
+								key={ `slider-option-${ option.value }` }
+								role="button"
+								tabIndex={ -1 }
+								onClick={ () => onChange?.( index ) }
+								onKeyDown={ ( event ) => {
+									if ( event.key === 'Enter' ) {
+										onChange?.( index );
+									}
+								} }
+							>
+								<div className="a4a-slider__marker-line"></div>
+								<div className="a4a-slider__marker-label">{ option.label }</div>
+								{ option.sub && <div className="a4a-slider__marker-sub">{ option.sub }</div> }
+							</div>
+						);
+					} ) }
+				</div>
+			</div>
+			<input
+				type="number"
+				className="a4a-slider__number-input"
+				value={ currentValue }
+				onChange={ onNumberInputChange }
+			></input>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -32,7 +32,7 @@ export default function A4AWPCOMSlider( {
 	sub,
 	minimum = 0,
 }: Props ) {
-	const total = 204;
+	const total = options.length * 10;
 	const mappedOptions = useMemo(
 		() => mapOptionsToSliderOptions( options, total ),
 		[ options, total ]

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -61,9 +61,9 @@ export default function A4AWPCOMSlider( {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const onNumberInputChange = ( event: any ) => {
-		const value = Number.parseInt( event.target.value ) || 1;
+		const value = event.target.value;
 		// Our next value will be determine based on the minimum input.
-		const next = value < minimum ? minimum : value;
+		const next = isNaN( value ) || value < minimum ? minimum : value;
 		onChange?.( next );
 		setCurrentValue( value ); // We do not want to override the value with next here to avoid disrupting user input.
 		setCurrentSliderPos( valueToSliderPos( next, mappedOptions ) );
@@ -71,7 +71,7 @@ export default function A4AWPCOMSlider( {
 
 	const onNumberInputBlur = () => {
 		// When the mouse cursor goes out, we need to make sure the value is within the range.
-		const next = currentValue < minimum ? minimum : currentValue;
+		const next = isNaN( currentValue ) || currentValue < minimum ? minimum : currentValue;
 		onChange?.( next );
 		setCurrentValue( next );
 		setCurrentSliderPos( valueToSliderPos( next, mappedOptions ) );

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
@@ -115,7 +115,7 @@
 	-moz-appearance: textfield; /* Firefox */
 	appearance: textfield; /* Other browsers */
 	width: 2rem;
-	align-self: center;
+	align-self: baseline;
 	text-align: center;
 	border: 1px solid var(--color-neutral-5);
 	border-radius: 4px;

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
@@ -135,5 +135,6 @@
 	background-color: var(--color-primary-0);
 	position: absolute;
 	top: 22px;
-	border-radius: 4px;
+	left: -1px;
+	border-radius: 4px 0 0 4px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
@@ -116,6 +116,9 @@
 	width: 2rem;
 	align-self: center;
 	text-align: center;
+	border: 1px solid var(--color-neutral-5);
+	border-radius: 4px;
+	min-height: 36px;
 }
 
 .a4a-slider__number-input::-webkit-inner-spin-button,

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
@@ -1,0 +1,125 @@
+
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.a4a-slider {
+	display: flex;
+	flex-direction: row;
+	gap: 24px;
+	align-items: flex-end;
+}
+
+.a4a-slider__input {
+	flex-grow: 1;
+}
+
+.a4a-slider__input [type="range"] {
+	-webkit-appearance: none;
+	appearance: none;
+	background: transparent;
+	height: 50px;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+
+	@mixin slider-track-style {
+		background: var(--color-primary-40);
+		height: 6px;
+		border-radius: 4px;
+	}
+
+	@mixin slider-thumb-style {
+		-webkit-appearance: none;
+		appearance: none;
+		background-color: var(--color-surface-backdrop);
+		height: 16px;
+		width: 16px;
+		border-radius: 50%;
+		border: 2.62px solid var(--color-border-light);
+		margin-block-start: -5px;
+		cursor: pointer;
+		z-index: 2;
+	}
+
+	&::-webkit-slider-runnable-track {
+		@include slider-track-style;
+	}
+
+	&::-moz-range-track {
+		@include slider-track-style;
+	}
+
+	&::-webkit-slider-thumb {
+		@include slider-thumb-style;
+	}
+
+	&::-moz-range-thumb {
+		@include slider-thumb-style;
+	}
+}
+
+.a4a-slider__marker-container {
+	position: relative;
+	margin-block-start: -24px;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+}
+
+.a4a-slider__marker {
+	width: 16px;
+	max-width: 16px;
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	justify-content: center;
+	gap: 4px;
+}
+
+.a4a-slider__marker-line {
+	height: 10px;
+	width: 0.5px;
+	background-color: var(--color-neutral-10);
+}
+
+.a4a-slider__label-container {
+	display: none;
+	text-align: right;
+
+	@include break-medium {
+		display: block;
+	}
+}
+
+.a4a-slider__sub {
+	margin-block-start: 4px;
+}
+
+.a4a-slider__label,
+.a4a-slider__sub,
+.a4a-slider__marker {
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1.1;
+}
+
+
+.a4a-slider__sub,
+.a4a-slider__marker-sub {
+	color: var(--color-success);
+}
+
+.a4a-slider__number-input {
+	-webkit-appearance: none; /* Safari and Chrome */
+	-moz-appearance: textfield; /* Firefox */
+	appearance: textfield; /* Other browsers */
+	width: 2rem;
+	align-self: center;
+	text-align: center;
+}
+
+.a4a-slider__number-input::-webkit-inner-spin-button,
+.a4a-slider__number-input::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
@@ -10,6 +10,7 @@
 }
 
 .a4a-slider__input {
+	position: relative;
 	flex-grow: 1;
 }
 
@@ -119,10 +120,20 @@
 	border: 1px solid var(--color-neutral-5);
 	border-radius: 4px;
 	min-height: 36px;
+	position: relative;
 }
 
 .a4a-slider__number-input::-webkit-inner-spin-button,
 .a4a-slider__number-input::-webkit-outer-spin-button {
 	-webkit-appearance: none;
 	margin: 0;
+}
+
+.a4a-slider__input-disabled-area {
+	min-height: 6px;
+	width: 0;
+	background-color: var(--color-primary-0);
+	position: absolute;
+	top: 22px;
+	border-radius: 4px;
 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -26,8 +26,8 @@ export default function NeedSetup() {
 
 	const availableSites =
 		pendingSites?.filter(
-			( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
-				features.wpcom_atomic.state === 'pending'
+			( { features }: { features: { wpcom_atomic: { state: string; license_key: string } } } ) =>
+				features.wpcom_atomic.state === 'pending' && !! features.wpcom_atomic.license_key
 		) ?? [];
 
 	const availablePlans: AvailablePlans[] = availableSites.length
@@ -43,8 +43,8 @@ export default function NeedSetup() {
 	const isProvisioning =
 		isCreatingSite ||
 		pendingSites?.find(
-			( { features }: { features: { wpcom_atomic: { state: string } } } ) =>
-				features.wpcom_atomic.state === 'provisioning'
+			( { features }: { features: { wpcom_atomic: { state: string; license_key: string } } } ) =>
+				features.wpcom_atomic.state === 'provisioning' && !! features.wpcom_atomic.license_key
 		);
 
 	const onCreateSite = useCallback(

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -118,7 +118,7 @@ export interface APIProductFamily {
 	discounts?: {
 		tiers: {
 			quantity: number;
-			discount: number;
+			discount_percent: number;
 		}[];
 	};
 }


### PR DESCRIPTION
Update the Volume slider to account for existing WPCOM plans that the user previously bought.

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/385

https://github.com/Automattic/wp-calypso/assets/56598660/59794dfa-b243-45da-bf7a-17b5bcdc22db


## Proposed Changes
* Implement a WPCOM slider that can handle minimum input and custom quantity fields. The component also displays the total WPCOM plans the user already owns.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/hosting?flags=a8c-for-agencies/wpcom-creator-plan-purchase-flow`
* Select WPCOM option.
* Test if the Volume slider works as expected.
* Purchase a WPCOM license (Please only purchase one at a time as the backend endpoint cannot handle yet bulk purchases).
* Go back to the WPCOM hosting page.
* Confirm that the slider accounts for the existing plan you owned.

**Note that the discount bracket is determined by the backend endpoint. The UI should already represent it visually. However, currently, the backend does not provide any discounts, so you won't see any.***

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?