### PR TITLE
Updated header styles for select reader sections

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -1,10 +1,10 @@
 .section-header.card {
 	align-items: flex-start;
+	box-shadow: none;
 	display: flex;
 	flex-flow: row wrap;
 	line-height: 28px;
-	padding-top: 11px;
-	padding-bottom: 11px;
+	padding: 0;
 	position: relative;
 
 	&::after {
@@ -13,6 +13,12 @@
 
 	&.is-empty .section-header__label::after {
 		content: "\00a0";
+	}
+
+	.section-header__label-text {
+		font-size: 1.25rem;
+		font-weight: 500;
+		line-height: 26px;
 	}
 }
 

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -1,10 +1,10 @@
 .section-header.card {
 	align-items: flex-start;
-	box-shadow: none;
 	display: flex;
 	flex-flow: row wrap;
 	line-height: 28px;
-	padding: 0;
+	padding-top: 11px;
+	padding-bottom: 11px;
 	position: relative;
 
 	&::after {
@@ -13,12 +13,6 @@
 
 	&.is-empty .section-header__label::after {
 		content: "\00a0";
-	}
-
-	.section-header__label-text {
-		font-size: 1.25rem;
-		font-weight: 500;
-		line-height: 26px;
 	}
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -407,4 +407,14 @@ body.is-mobile-app-view {
 	.layout__content {
 		background: var(--studio-white);
 	}
+	.section-header.card {
+		box-shadow: none;
+		padding: 0;
+
+		.section-header__label-text {
+			font-size: 1.25rem;
+			font-weight: 500;
+			line-height: 26px;
+		}
+	}
 }


### PR DESCRIPTION
## Description

This PR aims to remedy https://github.com/Automattic/loop/issues/175

Multiple reader sections have this awkward looking square looking header. We can likely remove the border around it and add a header tag to clean this up a bit:

## Before

![Image](https://github.com/Automattic/loop/assets/5634774/7756c1a3-ae04-4b3d-b509-6636afd39316)

## After

![Image](https://github.com/Automattic/loop/assets/5634774/2175d6a8-3ccb-4f1d-bb83-2b1a2f6d3bc9)

## Testing instructions
- Apply this patch
- Visit /read/a8c
- Visit /read/p2