### PR TITLE
Site dashboard v2 - update site list rows hover colors

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -72,6 +72,16 @@
 		flex-wrap: nowrap;
 	}
 
+	.dataviews-wrapper {
+		thead tr.dataviews-view-table__row:hover {
+			background: var(--studio-white);
+		}
+
+		tr.dataviews-view-table__row:hover {
+			background-color: #f7faff;
+		}
+	}
+
 	table.dataviews-view-table thead .dataviews-view-table__row th {
 		border-bottom-color: var(--color-border-secondary);
 
@@ -336,7 +346,8 @@
 				border-bottom: 1px solid #f1f1f1 !important;
 			}
 
-			li.is-selected {
+			li.is-selected,
+			li:hover {
 				background-color: #f7faff;
 			}
 		}

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -494,6 +494,15 @@
 			.components-button:focus:not(:disabled) {
 				box-shadow: 0 0 0 2px var(--color-primary-light);
 			}
+
+			thead tr.dataviews-view-table__row:hover {
+				background: var(--studio-white);
+			}
+
+			tr.dataviews-view-table__row:hover,
+			ul.dataviews-view-list li:hover {
+				background-color: #f7faff;
+			}
 		}
 
 		.a4a-layout__top-wrapper,

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -494,15 +494,6 @@
 			.components-button:focus:not(:disabled) {
 				box-shadow: 0 0 0 2px var(--color-primary-light);
 			}
-
-			thead tr.dataviews-view-table__row:hover {
-				background: var(--studio-white);
-			}
-
-			tr.dataviews-view-table__row:hover,
-			ul.dataviews-view-list li:hover {
-				background-color: #f7faff;
-			}
 		}
 
 		.a4a-layout__top-wrapper,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/6954

## Proposed Changes

applies styles for hovering the site list rows in the dotcom styles file for our overrides.

This changes:
* The table header row: no longer shows a different state for hover.
* The table list: updates hover color from the gray to the desired blue.
* The compact sites list: updates hover color the gray to the desired blue.

BEFORE

hovering the headers:
<img width="1234" alt="Screenshot 2024-05-06 at 1 14 31 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/7e6a33a7-8cb1-4bfe-9bc4-63707c74c032">

hovering an item:
<img width="1293" alt="Screenshot 2024-05-06 at 1 14 51 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/66167f4f-886c-4aa7-a2b8-5e67296df070">

hovering an item in the compact list:
<img width="431" alt="Screenshot 2024-05-06 at 1 15 07 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/deb18884-9d4b-49c7-a201-98d1babbb322">


AFTER

hovering the header:
<img width="1004" alt="Screenshot 2024-05-06 at 1 14 02 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/cbaf5f1b-f7d1-49da-a3e1-dc3279243d72">

hovering an item:
<img width="1048" alt="Screenshot 2024-05-06 at 1 13 37 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/7e8de14f-f430-406c-890b-f0abf62f7308">


hovering an item in the compact list:
<img width="448" alt="Screenshot 2024-05-06 at 1 13 14 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d66f63d9-3778-4553-83bd-491ff1c0b4fd">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build
* Go to the site dasbhaord
* test hover colors of areas defined above.
* smoke test a4a there should be no visible changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
