### PR TITLE
Scheduled Updates: add paths label + validation

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -93,7 +93,7 @@ export function ScheduleFormPaths( props: Props ) {
 	useEffect( handleAsyncValidationError, [ handleAsyncValidationError ] );
 	useEffect( () => {
 		setNewPathSubmitted( false );
-		onTouch?.( true );
+		onTouch?.( false );
 	}, [ newPath ] );
 	useEffect(
 		() => onChange?.( { paths, hasUnsubmittedPath: newPath.length > 0 } ),

--- a/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-paths.tsx
@@ -5,7 +5,7 @@ import {
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
-import { check, plus, closeSmall, rotateRight } from '@wordpress/icons';
+import { check, Icon, info, rotateRight } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect } from 'react';
@@ -15,17 +15,28 @@ import getSiteId from 'calypso/state/sites/selectors/get-site-id';
 import { MAX_SELECTABLE_PATHS } from './config';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { prepareRelativePath, validatePath } from './schedule-form.helper';
+import type { PathsOnChangeEvent } from './types';
 
 interface Props {
 	paths?: string[];
-	onChange?: ( value: string[] ) => void;
+	onChange?: ( data: PathsOnChangeEvent ) => void;
 	borderWrapper?: boolean;
+	error?: string;
+	showError?: boolean;
+	onTouch?: ( touched: boolean ) => void;
 }
 export function ScheduleFormPaths( props: Props ) {
 	const translate = useTranslate();
 	const siteSlug = useSiteSlug();
 	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
-	const { paths: initPaths = [], onChange, borderWrapper = true } = props;
+	const {
+		paths: initPaths = [],
+		onChange,
+		borderWrapper = true,
+		error,
+		showError = false,
+		onTouch,
+	} = props;
 
 	const [ paths, setPaths ] = useState( initPaths );
 	const [ newPath, setNewPath ] = useState( '' );
@@ -80,8 +91,14 @@ export function ScheduleFormPaths( props: Props ) {
 	 */
 	useEffect( addPath, [ addPath ] );
 	useEffect( handleAsyncValidationError, [ handleAsyncValidationError ] );
-	useEffect( () => setNewPathSubmitted( false ), [ newPath ] );
-	useEffect( () => onChange?.( paths ), [ paths ] );
+	useEffect( () => {
+		setNewPathSubmitted( false );
+		onTouch?.( true );
+	}, [ newPath ] );
+	useEffect(
+		() => onChange?.( { paths, hasUnsubmittedPath: newPath.length > 0 } ),
+		[ paths, newPath, newPathSubmitted ]
+	);
 
 	return (
 		<div className="form-field form-field--paths">
@@ -116,11 +133,9 @@ export function ScheduleFormPaths( props: Props ) {
 								<InputControl value={ path } size="__unstable-large" readOnly />
 							</FlexItem>
 							<FlexItem>
-								<Button
-									icon={ closeSmall }
-									__next40pxDefaultSize
-									onClick={ () => removePath( i ) }
-								/>
+								<Button __next40pxDefaultSize onClick={ () => removePath( i ) } variant="secondary">
+									{ translate( 'Remove' ) }
+								</Button>
 							</FlexItem>
 						</Flex>
 					) ) }
@@ -155,12 +170,14 @@ export function ScheduleFormPaths( props: Props ) {
 							<FlexItem>
 								<Button
 									className={ classnames( { 'is-verifying': isVerifying } ) }
-									icon={ isVerifying ? rotateRight : plus }
+									icon={ isVerifying ? rotateRight : null }
 									disabled={ isVerifying }
 									variant="secondary"
 									onClick={ onNewPathSubmit }
 									__next40pxDefaultSize
-								/>
+								>
+									{ translate( 'Add' ) }
+								</Button>
 							</FlexItem>
 						</Flex>
 					</div>
@@ -172,6 +189,12 @@ export function ScheduleFormPaths( props: Props ) {
 					{ translate( 'You reached the maximum number of paths.' ) }
 				</Text>
 			) }
+			{ error && showError ? (
+				<Text className="validation-msg">
+					<Icon className="icon-info" icon={ info } size={ 16 } />
+					{ error }
+				</Text>
+			) : null }
 		</div>
 	);
 }

--- a/client/blocks/plugins-scheduled-updates/schedule-form.helper.ts
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.helper.ts
@@ -172,3 +172,14 @@ export const validatePath = ( path: string, paths: string[] ): string => {
 
 	return error;
 };
+
+/* Validate paths
+ * check if path is submitted before saving the schedule
+ */
+export const validatePaths = ( hasUnsubmittedPath: boolean ): string => {
+	let error = '';
+	if ( hasUnsubmittedPath ) {
+		error = translate( 'Please submit the path before saving the schedule.' );
+	}
+	return error;
+};

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -210,6 +210,14 @@
 	}
 
 	.form-field--paths {
+		.paths,
+		.new-path {
+			.components-button {
+				min-width: rem(100px);
+				justify-content: center;
+			}
+		}
+
 		.paths {
 			.components-input-control__backdrop {
 				border-color: var(--studio-gray-0);

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -192,7 +192,7 @@ export const ScheduleForm = ( props: Props ) => {
 				error={ validationErrors?.paths }
 				showError={ fieldTouched?.paths }
 				onTouch={ ( touched ) => {
-					setFieldTouched( { ...fieldTouched, plugins: touched } );
+					setFieldTouched( { ...fieldTouched, paths: touched } );
 				} }
 			/>
 		</form>

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -16,8 +16,8 @@ import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleFormFrequency } from './schedule-form-frequency';
 import { ScheduleFormPaths } from './schedule-form-paths';
 import { ScheduleFormPlugins } from './schedule-form-plugins';
-import { validatePlugins, validateTimeSlot } from './schedule-form.helper';
-import type { SyncSuccessParams } from './types';
+import { validatePaths, validatePlugins, validateTimeSlot } from './schedule-form.helper';
+import type { PathsOnChangeEvent, SyncSuccessParams } from './types';
 
 import './schedule-form.scss';
 
@@ -49,6 +49,8 @@ export const ScheduleForm = ( props: Props ) => {
 		scheduleForEdit?.health_check_paths || []
 	);
 
+	const [ hasUnsubmittedPath, setHasUnsubmittedPath ] = useState( false );
+
 	const scheduledTimeSlots = schedules.map( ( schedule ) => ( {
 		timestamp: schedule.timestamp,
 		frequency: schedule.schedule,
@@ -57,6 +59,7 @@ export const ScheduleForm = ( props: Props ) => {
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {
 		plugins: validatePlugins( selectedPlugins, scheduledPlugins ),
 		timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
+		paths: validatePaths( hasUnsubmittedPath ),
 	} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
 
@@ -85,6 +88,7 @@ export const ScheduleForm = ( props: Props ) => {
 		setFieldTouched( {
 			plugins: true,
 			timestamp: true,
+			paths: true,
 		} );
 
 		const params = {
@@ -125,6 +129,21 @@ export const ScheduleForm = ( props: Props ) => {
 			} ),
 		[ timestamp ]
 	);
+
+	// Paths validation
+	useEffect(
+		() =>
+			setValidationErrors( {
+				...validationErrors,
+				paths: validatePaths( hasUnsubmittedPath ),
+			} ),
+		[ hasUnsubmittedPath ]
+	);
+
+	const onPathChange = ( data: PathsOnChangeEvent ) => {
+		setHealthCheckPaths( data.paths );
+		setHasUnsubmittedPath( data.hasUnsubmittedPath );
+	};
 
 	return (
 		<form
@@ -169,7 +188,12 @@ export const ScheduleForm = ( props: Props ) => {
 			<ScheduleFormPaths
 				paths={ healthCheckPaths }
 				borderWrapper={ false }
-				onChange={ setHealthCheckPaths }
+				onChange={ onPathChange }
+				error={ validationErrors?.paths }
+				showError={ fieldTouched?.paths }
+				onTouch={ ( touched ) => {
+					setFieldTouched( { ...fieldTouched, plugins: touched } );
+				} }
 			/>
 		</form>
 	);

--- a/client/blocks/plugins-scheduled-updates/types.ts
+++ b/client/blocks/plugins-scheduled-updates/types.ts
@@ -4,3 +4,8 @@ export type SyncSuccessParams = {
 	hours: number;
 	weekday?: number;
 };
+
+export type PathsOnChangeEvent = {
+	paths: string[];
+	hasUnsubmittedPath: boolean;
+};


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/90270

## Proposed Changes

* Add "Add" & "Remove" labels to the buttons
* Shows validation error when the add path field is dirty & resubmitted

<img width="1043" alt="image" src="https://github.com/Automattic/wp-calypso/assets/528287/0e751bba-57e3-4908-9705-bb345177e2cb">

## Testing Instructions

Test adding/editing a schedule & leave text filled in in the add path input field.

![CleanShot 2024-05-06 at 14 40 54@2x](https://github.com/Automattic/wp-calypso/assets/528287/e0d2b691-9ac6-460b-a102-c6b614eb5b88)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?