### PR TITLE
Remove unused hosting trial loading code from PreMigrationScreen

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -10,7 +10,6 @@ import { UpdatePluginInfo } from 'calypso/blocks/importer/wordpress/import-every
 import { UpgradePlan } from 'calypso/blocks/importer/wordpress/upgrade-plan';
 import QuerySites from 'calypso/components/data/query-sites';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -97,12 +96,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		isRequestingSitePlans( state, targetSite.ID )
 	);
 
-	const { isPending: isAddingTrial } = useAddHostingTrialMutation( {
-		onSuccess: () => {
-			setQueryTargetSitePlanStatus( 'fetching' );
-		},
-	} );
-
 	const {
 		hasCredentials,
 		isRequesting: isFetchingCredentials,
@@ -164,7 +157,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	useEffect( () => {
 		if (
 			! isInitFetchingDone &&
-			( isFetchingMigrationData || isAddingTrial || queryTargetSitePlanStatus === 'fetched' )
+			( isFetchingMigrationData || queryTargetSitePlanStatus === 'fetched' )
 		) {
 			setRenderState( 'loading' );
 		} else if ( requiresPluginUpdate ) {
@@ -239,9 +232,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 					<UpgradePlan
 						site={ targetSite }
 						navigateToVerifyEmailStep={ navigateToVerifyEmailStep }
-						isBusy={
-							isFetchingMigrationData || isAddingTrial || queryTargetSitePlanStatus === 'fetched'
-						}
+						isBusy={ isFetchingMigrationData || queryTargetSitePlanStatus === 'fetched' }
 						onFreeTrialClick={ onFreeTrialClick }
 						ctaText={ translate( 'Upgrade and migrate' ) }
 						onCtaClick={ onUpgradeAndMigrateClick }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6638

## Proposed Changes

This is a sub part of https://github.com/Automattic/dotcom-forge/issues/6638, a task to remove code related to the old endpoint for starting trials. Doing multiple PRs otherwise the diff is quite large.

This PR removes the use of `useAddHostingTrialMutation` from the `PreMigrationScreen` component. Previously it was used to render the loading state for when the trial is being created. But since that's now done in the checkout screen, this is no longer relevant.

I think this component is actually stale now (see testing instructions), but the PR is still needed so we can remove all usage of `useAddHostingTrialMutation`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Review the code.

AFAICT it's no longer possible to render the `<PreMigrationScreen>` component. It would be part of the `/setup/site-setup` flow when you choose that your goals in to import existing content. However the `onboarding/new-migration-flow` flag is now enabled in all environments which means that part of the flow is now inaccessable.

https://github.com/Automattic/wp-calypso/blob/c9b561152efa79e930059ebcfbaa1e0760fb732f/client/landing/stepper/declarative-flow/site-setup-flow.ts#L339-L341

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?