### PR TITLE
Scheduled Updates: Adjust heading and button alignment on schedule list

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-filter.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-filter.tsx
@@ -4,8 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import { MultisitePluginUpdateManagerContext } from './context';
 
-import './styles.scss';
-
 const SearchSVG = (
 	<svg
 		className="plugins-update-manager-multisite-filter__search-icon"

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -5,7 +5,6 @@ import {
 	Notice,
 	Spinner,
 } from '@wordpress/components';
-import { plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useState } from 'react';
 import { MultisitePluginUpdateManagerContext } from 'calypso/blocks/plugins-scheduled-updates-multisite/context';
@@ -15,6 +14,8 @@ import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ScheduleListFilter } from './schedule-list-filter';
 import { ScheduleListTable } from './schedule-list-table';
+
+import './styles.scss';
 
 type Props = {
 	onEditSchedule: ( id: string ) => void;
@@ -88,16 +89,17 @@ export const ScheduleList = ( props: Props ) => {
 
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
-			<h1 className="wp-brand-font">List schedules</h1>
-			<Button
-				__next40pxDefaultSize
-				icon={ plus }
-				variant="primary"
-				onClick={ onCreateNewSchedule }
-				disabled={ false }
-			>
-				{ translate( 'Add new schedule' ) }
-			</Button>
+			<div className="plugins-update-manager-multisite-header">
+				<h1>{ translate( 'Update schedules' ) }</h1>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					onClick={ onCreateNewSchedule }
+					disabled={ false }
+				>
+					{ translate( 'New schedule' ) }
+				</Button>
+			</div>
 			{ errors.length ? (
 				<Notice status="warning" isDismissible={ true } onDismiss={ () => clearErrors() }>
 					{ translate(

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -89,7 +89,7 @@ export const ScheduleList = ( props: Props ) => {
 
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
-			<div className="plugins-update-manager-multisite-header">
+			<div className="plugins-update-manager-multisite__header">
 				<h1>{ translate( 'Update schedules' ) }</h1>
 				<Button
 					__next40pxDefaultSize

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -106,7 +106,7 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 		}
 	}
-	.plugins-update-manager-multisite-header {
+	.plugins-update-manager-multisite__header {
 		align-items: center;
 		border-block-end: 1px solid var(--color-border-secondary);
 		display: flex;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -106,7 +106,7 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 		}
 	}
-	.plugins-update-manager-multisite__header {
+	&__header {
 		align-items: center;
 		border-block-end: 1px solid var(--color-border-secondary);
 		display: flex;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -3,6 +3,11 @@
 $brand-display: "SF Pro Display", sans-serif;
 
 .plugins-update-manager-multisite {
+	h1 {
+		font-size: 2rem;
+		margin-bottom: 1rem;
+	}
+
 	.components-notice {
 		margin-bottom: 1.25rem;
 		margin-top: 1.25rem;
@@ -114,6 +119,7 @@ $brand-display: "SF Pro Display", sans-serif;
 			font-style: normal;
 			font-weight: 500;
 			line-height: 1.2;
+			margin-bottom: 0;
 		}
 
 		button {

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -1,11 +1,8 @@
 @import "~@automattic/color-studio/dist/color-variables";
 
-.plugins-update-manager-multisite {
-	h1 {
-		font-size: 2rem;
-		margin-bottom: 1rem;
-	}
+$brand-display: "SF Pro Display", sans-serif;
 
+.plugins-update-manager-multisite {
 	.components-notice {
 		margin-bottom: 1.25rem;
 		margin-top: 1.25rem;
@@ -102,6 +99,26 @@
 			.components-spinner {
 				display: none;
 			}
+		}
+	}
+	.plugins-update-manager-multisite-header {
+		align-items: center;
+		border-block-end: 1px solid var(--color-border-secondary);
+		display: flex;
+		font-family: $brand-display;
+		justify-content: space-between;
+		padding-bottom: 1.5rem;
+
+		h1 {
+			font-size: 1.5rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 1.2;
+		}
+
+		button {
+			font-size: rem(14px);
+			border-radius: 4px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89964

## Proposed Changes

* Update title font, button alignment on multi-site level schedule list screen.

| Before | After |
|-|-|
| ![Screen Shot 2024-05-01 at 3 25 18 PM](https://github.com/Automattic/wp-calypso/assets/4074459/b4ab3eb8-5a52-452f-a47d-439a36e64e27) | ![Screen Shot 2024-05-01 at 3 22 48 PM](https://github.com/Automattic/wp-calypso/assets/4074459/44ad4e58-ae34-4451-980e-9767c7a875e5) |





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/plugins/scheduled-updates.
* Check and see if title font and button alignment is showing correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?