### PR TITLE
Scheduled updates: Wrap header on mobile

### DIFF
--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -100,6 +100,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 			{ ! isSitePlansLoaded && <QuerySitePlans siteId={ siteId } /> }
 			<MainComponent wideLayout>
 				<NavigationHeader
+					className="plugins-update-manager-header"
 					navigationItems={ [] }
 					title={ translate( 'Plugin Update Manager' ) }
 					subtitle={ translate(

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -4,6 +4,15 @@
 	text-align: left;
 }
 
+.plugins-update-manager-header {
+	.navigation-header__main {
+		@media screen and (max-width: $break-small) {
+			flex-wrap: wrap;
+			row-gap: 10px;
+		}
+	}
+}
+
 .plugins-update-manager {
 	@media screen and (max-width: $break-small) {
 		margin: 0 1rem;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/90311

## Proposed Changes

| Before | After
|-|-|
| ![CleanShot 2024-05-06 at 09 05 19@2x](https://github.com/Automattic/wp-calypso/assets/528287/4f0ca3c3-61e7-4b10-b4e5-a297aa14b568) | ![CleanShot 2024-05-06 at 09 05 28@2x](https://github.com/Automattic/wp-calypso/assets/528287/7414cd3a-e55d-4ad4-a813-67a7dfb4ee3b) |

* Wrap the header on mobile

## Testing Instructions

1. Apply this PR
2. Navigate to http://calypso.localhost:3000/plugins/scheduled-updates/<yoursite> on a mobile viewport
3. Verify that the header wraps

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?