### PR TITLE
Scheduled Updates: Allow unlimited update schedules

### DIFF
--- a/client/blocks/plugins-scheduled-updates/config.ts
+++ b/client/blocks/plugins-scheduled-updates/config.ts
@@ -1,3 +1,3 @@
-export const MAX_SCHEDULES = 24;
+export const MAX_SCHEDULES = -1;
 export const MAX_SELECTABLE_PLUGINS = 10;
 export const MAX_SELECTABLE_PATHS = 5;

--- a/client/blocks/plugins-scheduled-updates/config.ts
+++ b/client/blocks/plugins-scheduled-updates/config.ts
@@ -1,3 +1,3 @@
-export const MAX_SCHEDULES = 2;
+export const MAX_SCHEDULES = 24;
 export const MAX_SELECTABLE_PLUGINS = 10;
 export const MAX_SELECTABLE_PATHS = 5;

--- a/client/blocks/plugins-scheduled-updates/config.ts
+++ b/client/blocks/plugins-scheduled-updates/config.ts
@@ -1,3 +1,2 @@
-export const MAX_SCHEDULES = -1;
 export const MAX_SELECTABLE_PLUGINS = 10;
 export const MAX_SELECTABLE_PATHS = 5;

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -52,7 +52,9 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 
 	const hideCreateButton =
-		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
+		! isEligibleForFeature ||
+		( MAX_SCHEDULES && schedules.length === MAX_SCHEDULES ) ||
+		schedules.length === 0;
 
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins( siteSlug );
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -11,7 +11,6 @@ import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedule
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { MAX_SCHEDULES } from './config';
 import { PluginUpdateManagerContextProvider } from './context';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
@@ -51,10 +50,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 	const { isEligibleForFeature, isSitePlansLoaded } = useIsEligibleForFeature();
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 
-	const hideCreateButton =
-		! isEligibleForFeature ||
-		( MAX_SCHEDULES && schedules.length === MAX_SCHEDULES ) ||
-		schedules.length === 0;
+	const hideCreateButton = ! isEligibleForFeature || schedules.length === 0;
 
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins( siteSlug );
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );

--- a/client/blocks/plugins-scheduled-updates/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-create.tsx
@@ -50,7 +50,7 @@ export const ScheduleCreate = ( props: Props ) => {
 	const [ syncError, setSyncError ] = useState( '' );
 
 	useEffect( () => {
-		if ( isFetched && schedules.length >= MAX_SCHEDULES ) {
+		if ( isFetched && MAX_SCHEDULES && schedules.length >= MAX_SCHEDULES ) {
 			onNavBack && onNavBack();
 		}
 	}, [ isFetched ] );

--- a/client/blocks/plugins-scheduled-updates/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-create.tsx
@@ -14,8 +14,6 @@ import { arrowLeft, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { Banner } from 'calypso/components/banner';
-import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
-import { MAX_SCHEDULES } from './config';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useCreateMonitor } from './hooks/use-create-monitor';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
@@ -35,10 +33,6 @@ export const ScheduleCreate = ( props: Props ) => {
 	const { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading } =
 		useSiteHasEligiblePlugins();
 	const { onNavBack } = props;
-	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
-		siteSlug,
-		isEligibleForFeature
-	);
 	const { canCreateSchedules, errors: eligibilityCheckErrors } = useCanCreateSchedules(
 		siteSlug,
 		isEligibleForFeature
@@ -48,12 +42,6 @@ export const ScheduleCreate = ( props: Props ) => {
 	} );
 	const isBusy = pendingMutations.length > 0;
 	const [ syncError, setSyncError ] = useState( '' );
-
-	useEffect( () => {
-		if ( isFetched && MAX_SCHEDULES && schedules.length >= MAX_SCHEDULES ) {
-			onNavBack && onNavBack();
-		}
-	}, [ isFetched ] );
 
 	// Redirect back to list when no eligible plugins are installed
 	useEffect( () => {

--- a/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
@@ -26,7 +26,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 						return translate( 'This site is unable to schedule auto-updates for plugins.' );
 					}
 					return translate(
-						"Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Up to twenty-four schedules let you enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind."
+						"Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Enjoy hassle-free automatic updates with our built-in rollback feature, reverting any flawed updates for added peace of mind."
 					);
 				} )() }
 			</Text>

--- a/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
@@ -26,7 +26,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 						return translate( 'This site is unable to schedule auto-updates for plugins.' );
 					}
 					return translate(
-						"Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Up to two schedules let you enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind."
+						"Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Up to twenty-four schedules let you enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind."
 					);
 				} )() }
 			</Text>


### PR DESCRIPTION
> [!WARNING] 
> Only merge this after a new version of `jetpack-mu-wpcom` is released 

Related to https://github.com/Automattic/wp-calypso/issues/89793

## Proposed Changes

- Frontend changes to allow up to 24 updates.

<img width="1149" alt="image" src="https://github.com/Automattic/wp-calypso/assets/528287/77c61626-bad0-4b92-a28b-a02502120d07">


## Testing Instructions

- Test together with https://github.com/Automattic/jetpack/pull/37181
- See if you can make more than 2 updates for a site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?