### PR TITLE
Scheduled Updates Multisite: Add <title>

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,4 +1,6 @@
+import { useTranslate } from 'i18n-calypso';
 import { MultisitePluginUpdateManagerContextProvider } from 'calypso/blocks/plugins-scheduled-updates-multisite/context';
+import DocumentHead from 'calypso/components/data/document-head';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleList } from './schedule-list';
 
@@ -19,8 +21,16 @@ export const PluginsScheduledUpdatesMultisite = ( {
 	onEditSchedule,
 	onShowLogs,
 }: Props ) => {
+	const translate = useTranslate();
+	const title = {
+		create: translate( 'New schedule' ),
+		edit: translate( 'Edit schedule' ),
+		list: translate( 'Update schedules' ),
+	}[ context ];
+
 	return (
 		<MultisitePluginUpdateManagerContextProvider>
+			<DocumentHead title={ title } />
 			{ ( () => {
 				switch ( context ) {
 					case 'create':


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/90148

## Proposed Changes

* Add title tags

## Testing Instructions

1. Apply this PR
2. Navigate to ttp://calypso.localhost:3000/plugins/scheduled-updates
3. Ensure the title tags are there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?