### PR TITLE
Entrepreneur Plan: Update heading on the `plans/my-plan/trial-upgraded` page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -42,6 +43,16 @@ const TrialUpgradeConfirmation = () => {
 	} );
 
 	const currentPlanName = isFetchingSitePlan ? '' : selectedSite?.plan?.product_name_short ?? '';
+	const isEnrepreneurTrialFlow = config.isEnabled( 'entrepreneur-my-home' );
+	const entrepreneurTrialWelcome =
+		currentPlanName &&
+		translate( 'Welcome to the %(planName)s plan', {
+			args: { planName: currentPlanName },
+			comment: 'The `planName` is the name of the plan the user has just upgraded to.',
+		} );
+	const welcomeTitle = isEnrepreneurTrialFlow
+		? entrepreneurTrialWelcome
+		: translate( 'Woo! Welcome to Woo Express' );
 
 	return (
 		<>
@@ -54,9 +65,7 @@ const TrialUpgradeConfirmation = () => {
 					title="Plans > Ecommerce Trial Post Upgrade Actions"
 				/>
 				<div className="trial-upgrade-confirmation__header">
-					<h1 className="trial-upgrade-confirmation__title">
-						{ translate( 'Woo! Welcome to Woo Express' ) }
-					</h1>
+					<h1 className="trial-upgrade-confirmation__title">{ welcomeTitle }</h1>
 					<div className="trial-upgrade-confirmation__subtitle">
 						<span className="trial-upgrade-confirmation__subtitle-line">
 							{ currentPlanName &&


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/6930.

## Proposed Changes

* update the heading on the `plans/my-plan/trial-upgraded` page to `Welcome to the %(planName)s plan`
* the change is applied only when the `entrepreneur-my-home` feature flag is enabled (I did not introduce another feature flag on purpose; once switching from Woo Express Trial to the Entrepreneur Trial plan, we will just remove the feature flag together with the Woo Express copy)

| Before | After |
|--------|--------|
| ![Markup on 2024-05-06 at 17:40:15](https://github.com/Automattic/wp-calypso/assets/25105483/0d68757c-f774-4e16-aecb-b7e33a6494fa) | ![Markup on 2024-05-06 at 17:39:53](https://github.com/Automattic/wp-calypso/assets/25105483/4cd270da-039a-479d-9e1a-1034d5d2a717) | 

## Testing Instructions

1. Prepare a site with Entrepreneur plan (you can use SA to add the plan to your test site).
2. Navigate to `http://calypso.localhost:3000/plans/my-plan/trial-upgraded/<site-slug-goes-here>?flags=entrepreneur-my-home`.
3. The new page heading should load (as can be seen in the screenshot above).
4. If you like to perform a complete test, prepare an Entrepreneur **Trial** site and upgrade it to the **full** Entrepreneur plan; as soon as you finish the checkout process, you should end up on the `http://calypso.localhost:3000/plans/my-plan/trial-upgraded/<site-slug-goes-here>` page. Now it is necessary to add the feature flag to the URL → `http://calypso.localhost:3000/plans/my-plan/trial-upgraded/<site-slug-goes-here>?flags=entrepreneur-my-home` and reload the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?