### PR TITLE
Subscription Manager: Add Switch account link

### DIFF
--- a/client/blocks/reader-site-subscription/index.tsx
+++ b/client/blocks/reader-site-subscription/index.tsx
@@ -9,6 +9,7 @@ import { useDispatch } from 'react-redux';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
+import { login } from 'calypso/lib/paths';
 import { infoNotice } from 'calypso/state/notices/actions';
 import { Path, useSiteSubscription } from './context';
 import SiteSubscriptionDetails from './details';
@@ -77,7 +78,11 @@ const ReaderSiteSubscription = ( { transition }: ReaderSiteSubscriptionProps ) =
 							className="site-subscription-page__fetch-details-error"
 							type={ NoticeType.Error }
 						>
-							{ translate( 'Subscription not found' ) }
+							{ translate( 'Subscription not found. {{a}}Switch account{{/a}}.', {
+								components: {
+									a: <a href={ login( { redirectTo: window.location.href } ) } />,
+								},
+							} ) }
 						</Notice>
 					) : (
 						<SiteSubscriptionDetails


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/36504

## Proposed Changes

Before:
<img width="1507" alt="Screenshot 2024-05-02 at 11 30 09 AM" src="https://github.com/Automattic/wp-calypso/assets/104869/c63c5975-1722-4011-a058-eb35d10d0e3d">

After:
<img width="993" alt="Screenshot 2024-05-02 at 12 16 07 PM" src="https://github.com/Automattic/wp-calypso/assets/104869/45216d39-6fe1-42ea-8b58-a8fa0f5211ae">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?