### PR TITLE
Global Sidebar - prevent collapsed state from bleeding into other areas.

### DIFF
--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -51,13 +51,13 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	sectionGroup: string,
 	sectionName: string
 ) => {
-	const isSitesDashboard = sectionGroup === 'sites-dashboard';
+	const isSitesDashboardSection = sectionGroup === 'sites-dashboard' || sectionGroup === 'sites';
 	const siteSelected = !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
 
 	return (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
-		isSitesDashboard &&
+		isSitesDashboardSection &&
 		( siteSelected || siteLoaded || isWithinBreakpoint( '<782px' ) )
 	);
 };

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -51,13 +51,13 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	sectionGroup: string,
 	sectionName: string
 ) => {
-	const isSitesDashboardSection = sectionGroup === 'sites-dashboard' || sectionGroup === 'sites';
-	const siteSelected = !! siteId;
+	const isAllowedRegion = sectionGroup === 'sites-dashboard' || sectionGroup === 'sites';
+	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
 
 	return (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
-		isSitesDashboardSection &&
+		isAllowedRegion &&
 		( siteSelected || siteLoaded || isWithinBreakpoint( '<782px' ) )
 	);
 };

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -51,11 +51,13 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	sectionGroup: string,
 	sectionName: string
 ) => {
-	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
+	const isSitesDashboard = sectionGroup === 'sites-dashboard';
+	const siteSelected = !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
 
 	return (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
+		isSitesDashboard &&
 		( siteSelected || siteLoaded || isWithinBreakpoint( '<782px' ) )
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to a bug we noticed while testing # https://github.com/Automattic/wp-calypso/pull/90229

## Proposed Changes

* Ensures we are on the sites dashboard before returning `true` from `getShouldShowCollapsedGlobalSidebar`

This fixes a weird bug that is semi difficult to repro. But if you go to the reader -> conversations (maybe not required this specific tab but it seemed to happen more here for me) -> reduce the width to mobile -> slowly expand width. You can see a point where the sidebar gets stuck in a collapsed state that it should never be in.

<img width="337" alt="Screenshot 2024-05-03 at 8 27 20 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a7df0416-af8a-497f-bc40-1810786840f5">

This PR resolves this issue. The `getShouldShowCollapsedGlobalSidebar` would return `true` simply for having the redesign flag and being under a specific breakpoint. It doesn't seem like it should ever return true if we aren't in section groups that require this behavior (I think that is limited to `sites-dashboard` and `sites` ?) .

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the sites dashboard and verify the collapsed mode works as expected.
* Verify you can not repro the above noted bug in the reader.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
