### PR TITLE
Nav redesign - fix blinking tooltip on hosting card

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -120,7 +120,17 @@ export function PlanStorage( {
 	);
 
 	const showTooltip = () => setTooltipVisible( true );
-	const hideTooltip = () => setTooltipVisible( false );
+	const hideTooltip = ( event ) => {
+		const relatedTarget = event?.relatedTarget;
+		// This checks if there is a blur event caused by the displaying of the tooltip.
+		// We don't want to move focus in this case, so return the focus to the target element.
+		if ( event?.type === 'blur' && relatedTarget?.closest?.( '.popover.tooltip.is-top' ) ) {
+			event.stopPropagation();
+			event.target.focus();
+			return;
+		}
+		setTooltipVisible( false );
+	};
 
 	if ( displayUpgradeLink ) {
 		return (
@@ -130,7 +140,7 @@ export function PlanStorage( {
 					href={ `/plans/${ siteSlug }` }
 					ref={ tooltipAnchorRef }
 					onMouseOver={ showTooltip }
-					onMouseOut={ hideTooltip }
+					onMouseLeave={ hideTooltip }
 					onFocus={ showTooltip }
 					onBlur={ hideTooltip }
 				>
@@ -150,7 +160,7 @@ export function PlanStorage( {
 					className={ classNames( className, 'plan-storage plan-storage__shared_quota' ) }
 					ref={ tooltipAnchorRef }
 					onMouseOver={ showTooltip }
-					onMouseOut={ hideTooltip }
+					onMouseLeave={ hideTooltip }
 					onFocus={ showTooltip }
 					onBlur={ hideTooltip }
 				>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/6897

<img width="484" alt="Screenshot 2024-05-03 at 15 49 04" src="https://github.com/Automattic/wp-calypso/assets/5560595/c90d5f62-f5b4-45c3-9f37-392cbafec64a">

There are 2 issues from what I can tell;
* The `mouseOut` appears to fire much more regularly than `mouseLeave` inside the card container, this alone stops the blinking.
* The other issue is when you tab to the "Need more storage?" link inside the card. The link immediately loses focus and the tooltip is also hidden.

## Before

https://github.com/Automattic/wp-calypso/assets/5560595/1ccd84f5-81b9-4478-a860-933f4037e8be

## After

https://github.com/Automattic/wp-calypso/assets/5560595/60144b61-1bfc-4c24-a3ba-19f489b8b116

## Proposed Changes

* Use 'mouseLeave' instead of `mouseOut` when hiding the tooltip to prevent the blinking.
* Adds a check when hiding the tooltip on the event that triggered it. It's possible that when the tooltip is shown, it causes whatever element is in focus, to lose focus (i.e. a blur event). We need to check blur events, if the related target is the tooltip, then we need to ignore this event and switch the focus back to where it started.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.live `/sites?flags=layout/dotcom-nav-redesign-v2` (with feature flag) and confirm the card works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?