### PR TITLE
Removes stale code from /plugins/upload for starting the Creator trial

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -15,7 +15,6 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import HostingActivateStatus from 'calypso/hosting/server-settings/hosting-activate-status';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { TrialAcknowledgeModal } from 'calypso/my-sites/plans/trials/trial-acknowledge/acknowlege-modal';
 import { WithOnclickTrialRequest } from 'calypso/my-sites/plans/trials/trial-acknowledge/with-onclick-trial-request';
 import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
 import {
@@ -49,8 +48,6 @@ import {
 class PluginUpload extends Component {
 	state = {
 		showEligibility: this.props.showEligibility,
-		showTrialAcknowledgeModal: false,
-		hasRequestedTrial: false,
 	};
 
 	componentDidMount() {
@@ -81,10 +78,8 @@ class PluginUpload extends Component {
 	};
 
 	onProceedClick = () => {
-		const isFreeTrialEligible = this.props.isEligibleForHostingTrial;
 		this.setState( {
-			showEligibility: isFreeTrialEligible,
-			showTrialAcknowledgeModal: isFreeTrialEligible,
+			showEligibility: false,
 			isTransferring: false,
 		} );
 	};
@@ -121,14 +116,6 @@ class PluginUpload extends Component {
 		);
 	}
 
-	setOpenModal = ( isOpen ) => {
-		this.setState( { showTrialAcknowledgeModal: isOpen } );
-	};
-
-	trialRequested = () => {
-		this.setState( { hasRequestedTrial: true, showEligibility: false } );
-	};
-
 	requestUpdatedSiteData = ( isTransferring, wasTransferring, isTransferCompleted ) => {
 		if ( isTransferring ) {
 			this.setState( { isTransferring: true } );
@@ -140,21 +127,11 @@ class PluginUpload extends Component {
 	};
 
 	render() {
-		const {
-			translate,
-			isJetpackMultisite,
-			siteId,
-			siteSlug,
-			isEligibleForHostingTrial,
-			isJetpack,
-			isTrialSite,
-			isAtomic,
-		} = this.props;
-		const { showEligibility, showTrialAcknowledgeModal, isTransferring, hasRequestedTrial } =
-			this.state;
+		const { translate, isJetpackMultisite, siteId, siteSlug, isJetpack, isTrialSite, isAtomic } =
+			this.props;
+		const { showEligibility, isTransferring } = this.state;
 
-		const showEligibilityWarnings =
-			showEligibility && ! isTransferring && ! isTrialSite && ! hasRequestedTrial;
+		const showEligibilityWarnings = showEligibility && ! isTransferring && ! isTrialSite;
 
 		return (
 			<Main>
@@ -162,29 +139,18 @@ class PluginUpload extends Component {
 				<QueryEligibility siteId={ siteId } />
 				<NavigationHeader navigationItems={ [] } title={ translate( 'Plugins' ) } />
 				<HeaderCake onClick={ this.back }>{ translate( 'Install plugin' ) }</HeaderCake>
-				{ ! showTrialAcknowledgeModal && ! isJetpack && (
-					<HostingActivateStatus
-						context="plugin"
-						onTick={ this.requestUpdatedSiteData }
-						keepAlive={ hasRequestedTrial && ! isJetpack && ! isAtomic }
-					/>
+				{ ! isJetpack && (
+					<HostingActivateStatus context="plugin" onTick={ this.requestUpdatedSiteData } />
 				) }
 				{ isJetpackMultisite && this.renderNotAvailableForMultisite() }
 				{ showEligibilityWarnings && (
 					<EligibilityWarnings
 						backUrl={ `/plugins/${ siteSlug }` }
 						onProceed={ this.onProceedClick }
-						showFreeTrial={ isEligibleForHostingTrial }
 					/>
 				) }
 				{ ( ( ! isJetpackMultisite && ! showEligibility ) || isAtomic || isTrialSite ) &&
 					this.renderUploadCard() }
-				{ isEligibleForHostingTrial && showTrialAcknowledgeModal && (
-					<TrialAcknowledgeModal
-						setOpenModal={ this.setOpenModal }
-						trialRequested={ this.trialRequested }
-					/>
-				) }
 			</Main>
 		);
 	}
@@ -202,9 +168,6 @@ const mapStateToProps = ( state ) => {
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
-	// This value is hardcoded to 'false' to disable the free trial banner
-	// see https://github.com/Automattic/wp-calypso/pull/89217
-	const isEligibleForHostingTrial = false;
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);
@@ -223,7 +186,6 @@ const mapStateToProps = ( state ) => {
 		isJetpackMultisite,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
-		isEligibleForHostingTrial,
 		isTrialSite: isHostingTrialSite( site ),
 	};
 };

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -15,7 +15,6 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import HostingActivateStatus from 'calypso/hosting/server-settings/hosting-activate-status';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { WithOnclickTrialRequest } from 'calypso/my-sites/plans/trials/trial-acknowledge/with-onclick-trial-request';
 import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
 import {
 	fetchAutomatedTransferStatus,
@@ -121,7 +120,6 @@ class PluginUpload extends Component {
 			this.setState( { isTransferring: true } );
 		}
 		if ( wasTransferring && isTransferCompleted ) {
-			this.props.fetchUpdatedData();
 			this.setState( { isTransferring: false } );
 		}
 	};
@@ -202,4 +200,4 @@ const flowRightArgs = [
 	localize,
 ];
 
-export default flowRight( ...flowRightArgs )( WithOnclickTrialRequest( PluginUpload ) );
+export default flowRight( ...flowRightArgs )( PluginUpload );


### PR DESCRIPTION
A sub part of https://github.com/Automattic/dotcom-forge/issues/6638


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This is a sub part of https://github.com/Automattic/dotcom-forge/issues/6638, a task to remove code related to the old endpoint for starting trials. Doing multiple PRs otherwise the diff is quite large.

The trial button was originally removed in #89217, but we're removing more code so we can eventually remove the `useAddHostingTrialMutation` hook

~The plugin upload page also uses the `WithOnclickTrialRequest` HoC, which from the name appears to have something to do with a trial, but when I looked at the code it's unrelated to the hosting trial.~
I've removed `WithOnclickTrialRequest`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Review the code and test the plugin upload page. There should be no changes to the plugin upload page.

This is the page I'm referring to, accessed by the plugins UI in Calypso and then clicking "Upload". Specifically it's at `https://container-goofy-merkle.calypso.live/plugins/upload/{{ siteSlug }}`
![CleanShot 2024-05-01 at 21 50 46@2x](https://github.com/Automattic/wp-calypso/assets/1500769/f846d324-fb1f-4163-8189-f2510adbfe88)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?