### PR TITLE
Nav Redesign - fix color scheme switch when viewing GSV

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -222,10 +222,20 @@ class Layout extends Component {
 		this.refreshColorScheme( undefined, this.props.colorScheme );
 	}
 
+	/**
+	 * Refresh the color scheme if
+	 * - the color scheme has changed
+	 * - the global sidebar is visible and the color scheme is not `modern`
+	 * - the global sidebar was visible and is now hidden and the color scheme is not `modern`
+	 * @param prevProps object
+	 */
 	componentDidUpdate( prevProps ) {
 		if (
 			prevProps.colorScheme !== this.props.colorScheme ||
-			( this.props.isGlobalSidebarVisible && this.props.colorScheme !== 'modern' )
+			( this.props.isGlobalSidebarVisible && this.props.colorScheme !== 'modern' ) ||
+			( prevProps.isGlobalSidebarVisible &&
+				! this.props.isGlobalSidebarVisible &&
+				this.props.colorScheme !== 'modern' )
 		) {
 			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/90158

This fixes an issue where you switch from the new dashboard to the global site view dashboard, the dashboard does not use the users color scheme unless you refresh the page.

![nav-colors-uh-ohs](https://github.com/Automattic/wp-calypso/assets/5560595/d1390142-8936-419b-a361-f655a652481f)

## Proposed Changes

* This updates the layout `componentDidUpdate` to refresh the color scheme when moving from a page with a global sidebar to a page without one and the users color scheme is not already modern.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change the color scheme to something other than `modern`
* Go to the calypso live `/sites?flags=layout/dotcom-nav-redesign-v2` (with feature flag)
* Go to a site with a global site view, go to the actions->settings in table and it should load the GSV for that site
* The site should load with the correct color scheme

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?