### PR TITLE
Change health check path item schema

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -92,8 +92,11 @@ export const ScheduleForm = ( props: Props ) => {
 			schedule: {
 				timestamp,
 				interval: frequency,
+				// Temporary: this field is left here for backward compatibility.
+				// Will be removed after https://github.com/Automattic/jetpack/pull/37223 is landed.
 				health_check_paths: healthCheckPaths,
 			},
+			health_check_paths: healthCheckPaths,
 		};
 
 		if ( formValid ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/90316

## Proposed Changes

* Change scheduled updates submit form schema
* Left a comment for removing the old field after Jetpack has landed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On trunk add some health check paths to a schedule update and save it. Ensure they are still there.
* On Jetpack beta apply https://github.com/Automattic/jetpack/pull/37223 and ensure everything is still working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?