### PR TITLE
Scheduled Updates Multisite: make logs back button return correctly

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -116,7 +116,14 @@ export function plugins( context, next ) {
 export function scheduledUpdates( context, next ) {
 	const siteSlug = context?.params?.site_slug;
 	const scheduleId = context?.params?.schedule_id;
-	const goToScheduledUpdatesList = () => page.show( `/plugins/scheduled-updates/${ siteSlug }` );
+	const goToScheduledUpdatesList = () => {
+		// check if window.location query has multisite
+		if ( window?.location.search.includes( 'multisite' ) ) {
+			page.show( `/plugins/scheduled-updates` );
+		} else {
+			page.show( `/plugins/scheduled-updates/${ siteSlug }` );
+		}
+	};
 
 	if ( ! siteSlug ) {
 		sites( context, next );
@@ -203,7 +210,7 @@ export function scheduledUpdatesMultisite( context, next ) {
 				context: 'list',
 				onEditSchedule: ( id ) => page.show( `/plugins/scheduled-updates/edit/${ id }` ),
 				onShowLogs: ( id, siteSlug ) =>
-					page.show( `/plugins/scheduled-updates/logs/${ siteSlug }/${ id }` ),
+					page.show( `/plugins/scheduled-updates/logs/${ siteSlug }/${ id }?multisite` ),
 				onCreateNewSchedule: () => page.show( `/plugins/scheduled-updates/create/` ),
 			} );
 			break;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/89982

## Proposed Changes

* Changes the behavior of the back navigation link in Scheduled Updates to link to Multisite when `?multisite` is present in the query string.

## Testing Instructions

1. Apply this PR
2. Restart Calypso
3. Go to ttp://calypso.localhost:3000/plugins/scheduled-updates/
4. Expand a row
5. Click Logs
6. Clicking the "Back" navigation link in the UI should return you to the multisite list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?