### PR TITLE
A4A: fix wpcom hosting cart prices

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -1,11 +1,11 @@
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { getTotalInvoiceValue } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import ShoppingCartMenuItem from '../shopping-cart/shopping-cart-menu/item';
+import { useTotalInvoiceValue } from '../wpcom-overview/hooks/use-total-invoice-value';
 import type { ShoppingCartItem } from '../types';
 
 type Props = {
@@ -18,6 +18,9 @@ export default function PricingSummary( { items, onRemoveItem }: Props ) {
 	const dispatch = useDispatch();
 
 	const userProducts = useSelector( getProductsList );
+
+	const { getTotalInvoiceValue } = useTotalInvoiceValue();
+
 	const { discountedCost, actualCost } = getTotalInvoiceValue( userProducts, items );
 
 	const currency = items[ 0 ]?.currency ?? 'USD'; // FIXME: Fix if multiple currencies are supported

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -14,7 +14,6 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
-	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
@@ -22,7 +21,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingOverview from '../common/hosting-overview';
 import useShoppingCart from '../hooks/use-shopping-cart';
-import ShoppingCart, { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
+import ShoppingCart from '../shopping-cart';
 import PressableOverviewFeatures from './footer';
 import PressableOverviewPlanSelection from './plan-selection';
 
@@ -49,10 +48,9 @@ export default function PressableOverview() {
 			);
 
 			setSelectedCartItems( [ ...items, { ...item, quantity: 1 } ] );
-
-			page( A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK + CART_URL_HASH_FRAGMENT );
+			setShowCart( true );
 		},
-		[ selectedCartItems, setSelectedCartItems ]
+		[ selectedCartItems, setSelectedCartItems, setShowCart ]
 	);
 
 	const PRESSABLE_LINK = 'https://pressable.com/';

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -14,8 +14,8 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_LINK,
-	A4A_MARKETPLACE_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -50,7 +50,7 @@ export default function PressableOverview() {
 
 			setSelectedCartItems( [ ...items, { ...item, quantity: 1 } ] );
 
-			page( A4A_MARKETPLACE_PRODUCTS_LINK + CART_URL_HASH_FRAGMENT );
+			page( A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK + CART_URL_HASH_FRAGMENT );
 		},
 		[ selectedCartItems, setSelectedCartItems ]
 	);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -4,12 +4,12 @@ import formatCurrency from '@automattic/format-currency';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { getProductPricingInfo } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import SimpleList from '../../common/simple-list';
+import { useGetProductPricingInfo } from '../../wpcom-overview/hooks/use-total-invoice-value';
 import getPressablePlan from '../lib/get-pressable-plan';
 import getPressableShortName from '../lib/get-pressable-short-name';
 
@@ -27,6 +27,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 	const customString = translate( 'Custom' );
 
 	const userProducts = useSelector( getProductsList );
+	const { getProductPricingInfo } = useGetProductPricingInfo();
 
 	const { discountedCost } = selectedPlan
 		? getProductPricingInfo( userProducts, selectedPlan, 1 )

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -3,9 +3,9 @@ import { formatCurrency } from '@automattic/format-currency';
 import { Popover } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { getTotalInvoiceValue } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import { useTotalInvoiceValue } from '../../wpcom-overview/hooks/use-total-invoice-value';
 import ShoppingCartMenuItem from './item';
 import type { ShoppingCartItem } from '../../types';
 
@@ -22,6 +22,7 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 	const translate = useTranslate();
 
 	const userProducts = useSelector( getProductsList );
