### PR TITLE
A4A: Enable 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' feature flag.

### DIFF
--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -28,7 +28,7 @@
 	"oauth_client_id": 95932,
 	"features": {
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": false,
+		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"oauth": true,
 		"a4a-logged-out-signup": true
 	},


### PR DESCRIPTION
This PR enables WPCOM Creator plan purchase flow in production.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/394

## Proposed Changes

* Enable 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' feature flag.

## Testing Instructions

* Verify that the changes look good.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?