### PR TITLE
Fix/reader mobile daily prompt styles

### DIFF
--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -1,4 +1,5 @@
 import { Card, Button, Gridicon } from '@automattic/components';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
@@ -74,8 +75,6 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 		);
 	};
 
-	const isHome = viewContext === 'home' ? 'customer-home__card' : '';
-
 	const renderMenu = () => {
 		if ( ! showMenu ) {
 			return;
@@ -102,7 +101,11 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 
 	return (
 		<div className="blogging-prompt">
-			<Card className={ `blogging-prompt__card ${ isHome }` }>
+			<Card
+				className={ classnames( 'blogging-prompt__card', {
+					'customer-home__card': viewContext === 'home',
+				} ) }
+			>
 				<PromptsNavigation
 					siteId={ siteId }
 					prompts={ prompts }

--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -1,5 +1,4 @@
 import { Card, Button, Gridicon } from '@automattic/components';
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
@@ -75,6 +74,8 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 		);
 	};
 
+	const isHome = viewContext === 'home' ? 'customer-home__card' : '';
+
 	const renderMenu = () => {
 		if ( ! showMenu ) {
 			return;
@@ -101,7 +102,7 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 
 	return (
 		<div className="blogging-prompt">
-			<Card className={ classnames( 'customer-home__card', 'blogging-prompt__card' ) }>
+			<Card className={ `blogging-prompt__card ${ isHome }` }>
 				<PromptsNavigation
 					siteId={ siteId }
 					prompts={ prompts }

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -124,13 +124,13 @@
 			.blogging-prompt__prompt-navigation {
 				gap: 10px;
 			}
-			button.navigation-link {
-				&:first-child {
-					margin-left: -36px;
-				}
-				&:last-child {
-					margin-right: -36px;
-				}
+		}
+		.card:not(.customer-home__card) .blogging-prompt__prompt-container button.navigation-link {
+			&:first-child {
+				margin-left: -36px;
+			}
+			&:last-child {
+				margin-right: -36px;
 			}
 		}
 		.blogging-prompt__prompt-answers .blogging-prompt__prompt-responses-users {

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -34,7 +34,7 @@
 		.blogging-prompt__prompt-navigation {
 			align-items: center;
 			display: flex;
-			gap: 10px;
+			gap: 20px;
 		}
 		.blogging-prompt__prompt-text {
 			flex: 1;
@@ -43,24 +43,12 @@
 			line-height: 26px;
 			text-wrap: pretty;
 		}
-		@include breakpoint-deprecated( "<660px" ) {
-			.blogging-prompt__prompt-text {
-				text-align: center;
-			}
-		}
 		button.navigation-link {
 			border-radius: 50%;
 			height: 44px;
 			margin: 0;
 			padding: 0;
 			width: 44px;
-
-			&:first-child {
-				margin-left: -36px;
-			}
-			&:last-child {
-				margin-right: -36px;
-			}
 		}
 	}
 	/* Blogging Prompt Replies & Answer Button ------------------------ */
@@ -126,10 +114,27 @@
 			font-size: $font-body-small;
 			gap: 6px;
 		}
-		@include breakpoint-deprecated( "<660px" ) {
-			.blogging-prompt__prompt-responses-users {
-				display: none;
+	}
+	/* Responsive styles */
+	@include breakpoint-deprecated( "<660px" ) {
+		.blogging-prompt__prompt-container {
+			.blogging-prompt__prompt-text {
+				text-align: center;
 			}
+			.blogging-prompt__prompt-navigation {
+				gap: 10px;
+			}
+			button.navigation-link {
+				&:first-child {
+					margin-left: -36px;
+				}
+				&:last-child {
+					margin-right: -36px;
+				}
+			}
+		}
+		.blogging-prompt__prompt-answers .blogging-prompt__prompt-responses-users {
+			display: none;
 		}
 	}
 	/* Blogging Prompt Menu ------------------------ */

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -34,7 +34,7 @@
 		.blogging-prompt__prompt-navigation {
 			align-items: center;
 			display: flex;
-			gap: 20px;
+			gap: 10px;
 		}
 		.blogging-prompt__prompt-text {
 			flex: 1;
@@ -43,12 +43,24 @@
 			line-height: 26px;
 			text-wrap: pretty;
 		}
+		@include breakpoint-deprecated( "<660px" ) {
+			.blogging-prompt__prompt-text {
+				text-align: center;
+			}
+		}
 		button.navigation-link {
 			border-radius: 50%;
 			height: 44px;
 			margin: 0;
 			padding: 0;
 			width: 44px;
+
+			&:first-child {
+				margin-left: -36px;
+			}
+			&:last-child {
+				margin-right: -36px;
+			}
 		}
 	}
 	/* Blogging Prompt Replies & Answer Button ------------------------ */
@@ -113,6 +125,11 @@
 			flex: 1;
 			font-size: $font-body-small;
 			gap: 6px;
+		}
+		@include breakpoint-deprecated( "<660px" ) {
+			.blogging-prompt__prompt-responses-users {
+				display: none;
+			}
 		}
 	}
 	/* Blogging Prompt Menu ------------------------ */

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -939,15 +939,10 @@
 }
 
 .reader-stream__blogging-prompt {
-	padding: 12px 15px 4px 0;
 	clear: both;
 	display: flex;
 	flex-direction: column;
 	margin: 6px 0 0 0;
-
-	@include breakpoint-deprecated(">660px") {
-		padding: 0;
-	}
 
 	@include breakpoint-deprecated( ">960px" ) {
 		margin: 0;


### PR DESCRIPTION
## Description

This card just feels awkward on mobile. There's likely some stuff I can do to make it feel less crowded.

## Before

![Image](https://github.com/Automattic/loop/assets/5634774/882e5583-e4d8-47aa-bf55-d642e07d5c21)

## After

![CleanShot 2024-05-01 at 15 57 32](https://github.com/Automattic/wp-calypso/assets/5634774/e7818e80-d727-4e06-8df7-28bd2f4a1fb7)

## Desktop after changes have been made

![CleanShot 2024-05-01 at 16 02 17](https://github.com/Automattic/wp-calypso/assets/5634774/71c87c4d-baf6-4703-b610-695695004c6a)


## Testing instructions

- Apply diff
- Go to /read
- Scroll down (keep scrolling) till you see this daily prompts container