### PR TITLE
Add nav redesign frame to Reader /read and /discover behind flag

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -129,6 +129,8 @@ export class FullPostView extends Component {
 		this.stopResize =
 			this.postContentWrapper.current && WPiFrameResize( this.postContentWrapper.current );
 
+		document.querySelector( 'body' ).classList.add( 'is-reader-full-post' );
+
 		document.addEventListener( 'keydown', this.handleKeydown, true );
 	}
 	componentDidUpdate( prevProps ) {
@@ -168,7 +170,7 @@ export class FullPostView extends Component {
 		// Remove WPiFrameResize listener.
 		this.stopResize?.();
 		this.props.enableAppBanner(); // reset the app banner
-
+		document.querySelector( 'body' ).classList.remove( 'is-reader-full-post' );
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
 	}
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -666,3 +666,7 @@
 .wp-block-latest-posts__post-date::before {
 	content: " - ";
 }
+
+.is-reader-full-post {
+	background: var(--color-surface);
+}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -170,6 +170,7 @@
 
 			@include breakpoint-deprecated( "<660px" ) {
 				flex-direction: column-reverse;
+				gap: 12px;
 			}
 
 			&.reader-post-card__no-excerpt {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -402,10 +402,10 @@ body.is-mobile-app-view {
 
 // Ensure reader streams have the neutral background.
 .layout.is-section-reader {
-	background: var(--studio-white);
+	background: var(--studio-white); // TODO: Remove after nav-redesign-v2 for reader is done.
 	min-height: 100vh;
 	.layout__content {
-		background: var(--studio-white);
+		background: var(--studio-white); // TODO: Remove after nav-redesign-v2 for reader is done.
 	}
 	.section-header.card {
 		box-shadow: none;

--- a/client/reader/components/reader-main/style.scss
+++ b/client/reader/components/reader-main/style.scss
@@ -1,6 +1,6 @@
 body.is-reader-page,
 .is-reader-page .layout {
-	background-color: var(--color-surface);
+	background-color: var(--color-surface); // TODO: Remove after nav-redesign-v2 for reader is done.
 }
 
 .is-reader-page .list-end {

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -68,8 +68,9 @@ const DiscoverStream = ( props ) => {
 
 				div.layout.is-global-sidebar-visible {
 					.main {
-						padding-top: 24px;
-						padding-inline: 64px;
+						@media only screen and ( min-width: 660px ) {
+							padding: 24px;
+						}
 						border-block-end: 1px solid var( --studio-gray-0 );
 					}
 					.layout__primary > div {
@@ -112,9 +113,17 @@ const DiscoverStream = ( props ) => {
 						border-radius: 8px;
 						height: calc( 100vh - 32px );
 					}
-					header.navigation-header {
-						padding-inline: 16px;
-						padding-bottom: 0;
+				}
+
+				.is-discover-stream {
+					header.navigation-header.discover-stream-header {
+						padding: 0;
+					}
+					@media only screen and ( max-width: 660px ) {
+						.discover-stream-navigation {
+							margin-left: 0;
+							margin-right: 0;
+						}
 					}
 				}
 			}

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -68,8 +68,11 @@ const DiscoverStream = ( props ) => {
 
 				div.layout.is-global-sidebar-visible {
 					.main {
-						@media only screen and ( min-width: 660px ) {
+						@media only screen and ( min-width: 600px ) and ( max-width: 960px ) {
 							padding: 24px;
+						}
+						@media only screen and ( max-width: 660px ) {
+							padding-top: 0;
 						}
 						border-block-end: 1px solid var( --studio-gray-0 );
 					}
@@ -87,7 +90,8 @@ const DiscoverStream = ( props ) => {
 					}
 					.layout__primary > div > div {
 						height: 100%;
-						overflow: auto;
+						overflow-y: auto;
+						overflow-x: hidden;
 					}
 				}
 

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -1,4 +1,6 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
+import { Global, css } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -24,6 +26,100 @@ import {
 } from './helper';
 
 const DiscoverStream = ( props ) => {
+	let navRedesignV2GlobalStyles;
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		navRedesignV2GlobalStyles = css`
+			html {
+				overflow-y: auto;
+			}
+			body.is-reader-page,
+			.is-reader-page .layout,
+			.layout.is-section-reader,
+			.layout.is-section-reader .layout__content,
+			.is-section-reader {
+				background: initial;
+			}
+			body.is-section-reader {
+				background: var( --studio-gray-0 );
+
+				&.rtl .layout__content {
+					padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
+				}
+
+				.layout__content {
+					// Add border around everything
+					overflow: hidden;
+					min-height: 100vh;
+					@media only screen and ( min-width: 782px ) {
+						padding: 16px 16px 16px calc( var( --sidebar-width-max ) ) !important;
+					}
+					.layout_primary > div {
+						padding-bottom: 0;
+					}
+				}
+
+				.layout__secondary .global-sidebar {
+					border: none;
+				}
+
+				.has-no-masterbar .layout__content .main {
+					padding-top: 16px;
+				}
+
+				div.layout.is-global-sidebar-visible {
+					.main {
+						padding-top: 24px;
+						padding-inline: 64px;
+						border-block-end: 1px solid var( --studio-gray-0 );
+					}
+					.layout__primary > div {
+						background: var( --color-surface );
+						border-radius: 8px;
+						box-shadow: none;
+						@media only screen and ( min-width: 600px ) {
+							height: calc( 100vh - var( --masterbar-height ) - 50px );
+						}
+						@media only screen and ( min-width: 782px ) {
+							height: calc( 100vh - 32px );
+						}
+						overflow: hidden;
+					}
+					.layout__primary > div > div {
+						height: 100%;
+						overflow: auto;
+					}
+				}
+
+				@media only screen and ( max-width: 600px ) {
+					.navigation-header__main {
+						justify-content: normal;
+						align-items: center;
+						.formatted-header {
+							flex: none;
+						}
+					}
+				}
+
+				@media only screen and ( max-width: 781px ) {
+					div.layout.is-global-sidebar-visible {
+						.layout__primary {
+							overflow-x: auto;
+						}
+					}
+					.layout__primary > div {
+						background: var( --color-surface );
+						margin: 0;
+						border-radius: 8px;
+						height: calc( 100vh - 32px );
+					}
+					header.navigation-header {
+						padding-inline: 16px;
+						padding-bottom: 0;
+					}
+				}
+			}
+		`;
+	}
 	const locale = useLocale();
 	const translate = useTranslate();
 	const followedTags = useSelector( getReaderFollowedTags );
@@ -128,13 +224,15 @@ const DiscoverStream = ( props ) => {
 
 	return (
 		<>
-			{ DiscoverHeader() }
-			<DiscoverNavigation
-				width={ props.width }
-				selectedTab={ selectedTab }
-				recommendedTags={ interestTags }
-			/>
-			<Stream { ...streamProps } />
+			<Global styles={ navRedesignV2GlobalStyles } />
+			<Stream { ...streamProps }>
+				{ DiscoverHeader() }
+				<DiscoverNavigation
+					width={ props.width }
+					selectedTab={ selectedTab }
+					recommendedTags={ interestTags }
+				/>
+			</Stream>
 		</>
 	);
 };

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Global, css } from '@emotion/react';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
@@ -11,9 +13,104 @@ import FollowingIntro from './intro';
 import './style.scss';
 
 function FollowingStream( { ...props } ) {
+	let navRedesignV2GlobalStyles;
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		navRedesignV2GlobalStyles = css`
+			html {
+				overflow-y: auto;
+			}
+			body.is-reader-page,
+			.is-reader-page .layout,
+			.layout.is-section-reader,
+			.layout.is-section-reader .layout__content,
+			.is-section-reader {
+				background: initial;
+			}
+			body.is-section-reader {
+				background: var( --studio-gray-0 );
+
+				&.rtl .layout__content {
+					padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
+				}
+
+				.layout__content {
+					// Add border around everything
+					overflow: hidden;
+					min-height: 100vh;
+					@media only screen and ( min-width: 782px ) {
+						padding: 16px 16px 16px calc( var( --sidebar-width-max ) ) !important;
+					}
+					.layout_primary > div {
+						padding-bottom: 0;
+					}
+				}
+
+				.layout__secondary .global-sidebar {
+					border: none;
+				}
+
+				.has-no-masterbar .layout__content .main {
+					padding-top: 16px;
+				}
+
+				div.layout.is-global-sidebar-visible {
+					.main {
+						padding-top: 24px;
+						padding-inline: 64px;
+						border-block-end: 1px solid var( --studio-gray-0 );
+					}
+					.layout__primary > div {
+						background: var( --color-surface );
+						border-radius: 8px;
+						box-shadow: none;
+						@media only screen and ( min-width: 600px ) {
+							height: calc( 100vh - var( --masterbar-height ) - 50px );
+						}
+						@media only screen and ( min-width: 782px ) {
+							height: calc( 100vh - 32px );
+						}
+						overflow: hidden;
+					}
+					.layout__primary > div > div {
+						height: 100%;
+						overflow: auto;
+					}
+				}
+
+				@media only screen and ( max-width: 600px ) {
+					.navigation-header__main {
+						justify-content: normal;
+						align-items: center;
+						.formatted-header {
+							flex: none;
+						}
+					}
+				}
+
+				@media only screen and ( max-width: 781px ) {
+					div.layout.is-global-sidebar-visible {
+						.layout__primary {
+							overflow-x: auto;
+						}
+					}
+					.layout__primary > div {
+						background: var( --color-surface );
+						margin: 0;
+						border-radius: 8px;
+						height: calc( 100vh - 32px );
+					}
+					header.navigation-header {
+						padding-inline: 16px;
+						padding-bottom: 0;
+					}
+				}
+			}
+		`;
+	}
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<>
+			<Global styles={ navRedesignV2GlobalStyles } />
 			<Stream
 				{ ...props }
 				className="following"

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -55,8 +55,11 @@ function FollowingStream( { ...props } ) {
 
 				div.layout.is-global-sidebar-visible {
 					.main {
-						@media only screen and ( min-width: 660px ) {
+						@media only screen and ( min-width: 600px ) and ( max-width: 960px ) {
 							padding: 24px;
+						}
+						@media only screen and ( max-width: 660px ) {
+							padding-top: 0;
 						}
 						border-block-end: 1px solid var( --studio-gray-0 );
 					}
@@ -74,7 +77,8 @@ function FollowingStream( { ...props } ) {
 					}
 					.layout__primary > div > div {
 						height: 100%;
-						overflow: auto;
+						overflow-y: auto;
+						overflow-x: hidden;
 					}
 				}
 

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -55,8 +55,9 @@ function FollowingStream( { ...props } ) {
 
 				div.layout.is-global-sidebar-visible {
 					.main {
-						padding-top: 24px;
-						padding-inline: 64px;
+						@media only screen and ( min-width: 660px ) {
+							padding: 24px;
+						}
 						border-block-end: 1px solid var( --studio-gray-0 );
 					}
 					.layout__primary > div {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -49,7 +49,9 @@ import PostLifecycle from './post-lifecycle';
 import PostPlaceholder from './post-placeholder';
 import './style.scss';
 
-export const WIDE_DISPLAY_CUTOFF = 900;
+// minimal size for the two-column layout to show without cut off
+// 64 is padding, 8 is margin
+export const WIDE_DISPLAY_CUTOFF = 950 + 64 * 2 + 8 * 2;
 const GUESSED_POST_HEIGHT = 600;
 const HEADER_OFFSET_TOP = 46;
 const noop = () => {};

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .is-section-reader {
-	background: var(--studio-white);
+	background: var(--studio-white); // TODO: Remove after nav-redesign-v2 for reader is done.
 }
 
 .layout.has-header-section.is-section-reader .layout__header-section-content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6856

## Proposed Changes

* Adds the frame to /read and /discover
* Still behind the flag because we don't want to make things even more inconsistent with some parts of the Reader with the frame and some don't

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test /read, /discover and see if there's anything weird
* Disable the flag `?flags=-layout/dotcom-nav-redesign-v2` and see if there are regressions


https://github.com/Automattic/wp-calypso/assets/6586048/f2e11e04-b288-4989-babc-c23689d83945




https://github.com/Automattic/wp-calypso/assets/6586048/50b52b33-03b8-458b-8277-3c4be0df7d48





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?