### PR TITLE
Site restore: show staging sites as deleted but don't allow restore

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
@@ -109,7 +109,7 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 		if ( isRestoring ) {
 			return <Spinner />;
 			// `is_wpcom_staging_site` is false for deleted staging
-			// sites so need to check the slub
+			// sites so need to check the slug
 		} else if ( ! site.slug.startsWith( 'staging-' ) ) {
 			return (
 				<RestoreButton borderless onClick={ handleRestoreSite }>

--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-status.tsx
@@ -105,17 +105,25 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 		restoreSite( site.ID );
 	};
 
+	const renderDeletedContent = () => {
+		if ( isRestoring ) {
+			return <Spinner />;
+			// `is_wpcom_staging_site` is false for deleted staging
+			// sites so need to check the slub
+		} else if ( ! site.slug.startsWith( 'staging-' ) ) {
+			return (
+				<RestoreButton borderless onClick={ handleRestoreSite }>
+					{ __( 'Restore' ) }
+				</RestoreButton>
+			);
+		}
+	};
+
 	if ( site.is_deleted ) {
 		return (
 			<DeletedStatus>
 				<span>{ __( 'Deleted' ) }</span>
-				{ isRestoring ? (
-					<Spinner />
-				) : (
-					<RestoreButton borderless onClick={ handleRestoreSite }>
-						{ __( 'Restore' ) }
-					</RestoreButton>
-				) }
+				{ renderDeletedContent() }
 			</DeletedStatus>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context p1714649417289399-slack-C0347E545HR

Related to D147488-code

<img width="1186" alt="Screenshot 2567-05-03 at 12 47 28" src="https://github.com/Automattic/wp-calypso/assets/6851384/d46ac4ef-9826-4a34-a08e-21e6876b8d67">

## Proposed Changes

* Don't show the "Restore" button for deleted staging sites as we don't support restoring staging sites currently. 



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D147550-code
* Delete a staging site 
* Go to `/sites` and confirm you see it when filtering to status `deleted`
* Confirm it can't be restored but other sites can

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?