### PR TITLE
Schedule Updates: Modify the button text for empty view

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-empty.tsx
@@ -18,7 +18,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 				) }
 			</Text>
 			<Button __next40pxDefaultSize icon={ plus } variant="primary" onClick={ onCreateNewSchedule }>
-				{ translate( 'Setup a new schedule' ) }
+				{ translate( 'Add new schedule' ) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90205

## Proposed Changes

* This is a follow up from https://github.com/Automattic/wp-calypso/pull/90205#discussion_r1587663473 where we modify the text to align with the "add schedule" button on single sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review should be enough but if you want to double-check, follow the instructions in #90205 and make sure you see the button text as "Add new schedule".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?