### PR TITLE
Newsletter: Only update jetpack form fields that are dirty

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -243,17 +243,19 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 				this.props;
 			this.props.removeNotice( 'site-settings-save' );
 			debug( 'submitForm', { fields, settingsFields } );
+			const siteFields = pick( fields, settingsFields.site );
+			const modifiedFields = pick( siteFields, dirtyFields );
 
-			if ( siteIsJetpack && Object.keys( jetpackFieldsToUpdate ).length > 0 ) {
-				this.props.saveJetpackSettings( siteId, jetpackFieldsToUpdate );
+			const modifiedJetpackFields = pick( jetpackFieldsToUpdate, dirtyFields );
+			const jetpackOnlyModifiedFields = omit( modifiedJetpackFields, keys( modifiedFields ) );
+
+			if ( siteIsJetpack && Object.keys( jetpackOnlyModifiedFields ).length > 0 ) {
+				this.props.saveJetpackSettings( siteId, jetpackOnlyModifiedFields );
 			}
 
 			if ( typeof fields?.p2_preapproved_domains !== 'undefined' ) {
 				return this.props.saveP2SiteSettings( siteId, fields );
 			}
-
-			const siteFields = pick( fields, settingsFields.site );
-			const modifiedFields = pick( siteFields, dirtyFields );
 
 			this.props.saveSiteSettings( siteId, modifiedFields );
 


### PR DESCRIPTION
Currently when we save jetpack setting we make 2 endpoint calls. 
1 for jetpack and other to the site settings endpoint. 
This results in the same setting being saved twice. 

This PR tries to fix this my calculating the settings that should only be saved via site setting endpoint and if there are any settings that are only to be saved via the jetpack settings then we use those settings. 

This Pr intends to fix the https://github.com/Automattic/wp-calypso/issues/89109 

## Proposed Changes

* Reduce the API requests to the jetpack settings endpoint. Since they are causing issues with the form fields saving the option multiple times. 

## Testing Instructions
* For a jetpack site. Visit /settings/newsletter/example.com and notice that you are able to save all the different settings as expected. 
* Notice that only one POST request is made to the site as expected. 
* Since this change also applies to other Jetpack settings. 
* Navigate to other parts of calypso and notice that settings save as expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?