### PR TITLE
A4A: Update referral percentage from 30 to 50

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -59,7 +59,7 @@ export default function ReferralsOverview() {
 
 			<LayoutBody>
 				<div className="referrals-overview__section-heading">
-					{ translate( 'Receive up to 30% revenue share on Automattic product referrals.' ) }
+					{ translate( 'Receive up to 50% revenue share on Automattic product referrals.' ) }
 				</div>
 				<div className="referrals-overview__section-container">
 					{ isFetching ? (


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/410

## Proposed Changes

* Change referral percentage from 30 to 50

## Testing Instructions

* Go to the referrals page (`http://agencies.localhost:3000/referrals`) 
* Verify that percentage displayed is 50 (`Receive up to 50%...`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?