### PR TITLE
A4A: Update sidebar "get help" links

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -1,26 +1,32 @@
+import page from '@automattic/calypso-router';
 import { Button, Gravatar } from '@automattic/components';
-import { Icon, chevronDown, external } from '@wordpress/icons';
+import { Icon, chevronDown } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
+import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/overview/sidebar/contact-support';
 import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { A4A_OVERVIEW_LINK } from '../../sidebar-menu/lib/constants';
 
 import './style.scss';
 
 type DropdownMenuProps = {
 	isExpanded: boolean;
+	setMenuExpanded: ( isExpanded: boolean ) => void;
 };
-const DropdownMenu = ( { isExpanded }: DropdownMenuProps ) => {
+const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const onGetHelp = useCallback( () => {
+		page( A4A_OVERVIEW_LINK + CONTACT_URL_HASH_FRAGMENT );
+		setMenuExpanded( false );
 		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_gethelp' ) );
-	}, [ dispatch ] );
+	}, [ dispatch, setMenuExpanded ] );
 	const onSignOut = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_signout' ) );
 		dispatch( redirectToLogout() );
@@ -29,16 +35,8 @@ const DropdownMenu = ( { isExpanded }: DropdownMenuProps ) => {
 	return (
 		<ul className="a4a-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
-				<Button
-					className="a4a-sidebar__external-link"
-					borderless
-					href="https://agencies.automattic.com/support"
-					rel="noreferrer"
-					target="_blank"
-					onClick={ onGetHelp }
-				>
+				<Button borderless onClick={ onGetHelp }>
 					{ translate( 'Get help' ) }
-					<Icon icon={ external } size={ 24 } />
 				</Button>
 			</li>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
@@ -113,7 +111,7 @@ const ProfileDropdown = ( { compact, dropdownPosition = 'down' }: ProfileDropdow
 					</div>
 				) }
 			</Button>
-			<DropdownMenu isExpanded={ isMenuExpanded } />
+			<DropdownMenu isExpanded={ isMenuExpanded } setMenuExpanded={ setMenuExpanded } />
 		</nav>
 	);
 };

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -1,5 +1,7 @@
+import page from '@automattic/calypso-router';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/overview/sidebar/contact-support';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,
@@ -10,6 +12,7 @@ import Sidebar, {
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { A4A_OVERVIEW_LINK } from '../sidebar-menu/lib/constants';
 import SidebarHeader from './header';
 import ProfileDropdown from './header/profile-dropdown';
 
@@ -87,14 +90,14 @@ const A4ASidebar = ( {
 				<ul>
 					{ withGetHelpLink && (
 						<SidebarNavigatorMenuItem
-							isExternalLink
 							title={ translate( 'Get help', {
 								comment: 'A4A sidebar navigation item',
 							} ) }
-							link="https://agencies.automattic.com/support"
+							link=""
 							path=""
 							icon={ <JetpackIcons icon="help" /> }
 							onClickMenuItem={ () => {
+								page( A4A_OVERVIEW_LINK + CONTACT_URL_HASH_FRAGMENT );
 								dispatch(
 									recordTracksEvent( 'calypso_a4a_sidebar_menu_click', {
 										menu_item: 'A4A / Support',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/413

## Proposed Changes

* Changes the "/support" links (404s) to "/overview#contact-support", which displays the contact form on load.
* Removes the external link icons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open any screen in A4A, toggle open the sidebar profile menu on the bottom left of the screen, and select the "Get Help" navigation item.
* Confirm you are redirected to the support form.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="278" alt="Screenshot 2024-05-02 at 7 25 48 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/95d1cfdd-1395-4017-80d7-f1aa6c50839a">

