### PR TITLE
A4A: Fix count of plans included in cart

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -59,6 +59,11 @@ export default function Checkout() {
 
 	const checkoutItems = siteId ? selectedProductsBySlug : sortedSelectedItems;
 
+	const checkoutPlansCount = useMemo(
+		() => checkoutItems.reduce( ( acc, item ) => acc + item.quantity, 0 ),
+		[ checkoutItems ]
+	);
+
 	const onCheckout = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_checkout_click' ) );
 
@@ -150,9 +155,9 @@ export default function Checkout() {
 							>
 								{ translate( 'Purchase %(count)d plan', 'Purchase %(count)d plans', {
 									context: 'button label',
-									count: checkoutItems.length,
+									count: checkoutPlansCount,
 									args: {
-										count: checkoutItems.length,
+										count: checkoutPlansCount,
 									},
 								} ) }
 							</Button>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -59,11 +59,6 @@ export default function Checkout() {
 
 	const checkoutItems = siteId ? selectedProductsBySlug : sortedSelectedItems;
 
-	const checkoutPlansCount = useMemo(
-		() => checkoutItems.reduce( ( acc, item ) => acc + item.quantity, 0 ),
-		[ checkoutItems ]
-	);
-
 	const onCheckout = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_checkout_click' ) );
 
@@ -153,13 +148,7 @@ export default function Checkout() {
 								disabled={ ! checkoutItems.length || ! isReady }
 								busy={ ! isReady }
 							>
-								{ translate( 'Purchase %(count)d plan', 'Purchase %(count)d plans', {
-									context: 'button label',
-									count: checkoutPlansCount,
-									args: {
-										count: checkoutPlansCount,
-									},
-								} ) }
+								{ translate( 'Purchase' ) }
 							</Button>
 
 							{ siteId ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* The "Purchase X plans" button currently uses the amount of items in the cart to determine the X value.
* This does not work for bulk purchases, as they are single items with multiple plans included.
* This PR updates it to use the `quantity` value from each cart item to calculate the total amount of plans in the cart.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/marketplace/hosting/wpcom` and use the slider to add multiple plans to your cart.
* Go to checkout, and validate that the button text is accurate.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1313" alt="Screenshot 2024-05-01 at 2 37 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/7b61da2a-6ed9-448b-882c-32525dfb31a0">
