### PR TITLE
Reader cards - add contrasting background

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -31,7 +31,7 @@
 .reader-post-card.card {
 	border-bottom: 5px solid var(--color-neutral-0);
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
-	box-shadow: none;
+	box-shadow: rgba(0, 0, 0, 0.05) 0 0 0 1px inset;
 	margin: 0;
 	margin-bottom: 24px;
 	position: relative;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -37,6 +37,11 @@
 	position: relative;
 	background: #FAFAFA; /* stylelint-disable color-hex-case */
 
+	@include breakpoint-deprecated( "<660px" ) {
+		background: none;
+		border-radius: 0;
+	}
+
 	@include breakpoint-deprecated( ">660px" ) {
 		border-bottom: 1px solid #e9e9ea;
 	}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -40,6 +40,7 @@
 	@include breakpoint-deprecated( "<660px" ) {
 		background: none;
 		border-radius: 0;
+		box-shadow: none;
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -35,7 +35,7 @@
 	margin: 0;
 	margin-bottom: 24px;
 	position: relative;
-	background: #FBFBFB; /* stylelint-disable color-hex-case */
+	background: #FAFAFA; /* stylelint-disable color-hex-case */
 
 	@include breakpoint-deprecated( ">660px" ) {
 		border-bottom: 1px solid #e9e9ea;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -30,12 +30,12 @@
 
 .reader-post-card.card {
 	border-bottom: 5px solid var(--color-neutral-0);
-	border-radius: 0;
+	border-radius: 15px; /* stylelint-disable-line scales/radii */
 	box-shadow: none;
 	margin: 0;
 	margin-bottom: 16px;
-	padding: 16px 0 32px 0;
 	position: relative;
+	background: var(--studio-gray-0);
 
 	@include breakpoint-deprecated( ">660px" ) {
 		border-bottom: 1px solid #e9e9ea;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -30,10 +30,10 @@
 
 .reader-post-card.card {
 	border-bottom: 5px solid var(--color-neutral-0);
-	border-radius: 15px; /* stylelint-disable-line scales/radii */
+	border-radius: 6px; /* stylelint-disable-line scales/radii */
 	box-shadow: none;
 	margin: 0;
-	margin-bottom: 16px;
+	margin-bottom: 24px;
 	position: relative;
 	background: var(--studio-gray-0);
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -35,7 +35,7 @@
 	margin: 0;
 	margin-bottom: 24px;
 	position: relative;
-	background: var(--studio-gray-0);
+	background: #FBFBFB; /* stylelint-disable color-hex-case */
 
 	@include breakpoint-deprecated( ">660px" ) {
 		border-bottom: 1px solid #e9e9ea;

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -98,10 +98,6 @@
 	}
 }
 
-.following-stream-header .navigation-header__main {
-	margin-bottom: 24px;
-}
-
 #primary header.navigation-header header.formatted-header {
 	margin: 0;
 }

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -46,6 +46,7 @@
 	align-items: flex-start;
 	box-sizing: border-box;
 	column-gap: 10px;
+	margin-bottom: 24px;
 
 	> .formatted-header {
 		flex: 1;

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -46,7 +46,6 @@
 	align-items: flex-start;
 	box-sizing: border-box;
 	column-gap: 10px;
-	margin-bottom: 24px;
 
 	> .formatted-header {
 		flex: 1;
@@ -97,6 +96,10 @@
 		align-items: center;
 		gap: 16px;
 	}
+}
+
+.following-stream-header .navigation-header__main {
+	margin-bottom: 24px;
 }
 
 #primary header.navigation-header header.formatted-header {

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -3,6 +3,7 @@
 	display: flex;
 	flex-flow: row wrap;
 	line-height: 28px;
+	margin-bottom: 24px;
 	padding-top: 11px;
 	padding-bottom: 11px;
 	position: relative;

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -6,6 +6,10 @@
 		max-width: 968px; // Max width of dual column reader stream.
 	}
 
+	.navigation-header__main {
+		margin-bottom: 24px;
+	}
+
 	@media (max-width: 660px) {
 		.navigation-header__main {
 			min-height: auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/171

## Proposed Changes

* Changes background color of reader cards to --studio-gray-0
* Removes padding overrides to allow the default 24px from the card component.
* Applies a 15px border radius, Im not entirely sure what @davemart-in had in his design but this seems close.


BEFORE


<img width="750" alt="Screenshot 2024-05-01 at 1 49 44 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/72933527-9bff-4563-a656-eb8605ea7252">

AFTER

<img width="708" alt="Screenshot 2024-05-01 at 1 49 19 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/42df1bcc-fd66-445f-98c3-9d712941a9b0">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build
* Visit the reader and test the new visuals on cards in various streams.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
