### PR TITLE
Automattic for Agencies: Fix the product checkout flow

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method.ts
@@ -4,7 +4,7 @@ export default function usePaymentMethod() {
 	// Fetch the stored cards from the cache if they are available.
 	const {
 		data: { allStoredCards },
-	} = useStoredCards( undefined, { staleTime: Infinity } );
+	} = useStoredCards( undefined, true );
 
 	const hasValidPaymentMethod = allStoredCards?.length > 0;
 

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -15,11 +15,21 @@ export const getFetchStoredCardsKey = ( agencyId?: number, paging?: Paging ) => 
 	agencyId,
 ];
 
-export default function useStoredCards( paging?: Paging, options?: { staleTime: number } ) {
+export default function useStoredCards( paging?: Paging, useStaleData = false ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
+	const queryClient = useQueryClient();
+	const data = queryClient.getQueryData( getFetchStoredCardsKey( agencyId, paging ) );
+
+	let staleTime = 0;
+
+	// If we have data and we want to use stale data, set the stale time to Infinity to prevent refetching.
+	if ( useStaleData && data ) {
+		staleTime = Infinity;
+	}
+
 	return useQuery( {
-		...options,
+		staleTime,
 		queryKey: getFetchStoredCardsKey( agencyId, paging ),
 		queryFn: () =>
 			wpcom.req.get(

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -84,7 +84,7 @@ function PaymentMethodForm() {
 		stripe,
 	} );
 
-	const { refetch: refetchStoredCards } = useStoredCards( undefined, { staleTime: Infinity } );
+	const { refetch: refetchStoredCards } = useStoredCards( undefined, true );
 
 	const paymentMethods = useMemo(
 		() => [ stripeMethod ].filter( isValueTruthy ),

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
@@ -32,7 +32,7 @@ const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
 	const {
 		data: { allStoredCards },
 		isFetching,
-	} = useStoredCards( paging, { staleTime: Infinity } );
+	} = useStoredCards( paging, true );
 
 	return (
 		<Dialog

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
@@ -44,7 +44,7 @@ export default function StoredCreditCard( {
 	// Fetch the stored cards from the cache if they are available.
 	const {
 		data: { allStoredCards },
-	} = useStoredCards( paging, { staleTime: Infinity } );
+	} = useStoredCards( paging, true );
 
 	const { isDeleteDialogVisible, setIsDeleteDialogVisible, handleDelete, isDeleteInProgress } =
 		useDeleteCard( creditCard, allStoredCards );


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/420

## Proposed Changes

This PR fixes an issue with the checkout flow that assumes there is no existing payment method by setting to use the stale data only when the data is available. 

## Testing Instructions

1) Open the A4A live link.
2) Make sure you have added a payment method: /purchases/payment-methods
3) Visit /marketplace/products > Add a few products > Click on Checkout > Verify that you are redirected to the Checkout page without being redirected to the add payment method page.
4) Come back to Marketplace > Refresh the page and notice no fresh request is being made to fetch the payment methods 
5) Open the console > Run `localStorage.clear();` and hard refresh the page > Authorize > When redirected to the Marketplace, verify that the new request to fetch the payment method is made. You might have to repeat this step until the data is not cached. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?