### PR TITLE
A8C For Agencies: Update hosting tab to improve Pressable owning condition

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -81,7 +81,11 @@ export function getHostingLogo( slug: string ) {
  * @returns boolean True if Pressable hosting product, false if not
  */
 export function isPressableHostingProduct( keyOrSlug: string ) {
-	return keyOrSlug.startsWith( 'pressable-hosting' ) || keyOrSlug.startsWith( 'jetpack-pressable' );
+	return (
+		keyOrSlug.startsWith( 'pressable-wp' ) ||
+		keyOrSlug.startsWith( 'pressable-hosting' ) ||
+		keyOrSlug.startsWith( 'jetpack-pressable' )
+	);
 }
 
 /**

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -6,53 +6,47 @@ export type PressablePlan = {
 };
 
 const PLAN_DATA: Record< string, PressablePlan > = {
-	'jetpack-pressable-personal': {
-		slug: 'jetpack-pressable-personal',
+	'pressable-wp-1': {
+		slug: 'pressable-wp-1',
 		install: 1,
-		visits: 30000,
+		visits: 50000,
 		storage: 20,
 	},
-	'jetpack-pressable-starter': {
-		slug: 'jetpack-pressable-starter',
-		install: 3,
-		visits: 50000,
-		storage: 30,
-	},
-	'jetpack-pressable-advanced': {
-		slug: 'jetpack-pressable-advanced',
+	'pressable-wp-2': {
+		slug: 'pressable-wp-2',
 		install: 5,
-		visits: 75000,
-		storage: 35,
-	},
-	'jetpack-pressable-pro': {
-		slug: 'jetpack-pressable-pro',
-		install: 10,
-		visits: 150000,
+		visits: 100000,
 		storage: 50,
 	},
-	'jetpack-pressable-premium': {
-		slug: 'jetpack-pressable-premium',
-		install: 20,
-		visits: 400000,
+	'pressable-wp-3': {
+		slug: 'pressable-wp-3',
+		install: 10,
+		visits: 250000,
 		storage: 80,
 	},
-	'jetpack-pressable-business': {
-		slug: 'jetpack-pressable-business',
+	'pressable-wp-4': {
+		slug: 'pressable-wp-4',
+		install: 25,
+		visits: 500000,
+		storage: 175,
+	},
+	'pressable-wp-5': {
+		slug: 'pressable-wp-5',
 		install: 50,
 		visits: 1000000,
-		storage: 200,
+		storage: 250,
 	},
-	'jetpack-pressable-business-80': {
-		slug: 'jetpack-pressable-business-80',
-		install: 80,
-		visits: 1600000,
-		storage: 275,
+	'pressable-wp-6': {
+		slug: 'pressable-wp-6',
+		install: 75,
+		visits: 1500000,
+		storage: 350,
 	},
-	'jetpack-pressable-business-100': {
-		slug: 'jetpack-pressable-business-100',
+	'pressable-wp-7': {
+		slug: 'pressable-wp-7',
 		install: 100,
 		visits: 2000000,
-		storage: 325,
+		storage: 500,
 	},
 };
 

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -16,6 +16,14 @@ export interface Agency {
 		img: string;
 		icon: string;
 	};
+	third_party: null | {
+		pressable: null | {
+			a4a_id: string;
+			email: string;
+			name: string;
+			pressable_id: number;
+		};
+	};
 }
 
 export interface AgencyStore {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Pressable ownership condition now relies on the Agency account data.
* Added a new property to the Agency type, that stores information about third-party accounts ( Pressable )
* Instead of relying on license counts, we now rely on the agency account data to know if the user already has Pressable
* This will work for users who have acquired Pressable through A4A or directly with Pressable.
* This fixes the bug that users that already had a regular Pressable account with the same e-mail and tried to acquire Pressable via A4A and ended on a broken license state that couldn't be revoked.
* Updates Pressable plan slugs on selectors and filters for the Pressable slider UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Case 1 - Have regular Pressable account**
* Register to Pressable via Pressable with the same email that is used by your test agency owner.
* Go to A4A hosting tab, and the UI should tell that you already own Pressable

**Case 2 - Have acquired Pressable via A4A**
* Acquire Pressable via A4A ( you'll need an account that does not have a Pressable account )
* Go to A4A hosting tab, and the UI should tell that you already own Pressable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?