### PR TITLE
Sites Dashboard v2: Avoid unnecessary scrolling

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -398,6 +398,11 @@
 			}
 		}
 	}
+
+	// Prevent the content pushed out via translateX(100%) creating a scrollbar
+	&.focus-sidebar .layout__content .layout__primary {
+		overflow-x: hidden;
+	}
 }
 
 .wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -381,7 +381,8 @@
 // Override styles from my-sites/sidebar
 .wpcom-site div.is-group-sites:not(.has-no-masterbar),
 .wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) {
-	&.focus-content .layout__content {
+	&.focus-content .layout__content,
+	&.focus-sidebar .layout__content {
 		padding-bottom: 0;
 		padding-top: var(--masterbar-height);
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -45,9 +45,6 @@
 	}
 
 	height: calc(100vh - var(--masterbar-height));
-	@media ( min-width: 601px ) {
-		height: calc(100vh - var(--masterbar-height) - 48px);
-	}
 
 	@media ( min-width: 782px ) {
 		height: calc(100vh - var(--masterbar-height) - 32px);
@@ -173,6 +170,8 @@
 .wpcom-site .is-group-sites.is-global-sidebar-collapsed,
 .wpcom-site .is-group-sites.is-global-sidebar-visible:not(.is-section-domains) {
 	.layout__content {
+		min-height: 100vh;
+
 		@include break-medium {
 			padding: 16px 16px 16px calc(var(--sidebar-width-max));
 		}
@@ -374,6 +373,27 @@
 			.dataviews-view-list {
 				flex: 1;
 				max-height: none;
+			}
+		}
+	}
+}
+
+// Override styles from my-sites/sidebar
+.wpcom-site div.is-group-sites:not(.has-no-masterbar),
+.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) {
+	&.focus-content .layout__content {
+		padding-bottom: 0;
+		padding-top: var(--masterbar-height);
+
+		@include break-small {
+			padding-top: calc(var(--masterbar-height) + 24px);
+		}
+
+		.main.a4a-layout.sites-dashboard.sites-dashboard__layout {
+			height: calc(100vh - var(--masterbar-height));
+
+			@include break-small {
+				height: calc(100vh - var(--masterbar-height) - 48px);
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6895

## Proposed Changes

This PR updates the CSS so that there's no unnecessary scrolling from outer containers. For instance:

![Screenshot 2024-05-03 at 12 46 24 PM](https://github.com/Automattic/wp-calypso/assets/797888/58056356-2279-4810-9570-abc2400fd257)

![Screenshot 2024-05-03 at 12 46 43 PM](https://github.com/Automattic/wp-calypso/assets/797888/cee562d3-8a67-4553-91ae-2bc3d9191c67)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that there's no unnecessary scrolling from outer containers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?