### PR TITLE
A4A: Add line item for WooCommerce Referrals to the overview card

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -70,6 +70,7 @@ const OverviewBodyProducts = () => {
 				'Product Bundles: Offer personalized bundles, bulk discounts, and assembled products.'
 			),
 			translate( 'Subscriptions: Enable weekly, monthly, or annual subscriptions.' ),
+			translate( 'WooPayments Referrals: Coming soon.' ),
 		],
 		// translators: Button navigating to A4A Marketplace
 		buttonTitle: translate( 'View all WooCommerce products' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/417

## Proposed Changes

* Adds a requested additional list item to the WooCommerce overview card.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the card on the `/overview` page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="818" alt="Screenshot 2024-05-02 at 2 19 07 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/97a07f77-52ca-405a-9e6b-3efef82a2540">

