### PR TITLE
Checkout: Add credit amount to credit summary

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/src/payment-methods/free-purchase.tsx
@@ -132,7 +132,21 @@ function WordPressFreePurchaseSummary() {
 	const { responseCart } = useShoppingCart( cartKey );
 
 	if ( doesPurchaseHaveFullCredits( responseCart ) ) {
-		return <div>{ __( 'WordPress.com Credits' ) }</div>;
+		return (
+			<>
+				<div>
+					{
+						/* translators: %(amount)s is the total amount of credits available in localized currency */
+						sprintf( __( 'WordPress.com Credits: %(amount)s available' ), {
+							amount: formatCurrency( responseCart.credits_integer, responseCart.currency, {
+								isSmallestUnit: true,
+								stripZeros: true,
+							} ),
+						} )
+					}
+				</div>
+			</>
+		);
 	}
 
 	return <div>{ __( 'Free Purchase' ) }</div>;


### PR DESCRIPTION
In Checkout if an account has enough credits to cover the total amount of the cart then the credits are used automatically in place of any other payment method.

Generally, when a customer edits the payment method section the payment method components toggle between an active and inactive state (active if the payment method section is editable). 

In the case of the WordPress.com Credits we toggle between the `WordPressFreePurchaseSummary` and `WordPressFreePurchaseLabel`, the latter of which shows the actual available credit amount.

As outlined in #88863 it would be useful to also show this credit amount in the `WordPressFreePurchaseSummary`.

This PR adds the amount to the summary component. Hiding the edit button will be handled in a follow up PR.

Related to #88863

## Testing Instructions

* Add enough credit to your account to cover the cost of a purchase renewal
* Go to an existing purchase and renew it
* Go to your cart with a purchase renewal and scroll down to the Payment Method section
* Before clicking on Edit you should see the actual amount of credits available in the 'WordPress.com Credits' payment method
* When you edit the payment method section you should still see the credit amount displayed

| Before edit | After edit |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/119784cc-380b-40c4-aed5-9e370b858e2d) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/282f9a39-df31-46e9-9bff-822781760f7e) |

