### PR TITLE
A4A: Add WPCOM hosting section back to the Overview page

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -54,8 +54,6 @@ const OverviewBodyHosting = () => {
 		},
 	};
 
-	// TODO: Add WordPress.com offering once it's available in the A4A Marketplace
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const wpcom: OfferingItemProps = {
 		//translators: Title for the action card
 		title: translate( 'WordPress.com' ),
@@ -91,7 +89,7 @@ const OverviewBodyHosting = () => {
 			description={ translate(
 				'Choose the hosting that suits your needs from our best-in-class offerings.'
 			) }
-			items={ [ pressable ] }
+			items={ [ pressable, wpcom ] }
 		/>
 	);
 };

--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -76,7 +76,7 @@ const OverviewBodyHosting = () => {
 		],
 		// translators: Button navigating to A4A Marketplace
 		buttonTitle: translate( 'Explore WordPress.com' ),
-		expanded: false,
+		expanded: true,
 		actionHandler: () => {
 			actionHandlerCallback( 'hosting', 'wordpress.com' );
 			page( A4A_MARKETPLACE_HOSTING_WPCOM_LINK );


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/412

## Proposed Changes

* This PR adds WPCOM hosting section back to the Overview page

## Testing Instructions

* Go to the overview page (`http://agencies.localhost:3000/overview`)
* Verify that WPCOM shows under hosting.

![image](https://github.com/Automattic/wp-calypso/assets/37049295/90411604-340e-48a1-84fc-a4cbd54ccf6f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?