### PR TITLE
New instructions: add track event when site is prepared

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -57,6 +57,12 @@ const SiteMigrationInstructions: Step = function () {
 		}
 	}, [ fromUrl, hasErrorGetMigrationKey ] );
 
+	useEffect( () => {
+		if ( isSetupCompleted ) {
+			recordTracksEvent( 'calypso_onboarding_site_migration_instructions_preparation_complete' );
+		}
+	}, [ isSetupCompleted ] );
+
 	const stepContent = (
 		<div className="site-migration-instructions__content">
 			<ol className="site-migration-instructions__list">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -59,7 +59,7 @@ const SiteMigrationInstructions: Step = function () {
 
 	useEffect( () => {
 		if ( isSetupCompleted ) {
-			recordTracksEvent( 'calypso_onboarding_site_migration_instructions_preparation_complete' );
+			recordTracksEvent( 'calypso_site_migration_instructions_preparation_complete' );
 		}
 	}, [ isSetupCompleted ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

We want to be able to track progress along the new instructions screen. In order to do that, this PR adds a new track event called `calypso_onboarding_site_migration_instructions_preparation_complete` that fires when the site preparation is complete, ie: at transfer ready & plugins installed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the site-migration flow with the `migration-flow/remove-processing-step` feature flag enabled. (you can enable it via console by running `sessionStorage.setItem('flags', 'migration-flow/remove-processing-step') `.
* Once you get to the instructions screen verify that the track event is fired when the first two items are marked as complete


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?