### PR TITLE
A4A: Add a link to the A4A plugin zip file on the Referrals page

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -10,6 +10,7 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_REFERRALS_BANK_DETAILS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import { A4A_DOWNLOAD_LINK_ON_GITHUB } from 'calypso/a8c-for-agencies/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -29,6 +30,10 @@ export default function ReferralsOverview() {
 
 	const onAddBankDetailsClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );
+	}, [ dispatch ] );
+
+	const onDownloadA4APluginClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_referrals_download_a4a_plugin_button_click' ) );
 	}, [ dispatch ] );
 
 	const { data, isFetching } = useGetTipaltiPayee();
@@ -104,6 +109,8 @@ export default function ReferralsOverview() {
 									buttonProps={ {
 										children: translate( 'Download plugin to verify my referrals' ),
 										compact: true,
+										href: A4A_DOWNLOAD_LINK_ON_GITHUB,
+										onClick: onDownloadA4APluginClick,
 									} }
 								/>
 							</StepSection>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/399

## Proposed Changes

Update the Referrals page to include a link to a zip file containing the latest version of the A4A plugin.

## Testing Instructions

* Either locally or via Live Branch, visit `/referrals`.
* Click the `[Download plugin to verify my referrals]` and verify it downloads a zip file containing the 0.1.0 version of the A4A plugin.
* Verify the `calypso_a4a_referrals_download_a4a_plugin_button_click` Track event is fired.


![image](https://github.com/Automattic/wp-calypso/assets/3418513/0bbad4a2-ed20-4530-a656-819a4f24b63d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?