### PR TITLE
A4A: Sites dashboard - Show site error and disable preview

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -362,7 +362,11 @@ export const JetpackSitesDataViews = ( {
 					return (
 						<>
 							{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
-							<div className="sites-dataviews__actions">
+							<div
+								className={ `sites-dataviews__actions ${
+									item.site.error ? 'sites-dataviews__actions-error' : ''
+								}` }
+							>
 								<SiteActions
 									isLargeScreen={ isLargeScreen }
 									site={ item.site }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -41,15 +41,30 @@ export const JetpackSitesDataViews = ( {
 	const sitesPerPage = dataViewsState.perPage > 0 ? dataViewsState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 
-	const sites = useFormattedSites( data?.sites ?? [] );
+	const sites = useFormattedSites( data?.sites ?? [] ).reduce< SiteData[] >( ( acc, item ) => {
+		acc.push( item );
+		// If this site has an error we should add a row to display an error message below this site's row
+		if ( item.site.error ) {
+			acc.push( {
+				...item,
+				site: {
+					...item.site,
+					type: 'error',
+				},
+			} );
+		}
+		return acc;
+	}, [] );
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
-			setDataViewsState( ( prevState: DataViewsState ) => ( {
-				...prevState,
-				selectedItem: site,
-				type: DATAVIEWS_LIST,
-			} ) );
+			if ( site.is_connection_healthy ) {
+				setDataViewsState( ( prevState: DataViewsState ) => ( {
+					...prevState,
+					selectedItem: site,
+					type: DATAVIEWS_LIST,
+				} ) );
+			}
 		},
 		[ setDataViewsState ]
 	);
@@ -60,15 +75,22 @@ export const JetpackSitesDataViews = ( {
 				return <TextPlaceholder />;
 			}
 
+			if ( item.site.type === 'error' ) {
+				return <div className="sites-dataview__site-error"></div>;
+			}
+
 			if ( column ) {
 				return (
-					<SiteStatusContent
-						rows={ item }
-						type={ column }
-						isLargeScreen={ isLargeScreen }
-						isFavorite={ item.isFavorite }
-						siteError={ item.site.error }
-					/>
+					<>
+						{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
+						<SiteStatusContent
+							rows={ item }
+							type={ column }
+							isLargeScreen={ isLargeScreen }
+							isFavorite={ item.isFavorite }
+							siteError={ item.site.error }
+						/>
+					</>
 				);
 			}
 		},
@@ -134,12 +156,25 @@ export const JetpackSitesDataViews = ( {
 						return <TextPlaceholder />;
 					}
 					const site = item.site.value;
+
+					if ( item.site.type === 'error' ) {
+						return (
+							<div className="sites-dataview__site-error">
+								<Gridicon size={ 18 } icon="notice-outline" />
+								<span>Jetpack is unable to connect to this site.</span>
+							</div>
+						);
+					}
+
 					return (
-						<SiteDataField
-							site={ site }
-							isLoading={ isLoading }
-							onSiteTitleClick={ openSitePreviewPane }
-						/>
+						<>
+							{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
+							<SiteDataField
+								site={ site }
+								isLoading={ isLoading }
+								onSiteTitleClick={ openSitePreviewPane }
+							/>
+						</>
 					);
 				},
 				enableHiding: false,
@@ -291,14 +326,22 @@ export const JetpackSitesDataViews = ( {
 					if ( isLoading ) {
 						return <TextPlaceholder />;
 					}
+
+					if ( item.site.type === 'error' ) {
+						return <div className="sites-dataview__site-error"></div>;
+					}
+
 					return (
-						<span className="sites-dataviews__favorite-btn-wrapper">
-							<SiteSetFavorite
-								isFavorite={ item.isFavorite || false }
-								siteId={ item.site.value.blog_id }
-								siteUrl={ item.site.value.url }
-							/>
-						</span>
+						<>
+							{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
+							<span className="sites-dataviews__favorite-btn-wrapper">
+								<SiteSetFavorite
+									isFavorite={ item.isFavorite || false }
+									siteId={ item.site.value.blog_id }
+									siteUrl={ item.site.value.url }
+								/>
+							</span>
+						</>
 					);
 				},
 				enableHiding: false,
@@ -311,22 +354,30 @@ export const JetpackSitesDataViews = ( {
 					if ( isLoading ) {
 						return <TextPlaceholder />;
 					}
+
+					if ( item.site.type === 'error' ) {
+						return <div className="sites-dataview__site-error"></div>;
+					}
+
 					return (
-						<div className="sites-dataviews__actions">
-							<SiteActions
-								isLargeScreen={ isLargeScreen }
-								site={ item.site }
-								siteError={ item.site.error }
-							/>
-							<Button
-								onClick={ () => openSitePreviewPane( item.site.value ) }
-								className="site-preview__open"
-								borderless
-								ref={ ( ref ) => setActionsRef( ( current ) => current || ref ) }
-							>
-								<Gridicon icon="chevron-right" />
-							</Button>
-						</div>
+						<>
+							{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
+							<div className="sites-dataviews__actions">
+								<SiteActions
+									isLargeScreen={ isLargeScreen }
+									site={ item.site }
+									siteError={ item.site.error }
+								/>
+								<Button
+									onClick={ () => openSitePreviewPane( item.site.value ) }
+									className="site-preview__open"
+									borderless
+									ref={ ( ref ) => setActionsRef( ( current ) => current || ref ) }
+								>
+									<Gridicon icon="chevron-right" />
+								</Button>
+							</div>
+						</>
 					);
 				},
 				header: (

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -43,7 +43,7 @@ export const JetpackSitesDataViews = ( {
 
 	const sites = useFormattedSites( data?.sites ?? [] ).reduce< SiteData[] >( ( acc, item ) => {
 		acc.push( item );
-		// If this site has an error we should add a row to display an error message below this site's row
+		// If this site has an error, we duplicate this row - while changing the duplicate's type to 'error' - to display an error message below it.
 		if ( item.site.error ) {
 			acc.push( {
 				...item,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -161,7 +161,7 @@ export const JetpackSitesDataViews = ( {
 						return (
 							<div className="sites-dataview__site-error">
 								<Gridicon size={ 18 } icon="notice-outline" />
-								<span>Jetpack is unable to connect to this site.</span>
+								<span>{ translate( "Jetpack can't connect to this site." ) }</span>
 							</div>
 						);
 					}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -51,7 +51,7 @@ export const JetpackSitesDataViews = ( {
 				type: DATAVIEWS_LIST,
 			} ) );
 		},
-		[ setDataViewsState, dataViewsState ]
+		[ setDataViewsState ]
 	);
 
 	const renderField = useCallback(

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -132,6 +132,7 @@
 		.dataviews-view-table tr th:first-child,
 		.dataviews-view-table tr td:first-child {
 			padding: 8px 24px 8px 8px;
+			width: 70%;
 		}
 
 		.dataviews-view-table tr td:first-child:has(.sites-dataview__site-error) {
@@ -337,6 +338,15 @@
 					border-bottom: 1px solid var(--color-accent-5);
 				}
 
+				li:has(.sites-dataview__site-error-span) {
+					padding: 8px;
+					border-bottom: 0;
+				}
+
+				li:has(.sites-dataview__site-error) {
+					padding: 0 10px 24px 0;
+				}
+
 				.dataviews-view-list__fields {
 					display: flex;
 					justify-content: space-between;
@@ -363,6 +373,12 @@
 						.sites-dataviews__site {
 							width: 100%;
 							justify-content: flex-start;
+						}
+
+						.sites-dataview__site-error {
+							font-size: rem(13px);
+							border-radius: 4px;
+							padding: 4px 4px 4px 2px;
 						}
 					}
 				}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -133,6 +133,10 @@
 		.dataviews-view-table tr td:first-child {
 			padding: 8px 24px 8px 8px;
 		}
+
+		.dataviews-view-table tr td:first-child:has(.sites-dataview__site-error) {
+			padding: 8px 0 8px 8px;
+		}
 		.dataviews-view-table tr td:last-child {
 			padding: 0;
 			padding-inline-end: 8px;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -399,6 +399,45 @@
 		}
 	}
 
+	td:has(.sites-dataview__site-error-span) {
+		border-bottom: 0;
+	}
+
+	td:has(.sites-dataview__site-error) {
+		padding: 0 0 16px 0;
+		height: 40px;
+	}
+
+	td:first-child:has(.sites-dataview__site-error) {
+		padding: 0 0 16px 64px;
+
+		.sites-dataview__site-error {
+			padding-left: 10px;
+			border-radius: 4px 0 0 4px;
+		}
+	}
+
+	td:last-child:has(.sites-dataview__site-error) {
+		padding: 0 64px 16px 0;
+
+		.sites-dataview__site-error {
+			border-radius: 0 4px 4px 0;
+		}
+	}
+
+	.dataviews-view-table__cell-content-wrapper:has(.sites-dataview__site-error) {
+		height: 100%;
+	}
+
+	.sites-dataview__site-error {
+		color: #691c1c;
+		background-color: #facfd2;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
 	.sites-overview__content-wrapper {
 		max-width: none;
 	}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -139,8 +139,7 @@
 			padding: 8px 0 8px 8px;
 		}
 		.dataviews-view-table tr td:last-child {
-			padding: 0;
-			padding-inline-end: 8px;
+			padding: 8px 8px 8px 0;
 		}
 
 		.components-button.is-compact.has-icon:not(.has-text).dataviews-filters-button {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -418,6 +418,11 @@
 		}
 	}
 
+	tr:has(.sites-dataview__site-error):hover {
+		background: unset;
+		background-color: unset;
+	}
+
 	td:has(.sites-dataview__site-error-span) {
 		border-bottom: 0;
 	}

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
@@ -44,7 +44,7 @@ const SitesDataViews = ( {
 				type: DATAVIEWS_LIST,
 			} ) );
 		},
-		[ setDataViewsState, dataViewsState ]
+		[ setDataViewsState ]
 	);
 
 	const renderField = useCallback(

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -154,6 +154,12 @@
 				height: 18px;
 			}
 		}
+
+		&.sites-dataviews__actions-error {
+			svg {
+				color: var(--color-accent-5);
+			}
+		}
 	}
 
 	.dataviews-no-results,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -9,6 +9,7 @@ import {
 import {
 	BackupNode,
 	BoostNode,
+	ErrorNode,
 	MonitorNode,
 	PluginNode,
 	ScanNode,
@@ -184,6 +185,12 @@ const useFormatPluginData = () => {
 	);
 };
 
+const formatErrorData = ( site: Site ): ErrorNode => ( {
+	status: site.is_connection_healthy ? 'success' : 'failed',
+	type: 'error',
+	value: site.is_connection_healthy ? 'error' : '',
+} );
+
 const useFormatSite = () => {
 	const formatBackupData = useFormatBackupData();
 	const formatMonitorData = useFormatMonitorData();
@@ -205,6 +212,7 @@ const useFormatSite = () => {
 				scan: formatScanData( site ),
 				monitor: formatMonitorData( site ),
 				plugin: formatPluginData( site ),
+				error: formatErrorData( site ),
 				isFavorite: site.is_favorite,
 				isSelected: site.isSelected,
 				onSelect: site.onSelect,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -168,6 +168,7 @@ export interface SiteData {
 	scan: ScanNode;
 	plugin: PluginNode;
 	monitor: MonitorNode;
+	error?: boolean;
 	isFavorite?: boolean;
 	isSelected?: boolean;
 	onSelect?: () => void;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -2,7 +2,15 @@ import { TranslateResult } from 'i18n-calypso';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 // All types based on which the data is populated on the agency dashboard table rows
-export type AllowedTypes = 'site' | 'stats' | 'boost' | 'backup' | 'scan' | 'monitor' | 'plugin';
+export type AllowedTypes =
+	| 'site'
+	| 'stats'
+	| 'boost'
+	| 'backup'
+	| 'scan'
+	| 'monitor'
+	| 'plugin'
+	| 'error';
 
 // Site column object which holds key and title of each column
 export type SiteColumns = Array< {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -168,7 +168,7 @@ export interface SiteData {
 	scan: ScanNode;
 	plugin: PluginNode;
 	monitor: MonitorNode;
-	error?: boolean;
+	error: boolean;
 	isFavorite?: boolean;
 	isSelected?: boolean;
 	onSelect?: () => void;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -160,6 +160,11 @@ export interface MonitorNode {
 	error?: boolean;
 	settings?: MonitorSettings;
 }
+export interface ErrorNode {
+	type: AllowedTypes;
+	status: AllowedStatusTypes;
+	value: string;
+}
 export interface SiteData {
 	site: SiteNode;
 	stats: StatsNode;
@@ -168,7 +173,7 @@ export interface SiteData {
 	scan: ScanNode;
 	plugin: PluginNode;
 	monitor: MonitorNode;
-	error: boolean;
+	error: ErrorNode;
 	isFavorite?: boolean;
 	isSelected?: boolean;
 	onSelect?: () => void;

--- a/client/jetpack-cloud/sections/onboarding-tours/constants.ts
+++ b/client/jetpack-cloud/sections/onboarding-tours/constants.ts
@@ -142,6 +142,11 @@ export const JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE: SiteData[] = [
 			type: 'plugin',
 			updates: 0,
 		},
+		error: {
+			value: '',
+			status: 'failed',
+			type: 'error',
+		},
 		isFavorite: false,
 	},
 ];


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/286

## Proposed Changes

* This PR adds a notification row to sites in an error state, and prevents the preview pane from opening for these sites. 
  * Note: This PR does not include the 'Fix Now' icon because we currently do not have a page to link it to.

## Testing Instructions

* Open the sites dashboard (`http://agencies.localhost:3000/sites`)
* If you don't have a site in an error state, follow these steps:
  * Spin up a Jurassic Ninja
  * Add this Jurassic Ninja site to your sites dashboard (using the `Add new site` button in `/sites`)
  * In your Jurassic Ninja's wp-admin, go to `Tools` -> `Plugin File Editor` (`https://some-shy-site.jurassic.ninja/wp-admin/plugin-editor.php`), and comment out (by adding // at the beginning of the line) lines:
     * 143: `//$jetpack_autoloader           = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';`
     *  219: `//require_once JETPACK__PLUGIN_DIR . 'load-jetpack.php';`
     * Save changes by clicking on `Update File`
   * Go to your dashboard
   * Verify that the error row shows correctly in all page sizes:
     * Desktop window over 960px
     * Desktop window below 960px
     * Mobile window
     * Desktop window with preview pane open


 * Verify that the preview pane does not open for sites in an error state

Figma: 
![image](https://github.com/Automattic/wp-calypso/assets/37049295/de6d6eb0-a8a9-447e-a43d-e74837ceb68b)

This Branch:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/5ea50625-71f3-4514-bce0-9c6560cf5038)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?