### PR TITLE
A4A: Remove note from migration incentives card

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -24,12 +24,10 @@ const MigrationOfferBody = () => {
 	const description = translate(
 		'Migrate your clients sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2024. You’ll also receive an additional $100 for each migrated site—up to $3,000 until July 31, 2024.'
 	);
-	const note = translate( 'Must have 3 or more sites to be eligible.' );
 
 	return (
 		<>
 			<p className="a4a-migration-offer__description">{ description }</p>
-			<p className="a4a-migration-offer__note">{ note }</p>
 			<Button
 				className="a4a-migration-offer__chat-button"
 				href="mailto:partnerships@automattic.com"

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -46,13 +46,6 @@
 		line-height: 32px;
 	}
 
-	.a4a-migration-offer__note {
-		font-size: 0.875rem;
-		font-style: italic;
-		font-weight: 400;
-		margin-block-end: 24px;
-	}
-
 	.a4a-migration-offer__details-button {
 		margin-inline-start: 10px;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/435

## Proposed Changes

* Removes the "Must have 3 or more sites to be eligible" note from the migration incentives card.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the /overview page and review the card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="805" alt="Screenshot 2024-05-03 at 4 32 34 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/94b0d640-d2cc-42b4-95be-05e3f0f48d6a">

