### PR TITLE
Update e2e tests to reflect that drafts are now part of post status

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -16,6 +16,10 @@ const selectors = {
 
 	// Preview
 	previewButton: `${ panel } :text("View"):visible, [aria-label="View"]:visible`,
+
+	// Post status
+	postStatusButton: `button.editor-post-status-trigger`,
+
 	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
 		`button[role="menuitem"] span:text("${ target }")`,
 	previewPane: `.edit-post-visual-editor`,
@@ -265,7 +269,7 @@ export class EditorToolbarComponent {
 	 *
 	 * This is applicable for the following scenarios:
 	 * 	- publish of a new article (Publish)
-	 * 	- update an existing article (Update)
+	 * 	- update/save an existing article (Update)
 	 * 	- schedule a post (Schedule)
 	 */
 	async clickPublish(): Promise< void > {
@@ -282,6 +286,11 @@ export class EditorToolbarComponent {
 		const editorParent = await this.editor.parent();
 
 		await Promise.race( [
+			( async () => {
+				// Works with Gutenberg >=v18.2.0
+				await editorParent.locator( selectors.postStatusButton ).click();
+				await editorParent.getByRole( 'radio', { name: 'Draft' } ).click();
+			} )(),
 			( async () => {
 				// Works with Gutenberg >=v15.8.0
 				await this.openSettings( 'Settings' );

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -709,7 +709,7 @@ export class EditorPage {
 		// is merely being updated.
 		// If not yet published, a second click on the EditorPublishPanelComponent
 		// is added to the array of actions.
-		if ( publishButtonText.toLowerCase() !== 'update' ) {
+		if ( publishButtonText.toLowerCase() !== 'save' ) {
 			actionsArray.push( this.editorPublishPanelComponent.publish() );
 		}
 
@@ -769,10 +769,10 @@ export class EditorPage {
 	 */
 	async unpublish(): Promise< void > {
 		const editorParent = await this.editor.parent();
-
 		await this.editorToolbarComponent.switchToDraft();
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
-		await editorParent.getByRole( 'button' ).getByText( 'OK' ).click();
+		// Saves the draft
+		await this.editorToolbarComponent.clickPublish();
 		// @TODO: eventually refactor this out to a EditorToastNotificationComponent.
 		await editorParent.getByRole( 'button', { name: 'Dismiss this notice' } ).waitFor();
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -706,10 +706,10 @@ export class EditorPage {
 		actionsArray.push( this.editorToolbarComponent.clickPublish() );
 
 		// Determine whether the post/page is yet to be published or the post/page
-		// is merely being updated.
+		// is merely being saved/updated.
 		// If not yet published, a second click on the EditorPublishPanelComponent
 		// is added to the array of actions.
-		if ( publishButtonText.toLowerCase() !== 'save' ) {
+		if ( ! [ 'save', 'update' ].includes( publishButtonText.toLowerCase() ) ) {
 			actionsArray.push( this.editorPublishPanelComponent.publish() );
 		}
 
@@ -772,7 +772,10 @@ export class EditorPage {
 		await this.editorToolbarComponent.switchToDraft();
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
 		// Saves the draft
-		await this.editorToolbarComponent.clickPublish();
+		Promise.race( [
+			this.editorToolbarComponent.clickPublish(),
+			editorParent.getByRole( 'button' ).getByText( 'OK' ).click(),
+		] );
 		// @TODO: eventually refactor this out to a EditorToastNotificationComponent.
 		await editorParent.getByRole( 'button', { name: 'Dismiss this notice' } ).waitFor();
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -772,7 +772,7 @@ export class EditorPage {
 		await this.editorToolbarComponent.switchToDraft();
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
 		// Saves the draft
-		Promise.race( [
+		await Promise.race( [
 			this.editorToolbarComponent.clickPublish(),
 			editorParent.getByRole( 'button' ).getByText( 'OK' ).click(),
 		] );


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/90290
Related: https://github.com/WordPress/gutenberg/pull/60456

The UI for unpublishing a post has [changed](https://github.com/WordPress/gutenberg/pull/60456) such that you now have to interact with the post status panel pop out. Also, the `Update` CTA text has changed to `save`

This is currently breaking some nightly e2e tests for Gutenberg. This change modifies the e2e's expectations to fit the new realities.

Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

Run the page basic flow e2e edge tests for Simple and AT sites, which were failing before this fix:

```bash
cd test/e2e
yarn jest --clearCache && yarn build 
GUTENBERG_EDGE=1 yarn jest specs/editor/editor__post-advanced-flow.ts
GUTENBERG_EDGE=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__post-advanced-flow.ts
```