### PR TITLE
A4A: Enable WPCOM Bulk purchase in  in horizon and staging.

### DIFF
--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -26,7 +26,7 @@
 	],
 	"features": {
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": false,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"oauth": false,
 		"a4a/site-details-pane": true,
 		"a4a-logged-out-signup": true

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -28,7 +28,7 @@
 	"oauth_client_id": 95932,
 	"features": {
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": false,
 		"oauth": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -28,7 +28,7 @@
 	"oauth_client_id": 95932,
 	"features": {
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": false,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"oauth": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -28,7 +28,7 @@
 	"oauth_client_id": 95931,
 	"features": {
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": false,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"oauth": true,
 		"a4a/site-details-pane": true,
 		"a4a-logged-out-signup": true


### PR DESCRIPTION

## Proposed Changes

* Enable 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' feature flag in Horizon, Staging.

## Testing Instructions

* Test the A4A live link below and see we no longer need the feature flag to access the new changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?