### PR TITLE
Global Sidebar - update submenu group color

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -149,6 +149,7 @@ $brand-text: "SF Pro Text", $sans;
 				.sidebar__menu-link {
 					margin: 0;
 					color: var(--color-sidebar-submenu-text);
+					border-radius: 0;
 				}
 
 				.reader-sidebar-tags__text-input {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -46,7 +46,7 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-menu-selected-text: var(--studio-white);
 		--color-sidebar-menu-hover-text: var(--studio-black);
 		--color-sidebar-menu-hover-background: #eee;
-		--color-sidebar-submenu-background: var(--studio-gray-5);
+		--color-sidebar-submenu-background: var(--studio-white);
 		--color-sidebar-border: var(--studio-gray-5);
 		--color-sidebar-submenu-text: var(--color-sidebar-text);
 		--color-sidebar-submenu-selected-text: var(--color-sidebar-menu-selected-text);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/172

## Proposed Changes

* Updates submenu group color for the global sidebar to studio-white.

BEFORE

<img width="285" alt="Screenshot 2024-05-01 at 1 16 52 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/bd21615a-6c07-4a91-bc25-7e0b38aa0d3b">


AFTER

<img width="314" alt="Screenshot 2024-05-01 at 1 16 27 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a6459c58-bc46-4e28-9388-429663308f78">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build
* Open a submenu group in the reader sidebar (there shouldn't be any submenu groups outside of the reader).
* Verify the colors updated as expected.
* Smoke test the rest of the global sidebar and it looks good in /me, /sites as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
