### PR TITLE
Scheduled Updates Multisite: Implement editing

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/context/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/context/index.tsx
@@ -6,6 +6,7 @@ import type { Dispatch, SetStateAction } from 'react';
 export type MultisitePluginUpdateManagerErrors = {
 	siteSlug: SiteSlug;
 	error: string;
+	operation: 'create' | 'update' | 'delete';
 	site?: SiteDetails | null;
 }[];
 

--- a/client/blocks/plugins-scheduled-updates-multisite/hooks/use-errors.ts
+++ b/client/blocks/plugins-scheduled-updates-multisite/hooks/use-errors.ts
@@ -8,14 +8,25 @@ export const useErrors = () => {
 	const { errors, setErrors } = useContext( MultisitePluginUpdateManagerContext );
 	const sites = useSelector( getSites );
 
-	const addError = ( siteSlug: SiteSlug, error: string ) => {
+	const addError = (
+		siteSlug: SiteSlug,
+		operation: 'create' | 'update' | 'delete',
+		error: string
+	) => {
 		const site = sites.find( ( site ) => site?.slug === siteSlug );
-		setErrors( ( prevErrors ) => [ ...( prevErrors || [] ), { siteSlug, error, site } ] );
+		setErrors( ( prevErrors ) => [
+			...( prevErrors || [] ),
+			{ siteSlug, error, operation, site },
+		] );
 	};
 
 	const clearErrors = () => {
 		setErrors( [] );
 	};
 
-	return { errors, addError, clearErrors };
+	const createErrors = errors.filter( ( error ) => error.operation === 'create' );
+	const updateErrors = errors.filter( ( error ) => error.operation === 'update' );
+	const deleteErrors = errors.filter( ( error ) => error.operation === 'delete' );
+
+	return { errors, createErrors, updateErrors, deleteErrors, addError, clearErrors };
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/hooks/use-load-schedule-from-id.ts
+++ b/client/blocks/plugins-scheduled-updates-multisite/hooks/use-load-schedule-from-id.ts
@@ -1,0 +1,12 @@
+import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+
+export const useLoadScheduleFromId = ( id: string ) => {
+	const { data: schedules, isFetched = [] } = useMultisiteUpdateScheduleQuery( true );
+
+	const schedule = schedules?.find( ( schedule ) => schedule.id === id );
+	// Make sure the sites are loaded, otherwise we pass undefined for the initial data
+	const scheduleLoaded = isFetched && schedule?.sites?.every( ( site ) => site.ID );
+	const scheduleNotFound = ! schedule && isFetched;
+
+	return { schedule, scheduleLoaded, scheduleNotFound };
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -2,12 +2,14 @@ import { useTranslate } from 'i18n-calypso';
 import { MultisitePluginUpdateManagerContextProvider } from 'calypso/blocks/plugins-scheduled-updates-multisite/context';
 import DocumentHead from 'calypso/components/data/document-head';
 import { ScheduleCreate } from './schedule-create';
+import { ScheduleEdit } from './schedule-edit';
 import { ScheduleList } from './schedule-list';
 
 import './styles.scss';
 
 type Props = {
 	onNavBack?: () => void;
+	id?: string;
 	context: 'create' | 'edit' | 'list';
 	onEditSchedule: ( id: string ) => void;
 	onShowLogs: ( id: string, siteSlug: string ) => void;
@@ -16,6 +18,7 @@ type Props = {
 
 export const PluginsScheduledUpdatesMultisite = ( {
 	context,
+	id,
 	onNavBack,
 	onCreateNewSchedule,
 	onEditSchedule,
@@ -43,6 +46,8 @@ export const PluginsScheduledUpdatesMultisite = ( {
 								onShowLogs={ onShowLogs }
 							/>
 						);
+					case 'edit':
+						return <ScheduleEdit id={ id! } onNavBack={ onNavBack } />;
 					default:
 						return <p>TODO</p>;
 				}

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
@@ -1,0 +1,31 @@
+import { Spinner } from '@wordpress/components';
+import { useEffect } from 'react';
+import { useLoadScheduleFromId } from './hooks/use-load-schedule-from-id';
+import { ScheduleForm } from './schedule-form';
+
+type Props = {
+	id: string;
+	onNavBack?: () => void;
+};
+
+export const ScheduleEdit = ( { id, onNavBack }: Props ) => {
+	const { schedule, scheduleLoaded, scheduleNotFound } = useLoadScheduleFromId( id );
+
+	// If the schedule is not found, navigate back to the list
+	useEffect( () => {
+		if ( scheduleNotFound ) {
+			onNavBack?.();
+		}
+	}, [ scheduleNotFound, onNavBack ] );
+
+	return (
+		<div className="plugins-update-manager plugins-update-manager-multisite">
+			<h1 className="wp-brand-font">Edit schedule</h1>
+			{ schedule && scheduleLoaded ? (
+				<ScheduleForm onNavBack={ onNavBack } scheduleForEdit={ schedule } />
+			) : (
+				<Spinner />
+			) }
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-errors.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-errors.tsx
@@ -1,0 +1,61 @@
+import { Notice } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
+import { useErrors } from './hooks/use-errors';
+
+export const ScheduleErrors = () => {
+	const { errors, createErrors, updateErrors, deleteErrors, clearErrors } = useErrors();
+	const translate = useTranslate();
+
+	if ( errors.length === 0 ) {
+		return null;
+	}
+
+	const renderErrorList = ( errorList: typeof errors, errorMessage: ReactNode ) => {
+		if ( errorList.length === 0 ) {
+			return null;
+		}
+
+		return (
+			<>
+				{ errorMessage }
+				<ul>
+					{ errorList.map( ( error, idx ) => (
+						<li key={ `${ error.siteSlug }.${ idx }` }>
+							<strong>{ error.site?.title }: </strong> { error.error }
+						</li>
+					) ) }
+				</ul>
+			</>
+		);
+	};
+
+	return (
+		<Notice status="warning" isDismissible={ true } onDismiss={ () => clearErrors() }>
+			{ renderErrorList(
+				createErrors,
+				translate(
+					'An error was encountered while creating the schedule.',
+					'Some errors were encountered while creating the schedule.',
+					{ count: createErrors.length }
+				)
+			) }
+			{ renderErrorList(
+				updateErrors,
+				translate(
+					'An error was encountered while updating the schedule.',
+					'Some errors were encountered while updating the schedule.',
+					{ count: updateErrors.length }
+				)
+			) }
+			{ renderErrorList(
+				deleteErrors,
+				translate(
+					'An error was encountered while deleting the schedule.',
+					'Some errors were encountered while deleting the schedule.',
+					{ count: deleteErrors.length }
+				)
+			) }
+		</Notice>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -3,7 +3,12 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useCreateMonitors } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-create-monitor';
 import { useCoreSitesPluginsQuery } from 'calypso/data/plugins/use-core-sites-plugins-query';
-import { useBatchCreateUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
+import {
+	useBatchCreateUpdateScheduleMutation,
+	useBatchDeleteUpdateScheduleMutation,
+	useBatchEditUpdateScheduleMutation,
+} from 'calypso/data/plugins/use-update-schedules-mutation';
+import { MultisiteSchedulesUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { ScheduleFormFrequency } from '../plugins-scheduled-updates/schedule-form-frequency';
 import { ScheduleFormPlugins } from '../plugins-scheduled-updates/schedule-form-plugins';
@@ -12,16 +17,35 @@ import { useErrors } from './hooks/use-errors';
 import { ScheduleFormSites } from './schedule-form-sites';
 
 type Props = {
+	scheduleForEdit?: MultisiteSchedulesUpdates;
 	onNavBack?: () => void;
 };
 
-export const ScheduleForm = ( { onNavBack }: Props ) => {
-	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
-	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( [] );
+type InitialData = {
+	sites: number[];
+	plugins: string[];
+	schedule: string;
+	timestamp: number;
+};
+
+export const ScheduleForm = ( { onNavBack, scheduleForEdit }: Props ) => {
+	const initialData: InitialData = scheduleForEdit
+		? {
+				sites: scheduleForEdit?.sites.map( ( site ) => site.ID ),
+				plugins: scheduleForEdit?.args,
+				schedule: scheduleForEdit?.schedule,
+				timestamp: scheduleForEdit?.timestamp * 1000,
+		  }
+		: { sites: [], plugins: [], schedule: 'daily', timestamp: Date.now() / 1000 };
+
+	const [ selectedSites, setSelectedSites ] = useState< number[] >( initialData.sites );
+	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( initialData.plugins );
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
-	const [ frequency, setFrequency ] = useState< 'daily' | 'weekly' >( 'daily' );
-	const [ timestamp, setTimestamp ] = useState< number >( Date.now() );
+	const [ frequency, setFrequency ] = useState< 'daily' | 'weekly' >(
+		initialData.schedule as 'daily' | 'weekly'
+	);
+	const [ timestamp, setTimestamp ] = useState< number >( initialData.timestamp );
 
 	const { addError, clearErrors } = useErrors();
 
@@ -31,7 +55,7 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 	const {
 		data: plugins,
 		isInitialLoading: isPluginsFetching,
-		isFetchedAfterMount: isPluginsFetched,
+		isFetched: isPluginsFetched,
 	} = useCoreSitesPluginsQuery( selectedSites, true, true );
 
 	const prevPlugins = useRef( plugins );
@@ -69,20 +93,46 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 		if ( selectedSites.length && plugins !== undefined ) {
 			prevPlugins.current = plugins;
 		}
-	}, [ plugins ] );
+	}, [ selectedSites, plugins ] );
 
 	useEffect( () => {
 		clearErrors();
 	}, [] );
 
-	const selectedSiteSlugs = sites
-		? sites.filter( ( site ) => selectedSites.includes( site.ID ) ).map( ( site ) => site.slug )
-		: [];
+	const siteIdsToSlugs = useCallback(
+		( siteIds: number[] ) => {
+			return sites
+				? sites.filter( ( site ) => siteIds.includes( site.ID ) ).map( ( site ) => site.slug )
+				: [];
+		},
+		[ sites ]
+	);
 
 	const { createMonitors } = useCreateMonitors();
 
+	// check initial data if site was not already there
+	const sitesNotInInitialData = selectedSites.filter(
+		( siteId ) => ! initialData.sites.includes( siteId )
+	);
+	const sitesInInitialData = selectedSites.filter( ( siteId ) =>
+		initialData.sites.includes( siteId )
+	);
+	const initialSitesNotInSelectedSites = initialData.sites.filter(
+		( siteId ) => ! selectedSites.includes( siteId )
+	);
+
+	const siteSlugsToCreate = siteIdsToSlugs( sitesNotInInitialData );
+	const siteSlugsToDelete = siteIdsToSlugs( initialSitesNotInSelectedSites );
+	const siteSlugsToUpdate = siteIdsToSlugs( sitesInInitialData );
+
 	const { mutateAsync: createUpdateScheduleAsync, isPending: createUpdateSchedulePending } =
-		useBatchCreateUpdateScheduleMutation( selectedSiteSlugs );
+		useBatchCreateUpdateScheduleMutation( siteSlugsToCreate );
+
+	const { mutateAsync: editUpdateScheduleAsync, isPending: editUpdateSchedulePending } =
+		useBatchEditUpdateScheduleMutation( siteSlugsToUpdate );
+
+	const { mutateAsync: deleteUpdateScheduleAsync, isPending: deleteUpdateSchedulePending } =
+		useBatchDeleteUpdateScheduleMutation( siteSlugsToDelete );
 
 	const submitForm = async ( event: React.FormEvent ) => {
 		event.preventDefault();
@@ -95,14 +145,41 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 			},
 		};
 
+		const successfulSiteSlugs = [];
+		// Create new schedules
 		const createResults = await createUpdateScheduleAsync( params );
-		const successfulSiteSlugs = createResults
-			.filter( ( result ) => ! result.error )
-			.map( ( result ) => result.siteSlug );
-		// Store errors
+		successfulSiteSlugs.push(
+			...createResults.filter( ( result ) => ! result.error ).map( ( result ) => result.siteSlug )
+		);
 		createResults
 			.filter( ( result ) => result.error )
-			.forEach( ( result ) => addError( result.siteSlug, ( result.error as Error ).message ) );
+			.forEach( ( result ) =>
+				addError( result.siteSlug, 'create', ( result.error as Error ).message )
+			);
+
+		// Update existing schedules
+		if ( scheduleForEdit ) {
+			const updateResults = await editUpdateScheduleAsync( {
+				id: scheduleForEdit.schedule_id,
+				params,
+			} );
+			successfulSiteSlugs.push(
+				...createResults.filter( ( result ) => ! result.error ).map( ( result ) => result.siteSlug )
+			);
+			updateResults
+				.filter( ( result ) => result.error )
+				.forEach( ( result ) =>
+					addError( result.siteSlug, 'update', ( result.error as Error ).message )
+				);
+
+			// Delete schedules no longer needed
+			const deleteResults = await deleteUpdateScheduleAsync( scheduleForEdit.schedule_id );
+			deleteResults
+				.filter( ( result ) => result.error )
+				.forEach( ( result ) =>
+					addError( result.siteSlug, 'delete', ( result.error as Error ).message )
+				);
+		}
 
 		// Create monitors for sites that have been successfully scheduled
 		createMonitors( successfulSiteSlugs );
@@ -116,6 +193,7 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 				<ScheduleFormSites
 					sites={ sites }
 					onChange={ setSelectedSites }
+					selectedSites={ selectedSites }
 					onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, sites: touched } ) }
 					error={ validationErrors?.sites }
 					showError={ fieldTouched?.sites }
@@ -135,7 +213,8 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 
 				<Text>{ translate( 'Step 3' ) }</Text>
 				<ScheduleFormFrequency
-					initFrequency="daily"
+					initFrequency={ frequency }
+					initTimestamp={ timestamp }
 					onChange={ ( frequency, timestamp ) => {
 						setTimestamp( timestamp );
 						setFrequency( frequency );
@@ -150,12 +229,18 @@ export const ScheduleForm = ( { onNavBack }: Props ) => {
 				form="schedule"
 				type="submit"
 				variant="primary"
-				isBusy={ createUpdateSchedulePending }
+				isBusy={
+					createUpdateSchedulePending || editUpdateSchedulePending || deleteUpdateSchedulePending
+				}
 				disabled={
-					! selectedSites.length || ! selectedPlugins.length || createUpdateSchedulePending
+					! selectedSites.length ||
+					! selectedPlugins.length ||
+					createUpdateSchedulePending ||
+					editUpdateSchedulePending ||
+					deleteUpdateSchedulePending
 				}
 			>
-				{ translate( 'Create' ) }
+				{ scheduleForEdit ? translate( 'Edit' ) : translate( 'Create' ) }
 			</Button>
 		</form>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -2,17 +2,16 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
-	Notice,
 	Spinner,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useState } from 'react';
 import { MultisitePluginUpdateManagerContext } from 'calypso/blocks/plugins-scheduled-updates-multisite/context';
-import { useErrors } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-errors';
 import { useBatchDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ScheduleListEmpty } from './schedule-list-empty';
+import { ScheduleErrors } from './schedule-errors';
 import { ScheduleListFilter } from './schedule-list-filter';
 import { ScheduleListTable } from './schedule-list-table';
 
@@ -37,8 +36,6 @@ export const ScheduleList = ( props: Props ) => {
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< string | undefined >();
 	const [ selectedSiteSlugs, setSelectedSiteSlugs ] = useState< string[] >( [] );
-
-	const { clearErrors, errors } = useErrors();
 
 	useEffect( () => {
 		const schedule = schedules?.find( ( schedule ) => schedule.schedule_id === selectedScheduleId );
@@ -104,22 +101,9 @@ export const ScheduleList = ( props: Props ) => {
 					</Button>
 				) }
 			</div>
-			{ errors.length ? (
-				<Notice status="warning" isDismissible={ true } onDismiss={ () => clearErrors() }>
-					{ translate(
-						'An error was encountered while creating the schedule.',
-						'Some errors were encountered while creating the schedule.',
-						{ count: errors.length }
-					) }
-					<ul>
-						{ errors.map( ( error, idx ) => (
-							<li key={ `${ error.siteSlug }.${ idx }` }>
-								<strong>{ error.site?.title }: </strong> { error.error }
-							</li>
-						) ) }
-					</ul>
-				</Notice>
-			) : null }
+
+			<ScheduleErrors />
+
 			{ schedules.length === 0 && isLoading && <Spinner /> }
 			{ isScheduleEmpty && <ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } /> }
 			{ isFetched && filteredSchedules.length > 0 && ScheduleListComponent ? (

--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -43,11 +43,12 @@ export function ScheduleFormPlugins( props: Props ) {
 	const [ fieldTouched, setFieldTouched ] = useState( false );
 
 	const removeUnlistedSelectedPlugins = useCallback( () => {
-		setSelectedPlugins(
-			selectedPlugins.filter( ( plugin ) => plugins.find( ( p ) => p.plugin === plugin ) )
-		);
-	}, [ plugins, selectedPlugins ] );
-
+		if ( isPluginsFetched ) {
+			setSelectedPlugins(
+				selectedPlugins.filter( ( plugin ) => plugins.find( ( p ) => p.plugin === plugin ) )
+			);
+		}
+	}, [ plugins, isPluginsFetched ] );
 	const onPluginSelectionChange = useCallback(
 		( plugin: CorePlugin, isChecked: boolean ) => {
 			if ( isChecked ) {
@@ -82,7 +83,7 @@ export function ScheduleFormPlugins( props: Props ) {
 
 	useEffect( () => onTouch?.( fieldTouched ), [ fieldTouched ] );
 	useEffect( () => onChange?.( selectedPlugins ), [ selectedPlugins ] );
-	useEffect( () => removeUnlistedSelectedPlugins(), [ plugins ] );
+	useEffect( () => removeUnlistedSelectedPlugins(), [ plugins, isPluginsFetched ] );
 
 	return (
 		<div className="form-field form-field--plugins">

--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -250,16 +250,12 @@ export function useBatchDeleteUpdateScheduleMutation( siteSlugs: SiteSlug[], que
 							} );
 							return { siteSlug, response };
 						} catch ( error ) {
-							throw { siteSlug, error };
+							return { siteSlug, error };
 						}
 					} )
 				);
 
-			// check if any of the requests failed
-			const failedRequests = results.filter( ( result ) => result.error );
-			if ( failedRequests.length ) {
-				throw failedRequests;
-			}
+			return results;
 		},
 		onSettled: () => {
 			queryClient.removeQueries( { queryKey: [ 'multisite-schedules-update' ] } );

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -192,7 +192,7 @@ export function scheduledUpdatesMultisite( context, next ) {
 		case 'edit':
 			context.primary = createElement( PluginsScheduledUpdatesMultisite, {
 				onNavBack: goToScheduledUpdatesList,
-				scheduleId: context.params.scheduleId,
+				id: context.params.id,
 				context: 'edit',
 			} );
 			break;

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -147,7 +147,7 @@ export default function ( router ) {
 			[
 				`/${ langParam }/plugins/scheduled-updates`,
 				`/${ langParam }/plugins/scheduled-updates/:action(create)`,
-				`/${ langParam }/plugins/scheduled-updates/:action(edit)/:schedule_id`,
+				`/${ langParam }/plugins/scheduled-updates/:action(edit)/:id`,
 			],
 			redirectLoggedOut,
 			navigation,


### PR DESCRIPTION
Closes #90107 

## Proposed Changes

* Adds the `<ScheduleEdit />` component
* Adds a hook to load a schedule by Id `useLoadScheduleFromId`
* Adds the initialData to the form
* When saving, makes a list of schedules to create (new sites added), to update and to delete (sites deselected)
* Break out the error list to its own component `<ScheduleErrors />`
* Small changes to the mutation to fit this solution

While testing I came across some syncing issues (the schedule is created on the site - but it's not stored inside the option). Since this doesn't seem to be related to anything on the Calypso end, I'd say we investigate this later.

## Testing Instructions

1. Apply this PR
2. Visit http://calypso.localhost:3000/plugins/scheduled-updates
3. Add some schedules
4. Edit them. Make sure to test scenarios where for example you add a site to the schedule or remove one.

Make sure to also test with a clean indexedDB cache. I ran into some problems with caches not being populated yet, and I hope to have resolved all of them:

![CleanShot 2024-05-01 at 12 59 52@2x](https://github.com/Automattic/wp-calypso/assets/528287/80fa45ca-8f0c-461b-83ea-313be268251d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?