### PR TITLE
Nav redesign: drop site row fixed width CSS

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -16,7 +16,6 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	width: 180px;
 	font-weight: 500;
 	font-size: rem(14px);
 }

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -30,6 +30,10 @@
 }
 
 .preview-hidden {
+	.sites-dataviews__site-name {
+		width: 180px;
+	}
+
 	@media (min-width: 2040px) {
 		.sites-dataviews__site-name {
 			width: 250px;


### PR DESCRIPTION
## Proposed Changes

Somehow, the site list width is fixed to 180px, which makes it look ugly on wider screens. This PR proposes to remove that CSS rule.

|Before|After|
|-|-|
|<img width="450" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/df74650c-a00a-4e81-9714-7e508df98981">|<img width="449" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/944e57c4-8410-4591-b17e-faf954dd2644">|


## Testing Instructions

1. Go to `<Calypso Live URL>/sites`
2. Select a site
3. Observe that the site list width now expands to its parent width beautifully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?