### PR TITLE
Nav redesign: Add missing tooltips

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -51,6 +51,7 @@ export default function SidebarItem( props ) {
 				onClick={ handleNavigate }
 				href={ props.link }
 				onMouseEnter={ itemPreload }
+				data-tooltip={ props.tooltip }
 				{ ...linkProps }
 			>
 				{ icon && <Gridicon className="sidebar__menu-icon" icon={ icon } size={ 24 } /> }
@@ -92,6 +93,7 @@ export default function SidebarItem( props ) {
 
 SidebarItem.propTypes = {
 	label: TranslatableString.isRequired,
+	tooltip: TranslatableString,
 	className: PropTypes.string,
 	link: PropTypes.string.isRequired,
 	onNavigate: PropTypes.func,

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -15,6 +15,7 @@ export default function SidebarItem( props ) {
 	const classes = classnames( props.className, props.tipTarget, {
 		selected: props.selected,
 		'has-unseen': props.hasUnseen,
+		tooltip: !! props.tooltip,
 	} );
 	const sidebarIsCollapsed = useSelector( getSidebarIsCollapsed );
 	const { materialIcon, materialIconStyle, icon, customIcon, count, badge } = props;
@@ -45,13 +46,17 @@ export default function SidebarItem( props ) {
 	const linkProps = showAsExternal ? { target: '_blank', rel: 'noreferrer' } : {};
 
 	return (
-		<li className={ classes } data-tip-target={ props.tipTarget } data-post-type={ props.postType }>
+		<li
+			className={ classes }
+			data-tip-target={ props.tipTarget }
+			data-tooltip={ props.tooltip }
+			data-post-type={ props.postType }
+		>
 			<a
 				className="sidebar__menu-link"
 				onClick={ handleNavigate }
 				href={ props.link }
 				onMouseEnter={ itemPreload }
-				data-tooltip={ props.tooltip }
 				{ ...linkProps }
 			>
 				{ icon && <Gridicon className="sidebar__menu-icon" icon={ icon } size={ 24 } /> }

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -8,6 +8,7 @@ import SitePicker from 'calypso/my-sites/picker';
 import MySitesSidebarUnifiedBody from 'calypso/my-sites/sidebar/body';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
+	getShouldShowCollapsedGlobalSidebar,
 	getShouldShowGlobalSidebar,
 	getShouldShowUnifiedSiteSidebar,
 } from 'calypso/state/global-sidebar/selectors';
@@ -91,6 +92,7 @@ class MySitesNavigation extends Component {
 		return (
 			<GlobalSidebar { ...asyncProps }>
 				<MySitesSidebarUnifiedBody
+					isGlobalSidebarCollapsed={ this.props.isGlobalSidebarCollapsed }
 					path={ this.props.path }
 					onMenuItemClick={ this.handleGlobalSidebarMenuItemClick }
 				/>
@@ -116,6 +118,12 @@ export default withCurrentRoute(
 				sectionGroup,
 				sectionName
 			);
+			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,
 				siteId,
@@ -125,6 +133,7 @@ export default withCurrentRoute(
 			return {
 				siteDomain,
 				isGlobalSidebarVisible: shouldShowGlobalSidebar,
+				isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar,
 				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar,
 			};
 		},

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -16,7 +16,12 @@ import 'calypso/state/admin-menu/init';
 
 import './style.scss';
 
-export const MySitesSidebarUnifiedBody = ( { path, children, onMenuItemClick } ) => {
+export const MySitesSidebarUnifiedBody = ( {
+	isGlobalSidebarCollapsed,
+	path,
+	children,
+	onMenuItemClick,
+} ) => {
 	const menuItems = useSiteMenuItems();
 	const sidebarIsCollapsed = useSelector( getSidebarIsCollapsed );
 	const site = useSelector( getSelectedSite );
@@ -71,6 +76,7 @@ export const MySitesSidebarUnifiedBody = ( { path, children, onMenuItemClick } )
 							key={ item.slug }
 							selected={ isSelected }
 							shouldOpenExternalLinksInCurrentTab={ shouldOpenExternalLinksInCurrentTab }
+							showTooltip={ !! isGlobalSidebarCollapsed }
 							trackClickEvent={ onMenuItemClick }
 							{ ...item }
 						/>

--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -26,6 +26,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	url,
 	className = '',
 	shouldOpenExternalLinksInCurrentTab,
+	showTooltip = false,
 	forceExternalLink = false,
 	forceShowExternalIcon = false,
 	forceChevronIcon = false,
@@ -47,6 +48,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			badge={ badge }
 			count={ count }
 			label={ title }
+			tooltip={ showTooltip && title }
 			link={ url }
 			onNavigate={ onNavigate }
 			selected={ selected }
@@ -72,6 +74,7 @@ MySitesSidebarUnifiedItem.propTypes = {
 	sectionId: PropTypes.string,
 	slug: PropTypes.string,
 	title: PropTypes.string,
+	showTooltip: PropTypes.bool,
 	url: PropTypes.string,
 	shouldOpenExternalLinksInCurrentTab: PropTypes.bool.isRequired,
 	forceExternalLink: PropTypes.bool,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6871

## Proposed Changes

* Make `MySitesSidebarUnifiedBody` aware of whether the global sidebar is collapsed
* When the sidebar is collapsed, pass `showTooltip` to `MySitesSidebarUnifiedItem` 
* When `showTooltip` is `true`, add the needed classname and data attribute to `SidebarItem` so it can show the same tooltip that's defined on:

https://github.com/Automattic/wp-calypso/blob/983a9cf398ca5eca2b4752c9e90ba379ebc7acd3/client/layout/global-sidebar/style.scss#L20-L39

* I tried to add the tooltip class and data attr to the `a` element, but for some reason it didn't render the `::after` pseudo-element, so that's why I went with the parent `li` element.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/sites` so the sidebar on the left is collapsed
* Hover over the sites, domains and reader links, check that all three have a tooltip when that happens

![image](https://github.com/Automattic/wp-calypso/assets/8511199/d1c42342-c61d-43b5-99ed-8756d8968258)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?