### PR TITLE
Sites Dashboard V2: Fix table layout when the sidebar is auto collapsed on small screen

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -413,7 +413,7 @@ $brand-text: "SF Pro Text", $sans;
 	}
 }
 
-@media ( min-width: 660px ) {
+@media ( min-width: 661px ) {
 	.is-global-sidebar-collapsed {
 		.global-sidebar {
 			.sidebar__header,

--- a/client/sites-dashboard-v2/controller.tsx
+++ b/client/sites-dashboard-v2/controller.tsx
@@ -64,6 +64,11 @@ export function sitesDashboard( context: Context, next: () => void ) {
 				min-height: 100vh;
 				padding: calc( var( --masterbar-height ) + 16px ) 16px 16px
 					calc( var( --sidebar-width-max ) );
+
+				@media only screen and ( max-width: 781px ) {
+					padding: calc( var( --masterbar-height ) + 24px ) 24px 24px
+						calc( var( --sidebar-width-max ) );
+				}
 			}
 
 			.layout__secondary .global-sidebar {
@@ -73,19 +78,16 @@ export function sitesDashboard( context: Context, next: () => void ) {
 
 		body.is-group-sites-dashboard.rtl .layout__content {
 			padding: calc( var( --masterbar-height ) + 16px ) calc( var( --sidebar-width-max ) ) 16px 16px;
+
+			@media only screen and ( max-width: 781px ) {
+				padding: calc( var( --masterbar-height ) + 24px ) calc( var( --sidebar-width-max ) ) 24px
+					24px;
+			}
 		}
 
 		.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {
-			height: calc( 100vh - 32px );
 			padding-bottom: 0;
 			box-shadow: none;
-		}
-
-		div.is-group-sites-dashboard:not( .has-no-masterbar ) {
-			.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {
-				// Fix for scrollbars when global-sidebar is not visible because masterbar is visible
-				height: calc( 100vh - 95px );
-			}
 		}
 
 		// Update body margin to account for the sidebar width

--- a/client/sites-dashboard-v2/controller.tsx
+++ b/client/sites-dashboard-v2/controller.tsx
@@ -62,7 +62,8 @@ export function sitesDashboard( context: Context, next: () => void ) {
 				// Add border around everything
 				overflow: hidden;
 				min-height: 100vh;
-				padding: 16px 16px 16px calc( var( --sidebar-width-max ) );
+				padding: calc( var( --masterbar-height ) + 16px ) 16px 16px
+					calc( var( --sidebar-width-max ) );
 			}
 
 			.layout__secondary .global-sidebar {
@@ -71,7 +72,7 @@ export function sitesDashboard( context: Context, next: () => void ) {
 		}
 
 		body.is-group-sites-dashboard.rtl .layout__content {
-			padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
+			padding: calc( var( --masterbar-height ) + 16px ) calc( var( --sidebar-width-max ) ) 16px 16px;
 		}
 
 		.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -268,6 +268,19 @@
 	}
 }
 
+.wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout {
+	.a4a-layout-column__container {
+		.dataviews-wrapper {
+			position: relative;
+
+			.dataviews-pagination {
+				margin: 0;
+				position: relative;
+			}
+		}
+	}
+}
+
 // Use flexbox to structure of fly-out panel.
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout:not(.preview-hidden) {
 	.a4a-layout-column__container {
@@ -310,16 +323,11 @@
 				flex: 1;
 				max-height: none;
 			}
-
-			.dataviews-pagination {
-				margin: 0;
-				position: relative;
-			}
 		}
 	}
 }
 
 .wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {
 	// With masterbar
-	max-height: calc(100vh - 347px); /* 347px is the size of all the height above and below the dataviews-view-table-wrapper */
+	max-height: calc(100vh - 323px); /* 323px is the size of all the height above and below the dataviews-view-table-wrapper */
 }

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -283,6 +283,7 @@
 			.dataviews-pagination {
 				margin: 0;
 				position: relative;
+				width: 100%;
 			}
 		}
 	}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -44,8 +44,13 @@
 		}
 	}
 
-	@media (max-width: $break-large) {
-		height: calc(100vh - 32px);
+	height: calc(100vh - var(--masterbar-height));
+	@media ( min-width: 601px ) {
+		height: calc(100vh - var(--masterbar-height) - 48px);
+	}
+
+	@media ( min-width: 782px ) {
+		height: calc(100vh - var(--masterbar-height) - 32px);
 	}
 }
 
@@ -149,9 +154,11 @@
 		}
 	}
 	.is-global-sidebar-collapsed {
-		@media ( min-width: 660px ) {
+		@media ( min-width: 661px ) {
 			.global-sidebar {
 				.sidebar__body {
+					padding-top: 24px;
+
 					.sidebar__menu-link {
 						width: fit-content;
 
@@ -328,6 +335,10 @@
 }
 
 .wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {
-	// With masterbar
-	max-height: calc(100vh - 323px); /* 323px is the size of all the height above and below the dataviews-view-table-wrapper */
+	max-height: calc(100vh - 276px); /* 276px is the size of all the height above and below the dataviews-view-table-wrapper */
+
+	// With 48px padding.
+	@media ( min-width: 601px ) {
+		max-height: calc(100vh - 324px); /* 324px is the size of all the height above and below the dataviews-view-table-wrapper */
+	}
 }

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -59,11 +59,7 @@
 }
 
 .sites-dashboard__layout:not(.preview-hidden) {
-
 	.dataviews-pagination {
-		line-height: 1;
-		width: 368px;
-
 		.components-base-control {
 			width: unset !important;
 			margin-right: 0 !important;

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -1110,3 +1110,8 @@
 	}
 }
 
+.layout__content {
+	@include breakpoint-deprecated( "<960px" ) {
+		padding: 71px 24px 24px calc(var(--sidebar-width-min) + 1px);
+	}
+}

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -1098,13 +1098,6 @@
 	box-sizing: border-box;
 	width: 100%;
 
-	@media only screen and ( min-width: 600px ) {
-		width: calc(100% - 48px);
-	}
-
-	@media only screen and ( min-width: 782px ) {
-		width: calc(100% - ( var(--sidebar-width-max) + 16px));
-	}
 	.components-input-control__container > div.components-input-control__backdrop {
 		border-color: var(--color-border-subtle);
 	}

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { isWithinBreakpoint } from '@automattic/viewport';
 import { isGlobalSiteViewEnabled } from '../sites/selectors';
 import type { AppState } from 'calypso/types';
 
@@ -53,7 +54,10 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
 
-	return isEnabled( 'layout/dotcom-nav-redesign-v2' ) && ( siteSelected || siteLoaded );
+	return (
+		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
+		( siteSelected || siteLoaded || isWithinBreakpoint( '<782px' ) )
+	);
 };
 
 export const getShouldShowUnifiedSiteSidebar = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6894

## Proposed Changes

Fix the responsive styles as much as possible
* The sidebar is auto collapsed when the vw is smaller than 782px, so add the breaking point check to determine whether it's collapsed
* Include the height of the masterbar into the padding-top of the `layout__content`
* Reduce the height of the masterbar from the height of the `sites-dashboard`
* Use absolute-positioning on the pagination of `dataviews`

**Default View**

https://github.com/Automattic/wp-calypso/assets/13596067/aa993b5e-ecb1-4429-9518-abfcb23faff6

**GSV View**

https://github.com/Automattic/wp-calypso/assets/13596067/58436559-2f5b-45b7-a638-22580d99f373

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Resize your viewport width and toggle the sidebar
* Make sure everything looks good
* Select any site
* Resize your viewport width and toggle the sidebar again
* Make sure everything still looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?