### PR TITLE
Nav Redesign - remove horizontal scroll in sites table

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -82,6 +82,39 @@
 	table.dataviews-view-table .dataviews-view-table__row td {
 		border-bottom-color: var(--color-border-secondary);
 	}
+
+	table.dataviews-view-table th,
+	table.dataviews-view-table td {
+		white-space: nowrap; /* Optional: ensures text in cells does not wrap */
+	}
+
+	table.dataviews-view-table th:first-child,
+	table.dataviews-view-table td:first-child,
+	table.dataviews-view-table th:last-child,
+	table.dataviews-view-table td:last-child {
+		display: table-cell; /* ensures these cells are always shown */
+	}
+
+	@media (max-width: $break-wide) {
+		table.dataviews-view-table th:nth-child(5),
+		table.dataviews-view-table td:nth-child(5) {
+			display: none;
+		}
+	}
+
+	@media (max-width: $break-wide - 100px) {
+		table.dataviews-view-table th:nth-child(4),
+		table.dataviews-view-table td:nth-child(4) {
+			display: none;
+		}
+	}
+
+	@media (max-width: $break-xlarge) {
+		table.dataviews-view-table th:nth-child(3),
+		table.dataviews-view-table td:nth-child(3) {
+			display: none;
+		}
+	}
 }
 
 // Styles for actions (search, filters).


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fixes https://github.com/Automattic/dotcom-forge/issues/6885
* Adds styles to hide site table columns as the page width decreases, to avoid a horizontal scroll.
* Keep the first (Sites) and last (Actions) columns visible as the page width decreases as these columns are the most useful

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `calypso.live/sites?flags=layout/dotcom-nav-redesign-v2`
* Adjust the width of the page and make sure the table columns work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?