### PR TITLE
Scheduled Updates: Add empty view

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-empty.tsx
@@ -1,0 +1,25 @@
+import { __experimentalText as Text, Button } from '@wordpress/components';
+import { plus } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	onCreateNewSchedule: () => void;
+}
+export const ScheduleListEmpty = ( props: Props ) => {
+	const translate = useTranslate();
+
+	const { onCreateNewSchedule } = props;
+
+	return (
+		<div className="empty-state">
+			<Text as="p">
+				{ translate(
+					"Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind."
+				) }
+			</Text>
+			<Button __next40pxDefaultSize icon={ plus } variant="primary" onClick={ onCreateNewSchedule }>
+				{ translate( 'Setup a new schedule' ) }
+			</Button>
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -12,6 +12,7 @@ import { useErrors } from 'calypso/blocks/plugins-scheduled-updates-multisite/ho
 import { useBatchDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListFilter } from './schedule-list-filter';
 import { ScheduleListTable } from './schedule-list-table';
 
@@ -86,19 +87,22 @@ export const ScheduleList = ( props: Props ) => {
 
 	const isLoading = isLoadingSchedules;
 	const ScheduleListComponent = isMobile ? null : ScheduleListTable;
+	const isScheduleEmpty = schedules.length === 0 && isFetched;
 
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
 			<div className="plugins-update-manager-multisite__header">
 				<h1>{ translate( 'Update schedules' ) }</h1>
-				<Button
-					__next40pxDefaultSize
-					variant="primary"
-					onClick={ onCreateNewSchedule }
-					disabled={ false }
-				>
-					{ translate( 'New schedule' ) }
-				</Button>
+				{ ! isScheduleEmpty && (
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						onClick={ onCreateNewSchedule }
+						disabled={ false }
+					>
+						{ translate( 'New schedule' ) }
+					</Button>
+				) }
 			</div>
 			{ errors.length ? (
 				<Notice status="warning" isDismissible={ true } onDismiss={ () => clearErrors() }>
@@ -117,7 +121,8 @@ export const ScheduleList = ( props: Props ) => {
 				</Notice>
 			) : null }
 			{ schedules.length === 0 && isLoading && <Spinner /> }
-			{ isFetched && filteredSchedules && ScheduleListComponent ? (
+			{ isScheduleEmpty && <ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } /> }
+			{ isFetched && filteredSchedules.length > 0 && ScheduleListComponent ? (
 				<>
 					<ScheduleListFilter />
 					<ScheduleListComponent

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -127,4 +127,17 @@ $brand-display: "SF Pro Display", sans-serif;
 			border-radius: 4px;
 		}
 	}
+
+	.empty-state {
+		max-width: 50%;
+		text-align: left;
+		padding: 0;
+
+		p {
+			color: var(--studio-gray-100);
+			margin: 1.5rem auto;
+			font-size: rem(18px);
+			line-height: 1.625;
+		}
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89971

## Proposed Changes

* Add an empty view for multi-site level screen.

![Screen Shot 2024-05-02 at 6 41 58 PM](https://github.com/Automattic/wp-calypso/assets/4074459/05d1d347-6bb7-48c3-8b4e-0bec2f8a443d)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/plugins/scheduled-updates
* You can mock 0 schedules by going to `use-update-schedules-query.ts` and return an empty array in `select`.
* Check and see if it shows as the screenshot above.
* Note: The mobile style will be handle in the upcoming PRs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?