### PR TITLE
A4A: highlight migration offer incentive

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -1,0 +1,75 @@
+import { Button, FoldableCard } from '@automattic/components';
+import { Icon, reusableBlock, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+type Props = {
+	foldable?: boolean;
+};
+
+const MigrationOfferHeader = () => {
+	const translate = useTranslate();
+	const title = translate( 'Special limited-time migration offer for our partners' );
+	return (
+		<div className="a4a-migration-offer__title">
+			<Icon icon={ reusableBlock } size={ 32 } />
+			<h3>{ title }</h3>
+		</div>
+	);
+};
+
+const MigrationOfferBody = () => {
+	const translate = useTranslate();
+	const description = translate(
+		'Migrate your clients sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2024. You’ll also receive an additional $100 for each migrated site—up to $3,000 until July 31, 2024.'
+	);
+	const note = translate( 'Must have 3 or more sites to be eligible.' );
+
+	return (
+		<>
+			<p className="a4a-migration-offer__description">{ description }</p>
+			<p className="a4a-migration-offer__note">{ note }</p>
+			<Button
+				className="a4a-migration-offer__chat-button"
+				href="mailto:partnerships@automattic.com"
+				primary
+			>
+				{ translate( 'Chat with us' ) }
+				<Icon icon={ external } size={ 18 } />
+			</Button>
+			<Button
+				className="a4a-migration-offer__details-button"
+				href="https://automattic.com/for-agencies/program-incentives/"
+				rel="nooppener norefferer"
+				target="_blank"
+			>
+				{ translate( 'See details' ) }
+				<Icon icon={ external } size={ 18 } />
+			</Button>
+		</>
+	);
+};
+
+const MigrationOffer = ( props: Props ) => {
+	const { foldable } = props;
+
+	return foldable ? (
+		<FoldableCard
+			className="a4a-migration-offer__wrapper"
+			header={ <MigrationOfferHeader /> }
+			expanded
+			clickableHeader
+			summary={ false }
+		>
+			<MigrationOfferBody />
+		</FoldableCard>
+	) : (
+		<div className="a4a-migration-offer__wrapper non-foldable">
+			<MigrationOfferHeader />
+			<MigrationOfferBody />
+		</div>
+	);
+};
+
+export default MigrationOffer;

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -8,6 +8,10 @@
 		padding: 16px;
 		margin-block-end: 16px;
 		border: 1px solid var(--studio-automattic-blue-5);
+
+		p {
+			max-width: 70%;
+		}
 	}
 
 	.foldable-card__content {

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -1,0 +1,55 @@
+.a4a-migration-offer__wrapper {
+	border-radius: 4px;
+	background-color: var(--studio-automattic-blue-0);
+	border: 1px solid var(--studio-automattic-blue-5);
+	box-shadow: none;
+
+	&.non-foldable {
+		padding: 16px;
+		margin-block-end: 16px;
+		border: 1px solid var(--studio-automattic-blue-5);
+	}
+
+	.foldable-card__content {
+		border: none;
+	}
+
+	&.foldable-card.is-expanded .foldable-card__content {
+		border: none;
+		padding-block-start: 8px;
+	}
+
+	.a4a-migration-offer__title {
+		display: flex;
+		gap: 8px;
+		align-items: center;
+
+		svg {
+			min-width: 32px;
+		}
+
+		h3 {
+			color: var(--studio-gray-100);
+			font-weight: 500;
+			font-size: 1rem;
+		}
+	}
+
+	.a4a-migration-offer__description {
+		font-size: 1rem;
+		color: var(--studio-gray-80);
+		font-weight: 400;
+		line-height: 32px;
+	}
+
+	.a4a-migration-offer__note {
+		font-size: 0.875rem;
+		font-style: italic;
+		font-weight: 400;
+		margin-block-end: 24px;
+	}
+
+	.a4a-migration-offer__details-button {
+		margin-inline-start: 10px;
+	}
+}

--- a/client/a8c-for-agencies/components/offering/index.tsx
+++ b/client/a8c-for-agencies/components/offering/index.tsx
@@ -2,11 +2,12 @@ import OfferingItem from './offering-item';
 import { OfferingCardProps } from './types';
 import './style.scss';
 
-const Offering: React.FC< OfferingCardProps > = ( { title, description, items } ) => {
+const Offering: React.FC< OfferingCardProps > = ( { title, description, items, children } ) => {
 	return (
 		<div className="a4a-offering-card__wrapper">
 			<h2 className="a4a-offering-card__title">{ title }</h2>
 			<p className="a4a-offering-card__description">{ description }</p>
+			{ children }
 			{ items?.map( ( item ) => <OfferingItem key={ item.title } { ...item } /> ) }
 		</div>
 	);

--- a/client/a8c-for-agencies/components/offering/types.ts
+++ b/client/a8c-for-agencies/components/offering/types.ts
@@ -2,6 +2,7 @@ export type OfferingCardProps = {
 	title: string;
 	description: string;
 	items?: OfferingItemProps[];
+	children?: React.ReactNode;
 };
 
 export type OfferingItemProps = {

--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
 import Offering from 'calypso/a8c-for-agencies/components/offering';
 import { OfferingItemProps } from 'calypso/a8c-for-agencies/components/offering/types';
 import {
@@ -83,12 +84,15 @@ const OverviewBodyHosting = () => {
 		},
 	};
 
+	const migrationOffer = <MigrationOffer foldable />;
+
 	return (
 		<Offering
 			title={ translate( 'Hosting' ) }
 			description={ translate(
 				'Choose the hosting that suits your needs from our best-in-class offerings.'
 			) }
+			children={ migrationOffer }
 			items={ [ pressable, wpcom ] }
 		/>
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,6 +1,7 @@
 import { plugins, payment, percent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -118,6 +119,7 @@ export default function ReferralsOverview() {
 								heading={ translate( 'Earn commissions from your referrals' ) }
 								stepCount={ 2 }
 							>
+								<MigrationOffer />
 								<StepSectionItem
 									icon={ payment }
 									heading={ translate( 'Encourage your clients to purchase Automattic products' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-roadmap/issues/1527

## Proposed Changes

Adds new card to Overview and Referrals page to promote migration incentives


**Referrals**
![Image](https://github.com/Automattic/jetpack-roadmap/assets/60262784/dda3e3af-3301-4905-b825-95723ac2f77f)

---

**Overview**
![Image](https://github.com/Automattic/jetpack-roadmap/assets/60262784/d8e9cf59-e053-4a35-885c-ad0d3139bb98)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using this branch visit `/overview` and `/referrals` pages.
- Check new card. Verify it on different screens.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?