### PR TITLE
Nav Redesign - update link colors

### DIFF
--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -118,7 +118,7 @@
 }
 
 a.hosting-overview__link-button {
-	color: var(--color-link);
+	color: var(--Primary-Blue, #007cba);
 	font-family: "SF Pro Text", $sans;
 	font-size: $font-body-extra-small;
 	line-height: 16px;

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -118,7 +118,7 @@
 }
 
 a.hosting-overview__link-button {
-	color: var(--Primary-Blue, #007cba);
+	color: var(--color-link);
 	font-family: "SF Pro Text", $sans;
 	font-size: $font-body-extra-small;
 	line-height: 16px;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -235,6 +235,12 @@ class Layout extends Component {
 
 		if ( typeof document !== 'undefined' ) {
 			const classList = document.querySelector( 'body' ).classList;
+
+			if ( this.props.isGlobalSidebarVisible && nextColorScheme !== 'modern' ) {
+				// We only want to apply the `modern` color scheme when the global sidebar is visible
+				nextColorScheme = 'modern';
+			}
+
 			classList.remove( `is-${ prevColorScheme }` );
 			classList.add( `is-${ nextColorScheme }` );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -223,7 +223,10 @@ class Layout extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( prevProps.colorScheme !== this.props.colorScheme ) {
+		if (
+			prevProps.colorScheme !== this.props.colorScheme ||
+			( this.props.isGlobalSidebarVisible && this.props.colorScheme !== 'modern' )
+		) {
 			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
 		}
 	}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -236,8 +236,10 @@ class Layout extends Component {
 		if ( typeof document !== 'undefined' ) {
 			const classList = document.querySelector( 'body' ).classList;
 
+			// We only want to apply the `modern` color scheme when the global sidebar is visible
 			if ( this.props.isGlobalSidebarVisible && nextColorScheme !== 'modern' ) {
-				// We only want to apply the `modern` color scheme when the global sidebar is visible
+				// Remove the color scheme in case it was set before
+				classList.remove( `is-${ nextColorScheme }` );
 				nextColorScheme = 'modern';
 			}
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -6,14 +6,6 @@
 // Add new Dotcom specific styles to this file.
 .wpcom-site .layout__primary .main {
 	padding-bottom: 0;
-	--color-accent: #3858e9;
-	--color-accent-40: #3858e9;
-	--color-accent-60: #3858e9;
-	--color-link: #3858e9;
-	--color-primary: #3858e9;
-	--color-primary-50: #3858e9;
-	--color-primary-60: #3858e9;
-	--wp-admin-theme-color: #3858e9;
 }
 
 .wpcom-site .a4a-layout-with-columns__container {
@@ -119,12 +111,6 @@
 
 			&::placeholder {
 				color: var(--studio-gray-40);
-			}
-
-			&:focus {
-				.components-input-control__backdrop {
-					border-color: var(--color-link);
-				}
 			}
 		}
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -6,6 +6,14 @@
 // Add new Dotcom specific styles to this file.
 .wpcom-site .layout__primary .main {
 	padding-bottom: 0;
+	--color-accent: #3858e9;
+	--color-accent-40: #3858e9;
+	--color-accent-60: #3858e9;
+	--color-link: #3858e9;
+	--color-primary: #3858e9;
+	--color-primary-50: #3858e9;
+	--color-primary-60: #3858e9;
+	--wp-admin-theme-color: #3858e9;
 }
 
 .wpcom-site .a4a-layout-with-columns__container {
@@ -111,6 +119,12 @@
 
 			&::placeholder {
 				color: var(--studio-gray-40);
+			}
+
+			&:focus {
+				.components-input-control__backdrop {
+					border-color: var(--color-link);
+				}
 			}
 		}
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -260,6 +260,7 @@
 			height: 16px;
 			padding-left: 0;
 			padding-right: 0;
+			color: var(--color-link);
 
 			@include break-medium {
 				height: 32px;

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -104,6 +104,7 @@ const DownloadIcon = styled( Icon )`
 const popoverHoverStyles = css`
 	&:hover,
 	&:focus {
+		background-color: #3858e9; !important;
 		fill: var( --color-text-inverted );
 	}
 `;
@@ -140,6 +141,7 @@ const SitesDashboardHeader = () => {
 					isMobile={ isMobile }
 				>
 					<PopoverMenuItem
+						className={ `${ popoverHoverStyles }` }
 						onClick={ () => {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
 						} }

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -104,7 +104,6 @@ const DownloadIcon = styled( Icon )`
 const popoverHoverStyles = css`
 	&:hover,
 	&:focus {
-		background-color: #3858e9; !important;
 		fill: var( --color-text-inverted );
 	}
 `;
@@ -141,7 +140,6 @@ const SitesDashboardHeader = () => {
 					isMobile={ isMobile }
 				>
 					<PopoverMenuItem
-						className={ `${ popoverHoverStyles }` }
 						onClick={ () => {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
 						} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6851

Some examples of color changes;

**Before**
<img width="529" alt="Screenshot 2024-05-01 at 22 24 01" src="https://github.com/Automattic/wp-calypso/assets/5560595/14b9f152-d72c-4920-93f9-a787d9589aaa">
**After**
<img width="529" alt="Screenshot 2024-05-01 at 22 27 37" src="https://github.com/Automattic/wp-calypso/assets/5560595/00c7d2dd-85c7-4144-bb04-144dfa54d938">

**Before**

https://github.com/Automattic/wp-calypso/assets/5560595/aed4fd15-f254-4d19-8e05-a3bc96ca2ee8

**After**

https://github.com/Automattic/wp-calypso/assets/5560595/740f7421-d973-481e-a57c-074d91664a3f

**Before**
<img width="572" alt="Screenshot 2024-05-01 at 21 51 58" src="https://github.com/Automattic/wp-calypso/assets/5560595/dbdcf3d0-f55e-4cd5-9bad-966e60394ea7">
**After**
<img width="535" alt="Screenshot 2024-05-01 at 21 54 54" src="https://github.com/Automattic/wp-calypso/assets/5560595/343b51b8-1e36-4a38-9cc5-55d4a5412e46">

## Proposed Changes

* Override the color theme used on new dashboard to always be 'modern' when the global sidebar is visible.
* Updates the close preview icon to also use this color

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update your test WP account settings to use an non-default dashboard theme
 
<img width="1011" alt="Screenshot 2024-05-01 at 22 32 35" src="https://github.com/Automattic/wp-calypso/assets/5560595/d1b89b7f-61e7-48fa-b546-1fe7cda13cf5">

* Go to calypso live sites with the flag `?flags=layout/dotcom-nav-redesign-v2`
* Confirm all links, buttons, hover states etc have the blueberry color in the dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?