### PR TITLE
Nav Redesign: Fix inconsistent submenu colors

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -294,22 +294,30 @@ body.is-mobile-app-view {
 		color: var(--color-masterbar-icon);
 	}
 
+	// The hover colors are supposed to be the same as those in wp-admin.
 	&:hover {
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);
 			color: var(--color-masterbar-highlight);
-
 			.masterbar--is-checkout & {
 				background: var(--color-checkout-masterbar-item-hover-background);
 				color: var(--color-checkout-masterbar-text);
 			}
-
 			.masterbar__item-content {
 				color: var(--color-masterbar-highlight);
 			}
-
 			.dashicons-before {
 				color: var(--color-masterbar-highlight);
+			}
+		}
+	}
+	// Reader icon is only available on Default interface sites, so we apply the Calypso color for consistency.
+	// https://github.com/Automattic/wp-calypso/pull/90136#issuecomment-2089512298
+	&.masterbar__reader:hover {
+		@include breakpoint-deprecated( ">480px" ) {
+			color: var(--color-masterbar-text);
+			.masterbar__item-content {
+				color: var(--color-masterbar-text);
 			}
 		}
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -291,16 +291,25 @@ body.is-mobile-app-view {
 
 	.dashicons-before {
 		height: 20px;
+		color: var(--color-masterbar-icon);
 	}
 
 	&:hover {
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);
-			color: var(--color-masterbar-text);
+			color: var(--color-masterbar-highlight);
 
 			.masterbar--is-checkout & {
 				background: var(--color-checkout-masterbar-item-hover-background);
 				color: var(--color-checkout-masterbar-text);
+			}
+
+			.masterbar__item-content {
+				color: var(--color-masterbar-highlight);
+			}
+
+			.dashicons-before {
+				color: var(--color-masterbar-highlight);
 			}
 		}
 	}
@@ -1042,6 +1051,16 @@ a.masterbar__quick-language-switcher {
 
 		@media only screen and ( min-width: 783px ) {
 			padding: 0 8px 0 4px;
+		}
+
+		svg {
+			fill: var(--color-masterbar-icon);
+		}
+
+		&:hover {
+			svg {
+				fill: var(--color-masterbar-highlight);
+			}
 		}
 	}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -610,6 +610,24 @@ $font-size: rem(14px);
 				}
 			}
 		}
+		.sidebar .sidebar__menu--selected .sidebar__heading {
+			color: var(--color-navredesign-sidebar-menu-selected-text);
+		}
+		.sidebar .sidebar__expandable-content {
+			.selected .sidebar__menu-link {
+				background-color: revert;
+				color: var(--color-navredesign-sidebar-submenu-selected-text);
+				font-weight: 600;
+			}
+			.sidebar__menu-link {
+				color: var(--color-navredesign-sidebar-submenu-text);
+				&:hover,
+				&:focus {
+					background-color: revert;
+					color: var(--color-navredesign-sidebar-submenu-hover-text);
+				}
+			}
+		}
 	}
 
 	&.is-classic-bright,

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -612,6 +612,7 @@ $font-size: rem(14px);
 		}
 		.sidebar .sidebar__menu--selected .sidebar__heading {
 			color: var(--color-navredesign-sidebar-menu-selected-text);
+			background-color: var(--color-sidebar-menu-selected-background);
 		}
 		.sidebar .sidebar__expandable-content {
 			.selected .sidebar__menu-link {

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -144,6 +144,12 @@ Used studio-blue for the primary+accent.
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: var(--theme-text-color);
 
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: #e2ecf1; /* $menu-submenu-text: */
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: var(--theme-text-color);
+
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-highlight-color);
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_blue.scss
@@ -102,7 +102,9 @@ Used studio-blue for the primary+accent.
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-text-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
@@ -143,6 +143,12 @@ The wp-admin highlight color hue is 27, while studio-orange ranges from 25 to 35
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: var(--theme-highlight-color);
 
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
+
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-base-color);
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_coffee.scss
@@ -100,7 +100,9 @@ The wp-admin highlight color hue is 27, while studio-orange ranges from 25 to 35
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -255,7 +255,9 @@
 
 	--color-masterbar-background: #101517;
 	--color-masterbar-border: #333;
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: #f0f0f1; /* Direct from wp-admin */
+	--color-masterbar-icon: rgba(240, 246, 252, 0.6); /* Direct from wp-admin */
+	--color-masterbar-highlight: #72aee6; /* Direct from wp-admin */
 	--color-masterbar-item-hover-background: #333;
 	--color-masterbar-item-active-background: #23282d;
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -350,4 +350,10 @@
 	--color-sidebar-submenu-text: var(--studio-blue-70);
 	--color-sidebar-submenu-hover-text: var(--color-accent);
 	--color-sidebar-submenu-selected-text: var(--color-accent);
