### PR TITLE
Remove the layout/dotcom-nav-redesign-v2 check for /domains/manage

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
 import { Global, css } from '@emotion/react';
@@ -40,10 +39,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	const { domains, isLoading } = useDomainsTable( fetchAllDomains );
 	const translate = useTranslate();
 	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
-	let sitesDashboardGlobalStyles;
-
-	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		sitesDashboardGlobalStyles = css`
+	const sitesDashboardGlobalStyles = css`
 			html {
 				overflow-y: auto;
 			}
@@ -189,7 +185,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 
 			}
 		`;
-	}
 	const item = {
 		label: translate( 'All Domains' ),
 		subtitle: translate(


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6856

## Proposed Changes

* The Site Dashboard already has the "frame" applied, so I don't think we need this gated behind the feature flag anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/2a85e8f6-67c1-46fb-8497-0c5de9fe3712">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/efc31551-b3ac-4517-8f1d-1d6cb401c8a3">|


* Go to /domains/manage, remove the flag by adding `?flags=-layout/dotcom-nav-redesign-v2` to the end fo the url
* Should show the new styles applied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?