### PR TITLE
E2E: Update test to still pass with released versions of Gutenberg

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -368,8 +368,9 @@ export class EditorSettingsSidebarComponent {
 	 */
 	async enterUrlSlug( slug: string ) {
 		const editorParent = await this.editor.parent();
-		await editorParent.getByRole( 'button', { name: /Change link:/ } ).click();
-		await editorParent.getByLabel( 'Link', { exact: true } ).fill( slug );
+		// TODO: Once WordPress/gutenberg#60632 is everywhere, remove the alternation.
+		await editorParent.getByRole( 'button', { name: /Change (link|URL):/ } ).click();
+		await editorParent.getByRole( 'textbox', { name: /^(Link|Permalink)$/ } ).fill( slug );
 		await editorParent.getByRole( 'button', { name: 'Close', exact: true } ).click();
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

PR #90225 updated a test to pass in the run against the nightly Gutenberg release after WordPress/gutenberg#60632 changed some labels. Unfortunately that broke the runs against released versions of Gutenberg.

This adjusts the test to match both the old and new labels, with a TODO comment pointing out that it can be adjusted once that Gutenberg change is released to all the environments we test against.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=default TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__page-basic-flow.ts`
* `yarn workspace wp-e2e-tests build && GUTENBERG_EDGE=1 TEST_ON_ATOMIC=true yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__page-basic-flow.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
