### PR TITLE
Fix inconsistent hover color on Masterbar

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -294,22 +294,30 @@ body.is-mobile-app-view {
 		color: var(--color-masterbar-icon);
 	}
 
+	// The hover colors are supposed to be the same as those in wp-admin.
 	&:hover {
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);
 			color: var(--color-masterbar-highlight);
-
 			.masterbar--is-checkout & {
 				background: var(--color-checkout-masterbar-item-hover-background);
 				color: var(--color-checkout-masterbar-text);
 			}
-
 			.masterbar__item-content {
 				color: var(--color-masterbar-highlight);
 			}
-
 			.dashicons-before {
 				color: var(--color-masterbar-highlight);
+			}
+		}
+	}
+	// Reader icon is only available on Default interface sites, so we apply the Calypso color for consistency.
+	// https://github.com/Automattic/wp-calypso/pull/90136#issuecomment-2089512298
+	&.masterbar__reader:hover {
+		@include breakpoint-deprecated( ">480px" ) {
+			color: var(--color-masterbar-text);
+			.masterbar__item-content {
+				color: var(--color-masterbar-text);
 			}
 		}
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -291,16 +291,25 @@ body.is-mobile-app-view {
 
 	.dashicons-before {
 		height: 20px;
+		color: var(--color-masterbar-icon);
 	}
 
 	&:hover {
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);
-			color: var(--color-masterbar-text);
+			color: var(--color-masterbar-highlight);
 
 			.masterbar--is-checkout & {
 				background: var(--color-checkout-masterbar-item-hover-background);
 				color: var(--color-checkout-masterbar-text);
+			}
+
+			.masterbar__item-content {
+				color: var(--color-masterbar-highlight);
+			}
+
+			.dashicons-before {
+				color: var(--color-masterbar-highlight);
 			}
 		}
 	}
@@ -1042,6 +1051,16 @@ a.masterbar__quick-language-switcher {
 
 		@media only screen and ( min-width: 783px ) {
 			padding: 0 8px 0 4px;
+		}
+
+		svg {
+			fill: var(--color-masterbar-icon);
+		}
+
+		&:hover {
+			svg {
+				fill: var(--color-masterbar-highlight);
+			}
 		}
 	}
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -102,7 +102,9 @@ Used studio-blue for the primary+accent.
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-text-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
@@ -100,7 +100,9 @@ The wp-admin highlight color hue is 27, while studio-orange ranges from 25 to 35
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -255,7 +255,9 @@
 
 	--color-masterbar-background: #101517;
 	--color-masterbar-border: #333;
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: #f0f0f1; /* Direct from wp-admin */
+	--color-masterbar-icon: rgba(240, 246, 252, 0.6); /* Direct from wp-admin */
+	--color-masterbar-highlight: #72aee6; /* Direct from wp-admin */
 	--color-masterbar-item-hover-background: #333;
 	--color-masterbar-item-active-background: #23282d;
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
@@ -139,7 +139,9 @@ Created this definition in color-studio to generate 0-100 shades:
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -117,7 +117,9 @@ Primary+Accent is studio blue.
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-black);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -93,7 +93,9 @@ $notification-color: #69a8bb;
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -131,7 +131,9 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: #33f078; /* Direct from wp-admin */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
@@ -105,7 +105,9 @@ opinion.  Celadon seems to match the ocean colors better.
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -104,7 +104,9 @@ Well use studio-orange for both the primary and accent colors
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-submenu-hover-text-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);


### PR DESCRIPTION
Fix https://github.com/Automattic/dotcom-forge/issues/6798

## Proposed Changes

This PR fixes the inconsistent hover color on the Masterbar.

