### PR TITLE
GSV: Improve the header styles on PHP Logs

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -8,6 +8,7 @@
 		flex-direction: row;
 		align-items: top;
 		justify-content: space-between;
+		flex-wrap: wrap;
 	}
 
 	.components-toggle-control {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6854

## Proposed Changes

* Improve the header styles on PHP Logs by adding `flex-wrap: wrap`

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/fb4a9795-2d6f-4cd2-b259-931cf0074b1f) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6585b94a-0345-4faf-8342-601e3b03c27e) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/62e9877d-0d46-4c34-808d-38928625007d) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ab3bd215-f200-43af-a51f-fec300292cb4) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select a site
* Switch to "PHP Logs"
* Make sure the header styles look good on a 1300px viewport
* Go to /site-monitoring/<your_site>/php
* Make sure the header styles still look good on a 1300px viewport

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?