### PR TITLE
Trail Map: Centralise experiment logic within hook

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
+++ b/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
@@ -14,6 +14,8 @@ interface Params {
 }
 
 function useExperimentForTrailMap( { flowName }: Params ): {
+	isLoading: boolean;
+	variant: VariantType;
 	isTrailMapAny: boolean;
 	isTrailMapCopy: boolean;
 	isTrailMapStructure: boolean;
@@ -26,11 +28,11 @@ function useExperimentForTrailMap( { flowName }: Params ): {
 	let variant = ( assignment?.variationName ?? 'control' ) as VariantType;
 
 	if ( config.isEnabled( 'onboarding/trail-map-feature-grid-copy' ) ) {
-		variant = 'treatment-copy';
+		variant = 'treatment_copy';
 	} else if ( config.isEnabled( 'onboarding/trail-map-feature-grid-structure' ) ) {
-		variant = 'treatment-structure';
+		variant = 'treatment_structure';
 	} else if ( config.isEnabled( 'onboarding/trail-map-feature-grid' ) ) {
-		variant = 'treatment-copy-and-structure';
+		variant = 'treatment_copy_and_structure';
 	}
 
 	useEffect( () => {
@@ -38,6 +40,8 @@ function useExperimentForTrailMap( { flowName }: Params ): {
 	}, [ isLoading, variant ] );
 
 	return {
+		isLoading,
+		variant,
 		isTrailMapAny: isTrailMapAnyVariant( variant ),
 		isTrailMapCopy: isTrailMapCopyVariant( variant ),
 		isTrailMapStructure: isTrailMapStructureVariant( variant ),

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -14,7 +14,6 @@ import {
 	getWooExpressFeaturesGrouped,
 	getPlanFeaturesGrouped,
 	isWooExpressPlan,
-	setTrailMapExperiment,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -73,7 +72,7 @@ import useGenerateActionCallback from './hooks/use-action-callback';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useDeemphasizeFreePlan from './hooks/use-deemphasize-free-plan';
-import useExperimentForTrailMap, { TrailMapVariant } from './hooks/use-experiment-for-trail-map';
+import useExperimentForTrailMap from './hooks/use-experiment-for-trail-map';
 import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-intervals';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
@@ -296,18 +295,9 @@ const PlansFeaturesMain = ( {
 		...( selectedPlan ? { defaultValue: getPlan( selectedPlan )?.term } : {} ),
 	} );
 
-	const trailMapExperiment = useExperimentForTrailMap( { flowName } );
-	const isAnyTrailMapTreatment = trailMapExperiment.result !== TrailMapVariant.Control;
-	const isTrailMapCopy =
-		trailMapExperiment.result === TrailMapVariant.TreatmentCopy ||
-		trailMapExperiment.result === TrailMapVariant.TreatmentCopyAndStructure;
-	const isTrailMapStructure =
-		trailMapExperiment.result === TrailMapVariant.TreatmentStructure ||
-		trailMapExperiment.result === TrailMapVariant.TreatmentCopyAndStructure;
-
-	useEffect( () => {
-		setTrailMapExperiment( trailMapExperiment.result ?? TrailMapVariant.Control );
-	}, [ trailMapExperiment.isLoading, trailMapExperiment.result ] );
+	const { isTrailMapAny, isTrailMapCopy, isTrailMapStructure } = useExperimentForTrailMap( {
+		flowName,
+	} );
 
 	const intentFromSiteMeta = usePlanIntentFromSiteMeta();
 	const planFromUpsells = usePlanFromUpsells();
@@ -790,7 +780,7 @@ const PlansFeaturesMain = ( {
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
 					onFreePlanCTAClick={ onFreePlanCTAClick }
-					showPlanBenefits={ isInSignup && isAnyTrailMapTreatment }
+					showPlanBenefits={ isInSignup && isTrailMapAny }
 				/>
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -295,7 +295,13 @@ const PlansFeaturesMain = ( {
 		...( selectedPlan ? { defaultValue: getPlan( selectedPlan )?.term } : {} ),
 	} );
 
-	const { isTrailMapAny, isTrailMapCopy, isTrailMapStructure } = useExperimentForTrailMap( {
+	const {
+		isLoading: isTrailMapExperimentLoading,
+		variant: trailMapExperimentVariant,
+		isTrailMapAny,
+		isTrailMapCopy,
+		isTrailMapStructure,
+	} = useExperimentForTrailMap( {
 		flowName,
 	} );
 
@@ -423,7 +429,7 @@ const PlansFeaturesMain = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
-		includePreviousPlanFeatures: trailMapExperiment.result === 'treatment-structure',
+		includePreviousPlanFeatures: trailMapExperimentVariant === 'treatment_structure',
 	} );
 
 	// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.
@@ -689,7 +695,11 @@ const PlansFeaturesMain = ( {
 		'calypso_signup_onboarding_plans_paid_domain_free_plan_modal_optimization'
 	);
 	const isLoadingGridPlans = Boolean(
-		! intent || ! gridPlansForFeaturesGrid || ! gridPlansForComparisonGrid || isExperimentLoading
+		! intent ||
+			! gridPlansForFeaturesGrid ||
+			! gridPlansForComparisonGrid ||
+			isExperimentLoading ||
+			isTrailMapExperimentLoading
 	);
 	const isPlansGridReady =
 		! isLoadingGridPlans &&

--- a/packages/calypso-products/src/experiments.ts
+++ b/packages/calypso-products/src/experiments.ts
@@ -25,9 +25,9 @@ export const getPlansListExperiment = ( experimentName: string ): string | undef
 
 export type TrailMapVariantType =
 	| 'control'
-	| 'treatment-copy-and-structure'
-	| 'treatment-copy'
-	| 'treatment-structure';
+	| 'treatment_copy_and_structure'
+	| 'treatment_copy'
+	| 'treatment_structure';
 
 export const setTrailMapExperiment = ( variation: TrailMapVariantType ): void => {
 	setExperiment( PLANS_LIST_NAMESPACE, 'wpcom_trail_map_feature_structure_experiment', variation );
@@ -42,10 +42,10 @@ export const isTrailMapControlVariant = ( variant = getTrailMapExperiment() ): b
 	variant === 'control';
 
 export const isTrailMapCopyVariant = ( variant = getTrailMapExperiment() ): boolean =>
-	variant === 'treatment-copy-and-structure' || variant === 'treatment-copy';
+	variant === 'treatment_copy_and_structure' || variant === 'treatment_copy';
 
 export const isTrailMapStructureVariant = ( variant = getTrailMapExperiment() ): boolean =>
-	variant === 'treatment-copy-and-structure' || variant === 'treatment-structure';
+	variant === 'treatment_copy_and_structure' || variant === 'treatment_structure';
 
 export const isTrailMapAnyVariant = ( variant = getTrailMapExperiment() ): boolean =>
 	variant !== 'control';

--- a/packages/calypso-products/src/experiments.ts
+++ b/packages/calypso-products/src/experiments.ts
@@ -23,7 +23,7 @@ export const getPlansListExperiment = ( experimentName: string ): string | undef
 	return getExperiment( PLANS_LIST_NAMESPACE, experimentName );
 };
 
-type TrailMapVariantType =
+export type TrailMapVariantType =
 	| 'control'
 	| 'treatment-copy-and-structure'
 	| 'treatment-copy'
@@ -38,10 +38,14 @@ export const getTrailMapExperiment = () => {
 		'control' ) as TrailMapVariantType;
 };
 
-export const isTrailMapCopyVariant = (): boolean =>
-	getTrailMapExperiment() === 'treatment-copy-and-structure' ||
-	getTrailMapExperiment() === 'treatment-copy';
+export const isTrailMapControlVariant = ( variant = getTrailMapExperiment() ): boolean =>
+	variant === 'control';
 
-export const isTrailMapStructureVariant = (): boolean =>
-	getTrailMapExperiment() === 'treatment-copy-and-structure' ||
-	getTrailMapExperiment() === 'treatment-structure';
+export const isTrailMapCopyVariant = ( variant = getTrailMapExperiment() ): boolean =>
+	variant === 'treatment-copy-and-structure' || variant === 'treatment-copy';
+
+export const isTrailMapStructureVariant = ( variant = getTrailMapExperiment() ): boolean =>
+	variant === 'treatment-copy-and-structure' || variant === 'treatment-structure';
+
+export const isTrailMapAnyVariant = ( variant = getTrailMapExperiment() ): boolean =>
+	variant !== 'control';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -583,8 +583,8 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 	],
 	get2023PricingGridSignupWpcomFeatures: () => {
 		if (
-			getTrailMapExperiment() === 'treatment-copy' ||
-			getTrailMapExperiment() === 'treatment-copy-and-structure'
+			getTrailMapExperiment() === 'treatment_copy' ||
+			getTrailMapExperiment() === 'treatment_copy_and_structure'
 		) {
 			return [
 				FEATURE_WP_SUBDOMAIN_SIGNUP,
@@ -834,7 +834,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
 	],
 	get2023PricingGridSignupWpcomFeatures: () => {
-		if ( getTrailMapExperiment() === 'treatment-copy' ) {
+		if ( getTrailMapExperiment() === 'treatment_copy' ) {
 			return [
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_20_PREMIUM_THEMES,
@@ -842,7 +842,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 				FEATURE_EMAIL_SUPPORT,
 			];
 		}
-		if ( getTrailMapExperiment() === 'treatment-copy-and-structure' ) {
+		if ( getTrailMapExperiment() === 'treatment_copy_and_structure' ) {
 			return [
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_USERS,
@@ -1043,7 +1043,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			PREMIUM_DESIGN_FOR_STORES,
 		].filter( isValueTruthy ),
 	get2023PricingGridSignupWpcomFeatures: () => {
-		if ( getTrailMapExperiment() === 'treatment-copy' ) {
+		if ( getTrailMapExperiment() === 'treatment_copy' ) {
 			return [
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_PAYMENT_TRANSACTION_FEES_0,
@@ -1051,7 +1051,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 				FEATURE_PRE_INSTALLED_ECOMMERCE_PLUGINS,
 			];
 		}
-		if ( getTrailMapExperiment() === 'treatment-copy-and-structure' ) {
+		if ( getTrailMapExperiment() === 'treatment_copy_and_structure' ) {
 			return [
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_USERS,
@@ -1479,7 +1479,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_GOOGLE_ANALYTICS,
 		].filter( isValueTruthy ),
 	get2023PricingGridSignupWpcomFeatures: () => {
-		if ( getTrailMapExperiment() === 'treatment-copy' ) {
+		if ( getTrailMapExperiment() === 'treatment_copy' ) {
 			return [
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_48_PREMIUM_THEMES,
@@ -1489,7 +1489,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 				FEATURE_PAYMENT_TRANSACTION_FEES_4,
 			];
 		}
-		if ( getTrailMapExperiment() === 'treatment-copy-and-structure' ) {
+		if ( getTrailMapExperiment() === 'treatment_copy_and_structure' ) {
 			return [
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_USERS,
@@ -1669,7 +1669,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SFTP_DATABASE,
 		].filter( isValueTruthy ),
 	get2023PricingGridSignupWpcomFeatures: () => {
-		if ( getTrailMapExperiment() === 'treatment-copy' ) {
+		if ( getTrailMapExperiment() === 'treatment_copy' ) {
 			return [
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_INSTALL_PLUGINS,
@@ -1692,7 +1692,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 				FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			];
 		}
-		if ( getTrailMapExperiment() === 'treatment-copy-and-structure' ) {
+		if ( getTrailMapExperiment() === 'treatment_copy_and_structure' ) {
 			return [
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_USERS,

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -1,4 +1,5 @@
 import {
+	TrailMapVariantType,
 	getFeaturesList,
 	getPlanFeaturesGrouped,
 	setTrailMapExperiment,
@@ -39,11 +40,7 @@ const RenderFeaturesGrid = (
 const meta: Meta<
 	FeaturesGridExternalProps & {
 		includePreviousPlanFeatures: boolean;
-		trailMapVariant:
-			| 'control'
-			| 'treatment-copy'
-			| 'treatment-structure'
-			| 'treatment-copy-and-structure';
+		trailMapVariant: TrailMapVariantType;
 	}
 > = {
 	title: 'FeaturesGrid',
@@ -70,11 +67,7 @@ export default meta;
 type Story = StoryObj<
 	FeaturesGridExternalProps & {
 		includePreviousPlanFeatures: boolean;
-		trailMapVariant:
-			| 'control'
-			| 'treatment-copy'
-			| 'treatment-structure'
-			| 'treatment-copy-and-structure';
+		trailMapVariant: TrailMapVariantType;
 	}
 >;
 
@@ -117,7 +110,7 @@ export const TrailMapControl: Story = {
 export const TrailMapStructure: Story = {
 	args: {
 		...TrailMapControl.args,
-		trailMapVariant: 'treatment-structure',
+		trailMapVariant: 'treatment_structure',
 		enableCategorisedFeatures: true,
 		includePreviousPlanFeatures: true,
 	},
@@ -126,13 +119,13 @@ export const TrailMapStructure: Story = {
 export const TrailMapCopy: Story = {
 	args: {
 		...TrailMapControl.args,
-		trailMapVariant: 'treatment-copy',
+		trailMapVariant: 'treatment_copy',
 	},
 };
 export const TrailMapCopyAndStructure: Story = {
 	args: {
 		...TrailMapControl.args,
-		trailMapVariant: 'treatment-copy-and-structure',
+		trailMapVariant: 'treatment_copy_and_structure',
 		enableCategorisedFeatures: true,
 	},
 };


### PR DESCRIPTION
Relates to https://github.com/Automattic/wp-calypso/milestone/476

## Proposed Changes

Cleanup focused PR to simplify/consolidate our experiment-related code.

- Moves experiment logic out of `plans-features-main/index.tsx` and into the hook `use-experiment-for-trail-map.ts`
- Addresses the duplication of business logic between `use-experiment-for-trail-map.ts` and `experiments.ts`
    - Both previously contained the same variant checks:
        - eg. `variant === 'treatment-copy-and-structure' || variant === 'treatment-copy'`
    - Now only `experiments.ts` includes this logic, which is then reused by the hook

## Testing Instructions

This is a refactor with no expected functional changes, so please just smoke test each variant:

- `/start/plans?flags=onboarding/trail-map-feature-grid-copy`
- `/start/plans?flags=onboarding/trail-map-feature-grid-structure`
- `/start/plans?flags=onboarding/trail-map-feature-grid`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?