### PR TITLE
DIFM: accept coupon in signup flows

### DIFF
--- a/client/my-sites/checkout/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/purchase-modal/content.tsx
@@ -7,6 +7,7 @@ import {
 	getItemIntroductoryOfferDisplay,
 	LineItemSublabelAndPrice,
 	LineItemType,
+	getCouponLineItemFromCart,
 } from '@automattic/wpcom-checkout';
 import { sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
@@ -161,11 +162,13 @@ function PaymentMethodStep( {
 
 function OrderReview( {
 	creditsLineItem,
+	couponLineItem,
 	shouldDisplayTax,
 	tax,
 	total,
 }: {
 	creditsLineItem?: LineItemType | null;
+	couponLineItem?: LineItemType | null;
 	shouldDisplayTax: boolean;
 	tax: string;
 	total: string;
@@ -177,6 +180,11 @@ function OrderReview( {
 			{ creditsLineItem && <dt className="purchase-modal__credits">{ creditsLineItem.label }</dt> }
 			{ creditsLineItem && (
 				<dd className="purchase-modal__credits">{ creditsLineItem.formattedAmount }</dd>
+			) }
+
+			{ couponLineItem && <dt className="purchase-modal__coupon">{ couponLineItem.label }</dt> }
+			{ couponLineItem && (
+				<dd className="purchase-modal__coupon">{ couponLineItem.formattedAmount }</dd>
 			) }
 
 			{ shouldDisplayTax && <dt className="purchase-modal__tax">{ translate( 'Taxes' ) }</dt> }
@@ -239,6 +247,7 @@ export default function PurchaseModalContent( {
 } ) {
 	const translate = useTranslate();
 	const creditsLineItem = getCreditsLineItemFromCart( cart );
+	const couponLineItem = getCouponLineItemFromCart( cart );
 	const firstCard = cards.length > 0 ? cards[ 0 ] : undefined;
 
 	return (
@@ -259,6 +268,7 @@ export default function PurchaseModalContent( {
 				<CheckoutTerms cart={ cart } />
 				<OrderReview
 					creditsLineItem={ cart.sub_total_integer > 0 ? creditsLineItem : null }
+					couponLineItem={ couponLineItem }
 					shouldDisplayTax={ cart.tax.display_taxes }
 					total={ formatCurrency( cart.total_cost_integer, cart.currency, {
 						isSmallestUnit: true,

--- a/client/my-sites/checkout/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/purchase-modal/index.tsx
@@ -37,6 +37,7 @@ type PurchaseModalProps = {
 	onClose: () => void;
 	siteSlug: string;
 	productToAdd: MinimalRequestCartProduct;
+	coupon?: string;
 	showFeatureList: boolean;
 } & (
 	| {
@@ -112,6 +113,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 		onPurchaseSuccess = null,
 		disabledThankYouPage,
 		productToAdd,
+		coupon,
 		siteSlug,
 		showFeatureList,
 	} = props;
@@ -132,7 +134,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	const { razorpayConfiguration } = useRazorpay();
 	const reduxDispatch = useDispatch();
 	const cartKey = useCartKey();
-	const { responseCart, updateLocation, replaceProductsInCart, isPendingUpdate } =
+	const { responseCart, updateLocation, replaceProductsInCart, isPendingUpdate, applyCoupon } =
 		useShoppingCart( cartKey );
 	const selectedSite = useSelector( getSelectedSite );
 	const paymentMethodsState = useStoredPaymentMethods( {
@@ -204,7 +206,9 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 				city: wrapValueInManagedValue( storedCard.tax_location?.city ),
 				postalCode: wrapValueInManagedValue( storedCard.tax_location?.postal_code ),
 			};
+
 			setRequestSent( true );
+
 			updateCartContactDetailsForCheckout(
 				countries ?? [],
 				responseCart,
@@ -213,6 +217,9 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 				vatDetails
 			);
 			replaceProductsInCart( [ productToAdd ] );
+			if ( coupon ) {
+				applyCoupon( coupon );
+			}
 		}
 	}, [
 		replaceProductsInCart,
@@ -225,6 +232,8 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 		requestSent,
 		setRequestSent,
 		responseCart,
+		applyCoupon,
+		coupon,
 	] );
 
 	const handleOnClose = () => {

--- a/client/my-sites/checkout/purchase-modal/style.scss
+++ b/client/my-sites/checkout/purchase-modal/style.scss
@@ -237,6 +237,11 @@ $left-margin: 36px;
 	font-size: $font-body-small;
 }
 
+.purchase-modal__coupon {
+	font-weight: normal;
+	font-size: $font-body-small;
+}
+
 /**
  * Pay button
  */

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -524,6 +524,8 @@ export function generateFlows( {
 			enableBranchSteps: true,
 			hideProgressIndicator: true,
 			enablePresales: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
 		},
 		{
 			name: 'do-it-for-me-store',
@@ -543,6 +545,8 @@ export function generateFlows( {
 			enableBranchSteps: true,
 			hideProgressIndicator: true,
 			enablePresales: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
 		},
 		{
 			name: 'website-design-services',

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -380,12 +380,14 @@ function OneClickPurchaseModal( {
 	selectedPages,
 	isStoreFlow,
 	flowName,
+	coupon,
 }: {
 	onClose: () => void;
 	siteSlug: SiteSlug;
 	selectedPages: string[];
 	isStoreFlow: boolean;
 	flowName: string;
+	coupon?: string;
 } ) {
 	const translate = useTranslate();
 	const signupDependencies = useSelector( getSignupDependencyStore );
@@ -414,6 +416,7 @@ function OneClickPurchaseModal( {
 				<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
 					<PurchaseModal
 						productToAdd={ product }
+						coupon={ coupon }
 						onClose={ onClose }
 						showFeatureList={ false }
 						siteSlug={ siteSlug }
@@ -428,7 +431,12 @@ function DIFMPagePicker( props: StepProps ) {
 	const {
 		stepName,
 		goToNextStep,
-		signupDependencies: { siteId: siteIdFromDependencies, siteSlug, newOrExistingSiteChoice },
+		signupDependencies: {
+			siteId: siteIdFromDependencies,
+			siteSlug,
+			newOrExistingSiteChoice,
+			coupon,
+		},
 		flowName,
 	} = props;
 	const translate = useTranslate();
@@ -576,6 +584,7 @@ function DIFMPagePicker( props: StepProps ) {
 							selectedPages={ selectedPages }
 							isStoreFlow={ isStoreFlow }
 							flowName={ flowName }
+							coupon={ coupon }
 						/>
 					) }
 					<PageSelector


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thlinked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2885

## Proposed Changes

* This PR enables the `do-it-for-me` and `do-it-for-me-store` signup flows to accept the `coupon` query param.
* Also adds support for the 1-click checkout modal to apply the coupon and show the coupon line item if applied.

<img width="548" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/2a0e70d5-65b4-4dc1-930c-4c56a643cdff">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you have a saved credit card.
* Enable the store sandbox and go to `/start/do-it-for-me?coupon=testdifmcoupon`.
* Select an existing site.
* Go through the flow steps till you reach the page picker step and click on the checkout CTA.
* Confirm that the coupon has been applied and the purchase modal matches the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?