### PR TITLE
A4A: Improve post-atomic site creation flow.

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-fetch-active-sites.ts
+++ b/client/a8c-for-agencies/data/sites/use-fetch-active-sites.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+type Props = {
+	autoRefresh: boolean;
+};
+
+const REFRESH_INTERVAL = 1000;
+
+export default function useFetchActiveSites( { autoRefresh }: Props ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: [ 'a4a-sites', agencyId ],
+		queryFn: () =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/sites`,
+			} ),
+		select: ( data ) => {
+			return data;
+		},
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+		refetchInterval: autoRefresh ? REFRESH_INTERVAL : false,
+	} );
+}

--- a/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
+++ b/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import useFetchActiveSites from './use-fetch-active-sites';
+
+type Props = {
+	siteId: number;
+};
+
+type Site = {
+	id: number;
+	url: string;
+	features: {
+		wpcom_atomic: {
+			state: string;
+		};
+	};
+};
+export default function useIsSiteReady( { siteId }: Props ) {
+	const [ site, setSite ] = useState< Site | null >( null );
+	const { data } = useFetchActiveSites( { autoRefresh: ! site } );
+
+	useEffect( () => {
+		const match = data?.find(
+			( site: Site ) => site.id === siteId && site.features.wpcom_atomic.state === 'active'
+		);
+
+		if ( match ) {
+			setSite( match );
+		}
+	}, [ data, site, siteId ] );
+
+	return {
+		isReady: !! site,
+		site,
+	};
+}

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -56,7 +57,7 @@ export default function NeedSetup() {
 				{
 					onSuccess: () => {
 						refetchPendingSites();
-						page( A4A_SITES_LINK );
+						page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
 					},
 				}
 			);

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { isWithinBreakpoint } from '@automattic/viewport';
+import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState } from 'react';
@@ -41,6 +42,7 @@ import SitesHeaderActions from '../sites-header-actions';
 import SiteNotifications from '../sites-notifications';
 import EmptyState from './empty-state';
 import { getSelectedFilters } from './get-selected-filters';
+import ProvisioningSiteNotification from './provisioning-site-notification';
 import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
 
 import './style.scss';
@@ -51,6 +53,12 @@ export default function SitesDashboard() {
 	const dispatch = useDispatch();
 
 	const agencyId = useSelector( getActiveAgencyId );
+
+	const createdSiteQuery = getQueryArg( window.location.href, 'created_site' );
+
+	const [ recentlyCreatedSite, setRecentlyCreatedSite ] = useState< number | null >(
+		createdSiteQuery ? Number( createdSiteQuery ) : null
+	);
 
 	const {
 		dataViewsState,
@@ -219,6 +227,13 @@ export default function SitesDashboard() {
 			{ ! hideListing && (
 				<LayoutColumn className="sites-overview" wide>
 					<LayoutTop withNavigation={ navItems.length > 1 }>
+						{ recentlyCreatedSite && (
+							<ProvisioningSiteNotification
+								siteId={ recentlyCreatedSite }
+								onClose={ () => setRecentlyCreatedSite( null ) }
+							/>
+						) }
+
 						<LayoutHeader>
 							<Title>{ translate( 'Sites' ) }</Title>
 							<Actions>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -54,11 +54,7 @@ export default function SitesDashboard() {
 
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const createdSiteQuery = getQueryArg( window.location.href, 'created_site' );
-
-	const [ recentlyCreatedSite, setRecentlyCreatedSite ] = useState< number | null >(
-		createdSiteQuery ? Number( createdSiteQuery ) : null
-	);
+	const recentlyCreatedSite = getQueryArg( window.location.href, 'created_site' ) ?? null;
 
 	const {
 		dataViewsState,
@@ -228,10 +224,7 @@ export default function SitesDashboard() {
 				<LayoutColumn className="sites-overview" wide>
 					<LayoutTop withNavigation={ navItems.length > 1 }>
 						{ recentlyCreatedSite && (
-							<ProvisioningSiteNotification
-								siteId={ recentlyCreatedSite }
-								onClose={ () => setRecentlyCreatedSite( null ) }
-							/>
+							<ProvisioningSiteNotification siteId={ Number( recentlyCreatedSite ) } />
 						) }
 
 						<LayoutHeader>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -17,6 +17,11 @@ export default function ProvisioningSiteNotification( { siteId, onClose }: Props
 			level={ isReady ? 'success' : 'warning' }
 			hideCloseButton={ ! isReady }
 			onClose={ onClose }
+			title={
+				isReady
+					? translate( 'Congratulation on your new WordPress.com site!' )
+					: translate( 'Setting up your new WordPress.com site' )
+			}
 		>
 			{ isReady
 				? translate( 'Your {{a}}%(siteURL)s{{/a}} is now ready.', {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -1,48 +1,51 @@
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import useIsSiteReady from 'calypso/a8c-for-agencies/data/sites/use-is-site-ready';
 
 type Props = {
 	siteId: number;
-	onClose?: () => void;
 };
 
-export default function ProvisioningSiteNotification( { siteId, onClose }: Props ) {
+export default function ProvisioningSiteNotification( { siteId }: Props ) {
 	const { isReady, site } = useIsSiteReady( { siteId } );
+	const [ showBanner, setShowBanner ] = useState( true );
 
 	const translate = useTranslate();
 
 	return (
-		<NoticeBanner
-			level={ isReady ? 'success' : 'warning' }
-			hideCloseButton={ ! isReady }
-			onClose={ onClose }
-			title={
-				isReady
-					? translate( 'Congratulation on your new WordPress.com site!' )
-					: translate( 'Setting up your new WordPress.com site' )
-			}
-		>
-			{ isReady
-				? translate( 'Your {{a}}%(siteURL)s{{/a}} is now ready.', {
-						args: { siteURL: site?.url ?? '' },
-						components: {
-							a: (
-								<a
-									href={ `https://wordpress.com/home/${ site?.url?.replace(
-										/(^\w+:|^)\/\//,
-										''
-									) }` }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-						},
-						comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
-				  } )
-				: translate(
-						"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
-				  ) }
-		</NoticeBanner>
+		showBanner && (
+			<NoticeBanner
+				level={ isReady ? 'success' : 'warning' }
+				hideCloseButton={ ! isReady }
+				onClose={ () => setShowBanner( false ) }
+				title={
+					isReady
+						? translate( 'Congratulation on your new WordPress.com site!' )
+						: translate( 'Setting up your new WordPress.com site' )
+				}
+			>
+				{ isReady
+					? translate( 'Your {{a}}%(siteURL)s{{/a}} is now ready.', {
+							args: { siteURL: site?.url ?? '' },
+							components: {
+								a: (
+									<a
+										href={ `https://wordpress.com/home/${ site?.url?.replace(
+											/(^\w+:|^)\/\//,
+											''
+										) }` }
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+							},
+							comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
+					  } )
+					: translate(
+							"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
+					  ) }
+			</NoticeBanner>
+		)
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -1,0 +1,43 @@
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import { useTranslate } from 'i18n-calypso';
+import useIsSiteReady from 'calypso/a8c-for-agencies/data/sites/use-is-site-ready';
+
+type Props = {
+	siteId: number;
+	onClose?: () => void;
+};
+
+export default function ProvisioningSiteNotification( { siteId, onClose }: Props ) {
+	const { isReady, site } = useIsSiteReady( { siteId } );
+
+	const translate = useTranslate();
+
+	return (
+		<NoticeBanner
+			level={ isReady ? 'success' : 'warning' }
+			hideCloseButton={ ! isReady }
+			onClose={ onClose }
+		>
+			{ isReady
+				? translate( 'Your {{a}}%(siteURL)s{{/a}} is now ready.', {
+						args: { siteURL: site?.url ?? '' },
+						components: {
+							a: (
+								<a
+									href={ `https://wordpress.com/home/${ site?.url?.replace(
+										/(^\w+:|^)\/\//,
+										''
+									) }` }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+						comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
+				  } )
+				: translate(
+						"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
+				  ) }
+		</NoticeBanner>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -1143,3 +1143,11 @@
 	}
 }
 
+.sites-dashboard .notice-banner {
+	display: none;
+}
+
+.sites-dashboard.preview-hidden .notice-banner {
+	display: flex;
+	margin: 0 64px 24px !important;
+}


### PR DESCRIPTION
When a user clicks the **'Create new site'** button on the **Needs setup** page, the UI currently redirects them to the 'All' sites page without any indication of which site is being created. This can be confusing for the user. To improve the UI experience, this PR adds an indicator to show what is happening behind the scenes and specifies which site has been provisioned.

<img width="1100" alt="Screenshot 2024-05-06 at 9 35 54 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/28b97516-ef78-4bec-b243-be5603eaaed8">
<img width="1390" alt="Screenshot 2024-05-06 at 9 36 28 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6dc9985d-e7cb-423b-be95-0c1207768021">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/423

## Proposed Changes

* We now include which site was created in the URL (`created_site` query string) when pressing the **'Create new site'** button in the **Needs setup** page. 
* The `created_site` query string will be used by the UI to determine which site to closely track and display the provisioning state in the form of notification banners.
* Right now, provisioning takes a few seconds, and the UI will display a message telling the user to wait for a few minutes.

## Testing Instructions

* Use the A4A live link below and purchase a WPCOM plan in `/marketplace/hosting/wpcom`.
* In the Needs setup page, press the 'Create new site' button.
* Confirm that you are redirected to the 'All' sites page with a banner telling the user to wait a few minutes.
* After some time, confirm that a successful message will indicate which site was recently created.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?