### PR TITLE
Nav redesign: add Hosting Overview button in My Home

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -177,7 +177,7 @@ const Home = ( {
 			</Button>
 			{ config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && (
 				<Button primary href={ `/hosting/${ site.slug }` }>
-					{ translate( 'Go to Hosting Overview' ) }
+					{ translate( 'Hosting Overview' ) }
 				</Button>
 			) }
 		</>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -175,6 +175,11 @@ const Home = ( {
 			<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
 				{ isGlobalSiteViewEnabled ? translate( 'View site' ) : translate( 'Visit site' ) }
 			</Button>
+			{ config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && (
+				<Button primary href={ `/hosting/${ site.slug }` }>
+					{ translate( 'Go to Hosting Overview' ) }
+				</Button>
+			) }
 		</>
 	);
 	const header = (


### PR DESCRIPTION
Part of:

- https://github.com/Automattic/dotcom-forge/issues/6874

## Proposed Changes

> [!NOTE]
> This depends on whether we want to go with `Hosting Overview` term; see https://github.com/Automattic/jetpack/pull/37228.


This PR adds a new `Hosting Overview` button that links to `/hosting/:site`.

<img width="1180" alt="Screen Shot 2024-05-06 at 11 57 02 AM" src="https://github.com/Automattic/wp-calypso/assets/1689238/2fa4e47b-7c5f-4b36-8c32-8169ec9a14aa">



## Testing Instructions

1. Go to `/home/:site/`
2. Verify that the new button is there
3. Click the button and verify that it takes you to the hosting overview page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?