### PR TITLE
Nav redesign: speed up transition for faster data fetching

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -138,13 +138,13 @@
 // Styles collapsed site list.
 .wpcom-site {
 	.layout__secondary {
-		transition: all 0.3s ease-in-out;
+		transition: all 0.2s ease-in-out;
 
 		.sidebar__header {
 			span.dotcom,
 			button.sidebar__item-search,
 			a.sidebar__item-notifications {
-				transition: all 0.3s ease-in-out;
+				transition: all 0.2s ease-in-out;
 			}
 		}
 	}

--- a/client/sites-dashboard-v2/hooks/use-sync-selected-site-feature.ts
+++ b/client/sites-dashboard-v2/hooks/use-sync-selected-site-feature.ts
@@ -55,7 +55,7 @@ export function useSyncSelectedSiteFeature( {
 		window.setTimeout(
 			syncUrl,
 			// Delay the update while the left sidebar is animating.
-			shouldAnimate ? 500 : 0
+			shouldAnimate ? 300 : 0
 		);
 	}, [ dataViewsState.selectedItem?.slug, selectedSiteFeature ] );
 


### PR DESCRIPTION
## Proposed Changes

I just realized that currently, we have to wait until the sidebar animation finishes before fetching the tab content route. Fixing this is a bit complicated because we need to maintain the animation while syncing the URL after clicking the site row.

This is the best solution I found now: reducing the transition animation duration. With this, the delay is not that noticeable anymore.

## Testing Instructions

1. Go to `<Calypso URL>/sites`
2. Select a site
3. You should "feel" that the site overview loads faster than it is in Horizon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?