### PR TITLE
fix spacing for cards with caption

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -79,7 +79,7 @@
 			.reader-post-card__post-details {
 				flex: 0 auto; // IE11 Photo card actions hidden
 				margin: 0;
-				padding-top: 8px;
+				padding-top: 24px;
 			}
 
 			.reader-post-card__title {
@@ -305,8 +305,7 @@
 	position: relative;
 	top: 0;
 	height: 300px;
-	margin-right: 0;
-	margin-bottom: 0;
+	margin: 24px 0 0;
 	max-width: 100%;
 
 	&:hover {


### PR DESCRIPTION
## Description

This PR aims to address https://github.com/Automattic/loop/issues/174 by adding a bit more padding above and below cards with a caption

## Before

![CleanShot 2024-05-01 at 13 50 31](https://github.com/Automattic/wp-calypso/assets/5634774/fc3da2e3-1792-4ce4-9830-2e587c8c1c15)

## After

![CleanShot 2024-05-01 at 13 53 22](https://github.com/Automattic/wp-calypso/assets/5634774/73e0a46a-234b-414a-be70-7e9c24e03aba)

## Testing instructions
- Apply this patch
- Create a new list
- Add this site to your list: https://bestindianfoodblog.wordpress.com/
- View this list