### PR TITLE
Reader sidebar - remove box shadow of promo banner

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -128,6 +128,10 @@
 			color: var(--color-link-dark);
 		}
 	}
+
+	.sidebar__app-promo .app-promo-sidebar {
+		box-shadow: none;
+	}
 }
 
 .is-reader-page.theme-default .sidebar .sidebar__menu-link::after {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/173

## Proposed Changes

* Removes the box shadow from the promo banner specifically in the context of the reader sidebar.

BEFORE

<img width="301" alt="Screenshot 2024-05-01 at 1 28 28 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/67124c28-b705-4a2c-9d27-e6a8efb38d24">



AFTER

<img width="292" alt="Screenshot 2024-05-01 at 1 27 14 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/bfa09ca2-7565-4d1b-8812-f90bb0304372">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build.
* Visit the reader and verify the promo banner has no border.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
