### PR TITLE
A4A: Remove mention of Creator plan in checkout popup

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -29,7 +29,7 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 			? translate( '%(productName)s x %(quantity)s', {
 					args: { productName: productDisplayName, quantity: item.quantity },
 			  } )
-			: item.name;
+			: productDisplayName;
 
 	return (
 		<li className="shopping-cart__menu-list-item">


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/414

## Proposed Changes

* Remove mention to the Creator plan in the checkout popup, this should have been changed in PR https://github.com/Automattic/wp-calypso/pull/90223 but it was overlooked.

## Testing Instructions
* Open up the `Hosting` tab in the `Marketplace` link (`http://agencies.localhost:3000/marketplace/hosting`)
* Click on the button `Explore WordPress.com plans`
* Add a single WordPress site to your card and verify that there are no mentions to the Creator plan in the popup shown.

Before:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/2006ff07-c3c8-450f-88d4-4e5af9b1bdfc)

After:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/d2964ed6-6e39-45da-a60e-f834df4ae265)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?