### PR TITLE
Segmentation Survey: Add support to custom navigation based on user answers

### DIFF
--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -12,8 +12,8 @@ import useSegmentationSurveyNavigation from './hooks/use-segmentation-survey-nav
 
 type SegmentationSurveyProps = {
 	surveyKey: string;
-	onBack?: () => void; // This is a function that navigates to the previous step
-	onNext?: ( questionKey: string, answerKeys: string[], isLastQuestion?: boolean ) => void; // This is a function that navigates to the next question/step
+	onBack?: () => void;
+	onNext?: ( questionKey: string, answerKeys: string[], isLastQuestion?: boolean ) => void;
 };
 
 /**

--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import SurveyContainer from 'calypso/components/survey-container';
 import { Question } from 'calypso/components/survey-container/types';
@@ -13,10 +13,18 @@ import useSegmentationSurveyNavigation from './hooks/use-segmentation-survey-nav
 type SegmentationSurveyProps = {
 	surveyKey: string;
 	onBack?: () => void; // This is a function that navigates to the previous step
-	onComplete?: () => void; // This is a function that navigates to the next step
+	onNext?: ( questionKey: string, answerKeys: string[], isLastQuestion?: boolean ) => void; // This is a function that navigates to the next question/step
 };
 
-const SegmentationSurvey = ( { surveyKey, onBack, onComplete }: SegmentationSurveyProps ) => {
+/**
+ * A component that renders a segmentation survey.
+ * @param {SegmentationSurveyProps} props
+ * @param {string} props.surveyKey - The key of the survey to render.
+ * @param {() => void} [props.onBack] - A function that navigates to the previous step.
+ * @param {(questionKey: string, answerKeys: string[], isLastQuestion?: boolean) => void} [props.onNext] - A function that navigates to the next question/step.
+ * @returns {React.ReactComponentElement}
+ */
+const SegmentationSurvey = ( { surveyKey, onBack, onNext }: SegmentationSurveyProps ) => {
 	const { data: questions } = useSurveyStructureQuery( { surveyKey } );
 	const { mutateAsync, isPending } = useSaveAnswersMutation( { surveyKey } );
 	const { answers, setAnswers, clearAnswers } = useCachedAnswers( surveyKey );
@@ -37,10 +45,13 @@ const SegmentationSurvey = ( { surveyKey, onBack, onComplete }: SegmentationSurv
 					answerKeys,
 				} );
 
+				const isLastQuestion = questions?.[ questions.length - 1 ].key === currentQuestion.key;
+
 				if ( questions?.[ questions.length - 1 ].key === currentQuestion.key ) {
 					clearAnswers();
-					onComplete?.();
 				}
+
+				onNext?.( currentQuestion.key, answerKeys, isLastQuestion );
 			} catch ( e ) {
 				const error = e as Error;
 
@@ -52,7 +63,7 @@ const SegmentationSurvey = ( { surveyKey, onBack, onComplete }: SegmentationSurv
 				} );
 			}
 		},
