### PR TITLE
A4A: Update the Sites Dashboard empty state UI

### DIFF
--- a/client/a8c-for-agencies/constants/index.ts
+++ b/client/a8c-for-agencies/constants/index.ts
@@ -1,0 +1,4 @@
+export const A4A_DOWNLOAD_LINK_ON_GITHUB =
+	'https://github.com/Automattic/automattic-for-agencies-client/releases/download/v0.1.0/automattic-for-agencies-client.zip';
+export const JETPACK_CONNECT_A4A_LINK =
+	'https://wordpress.com/jetpack/connect?source=a8c-for-agencies';

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
@@ -8,6 +8,10 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import {
+	A4A_DOWNLOAD_LINK_ON_GITHUB,
+	JETPACK_CONNECT_A4A_LINK,
+} from 'calypso/a8c-for-agencies/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -16,9 +20,6 @@ export default function EmptyState() {
 	const dispatch = useDispatch();
 
 	const title = translate( 'Sites' );
-
-	const pluginDownloadLink = ''; // FIXME: Provide correct download link.
-	const connectSiteViaJetpackLink = 'https://wordpress.com/jetpack/connect?source=a8c-for-agencies';
 
 	return (
 		<Layout title={ title } wide withBorder sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -63,7 +64,7 @@ export default function EmptyState() {
 
 							<div className="sites-dashboard-empty__content-button">
 								<Button
-									href={ pluginDownloadLink }
+									href={ A4A_DOWNLOAD_LINK_ON_GITHUB }
 									target="_blank"
 									primary
 									onClick={ () =>
@@ -75,7 +76,7 @@ export default function EmptyState() {
 									{ translate( 'Download the A4A client plugin' ) }
 								</Button>
 								<Button
-									href={ connectSiteViaJetpackLink }
+									href={ JETPACK_CONNECT_A4A_LINK }
 									target="_blank"
 									onClick={ () =>
 										dispatch(

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/empty-state.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
-// import { Icon, external } from '@wordpress/icons';
+import { Icon, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -18,8 +17,8 @@ export default function EmptyState() {
 
 	const title = translate( 'Sites' );
 
-	const pluginDownloadLink = 'https://wordpress.org/plugins/jetpack/'; // FIXME: Provide correct download link.
-	// const resourceLink = ''; // FIXME: Provide correct resource link.
+	const pluginDownloadLink = ''; // FIXME: Provide correct download link.
+	const connectSiteViaJetpackLink = 'https://wordpress.com/jetpack/connect?source=a8c-for-agencies';
 
 	return (
 		<Layout title={ title } wide withBorder sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -30,50 +29,64 @@ export default function EmptyState() {
 			</LayoutTop>
 
 			<LayoutBody>
-				<div className="sites-dashboard__empty">
-					<A4ALogo className="sites-dashboard__empty-logo" size={ 64 } />
+				<div className="sites-dashboard-empty">
+					<h1 className="sites-dashboard-empty__heading">
+						{ translate( 'Connect your sites and simplify your work' ) }
+					</h1>
 
-					<p className="sites-dashboard__empty-message">
-						{ translate(
-							'Add all of your sites to your dashboard by installing the Automattic for Agencies connection plugin. Once connected within wp-admin, your sites will automatically sync here.'
-						) }
+					<p className="sites-dashboard-empty__subheading">
+						{ translate( "Manage all your sites's products from one place." ) }
 					</p>
+					<div className="sites-dashboard-empty__body">
+						<div className="sites-dashboard-empty__plugins-icon">
+							<Icon
+								className="sidebar__menu-icon"
+								style={ { fill: 'currentcolor' } }
+								icon={ plugins }
+								size={ 24 }
+							/>
+						</div>
+						<div className="sites-dashboard-empty__content">
+							<div className="sites-dashboard-empty__content-heading">
+								{ translate( 'Install the A4A plugin to manage your sites in the dashboard' ) }
+							</div>
+							<p className="sites-dashboard-empty__content-description">
+								{ translate(
+									"Use the A4A plugin to actively connect your clients' sites to Automattic for Agencies — it's lightweight and efficient, working seamlessly in the background."
+								) }
+							</p>
+							<p className="sites-dashboard-empty__content-description">
+								{ translate(
+									'Already have Jetpack installed? You can use it as a connection option as well.'
+								) }
+							</p>
 
-					<div className="sites-dashboard__empty-actions">
-						<Button
-							href={ pluginDownloadLink }
-							target="_blank"
-							primary
-							onClick={ () =>
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_sites_dashboard_download_a4a_plugin_click' )
-								)
-							}
-						>
-							{ translate( 'Connect sites with Jetpack (Temporary)' ) }
-						</Button>
-						{ /* TODO: replace this after A4A plugin and docs are ready */ }
-						{ /* <Button
-							href={ pluginDownloadLink }
-							target="_blank"
-							primary
-							onClick={ () =>
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_sites_dashboard_download_a4a_plugin_click' )
-								)
-							}
-						>
-							{ translate( 'Download A4A Plugin' ) }
-						</Button>
-						<Button
-							href={ resourceLink }
-							target="_blank"
-							onClick={ () =>
-								dispatch( recordTracksEvent( 'calypso_a4a_sites_dashboard_learn_more_click' ) )
-							}
-						>
-							{ translate( 'Learn more' ) } <Icon icon={ external } size={ 18 } />
-						</Button> */ }
+							<div className="sites-dashboard-empty__content-button">
+								<Button
+									href={ pluginDownloadLink }
+									target="_blank"
+									primary
+									onClick={ () =>
+										dispatch(
+											recordTracksEvent( 'calypso_a4a_sites_dashboard_download_a4a_plugin_click' )
+										)
+									}
+								>
+									{ translate( 'Download the A4A client plugin' ) }
+								</Button>
+								<Button
+									href={ connectSiteViaJetpackLink }
+									target="_blank"
+									onClick={ () =>
+										dispatch(
+											recordTracksEvent( 'calypso_a4a_sites_dashboard_connect_jetpack_click' )
+										)
+									}
+								>
+									{ translate( 'Connect a site via Jetpack' ) }
+								</Button>
+							</div>
+						</div>
 					</div>
 				</div>
 			</LayoutBody>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -1049,37 +1049,91 @@
 	}
 }
 
-.sites-dashboard__empty {
+.sites-dashboard-empty {
 	display: flex;
 	flex-direction: column;
-	gap: 24px;
+	gap: 12px;
 	align-items: center;
 
 	margin: 24px auto;
-	padding: 64px 0;
 	max-width: 700px;
 	text-align: center;
-}
 
-.sites-dashboard__empty-message {
-	font-size: 1rem;
-	font-weight: 400;
-	line-height: 1.5;
-}
-
-.sites-dashboard__empty-actions {
-	display: flex;
-	flex-direction: row;
-	gap: 8px;
-
-	margin: 0 auto;
-
-	> .button {
-		display: flex;
-		align-items: center;
-		justify-content: center;
+	@include break-large {
+		align-items: start;
+		text-align: left;
 	}
 }
+
+.sites-dashboard-empty__heading {
+	font-size: rem(24px);
+	font-weight: 600;
+}
+
+.sites-dashboard-empty__subheading {
+	font-size: inherit;
+}
+
+.sites-dashboard-empty__body {
+	margin-block-end: 16px;
+	border-radius: 4px;
+	border: 1px solid var(--color-accent-5);
+	padding: 16px 24px;
+
+	@include break-large {
+		display: flex;
+		gap: 16px;
+	}
+
+	.sites-dashboard-empty__plugins-icon {
+		display: none;
+		opacity: 0.7;
+
+		@include break-large {
+			display: block;
+		}
+	}
+
+	.sites-dashboard-empty__content {
+		text-align: left;
+	}
+
+	.sites-dashboard-empty__content-heading {
+		font-size: rem(16px);
+		font-weight: 500;
+	}
+
+	.sites-dashboard-empty__content-description {
+		margin-block-start: 4px;
+		font-size: rem(14px);
+		line-height: 1.7;
+		color: var(--color-accent);
+	}
+
+	.sites-dashboard-empty__content-button {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+
+		margin-block-start: 16px;
+		margin-inline-start: auto;
+
+		@include break-large {
+			flex-direction: row;
+		}
+
+		.button {
+			width: 100%;
+			height: 40px;
+
+			@include break-large {
+				width: auto;
+				height: inherit;
+			}
+		}
+	}
+}
+
 
 /* See wp-calypso/client/layout/style.scss for the original style - this is removed on sites dashboard to enable pagination to display properly. */
 .layout__primary .preview-hidden {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/380

## Proposed Changes

Update the empty-state UI of the Sites Dashboard to display a link to download the latest version of the A4A plugin in a zip file.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img width="1403" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/f8c318e6-1b1b-4cde-856c-ede47938f742"></td>
<td><img width="1403" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/34f4a2db-59fa-4944-8eac-e9be986d544b"></td>
</tr>
</table>

## Testing Instructions

* Locally or via Live Branch, using an account with no sites, visit `/sites`.
* Verify that the page looks like the screenshot provided above.
* Verify that the primary button downloads a zip file with the latest version of the A4A plugin.
* Verify that the secondary button takes you to the Jetpack Connection flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?