### PR TITLE
A4A: Update the Referrals page based on the new design.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -8,12 +8,12 @@ type Props = {
 	foldable?: boolean;
 };
 
-const MigrationOfferHeader = () => {
+const MigrationOfferHeader = ( { withIcon }: { withIcon?: boolean } ) => {
 	const translate = useTranslate();
 	const title = translate( 'Special limited-time migration offer for our partners' );
 	return (
 		<div className="a4a-migration-offer__title">
-			<Icon icon={ reusableBlock } size={ 32 } />
+			{ withIcon && <Icon icon={ reusableBlock } size={ 32 } /> }
 			<h3>{ title }</h3>
 		</div>
 	);
@@ -57,7 +57,7 @@ const MigrationOffer = ( props: Props ) => {
 	return foldable ? (
 		<FoldableCard
 			className="a4a-migration-offer__wrapper"
-			header={ <MigrationOfferHeader /> }
+			header={ <MigrationOfferHeader withIcon /> }
 			expanded
 			clickableHeader
 			summary={ false }
@@ -66,8 +66,14 @@ const MigrationOffer = ( props: Props ) => {
 		</FoldableCard>
 	) : (
 		<div className="a4a-migration-offer__wrapper non-foldable">
-			<MigrationOfferHeader />
-			<MigrationOfferBody />
+			<div className="a4a-migration-offer__aside">
+				<Icon icon={ reusableBlock } size={ 24 } />
+			</div>
+
+			<div className="a4a-migration-offer__main">
+				<MigrationOfferHeader />
+				<MigrationOfferBody />
+			</div>
 		</div>
 	);
 };

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -48,10 +48,11 @@
 	}
 
 	.a4a-migration-offer__description {
-		font-size: 1rem;
 		color: var(--studio-gray-80);
+		font-size: 1rem;
 		font-weight: 400;
-		line-height: 32px;
+		line-height: 1.65;
+		margin-block-start: 16px;
 	}
 
 	.a4a-migration-offer__note {

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -5,6 +5,10 @@
 	box-shadow: none;
 
 	&.non-foldable {
+		display: flex;
+		flex-direction: row;
+		gap: 16px;
+
 		padding: 16px;
 		margin-block-end: 16px;
 		border: 1px solid var(--studio-automattic-blue-5);
@@ -12,6 +16,10 @@
 		p {
 			max-width: 70%;
 		}
+	}
+
+	.a4a-migration-offer__aside {
+		min-width: 24px;
 	}
 
 	.foldable-card__content {

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -18,6 +18,7 @@ export const A4A_MARKETPLACE_ASSIGN_LICENSE_LINK = `${ A4A_MARKETPLACE_LINK }/as
 export const A4A_PURCHASES_LINK = '/purchases';
 export const A4A_REFERRALS_LINK = '/referrals';
 export const A4A_REFERRALS_BANK_DETAILS_LINK = '/referrals/bank-details';
+export const A4A_REFERRALS_COMMISSIONS_LINK = '/referrals/commissions';
 export const A4A_LICENSES_LINK = `${ A4A_PURCHASES_LINK }/licenses`;
 export const A4A_UNASSIGNED_LICENSES_LINK = `${ A4A_LICENSES_LINK }/unassigned`;
 export const A4A_BILLING_LINK = `${ A4A_PURCHASES_LINK }/billing`;

--- a/client/a8c-for-agencies/sections/referrals/common/step-section/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section/index.tsx
@@ -4,7 +4,7 @@ import './style.scss';
 
 interface StepSectionProps {
 	heading: string;
-	stepCount: number;
+	stepCount?: number;
 	children: React.ReactNode;
 }
 
@@ -12,7 +12,7 @@ export default function StepSection( { stepCount, heading, children }: StepSecti
 	return (
 		<div className="step-section">
 			<div className="step-section__header">
-				<div className="step-section__step-count">{ stepCount }</div>
+				{ !! stepCount && <div className="step-section__step-count">{ stepCount }</div> }
 				<div className="step-section__step-heading">{ heading }</div>
 			</div>
 			<div className="step-section__content">{ children }</div>

--- a/client/a8c-for-agencies/sections/referrals/common/step-section/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section/style.scss
@@ -27,6 +27,7 @@
 
 		.step-section__step-heading {
 			font-size: rem(20px);
+			font-weight: 600;
 			text-wrap: pretty;
 		}
 	}

--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -1,6 +1,7 @@
 import { type Callback } from '@automattic/calypso-router';
 import MainSidebar from '../../components/sidebar-menu/main';
 import ReferralsBankDetails from './primary/bank-details';
+import CommissionOverview from './primary/commission-overview';
 import ReferralsOverview from './primary/referrals-overview';
 
 export const referralsContext: Callback = ( context, next ) => {
@@ -11,6 +12,12 @@ export const referralsContext: Callback = ( context, next ) => {
 
 export const referralsBankDetailsContext: Callback = ( context, next ) => {
 	context.primary = <ReferralsBankDetails />;
+	context.secondary = <MainSidebar path={ context.path } />;
+	next();
+};
+
+export const referralsCommissionOverviewContext: Callback = ( context, next ) => {
+	context.primary = <CommissionOverview />;
 	context.secondary = <MainSidebar path={ context.path } />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/referrals/index.ts
+++ b/client/a8c-for-agencies/sections/referrals/index.ts
@@ -2,15 +2,31 @@ import page from '@automattic/calypso-router';
 import {
 	A4A_REFERRALS_LINK,
 	A4A_REFERRALS_BANK_DETAILS_LINK,
+	A4A_REFERRALS_COMMISSIONS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
 export default function () {
-	page( A4A_REFERRALS_LINK, controller.referralsContext, makeLayout, clientRender );
+	page(
+		A4A_REFERRALS_LINK,
+		requireAccessContext,
+		controller.referralsContext,
+		makeLayout,
+		clientRender
+	);
 	page(
 		A4A_REFERRALS_BANK_DETAILS_LINK,
+		requireAccessContext,
 		controller.referralsBankDetailsContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_REFERRALS_COMMISSIONS_LINK,
+		requireAccessContext,
+		controller.referralsCommissionOverviewContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -1,0 +1,108 @@
+import { FoldableCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderBreadcrumb as Breadcrumb,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_REFERRALS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import WooCommerceLogo from 'calypso/components/woocommerce-logo';
+import WordPressLogo from 'calypso/components/wordpress-logo';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import StepSection from '../../common/step-section';
+
+import './style.scss';
+
+export default function CommissionOverview() {
+	const translate = useTranslate();
+
+	const title = translate( 'Referrals - Commission details and terms' );
+
+	return (
+		<Layout
+			className="commission-overview"
+			title={ title }
+			wide
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
+			<PageViewTracker title={ title } path="/referrals/" />
+
+			<LayoutTop>
+				<LayoutHeader>
+					<Breadcrumb
+						items={ [
+							{ label: translate( 'Referrals' ), href: A4A_REFERRALS_LINK },
+							{ label: translate( 'Commission details and terms' ) },
+						] }
+					/>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<StepSection heading={ translate( 'How much can I earn?' ) }>
+					<FoldableCard
+						header={
+							<div className="commission-overview__heading">
+								<img src={ pressableIcon } alt="Pressable" />
+								<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
+								{ translate( 'Hosting revenue share (WordPress.com and Pressable)' ) }
+							</div>
+						}
+						expanded
+						clickableHeader
+						summary={ false }
+					>
+						{ translate(
+							'Get a 20% revenue share when you refer your clients to WordPress.com and Pressable until June 30th, 2025 (and renewals on those subscriptions).'
+						) }
+					</FoldableCard>
+
+					<FoldableCard
+						header={
+							<div className="commission-overview__heading">
+								<JetpackLogo className="jetpack-logo" size={ 24 } />
+								<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
+								{ translate( 'Jetpack products and Woo-owned extensions' ) }
+							</div>
+						}
+						expanded
+						clickableHeader
+						summary={ false }
+					>
+						{ translate(
+							'Get a 50% revenue share on Jetpack products and Woo-owned extensions until June 30th, 2025 (and renewals on those subscriptions).'
+						) }
+					</FoldableCard>
+				</StepSection>
+
+				<StepSection heading={ translate( 'Eligibility requirements and terms of use?' ) }>
+					<FoldableCard
+						header={ translate( 'Active referrals' ) }
+						expanded
+						clickableHeader
+						summary={ false }
+					>
+						{ translate(
+							'To continue earning a revenue share on all of the above, you must refer at least one new client to a WordPress.com or Pressable plan each year, starting from the date that you joined the Automattic for Agencies program.'
+						) }
+					</FoldableCard>
+
+					<FoldableCard
+						header={ translate( 'Automattic Affiliate Program' ) }
+						expanded
+						clickableHeader
+						summary={ false }
+					>
+						{ translate(
+							'If you are also a member of the Automattic Affiliate Program, you will not be paid out again on any transactions that you have already received commission on.'
+						) }
+					</FoldableCard>
+				</StepSection>
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -14,6 +14,7 @@ import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import StepSection from '../../common/step-section';
+import ReferralsFooter from '../footer';
 
 import './style.scss';
 
@@ -43,65 +44,69 @@ export default function CommissionOverview() {
 			</LayoutTop>
 
 			<LayoutBody>
-				<StepSection heading={ translate( 'How much can I earn?' ) }>
-					<FoldableCard
-						header={
-							<div className="commission-overview__heading">
-								<img src={ pressableIcon } alt="Pressable" />
-								<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
-								{ translate( 'Hosting revenue share (WordPress.com and Pressable)' ) }
-							</div>
-						}
-						expanded
-						clickableHeader
-						summary={ false }
-					>
-						{ translate(
-							'Get a 20% revenue share when you refer your clients to WordPress.com and Pressable until June 30th, 2025 (and renewals on those subscriptions).'
-						) }
-					</FoldableCard>
+				<div className="commission-overview__section-container">
+					<StepSection heading={ translate( 'How much can I earn?' ) }>
+						<FoldableCard
+							header={
+								<div className="commission-overview__heading">
+									<img src={ pressableIcon } alt="Pressable" />
+									<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
+									{ translate( 'Hosting revenue share (WordPress.com and Pressable)' ) }
+								</div>
+							}
+							expanded
+							clickableHeader
+							summary={ false }
+						>
+							{ translate(
+								'Get a 20% revenue share when you refer your clients to WordPress.com and Pressable until June 30th, 2025 (and renewals on those subscriptions).'
+							) }
+						</FoldableCard>
 
-					<FoldableCard
-						header={
-							<div className="commission-overview__heading">
-								<JetpackLogo className="jetpack-logo" size={ 24 } />
-								<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
-								{ translate( 'Jetpack products and Woo-owned extensions' ) }
-							</div>
-						}
-						expanded
-						clickableHeader
-						summary={ false }
-					>
-						{ translate(
-							'Get a 50% revenue share on Jetpack products and Woo-owned extensions until June 30th, 2025 (and renewals on those subscriptions).'
-						) }
-					</FoldableCard>
-				</StepSection>
+						<FoldableCard
+							header={
+								<div className="commission-overview__heading">
+									<JetpackLogo className="jetpack-logo" size={ 24 } />
+									<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
+									{ translate( 'Jetpack products and Woo-owned extensions' ) }
+								</div>
+							}
+							expanded
+							clickableHeader
+							summary={ false }
+						>
+							{ translate(
+								'Get a 50% revenue share on Jetpack products and Woo-owned extensions until June 30th, 2025 (and renewals on those subscriptions).'
+							) }
+						</FoldableCard>
+					</StepSection>
 
-				<StepSection heading={ translate( 'Eligibility requirements and terms of use?' ) }>
-					<FoldableCard
-						header={ translate( 'Active referrals' ) }
-						expanded
-						clickableHeader
-						summary={ false }
-					>
-						{ translate(
-							'To continue earning a revenue share on all of the above, you must refer at least one new client to a WordPress.com or Pressable plan each year, starting from the date that you joined the Automattic for Agencies program.'
-						) }
-					</FoldableCard>
+					<StepSection heading={ translate( 'Eligibility requirements and terms of use?' ) }>
+						<FoldableCard
+							header={ translate( 'Active referrals' ) }
+							expanded
+							clickableHeader
+							summary={ false }
+						>
+							{ translate(
+								'To continue earning a revenue share on all of the above, you must refer at least one new client to a WordPress.com or Pressable plan each year, starting from the date that you joined the Automattic for Agencies program.'
+							) }
+						</FoldableCard>
 
-					<FoldableCard
-						header={ translate( 'Automattic Affiliate Program' ) }
-						expanded
-						clickableHeader
-						summary={ false }
-					>
-						{ translate(
-							'If you are also a member of the Automattic Affiliate Program, you will not be paid out again on any transactions that you have already received commission on.'
-						) }
-					</FoldableCard>
-				</StepSection>
+						<FoldableCard
+							header={ translate( 'Automattic Affiliate Program' ) }
+							expanded
+							clickableHeader
+							summary={ false }
+						>
+							{ translate(
+								'If you are also a member of the Automattic Affiliate Program, you will not be paid out again on any transactions that you have already received commission on.'
+							) }
+						</FoldableCard>
+					</StepSection>
+				</div>
+
+				<ReferralsFooter />
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
@@ -1,0 +1,53 @@
+
+.commission-overview {
+	.step-section {
+		margin-block: 32px 64px;
+	}
+
+	.commission-overview__heading {
+		display: flex;
+		flex-direction: row;
+		gap: 8px;
+	}
+
+	.jetpack-logo {
+		fill: var(--color-jetpack);
+	}
+
+	.woocommerce-logo {
+		fill: var(--color-woocommerce);
+	}
+
+	.a4a-layout__body-wrapper {
+		max-width: 900px;
+	}
+
+	.foldable-card.card,
+	.foldable-card.card.is-expanded {
+		border: none;
+		border-radius: 4px;
+		margin-block-start: 0;
+		margin-block-end: 24px;
+	}
+
+	.foldable-card__header,
+	.foldable-card.is-expanded .foldable-card__content {
+		border: none;
+	}
+
+
+	.foldable-card__header {
+		padding: 24px 24px 16px;
+		font-size: rem(16px);
+		font-weight: 600;
+	}
+
+
+	.foldable-card.foldable-card__content,
+	.foldable-card.is-expanded .foldable-card__content {
+		font-size: rem(14px);
+		color: var(--color-neutral-50);
+		font-weight: 400;
+		padding: 0 24px 24px;
+	}
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
@@ -1,7 +1,10 @@
 
 .commission-overview {
-	.step-section {
-		margin-block: 32px 64px;
+	.commission-overview__section-container {
+		display: flex;
+		flex-direction: column;
+		gap: 40px;
+		margin-block: 32px 0;
 	}
 
 	.commission-overview__heading {

--- a/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
@@ -1,0 +1,22 @@
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+export default function ReferralsFooter() {
+	const translate = useTranslate();
+
+	const tosLink = ''; // FIXME: Add the correct link to the Terms of Service.
+
+	return (
+		<div className="referrals-footer">
+			{ translate(
+				"Every 60 days, we'll calculate and pay out your commissions based on your clients’ purchases. Read the {{a}}Terms of Service.{{/a}}",
+				{
+					components: {
+						a: <a href={ tosLink } target="_blank" rel="noreferrer" />,
+					},
+				}
+			) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
@@ -5,7 +5,7 @@ import './style.scss';
 export default function ReferralsFooter() {
 	const translate = useTranslate();
 
-	const tosLink = ''; // FIXME: Add the correct link to the Terms of Service.
+	const tosLink = 'https://automattic.com/for-agencies/platform-agreement/';
 
 	return (
 		<div className="referrals-footer">

--- a/client/a8c-for-agencies/sections/referrals/primary/footer/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/footer/style.scss
@@ -1,0 +1,12 @@
+.referrals-footer {
+	font-size: rem(14px);
+	font-weight: 400;
+	margin-block-end: 48px;
+	color: var(--color-neutral-50);
+
+	a,
+	a:visited {
+		color: var(--color-neutral-100);
+		text-decoration: underline;
+	}
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -109,9 +109,8 @@ export default function ReferralsOverview() {
 					</div>
 				) }
 				<div className="referrals-overview__section-heading">
-					{ translate(
-						'Recommend our products. Earn up to a 50% commission. No promo codes required.'
-					) }
+					{ translate( 'Recommend our products. Earn up to a 50% commission.' ) } <br />
+					{ translate( ' No promo codes required.' ) }
 				</div>
 
 				<div className="referrals-overview__section-subtitle">

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -26,6 +26,7 @@ import StepSectionItem from '../../common/step-section-item';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 import { getAccountStatus } from '../../lib/get-account-status';
 import tipaltiLogo from '../../lib/tipalti-logo';
+import ReferralsFooter from '../footer';
 
 import './style.scss';
 
@@ -178,6 +179,8 @@ export default function ReferralsOverview() {
 						</>
 					) }
 				</div>
+
+				{ ! isFetching && <ReferralsFooter /> }
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,5 +1,5 @@
 import NoticeBanner from '@automattic/components/src/notice-banner';
-import { plugins, payment, percent } from '@wordpress/icons';
+import { plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
@@ -10,7 +10,10 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_REFERRALS_BANK_DETAILS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_REFERRALS_BANK_DETAILS_LINK,
+	A4A_REFERRALS_COMMISSIONS_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { A4A_DOWNLOAD_LINK_ON_GITHUB } from 'calypso/a8c-for-agencies/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -105,8 +108,22 @@ export default function ReferralsOverview() {
 					</div>
 				) }
 				<div className="referrals-overview__section-heading">
-					{ translate( 'Receive up to 50% revenue share on Automattic product referrals.' ) }
+					{ translate(
+						'Recommend our products. Earn up to a 50% commission. No promo codes required.'
+					) }
 				</div>
+
+				<div className="referrals-overview__section-subtitle">
+					{ translate(
+						'Earn commissions from client purchases across our products, including WooCommerce, Jetpack, and hosting services from Pressable or WordPress.com. {{a}}How much can I earn?{{/a}}',
+						{
+							components: {
+								a: <a href={ A4A_REFERRALS_COMMISSIONS_LINK } />,
+							},
+						}
+					) }
+				</div>
+
 				<div className="referrals-overview__section-container">
 					{ isFetching ? (
 						<>
@@ -117,20 +134,18 @@ export default function ReferralsOverview() {
 						</>
 					) : (
 						<>
-							<StepSection
-								heading={ translate( 'Set up your commission payments' ) }
-								stepCount={ 1 }
-							>
+							<MigrationOffer />
+							<StepSection heading={ translate( 'How do I get started?' ) }>
 								<StepSectionItem
 									icon={ tipaltiLogo }
-									heading={ translate( 'Set up payment details in Tipalti' ) }
+									heading={ translate( 'Enter your bank details so we can pay you commissions' ) }
 									description={ translate(
 										'Get paid seamlessly by adding your bank details and tax forms to Tipalti, our trusted and secure platform for commission payments.'
 									) }
 									buttonProps={ {
 										children: hasPayeeAccount
 											? translate( 'Edit my bank details' )
-											: translate( 'Get started with secure payments' ),
+											: translate( 'Enter bank details' ),
 										href: A4A_REFERRALS_BANK_DETAILS_LINK,
 										onClick: onAddBankDetailsClick,
 										primary: ! hasPayeeAccount,
@@ -148,36 +163,16 @@ export default function ReferralsOverview() {
 								/>
 								<StepSectionItem
 									icon={ plugins }
-									heading={ translate( 'Install the A4A plugin to verify your referrals' ) }
+									heading={ translate( 'Verify your relationship with your clients' ) }
 									description={ translate(
-										'Install the A4A plugin on your clients’ sites to verify your referrals accurately and ensure easy tracking of Automattic product purchases.'
+										'Install the A4A plugin on your clients’ sites. This shows you have a direct relationship with the client.'
 									) }
 									buttonProps={ {
-										children: translate( 'Download plugin to verify my referrals' ),
+										children: translate( 'Download the plugin now' ),
 										compact: true,
 										href: A4A_DOWNLOAD_LINK_ON_GITHUB,
 										onClick: onDownloadA4APluginClick,
 									} }
-								/>
-							</StepSection>
-							<StepSection
-								heading={ translate( 'Earn commissions from your referrals' ) }
-								stepCount={ 2 }
-							>
-								<MigrationOffer />
-								<StepSectionItem
-									icon={ payment }
-									heading={ translate( 'Encourage your clients to purchase Automattic products' ) }
-									description={ translate(
-										'We offer commissions for each purchase of Automattic products by your clients, including Woo, Jetpack, and hosting from either Pressable or WordPress.com.'
-									) }
-								/>
-								<StepSectionItem
-									icon={ percent }
-									heading={ translate( 'Receive commissions on client purchases' ) }
-									description={ translate(
-										'Every 60 days, we will review your clients’ purchases and pay you a commission based on them.'
-									) }
 								/>
 							</StepSection>
 						</>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -5,8 +5,20 @@
 .referrals-overview__section-heading {
 	margin-block-start: 24px;
 	font-size: rem(24px);
-	margin-block-end: 48px;
+	margin-block-end: 8px;
 	font-weight: 600;
+}
+.referrals-overview__section-subtitle {
+	font-size: rem(14px);
+	font-weight: 400;
+	margin-block-end: 48px;
+	color: var(--color-neutral-50);
+
+	a,
+	a:visited {
+		color: var(--color-neutral-100);
+		text-decoration: underline;
+	}
 }
 
 .referrals-overview__section-container {

--- a/client/sections.js
+++ b/client/sections.js
@@ -777,7 +777,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-referrals',
-		paths: [ '/referrals', '/referrals/bank-details' ],
+		paths: [ '/referrals', '/referrals/bank-details', '/referrals/commissions' ],
 		module: 'calypso/a8c-for-agencies/sections/referrals',
 		group: 'a8c-for-agencies',
 	},


### PR DESCRIPTION
This PR updates the Referrals page based on the new design.

**Updated Referrals page**
| Before | After |
|--------|--------|
| <img width="966" alt="Screenshot 2024-05-07 at 12 14 11 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f7b2338d-fbd8-4670-8a7e-b76d10d7d6b1"> | <img width="971" alt="Screenshot 2024-05-07 at 6 38 11 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/38e90eda-9da5-4e0a-b2d9-f635c6aa9598"> |


**Dedicated Commission details and terms page**
<img width="1350" alt="Screenshot 2024-05-07 at 12 11 02 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d1884ce9-aeeb-404a-b91f-b8b4f8a142f1">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/438

## Proposed Changes

* Update the Referrals page with a more simplified text.
* Add a dedicated Commission details and terms page.

## Testing Instructions

* Use the A4A live link and go to `/referrals`
* Confirm that the page matches the new design.
* Click the 'How can I earn?' link.
* Confirm that you are redirected to the new dedicated Commission details and terms page.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?