### PR TITLE
Email Stats: Consistent Emails ordering across Emails Summary and Subscribers Pages

### DIFF
--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -73,7 +73,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 					moduleStrings={ { ...StatsStrings.emails, title: '' } }
 					period={ period }
 					query={ query }
-					statType="statsEmailsSummaryByOpens"
+					statType="statsEmailsSummary"
 					mainItemLabel={ translate( 'Latest Emails' ) }
 					hideSummaryLink
 					metricLabel={ translate( 'Clicks' ) }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -112,7 +112,7 @@ class StatsModule extends Component {
 			'statsSearchTerms',
 			'statsClicks',
 			'statsReferrers',
-			// statsEmailsOpen and statsEmailsClick are not used. statsEmailsSummary and statsEmailsSummaryByOpens are used at the moment,
+			// statsEmailsOpen and statsEmailsClick are not used. statsEmailsSummary are used at the moment,
 			// besides this, email page uses separate summary component: <StatsEmailSummary />
 			'statsEmailsOpen',
 			'statsEmailsClick',

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -45,7 +45,6 @@ const wpcomV1Endpoints = {
 	statsFileDownloads: 'stats/file-downloads',
 	statsAds: 'wordads/stats',
 	statsEmailsSummary: 'stats/emails/summary',
-	statsEmailsSummaryByOpens: 'stats/emails/summary',
 };
 
 const wpcomV2Endpoints = {
@@ -96,13 +95,6 @@ export function requestSiteStats( siteId, statType, query ) {
 						quantity: query.quantity ?? 10,
 						sort_field: query.sort_field ?? 'post_id',
 						sort_order: query.sort_order ?? 'desc',
-					};
-				case 'statsEmailsSummaryByOpens':
-					return {
-						period: PERIOD_ALL_TIME,
-						quantity: query.quantity ?? 10,
-						sort_field: 'opens',
-						sort_order: 'desc',
 					};
 				default:
 					return query;

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -974,15 +974,4 @@ export const normalizers = {
 			};
 		} );
 	},
-	/**
-	 * Returns a normalized statsEmailsSummaryByOpens array, ready for use in stats-module
-	 * @param   {Object} data   Stats data
-	 * @param   {Object} query  Stats query
-	 * @param   {number} siteId  Site ID
-	 * @param   {Object} site    Site object
-	 * @returns {Array}       Normalized stats data
-	 */
-	statsEmailsSummaryByOpens: ( data, query, siteId, site ) => {
-		return normalizers.statsEmailsSummary( data, query, siteId, site );
-	},
 };


### PR DESCRIPTION
Emails are ordered by `post_id` on Subscribers page (`/stats/subscribers/{site}`) and by `opens` on Emails Summary page (`stats/day/emails/{site}`. In both cases, the header of the table column is 'Latest Emails'.

Related to #73217, it looks like there wasn't a particular reason not to have a consistency between these 2 lists https://github.com/Automattic/wp-calypso/pull/73217#issuecomment-2095936807. I noticed it while implementing a similar feature on the mobile app pcdRpT-6pO-p2

## Proposed Changes

* Use `statsEmailsSummary` which sets `sort_field` to `post_id`  for both pages 

## Testing Instructions

1. Select a higher-traffic site with multiple emails sent
2. Open Stats
3. Open Subscribers
4. Observe Emails card and emails ordering
5. Click 'View all'
6. Confirm a longer list has the same ordering as Emails card

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?