### PR TITLE
Stats: Remove fit-content rule on video module.

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -19,7 +19,6 @@ $grid-vertical-gutters: 32px;
 	overflow-x: auto;
 
 	.stats-card--header-and-body {
-		width: fit-content;
 		min-width: 100%;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86958.

## Proposed Changes

Removes a CSS rule that was causing the Views column of the Video module to be pushed out of the content box.

### Before
<img width="617" alt="SCR-20240502-pgxe" src="https://github.com/Automattic/wp-calypso/assets/40267301/3777c2b3-7932-4fb8-b2bb-c0ad509b01f2">

### After
<img width="618" alt="SCR-20240502-pgzw" src="https://github.com/Automattic/wp-calypso/assets/40267301/c532e925-a8e7-4767-8f34-45d62ef43526">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Stats → Traffic page on a site with video plays.
* Scroll down to Video module.
* Confirm the Views column is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?