### PR TITLE
A4A: Hosting Marketplace Updates

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -4,12 +4,12 @@ import { useMemo } from 'react';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
 import {
 	A4A_MARKETPLACE_LINK,
-	A4A_MARKETPLACE_PRODUCTS_LINK,
 	A4A_LICENSES_LINK,
 	A4A_OVERVIEW_LINK,
 	A4A_PURCHASES_LINK,
 	A4A_REFERRALS_LINK,
 	A4A_SITES_LINK,
+	A4A_MARKETPLACE_HOSTING_LINK,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -51,7 +51,7 @@ const useMainMenuItems = ( path: string ) => {
 			{
 				icon: tag,
 				path: A4A_MARKETPLACE_LINK,
-				link: A4A_MARKETPLACE_PRODUCTS_LINK,
+				link: A4A_MARKETPLACE_HOSTING_LINK,
 				title: translate( 'Marketplace' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Marketplace',

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-marketplace-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-marketplace-menu-items.ts
@@ -14,24 +14,24 @@ const useMarketplaceMenuItems = ( path: string ) => {
 		return [
 			createItem(
 				{
-					icon: plugins,
-					path: A4A_MARKETPLACE_LINK,
-					link: A4A_MARKETPLACE_PRODUCTS_LINK,
-					title: translate( 'Products' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Marketplace / Products',
-					},
-				},
-				path
-			),
-			createItem(
-				{
 					icon: tool,
 					path: A4A_MARKETPLACE_LINK,
 					link: A4A_MARKETPLACE_HOSTING_LINK,
 					title: translate( 'Hosting' ),
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Marketplace / Hosting',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: plugins,
+					path: A4A_MARKETPLACE_LINK,
+					link: A4A_MARKETPLACE_PRODUCTS_LINK,
+					title: translate( 'Products' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Marketplace / Products',
 					},
 				},
 				path

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -1,6 +1,6 @@
 import { type Callback } from '@automattic/calypso-router';
 import page from '@automattic/calypso-router';
-import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_MARKETPLACE_HOSTING_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import getSites from 'calypso/state/selectors/get-sites';
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
@@ -12,7 +12,7 @@ import ProductsOverview from './products-overview';
 import WpcomOverview from './wpcom-overview';
 
 export const marketplaceContext: Callback = () => {
-	page.redirect( A4A_MARKETPLACE_PRODUCTS_LINK );
+	page.redirect( A4A_MARKETPLACE_HOSTING_LINK );
 };
 
 export const marketplaceProductsContext: Callback = ( context, next ) => {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
@@ -23,7 +23,7 @@ export default function useHostingDescription( slug: string ): {
 			case 'pressable-hosting':
 				name = translate( 'Pressable' );
 				description = translate(
-					'Best for developers and agencies who need advanced hosting controls and management tools.'
+					'Best for premier agencies and developers who need significant control and build sites that require scaling.'
 				);
 				features = [
 					translate( 'Optimized for high-traffic WooCommerce stores {{img/}}', {
@@ -31,28 +31,22 @@ export default function useHostingDescription( slug: string ): {
 							img: <WooCommerceLogo size={ 32 } />,
 						},
 					} ),
+					translate( '24/7 Expert Support with expanded support options' ),
+					translate( '20GB-1TB Storage' ),
 					translate( '100% uptime SLA' ),
-					translate( 'Great for teams with granular permission needs' ),
-					translate( 'Tooling to help you manage sites at scale with one-click config options' ),
-					translate( 'White-label tools for agencies' ),
-					translate(
-						'Partner sales concierge to assist with custom plans and complex purchasing requirements'
-					),
-					translate( 'Multiple support channels: Email, web chat, and Slack.' ),
-					translate( 'Decoupled (headless) support' ),
+					translate( 'Custom pricing and packaging are available' ),
+					translate( 'Agency tools to manage sites at scale' ),
 				];
 				break;
 			case 'wpcom-hosting':
 				name = translate( 'WordPress.com' );
-				description = translate(
-					'Best for those who want optimized, hassle-free WordPress hosting.'
-				);
+				description = translate( 'Best for those who want a hassle-free WordPress experience.' );
 				features = [
-					translate( 'Great for developers with client-managed sites' ),
-					translate( 'Unlimited visits' ),
-					translate( '50GB storage' ),
+					translate( 'Great for developers with client-managed sites.' ),
+					translate( '24/7 Expert Support' ),
+					translate( '50 GB Storage' ),
 					translate( 'Self-service sales' ),
-					translate( 'Local development environment, Studio' ),
+					translate( 'Studio (local dev)' ),
 				];
 				break;
 			case 'vip':

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
@@ -45,6 +45,7 @@ export default function useHostingDescription( slug: string ): {
 					translate( 'Great for developers with client-managed sites.' ),
 					translate( '24/7 Expert Support' ),
 					translate( '50 GB Storage' ),
+					translate( 'Unmetered Visits' ),
 					translate( 'Self-service sales' ),
 					translate( 'Studio (local dev)' ),
 				];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/426

## Proposed Changes

* Make the hosting section the first/primary "marketplace" navigation item.
* Update the copy on the hosting overview page (see task).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click the "marketplace" sidebar menu, ensure you are redirected to the hosting page.
* Go directly to the `/marketplace` link, ensure you are redirected to the hosting page.
* Ensure the hosting sub-nav item under Marketplace is the first item.
* Review the updated copy on `/marketplace/hosting`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1527" alt="Screenshot 2024-05-03 at 4 10 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/0c33b9b3-9bbf-4315-8451-57cf72684276">

