### PR TITLE
Fix: Allow subscribe.wordpress.com to be redirected to when logged in

### DIFF
--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -14,7 +14,9 @@ function isExternalUrl( url ) {
 
 	try {
 		const urlObject = new URL( url );
-		if ( urlObject.hostname === 'wordpress.com' && urlObject.protocol === 'https:' ) {
+		const allowedHostname = [ 'wordpress.com', 'subscribe.wordpress.com' ];
+
+		if ( allowedHostname.includes( urlObject.hostname ) && urlObject.protocol === 'https:' ) {
 			return false;
 		}
 	} catch {


### PR DESCRIPTION
Currently if you are logged in and you click on the magic link in the subsription email you don't get subscribed to the newsletter. 

This PR fixes it by making sure that the subscription link still works as expected for the end user. 


## Proposed Changes

* 

## Testing Instructions

visit 
http://calypso.localhost:3000/log-in/link/use/?redirect_to=https://enejtest.wordpress.com
Notice that you get redirected to `/` 

visit 
http://calypso.localhost:3000/log-in/link/use/?redirect_to=https://subscribe.wordpress.com

Notice that you get redirected to `subscribe.wordpress.com` 

Login link should still work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?