### PR TITLE
DIFM: pre-populate the site title and tagline

### DIFF
--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -5,8 +5,9 @@ import storeImageUrl from 'calypso/assets/images/onboarding/store-onboarding.svg
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSite } from 'calypso/state/sites/selectors';
 import SiteOptions from './site-options';
 import type { SiteOptionsFormValues } from './types';
 import './index.scss';
@@ -24,7 +25,9 @@ export default function SiteOptionsStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { stepName, signupDependencies, flowName, goToNextStep } = props;
-	const { siteTitle, tagline } = signupDependencies;
+	const { siteTitle, tagline, siteId } = signupDependencies;
+
+	const siteDetails = useSelector( ( state ) => ( siteId ? getSite( state, siteId ) : null ) );
 
 	const getSiteOptionsProps = ( stepName: string ) => {
 		switch ( stepName ) {
@@ -109,8 +112,8 @@ export default function SiteOptionsStep( props: Props ) {
 			headerImageUrl={ headerImage }
 			stepContent={
 				<SiteOptions
-					defaultSiteTitle={ siteTitle }
-					defaultTagline={ tagline }
+					defaultSiteTitle={ siteTitle || siteDetails?.title || '' }
+					defaultTagline={ tagline || siteDetails?.description || '' }
 					siteTitleLabel={ siteTitleLabel }
 					siteTitleExplanation={ siteTitleExplanation }
 					taglineExplanation={ taglineExplanation }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2725

## Proposed Changes

* Pre-populate the site title and tagline if available on the site options step. This step is currently used only in the DIFM flows, so there should be no change to other flows.

https://github.com/Automattic/wp-calypso/assets/5436027/303c570e-08a8-44a3-96f8-81c7ed580ad4


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and select "Existing site".
* Select any site.
* On the site options step, confirm that the site title and tagline are pre-populated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?