### PR TITLE
Segmentation Survey - Cache anon id for cases when it's cleared from …

### DIFF
--- a/client/data/segmentaton-survey/index.ts
+++ b/client/data/segmentaton-survey/index.ts
@@ -1,4 +1,5 @@
 export { default as useCachedAnswers } from './hooks/use-cached-answers';
+export { default as anonIdCache } from './local-storage/anonymous-user-id';
 export { default as useSaveAnswersMutation } from './mutations/use-save-answers-mutation';
 export { default as useLinkAnswersMutation } from './mutations/use-link-answers-mutation';
 export { default as useSurveyStructureQuery } from './queries/use-survey-structure-query';

--- a/client/data/segmentaton-survey/local-storage/anonymous-user-id.ts
+++ b/client/data/segmentaton-survey/local-storage/anonymous-user-id.ts
@@ -1,0 +1,29 @@
+// A set of utility functions designed to store and retrieve the anonymous user ID in local storage.
+// These functions are particularly useful in scenarios where the anonymous user ID,
+// initially stored in a cookie, might be reset. Such a reset can occur after a user,
+// initially not logged in, completes a survey and subsequently logs in or signs up.
+// Even if the cookie is reset, it is crucial to transmit the anonymous user ID to the server to request the linking of previously anonymous responses to the newly created account.
+const ANON_ID_KEY = 'ss-anon-id';
+
+const store = ( anonId: string ) => {
+	localStorage.setItem( ANON_ID_KEY, anonId );
+};
+
+const get = () => {
+	return localStorage.getItem( ANON_ID_KEY );
+};
+
+const clear = () => {
+	localStorage.removeItem( ANON_ID_KEY );
+};
+
+// Initially I was going to use this function in the cart logic, but the cart logic is in onboarding package and do not want to introduce cyclic dependecies
+// Perhaps there is some other package suitable for us to define those util functions which would be accessible from both the onboarding package and the calypso client
+// Otherwise just clean-up
+const pop = () => {
+	const anonId = get();
+	clear();
+	return anonId;
+};
+
+export default { store, get, clear, pop };

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -143,16 +143,18 @@ const entrepreneurFlow: Flow = {
 		const isLoggedIn = useSelector( isUserLoggedIn );
 
 		useEffect( () => {
-			if ( isLoggedIn ) {
-				// Proactively remove the anonymous user ID from localStorage if the user is logged in.
-				anonIdCache.clear();
-				return;
-			}
+			// if ( isLoggedIn ) {
+			// 	// Proactively remove the anonymous user ID from localStorage if the user is logged in.
+			// 	anonIdCache.clear();
+			// 	return;
+			// }
 
 			// We need to store the anonymous user ID in localStorage because
 			// we need to pass it to the server on site creation, i.e. after the user signs up or logs in.
 			const anonymousUserId = getTracksAnonymousUserId();
-			anonIdCache.store( anonymousUserId );
+			if ( anonymousUserId ) {
+				anonIdCache.store( anonymousUserId );
+			}
 		}, [ isLoggedIn ] );
 	},
 };

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -1,5 +1,10 @@
+import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { anonIdCache } from 'calypso/data/segmentaton-survey';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useFlowLocale } from '../hooks/use-flow-locale';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { getLoginUrl } from '../utils/path';
@@ -132,6 +137,23 @@ const entrepreneurFlow: Flow = {
 		}
 
 		return { submit };
+	},
+
+	useSideEffect() {
+		const isLoggedIn = useSelector( isUserLoggedIn );
+
+		useEffect( () => {
+			if ( isLoggedIn ) {
+				// Proactively remove the anonymous user ID from localStorage if the user is logged in.
+				anonIdCache.clear();
+				return;
+			}
+
+			// We need to store the anonymous user ID in localStorage because
+			// we need to pass it to the server on site creation, i.e. after the user signs up or logs in.
+			const anonymousUserId = getTracksAnonymousUserId();
+			anonIdCache.store( anonymousUserId );
+		}, [ isLoggedIn ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -143,12 +143,6 @@ const entrepreneurFlow: Flow = {
 		const isLoggedIn = useSelector( isUserLoggedIn );
 
 		useEffect( () => {
-			// if ( isLoggedIn ) {
-			// 	// Proactively remove the anonymous user ID from localStorage if the user is logged in.
-			// 	anonIdCache.clear();
-			// 	return;
-			// }
-
 			// We need to store the anonymous user ID in localStorage because
 			// we need to pass it to the server on site creation, i.e. after the user signs up or logs in.
 			const anonymousUserId = getTracksAnonymousUserId();

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -188,7 +188,9 @@ export const createSiteWithCart = async (
 			options: {
 				...newSiteParams.options,
 				has_segmentation_survey: hasSegmentationSurvey,
-				segmentation_survey_answers_anon_id: segmentationSurveyAnswersAnonId,
+				...( hasSegmentationSurvey && segmentationSurveyAnswersAnonId
+					? { segmentation_survey_answers_anon_id: segmentationSurveyAnswersAnonId }
+					: {} ),
 			},
 		},
 	} );

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -172,6 +172,9 @@ export const createSiteWithCart = async (
 	const locale = getLocaleSlug();
 	const hasSegmentationSurvey: boolean =
 		newSiteParams[ 'options' ][ 'site_creation_flow' ] === 'entrepreneur';
+	const segmentationSurveyAnswersAnonId = localStorage.getItem( 'ss-anon-id' );
+	localStorage.removeItem( 'ss-anon-id' );
+
 	const siteCreationResponse: NewSiteSuccessResponse = await wpcomRequest( {
 		path: '/sites/new',
 		apiVersion: '1.1',
@@ -182,7 +185,11 @@ export const createSiteWithCart = async (
 			lang_id: getLanguage( locale as string )?.value,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
-			options: { ...newSiteParams.options, has_segmentation_survey: hasSegmentationSurvey },
+			options: {
+				...newSiteParams.options,
+				has_segmentation_survey: hasSegmentationSurvey,
+				segmentation_survey_answers_anon_id: segmentationSurveyAnswersAnonId,
+			},
 		},
 	} );
 


### PR DESCRIPTION
…the cookie after the user logs in but we still need it to link his answers

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
