### PR TITLE
A4A: Remove mention of Creator plan

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -43,7 +43,9 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 
 	if ( product.family_slug === 'wpcom-hosting' ) {
 		productIcon = wpcomIcon;
-		productTitle = product.name;
+		// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
+		//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
+		productTitle = product.name === 'WordPress.com Creator' ? 'WordPress.com Site' : product.name;
 		productDescription = translate(
 			'Plan with %(install)d managed WordPress install, with 50GB of storage each.',
 			'Plan with %(install)d managed WordPress installs, with 50GB of storage each.',

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -20,18 +20,22 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 
 	const { getProductPricingInfo } = useGetProductPricingInfo();
 	const { actualCost, discountedCost } = getProductPricingInfo( userProducts, item, item.quantity );
+	// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
+	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
+	const productDisplayName =
+		item.name === 'WordPress.com Creator' ? 'WordPress.com Site' : item.name;
+	const itemDisplayName =
+		item.quantity > 1
+			? translate( '%(productName)s x %(quantity)s', {
+					args: { productName: productDisplayName, quantity: item.quantity },
+			  } )
+			: item.name;
 
 	return (
 		<li className="shopping-cart__menu-list-item">
 			<Icon className="shopping-cart__menu-list-item-icon" icon={ check } />
 			<div className="shopping-cart__menu-list-item-details">
-				<div className="shopping-cart__menu-list-item-title">
-					{ item.quantity > 1
-						? translate( '%(productName)s x %(quantity)s', {
-								args: { productName: item.name, quantity: item.quantity },
-						  } )
-						: item.name }
-				</div>
+				<div className="shopping-cart__menu-list-item-title">{ itemDisplayName }</div>
 				<div className="shopping-cart__menu-list-item-price">
 					<span className="shopping-cart__menu-list-item-price-discounted">
 						{ formatCurrency( discountedCost, item.currency ) }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -55,8 +55,8 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier, ownedPl
 
 					<span>
 						{ translate(
-							'You own {{b}}%(count)s Creator plan{{/b}}',
-							'You own {{b}}%(count)s Creator plans{{/b}}',
+							'You own {{b}}%(count)s plan{{/b}}',
+							'You own {{b}}%(count)s plans{{/b}}',
 							{
 								args: {
 									count: ownedPlans,
@@ -65,7 +65,7 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier, ownedPl
 									b: <strong />,
 								},
 								count: ownedPlans,
-								comment: '%(count)s is the number of Creator plans owned by the user',
+								comment: '%(count)s is the number of WordPress.com plans owned by the user',
 							}
 						) }
 					</span>

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts
@@ -9,7 +9,7 @@ export default function useWPCOMPlanDescription( slug: string ) {
 
 	// FIXME: Need to have correct slug. Right now we use whatever we have.
 	if ( slug === 'wpcom-hosting-business' ) {
-		name = translate( 'Creator' );
+		name = translate( 'WordPress.com' );
 		features1 = [
 			translate( '50GB of storage' ),
 			translate( 'Unrestricted bandwidth' ),

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -35,7 +35,7 @@ export default function NeedSetup() {
 	const availablePlans: AvailablePlans[] = availableSites.length
 		? [
 				{
-					name: translate( 'WordPress.com Creator' ),
+					name: translate( 'WordPress.com' ),
 					available: availableSites.length as number,
 					ids: availableSites.map( ( { id }: { id: number } ) => id ),
 				},

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -20,9 +20,7 @@ import { apiDeleteSite, getNewPlanName } from '../shared';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle(
-		'Plans: Create a WordPress.com Creator/Business site as exising user'
-	),
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com/Business site as exising user' ),
 	function () {
 		const planName = 'Business';
 		const newPlanName = getNewPlanName( planName );

--- a/test/e2e/specs/plugins/plugins__purchase.ts
+++ b/test/e2e/specs/plugins/plugins__purchase.ts
@@ -56,13 +56,10 @@ describe( 'Plugins: Add multiple to cart', function () {
 			await pluginsPage.clickInstallPlugin();
 		} );
 
-		it.each( [ 'WordPress.com Creator', pluginName ] )(
-			`%s is added to cart`,
-			async function ( target ) {
-				cartCheckoutPage = new CartCheckoutPage( page );
-				await cartCheckoutPage.validateCartItem( target );
-			}
-		);
+		it.each( [ 'WordPress.com', pluginName ] )( `%s is added to cart`, async function ( target ) {
+			cartCheckoutPage = new CartCheckoutPage( page );
+			await cartCheckoutPage.validateCartItem( target );
+		} );
 	} );
 
 	afterAll( async function () {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/414

## Proposed Changes

* This PR removes the mention of the Creator plan, and changes it to WordPress.com

## Testing Instructions

* Open up the `Hosting` tab in the `Marketplace` link (`http://agencies.localhost:3000/marketplace/hosting`)
* Click on the button `Explore WordPress.com plans`
* Verify that there are no mentions to the Creator plan when buying a single site, complete the whole purchase process.
* Verify that there are no mentions to the Creator plan when buying a bundle of sites, complete the whole purchase process.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?