-		[ clearAnswers, mutateAsync, onComplete, questions, surveyKey ]
+		[ clearAnswers, mutateAsync, onNext, questions, surveyKey ]
 	);
 
 	const onContinue = useCallback(

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -14,6 +14,8 @@ import { ProcessingResult } from './internals/steps-repository/processing-step/c
 import type { Flow, ProvidedDependencies } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
 
+const SEGMENTATION_SURVEY_SLUG = 'start';
+
 const entrepreneurFlow: Flow = {
 	name: ENTREPRENEUR_FLOW,
 
@@ -23,7 +25,7 @@ const entrepreneurFlow: Flow = {
 		return [
 			// Replacing the `segmentation-survey` slug with `start` as having the
 			// word `survey` in the address bar might discourage users from continuing.
-			{ ...STEPS.SEGMENTATION_SURVEY, ...{ slug: 'start' } },
+			{ ...STEPS.SEGMENTATION_SURVEY, ...{ slug: SEGMENTATION_SURVEY_SLUG } },
 			STEPS.SITE_CREATION_STEP,
 			STEPS.PROCESSING,
 			STEPS.WAIT_FOR_ATOMIC,
@@ -72,9 +74,9 @@ const entrepreneurFlow: Flow = {
 			recordSubmitStep( providedDependencies, '' /* intent */, flowName, currentStep );
 
 			switch ( currentStep ) {
-				case 'start': {
+				case SEGMENTATION_SURVEY_SLUG: {
 					if ( userIsLoggedIn ) {
-						return navigate( 'create-site' );
+						return navigate( STEPS.SITE_CREATION_STEP.slug );
 					}
 
 					// Redirect user to the sign-in/sign-up page before site creation.
@@ -82,23 +84,23 @@ const entrepreneurFlow: Flow = {
 					return window.location.replace( entrepreneurLoginUrl );
 				}
 
-				case 'create-site': {
-					return navigate( 'processing', {
+				case STEPS.SITE_CREATION_STEP.slug: {
+					return navigate( STEPS.PROCESSING.slug, {
 						currentStep,
 					} );
 				}
 
-				case 'processing': {
+				case STEPS.PROCESSING.slug: {
 					const processingResult = params[ 0 ] as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
-						return navigate( 'error' );
+						return navigate( STEPS.ERROR.slug );
 					}
 
 					const { siteId, siteSlug } = providedDependencies;
 
 					if ( providedDependencies?.finishedWaitingForAtomic ) {
-						return navigate( 'waitForPluginInstall', { siteId, siteSlug } );
+						return navigate( STEPS.WAIT_FOR_PLUGIN_INSTALL.slug, { siteId, siteSlug } );
 					}
 
 					if ( providedDependencies?.pluginsInstalled ) {
@@ -120,17 +122,17 @@ const entrepreneurFlow: Flow = {
 						return window.location.assign( redirectToWithSSO );
 					}
 
-					return navigate( 'waitForAtomic', { siteId, siteSlug } );
+					return navigate( STEPS.WAIT_FOR_ATOMIC.slug, { siteId, siteSlug } );
 				}
 
-				case 'waitForAtomic': {
-					return navigate( 'processing', {
+				case STEPS.WAIT_FOR_ATOMIC.slug: {
+					return navigate( STEPS.PROCESSING.slug, {
 						currentStep,
 					} );
 				}
 
-				case 'waitForPluginInstall': {
-					return navigate( 'processing' );
+				case STEPS.WAIT_FOR_PLUGIN_INSTALL.slug: {
+					return navigate( STEPS.PROCESSING.slug );
 				}
 			}
 			return providedDependencies;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -1,17 +1,53 @@
 import Main from 'calypso/components/main';
 import SegmentationSurvey from 'calypso/components/segmentation-survey';
-import type { Step } from '../../types';
+import { useCachedAnswers } from 'calypso/data/segmentaton-survey';
+import type { ProvidedDependencies, Step } from '../../types';
 import './style.scss';
 
 const SURVEY_KEY = 'entrepreneur-trial';
 
+type NavigationDecision = {
+	proceedWithNavigation: boolean;
+	providedDependencies: ProvidedDependencies;
+};
+
+const shouldNavigate = (
+	questionKey: string,
+	answerKeys: string[],
+	isLastQuestion?: boolean
+): NavigationDecision => {
+	return {
+		proceedWithNavigation: !! isLastQuestion,
+		providedDependencies: {},
+	};
+};
+
 const SegmentationSurveyStep: Step = ( { navigation } ) => {
+	const { clearAnswers } = useCachedAnswers( SURVEY_KEY );
+
+	const handleNext = ( questionKey: string, answerKeys: string[], isLastQuestion?: boolean ) => {
+		const { proceedWithNavigation, providedDependencies } = shouldNavigate(
+			questionKey,
+			answerKeys,
+			isLastQuestion
+		);
+
+		if ( proceedWithNavigation ) {
+			// For custom navigation, we need to clear the answers before the last question
+			if ( ! isLastQuestion ) {
+				clearAnswers();
+			}
+
+			navigation.submit?.( providedDependencies );
+		}
+	};
+
 	return (
 		<Main className="segmentation-survey-step">
 			<SegmentationSurvey
 				surveyKey={ SURVEY_KEY }
 				onBack={ navigation.goBack }
-				onComplete={ navigation.submit }
+				onNext={ handleNext }
 			/>
 		</Main>
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/90227

## Proposed Changes

This PR follows up on the POC (see https://github.com/Automattic/wp-calypso/pull/90235), making the component compatible with custom navigation based on answers.

* Replaced `onComplete` with `onNext` prop, passing question and answer keys.
* Updated SegmentationSurveyStep to be compatible with the onNext format

## Testing Instructions

* Apply this PR to your local
* First, perform regression tests on the existing survey features
* Then you need to apply some changes to the code, I recommend checking how it's done on the POC PR: https://github.com/Automattic/wp-calypso/pull/90235
* Introduce a condition to the `client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx`, on the `shouldNavigate` function, checking for question/answer keys, and updating the `providedDependencies` with a testing flag
* Go to the `submit` callback on the entrepreneur flow `client/components/segmentation-survey/index.tsx`
* Introduce a condition to verify if the flag is available on the `providedDependencies`, and if true, navigate to another step/flow
* Perform some tests to make sure the navigation based on answers is working as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?