### PR TITLE
Settings: Fix the page looks broken due to the margin-bottom of the header

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -3,7 +3,6 @@
 	display: flex;
 	flex-flow: row wrap;
 	line-height: 28px;
-	margin-bottom: 24px;
 	padding-top: 11px;
 	padding-bottom: 11px;
 	position: relative;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/90172

## Proposed Changes

* Remove the margin-bottom from `.section-header.card` as it made lots of pages look broken

| Before | After |
| - | - |
|  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1b51784b-d352-487a-8121-5ac69284d637) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/8b6778f2-d070-4e12-9bb1-ab2fb37fd301) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/05d92c7b-2c14-43c9-bec6-8b2e40402f3b) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/f72812af-6e0c-4ac3-b4cb-a571cd97970e) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /settings/general/<your_site>
* Make sure the gap between the header and content of the card is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?