### PR TITLE
Remove processing: enable flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -139,7 +139,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": false,
+		"migration-flow/remove-processing-step": true,
 		"migration_assistance_modal": false,
 		"my-sites/add-ons": true,
 		"network-connection": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -87,7 +87,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration_assistance_modal": false,
-		"migration-flow/remove-processing-step": false,
+		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -113,7 +113,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration_assistance_modal": false,
-		"migration-flow/remove-processing-step": false,
+		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -108,7 +108,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": false,
+		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,7 +84,7 @@
 		"migration_assistance_modal": false,
 		"me/account-close": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": false,
+		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2-enabled": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -107,7 +107,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": false,
+		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This effectively removes the processing step in `site-migration` and directs the user to the new instructions screen with the inline spinners.
This should be merged after https://github.com/Automattic/wp-calypso/pull/90328

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Run ` yarn feature-search migration-flow/remove-processing-step` and verify this is the output

<img width="598" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/05c5600d-0e47-4586-a0c1-0b48ddea26d9">

Go through the site migration flow and verify you see the new instructions screen in the end.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?