### PR TITLE
Site logs date picker - adjust hover styles

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -34,7 +34,15 @@
 			align-items: center;
 			gap: 16px;
 		}
+
+		input[type="datetime-local"] {
+			cursor: default;
+			&::-webkit-calendar-picker-indicator {
+				cursor: pointer;
+			}
+		}
 	}
+
 	.site-logs-toolbar__filter {
 		display: none;
 		float: right;

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -36,7 +36,7 @@
 		}
 
 		input[type="datetime-local"] {
-			cursor: default;
+			cursor: text;
 			&::-webkit-calendar-picker-indicator {
 				cursor: pointer;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/6938

## Proposed Changes

Adjusts the styles of the datetime picker for site logs. In this PR we set
* Set the cursor style of the datetime input to `cursor: text`. It was previously inheriting `cursor: pointer` from the general button styles).
* applies `cursor: pointer` to the calendar icon pseudo element supported by webkit (chrome and edge)

NOTEs
- This is an interesting case because these are native browser elements and different browsers display these inputs differently and with different behavior. E.g. chrome/firefox/edge have calendar icons that open the calendar picker, and allow selecting the text for updating numerical values inline while safari has no calendar icon and all clicks open the calendar picker (no inline numerical value support). Similarly firefox does not have a targetable pseudo element for the calendar icon while firefox/edge do.
- We don't seem to have a good way to target the individual browsers types specifically. I tried to use `@supports` css queries to target specific browsers but never found a good way to target individual browsers without bleeding into others. Chat GPT also led me in circles with various different recommendations that all seemed to bleed into other browsers making them not applicable. Even if we were able to find good browser specificity with `@supports` queries, it seems hacky and fragile and subject to change as browsers evolve. 
- Because of this, there are tradeoffs with the implementation.

BROWSER SPECIFIC CHANGES

Note - these after gifs are outdated to the recent changes. The cursor shown over the text fields is now the cursor: text. everything else remains the same.

- CHROME and EDGE - removes the cursor-pointer input from the inline numerical selection areas ✅ and adds cursor pointer to the calendar icon that triggers the popover ✅ 

BEFORE:

![datetime-chrome-before](https://github.com/Automattic/wp-calypso/assets/28742426/6bb77085-a842-4c1a-b41d-1d7ec4000905)


chrome after:
![datetime-after-chrome](https://github.com/Automattic/wp-calypso/assets/28742426/19168267-7bf7-4c09-92dd-e4025aa9ba06)

edge after:
![datetime-edge-after](https://github.com/Automattic/wp-calypso/assets/28742426/2bcdb5cb-7c82-4429-9bca-5725decf348e)

- FIREFOX - removes the cursor-pointer input from the inline numerical selection areas ✅ but does not add cursor pointer to the calendar icon that triggers the popover 🟡  - this still seems ok since the firefox calendar icon itself shows hover styles giving the same end effect of responsive indication ✅ 


before:
![datetime-firefox-before](https://github.com/Automattic/wp-calypso/assets/28742426/b258b84c-a81f-4989-be58-0d62fdaae204)



after:
![datetime-firefox-after](https://github.com/Automattic/wp-calypso/assets/28742426/f5d93833-d14d-47c4-9513-e98d89f1dfa8)


- SAFARI - removes the cursor-pointer from the input. 🔴  Because the entire input triggers the calendar selector popover, it seems like it would be better for this to be `cursor: pointer` across the entire input. However, I was unable to target safari alone to do this without affecting the other major browsers. 🟡  this still seems ok to me since we are essentially resetting to the default browser behavior for this input.

before:
![datetime-safari-before](https://github.com/Automattic/wp-calypso/assets/28742426/9c751ba2-7e9b-4624-8959-4ab39d195bed)


after:
![datetime-safari-after](https://github.com/Automattic/wp-calypso/assets/28742426/80a6c5ee-1f27-4bed-8738-e0426174f1ff)


This seems like an overall improvement to the main browsers (chrome, firefox, edge), and while it feels like the previous implementation may have fit safari better using its default styles to enable a better experience in the other browsers seems like a good tradeoff.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso PR.
* Visit the sites dashboard at /sites
* select an atomic site
* tab to php logs and server logs tabs
* test the input on various browsers (chrome, firefox, edge, safari)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