+
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: rgba(240, 246, 252, 0.7); /* Direct from wp-admin */
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: #72aee6; /* Direct from wp-admin */
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
@@ -181,6 +181,12 @@ Created this definition in color-studio to generate 0-100 shades:
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: var(--theme-highlight-color);
 
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
+
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-base-color);
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ectoplasm.scss
@@ -139,7 +139,9 @@ Created this definition in color-studio to generate 0-100 shades:
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -117,7 +117,9 @@ Primary+Accent is studio blue.
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-black);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -161,6 +161,12 @@ Primary+Accent is studio blue.
 	--color-sidebar-submenu-hover-text: var(--theme-highlight-color);
 	--color-sidebar-submenu-selected-text: #333;
 
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-submenu-background-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
+
 	/* Fix for notification bell */
 	.masterbar__item-notifications {
 		.gridicon {

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -135,6 +135,12 @@ $notification-color: #69a8bb;
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: var(--theme-highlight-color);
 
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
+
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-highlight-color);
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -93,7 +93,9 @@ $notification-color: #69a8bb;
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -131,7 +131,9 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: #33f078; /* Direct from wp-admin */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -133,7 +133,7 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	--color-masterbar-border: var(--theme-submenu-background-color);
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
-	--color-masterbar-highlight: #33f078; /* Direct from wp-admin */
+	--color-masterbar-highlight: #33f078; /* $menu-submenu-focus-text */
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);
@@ -171,7 +171,13 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	--color-sidebar-submenu-background: var(--theme-submenu-background-color);
 	--color-sidebar-submenu-text: var(--theme-submenu-text-color);
 	--color-sidebar-submenu-hover-background: transparent;
-	--color-sidebar-submenu-hover-text: #33f078;
+	--color-sidebar-submenu-hover-text: #33f078; /* $menu-submenu-focus-text */
+
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: #33f078; /* $menu-submenu-focus-text */
 
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-highlight-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
@@ -105,7 +105,9 @@ opinion.  Celadon seems to match the ocean colors better.
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_ocean.scss
@@ -147,6 +147,12 @@ opinion.  Celadon seems to match the ocean colors better.
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: var(--theme-highlight-color);
 
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
+
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-highlight-color);
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -147,6 +147,12 @@ Well use studio-orange for both the primary and accent colors
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: var(--theme-submenu-hover-text-color);
 
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: var(--theme-submenu-hover-text-color);
+
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-highlight-color);
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_sunrise.scss
@@ -104,7 +104,9 @@ Well use studio-orange for both the primary and accent colors
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
 	--color-masterbar-border: var(--theme-submenu-background-color);
-	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-submenu-hover-text-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
 
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix https://github.com/Automattic/dotcom-forge/issues/6801
Related https://github.com/Automattic/wp-calypso/pull/90136

## Proposed Changes

This PR fixes the inconsistent submenu highlight colors. 

| before | after |
|--------|--------|
| <img width="163" alt="Screenshot 2024-05-02 at 16 26 58" src="https://github.com/Automattic/wp-calypso/assets/5287479/00a4e8d9-d92c-40c1-8e04-cc6c67cbe19c"> | <img width="165" alt="Screenshot 2024-05-02 at 16 26 26" src="https://github.com/Automattic/wp-calypso/assets/5287479/d3078b3b-8e4f-4358-84ee-218572affa66"> | 
|(hover) <img width="164" alt="Screenshot 2024-05-02 at 16 27 41" src="https://github.com/Automattic/wp-calypso/assets/5287479/402d3547-60cb-481d-b275-2685588f20f2">| (hover) <img width="170" alt="Screenshot 2024-05-02 at 16 27 51" src="https://github.com/Automattic/wp-calypso/assets/5287479/1170cc9e-7caf-42af-8271-744470ae988b">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare an Atomin site with Classic View 
* Go to the site's `_cli` and run `wp option update wpcom_classic_early_release 1`.
* Compare the submenu highlight colors in wp-admin (e.g., `/wp-admin/profile.php`) and Calypso page (e.g., `/home/<your-site>`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?