### PR TITLE
Entrepreneur Signup: Add entrepreneur site setup launchpad.

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -51,6 +51,7 @@ export const TASK_STAGING = 'home-task-staging';
 export const TASK_FIVERR = 'home-task-fiverr';
 export const TASK_DOMAIN_UPSELL = 'home-task-domain-upsell';
 export const TASK_GOOGLE_DOMAIN_OWNERS = 'home-task-google-domain-owners';
+export const LAUNCHPAD_ENTREPRENEUR_SITE_SETUP = 'home-launchpad-entrepreneur-site-setup';
 export const LAUNCHPAD_INTENT_BUILD = 'home-launchpad-intent-build';
 export const LAUNCHPAD_INTENT_HOSTING = 'home-launchpad-intent-hosting';
 export const LAUNCHPAD_INTENT_WRITE = 'home-launchpad-intent-write';

--- a/client/my-sites/customer-home/cards/launchpad/entrepreneur-site-setup.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/entrepreneur-site-setup.tsx
@@ -1,0 +1,9 @@
+import CustomerHomeLaunchpad from '.';
+
+const checklistSlug = 'entrepreneur-site-setup';
+
+const LaunchpadEntrepreneurSiteSetup = (): JSX.Element => {
+	return <CustomerHomeLaunchpad checklistSlug={ checklistSlug }></CustomerHomeLaunchpad>;
+};
+
+export default LaunchpadEntrepreneurSiteSetup;

--- a/client/my-sites/customer-home/locations/card-components.ts
+++ b/client/my-sites/customer-home/locations/card-components.ts
@@ -4,6 +4,7 @@ import {
 	FEATURE_READER,
 	FEATURE_STATS,
 	FEATURE_SUPPORT,
+	LAUNCHPAD_ENTREPRENEUR_SITE_SETUP,
 	LAUNCHPAD_INTENT_BUILD,
 	LAUNCHPAD_INTENT_FREE_NEWSLETTER,
 	LAUNCHPAD_INTENT_HOSTING,
@@ -49,6 +50,7 @@ import DomainUpsellFeature from 'calypso/my-sites/customer-home/cards/features/d
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import ReaderCard from 'calypso/my-sites/customer-home/cards/features/reader';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
+import LaunchpadEntrepreneurSiteSetup from 'calypso/my-sites/customer-home/cards/launchpad/entrepreneur-site-setup';
 import LaunchpadIntentBuild from 'calypso/my-sites/customer-home/cards/launchpad/intent-build';
 import LaunchpadIntentHosting from 'calypso/my-sites/customer-home/cards/launchpad/intent-hosting';
 import {
@@ -132,6 +134,7 @@ const CARD_COMPONENTS: CardComponentMap = {
 	[ FEATURE_READER ]: ReaderCard,
 	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ FEATURE_STATS ]: Stats,
+	[ LAUNCHPAD_ENTREPRENEUR_SITE_SETUP ]: LaunchpadEntrepreneurSiteSetup,
 	[ LAUNCHPAD_INTENT_BUILD ]: LaunchpadIntentBuild,
 	[ LAUNCHPAD_INTENT_FREE_NEWSLETTER ]: LaunchpadIntentFreeNewsletter,
 	[ LAUNCHPAD_INTENT_HOSTING ]: LaunchpadIntentHosting,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6767.

## Proposed Changes

* Add a component that will render the entrepreneur site setup launchpad.

## Testing Instructions

* Apply the patch D147257-code on your sandbox.
* Sandbox `public-api.wordpress.com`.
* Go to `calypso.localhost:3000/home/your-site-here.wpcomstaging.com?&flags=entrepreneur-my-home`.
  * Alternatively, feel free to create a site via `/setup/entrepreneur/start?flags=ecommerce-segmentation-survey`.
* You should see the Entrepreneur Launchpad.

<img width="721" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/3e8e6121-65ac-4b8a-8830-a3701ed97ac5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?