### PR TITLE
Scheduled Updates multisite: mobile card view

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useDateTimeFormat } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-date-time-format';
 import { usePrepareMultisitePluginsTooltipInfo } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-plugins-tooltip-info';
 import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
-import { usePrepareSitesTooltipInfo } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-prepare-sites-tooltip-info';
 import { ScheduleListLastRunStatus } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status';
 import { ScheduleListTableRowMenu } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu';
 import { SiteSlug } from 'calypso/types';
@@ -23,12 +22,11 @@ type Props = {
 
 export const ScheduleListCard = ( props: Props ) => {
 	const { schedule, onEditClick, onRemoveClick, onLogsClick } = props;
-
-	const { prepareSitesTooltipInfo } = usePrepareSitesTooltipInfo();
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat();
-	const { preparePluginsTooltipInfo, countInstalledPlugins } =
-		usePrepareMultisitePluginsTooltipInfo( schedule.sites.map( ( site ) => site.ID ) );
+	const { preparePluginsTooltipInfo } = usePrepareMultisitePluginsTooltipInfo(
+		schedule.sites.map( ( site ) => site.ID )
+	);
 	const translate = useTranslate();
 	const [ isExpanded, setIsExpanded ] = useState( false );
 
@@ -43,6 +41,16 @@ export const ScheduleListCard = ( props: Props ) => {
 					>
 						{ prepareScheduleName( schedule as unknown as ScheduleUpdates ) }
 					</Button>
+					<span id="plugins">
+						<Tooltip
+							text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }
+							position="middle right"
+							delay={ 0 }
+							hideOnClick={ false }
+						>
+							<Icon className="icon-info" icon={ info } size={ 16 } />
+						</Tooltip>
+					</span>
 				</strong>
 				<ScheduleListTableRowMenu
 					schedule={ schedule }
@@ -50,21 +58,6 @@ export const ScheduleListCard = ( props: Props ) => {
 					onRemoveClick={ onRemoveClick }
 					onLogsClick={ onLogsClick }
 				/>
-			</div>
-
-			<div className="plugins-update-manager-multisite-card__label">
-				<label htmlFor="sites">{ translate( 'Sites' ) }</label>
-				<strong id="sites">
-					{ schedule.sites.length }{ ' ' }
-					<Tooltip
-						text={ prepareSitesTooltipInfo( schedule.sites ) as unknown as string }
-						position="middle right"
-						delay={ 0 }
-						hideOnClick={ false }
-					>
-						<Icon className="icon-info" icon={ info } size={ 16 } />
-					</Tooltip>
-				</strong>
 			</div>
 
 			<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
@@ -104,33 +97,6 @@ export const ScheduleListCard = ( props: Props ) => {
 			<div className="plugins-update-manager-multisite-card__label">
 				<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
 				<span id="next-update">{ prepareDateTime( schedule.timestamp ) }</span>
-			</div>
-
-			<div className="plugins-update-manager-multisite-card__label">
-				<label htmlFor="frequency">{ translate( 'Frequency' ) }</label>
-				<span id="frequency">
-					{
-						{
-							daily: translate( 'Daily' ),
-							weekly: translate( 'Weekly' ),
-						}[ schedule.schedule ]
-					}
-				</span>
-			</div>
-
-			<div className="plugins-update-manager-multisite-card__label">
-				<label htmlFor="plugins">{ translate( 'Plugins' ) }</label>
-				<span id="plugins">
-					{ countInstalledPlugins( schedule.args ) }
-					<Tooltip
-						text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }
-						position="middle right"
-						delay={ 0 }
-						hideOnClick={ false }
-					>
-						<Icon className="icon-info" icon={ info } size={ 16 } />
-					</Tooltip>
-				</span>
 			</div>
 		</div>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -34,15 +34,7 @@ export const ScheduleListCard = ( props: Props ) => {
 
 	return (
 		<div className="plugins-update-manager-multisite-card">
-			<ScheduleListTableRowMenu
-				schedule={ schedule }
-				onEditClick={ onEditClick }
-				onRemoveClick={ onRemoveClick }
-				onLogsClick={ onLogsClick }
-				className="plugins-update-manager-multisite-card__actions"
-			/>
-
-			<div className="plugins-update-manager-multisite-card__label">
+			<div className="plugins-update-manager-multisite-card__label  plugins-update-manager-multisite-card__name-label">
 				<strong id="name">
 					<Button
 						className="schedule-name"
@@ -52,6 +44,12 @@ export const ScheduleListCard = ( props: Props ) => {
 						{ prepareScheduleName( schedule as unknown as ScheduleUpdates ) }
 					</Button>
 				</strong>
+				<ScheduleListTableRowMenu
+					schedule={ schedule }
+					onEditClick={ onEditClick }
+					onRemoveClick={ onRemoveClick }
+					onLogsClick={ onLogsClick }
+				/>
 			</div>
 
 			<div className="plugins-update-manager-multisite-card__label">

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -1,0 +1,139 @@
+import { Button, Tooltip } from '@wordpress/components';
+import { chevronDown, chevronUp, Icon, info } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDateTimeFormat } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-date-time-format';
+import { usePrepareMultisitePluginsTooltipInfo } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-plugins-tooltip-info';
+import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
+import { usePrepareSitesTooltipInfo } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-prepare-sites-tooltip-info';
+import { ScheduleListLastRunStatus } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status';
+import { ScheduleListTableRowMenu } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu';
+import { SiteSlug } from 'calypso/types';
+import type {
+	MultisiteSchedulesUpdates,
+	ScheduleUpdates,
+} from 'calypso/data/plugins/use-update-schedules-query';
+
+type Props = {
+	schedule: MultisiteSchedulesUpdates;
+	onEditClick: ( id: string ) => void;
+	onRemoveClick: ( id: string ) => void;
+	onLogsClick: ( id: string, siteSlug: SiteSlug ) => void;
+};
+
+export const ScheduleListCard = ( props: Props ) => {
+	const { schedule, onEditClick, onRemoveClick, onLogsClick } = props;
+
+	const { prepareSitesTooltipInfo } = usePrepareSitesTooltipInfo();
+	const { prepareScheduleName } = usePrepareScheduleName();
+	const { prepareDateTime } = useDateTimeFormat();
+	const { preparePluginsTooltipInfo, countInstalledPlugins } =
+		usePrepareMultisitePluginsTooltipInfo( schedule.sites.map( ( site ) => site.ID ) );
+	const translate = useTranslate();
+	const [ isExpanded, setIsExpanded ] = useState( false );
+
+	return (
+		<div className="plugins-update-manager-multisite-card">
+			<ScheduleListTableRowMenu
+				schedule={ schedule }
+				onEditClick={ onEditClick }
+				onRemoveClick={ onRemoveClick }
+				onLogsClick={ onLogsClick }
+				className="plugins-update-manager-multisite-card__actions"
+			/>
+
+			<div className="plugins-update-manager-multisite-card__label">
+				<strong id="name">
+					<Button
+						className="schedule-name"
+						variant="link"
+						onClick={ () => onEditClick && onEditClick( schedule.id ) }
+					>
+						{ prepareScheduleName( schedule as unknown as ScheduleUpdates ) }
+					</Button>
+				</strong>
+			</div>
+
+			<div className="plugins-update-manager-multisite-card__label">
+				<label htmlFor="sites">{ translate( 'Sites' ) }</label>
+				<strong id="sites">
+					{ schedule.sites.length }{ ' ' }
+					<Tooltip
+						text={ prepareSitesTooltipInfo( schedule.sites ) as unknown as string }
+						position="middle right"
+						delay={ 0 }
+						hideOnClick={ false }
+					>
+						<Icon className="icon-info" icon={ info } size={ 16 } />
+					</Tooltip>
+				</strong>
+			</div>
+
+			<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
+				<label htmlFor="last-update">
+					{ translate( 'Last update' ) }
+					<Button variant="link" onClick={ () => setIsExpanded( ! isExpanded ) } size="small">
+						<Icon icon={ isExpanded ? chevronUp : chevronDown } />
+					</Button>
+				</label>
+				<button onClick={ () => setIsExpanded( ! isExpanded ) }>
+					<ScheduleListLastRunStatus schedule={ schedule } />
+				</button>
+			</div>
+
+			{ isExpanded && (
+				<div className="plugins-update-manager-multisite-card__sites">
+					{ schedule.sites.map( ( site ) => (
+						<div
+							key={ `${ schedule.schedule_id }.${ site.ID }` }
+							className="plugins-update-manager-multisite-card__sites-site"
+						>
+							<div className="plugins-update-manager-multisite-card__label">
+								<label htmlFor="name">{ translate( 'Name' ) }</label>
+								<strong id="name">{ site.title }</strong>
+							</div>
+							<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
+								<label htmlFor="last-update">{ translate( 'Last update' ) }</label>
+								<div>
+									<ScheduleListLastRunStatus schedule={ schedule } site={ site } />
+								</div>
+							</div>
+						</div>
+					) ) }
+				</div>
+			) }
+
+			<div className="plugins-update-manager-multisite-card__label">
+				<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
+				<span id="next-update">{ prepareDateTime( schedule.timestamp ) }</span>
+			</div>
+
+			<div className="plugins-update-manager-multisite-card__label">
+				<label htmlFor="frequency">{ translate( 'Frequency' ) }</label>
+				<span id="frequency">
+					{
+						{
+							daily: translate( 'Daily' ),
+							weekly: translate( 'Weekly' ),
+						}[ schedule.schedule ]
+					}
+				</span>
+			</div>
+
+			<div className="plugins-update-manager-multisite-card__label">
+				<label htmlFor="plugins">{ translate( 'Plugins' ) }</label>
+				<span id="plugins">
+					{ countInstalledPlugins( schedule.args ) }
+					<Tooltip
+						text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }
+						position="middle right"
+						delay={ 0 }
+						hideOnClick={ false }
+					>
+						<Icon className="icon-info" icon={ info } size={ 16 } />
+					</Tooltip>
+				</span>
+			</div>
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -62,14 +62,14 @@ export const ScheduleListCard = ( props: Props ) => {
 
 			<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
 				<label htmlFor="last-update">
-					{ translate( 'Last update' ) }
-					<Button variant="link" onClick={ () => setIsExpanded( ! isExpanded ) } size="small">
+					<Button variant="link" onClick={ () => setIsExpanded( ! isExpanded ) }>
+						{ translate( 'Last update' ) }
 						<Icon icon={ isExpanded ? chevronUp : chevronDown } />
 					</Button>
 				</label>
-				<button onClick={ () => setIsExpanded( ! isExpanded ) }>
+				<div>
 					<ScheduleListLastRunStatus schedule={ schedule } />
-				</button>
+				</div>
 			</div>
 
 			{ isExpanded && (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
@@ -1,0 +1,29 @@
+import { SiteSlug } from 'calypso/types';
+import { ScheduleListCard } from './schedule-list-card';
+import type { MultisiteSchedulesUpdates } from 'calypso/data/plugins/use-update-schedules-query';
+
+type Props = {
+	schedules: MultisiteSchedulesUpdates[];
+	onEditClick: ( id: string ) => void;
+	onRemoveClick: ( id: string ) => void;
+	onLogsClick: ( id: string, siteSlug: SiteSlug ) => void;
+	search?: string;
+};
+
+export const ScheduleListCards = ( props: Props ) => {
+	const { schedules, onEditClick, onLogsClick, onRemoveClick } = props;
+
+	return (
+		<div className="plugins-update-manager-multisite-cards">
+			{ schedules.map( ( schedule ) => (
+				<ScheduleListCard
+					schedule={ schedule }
+					onEditClick={ onEditClick }
+					onRemoveClick={ onRemoveClick }
+					onLogsClick={ onLogsClick }
+					key={ schedule.id }
+				/>
+			) ) }
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
@@ -1,0 +1,55 @@
+import { DropdownMenu } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { ellipsis } from 'calypso/blocks/plugins-scheduled-updates/icons';
+import { SiteSlug } from 'calypso/types';
+import type {
+	MultisiteSchedulesUpdates,
+	MultisiteSiteDetails,
+} from 'calypso/data/plugins/use-update-schedules-query';
+
+type Props = {
+	schedule: MultisiteSchedulesUpdates;
+	onEditClick: ( id: string ) => void;
+	onRemoveClick: ( id: string ) => void;
+	onLogsClick: ( id: string, siteSlug: SiteSlug ) => void;
+};
+
+export const ScheduleListTableRowMenu = ( {
+	schedule,
+	site,
+	onEditClick,
+	onRemoveClick,
+	onLogsClick,
+	className,
+}: Props & { site?: MultisiteSiteDetails; className?: string } ) => {
+	const translate = useTranslate();
+
+	const items = [
+		{
+			title: translate( 'Edit' ),
+			onClick: () => onEditClick( schedule.id ),
+		},
+	];
+
+	if ( site ) {
+		items.push( {
+			title: translate( 'Logs' ),
+			onClick: () => onLogsClick( schedule.schedule_id, site.slug ),
+		} );
+	}
+
+	items.push( {
+		title: translate( 'Remove' ),
+		onClick: () => onRemoveClick( schedule.schedule_id ),
+	} );
+
+	return (
+		<DropdownMenu
+			className={ className }
+			popoverProps={ { position: 'bottom left' } }
+			controls={ items }
+			icon={ ellipsis }
+			label={ translate( 'More' ) }
+		/>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
@@ -20,8 +20,7 @@ export const ScheduleListTableRowMenu = ( {
 	onEditClick,
 	onRemoveClick,
 	onLogsClick,
-	className,
-}: Props & { site?: MultisiteSiteDetails; className?: string } ) => {
+}: Props & { site?: MultisiteSiteDetails } ) => {
 	const translate = useTranslate();
 
 	const items = [
@@ -45,7 +44,6 @@ export const ScheduleListTableRowMenu = ( {
 
 	return (
 		<DropdownMenu
-			className={ className }
 			popoverProps={ { position: 'bottom left' } }
 			controls={ items }
 			icon={ ellipsis }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -1,17 +1,16 @@
-import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { chevronDown, chevronRight, Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDateTimeFormat } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-date-time-format';
 import { usePrepareMultisitePluginsTooltipInfo } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-plugins-tooltip-info';
 import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
-import { ellipsis } from 'calypso/blocks/plugins-scheduled-updates/icons';
 import { usePrepareSitesTooltipInfo } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-prepare-sites-tooltip-info';
 import { ScheduleListLastRunStatus } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status';
 import { SiteSlug } from 'calypso/types';
+import { ScheduleListTableRowMenu } from './schedule-list-table-row-menu';
 import type {
 	MultisiteSchedulesUpdates,
-	MultisiteSiteDetails,
 	ScheduleUpdates,
 } from 'calypso/data/plugins/use-update-schedules-query';
 
@@ -20,44 +19,6 @@ type Props = {
 	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
 	onLogsClick: ( id: string, siteSlug: SiteSlug ) => void;
-};
-
-const ScheduleListTableRowMenu = ( {
-	schedule,
-	site,
-	onEditClick,
-	onRemoveClick,
-	onLogsClick,
-}: Props & { site?: MultisiteSiteDetails } ) => {
-	const translate = useTranslate();
-
-	const items = [
-		{
-			title: translate( 'Edit' ),
-			onClick: () => onEditClick( schedule.id ),
-		},
-	];
-
-	if ( site ) {
-		items.push( {
-			title: translate( 'Logs' ),
-			onClick: () => onLogsClick( schedule.schedule_id, site.slug ),
-		} );
-	}
-
-	items.push( {
-		title: translate( 'Remove' ),
-		onClick: () => onRemoveClick( schedule.schedule_id ),
-	} );
-
-	return (
-		<DropdownMenu
-			popoverProps={ { position: 'bottom left' } }
-			controls={ items }
-			icon={ ellipsis }
-			label={ translate( 'More' ) }
-		/>
-	);
 };
 
 export const ScheduleListTableRow = ( props: Props ) => {

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -10,8 +10,9 @@ import { MultisitePluginUpdateManagerContext } from 'calypso/blocks/plugins-sche
 import { useBatchDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleErrors } from './schedule-errors';
+import { ScheduleListCards } from './schedule-list-cards';
+import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListFilter } from './schedule-list-filter';
 import { ScheduleListTable } from './schedule-list-table';
 
@@ -83,7 +84,7 @@ export const ScheduleList = ( props: Props ) => {
 		.filter( ( schedule ) => schedule.sites.length > 0 );
 
 	const isLoading = isLoadingSchedules;
-	const ScheduleListComponent = isMobile ? null : ScheduleListTable;
+	const ScheduleListComponent = isMobile ? ScheduleListCards : ScheduleListTable;
 	const isScheduleEmpty = schedules.length === 0 && isFetched;
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -180,6 +180,10 @@ $brand-display: "SF Pro Display", sans-serif;
 		&__last-update-label {
 			align-items: flex-start;
 
+			.components-button {
+				font-size: 0.875rem;
+			}
+
 			label {
 				display: inline-flex;
 				align-items: center;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -178,6 +178,8 @@ $brand-display: "SF Pro Display", sans-serif;
 		}
 
 		&__last-update-label {
+			align-items: flex-start;
+
 			label {
 				display: inline-flex;
 				align-items: center;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -1,8 +1,13 @@
 @import "~@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
 
 $brand-display: "SF Pro Display", sans-serif;
 
 .plugins-update-manager-multisite {
+	@media screen and (max-width: $break-small) {
+		margin: 1rem;
+	}
+
 	h1 {
 		font-size: 2rem;
 		margin-bottom: 1rem;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -140,4 +140,90 @@ $brand-display: "SF Pro Display", sans-serif;
 			line-height: 1.625;
 		}
 	}
+
+
+	.plugins-update-manager-multisite-card {
+		margin-bottom: 1rem;
+		border-bottom: solid 1px var(--studio-gray-5);
+
+		&__label {
+			font-size: 0.875rem;
+			margin-bottom: 0.75rem;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+
+			label {
+				display: block;
+				color: var(--studio-gray-40);
+			}
+
+			strong {
+				font-weight: 500;
+			}
+
+			.badge-component {
+				margin-inline-start: 0.5rem;
+			}
+		}
+
+		&__last-update-label {
+			label {
+				display: inline-flex;
+				align-items: center;
+			}
+
+			> div {
+				display: flex;
+				flex-direction: row-reverse;
+				align-items: center;
+
+				.badge-component {
+					margin-inline-end: 0;
+					padding: 0 9px;
+
+					svg {
+						top: 3px;
+						width: 18px;
+						height: 18px;
+					}
+				}
+			}
+		}
+
+		&__sites {
+			margin: 1rem -1rem;
+			background-color: $studio-gray-0;
+
+
+			&-site {
+				border-bottom: solid 1px var(--studio-gray-5);
+				padding-top: 1rem;
+
+				> div {
+					padding: 0 1rem 1rem 1rem;
+				}
+			}
+		}
+
+		&__actions {
+			position: absolute;
+			top: 0;
+			right: -10px;
+		}
+
+
+	}
+
+
+	.components-card__footer {
+		display: flex;
+		align-items: baseline;
+
+		.validation-msg {
+			width: 100%;
+		}
+	}
+
+
 }

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -167,6 +167,11 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 		}
 
+		&__name-label {
+			// Compensate for the big icon
+			margin-bottom: 0.75rem - rem(10px);
+		}
+
 		&__last-update-label {
 			label {
 				display: inline-flex;
@@ -205,13 +210,6 @@ $brand-display: "SF Pro Display", sans-serif;
 				}
 			}
 		}
-
-		&__actions {
-			position: absolute;
-			top: 0;
-			right: -10px;
-		}
-
 
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Adds the cards

![CleanShot 2024-05-03 at 14 44 08@2x](https://github.com/Automattic/wp-calypso/assets/528287/be5d5e76-faec-49a7-919d-ce3d58220f64)


## Testing Instructions

1. Apply this PR
2. Using a mobile viewport visit http://calypso.localhost:3000/plugins/scheduled-updates/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?