### PR TITLE
Scheduled Updates Multisite: Sort multisite schedules

### DIFF
--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -156,6 +156,14 @@ export const useMultisiteUpdateScheduleQuery = (
 				}
 			}
 
+			// sort by schedule (daily/weekly) then timestamp
+			result.sort( ( a, b ) => {
+				if ( a.schedule === b.schedule ) {
+					return a.timestamp - b.timestamp;
+				}
+				return a.schedule.localeCompare( b.schedule );
+			} );
+
 			return result;
 		},
 		refetchOnWindowFocus: false,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/90258

## Proposed Changes

* Sorts the list by daily/weekly, then timestamp

## Testing Instructions

1. Apply this PR
2. The list should be sorted correctly

![CleanShot 2024-05-03 at 10 34 27@2x](https://github.com/Automattic/wp-calypso/assets/528287/d4a7a20d-6618-4cd6-9d1a-4b3c3e9cf437)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?