### PR TITLE
Nav redesign: tidy up icon alignment in collapsed sidebar

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -183,7 +183,9 @@ $brand-text: "SF Pro Text", $sans;
 				}
 				&.svg_all-sites,
 				&.sidebar_svg-reader {
-					margin-left: -2px;
+					.is-global-sidebar-visible:not(.is-global-sidebar-collapsed) & {
+						margin-left: -2px;
+					}
 				}
 			}
 		}

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -180,6 +180,11 @@ $brand-text: "SF Pro Text", $sans;
 			.sidebar__menu-icon {
 				&.dashicons-admin-site-alt3 {
 					margin-right: 10px;
+					margin-left: 1px;
+
+					.is-global-sidebar-collapsed & {
+						margin-left: 2px;
+					}
 				}
 				&.svg_all-sites,
 				&.sidebar_svg-reader {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/90011#issuecomment-2082249019

## Proposed Changes

This PR fixes the misaligment of the All Sites icon when the sidebar is collapsed.

|Before|After|
|-|-|
|<img width="92" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/bc9d7fa1-826e-4520-91ce-1161c5ee7ded">|<img width="93" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/34a63285-b945-4cdb-8fac-52f83752c435">|

(it might be a bit hard comparing the above screenshots; better to try the Live URL yourself)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open `<Calypso Live URL>/sites`
2. Click a site
3. Verify that the All Sites icon is now centered against the selected state background (and compared to the other icons)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?