### PR TITLE
A4A: Round WPCOM discount percentages down to whole numbers

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -16,7 +16,7 @@ const wpcomBulkOptions = (
 	return discountOptions.map( ( option ) => ( {
 		value: option.quantity || 1,
 		label: option.quantity ? `${ option.quantity }` : '1',
-		sub: option.discount_percent ? `${ option.discount_percent * 100 }%` : '',
+		sub: option.discount_percent ? `${ Math.floor( option.discount_percent * 100 ) }%` : '',
 		discount: option.discount_percent ? option.discount_percent : 0,
 	} ) );
 };

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -41,7 +41,7 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect }: P
 								<span className="wpcom-plan-card__price-discount">
 									{ translate( 'You save %(discount)s%', {
 										args: {
-											discount: discount * 100,
+											discount: Math.floor( discount * 100 ),
 										},
 										comment: '%(discount)s is the discount percentage.',
 									} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/415

## Proposed Changes

* Rounds down the WPCOM hosting discount percentage values in both the slider and the product card. For example, `53.33%` will now be displayed as `53%`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out "/marketplace/hosting/wpcom" and validate the discount percentage values displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1208" alt="Screenshot 2024-05-02 at 2 13 45 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/0089b671-0417-43b2-b539-8093c0f6734c">