### PR TITLE
Site Migration: Skip bundle transfer step

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -228,19 +228,17 @@ const siteMigration: Flow = {
 					} );
 				}
 
+				// Remove it when the  'migration-flow/remove-processing-step' is enabled.
 				case STEPS.BUNDLE_TRANSFER.slug: {
-					if ( isEnabled( 'migration-flow/remove-processing-step' ) ) {
-						return navigate(
-							addQueryArgs( { siteSlug, siteId }, STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug )
-						);
-					}
 					return navigate( STEPS.PROCESSING.slug, { bundleProcessing: true } );
 				}
 
+				// Remove it when the  'migration-flow/remove-processing-step' is enabled.
 				case STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug: {
 					return navigate( STEPS.PROCESSING.slug, { pluginInstall: true } );
 				}
 
+				// Remove it when the  'migration-flow/remove-processing-step' is enabled.
 				case STEPS.PROCESSING.slug: {
 					// Any process errors go to the error step.
 					if ( providedDependencies?.error ) {
@@ -294,12 +292,17 @@ const siteMigration: Flow = {
 					}
 
 					if ( providedDependencies?.goToCheckout ) {
+						const destinationStep = isEnabled( 'migration-flow/remove-processing-step' )
+							? STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug
+							: STEPS.BUNDLE_TRANSFER.slug;
+
 						const destination = addQueryArgs(
 							{
 								siteSlug,
 								from: fromQueryParam,
+								siteId,
 							},
-							`/setup/${ FLOW_NAME }/${ STEPS.BUNDLE_TRANSFER.slug }`
+							`/setup/${ FLOW_NAME }/${ destinationStep }`
 						);
 
 						urlQueryParams.delete( 'showModal' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90146

## Proposed Changes
* Redirect the user directly to the migration screen page when the 'migration-flow/remove-processing-step'  is enabled

> [!NOTE]
> We need to double-check the verify-email step


## Testing Instructions


* Enable the flag via `sessionStorage.setItem('flags', "migration-flow/remove-processing-step")`
* Select a free plan
* Go through the migration steps
* Choose `Everything (requires a Creator Plan)` 
* When you arrive on the checkout page, check if the URL contains the value `site-migration-instructions-i2`
* Finish the payment
* Check if you were redirected directly to the `setup/site-migration/site-migration-instructions-i2` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?