### PR TITLE
Remove processing step:  Review instructions layout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -174,7 +174,7 @@ const SiteMigrationInstructions: Step = function () {
 			<StepContainer
 				stepName="site-migration-instructions"
 				shouldHideNavButtons={ false }
-				className="is-step-site-migration-instructions"
+				className="is-step-site-migration-instructions site-migration-instructions-i2"
 				hideSkip={ true }
 				hideBack={ true }
 				formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -158,7 +158,7 @@ const SiteMigrationInstructions: Step = function () {
 			</ol>
 			<p
 				className={ classNames( 'fade-in', {
-					active: showFallback,
+					active: showFallback || showCopyIntoNewSite,
 				} ) }
 			>
 				{ translate(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/pending-actions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/pending-actions/index.tsx
@@ -12,12 +12,13 @@ interface VisualStateIndicatorProps {
 
 const VisualStateIndicator = ( { state, text }: VisualStateIndicatorProps ) => {
 	let icon: string | JSX.Element;
+
 	switch ( state ) {
 		case 'pending':
 			icon = <Spinner />;
 			break;
 		case 'success':
-			icon = <Icon icon={ check } width={ 20 } />;
+			icon = <Icon icon={ check } width={ 30 } />;
 			break;
 		case 'error':
 			icon = '❌';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/pending-actions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/pending-actions/index.tsx
@@ -29,9 +29,11 @@ const VisualStateIndicator = ( { state, text }: VisualStateIndicatorProps ) => {
 	}
 
 	return (
-		<span className="pending-actions__action">
+		<span
+			className={ classNames( 'pending-actions__action', `pending-actions__action--${ state }` ) }
+		>
 			{ text }
-			<span className="pending-actions__action--icon">{ icon }</span>
+			<span className="pending-actions__action-icon">{ icon }</span>
 		</span>
 	);
 };
@@ -51,39 +53,25 @@ export const PendingActions: FC< Props > = ( { status }: Props ) => {
 
 	return (
 		<div className="pending-actions">
-			<span>
+			<span className="pending-actions__loading">
 				{ translate( 'Wait until we finish setting up your site to continue' ) }
 				{ allIdle && <Spinner /> }
 			</span>
 			<ul className="pending-actions__list">
-				{ ! [ 'idle' ].includes( siteTransfer! ) && (
-					<li
-						className={ classNames( 'fade-in', {
-							active: siteTransfer !== 'idle',
-						} ) }
-					>
-						<VisualStateIndicator
-							state={ siteTransfer! }
-							text={ translate( 'Creating your site' ) }
-						/>
-					</li>
-				) }
-				<li
-					className={ classNames( 'fade-in', {
-						active: pluginInstallation !== 'idle',
-					} ) }
-				>
+				<li>
+					<VisualStateIndicator
+						state={ siteTransfer! }
+						text={ translate( 'Provisioning your new site' ) }
+					/>
+				</li>
+				<li>
 					<VisualStateIndicator
 						state={ pluginInstallation! }
 						text={ translate( 'Installing the required plugins' ) }
 					/>
 				</li>
 				{ migrationKey !== 'error' && (
-					<li
-						className={ classNames( 'fade-in', {
-							active: migrationKey !== 'idle',
-						} ) }
-					>
+					<li>
 						<VisualStateIndicator
 							state={ migrationKey! }
 							text={ translate( 'Getting the migration key' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/pending-actions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/pending-actions/index.tsx
@@ -26,10 +26,10 @@ const VisualStateIndicator = ( { state, text }: VisualStateIndicatorProps ) => {
 			icon = '';
 			break;
 	}
+
 	return (
 		<span className="pending-actions__action">
-			{ state === 'pending' && <em>{ text }</em> }
-			{ state !== 'pending' && text }
+			{ text }
 			<span className="pending-actions__action--icon">{ icon }</span>
 		</span>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/pending-actions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/pending-actions/style.scss
@@ -1,29 +1,39 @@
-.pending-actions {
-	.fade-in {
-		opacity: 0;
-		transition: opacity 0.3s ease-in-out;
-	}
-
-	.fade-in.active {
-		opacity: 1;
-	}
-
-	ul.pending-actions__list {
+:root .pending-actions {
+	.pending-actions__list {
 		margin-top: 5px;
+		margin-left: 3px;
+
+		li::before {
+			content: "\b7\a0";
+		}
+
 		li {
+			list-style: none;
 			margin-bottom: 0;
 		}
 	}
 
-	&__action {
+	.pending-actions__action {
+		height: 30px;
+		color: var(--studio-gray-40);
+		transition: color 0.3s ease-in-out;
 		display: inline-flex;
+	}
 
-		&--icon {
+	.pending-actions__action--success {
+		.pending-actions__action-icon {
 			fill: #008a20;
 		}
+	}
 
-		.components-spinner {
-			margin: 5px 11px -3px;
-		}
+	.pending-actions__action--success,
+	.pending-actions__action--pending,
+	.pending-actions__action--error {
+		color: var(--studio-gray-80);
+	}
+
+	.pending-actions__loading {
+		display: inline-flex;
+		height: 30px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/style.scss
@@ -3,31 +3,24 @@
 @import "@wordpress/base-styles/mixins";
 
 .site-migration-instructions-i2 {
+	.formatted-header {
+		padding-top: rem(26px);
+		margin-bottom: rem(52px);
+	}
+
 	.step-container {
 		padding: 0 1.5rem 1.5rem 1rem;
 		max-width: 654px;
-		min-height: calc(100svh - 2 * #{$header-height});
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
-
-	}
-
-	.step-container__content {
-		height: auto;
-		min-height: auto;
-	}
-	.step-container__header {
-		margin-top: 0;
-		margin-bottom: 2rem;
 	}
 
 	.site-migration-instructions__list {
 		margin-left: 18px;
-		margin-bottom: 12px;
 
-		li {
+		> li {
 			margin-bottom: 0.5rem;
 		}
 	}
@@ -43,22 +36,6 @@
 
 	.step-container__header p {
 		margin-top: 1.5rem;
-	}
-	.loading {
-		tab-size: 4;
-		min-height: calc(100vh - 2 * #{$header-height});
-		width: 100%;
-		display: flex;
-		justify-content: center;
-		flex-direction: column;
-		align-items: center;
-
-		.loading__content {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			gap: 1rem;
-		}
 	}
 
 	.fade-in {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #90226

## Proposed Changes
* Align the step to the top following the same spaces used on the site-migration-identify
* Use the correct bullet point on the pending actions
* Fix items jumping during the animation
* Fix page jumping when a new copy is presented. 

https://github.com/Automattic/wp-calypso/assets/38718/aacabd3e-0e6f-4949-a4ea-4d014f777de1


## Testing Instructions
* Go to the `/start` 
* Enable the feature flag via `sessionStorage.setItem('flags', 'migration-flow/remove-processing-step') ` + reload
* Go through the migration steps until the checkout page
* Check if the layout is equal to the video


## Screenshots 
<img width="934" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/2a1f4d60-74cc-42ce-bc65-a68b9774e13c">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?