### PR TITLE
A4A:  Fix bugs and add improvements to the WPCOM plan purchase flow.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -1,12 +1,31 @@
 import { getQueryArg } from '@wordpress/url';
 import { useCallback, useEffect, useState } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
 import type { ShoppingCartItem } from '../types';
 
 const SELECTED_ITEMS_SESSION_STORAGE_KEY = 'shopping-card-selected-items';
 
 export default function useShoppingCart() {
 	const [ selectedCartItems, setSelectedCartItems ] = useState< ShoppingCartItem[] >( [] );
+
+	const [ showCart, setShowCart ] = useState( window.location.hash === CART_URL_HASH_FRAGMENT );
+
+	const toggleCart = () => {
+		setShowCart( ( prevState ) => {
+			const nextState = ! prevState;
+
+			const hashFragment = nextState ? CART_URL_HASH_FRAGMENT : '';
+
+			window.history.replaceState(
+				null,
+				'',
+				window.location.pathname + window.location.search + hashFragment
+			);
+
+			return nextState;
+		} );
+	};
 
 	const { data } = useProductsQuery();
 
@@ -81,5 +100,8 @@ export default function useShoppingCart() {
 		setSelectedCartItems: setAndCacheSelectedItems,
 		onRemoveCartItem,
 		onClearCart,
+		showCart,
+		setShowCart,
+		toggleCart,
 	};
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -17,7 +17,8 @@ import HostingList from './hosting-list';
 export default function Hosting() {
 	const translate = useTranslate();
 
-	const { selectedCartItems, onRemoveCartItem } = useShoppingCart();
+	const { selectedCartItems, onRemoveCartItem, showCart, setShowCart, toggleCart } =
+		useShoppingCart();
 
 	return (
 		<Layout
@@ -33,6 +34,9 @@ export default function Hosting() {
 					<Actions>
 						<MobileSidebarNavigation />
 						<ShoppingCart
+							showCart={ showCart }
+							setShowCart={ setShowCart }
+							toggleCart={ toggleCart }
 							items={ selectedCartItems }
 							onRemoveItem={ onRemoveCartItem }
 							onCheckout={ () => {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -32,7 +32,14 @@ export default function PressableOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { selectedCartItems, setSelectedCartItems, onRemoveCartItem } = useShoppingCart();
+	const {
+		selectedCartItems,
+		setSelectedCartItems,
+		onRemoveCartItem,
+		showCart,
+		setShowCart,
+		toggleCart,
+	} = useShoppingCart();
 
 	const onAddToCart = useCallback(
 		( item: APIProductFamilyProduct ) => {
@@ -83,6 +90,9 @@ export default function PressableOverview() {
 					<Actions>
 						<MobileSidebarNavigation />
 						<ShoppingCart
+							showCart={ showCart }
+							setShowCart={ setShowCart }
+							toggleCart={ toggleCart }
 							items={ selectedCartItems }
 							onRemoveItem={ onRemoveCartItem }
 							onCheckout={ () => {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -27,7 +27,14 @@ import './style.scss';
 export default function ProductsOverview( { siteId, suggestedProduct }: AssignLicenseProps ) {
 	const translate = useTranslate();
 
-	const { selectedCartItems, setSelectedCartItems, onRemoveCartItem } = useShoppingCart();
+	const {
+		selectedCartItems,
+		setSelectedCartItems,
+		onRemoveCartItem,
+		showCart,
+		setShowCart,
+		toggleCart,
+	} = useShoppingCart();
 
 	const { isLoading } = useProductsQuery();
 
@@ -73,6 +80,9 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 						<MobileSidebarNavigation />
 
 						<ShoppingCart
+							showCart={ showCart }
+							setShowCart={ setShowCart }
+							toggleCart={ toggleCart }
 							items={ selectedCartItems }
 							onRemoveItem={ onRemoveCartItem }
 							onCheckout={ () => {

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -2,7 +2,6 @@ import page from '@automattic/calypso-router';
 import { Badge, Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useState } from 'react';
 import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_PAYMENT_METHODS_ADD_LINK,
@@ -18,32 +17,22 @@ type Props = {
 	onCheckout: () => void;
 	onRemoveItem: ( item: ShoppingCartItem ) => void;
 	items: ShoppingCartItem[];
+	showCart: boolean;
+	setShowCart: ( state: boolean ) => void;
+	toggleCart: () => void;
 };
 
 export const CART_URL_HASH_FRAGMENT = '#cart';
 
-export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props ) {
-	const [ showShoppingCart, setShowShoppingCart ] = useState(
-		window.location.hash === CART_URL_HASH_FRAGMENT
-	);
-
+export default function ShoppingCart( {
+	onCheckout,
+	onRemoveItem,
+	items,
+	showCart,
+	setShowCart,
+	toggleCart,
+}: Props ) {
 	const { paymentMethodRequired } = usePaymentMethod();
-
-	const toggleShoppingCart = () => {
-		setShowShoppingCart( ( prevState ) => {
-			const nextState = ! prevState;
-
-			const hashFragment = nextState ? CART_URL_HASH_FRAGMENT : '';
-
-			window.history.replaceState(
-				null,
-				'',
-				window.location.pathname + window.location.search + hashFragment
-			);
-
-			return nextState;
-		} );
-	};
 
 	const handleOnCheckout = () => {
 		if ( paymentMethodRequired ) {
@@ -55,7 +44,7 @@ export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props
 
 	return (
 		<div className="shopping-cart">
-			<Button className="shopping-cart__button" onClick={ toggleShoppingCart } borderless>
+			<Button className="shopping-cart__button" onClick={ toggleCart } borderless>
 				<Icon className="shopping-cart__button-icon" icon={ <ShoppingCartIcon /> } />
 
 				<Badge
@@ -68,10 +57,10 @@ export default function ShoppingCart( { onCheckout, onRemoveItem, items }: Props
 				</Badge>
 			</Button>
 
-			{ showShoppingCart && (
+			{ showCart && (
 				<ShoppingCartMenu
 					onClose={ () => {
-						setShowShoppingCart( false );
+						setShowCart( false );
 						window.history.replaceState(
 							null,
 							'',

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -24,7 +24,6 @@ import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
-	A4A_MARKETPLACE_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
 import { useDispatch } from 'calypso/state';
@@ -35,7 +34,7 @@ import HostingOverviewFeatures from '../common/hosting-overview-features';
 import useProductAndPlans from '../hooks/use-product-and-plans';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { getWPCOMCreatorPlan } from '../lib/hosting';
-import ShoppingCart, { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
+import ShoppingCart from '../shopping-cart';
 import WPCOMBulkSelector from './bulk-selection';
 import wpcomBulkOptions from './lib/wpcom-bulk-options';
 import { DiscountTier } from './lib/wpcom-bulk-values-utils';
@@ -47,7 +46,14 @@ export default function WpcomOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { selectedCartItems, onRemoveCartItem, setSelectedCartItems } = useShoppingCart();
+	const {
+		selectedCartItems,
+		onRemoveCartItem,
+		setSelectedCartItems,
+		showCart,
+		setShowCart,
+		toggleCart,
+	} = useShoppingCart();
 
 	const { data: licenseCounts, isSuccess: isLicenseCountsReady } = useFetchLicenseCounts();
 
@@ -85,10 +91,10 @@ export default function WpcomOverview() {
 				);
 
 				setSelectedCartItems( [ ...items, { ...plan, quantity } ] );
-				page( A4A_MARKETPLACE_PRODUCTS_LINK + CART_URL_HASH_FRAGMENT );
+				setShowCart( true );
 			}
 		},
-		[ selectedCartItems, setSelectedCartItems ]
+		[ selectedCartItems, setSelectedCartItems, setShowCart ]
 	);
 
 	const WPCOM_PRICING_PAGE_LINK = 'https://wordpress.com/pricing/';
@@ -122,6 +128,9 @@ export default function WpcomOverview() {
 
 					<Actions>
 						<ShoppingCart
+							showCart={ showCart }
+							setShowCart={ setShowCart }
+							toggleCart={ toggleCart }
 							items={ selectedCartItems }
 							onRemoveItem={ onRemoveCartItem }
 							onCheckout={ () => {

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -79,7 +79,7 @@ export default function A4AWPCOMSlider( {
 
 	const ratio = valueToSliderPos( minimum, mappedOptions ) / total;
 
-	const thumbSize = -14;
+	const thumbSize = 14;
 	const sliderWidth = rangeRef.current?.offsetWidth ?? 1;
 	const disabledAreaWidth =
 		minimum >= mappedOptions[ mappedOptions.length - 1 ].maxValue

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -8,6 +9,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import SitesHeaderActions from '../sites-header-actions';
@@ -53,8 +55,8 @@ export default function NeedSetup() {
 				{ id },
 				{
 					onSuccess: () => {
-						// refetch pending sites
 						refetchPendingSites();
+						page( A4A_SITES_LINK );
 					},
 				}
 			);

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
@@ -52,8 +52,7 @@ export default function PurchaseConfirmationMessage() {
 			onClose={ () => setSuccessNotification( false ) }
 		>
 			{ translate(
-				'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.' +
-					' Any add-ons you’ve purchased will be set up when you create your corresponding WordPress.com %(name)s site.',
+				'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.',
 				{
 					args: {
 						name,


### PR DESCRIPTION
This PR fixes couple of issues in the WPCOM plan purchase flow.

## Proposed Changes

* Fix overlapping issues on the Volume slider.
   | Before | After |
   |--------|--------|
   | <img width="663" alt="Screenshot 2024-05-02 at 2 52 41 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8f6969b5-87a0-441b-a870-3c05bc604e1c"> | <img width="663" alt="Screenshot 2024-05-02 at 2 52 57 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6de342f8-93db-481f-a0ef-bc43cebb6a17"> | 
* Remove the Addon reference in the Site purchase confirmation message.
   | Before | After |
   |--------|--------|
   | <img width="1346" alt="Screenshot 2024-05-02 at 2 54 12 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/2402e40e-dc8b-4757-ad37-de3284cfc8f0"> | <img width="1332" alt="Screenshot 2024-05-02 at 2 54 24 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/33074d17-8047-4ec6-b54a-4d1526a4cd9b"> | 
* After adding the WPCOM plan to the cart, only show the cart instead of redirecting to the Products page. This involves refactoring with the Shopping cart state management as to allow consuming components to show/hide cart on demand.
* After a successful site creation, we now redirect users to all sites. However, right now, it does not highlight the newly created site. We will improve this later on a separate PR.

## Testing Instructions

**Volume Slider**
* Use the A4A live link below and go to `/marketplace/hosting//wpcom`
* Confirm that there is no overlapping issue with the thumbnail. (The issue happens if we have already purchased a WPCOM plan).

**Confirmation Message**
* Use the A4A live link below and go to `/marketplace/hosting//wpcom`
* Purchase a WPCOM plan and confirm the purchase confirmation message does not reference any Addon features.

**Add To Cart**
* Use the A4A live link below and go to `/marketplace/hosting//wpcom`
* Add WPCOM plan to cart.
* Confirm that the page do not redirect to Products page.

**Post-Site creation flow**
* Purchase some WPCOM plans
* Use the A4A live link below and go to `/sites/need-setup`.
* Press the Create site CTA button.
* Confirm that after a successful creation, you are redirected to the 'All' sites page. Note that we have not yet highlighted which site was recently created. This will be addressed on a separate PR).

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?