### PR TITLE
Add connection url to Blaze Dashboard

### DIFF
--- a/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
@@ -1,9 +1,11 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import privateSiteGraphic from 'calypso/assets/images/blaze/site-private-graphic@3x.png';
 
 export default function DisconnectedSite() {
 	const translate = useTranslate();
+	const connectUrl = config( 'connect_url' );
 
 	return (
 		<>
@@ -46,7 +48,9 @@ export default function DisconnectedSite() {
 									"You'll need to connect your WordPress.com account to integrate Blaze for WooCommerce with your store. Don’t have an account? Not to worry - we’ll help you create one!"
 								) }
 							</p>
-							<Button className="is-primary">{ translate( 'Connect now' ) }</Button>
+							<Button className="is-primary" href={ connectUrl } target="_self">
+								{ translate( 'Connect now' ) }
+							</Button>
 						</div>
 					</li>
 				</ul>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90070

## Proposed Changes

* This PR adds the connection URL to the connect button for disconnected sites using Blaze

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a WooCommerce site, and make sure the Jetpack plugin is deactivated or not installed
* Point `widgets.wp.com` to your WP Sandbox.
* Run `yarn start` to start calypso 
* Create a plugin build from the woo-blaze plugin repo and install it in your test blog OR run locally as described in repo readme.
* cd `apps/blaze-dashboard` and `yarn dev --sync` to sync blaze dashboard to WP sandbox OR run the commands here https://github.com/Automattic/wp-calypso/pull/90334#issuecomment-2096609636
* In WP Admin, Go to `Marketing` -> `Blaze for WooCommerce`
* Click `Connect now` button and you should see the Jetpack connect flow.

<img width="1728" alt="sample-connect-page" src="https://github.com/Automattic/wp-calypso/assets/9039613/2d882326-5f4d-4e97-bc09-c2e22b3374a1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
