### PR TITLE
Site Migration: Fix bug where users didn't get the trial plan after the verification

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-assign-trial-plan/index.tsx
@@ -27,7 +27,9 @@ const SiteMigrationAssignTrialPlanStep: Step = ( { navigation } ) => {
 	} );
 
 	useEffect( () => {
-		if ( site && ! site?.plan && ! isAddingTrial ) {
+		// A site is trial eligible if it has no plan or the free plan.
+		const siteIsTrialEligible = ! site?.plan || site?.plan?.product_slug === 'free_plan';
+		if ( site && siteIsTrialEligible && ! isAddingTrial ) {
 			setIsAddingTrial( true );
 			const assignMigrationTrialPlan = () => {
 				site.ID && addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY, HOSTING_INTENT_MIGRATE );


### PR DESCRIPTION
…redirect

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89401

## Proposed Changes

We have a safety check where we weren't assigning the trial plan on verification redirect if the site already had a plan. However the check failed when the user had a Free plan (which is what they normally have when going for the trial).

This fixes it so Free users are properly assigned the trial plan after redirecting from email verification.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This should be tested along with D146149-code. See the diff for testing instructions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)