### PR TITLE
Entrepreneur Signup: Include ref & flags when landing at Calypso My Home to help with dev testing & CFT.

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -110,7 +110,7 @@ const entrepreneurFlow: Flow = {
 						let redirectToWithSSO = `https://${ stagingUrl }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`;
 
 						// Temporarily redirect to Calypso My Home until Woo Express 8.9 is deployed.
-						redirectToWithSSO = `/home/${ stagingUrl }?flags=entrepreneur-my-home`;
+						redirectToWithSSO = `/home/${ stagingUrl }?ref=entrepreneur-signup&flags=entrepreneur-my-home`;
 
 						return window.location.assign( redirectToWithSSO );
 					}

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -110,7 +110,7 @@ const entrepreneurFlow: Flow = {
 						let redirectToWithSSO = `https://${ stagingUrl }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`;
 
 						// Temporarily redirect to Calypso My Home until Woo Express 8.9 is deployed.
-						redirectToWithSSO = `/home/${ stagingUrl }`;
+						redirectToWithSSO = `/home/${ stagingUrl }?flags=entrepreneur-my-home`;
 
 						return window.location.assign( redirectToWithSSO );
 					}


### PR DESCRIPTION
Related to #

## Proposed Changes

* At the end of the signup flow, we temporarily redirect to Calypso My Home instead of Design With AI.
* For now, we include the `ref=entrepreneur-signup&flags=entrepreneur-my-home` as part of the URL to help with dev testing and CFT.

## Testing Instructions

* Go to `setup/entrepreneur/start?flags=ecommerce-segmentation-survey`.
* At the end of the flow, you will land in `/home/your-new-site.wpcomstaging.com?ref=entrepreneur-signup&flags=entrepreneur-my-home`.

⚠️ **Known Behaviour:** Watch the URL closely (or enable Preserve Log in network panel), because while the patch D147085-code is not deployed yet, the old 2023 entrepreneur plan is still being assigned, which it will redirect back to wc-admin.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?