### PR TITLE
A4A: Change the Jetpack plan section to use a regular 3-column layout.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -313,7 +313,6 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 					description={ translate(
 						'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
 					) } // FIXME: Add proper description for A4A
-					isTwoColumns
 				>
 					{ getProductCards( plans ) }
 				</ListingSection>


### PR DESCRIPTION
There seems to be an issue with the Jetpack plan cards in the Marketplace, where they get squashed on smaller screens. This issue is primarily caused by the layout, which is not as responsive as the regular 3-column layout. To address this problem, this PR proposes using the regular 3-column layout to ensure that all product cards are aligned properly.

| Before | After |
|--------|--------|
| <img width="933" alt="Screenshot 2024-05-03 at 3 04 49 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a84c2b42-6ced-4f66-ac10-bb96d808f1ce"> | <img width="933" alt="Screenshot 2024-05-03 at 3 04 19 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/bb0efd8d-37af-4311-be87-5b7a8faece28"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/416

## Proposed Changes

* Update the Jetpack plan section in the Products page to use the regular 3-column layout.

## Testing Instructions

* Use the A4A live link and goto `/marketplace/products`
* Scroll down in the Jetpack plan section.
* Adjust your browser's width to test the responsiveness of the Jetpack plan section.
* Confirm that it is responsive similar to the rest of the sections.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?