### PR TITLE
Reader post actions - update spacing for consistency

### DIFF
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -22,13 +22,9 @@ const ReaderPostActions = ( props ) => {
 	const showReblog = shouldShowReblog( post, hasSites );
 	const showComments = shouldShowComments( post );
 	const showLikes = shouldShowLikes( post );
-	const numberOfActions = [ showShare, showReblog, showComments, showLikes ].filter(
-		( item ) => item
-	).length;
 
 	const listClassnames = classnames( className, {
 		'reader-post-actions': true,
-		'space-items-apart': numberOfActions > 2,
 	} );
 
 	/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -5,13 +5,9 @@
 	font-family: $sans;
 	flex-direction: row;
 	height: auto;
-	justify-content: flex-end;
+	justify-content: flex-start;
 	list-style-type: none;
 	margin: 10px 0 0;
-
-	&.space-items-apart {
-		justify-content: flex-start;
-	}
 
 	@include breakpoint-deprecated( "<660px" ) {
 		justify-content: space-evenly;
@@ -79,6 +75,19 @@
 			display: flex;
 			flex-direction: column;
 			height: auto;
+		}
+
+		.like-button {
+			gap: 0;
+			.like-button__like-icons {
+				margin-top: -1px;
+				margin-bottom: 1px;
+			}
+		}
+
+		.comment-button svg {
+			margin-top: -1px;
+			margin-bottom: 1px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/178 and https://github.com/Automattic/loop/issues/170 

## Proposed Changes
Updates the styles of post actions in the reader to
* Always be left aligned at desktop widths.
* Always be aligned space-between on mobile widths.
* Moves icon for comment 1 pixel higher on mobile where the button is in column view.
* Repositions text and icon for like button on mobile where the button is in column view.

BEFORE
<img width="676" alt="Screenshot 2024-05-02 at 1 50 06 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/c61a329c-1325-4964-9fe9-26014a0e6ce3">

<img width="291" alt="Screenshot 2024-05-02 at 1 49 29 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/5fc0af8d-7078-456b-af4d-a4a0eb754dcc">


AFTER
<img width="491" alt="Screenshot 2024-05-02 at 1 50 43 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/76f0f35b-f678-4ca3-b571-8592bc5b4577">

<img width="554" alt="Screenshot 2024-05-02 at 1 49 10 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/33310db5-8469-40c5-a5bf-0a021bb03421">





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit the reader and verify the above styles are applied on mobile and desktop views.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
