### PR TITLE
Style the sortable table headers

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -155,6 +155,16 @@
 	}
 }
 
+// Style the sortable table headers.
+.wpcom-site .dataviews-view-table .components-button.is-tertiary {
+	&:active:not(:disabled),
+	&:hover:not(:disabled) {
+		box-shadow: none;
+		background-color: inherit;
+		color: var(--color-accent) !important;
+	}
+}
+
 .wpcom-site .is-group-sites.is-global-sidebar-collapsed,
 .wpcom-site .is-group-sites.is-global-sidebar-visible:not(.is-section-domains) {
 	.layout__content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6821

## Proposed Changes

* Style the hover and focus state on the GSV sortable headers

Before

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/576a4259-ae27-4370-b7ea-1a78aa1747b3)

After

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/3caecbea-8fd5-46f5-a09d-e73b94b15347)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR and head to /sites?flags=layout%2Fdotcom-nav-redesign-v2
* View that the hover style has changed for "Status" and "Last Publish"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?