### PR TITLE
[Tour-kit] Fallback reference element to the desktop selector if the mobile selector is not provided

### DIFF
--- a/packages/tour-kit/CHANGELOG.md
+++ b/packages/tour-kit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+- Fallback reference element to the desktop selector if the mobile selector is not provided
+
 ## 1.1.2
 
 - Added 'onStepView' callback that's called each time a step is mounted

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/tour-kit",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "Tour lib for guided walkthroughs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -38,8 +38,9 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 	const tourContainerRef = useRef( null );
 	const isMobile = useMobileBreakpoint();
 	const lastStepIndex = config.steps.length - 1;
+	const referenceElements = config.steps[ currentStepIndex ].referenceElements;
 	const referenceElementSelector =
-		config.steps[ currentStepIndex ].referenceElements?.[ isMobile ? 'mobile' : 'desktop' ] || null;
+		referenceElements?.[ isMobile ? 'mobile' : 'desktop' ] || referenceElements?.desktop;
 	const referenceElement = referenceElementSelector
 		? document.querySelector< HTMLElement >( referenceElementSelector )
 		: null;

--- a/packages/tour-kit/src/storybook/index.stories.tsx
+++ b/packages/tour-kit/src/storybook/index.stories.tsx
@@ -46,7 +46,6 @@ const Tour = ( {
 			{
 				referenceElements: {
 					desktop: '.storybook__tourkit-references-a',
-					mobile: '.storybook__tourkit-references-a',
 				},
 				meta: {
 					description: 'Lorem ipsum dolor sit amet.',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/woocommerce/issues/39137



## Proposed Changes

Currently, if the mobile selector is not provided, the tour will not have a reference element to attach to. This PR adds a fallback to the desktop selector if the mobile selector is not provided.

We use tour-kit a lots in WooCommerce plugin and we don't set mobile selector in most of the cases. This PR will help us to avoid adding mobile selector in all the places where we use tour-kit.

* Add a fallback to the desktop selector if the mobile selector is not provided.
* Bump version for release

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn workspace @automattic/tour-kit run storybook`
* Go to http://localhost:56194/?path=/story/tour-kit--spotlight
* Click on "Start Tour" button
* Confirm it highlights the element correctly

![Screenshot 2024-05-01 at 16 54 25](https://github.com/Automattic/wp-calypso/assets/4344253/46fcbc17-5725-4992-80a2-44e6eb767fc6)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?