### PR TITLE
Pricing page: Change "Explore bulk pricing" link to "Jetpack for Agencies".

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,11 +1,9 @@
-//import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { ExternalLinkWithTracking } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
-//import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
-import { JETPACK_COM_A4A_LANDING_PAGE } from 'calypso/jetpack-cloud/sections/manage/pricing/controller';
+import { JETPACK_COM_A4A_LANDING_PAGE } from 'calypso/jetpack-cloud/sections/manage/pricing/constants';
 import CloudCart from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import { preventWidows } from 'calypso/lib/formatting';

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,9 +1,11 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { localizeUrl, useLocale } from '@automattic/i18n-utils';
+//import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { ExternalLinkWithTracking } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
+//import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
+import { JETPACK_COM_A4A_LANDING_PAGE } from 'calypso/jetpack-cloud/sections/manage/pricing/controller';
 import CloudCart from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -39,7 +41,6 @@ const useShowNoticeVAT = () => {
 
 const IntroPricingBanner: React.FC = () => {
 	const translate = useTranslate();
-	const locale = useLocale();
 	const shouldShowCart = useSelector( isJetpackCloudCartEnabled );
 	const clientRect = useBoundingClientRect( '.header__content .header__jetpack-masterbar-cart' );
 	const isSmallScreen = useBreakpoint( '<660px' );
@@ -110,17 +111,19 @@ const IntroPricingBanner: React.FC = () => {
 					</div>
 					<div className="intro-pricing-banner__item is-agencies">
 						<img className="intro-pricing-banner__item-icon" src={ people } alt="" />
-						<button
+						<ExternalLinkWithTracking
 							className="intro-pricing-banner__item-label is-link"
-							onClick={ () => {
-								recordTracksEvent( 'calypso_jpcom_agencies_page_intro_banner_link_click' );
-								window.location.assign(
-									localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale )
-								);
-							} }
+							tracksEventName="calypso_jpcom_agencies_page_intro_banner_link_click"
+							// The JETPACK_COM_A4A_LANDING_PAGE is only available in English at this time, so we
+							// won't worry about localizing the link for now. Although we may want to localize it
+							// in the future when/if the page gets translated & posted to other languages/locales.
+							href={ JETPACK_COM_A4A_LANDING_PAGE }
+							icon={ true }
+							iconClassName="intro-pricing-banner__external-link-icon"
+							iconSize={ 15 }
 						>
-							{ preventWidows( translate( 'Explore bulk pricing' ) ) }
-						</button>
+							{ preventWidows( translate( 'Jetpack for Agencies' ) ) }
+						</ExternalLinkWithTracking>
 					</div>
 					{ shouldShowCart && hasCrossed && (
 						<CloudCart cartStyle={ isSmallScreen ? {} : { left: clientRect.left } } />

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -91,6 +91,12 @@
 
 }
 
+.external-link {
+	.gridicons-external.intro-pricing-banner__external-link-icon {
+		color: var(--studio-gray-50);
+	}
+}
+
 
 // target Calypso pricing filter bar, not jetpack cloud
 .is-group-sites.is-section-plans .intro-pricing-banner.is-sticky {

--- a/client/jetpack-cloud/sections/manage/pricing/constants.ts
+++ b/client/jetpack-cloud/sections/manage/pricing/constants.ts
@@ -1,0 +1,1 @@
+export const JETPACK_COM_A4A_LANDING_PAGE = 'https://jetpack.com/for-agencies/';

--- a/client/jetpack-cloud/sections/manage/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/controller.tsx
@@ -1,6 +1,8 @@
 import { type Callback } from '@automattic/calypso-router';
 import ManagePricingPage from 'calypso/jetpack-cloud/sections/manage/pricing/primary';
 
+export const JETPACK_COM_A4A_LANDING_PAGE = 'https://jetpack.com/for-agencies/';
+
 export const jetpackManagePricingContext: Callback = ( context, next ) => {
 	context.primary = <ManagePricingPage />;
 

--- a/client/jetpack-cloud/sections/manage/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/controller.tsx
@@ -1,8 +1,6 @@
 import { type Callback } from '@automattic/calypso-router';
 import ManagePricingPage from 'calypso/jetpack-cloud/sections/manage/pricing/primary';
 
-export const JETPACK_COM_A4A_LANDING_PAGE = 'https://jetpack.com/for-agencies/';
-
 export const jetpackManagePricingContext: Callback = ( context, next ) => {
 	context.primary = <ManagePricingPage />;
 

--- a/client/my-sites/plans/jetpack-plans/product-store/need-more-info/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/need-more-info/index.tsx
@@ -1,7 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { JETPACK_COM_A4A_LANDING_PAGE } from 'calypso/jetpack-cloud/sections/manage/pricing/controller';
+import { JETPACK_COM_A4A_LANDING_PAGE } from 'calypso/jetpack-cloud/sections/manage/pricing/constants';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import MoreInfoBox from '../../more-info-box';
 

--- a/client/my-sites/plans/jetpack-plans/product-store/need-more-info/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/need-more-info/index.tsx
@@ -1,6 +1,7 @@
-import { localizeUrl, useLocale } from '@automattic/i18n-utils';
+import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { JETPACK_COM_A4A_LANDING_PAGE } from 'calypso/jetpack-cloud/sections/manage/pricing/controller';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import MoreInfoBox from '../../more-info-box';
 
@@ -24,7 +25,6 @@ const usePlanComparisonUrl = () => {
 
 export const NeedMoreInfo: React.FC = () => {
 	const translate = useTranslate();
-	const locale = useLocale();
 
 	const planComparisonUrl = usePlanComparisonUrl();
 
@@ -40,8 +40,11 @@ export const NeedMoreInfo: React.FC = () => {
 					trackEventName="calypso_plans_comparison_table_link_click"
 				/>
 				<MoreInfoBox
-					buttonLabel={ translate( 'Explore bulk pricing' ) }
-					buttonLink={ localizeUrl( 'https://cloud.jetpack.com/manage/pricing', locale ) }
+					buttonLabel={ translate( 'Jetpack for Agencies' ) }
+					// The JETPACK_COM_A4A_LANDING_PAGE is only available in English at this time, so we
+					// won't worry about localizing the link for now. Although we may want to localize it
+					// in the future when/if the page gets translated & posted to other languages/locales.
+					buttonLink={ JETPACK_COM_A4A_LANDING_PAGE }
 					trackEventName="calypso_jpcom_agencies_page_more_info_button_link_click"
 				/>
 			</div>


### PR DESCRIPTION
In this PR we change the "Explore bulk pricing" link(s) to say "Jetpack for Agencies" and link to the jetpack.com/for-agencies/ landing page.

Related to: PT: pbNhbs-axp-p2

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch and spin up calypso green, OR click the Jetpack Cloud live (direct link) below. ⤵️
- Go to the Jetpack cloud Pricing page: `/pricing`
- In the top-right general area of the page (See screenshot above), verify that the "Explore bulk pricing" link has now been changed to say, "Jetpack for Agencies".
- Verify the link opens up https://jetpack.com/for-agencies/ in a new tab.
- Verify the Tracks `calypso_jpcom_agencies_page_intro_banner_link_click` event is fired when the link is clicked.
- More towards the bottom of the page (*See screenshot above), verify the "Explore bulk pricing" button has now been changed to say, "Jetpack for Agencies".
- Verify the button open up https://jetpack.com/for-agencies/ in a new tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?