### PR TITLE
A4A: Use the "/licenses" endpoint to enable support for bulk hosting purchases

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-issue-license-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-issue-license-mutation.ts
@@ -19,8 +19,8 @@ function mutationIssueLicense( {
 	}
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
-		path: '/jetpack-licensing/license',
-		body: { product, quantity, agency_id: agencyId },
+		path: '/jetpack-licensing/licenses',
+		body: { product, quantity, agency_id: agencyId, bundle: false },
 	} );
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/403

## Proposed Changes

* Changes the API endpoint used for checkout from `/license` to `/licenses`.
* Provides the required "bulk" parameter as `false`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/marketplace/hosting/wpcom` and add multiple plans to your cart as a single item (i.e. use the slider).
* Checkout and complete the purchase.
* Validate the correct licenses/sites are added to your account.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?