### PR TITLE
Segmentation Survey: Redirect to migration flow when user selects "Migrate my store"

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -1,7 +1,7 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { anonIdCache } from 'calypso/data/segmentaton-survey';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -46,6 +46,7 @@ const entrepreneurFlow: Flow = {
 		);
 
 		const locale = useFlowLocale();
+		const [ isMigrationFlow, setIsMigrationFlow ] = useState( false );
 
 		const getEntrepreneurLoginUrl = () => {
 			let hasFlowParams = false;
@@ -75,6 +76,8 @@ const entrepreneurFlow: Flow = {
 
 			switch ( currentStep ) {
 				case SEGMENTATION_SURVEY_SLUG: {
+					setIsMigrationFlow( !! providedDependencies.isMigrationFlow );
+
 					if ( userIsLoggedIn ) {
 						return navigate( STEPS.SITE_CREATION_STEP.slug );
 					}
@@ -108,6 +111,10 @@ const entrepreneurFlow: Flow = {
 							'.wordpress.com',
 							'.wpcomstaging.com'
 						);
+
+						if ( isMigrationFlow ) {
+							return window.location.replace( `/setup/migration-signup?siteSlug=${ stagingUrl }` );
+						}
 
 						const redirectTo = encodeURIComponent(
 							`https://${ stagingUrl }/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai&ref=entrepreneur-signup`

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -5,6 +5,8 @@ import type { ProvidedDependencies, Step } from '../../types';
 import './style.scss';
 
 const SURVEY_KEY = 'entrepreneur-trial';
+const WHAT_WOULD_YOU_LIKE_TO_DO_QUESTION_KEY = 'what-would-you-like-to-do';
+const MIGRATE_MY_STORE_ANSWER_KEY = 'migrate-my-store';
 
 type NavigationDecision = {
 	proceedWithNavigation: boolean;
@@ -16,9 +18,13 @@ const shouldNavigate = (
 	answerKeys: string[],
 	isLastQuestion?: boolean
 ): NavigationDecision => {
+	const isMigrationFlow =
+		questionKey === WHAT_WOULD_YOU_LIKE_TO_DO_QUESTION_KEY &&
+		answerKeys.includes( MIGRATE_MY_STORE_ANSWER_KEY );
+
 	return {
-		proceedWithNavigation: !! isLastQuestion,
-		providedDependencies: {},
+		proceedWithNavigation: isLastQuestion || isMigrationFlow,
+		providedDependencies: { isMigrationFlow },
 	};
 };
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/6847

## Proposed Changes

Redirect to migration flow when the user selects "Migrate my site".

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur/start
* Select "Migrate my store"
* You should be redirected to the migration flow
* Additionally, perform regression tests on the entrepreneur flow/segmentation survey

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?