+	const { getTotalInvoiceValue } = useTotalInvoiceValue();
 	const { discountedCost } = getTotalInvoiceValue( userProducts, items );
 
 	return (

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -1,11 +1,10 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
-import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { getProductPricingInfo } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import { useGetProductPricingInfo } from '../../wpcom-overview/hooks/use-total-invoice-value';
 import type { ShoppingCartItem } from '../../types';
 
 import './style.scss';
@@ -19,8 +18,7 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 	const translate = useTranslate();
 	const userProducts = useSelector( getProductsList );
 
-	const siteId = getQueryArg( window.location.href, 'site_id' )?.toString();
-
+	const { getProductPricingInfo } = useGetProductPricingInfo();
 	const { actualCost, discountedCost } = getProductPricingInfo( userProducts, item, item.quantity );
 
 	return (

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/hooks/use-total-invoice-value.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/hooks/use-total-invoice-value.ts
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
+import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
+import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options';
+import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
+import { SelectedLicenseProp } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/types';
+import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+export const useGetProductPricingInfo = () => {
+	const { data } = useProductsQuery( false, true );
+	const wpcomProducts = data?.find(
+		( product ) => product.slug === 'wpcom-hosting'
+	) as unknown as APIProductFamily;
+	const options = useMemo(
+		() => wpcomBulkOptions( wpcomProducts?.discounts?.tiers ),
+		[ wpcomProducts?.discounts?.tiers ]
+	);
+	const { data: licenseCounts, isSuccess: isLicenseCountsReady } = useFetchLicenseCounts();
+	const { wpcomPlans } = useProductAndPlans( {} );
+	const creatorPlan = getWPCOMCreatorPlan( wpcomPlans );
+	const ownedPlans = useMemo( () => {
+		if ( isLicenseCountsReady && creatorPlan ) {
+			const productStats = licenseCounts?.products?.[ creatorPlan.slug ];
+			return productStats?.not_revoked || 0;
+		}
+	}, [ creatorPlan, isLicenseCountsReady, licenseCounts?.products ] );
+
+	const getProductPricingInfo = (
+		userProducts: Record< string, ProductListItem >,
+		product: SelectedLicenseProp | APIProductFamilyProduct,
+		quantity: number
+	) => {
+		const bundle = product?.supported_bundles?.find( ( bundle ) => bundle.quantity === quantity );
+		const bundleAmount = bundle && bundle.amount ? bundle.amount.replace( ',', '' ) : '';
+		const tier = calculateTier( options, quantity + ownedPlans );
+
+		if ( product.family_slug === 'wpcom-hosting' ) {
+			const actualCost = Number( product.amount ) * quantity;
+			return {
+				actualCost,
+				discountedCost: actualCost * ( 1 - tier.discount ),
+				discountPercentage: tier.discount,
+			};
+		}
+
+		const productBundleCost = bundle
+			? parseFloat( bundleAmount )
+			: parseFloat( product?.amount ) || 0;
+		const isDailyPricing = product.price_interval === 'day';
+
+		const discountInfo: {
+			actualCost: number;
+			discountedCost: number;
+			discountPercentage: number;
+		} = {
+			actualCost: 0,
+			discountedCost: productBundleCost, // This is the discounted cost based on the product quantity
+			discountPercentage: 0,
+		};
+		if ( Object.keys( userProducts ).length && product ) {
+			// Find the yearly version of the product in userProducts
+			const yearlyProduct = Object.values( userProducts ).find(
+				( prod ) => prod.product_id === product.product_id
+			);
+
+			// If a yearly product is found, find the monthly version of the product
+			const monthlyProduct =
+				yearlyProduct &&
+				Object.values( userProducts ).find(
+					( p ) =>
+						p.billing_product_slug === yearlyProduct.billing_product_slug &&
+						p.product_term === 'month'
+				);
+			// If a monthly product is found, calculate the actual cost and discount percentage
+			if ( monthlyProduct ) {
+				const monthlyProductBundleCost = parseFloat( product.amount ) * quantity;
+				const actualCost = isDailyPricing
+					? monthlyProductBundleCost / 365
+					: monthlyProductBundleCost;
+				const discountedCost = actualCost - productBundleCost;
+				discountInfo.discountPercentage = productBundleCost
+					? Math.round( ( discountedCost / actualCost ) * 100 )
+					: 100;
+				discountInfo.actualCost = actualCost;
+			}
+		}
+		return discountInfo;
+	};
+	return { getProductPricingInfo };
+};
+
+export const useTotalInvoiceValue = () => {
+	const { getProductPricingInfo } = useGetProductPricingInfo();
+
+	const getTotalInvoiceValue = (
+		userProducts: Record< string, ProductListItem >,
+		selectedLicenses: SelectedLicenseProp[]
+	) => {
+		// Use the reduce function to calculate the total invoice value
+		return selectedLicenses.reduce(
+			( acc, license ) => {
+				// Get the pricing information for the current license
+				const { actualCost, discountedCost, discountPercentage } = getProductPricingInfo(
+					userProducts,
+					license,
+					license.quantity
+				);
+
+				// Add the actual cost, discounted cost, and discount percentage to the accumulator
+				acc.actualCost += actualCost;
+				acc.discountedCost += discountedCost;
+				acc.discountPercentage += discountPercentage;
+				return acc;
+			},
+			{
+				actualCost: 0,
+				discountedCost: 0,
+				discountPercentage: 0,
+			}
+		);
+	};
+
+	return { getTotalInvoiceValue };
+};

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -32,7 +32,7 @@ export default function A4AWPCOMSlider( {
 	sub,
 	minimum = 0,
 }: Props ) {
-	const total = options.length * 10;
+	const total = ( options.length + 1 ) * 20;
 	const mappedOptions = useMemo(
 		() => mapOptionsToSliderOptions( options, total ),
 		[ options, total ]


### PR DESCRIPTION
Fixes issue with Shopping cart and Checkout page not calculating correct cost for WPCOM plans when purchased in bulk.

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/405

## Proposed Changes
<img width="899" alt="Screenshot 2024-05-01 at 6 59 59 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/680a9add-d2cb-419d-911a-d4df5bae331d">


<img width="366" alt="Screenshot 2024-05-01 at 7 00 35 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/b33fe2b9-ec61-49b6-a445-10c849173fef">


## Testing Instructions

* Use A4A live link and go to `/marketplace/hosting/wpcom`
* Add two plans in the cart.
* Confirm that the shopping cart shows the correct total.
* Press the Checkout button.
* Confirm that the Checkout page shows correct total.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?