### PR TITLE
 A4A: Redirect the user to the 'Need setup' page when purchasing a WPCOM plan.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from 'react';
 import {
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
+	A4A_SITES_LINK_NEEDS_SETUP,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { useDispatch } from 'calypso/state';
@@ -118,10 +119,18 @@ function useIssueAndAssignLicenses(
 			// then, redirect to somewhere more appropriate
 			const selectedSiteId = selectedSite?.ID;
 			if ( ! selectedSiteId ) {
-				const issuedMessage = getLicenseIssuedMessage( issuedLicenses );
-				dispatch( successNotice( issuedMessage, { displayOnNextPage: true } ) );
+				const hasPurchaseWPCOMPlan = issuedLicenses.some(
+					( license ) => license.slug?.startsWith( 'wpcom-hosting' )
+				);
 
-				page.redirect( A4A_LICENSES_LINK );
+				if ( ! hasPurchaseWPCOMPlan ) {
+					const issuedMessage = getLicenseIssuedMessage( issuedLicenses );
+					dispatch( successNotice( issuedMessage, { displayOnNextPage: true } ) );
+				}
+
+				page.redirect(
+					hasPurchaseWPCOMPlan ? `${ A4A_SITES_LINK_NEEDS_SETUP }?purchase` : A4A_LICENSES_LINK
+				);
 				return;
 			}
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { getQueryArg } from '@wordpress/url';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import {
@@ -119,9 +119,10 @@ function useIssueAndAssignLicenses(
 			// then, redirect to somewhere more appropriate
 			const selectedSiteId = selectedSite?.ID;
 			if ( ! selectedSiteId ) {
-				const hasPurchaseWPCOMPlan = issuedLicenses.some(
+				const wpcomPlan = issuedLicenses.find(
 					( license ) => license.slug?.startsWith( 'wpcom-hosting' )
 				);
+				const hasPurchaseWPCOMPlan = !! wpcomPlan;
 
 				if ( ! hasPurchaseWPCOMPlan ) {
 					const issuedMessage = getLicenseIssuedMessage( issuedLicenses );
@@ -129,7 +130,11 @@ function useIssueAndAssignLicenses(
 				}
 
 				page.redirect(
-					hasPurchaseWPCOMPlan ? `${ A4A_SITES_LINK_NEEDS_SETUP }?purchase` : A4A_LICENSES_LINK
+					hasPurchaseWPCOMPlan
+						? addQueryArgs( A4A_SITES_LINK_NEEDS_SETUP, {
+								wpcom_creator_purchased: wpcomPlan.slug,
+						  } )
+						: A4A_LICENSES_LINK
 				);
 				return;
 			}

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -12,6 +12,7 @@ import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import SitesHeaderActions from '../sites-header-actions';
 import { AvailablePlans } from './plan-field';
+import PurchaseConfirmationMessage from './purchase-confirmation-message';
 import NeedSetupTable from './table';
 
 export default function NeedSetup() {
@@ -65,6 +66,9 @@ export default function NeedSetup() {
 		<Layout className="sites-dashboard sites-dashboard__layout preview-hidden" wide title={ title }>
 			<LayoutColumn className="sites-overview" wide>
 				<LayoutTop>
+					<div className="sites-overview__banner">
+						<PurchaseConfirmationMessage />
+					</div>
 					<LayoutHeader>
 						<Title>{ translate( 'Sites' ) }</Title>
 						<Actions>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -57,3 +57,8 @@
 	}
 }
 
+.sites-overview__banner {
+	margin-inline: auto !important;
+	margin-block-end: 24px;
+	padding-inline: 64px;
+}


### PR DESCRIPTION
This pull request updates the purchase flow for WPCOM plans. After a successful purchase, the user should be directed to the "Need Setup" page with a confirmation message.

<img width="2239" alt="Screenshot 2024-05-01 at 1 02 34 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/864bfd3a-62ca-4f1f-8e5e-aef190806432">

## Proposed Changes

* Update purchase flow for WPCOM plans to eventually land the user on the **Need Setup** page.
* Render the Confirmation message when in the purchase flow.

## Testing Instructions

* Use the A4A live link and go to `/marketplace/hosting/wpcom`.
* Purchase a WPCOM plan.
* After a successful checkout, confirm that you are redirected to the **Need setup** page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?