### PR TITLE
A4A: Update slider's discount steps

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/volume-price-selector.tsx
@@ -11,11 +11,11 @@ const getDiscountPercentage = ( bundleSize: number ) => {
 	// FIXME: Need to calculate based on average discount per bundle size.
 	return {
 		1: '',
-		5: '8%',
-		10: '20%',
-		20: '40%',
-		50: '70%',
-		100: '80%',
+		5: '10%',
+		10: '15%',
+		20: '20%',
+		50: '40%',
+		100: '50%',
 	}[ bundleSize ];
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/418

## Proposed Changes

Replace the current discount structure with the following one: 

```
1: No discount
5: 10%
10: 15%
20: 20%
50: 40%
100: 50%
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Locally or via Live Branch, visit `http://agencies.localhost:3000/marketplace/products`.
* Verify the slider shows the discounts presented above.

![image](https://github.com/Automattic/wp-calypso/assets/3418513/b4257a17-68e7-4dc1-bc1e-596864909bae)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?