| before | after |
|--------|--------|
| <img width="235" alt="Screenshot 2024-05-01 at 14 18 51" src="https://github.com/Automattic/wp-calypso/assets/5287479/78d8c758-bace-4253-bb72-aab73a602ea7"> | <img width="222" alt="Screenshot 2024-05-01 at 14 19 03" src="https://github.com/Automattic/wp-calypso/assets/5287479/7bc07fbe-85f6-4ea4-bb1a-cfc910723ef8"> |
| <img width="222" alt="Screenshot 2024-05-01 at 14 19 40" src="https://github.com/Automattic/wp-calypso/assets/5287479/caebf7f8-bbfe-49f5-9c13-8372ed5543f5"> | <img width="230" alt="Screenshot 2024-05-01 at 14 19 53" src="https://github.com/Automattic/wp-calypso/assets/5287479/27822df0-83a1-45a0-82ac-8ab41475be5b"> |
| <img width="224" alt="Screenshot 2024-05-01 at 14 20 17" src="https://github.com/Automattic/wp-calypso/assets/5287479/57b687e9-3321-4786-91ea-b5e978dbf18b"> | <img width="220" alt="Screenshot 2024-05-01 at 14 20 23" src="https://github.com/Automattic/wp-calypso/assets/5287479/3e80e35e-260d-4716-80f0-3fe018c6cdd1"> |
| <img width="226" alt="Screenshot 2024-05-01 at 14 20 43" src="https://github.com/Automattic/wp-calypso/assets/5287479/3b16a3cf-40d2-4677-9b96-f1c4146680d1"> | <img width="223" alt="Screenshot 2024-05-01 at 14 20 57" src="https://github.com/Automattic/wp-calypso/assets/5287479/83dcf25d-1201-42d1-b166-f39ced4bac57"> |
| <img width="230" alt="Screenshot 2024-05-01 at 14 21 18" src="https://github.com/Automattic/wp-calypso/assets/5287479/28214f13-89d2-4497-8d6e-b8b452e93c10"> | <img width="223" alt="Screenshot 2024-05-01 at 14 21 39" src="https://github.com/Automattic/wp-calypso/assets/5287479/151d90be-bb84-48d8-8e5f-8308268323cd"> |
| <img width="222" alt="Screenshot 2024-05-01 at 14 22 07" src="https://github.com/Automattic/wp-calypso/assets/5287479/e3c4fb79-8240-444b-b1f7-b03362bfd88e"> | <img width="223" alt="Screenshot 2024-05-01 at 14 22 27" src="https://github.com/Automattic/wp-calypso/assets/5287479/82161c15-40c9-4871-bfaf-1d5719c5a6f0"> |
| <img width="228" alt="Screenshot 2024-05-01 at 14 24 20" src="https://github.com/Automattic/wp-calypso/assets/5287479/67f09e1f-9786-44f3-8ce5-992cc0991ccb"> | <img width="224" alt="Screenshot 2024-05-01 at 14 24 26" src="https://github.com/Automattic/wp-calypso/assets/5287479/3f151629-af57-4717-89a8-92d54676aa63"> |
| <img width="226" alt="Screenshot 2024-05-01 at 14 24 52" src="https://github.com/Automattic/wp-calypso/assets/5287479/4c3937ea-160b-4028-8548-e0cd93a6546d"> | <img width="224" alt="Screenshot 2024-05-01 at 14 25 09" src="https://github.com/Automattic/wp-calypso/assets/5287479/c5ec5e7a-e6fa-4ff6-a55d-1aa9fd98b82e"> |
| <img width="226" alt="Screenshot 2024-05-01 at 14 25 35" src="https://github.com/Automattic/wp-calypso/assets/5287479/120bfb89-dc15-470e-afca-4a71ebd64a5d"> | <img width="221" alt="Screenshot 2024-05-01 at 14 26 14" src="https://github.com/Automattic/wp-calypso/assets/5287479/9e7e636a-ac21-4433-b7e2-24aee377df84"> |

This PR only affects color schemes from Core:

<img width="980" alt="Screenshot 2024-05-01 at 14 23 34" src="https://github.com/Automattic/wp-calypso/assets/5287479/6917155a-2f93-440b-abfb-7768fd4e42d0">

Please be aware that the color schemes in Nav Unification for Calypso were intentionally different from those in wp-admin, as discussed in this GitHub issue: https://github.com/Automattic/wp-calypso/issues/45675. Now, in the Untangling & Nav Redesign projects, we aim for consistency between Calypso and wp-admin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare an Atomin site with Classic View 
* Go to the site's `_cli` and run `wp option update wpcom_classic_early_release 1`.
* Compare the Masterbar in wp-admin and Calypso page (e.g., `/home/<your-site>`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?