### PR TITLE
Trail Map: Best for ecommerce label for ecommerce plan

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -14,6 +14,7 @@ import {
 	getWooExpressFeaturesGrouped,
 	getPlanFeaturesGrouped,
 	isWooExpressPlan,
+	PLAN_ECOMMERCE,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -40,7 +41,7 @@ import {
 } from '@wordpress/element';
 import { hasQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
-import { localize, useTranslate } from 'i18n-calypso';
+import { TranslateResult, localize, useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
@@ -411,6 +412,13 @@ const PlansFeaturesMain = ( {
 		useFreeTrialPlanSlugs,
 	} );
 
+	let highlightLabelOverrides: { [ K in PlanSlug ]?: TranslateResult } | undefined;
+	if ( isTrailMapAny ) {
+		highlightLabelOverrides = {
+			[ PLAN_ECOMMERCE ]: translate( 'Best for eCommerce' ),
+		};
+	}
+
 	// we need only the visible ones for features grid (these should extend into plans-ui data store selectors)
 	const gridPlansForFeaturesGridRaw = useGridPlansForFeaturesGrid( {
 		allFeaturesList: getFeaturesList(),
@@ -430,6 +438,7 @@ const PlansFeaturesMain = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
+		highlightLabelOverrides,
 	} );
 
 	// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.

--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -1,5 +1,6 @@
 import { FeatureList, PlanSlug, TERMS_LIST } from '@automattic/calypso-products';
 import { AddOnMeta, Plans } from '@automattic/data-stores';
+import { TranslateResult } from 'i18n-calypso';
 import { GridPlan, HiddenPlans, PlansIntent } from '../../types';
 import { UseFreeTrialPlanSlugs } from './use-grid-plans';
 
@@ -21,6 +22,10 @@ export interface UseGridPlansParams {
 	term?: ( typeof TERMS_LIST )[ number ]; // defaults to monthly
 	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
 	useFreeTrialPlanSlugs?: UseFreeTrialPlanSlugs;
+	/**
+	 * Provide a map of plan slug keyed strings to display as the highlight label on top of each plan.
+	 */
+	highlightLabelOverrides?: { [ K in PlanSlug ]?: TranslateResult };
 }
 
 export type UseGridPlansType = (

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -22,6 +22,7 @@ const useGridPlansForFeaturesGrid = ( {
 	term,
 	useCheckPlanAvailabilityForPurchase,
 	useFreeTrialPlanSlugs,
+	highlightLabelOverrides,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
 		allFeaturesList,
@@ -40,6 +41,7 @@ const useGridPlansForFeaturesGrid = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
+		highlightLabelOverrides,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -212,6 +212,7 @@ const useGridPlans: UseGridPlansType = ( {
 	coupon,
 	siteId,
 	isDisplayingPlansNeededForFeature,
+	highlightLabelOverrides,
 } ) => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs?.( {
 		intent: intent ?? 'default',
@@ -251,6 +252,7 @@ const useGridPlans: UseGridPlansType = ( {
 		currentSitePlanSlug: sitePlanSlug,
 		selectedPlan,
 		plansAvailabilityForPurchase,
+		highlightLabelOverrides,
 	} );
 
 	// TODO: pricedAPIPlans to be queried from data-store package

--- a/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
@@ -19,6 +19,7 @@ interface Props {
 	plansAvailabilityForPurchase?: {
 		[ key: string ]: boolean;
 	};
+	highlightLabelOverrides?: { [ K in PlanSlug ]?: TranslateResult };
 }
 
 // TODO clk: move to plans data store
@@ -28,11 +29,19 @@ const useHighlightLabels = ( {
 	currentSitePlanSlug,
 	selectedPlan,
 	plansAvailabilityForPurchase,
+	highlightLabelOverrides,
 }: Props ) => {
 	const translate = useTranslate();
 
 	return planSlugs.reduce(
 		( acc, planSlug ) => {
+			if ( highlightLabelOverrides?.[ planSlug ] ) {
+				return {
+					...acc,
+					[ planSlug ]: highlightLabelOverrides[ planSlug ],
+				};
+			}
+
 			const isCurrentPlan = currentSitePlanSlug
 				? isSamePlan( currentSitePlanSlug, planSlug )
 				: false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90301

## Proposed Changes

* Adds a label for ecommerce plan for the trail map variants

![image](https://github.com/Automattic/wp-calypso/assets/3422709/d3e8ef22-d293-4a42-8d82-c43b1af474ea)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Make sure the available in the following feature flag views
    * Go to `http://calypso.localhost:3000/start/plans?flags=onboarding/trail-map-feature-grid-structure`
    * Go to `http://calypso.localhost:3000/start/plans?flags=onboarding/trail-map-feature-grid-structure-copy`
    * Go to `http://calypso.localhost:3000/start/plans?flags=onboarding/trail-map-feature-grid-structure-structure`
* Go to `/start/plans` and make sure the label is not visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?