### PR TITLE
Removes stale code from /hosting-config for starting the Creator trial

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -38,7 +38,6 @@ import { isSiteOnBusinessTrial, isSiteOnECommerceTrial } from 'calypso/state/sit
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { WithOnclickTrialRequest } from '../plans/trials/trial-acknowledge/with-onclick-trial-request';
 import SiteAdminInterface from '../site-settings/site-admin-interface';
 import CacheCard from './cache-card';
 import { GitHubDeploymentsCard } from './github-deployments-card';
@@ -267,7 +266,6 @@ const Hosting = ( props ) => {
 		hasSftpFeature,
 		hasStagingSitesFeature,
 		isJetpack,
-		fetchUpdatedData,
 		isSiteAtomic,
 		transferState,
 	} = props;
@@ -288,13 +286,9 @@ const Hosting = ( props ) => {
 	const showHostingActivationBanner = canSiteGoAtomic && ! hasTransfer;
 
 	const requestUpdatedSiteData = useCallback(
-		( isTransferring, wasTransferring, isTransferCompleted ) => {
+		( isTransferring ) => {
 			if ( isTransferring && ! hasTransfer ) {
 				setHasTransferring( true );
-			}
-
-			if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
-				fetchUpdatedData();
 			}
 		},
 		[ hasTransfer ]
@@ -457,4 +451,4 @@ export default connect(
 		fetchAutomatedTransferStatus,
 		requestSiteById: requestSite,
 	}
-)( localize( WithOnclickTrialRequest( Hosting ) ) );
+)( localize( Hosting ) );

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -32,18 +32,12 @@ import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/sel
 import { getAtomicHostingIsLoadingSftpData } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-data';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
-import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { isSiteOnBusinessTrial, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
-import { TrialAcknowledgeModal } from '../plans/trials/trial-acknowledge/acknowlege-modal';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { WithOnclickTrialRequest } from '../plans/trials/trial-acknowledge/with-onclick-trial-request';
 import SiteAdminInterface from '../site-settings/site-admin-interface';
 import CacheCard from './cache-card';
@@ -273,13 +267,11 @@ const Hosting = ( props ) => {
 		hasSftpFeature,
 		hasStagingSitesFeature,
 		isJetpack,
-		isEligibleForHostingTrial,
 		fetchUpdatedData,
 		isSiteAtomic,
 		transferState,
 	} = props;
 
-	const [ isTrialAcknowledgeModalOpen, setIsTrialAcknowledgeModalOpen ] = useState( false );
 	const [ hasTransfer, setHasTransferring ] = useState(
 		transferState &&
 			! [
@@ -294,14 +286,6 @@ const Hosting = ( props ) => {
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showHostingActivationBanner = canSiteGoAtomic && ! hasTransfer;
-
-	const setOpenModal = ( isOpen ) => {
-		setIsTrialAcknowledgeModalOpen( isOpen );
-	};
-
-	const trialRequested = () => {
-		setHasTransferring( true );
-	};
 
 	const requestUpdatedSiteData = useCallback(
 		( isTransferring, wasTransferring, isTransferCompleted ) => {
@@ -418,7 +402,7 @@ const Hosting = ( props ) => {
 				title={ translate( 'Hosting Config' ) }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
-			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (
+			{ ! showHostingActivationBanner && (
 				<HostingActivateStatus
 					context="hosting"
 					onTick={ requestUpdatedSiteData }
@@ -436,9 +420,6 @@ const Hosting = ( props ) => {
 				/>
 			) }
 			{ getContent() }
-			{ isEligibleForHostingTrial && isTrialAcknowledgeModalOpen && (
-				<TrialAcknowledgeModal setOpenModal={ setOpenModal } trialRequested={ trialRequested } />
-			) }
 			<QueryReaderTeams />
 		</Main>
 	);
@@ -453,9 +434,6 @@ export default connect(
 		const hasAtomicFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
 		const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 		const hasStagingSitesFeature = siteHasFeature( state, siteId, FEATURE_SITE_STAGING_SITES );
-		const site = getSelectedSite( state );
-		const isEligibleForHostingTrial =
-			isUserEligibleForFreeHostingTrial( state ) && site && site.plan?.is_free;
 		const isSiteAtomic = isSiteWpcomAtomic( state, siteId );
 
 		return {
@@ -471,7 +449,6 @@ export default connect(
 			siteId,
 			isWpcomStagingSite: isSiteWpcomStaging( state, siteId ),
 			hasStagingSitesFeature,
-			isEligibleForHostingTrial,
 			isSiteAtomic,
 		};
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6638

## Proposed Changes

This is a sub part of https://github.com/Automattic/dotcom-forge/issues/6638, a task to remove code related to the old endpoint for starting trials. Doing multiple PRs otherwise the diff is quite large.

There used to be a trial button in `/hosting-config` which was originally disabled in #88486. But it left some of the old code in place. We need to remove it so we can eventually remove the `useAddHostingTrialMutation` hook and API endpoint.

~The hosting config page also uses the `WithOnclickTrialRequest` HoC, which from the name appears to have something to do with a trial, but when I looked at the code it's unrelated to the hosting trial.~
I've removed `WithOnclickTrialRequest`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the code and test the hosting config page.
* There should be no changes to the hosting config page.
* Use `/hosting-config` to transfer a simple site to atomic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?