### PR TITLE
Scheduled Updates: Improve copy when there are no eligible plugins

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
@@ -20,7 +20,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 				{ ( () => {
 					if ( ! siteHasEligiblePlugins && canCreateSchedules ) {
 						return translate(
-							'To set up schedules to update your plugins, first you need to install plugins that are not managed by the plugin provider.'
+							'All installed plugins are provided by WordPress.com and automatically updated for you. Add a plugin from the WordPress.com Marketplace to create a schedule!'
 						);
 					} else if ( ! canCreateSchedules ) {
 						return translate( 'This site is unable to schedule auto-updates for plugins.' );


### PR DESCRIPTION
Makes the message a bit easier to understand and includes a call to action.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1714576596695849-slack-C01A60HCGUA

## Proposed Changes

* Updates string to make it a bit clearer.

<img width="880" alt="Screenshot 2024-05-02 at 4 08 00 PM" src="https://github.com/Automattic/wp-calypso/assets/1398304/61228ddd-6d03-493f-b625-2c55491502b2">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch and navigate to `/plugins/scheduled-updates`
* Select a WoA site that only contains managed plugins.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?