### PR TITLE
A4A: Fix the issue with the licenses row showing the Atomic site dropdown menu for non-WPCOM licenses.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -90,9 +90,9 @@ export function isPressableHostingProduct( keyOrSlug: string ) {
 
 /**
  * Determine if current slug is a WPCOM hosting product.
- * @param {string} slug - Product slug
+ * @param {string} keyOrSlug - Product slug
  * @returns {boolean} - True if WPCOM hosting product, false if not
  */
-export function isWPCOMHostingProduct( slug: string ) {
-	return slug.startsWith( 'wpcom-hosting' );
+export function isWPCOMHostingProduct( keyOrSlug: string ) {
+	return keyOrSlug.startsWith( 'wpcom-hosting' );
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -5,7 +5,10 @@ import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext } from 'react';
-import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import {
+	isPressableHostingProduct,
+	isWPCOMHostingProduct,
+} from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import FormattedDate from 'calypso/components/formatted-date';
 import getLicenseState from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-license-state';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
@@ -62,6 +65,7 @@ export default function LicensePreview( {
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
+	const isWPCOMLicense = isWPCOMHostingProduct( licenseKey );
 	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
 
 	const { filter } = useContext( LicensesOverviewContext );
@@ -248,7 +252,7 @@ export default function LicensePreview( {
 							bundleSize={ quantity }
 						/>
 					) }
-					{ isSiteAtomic ? (
+					{ isWPCOMLicense && isSiteAtomic ? (
 						<LicenseActions
 							siteUrl={ siteUrl }
 							licenseKey={ licenseKey }


### PR DESCRIPTION
This pull request resolves the issue with the Atomic site dropdown menu being displayed for non-WPCOM licenses in the Licenses row.

| Before | After |
|--------|--------|
| <img width="1516" alt="Screenshot 2024-05-07 at 1 08 14 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c0833e95-ba2c-4ddd-a31b-94c27127fd65"> | <img width="1507" alt="Screenshot 2024-05-07 at 1 07 55 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/96322ab6-0e0a-43be-83e3-897f35b2e9bd"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/431

## Proposed Changes

* Ensure that the Atomic site dropdown menu is only rendered when the License is a WPCOM plan.

## Testing Instructions


* Purchase a Woocommerce extension or a Jetpack product.
* Purchase a WPCOM plan and create a new atomic site. 
* Use the A4A live link and go to `/purchases/licenses`
* Assign the Woocommerce or Jetpack licenses to the atomic site.
* Confirm that that the Atomic site dropdown menu do not show up.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?