### PR TITLE
A4A: Add volume savings labels to the hosting cards

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -145,13 +145,13 @@ export default function HostingCard( {
 						</div>
 						<div className="hosting-card__price-interval">{ priceIntervalDescription }</div>
 					</div>
-					{ highestDiscountPercentage && (
+					{ highestDiscountPercentage ? (
 						<div className="hosting-card__price-discount">
 							{ translate( 'Volume savings up to %(highestDiscountPercentage)s%', {
 								args: { highestDiscountPercentage },
 							} ) }
 						</div>
-					) }
+					) : null }
 				</div>
 
 				<p className="hosting-card__description">{ description }</p>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -29,10 +29,16 @@ import './style.scss';
 type Props = {
 	plan: APIProductFamilyProduct;
 	pressableOwnership?: boolean;
+	highestDiscountPercentage?: number;
 	className?: string;
 };
 
-export default function HostingCard( { plan, pressableOwnership, className }: Props ) {
+export default function HostingCard( {
+	plan,
+	pressableOwnership,
+	highestDiscountPercentage,
+	className,
+}: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	//FIXME: We want to unify and refactor this logic, once we decide
@@ -131,12 +137,21 @@ export default function HostingCard( { plan, pressableOwnership, className }: Pr
 				</div>
 
 				<div className="hosting-card__price">
-					<b className="hosting-card__price-value">
-						{ translate( 'Starting at %(priceStartingAt)s', {
-							args: { priceStartingAt },
-						} ) }
-					</b>
-					<div className="hosting-card__price-interval">{ priceIntervalDescription }</div>
+					<div>
+						<div className="hosting-card__price-value">
+							{ translate( 'Starting at %(priceStartingAt)s', {
+								args: { priceStartingAt },
+							} ) }
+						</div>
+						<div className="hosting-card__price-interval">{ priceIntervalDescription }</div>
+					</div>
+					{ highestDiscountPercentage && (
+						<div className="hosting-card__price-discount">
+							{ translate( 'Volume savings up to %(highestDiscountPercentage)s%', {
+								args: { highestDiscountPercentage },
+							} ) }
+						</div>
+					) }
 				</div>
 
 				<p className="hosting-card__description">{ description }</p>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -29,6 +29,12 @@
 	}
 }
 
+.hosting-card__price {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
 .hosting-card__price-value {
 	display: block;
 	font-size: 1.5rem;
@@ -42,6 +48,12 @@
 	line-height: 1.1;
 	font-weight: 400;
 	color: var(--studio-gray-60, #50575e);
+}
+
+.hosting-card__price-discount {
+	color: var(--color-green-40, #00a32a);
+	font-size: 0.875rem;
+	line-height: 1.75;
 }
 
 .hosting-card__description {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -12,6 +12,7 @@ import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { getCheapestPlan } from '../../lib/hosting';
 import ListingSection from '../../listing-section';
 import { getAllPressablePlans } from '../../pressable-overview/lib/get-pressable-plan';
+import wpcomBulkOptions from '../../wpcom-overview/lib/wpcom-bulk-options';
 import HostingCard from '../hosting-card';
 
 import './style.scss';
@@ -45,9 +46,23 @@ export default function HostingList( { selectedSite }: Props ) {
 		[ pressablePlans ]
 	);
 
+	const highestDiscountPressable = 70; // FIXME: compute this value based on the actual data
+
 	const cheapestWPCOMPlan = useMemo(
 		() => ( isWPCOMOptionEnabled && wpcomPlans.length ? getCheapestPlan( wpcomPlans ) : null ),
 		[ isWPCOMOptionEnabled, wpcomPlans ]
+	);
+
+	const highestDiscountWPCOM = useMemo(
+		() =>
+			wpcomBulkOptions.reduce(
+				( highestDiscountPercentage, option ) =>
+					option.discount * 100 > highestDiscountPercentage
+						? option.discount * 100
+						: highestDiscountPercentage,
+				0
+			),
+		[]
 	);
 
 	const vipPlan = useMemo(
@@ -95,10 +110,19 @@ export default function HostingList( { selectedSite }: Props ) {
 				) }
 				isTwoColumns
 			>
-				{ cheapestWPCOMPlan && <HostingCard plan={ cheapestWPCOMPlan } /> }
+				{ cheapestWPCOMPlan && (
+					<HostingCard
+						plan={ cheapestWPCOMPlan }
+						highestDiscountPercentage={ highestDiscountWPCOM }
+					/>
+				) }
 
 				{ cheapestPressablePlan && (
-					<HostingCard plan={ cheapestPressablePlan } pressableOwnership={ hasPressablePlan } />
+					<HostingCard
+						plan={ cheapestPressablePlan }
+						pressableOwnership={ hasPressablePlan }
+						highestDiscountPercentage={ highestDiscountPressable }
+					/>
 				) }
 
 				{ isWPCOMOptionEnabled && (

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -63,7 +63,7 @@ export default function HostingList( { selectedSite }: Props ) {
 
 	const highestDiscountPressable = 70; // FIXME: compute this value based on the actual data
 
-	const creatorPlan = getWPCOMCreatorPlan( wpcomPlans );
+	const creatorPlan = isWPCOMOptionEnabled ? getWPCOMCreatorPlan( wpcomPlans ) : null;
 
 	const highestDiscountWPCOM = useMemo(
 		() =>
@@ -74,7 +74,7 @@ export default function HostingList( { selectedSite }: Props ) {
 						: highestDiscountPercentage,
 				0
 			),
-		[]
+		[ wpcomOptions ]
 	);
 
 	const vipPlan = useMemo(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/362

## Proposed Changes

* Adds the "Volume savings up to X%" labels to the WordPress.com and Pressable hosting cards.
  * Both values are currently derived from fixed data - WordPress potential savings is calculated using `wpcomBulkOptions`, and Pressable is a static value of `70`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the "/marketplace/hosting" page and verify the discount percentages displayed are accurate based on the prices shown on each hosting option's detail page.
* Verify the labels are displayed appropriately on all screen sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1456" alt="Screenshot 2024-04-30 at 6 11 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/9cbabb0a-3d58-480e-8d90-0319a11af9bc">

