### PR TITLE
Scheduled Updates multisite: Add close button to edit/create

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
@@ -1,3 +1,6 @@
+import { Button } from '@wordpress/components';
+import { close, Icon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { ScheduleForm } from './schedule-form';
 
 type Props = {
@@ -5,9 +8,15 @@ type Props = {
 };
 
 export const ScheduleCreate = ( { onNavBack }: Props ) => {
+	const translate = useTranslate();
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
-			<h1 className="wp-brand-font">New schedule</h1>
+			<div className="plugins-update-manager-multisite__header no-border">
+				<h1 className="wp-brand-font">{ translate( 'New schedule' ) }</h1>
+				<Button onClick={ onNavBack }>
+					<Icon icon={ close } />
+				</Button>
+			</div>
 			<ScheduleForm onNavBack={ onNavBack } />
 		</div>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
@@ -1,7 +1,11 @@
-import { Spinner } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
+import { close, Icon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
 import { useLoadScheduleFromId } from './hooks/use-load-schedule-from-id';
 import { ScheduleForm } from './schedule-form';
+import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 
 type Props = {
 	id: string;
@@ -10,6 +14,8 @@ type Props = {
 
 export const ScheduleEdit = ( { id, onNavBack }: Props ) => {
 	const { schedule, scheduleLoaded, scheduleNotFound } = useLoadScheduleFromId( id );
+	const { prepareScheduleName } = usePrepareScheduleName();
+	const translate = useTranslate();
 
 	// If the schedule is not found, navigate back to the list
 	useEffect( () => {
@@ -20,7 +26,16 @@ export const ScheduleEdit = ( { id, onNavBack }: Props ) => {
 
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
-			<h1 className="wp-brand-font">Edit schedule</h1>
+			<div className="plugins-update-manager-multisite__header no-border">
+				<h1 className="wp-brand-font">
+					{ schedule && scheduleLoaded
+						? prepareScheduleName( schedule as unknown as ScheduleUpdates )
+						: translate( 'Edit schedule' ) }
+				</h1>
+				<Button onClick={ onNavBack }>
+					<Icon icon={ close } />
+				</Button>
+			</div>
 			{ schedule && scheduleLoaded ? (
 				<ScheduleForm onNavBack={ onNavBack } scheduleForEdit={ schedule } />
 			) : (

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -114,6 +114,10 @@ $brand-display: "SF Pro Display", sans-serif;
 		justify-content: space-between;
 		padding-bottom: 1.5rem;
 
+		&.no-border {
+			border-block-end: none;
+		}
+
 		h1 {
 			font-size: 1.5rem;
 			font-style: normal;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/90276

## Proposed Changes

* Add close button to edit/create
* Show correct title for edit (schedule name)
* Wrap "Create schedule" in translate tags


## Testing Instructions

1. Apply this PR
2. Visit http://calypso.localhost:3000/plugins/scheduled-updates/<yoursite>
3. Create a new schedule
4. Test the close button
5. Edit a schedule
6. Verify that the title is correct
7. Test the close button


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?