### PR TITLE
Scheduled Updates: Redirect on save

### DIFF
--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -61,13 +61,14 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 
 	useEffect( () => {
 		if ( isSuccess ) {
+			onNavBack?.();
 			dispatch( successNotice( translate( 'Your notification settings have been saved.' ) ) );
 		} else if ( isError ) {
 			dispatch(
 				errorNotice( translate( 'Failed to save notification settings. Please try again.' ) )
 			);
 		}
-	}, [ isSuccess, isError ] );
+	}, [ isSuccess, isError, onNavBack ] );
 
 	const handleCheckboxChange = ( field: keyof typeof formValues ) => ( checked: boolean ) => {
 		setFormValues( ( prevValues ) => ( {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/90314
## Proposed Changes

* Redirect back to the list on save

## Testing Instructions

Test it by going to notification settings & saving

Code review should be fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?