### PR TITLE
Nav Redesign: Open sites preview pane on row click

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -63,7 +63,7 @@ const DotcomSitesDataViews = ( {
 
 	useEffect( () => {
 		// If the user clicks on a row, open the site preview pane by triggering the site button click.
-		const handleRowClick = ( event: MouseEvent ) => {
+		const handleRowClick = ( event: Event ) => {
 			const target = event.target as HTMLElement;
 			const row = target.closest( '.dataviews-view-table__row' );
 			if ( row ) {
@@ -77,10 +77,15 @@ const DotcomSitesDataViews = ( {
 			}
 		};
 
-		document.addEventListener( 'click', handleRowClick );
+		const rowsContainer = document.querySelector( '.dataviews-view-table' );
+		if ( rowsContainer ) {
+			rowsContainer.addEventListener( 'click', handleRowClick as EventListener );
+		}
 
 		return () => {
-			document.removeEventListener( 'click', handleRowClick );
+			if ( rowsContainer ) {
+				rowsContainer.removeEventListener( 'click', handleRowClick as EventListener );
+			}
 		};
 	}, [] );
 

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -61,6 +61,29 @@ const DotcomSitesDataViews = ( {
 		[ setDataViewsState ]
 	);
 
+	useEffect( () => {
+		// If the user clicks on a row, open the site preview pane by triggering the site button click.
+		const handleRowClick = ( event: MouseEvent ) => {
+			const target = event.target as HTMLElement;
+			const row = target.closest( '.dataviews-view-table__row' );
+			if ( row ) {
+				const isButtonOrLink = target.closest( 'button, a' );
+				if ( ! isButtonOrLink ) {
+					const button = row.querySelector( '.sites-dataviews__site' ) as HTMLButtonElement;
+					if ( button ) {
+						button.click();
+					}
+				}
+			}
+		};
+
+		document.addEventListener( 'click', handleRowClick );
+
+		return () => {
+			document.removeEventListener( 'click', handleRowClick );
+		};
+	}, [] );
+
 	// Generate DataViews table field-columns
 	const fields = useMemo< DataViewsColumn[] >(
 		() => [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6863

## Proposed Changes

* This PR listens for a click on the table row and triggers the site preview pane panel for that row.
* It ignores clicks on existing `buttons` and `a` tags.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR and head to http://calypso.localhost:3000/sites?flags=layout%2Fdotcom-nav-redesign-v2
* Click on row and make sure the site preview panel opens
* Click on existing `a` and `button` elements (such as stats and actions) to ensure they function as expected.
* Try and break it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?