### PR TITLE
Hosting Overview: Update quick action card links

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -15,6 +15,7 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const PlanCard: FC = () => {
+	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
@@ -29,14 +30,17 @@ const PlanCard: FC = () => {
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );
-	const translate = useTranslate();
 
 	const isLoading = ! pricing || ! planData;
 
 	return (
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
-			<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__plan' ) }>
+			<Card
+				className={ classNames( 'hosting-overview__card', 'hosting-overview__plan', {
+					'hosting-overview__plan--is-free': ! isPaidPlan,
+				} ) }
+			>
 				<div className="hosting-overview__plan-card-header">
 					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
 

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -9,6 +9,7 @@ import { WriteIcon } from 'calypso/layout/masterbar/write-icon';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getStatsUrl from 'calypso/state/selectors/get-stats-url';
 import getThemeInstallUrl from 'calypso/state/selectors/get-theme-install-url';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -33,15 +34,18 @@ const Action: FC< ActionProps > = ( { icon, href, text } ) => {
 };
 
 const QuickActionsCard: FC = () => {
+	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const site = useSelector( getSelectedSite );
+	const siteEditorUrl = useSelector( ( state: object ) =>
+		site?.ID ? getSiteEditorUrl( state, site.ID ) : ''
+	);
 	const { editorUrl, themeInstallUrl, pluginInstallUrl, statsUrl } = useSelector( ( state ) => ( {
 		editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
 		themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
 		pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
 		statsUrl: getStatsUrl( state, site?.ID ) ?? '',
 	} ) );
-	const translate = useTranslate();
 
 	return (
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
@@ -54,6 +58,13 @@ const QuickActionsCard: FC = () => {
 			</div>
 
 			<ul className="hosting-overview__actions-list">
+				<Action
+					icon={
+						<SidebarCustomIcon icon="dashicons-admin-customizer hosting-overview__dashicon" />
+					}
+					href={ siteEditorUrl }
+					text={ translate( 'Edit site' ) }
+				/>
 				<Action icon={ <WriteIcon /> } href={ editorUrl } text={ translate( 'Write post' ) } />
 				<Action
 					icon={
@@ -71,6 +82,11 @@ const QuickActionsCard: FC = () => {
 					icon={ <SidebarCustomIcon icon="dashicons-chart-bar hosting-overview__dashicon" /> }
 					href={ statsUrl }
 					text={ translate( 'See Jetpack Stats' ) }
+				/>
+				<Action
+					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }
+					href={ site ? site.options?.admin_url || `${ site.URL }/wp-admin` : '' }
+					text={ translate( 'WP Admin' ) }
 				/>
 			</ul>
 		</Card>

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -38,16 +38,15 @@ const QuickActionsCard: FC = () => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const site = useSelector( getSelectedSite );
-	const siteEditorUrl = useSelector( ( state: object ) =>
-		site?.ID ? getSiteEditorUrl( state, site.ID ) : ''
-	);
-	const { editorUrl, themeInstallUrl, pluginInstallUrl, statsUrl } = useSelector( ( state ) => ( {
-		editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
-		themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
-		pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
-		statsUrl: getStatsUrl( state, site?.ID ) ?? '',
-		siteAdminUrl: getSiteAdminUrl( state, site?.ID ) ?? '',
-	} ) );
+	const { editorUrl, themeInstallUrl, pluginInstallUrl, statsUrl, siteAdminUrl, siteEditorUrl } =
+		useSelector( ( state ) => ( {
+			editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
+			themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
+			pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
+			statsUrl: getStatsUrl( state, site?.ID ) ?? '',
+			siteAdminUrl: getSiteAdminUrl( state, site?.ID ) ?? '',
+			siteEditorUrl: site?.ID ? getSiteEditorUrl( state as object, site.ID ) : '',
+		} ) );
 
 	return (
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
@@ -62,7 +61,7 @@ const QuickActionsCard: FC = () => {
 			<ul className="hosting-overview__actions-list">
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }
-					href={ site ? site.options?.admin_url || `${ site.URL }/wp-admin` : '' }
+					href={ siteAdminUrl }
 					text={ translate( 'WP Admin' ) }
 				/>
 				<Action

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -5,11 +5,12 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { WriteIcon } from 'calypso/layout/masterbar/write-icon';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
+import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url';
-import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getStatsUrl from 'calypso/state/selectors/get-stats-url';
 import getThemeInstallUrl from 'calypso/state/selectors/get-theme-install-url';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
@@ -38,6 +39,7 @@ const QuickActionsCard: FC = () => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const site = useSelector( getSelectedSite );
+	const { data: activeThemeData } = useActiveThemeQuery( site?.ID || -1, !! site );
 	const { editorUrl, themeInstallUrl, pluginInstallUrl, statsUrl, siteAdminUrl, siteEditorUrl } =
 		useSelector( ( state ) => ( {
 			editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
@@ -45,7 +47,15 @@ const QuickActionsCard: FC = () => {
 			pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
 			statsUrl: getStatsUrl( state, site?.ID ) ?? '',
 			siteAdminUrl: getSiteAdminUrl( state, site?.ID ) ?? '',
-			siteEditorUrl: site?.ID ? getSiteEditorUrl( state as object, site.ID ) : '',
+			siteEditorUrl:
+				site?.ID && activeThemeData
+					? getCustomizeUrl(
+							state as object,
+							activeThemeData[ 0 ]?.stylesheet,
+							site?.ID,
+							activeThemeData[ 0 ]?.is_block_theme
+					  )
+					: '',
 		} ) );
 
 	return (

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -12,6 +12,7 @@ import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url'
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getStatsUrl from 'calypso/state/selectors/get-stats-url';
 import getThemeInstallUrl from 'calypso/state/selectors/get-theme-install-url';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 interface ActionProps {
@@ -45,6 +46,7 @@ const QuickActionsCard: FC = () => {
 		themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
 		pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
 		statsUrl: getStatsUrl( state, site?.ID ) ?? '',
+		siteAdminUrl: getSiteAdminUrl( state, site?.ID ) ?? '',
 	} ) );
 
 	return (
@@ -58,6 +60,11 @@ const QuickActionsCard: FC = () => {
 			</div>
 
 			<ul className="hosting-overview__actions-list">
+				<Action
+					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }
+					href={ site ? site.options?.admin_url || `${ site.URL }/wp-admin` : '' }
+					text={ translate( 'WP Admin' ) }
+				/>
 				<Action
 					icon={
 						<SidebarCustomIcon icon="dashicons-admin-customizer hosting-overview__dashicon" />
@@ -82,11 +89,6 @@ const QuickActionsCard: FC = () => {
 					icon={ <SidebarCustomIcon icon="dashicons-chart-bar hosting-overview__dashicon" /> }
 					href={ statsUrl }
 					text={ translate( 'See Jetpack Stats' ) }
-				/>
-				<Action
-					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }
-					href={ site ? site.options?.admin_url || `${ site.URL }/wp-admin` : '' }
-					text={ translate( 'WP Admin' ) }
 				/>
 			</ul>
 		</Card>

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -239,6 +239,7 @@ a.hosting-overview__link-button {
 	font-size: $font-body-small;
 	line-height: 20px;
 	letter-spacing: -0.15px;
+	width: 100%;
 
 	&:visited,
 	&:hover,

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -1,6 +1,8 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
 
+$card-padding: 24px;
+
 .hosting-overview {
 	margin: 0;
 	padding: 0;
@@ -10,32 +12,45 @@
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	grid-template-rows: auto auto;
-	grid-column-gap: 33px;
-	grid-row-gap: 38px;
+	grid-column-gap: 16px;
+	grid-row-gap: 16px;
 }
 
 .hosting-overview__card {
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-5);
 	box-shadow: none;
-	padding: 22px;
+	margin: 0;
+	padding: $card-padding;
 	width: 100%;
 	height: 100%;
 }
 
 .hosting-overview__plan {
-	grid-column: 1 / 2;
-	grid-row: 1 / 2;
+	&--is-free {
+		grid-column: 1 / -1;
+
+		& + .hosting-overview__quick-actions {
+			grid-column: 1 / -1;
+		}
+	}
+
+	&:not(:has(.plan-storage)) {
+		.hosting-overview__plan-card-header {
+			align-items: center;
+			display: flex;
+			margin-bottom: 0;
+		}
+	}
 }
 
 .hosting-overview__quick-actions {
-	grid-column: 2 / 3;
-	grid-row: 1 / 2;
+	padding-bottom: 10px;
 }
 
 .hosting-overview__active-domains {
-	grid-column: 1 / 3;
-	grid-row: 2 / 3;
+	grid-column: 1 / -1;
+	padding-bottom: 0;
 }
 
 @media ( max-width: $break-xlarge ) {
@@ -283,7 +298,12 @@ a.hosting-overview__link-button {
 
 	table {
 		border-top: 1px solid var(--color-border-secondary);
+		margin-bottom: $card-padding;
 		margin-top: 0;
+
+		tbody tr:last-child::after {
+			content: none;
+		}
 
 		th:not(.domains-table-checkbox-th):first-child,
 		th.domains-table-checkbox-th + th,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6830

## Proposed Changes

This PR adds the follow links to the Quick Actions card:
1. Edit site, which links to the Site Editor.
2. WP Admin, which links to `/wp-admin`.

As pointed out in https://github.com/Automattic/dotcom-forge/issues/6830#issuecomment-2089206917, the addition of these links will result in the Plan card look empty. This is especially true for non-dotcom sites where the storage UI is entirely missing:
 
![Screenshot 2024-05-02 at 11 17 31 AM](https://github.com/Automattic/wp-calypso/assets/797888/54c51986-bb95-42de-ae1e-5e17c0dc4ced)

This PR proposes to display the Plan and Quick Actions cards as full-width rows when the site does not have a paid plan. In addition, this PR introduces additional minor CSS improvements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the two added links work as intended.
* Ensure that for free sites, the Plans and Quick Actions cards are full-width rows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?