### PR TITLE
Segmentation Survey: Add support to required questions

### DIFF
--- a/client/components/survey-container/components/question-step.tsx
+++ b/client/components/survey-container/components/question-step.tsx
@@ -16,7 +16,7 @@ const questionTypeComponentMap = {
 
 export type QuestionSelectionComponentProps = {
 	question: Question;
-	value: string[];
+	value?: string[];
 	onChange: ( questionKey: string, value: string[] ) => void;
 	disabled?: boolean;
 };
@@ -30,7 +30,7 @@ type QuestionStepType = {
 
 const QuestionStep = ( {
 	question,
-	value,
+	value = [],
 	onChange,
 	onBack,
 	onContinue,
@@ -45,6 +45,7 @@ const QuestionStep = ( {
 		<StepContainer
 			className={ classNames( 'question-step', { disabled } ) }
 			hideBack={ hideBack }
+			hideSkip={ question.required }
 			goBack={ onBack }
 			goNext={ onSkip }
 			formattedHeader={
@@ -67,7 +68,7 @@ const QuestionStep = ( {
 						className="question-step__continue-button"
 						onClick={ onContinue }
 						variant="primary"
-						disabled={ disabled }
+						disabled={ disabled || ( question.required && value.length === 0 ) }
 					>
 						{ translate( 'Continue' ) }
 					</Button>

--- a/client/components/survey-container/index.tsx
+++ b/client/components/survey-container/index.tsx
@@ -34,7 +34,7 @@ const SurveyContainer = ( {
 	return (
 		<QuestionStep
 			question={ currentQuestion }
-			value={ answers[ currentQuestion.key ] || [] }
+			value={ answers[ currentQuestion.key ] }
 			onChange={ onChange }
 			onBack={ onBack }
 			onContinue={ onContinue }

--- a/client/components/survey-container/types.ts
+++ b/client/components/survey-container/types.ts
@@ -20,6 +20,7 @@ export type Question = {
 	subHeaderText?: string;
 	type: QuestionType;
 	options: Option[];
+	required: boolean;
 };
 
 export type Answers = Record< string, string[] >;

--- a/client/data/segmentaton-survey/queries/use-survey-structure-query.ts
+++ b/client/data/segmentaton-survey/queries/use-survey-structure-query.ts
@@ -11,6 +11,7 @@ type SurveyStructureResponse = {
 	key: string;
 	sub_header_text: string;
 	type: string;
+	required?: boolean;
 	options: {
 		label: string;
 		value: string;
@@ -32,6 +33,7 @@ const mapSurveyStructureResponse = ( response: SurveyStructureResponse ): Questi
 			} ),
 			subHeaderText: question.sub_header_text,
 			type: QuestionType[ question.type.toUpperCase() as keyof typeof QuestionType ],
+			required: !! question.required,
 		};
 	} );
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/90281

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?