### PR TITLE
Nav Redesign: Update site management panel home button copy

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -36,13 +36,13 @@ export default function ItemPreviewPaneHeader( {
 		const wpcomAdminInterface = getSiteOption( state, itemData.blogId, 'wpcom_admin_interface' );
 		if ( wpcomAdminInterface === 'wp-admin' ) {
 			return {
-				adminLabel: translate( 'Go to WP Admin' ),
+				adminLabel: translate( 'WP admin' ),
 				adminUrl: itemData.adminUrl,
 			};
 		}
 
 		return {
-			adminLabel: translate( 'Go to Dashboard' ),
+			adminLabel: translate( 'My home' ),
 			adminUrl: getSiteHomeUrl( state, itemData.blogId ),
 		};
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6913

## Proposed Changes

* Button copy for Classic view:
<img width="215" alt="Screen Shot 2024-05-06 at 1 10 29 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/0cb2a239-6453-45fd-a3b5-e1f9fe73851d">

- Button copy for default view:

<img width="195" alt="Screen Shot 2024-05-06 at 1 10 42 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/6badd429-8c1c-4fc7-a8c5-dda7f11e7ab4">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /sites
- Select a site
- Check that in the upper right there's a "My home" button that points to My Home for a site in default view.
- Check that in the upper right there's a "WP admin" button that points to wp-admin for a site in classic view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?