### PR TITLE
A4A: fix wpcom hosting purchase flow descriptions

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -62,6 +62,22 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 	if ( ! productDescription ) {
 		return null;
 	}
+	const countInfo =
+		product.family_slug === 'wpcom-hosting'
+			? translate( '%(numLicenses)d site', '%(numLicenses)d sites', {
+					context: 'button label',
+					count: product.quantity,
+					args: {
+						numLicenses: product.quantity,
+					},
+			  } )
+			: translate( '%(numLicenses)d plan', '%(numLicenses)d plans', {
+					context: 'button label',
+					count: product.quantity,
+					args: {
+						numLicenses: product.quantity,
+					},
+			  } );
 
 	return (
 		<div className="product-info">
@@ -73,15 +89,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 					<label htmlFor={ productTitle } className="product-info__label">
 						{ productTitle }
 					</label>
-					<span className="product-info__count">
-						{ translate( '%(numLicenses)d plan', '%(numLicenses)d plans', {
-							context: 'button label',
-							count: product.quantity,
-							args: {
-								numLicenses: product.quantity,
-							},
-						} ) }
-					</span>
+					<span className="product-info__count">{ countInfo }</span>
 				</div>
 				<p className="product-info__description">{ productDescription }</p>
 			</div>

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -55,8 +55,8 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier, ownedPl
 
 					<span>
 						{ translate(
-							'You own {{b}}%(count)s plan{{/b}}',
-							'You own {{b}}%(count)s plans{{/b}}',
+							'You own {{b}}%(count)s site{{/b}}',
+							'You own {{b}}%(count)s sites{{/b}}',
 							{
 								args: {
 									count: ownedPlans,
@@ -65,7 +65,7 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier, ownedPl
 									b: <strong />,
 								},
 								count: ownedPlans,
-								comment: '%(count)s is the number of WordPress.com plans owned by the user',
+								comment: '%(count)s is the number of WordPress.com sites owned by the user',
 							}
 						) }
 					</span>

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -49,8 +49,8 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect }: P
 							</>
 						) }
 						<div className="wpcom-plan-card__price-interval">
-							{ plan.price_interval === 'day' && translate( 'USD per site per day' ) }
-							{ plan.price_interval === 'month' && translate( 'USD per site per month' ) }
+							{ plan.price_interval === 'day' && translate( 'USD per day' ) }
+							{ plan.price_interval === 'month' && translate( 'USD per month' ) }
 						</div>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import useWPCOMPlanDescription from '../../marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description';
 
 export default function PurchaseConfirmationMessage() {
 	const translate = useTranslate();
@@ -15,7 +14,6 @@ export default function PurchaseConfirmationMessage() {
 		'' ) as string;
 
 	const [ successNotification, setSuccessNotification ] = useState< boolean >( false );
-	const [ hostingPlanSlug, setHostingPlanSlug ] = useState< string >( '' );
 
 	// Set the success notification when a WPCOM hosting plan is purchased and remove the query arg from the URL
 	useEffect( () => {
@@ -26,7 +24,6 @@ export default function PurchaseConfirmationMessage() {
 					hosting_plan: wpcomHostingPurchased,
 				} )
 			);
-			setHostingPlanSlug( wpcomHostingPurchased );
 			page(
 				removeQueryArgs(
 					window.location.pathname + window.location.search,
@@ -36,29 +33,14 @@ export default function PurchaseConfirmationMessage() {
 		}
 	}, [ dispatch, wpcomHostingPurchased ] );
 
-	const { name } = useWPCOMPlanDescription( hostingPlanSlug );
-
 	return successNotification ? (
 		<NoticeBanner
 			level="success"
-			title={
-				translate( 'Congratulations on your WordPress.com %(name)s purchase!', {
-					args: {
-						name,
-					},
-					comment: '%(name)s is the WPCOM plan name.',
-				} ) as string
-			}
+			title={ translate( 'Congratulations on your WordPress.com purchase!' ) }
 			onClose={ () => setSuccessNotification( false ) }
 		>
 			{ translate(
-				'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.',
-				{
-					args: {
-						name,
-					},
-					comment: '%(name)s is the WPCOM plan name.',
-				}
+				'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.'
 			) }
 		</NoticeBanner>
 	) : null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/434

## Proposed Changes

Some wording changes. Please see the original issue for the list.
Note: prices are not addressed in this PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- This PR covers WPCOM hosting purchase flow from `/marketplace/hosting/wpcom` to after purchase. Please verify that there are proper descriptions (eg. usage of `sites` vs `plans`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?