### PR TITLE
Automattic for Agencies: Fix WooCommerce product bundle discount

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing.ts
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing.ts
@@ -1,4 +1,5 @@
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { isWooCommerceProduct } from './woocommerce-product-slug-mapping';
 import type { SelectedLicenseProp } from '../types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
@@ -34,11 +35,15 @@ export const getProductPricingInfo = (
 		// If a yearly product is found, find the monthly version of the product
 		const monthlyProduct =
 			yearlyProduct &&
-			Object.values( userProducts ).find(
-				( p ) =>
-					p.billing_product_slug === yearlyProduct.billing_product_slug &&
+			Object.values( userProducts ).find( ( p ) => {
+				return (
+					( p.billing_product_slug === yearlyProduct.billing_product_slug ||
+						// Check if the product is a WooCommerce product
+						isWooCommerceProduct( p.billing_product_slug, yearlyProduct.billing_product_slug ) ) &&
 					p.product_term === 'month'
-			);
+				);
+			} );
+
 		// If a monthly product is found, calculate the actual cost and discount percentage
 		if ( monthlyProduct ) {
 			const monthlyProductBundleCost = parseFloat( product.amount ) * quantity;

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/woocommerce-product-slug-mapping.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/woocommerce-product-slug-mapping.tsx
@@ -1,0 +1,18 @@
+const wooCommerceProductSlugMapping: { [ key: string ]: string } = {
+	'woocommerce-min-max-quantities': 'jetpack-woocommerce-minmax-quantities',
+	'woocommerce-product-addons': 'jetpack-woocommerce-product-add-ons',
+};
+
+export const isWooCommerceProduct = ( slug: string, yearlyProductSlug: string ) => {
+	if ( slug === yearlyProductSlug ) {
+		return true;
+	}
+	if ( slug === yearlyProductSlug.replace( 'jetpack-', '' ) ) {
+		return true;
+	}
+	if ( slug === yearlyProductSlug.replace( 'jetpack-woocommerce', '' ) ) {
+		return true;
+	}
+	// WooCommerce product slug mapping is used to map the WooCommerce product slug to the correct product slug
+	return !! wooCommerceProductSlugMapping?.[ slug ];
+};


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/422

## Proposed Changes

This PR fixes an issue with the WooCommerce product bundle discount not showing up.

## Testing Instructions

1) Open the A4A live link.
2) Visit /marketplace/products > Change the bundle size using the volume selector and verify that the discount is not displayed for all the WooCommerce products.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1536" alt="Screenshot 2024-05-03 at 11 12 23 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a1039410-e011-45be-b408-4a093efa7e11">
</td>
<td>
<img width="1536" alt="Screenshot 2024-05-03 at 11 12 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/570eb5ad-4fd3-4d04-bbfb-a923ae9a7d10">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?