### PR TITLE
Nav Redesign - fix redirects to new dashboard panels

### DIFF
--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,8 +1,13 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
 import { canCurrentUser } from '../../state/selectors/can-current-user';
 import { GitHubDeploymentCreation } from './deployment-creation';
 import { GitHubDeploymentManagement } from './deployment-management';
@@ -83,6 +88,18 @@ export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
+	const site = getSelectedSite( state );
+	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
+	const isJetpackNonAtomic = ! isAtomicSite && !! site?.jetpack;
+
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		if ( isJetpackNonAtomic ) {
+			context.page.replace( `/hosting/${ site?.slug }` );
+			return;
+		}
+		next();
+		return;
+	}
 
 	if ( ! siteId ) {
 		context.page.replace( `/home/${ siteSlug }` );

--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -1,10 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { createElement } from 'react';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import HostingActivate from './hosting-activate';
 import Hosting from './main';
 
@@ -35,6 +36,18 @@ export async function handleHostingPanelRedirect( context, next ) {
 	await waitForState( context );
 	const state = store.getState();
 	const siteId = getSelectedSiteId( state );
+	const site = getSelectedSite( state );
+	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
+	const isJetpackNonAtomic = ! isAtomicSite && !! site?.jetpack;
+
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		if ( ! isJetpackNonAtomic ) {
+			context.page.replace( `/hosting/${ site?.slug }` );
+			return;
+		}
+		next();
+		return;
+	}
 
 	if ( isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId ) ) {
 		page.redirect( '/hosting-config' );

--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -41,7 +41,7 @@ export async function handleHostingPanelRedirect( context, next ) {
 	const isJetpackNonAtomic = ! isAtomicSite && !! site?.jetpack;
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		if ( ! isJetpackNonAtomic ) {
+		if ( isJetpackNonAtomic ) {
 			context.page.replace( `/hosting/${ site?.slug }` );
 			return;
 		}

--- a/client/my-sites/site-monitoring/controller.tsx
+++ b/client/my-sites/site-monitoring/controller.tsx
@@ -1,6 +1,6 @@
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isEnabled } from '@automattic/calypso-config';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteMetrics } from './main';
 import type { Callback } from '@automattic/calypso-router';
 
@@ -12,8 +12,19 @@ export const siteMetrics: Callback = ( context, next ) => {
 export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
+	const site = getSelectedSite( state );
+	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 
-	if ( ! isAtomicSite( state, siteId ) ) {
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		if ( ! isAtomicSite ) {
+			context.page.replace( `/hosting/${ site?.slug }` );
+			return;
+		}
+		next();
+		return;
+	}
+
+	if ( ! isAtomicSite ) {
 		context.page.replace( `/home/${ context.params.siteId }` );
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6882

Atomic sites, we show all tabs.
![Image](https://github.com/Automattic/dotcom-forge/assets/797888/48228e1d-ae65-4ddd-bca0-e3e417e963d6)

Simple sites, we show the Overview, Hosting Config, and GitHub Deployments.
![Image](https://github.com/Automattic/dotcom-forge/assets/797888/a9bce926-1585-4977-ba20-a49ee8595705)

Non-dotcom Jetpack connected sites, we just show the Overview tab.
![Image](https://github.com/Automattic/dotcom-forge/assets/797888/5e895081-f676-4176-b4a0-62e37658d55b)

Currently, selecting another site via the collapsed site list will open the site with the previously active tab.
This means that if I'm on an Atomic site with the PHP Logs tab active, and then select a Simple site, the experience breaks by redirecting me to the Stats page.

This PR adds checks to the dashboard panel controllers to check that the selected site supports the current feature tab. The PR uses the same logic as we use when deciding what tabs to show for the selected site.

Now when you go to say, an Atomic site, select a Site monitoring tab and then select a Simple site, you should be redirected to the `/hosting/` panel for that Simple site instead of trying to show the site monitoring feature panel.

## Example


https://github.com/Automattic/wp-calypso/assets/5560595/f99b8be4-c22f-45dd-9611-8a77bf836b09



## Testing Instructions

* Go to `https://container-quizzical-einstein.calypso.live/sites?flags=layout/dotcom-nav-redesign-v2` and navigate between site and feature tab types and confirm behaviour is as expected.

