### PR TITLE
GSV: Rename "Go to WP Admin" and point to My Home for Default view

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -5,6 +5,8 @@ import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
+import { useSelector } from 'calypso/state';
+import { getSiteOption, getSiteHomeUrl } from 'calypso/state/sites/selectors';
 import SiteFavicon from '../../site-favicon';
 import { ItemData, ItemPreviewPaneHeaderExtraProps } from '../types';
 
@@ -29,6 +31,21 @@ export default function ItemPreviewPaneHeader( {
 	const size = isLargerThan960px ? 64 : 50;
 
 	const focusRef = useRef< HTMLInputElement >( null );
+
+	const { adminLabel, adminUrl } = useSelector( ( state ) => {
+		const wpcomAdminInterface = getSiteOption( state, itemData.blogId, 'wpcom_admin_interface' );
+		if ( wpcomAdminInterface === 'wp-admin' ) {
+			return {
+				adminLabel: translate( 'Go to WP Admin' ),
+				adminUrl: itemData.adminUrl,
+			};
+		}
+
+		return {
+			adminLabel: translate( 'Go to Dashboard' ),
+			adminUrl: getSiteHomeUrl( state, itemData.blogId ),
+		};
+	} );
 
 	// Use useEffect to set the focus when the component mounts
 	useEffect( () => {
@@ -77,10 +94,10 @@ export default function ItemPreviewPaneHeader( {
 						<Button
 							variant="primary"
 							className="item-preview__admin-button"
-							href={ `${ itemData.adminUrl }` }
+							href={ `${ adminUrl }` }
 							ref={ focusRef }
 						>
-							{ translate( 'Go to WP Admin' ) }
+							{ adminLabel }
 						</Button>
 					</>
 				) : (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6913

## Proposed Changes

* Rename the CTA to "Go to Dashboard" for the default view
* Link to My Home for the default view

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select a site
* You will see
  *  The "Go to Dashboard" button that points to My Home for the default view
  * The "Go to WP Admin" button that points to WP Admin for the default view

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?