### PR TITLE
Update the eligibility check of the trail map experiment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
+++ b/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
@@ -11,9 +11,11 @@ import { useExperiment } from 'calypso/lib/explat';
 
 interface Params {
 	flowName?: string | null;
+	isInSignup: boolean;
+	intent?: string;
 }
 
-function useExperimentForTrailMap( { flowName }: Params ): {
+function useExperimentForTrailMap( { flowName, isInSignup, intent }: Params ): {
 	isLoading: boolean;
 	variant: VariantType;
 	isTrailMapAny: boolean;
@@ -22,7 +24,9 @@ function useExperimentForTrailMap( { flowName }: Params ): {
 } {
 	const [ isLoading, assignment ] = useExperiment(
 		'calypso_signup_onboarding_plans_trail_map_feature_grid',
-		{ isEligible: flowName === 'onboarding' }
+		{
+			isEligible: flowName === 'onboarding' || ( ! isInSignup && intent === 'plans-default-wpcom' ),
+		}
 	);
 
 	let variant = ( assignment?.variationName ?? 'control' ) as VariantType;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -295,16 +295,6 @@ const PlansFeaturesMain = ( {
 		...( selectedPlan ? { defaultValue: getPlan( selectedPlan )?.term } : {} ),
 	} );
 
-	const {
-		isLoading: isTrailMapExperimentLoading,
-		variant: trailMapExperimentVariant,
-		isTrailMapAny,
-		isTrailMapCopy,
-		isTrailMapStructure,
-	} = useExperimentForTrailMap( {
-		flowName,
-	} );
-
 	const intentFromSiteMeta = usePlanIntentFromSiteMeta();
 	const planFromUpsells = usePlanFromUpsells();
 	const [ forceDefaultPlans, setForceDefaultPlans ] = useState( false );
@@ -338,6 +328,18 @@ const PlansFeaturesMain = ( {
 
 	const showEscapeHatch =
 		intentFromSiteMeta.intent && ! isInSignup && 'plans-default-wpcom' !== intent;
+
+	const {
+		isLoading: isTrailMapExperimentLoading,
+		variant: trailMapExperimentVariant,
+		isTrailMapAny,
+		isTrailMapCopy,
+		isTrailMapStructure,
+	} = useExperimentForTrailMap( {
+		flowName,
+		isInSignup,
+		intent,
+	} );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #89685 

## Proposed Changes

This PR updates the eligibility check of the trail map experiment as either "in the main onboarding flow" or "in the logged-in plans page with the default wpcom intent". 

By doing so, whoever sees the trail map variation of the plans grid will have consistent experience among `/start/plans` and the logged-in `/plans`. That also means existing users will get a new assignment by visiting `/plans`. However, that shouldn't be a concern since the experiment 21737-explat-experiment is designed to be for new users + existing users + anonymous.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This will be eaiser to test once https://github.com/Automattic/wp-calypso/pull/90195 is merged.

* From 21737-explat-experiment, assign yourself to either variation and make sure you are seeing the same plans grid between `/start/plans` and `/plans`
* Spot-check some other flows and make sure they are not affected. e.g. create a newsletter site by going through /setup/newsletter.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
