### PR TITLE
Site Profiler: Add user info form

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -93,4 +93,5 @@ export type BasicMetrics = {
 export interface UrlBasicMetricsQueryResponse {
 	basic: BasicMetrics;
 	advanced: Record< string, string >;
+	token: string;
 }

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { UrlBasicMetricsQueryResponse } from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
 
-export const useUrlBasicMetricsQuery = ( url: string | null ) => {
+export const useUrlBasicMetricsQuery = ( url?: string ) => {
 	return useQuery( {
 		queryKey: [ 'url-', url ],
 		queryFn: (): Promise< UrlBasicMetricsQueryResponse > =>

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -6,10 +6,13 @@ export const useUrlBasicMetricsQuery = ( url: string | null ) => {
 	return useQuery( {
 		queryKey: [ 'url-', url ],
 		queryFn: (): Promise< UrlBasicMetricsQueryResponse > =>
-			wp.req.get( {
-				path: '/site-profiler/metrics/basic?url=' + encodeURIComponent( url ?? '' ),
-				apiNamespace: 'wpcom/v2',
-			} ),
+			wp.req.get(
+				{
+					path: '/site-profiler/metrics/basic',
+					apiNamespace: 'wpcom/v2',
+				},
+				{ url }
+			),
 		meta: {
 			persist: false,
 		},

--- a/client/site-profiler/components/get-report-form/index.tsx
+++ b/client/site-profiler/components/get-report-form/index.tsx
@@ -80,7 +80,7 @@ export function GetReportForm( {
 			return translate( 'Email is required' );
 		}
 		if ( fullValidation && ! emailValidator.validate( email ) ) {
-			return translate( 'Please enter a valid email address.' );
+			return translate( 'Please enter a valid email address' );
 		}
 		return null;
 	};

--- a/client/site-profiler/components/get-report-form/index.tsx
+++ b/client/site-profiler/components/get-report-form/index.tsx
@@ -1,12 +1,132 @@
-import { Gridicon } from '@automattic/components';
-import { CheckboxControl, Button, TextControl } from '@wordpress/components';
+import { FormLabel, FormInputValidation, Gridicon } from '@automattic/components';
+import { CheckboxControl, Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import wp from 'calypso/lib/wp';
 import './styles.scss';
 
-export function GetReportForm() {
+type Errors = {
+	name?: string;
+	email?: string;
+	termsAccepted?: string;
+};
+
+export function GetReportForm( { url, onClose }: { url: string; onClose: () => void } ) {
 	const [ name, setName ] = useState( '' );
 	const [ email, setEmail ] = useState( '' );
+	const [ isTermsChecked, setIsTermsChecked ] = useState( false );
+	const [ errors, setErrors ] = useState< Errors | null >( null );
+	const [ responseError, setResponseError ] = useState< string | null >( null );
+
+	const handleSubmit = async ( e: FormEvent< HTMLFormElement > ) => {
+		e.preventDefault();
+
+		const formData = new FormData( e.currentTarget );
+		const errors = validateForm( formData );
+		if ( errors ) {
+			setErrors( errors );
+			return;
+		}
+		setErrors( null );
+
+		let response = null;
+		try {
+			response = await wp.req.post(
+				{
+					path: '/site-profiler/lead',
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					name: formData.get( 'name' ),
+					email: formData.get( 'email' ),
+					url,
+				}
+			);
+		} catch ( error ) {
+			setResponseError( error instanceof Error ? error.message : String( error ) );
+			return;
+		}
+		if ( response.status !== 200 ) {
+			setResponseError( response.body.message );
+		}
+	};
+
+	const validateName = ( name: string ) => {
+		if ( name ) {
+			return null;
+		}
+		return 'Name is required';
+	};
+	const validateEmail = ( email: string ) => {
+		if ( email ) {
+			return null;
+		}
+		return 'Email is required';
+	};
+	const validateTerms = ( terms: boolean ) => {
+		if ( terms ) {
+			return null;
+		}
+		return 'Terms must be accepted';
+	};
+	function validateForm( formData: FormData ) {
+		let errors = {};
+		let hasErrors = false;
+
+		let error = validateName( formData.get( 'name' ) as string );
+		if ( error ) {
+			errors = { ...errors, name: error };
+			hasErrors = true;
+		}
+		error = validateEmail( formData.get( 'email' ) as string );
+		if ( error ) {
+			errors = { ...errors, email: error };
+			hasErrors = true;
+		}
+		error = validateTerms( Boolean( formData.get( 'termsAccepted' ) ) );
+		if ( error ) {
+			errors = { ...errors, termsAccepted: error };
+			hasErrors = true;
+		}
+		return hasErrors ? errors : null;
+	}
+
+	const handleNameChange = ( e: FormEvent< HTMLInputElement > ) => {
+		const error = validateName( e.currentTarget.value );
+		if ( error ) {
+			setErrors( { ...errors, name: error } );
+		} else {
+			setErrors( { ...errors, name: undefined } );
+		}
+		setName( e.currentTarget.value );
+	};
+
+	const handleEmailChange = ( e: FormEvent< HTMLInputElement > ) => {
+		const error = validateEmail( e.currentTarget.value );
+		if ( error ) {
+			setErrors( { ...errors, email: error } );
+		} else {
+			setErrors( { ...errors, email: undefined } );
+		}
+		setEmail( e.currentTarget.value );
+	};
+
+	const handleTermsChange = ( e: boolean ) => {
+		const error = validateTerms( e );
+		if ( error ) {
+			setErrors( { ...errors, termsAccepted: error } );
+		} else {
+			setErrors( { ...errors, termsAccepted: undefined } );
+		}
+		setIsTermsChecked( e );
+	};
+
+	const handleClose = () => {
+		onClose();
+	};
+
 	return (
 		<div className="get-report-form__container">
 			<div className="get-report-form__title">
@@ -20,47 +140,61 @@ export function GetReportForm() {
 						) }
 					</span>
 					<span>
-						<svg
-							width="20"
-							height="13"
-							viewBox="0 0 20 13"
-							fill="none"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<path
-								d="M17.0741 0.16626L9.75322 7.8889L2.43236 0.16626L0.183472 2.54375L9.75322 12.6607L19.323 2.54375L17.0741 0.16626Z"
-								fill="#3858E9"
-							/>
-						</svg>
+						<Gridicon icon="chevron-down" onClick={ handleClose } />
 					</span>
 				</div>
-				<div className="get-report-form__form">
-					<TextControl
-						className="get-report-form__form-name"
-						label={ translate( 'Name' ) }
-						value={ name }
-						onChange={ setName }
-					/>
-					<TextControl
-						className="get-report-form__form-email"
-						label={ translate( 'Email' ) }
-						value={ email }
-						onChange={ setEmail }
-					/>
-				</div>
-				<div className="get-report-form__footer">
-					<CheckboxControl
-						className="terms-checkbox"
-						onChange={ () => {} }
-						label={ translate(
-							`By submitting your details, you agree to WordPress.com‘s Privacy Policy and Terms of Service. You also consent to receiving occasional updates and offers. You can unsubscribe from these communications at any time through the instructions.`
-						) }
-					/>
-					<Button type="submit" className="submit-button">
-						{ translate( 'Get my report' ) }
-						<Gridicon icon="product-downloadable" />
-					</Button>
-				</div>
+				<form className="get-report-form__form" onSubmit={ handleSubmit }>
+					<div className="get-report-form__form-body">
+						<FormFieldset>
+							<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+							<FormTextInput
+								name="name"
+								className="get-report-form__form-name"
+								label={ translate( 'Name' ) }
+								value={ name }
+								isError={ errors?.name }
+								onChange={ handleNameChange }
+							/>
+
+							{ errors?.name && <FormInputValidation isError={ !! errors } text={ errors.name } /> }
+						</FormFieldset>
+						<FormFieldset>
+							<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
+							<FormTextInput
+								name="email"
+								className="get-report-form__form-email"
+								label={ translate( 'Email' ) }
+								value={ email }
+								isError={ errors?.email }
+								onChange={ handleEmailChange }
+							/>
+							{ errors?.email && (
+								<FormInputValidation isError={ !! errors } text={ errors.email } />
+							) }
+						</FormFieldset>
+					</div>
+					<div className="get-report-form__form-footer">
+						<FormFieldset>
+							<CheckboxControl
+								name="termsAccepted"
+								className="terms-checkbox"
+								checked={ isTermsChecked }
+								onChange={ handleTermsChange }
+								label={ translate(
+									`By submitting your details, you agree to WordPress.com‘s Privacy Policy and Terms of Service. You also consent to receiving occasional updates and offers. You can unsubscribe from these communications at any time through the instructions.`
+								) }
+							/>
+							{ errors?.termsAccepted && (
+								<FormInputValidation isError={ !! errors } text={ errors.termsAccepted } />
+							) }
+						</FormFieldset>
+						<Button type="submit" className="submit-button">
+							{ translate( 'Get my report' ) }
+							<Gridicon icon="product-downloadable" />
+						</Button>
+					</div>
+					{ responseError && <FormInputValidation isError={ true } text={ responseError } /> }
+				</form>
 			</div>
 		</div>
 	);

--- a/client/site-profiler/components/get-report-form/index.tsx
+++ b/client/site-profiler/components/get-report-form/index.tsx
@@ -13,13 +13,22 @@ type Errors = {
 	termsAccepted?: string;
 };
 
-export function GetReportForm( { url, onClose }: { url: string; onClose: () => void } ) {
+export function GetReportForm( {
+	url,
+	token,
+	onClose,
+}: {
+	url?: string;
+	token?: string;
+	onClose: () => void;
+} ) {
 	const [ name, setName ] = useState( '' );
 	const [ email, setEmail ] = useState( '' );
 	const [ isTermsChecked, setIsTermsChecked ] = useState( false );
 	const [ errors, setErrors ] = useState< Errors | null >( null );
 	const [ responseError, setResponseError ] = useState< string | null >( null );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ responseSuccess, setResponseSuccess ] = useState( false );
 
 	const handleSubmit = async ( e: FormEvent< HTMLFormElement > ) => {
 		e.preventDefault();
@@ -44,6 +53,7 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 					name: formData.get( 'name' ),
 					email: formData.get( 'email' ),
 					url,
+					hash: token,
 				}
 			);
 		} catch ( error ) {
@@ -52,8 +62,8 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 		} finally {
 			setIsSubmitting( false );
 		}
-		if ( response.status !== 200 ) {
-			setResponseError( response.body.message );
+		if ( response.success ) {
+			setResponseSuccess( true );
 		}
 	};
 
@@ -156,7 +166,7 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 								className="get-report-form__form-name"
 								label={ translate( 'Name' ) }
 								value={ name }
-								isError={ errors?.name }
+								isError={ !! errors?.name }
 								onChange={ handleNameChange }
 							/>
 
@@ -169,7 +179,7 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 								className="get-report-form__form-email"
 								label={ translate( 'Email' ) }
 								value={ email }
-								isError={ errors?.email }
+								isError={ !! errors?.email }
 								onChange={ handleEmailChange }
 							/>
 							{ errors?.email && (
@@ -192,12 +202,23 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 								<FormInputValidation isError={ !! errors } text={ errors.termsAccepted } />
 							) }
 						</FormFieldset>
-						<Button type="submit" className="submit-button" busy={ isSubmitting }>
+						<Button
+							type="submit"
+							className="submit-button"
+							busy={ isSubmitting }
+							disabled={ responseSuccess }
+						>
 							{ translate( 'Get my report' ) }
 							<Gridicon icon="product-downloadable" />
 						</Button>
 					</div>
 					{ responseError && <FormInputValidation isError={ true } text={ responseError } /> }
+					{ responseSuccess && (
+						<FormInputValidation
+							isError={ false }
+							text="Success! Email with the report link will be sent shortly"
+						/>
+					) }
 				</form>
 			</div>
 		</div>

--- a/client/site-profiler/components/get-report-form/index.tsx
+++ b/client/site-profiler/components/get-report-form/index.tsx
@@ -223,7 +223,7 @@ export function GetReportForm( {
 					{ responseSuccess && (
 						<FormInputValidation
 							isError={ false }
-							text="Success! Email with the report link will be sent shortly"
+							text="Success! An email with the report link will be sent shortly"
 						/>
 					) }
 				</form>

--- a/client/site-profiler/components/get-report-form/index.tsx
+++ b/client/site-profiler/components/get-report-form/index.tsx
@@ -1,5 +1,5 @@
-import { FormLabel, FormInputValidation, Gridicon } from '@automattic/components';
-import { CheckboxControl, Button } from '@wordpress/components';
+import { FormLabel, FormInputValidation, Gridicon, Button } from '@automattic/components';
+import { CheckboxControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { FormEvent, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -19,6 +19,7 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 	const [ isTermsChecked, setIsTermsChecked ] = useState( false );
 	const [ errors, setErrors ] = useState< Errors | null >( null );
 	const [ responseError, setResponseError ] = useState< string | null >( null );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
 	const handleSubmit = async ( e: FormEvent< HTMLFormElement > ) => {
 		e.preventDefault();
@@ -30,6 +31,7 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 			return;
 		}
 		setErrors( null );
+		setIsSubmitting( true );
 
 		let response = null;
 		try {
@@ -47,6 +49,8 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 		} catch ( error ) {
 			setResponseError( error instanceof Error ? error.message : String( error ) );
 			return;
+		} finally {
+			setIsSubmitting( false );
 		}
 		if ( response.status !== 200 ) {
 			setResponseError( response.body.message );
@@ -188,7 +192,7 @@ export function GetReportForm( { url, onClose }: { url: string; onClose: () => v
 								<FormInputValidation isError={ !! errors } text={ errors.termsAccepted } />
 							) }
 						</FormFieldset>
-						<Button type="submit" className="submit-button">
+						<Button type="submit" className="submit-button" busy={ isSubmitting }>
 							{ translate( 'Get my report' ) }
 							<Gridicon icon="product-downloadable" />
 						</Button>

--- a/client/site-profiler/components/get-report-form/index.tsx
+++ b/client/site-profiler/components/get-report-form/index.tsx
@@ -1,11 +1,11 @@
 import { FormLabel, FormInputValidation, Gridicon, Button } from '@automattic/components';
 import { CheckboxControl } from '@wordpress/components';
-import emailValidator from 'email-validator';
 import { translate } from 'i18n-calypso';
 import { FormEvent, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import wp from 'calypso/lib/wp';
+import * as validators from './validators';
 import './styles.scss';
 
 type Errors = {
@@ -35,7 +35,7 @@ export function GetReportForm( {
 		e.preventDefault();
 
 		const formData = new FormData( e.currentTarget );
-		const errors = validateForm( formData );
+		const errors = validators.validateForm( formData );
 		if ( errors ) {
 			setErrors( errors );
 			return;
@@ -68,54 +68,8 @@ export function GetReportForm( {
 		}
 	};
 
-	const validateName = ( name: string ) => {
-		if ( ! name ) {
-			return translate( 'Name is required' );
-		}
-		return null;
-	};
-
-	const validateEmail = ( email: string, fullValidation = false ) => {
-		if ( ! email ) {
-			return translate( 'Email is required' );
-		}
-		if ( fullValidation && ! emailValidator.validate( email ) ) {
-			return translate( 'Please enter a valid email address' );
-		}
-		return null;
-	};
-
-	const validateTerms = ( terms: boolean ) => {
-		if ( ! terms ) {
-			return translate( 'Terms must be accepted' );
-		}
-		return null;
-	};
-
-	function validateForm( formData: FormData ) {
-		let errors = {};
-		let hasErrors = false;
-
-		let error = validateName( formData.get( 'name' ) as string );
-		if ( error ) {
-			errors = { ...errors, name: error };
-			hasErrors = true;
-		}
-		error = validateEmail( formData.get( 'email' ) as string, true );
-		if ( error ) {
-			errors = { ...errors, email: error };
-			hasErrors = true;
-		}
-		error = validateTerms( Boolean( formData.get( 'termsAccepted' ) ) );
-		if ( error ) {
-			errors = { ...errors, termsAccepted: error };
-			hasErrors = true;
-		}
-		return hasErrors ? errors : null;
-	}
-
 	const handleNameChange = ( e: FormEvent< HTMLInputElement > ) => {
-		const error = validateName( e.currentTarget.value );
+		const error = validators.validateName( e.currentTarget.value );
 		if ( error ) {
 			setErrors( { ...errors, name: error } );
 		} else {
@@ -125,7 +79,7 @@ export function GetReportForm( {
 	};
 
 	const handleEmailChange = ( e: FormEvent< HTMLInputElement > ) => {
-		const error = validateEmail( e.currentTarget.value );
+		const error = validators.validateEmail( e.currentTarget.value );
 		if ( error ) {
 			setErrors( { ...errors, email: error } );
 		} else {
@@ -135,7 +89,7 @@ export function GetReportForm( {
 	};
 
 	const handleTermsChange = ( e: boolean ) => {
-		const error = validateTerms( e );
+		const error = validators.validateTerms( e );
 		if ( error ) {
 			setErrors( { ...errors, termsAccepted: error } );
 		} else {

--- a/client/site-profiler/components/get-report-form/index.tsx
+++ b/client/site-profiler/components/get-report-form/index.tsx
@@ -1,0 +1,67 @@
+import { Gridicon } from '@automattic/components';
+import { CheckboxControl, Button, TextControl } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+import { useState } from 'react';
+import './styles.scss';
+
+export function GetReportForm() {
+	const [ name, setName ] = useState( '' );
+	const [ email, setEmail ] = useState( '' );
+	return (
+		<div className="get-report-form__container">
+			<div className="get-report-form__title">
+				<span className="title">{ translate( 'Get full report' ) }</span>
+			</div>
+			<div className="get-report-form__body">
+				<div className="get-report-form__header">
+					<span className="description">
+						{ translate(
+							'Enter your details below to receive the full report with detailed insights and recommendations for your site.'
+						) }
+					</span>
+					<span>
+						<svg
+							width="20"
+							height="13"
+							viewBox="0 0 20 13"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								d="M17.0741 0.16626L9.75322 7.8889L2.43236 0.16626L0.183472 2.54375L9.75322 12.6607L19.323 2.54375L17.0741 0.16626Z"
+								fill="#3858E9"
+							/>
+						</svg>
+					</span>
+				</div>
+				<div className="get-report-form__form">
+					<TextControl
+						className="get-report-form__form-name"
+						label={ translate( 'Name' ) }
+						value={ name }
+						onChange={ setName }
+					/>
+					<TextControl
+						className="get-report-form__form-email"
+						label={ translate( 'Email' ) }
+						value={ email }
+						onChange={ setEmail }
+					/>
+				</div>
+				<div className="get-report-form__footer">
+					<CheckboxControl
+						className="terms-checkbox"
+						onChange={ () => {} }
+						label={ translate(
+							`By submitting your details, you agree to WordPress.com‘s Privacy Policy and Terms of Service. You also consent to receiving occasional updates and offers. You can unsubscribe from these communications at any time through the instructions.`
+						) }
+					/>
+					<Button type="submit" className="submit-button">
+						{ translate( 'Get my report' ) }
+						<Gridicon icon="product-downloadable" />
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/site-profiler/components/get-report-form/index.tsx
+++ b/client/site-profiler/components/get-report-form/index.tsx
@@ -1,5 +1,6 @@
 import { FormLabel, FormInputValidation, Gridicon, Button } from '@automattic/components';
 import { CheckboxControl } from '@wordpress/components';
+import emailValidator from 'email-validator';
 import { translate } from 'i18n-calypso';
 import { FormEvent, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -68,23 +69,29 @@ export function GetReportForm( {
 	};
 
 	const validateName = ( name: string ) => {
-		if ( name ) {
-			return null;
+		if ( ! name ) {
+			return translate( 'Name is required' );
 		}
-		return 'Name is required';
+		return null;
 	};
-	const validateEmail = ( email: string ) => {
-		if ( email ) {
-			return null;
+
+	const validateEmail = ( email: string, fullValidation = false ) => {
+		if ( ! email ) {
+			return translate( 'Email is required' );
 		}
-		return 'Email is required';
+		if ( fullValidation && ! emailValidator.validate( email ) ) {
+			return translate( 'Please enter a valid email address.' );
+		}
+		return null;
 	};
+
 	const validateTerms = ( terms: boolean ) => {
-		if ( terms ) {
-			return null;
+		if ( ! terms ) {
+			return translate( 'Terms must be accepted' );
 		}
-		return 'Terms must be accepted';
+		return null;
 	};
+
 	function validateForm( formData: FormData ) {
 		let errors = {};
 		let hasErrors = false;
@@ -94,7 +101,7 @@ export function GetReportForm( {
 			errors = { ...errors, name: error };
 			hasErrors = true;
 		}
-		error = validateEmail( formData.get( 'email' ) as string );
+		error = validateEmail( formData.get( 'email' ) as string, true );
 		if ( error ) {
 			errors = { ...errors, email: error };
 			hasErrors = true;

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -75,8 +75,11 @@ input[type="text"].form-text-input.get-report-form__form {
 	display: flex;
 	gap: 20px;
 	align-items: center;
+	flex-wrap: wrap;
+	justify-content: space-between;
 	& fieldset {
 		margin-bottom: 0;
+		flex-basis: 70%;
 	}
 	.terms-checkbox {
 		font-size: 0.75rem;

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -1,0 +1,58 @@
+.get-report-form__container {
+	box-sizing: border-box;
+	padding: 3.25rem 0;
+	height: 320px;
+	border: 1px solid #cbcbcb;
+	background-color: #f8f8f8;
+	display: flex;
+	justify-content: space-between;
+	gap: 20px;
+}
+.get-report-form__title {
+	color: #000;
+	width: 300px;
+	height: 100%;
+}
+
+.get-report-form__body {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+
+.get-report-form__header {
+	display: flex;
+	gap: 10px;
+	justify-content: space-between;
+
+	.description {
+		color: #3c4043;
+	}
+}
+
+.get-report-form__form {
+	display: flex;
+	gap: 20px;
+}
+
+.get-report-form__footer {
+	display: flex;
+	gap: 20px;
+	.terms-checkbox {
+		font-size: 0.75rem;
+		line-height: 1.5;
+	}
+	.submit-button {
+		background-color: var(--color-accent);
+		color: #fff;
+		border-radius: 4px;
+		font-weight: 500;
+		font-size: 1rem;
+		padding: 1.5rem;
+		text-decoration: none;
+		min-width: 191px;
+		svg {
+			margin-left: 1rem;
+		}
+	}
+}

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -1,23 +1,24 @@
 .get-report-form__container {
 	box-sizing: border-box;
 	padding: 3.25rem 0;
-	height: 320px;
 	border: 1px solid #cbcbcb;
 	background-color: #f8f8f8;
 	display: flex;
 	justify-content: space-between;
-	gap: 20px;
+	flex-wrap: wrap;
 }
 .get-report-form__title {
 	color: #000;
-	width: 300px;
-	height: 100%;
+	flex-basis: 170px;
 }
 
 .get-report-form__body {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+	flex-basis: 500px;
+	gap: 20px;
+	flex-grow: 1;
 }
 
 .get-report-form__header {
@@ -33,6 +34,7 @@
 .get-report-form__form {
 	display: flex;
 	gap: 20px;
+	flex-wrap: wrap;
 }
 
 .get-report-form__footer {

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -3,7 +3,7 @@
 	margin: 0 -3rem;
 	padding: 3rem 3rem;
 	border: 1px solid #cbcbcb;
-	// background-color: #f8f8f8;
+	background-color: var(--studio-gray-0);
 	display: flex;
 	justify-content: space-between;
 	flex-wrap: wrap;

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -1,11 +1,13 @@
 .get-report-form__container {
 	box-sizing: border-box;
-	padding: 3.25rem 0;
+	margin: 0 -3rem;
+	padding: 3rem 3rem;
 	border: 1px solid #cbcbcb;
 	background-color: #f8f8f8;
 	display: flex;
 	justify-content: space-between;
 	flex-wrap: wrap;
+	gap: 20px;
 }
 .get-report-form__title {
 	color: #000;

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -46,7 +46,7 @@
 
 .get-report-form__form-body {
 	display: flex;
-	gap: 20px;
+	gap: 30px;
 	flex-wrap: wrap;
 	flex-grow: 1;
 
@@ -74,6 +74,10 @@ input[type="text"].form-text-input.get-report-form__form {
 .get-report-form__form-footer {
 	display: flex;
 	gap: 20px;
+	align-items: center;
+	& fieldset {
+		margin-bottom: 0;
+	}
 	.terms-checkbox {
 		font-size: 0.75rem;
 		line-height: 1.5;
@@ -84,9 +88,11 @@ input[type="text"].form-text-input.get-report-form__form {
 		border-radius: 4px;
 		font-weight: 500;
 		font-size: 1rem;
-		padding: 1.5rem;
+		padding: 1rem;
+		line-height: 1;
 		text-decoration: none;
 		min-width: 191px;
+		border: none;
 		svg {
 			margin-left: 1rem;
 		}

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -3,7 +3,7 @@
 	margin: 0 -3rem;
 	padding: 3rem 3rem;
 	border: 1px solid #cbcbcb;
-	background-color: #f8f8f8;
+	// background-color: #f8f8f8;
 	display: flex;
 	justify-content: space-between;
 	flex-wrap: wrap;
@@ -18,7 +18,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	flex-basis: 500px;
+	flex-basis: 620px;
 	gap: 20px;
 	flex-grow: 1;
 }
@@ -35,11 +35,43 @@
 
 .get-report-form__form {
 	display: flex;
-	gap: 20px;
+	gap: 25px;
 	flex-wrap: wrap;
+
+	&-email.form-text-input {
+		flex-basis: 300px;
+	}
 }
 
-.get-report-form__footer {
+
+.get-report-form__form-body {
+	display: flex;
+	gap: 20px;
+	flex-wrap: wrap;
+	flex-grow: 1;
+
+	& fieldset {
+		flex-basis: 300px;
+		margin-bottom: 0;
+	}
+}
+
+input[type="text"].form-text-input.get-report-form__form {
+	&-name,
+	&-email {
+		border-top: none;
+		border-left: none;
+		border-right: none;
+
+		&:focus,
+		&:hover,
+		&:focus:hover {
+			box-shadow: none;
+		}
+	}
+}
+
+.get-report-form__form-footer {
 	display: flex;
 	gap: 20px;
 	.terms-checkbox {

--- a/client/site-profiler/components/get-report-form/validators.tsx
+++ b/client/site-profiler/components/get-report-form/validators.tsx
@@ -1,0 +1,48 @@
+import emailValidator from 'email-validator';
+import { translate } from 'i18n-calypso';
+
+export const validateName = ( name: string ) => {
+	if ( ! name ) {
+		return translate( 'Name is required' );
+	}
+	return null;
+};
+
+export const validateEmail = ( email: string, fullValidation = false ) => {
+	if ( ! email ) {
+		return translate( 'Email is required' );
+	}
+	if ( fullValidation && ! emailValidator.validate( email ) ) {
+		return translate( 'Please enter a valid email address' );
+	}
+	return null;
+};
+
+export const validateTerms = ( terms: boolean ) => {
+	if ( ! terms ) {
+		return translate( 'Terms must be accepted' );
+	}
+	return null;
+};
+
+export function validateForm( formData: FormData ) {
+	let errors = {};
+	let hasErrors = false;
+
+	let error = validateName( formData.get( 'name' ) as string );
+	if ( error ) {
+		errors = { ...errors, name: error };
+		hasErrors = true;
+	}
+	error = validateEmail( formData.get( 'email' ) as string, true );
+	if ( error ) {
+		errors = { ...errors, email: error };
+		hasErrors = true;
+	}
+	error = validateTerms( Boolean( formData.get( 'termsAccepted' ) ) );
+	if ( error ) {
+		errors = { ...errors, termsAccepted: error };
+		hasErrors = true;
+	}
+	return hasErrors ? errors : null;
+}

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -96,7 +96,7 @@ export default function SiteProfiler( props: Props ) {
 	let showGetReportForm = false;
 
 	if ( isEnabled( 'site-profiler/metrics' ) ) {
-		showGetReportForm = showResultScreen && !! url;
+		showGetReportForm = !! showBasicMetrics && !! url;
 	}
 
 	const updateDomainRouteParam = ( value: string ) => {

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -18,6 +18,7 @@ import { normalizeWhoisField } from '../utils/normalize-whois-entry';
 import { BasicMetrics } from './basic-metrics';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
+import { GetReportForm } from './get-report-form';
 import HeadingInformation from './heading-information';
 import HostingInformation from './hosting-information';
 import HostingIntro from './hosting-intro';
@@ -92,6 +93,12 @@ export default function SiteProfiler( props: Props ) {
 		);
 	}
 
+	let showGetReportForm = false;
+
+	if ( isEnabled( 'site-profiler/metrics' ) ) {
+		showGetReportForm = true;
+	}
+
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;
 		// URL param is the source of truth
@@ -157,6 +164,11 @@ export default function SiteProfiler( props: Props ) {
 				</LayoutBlock>
 			) }
 
+			{ showGetReportForm && (
+				<LayoutBlock>
+					<GetReportForm />
+				</LayoutBlock>
+			) }
 			<LayoutBlock
 				className="hosting-intro-block globe-bg"
 				isMonoBg={ showResultScreen && conversionAction && conversionAction !== 'register-domain' }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -166,7 +166,7 @@ export default function SiteProfiler( props: Props ) {
 
 			{ showGetReportForm && (
 				<LayoutBlock>
-					<GetReportForm url={ url } />
+					<GetReportForm url={ url } token={ basicMetrics?.token } onClose={ () => {} } />
 				</LayoutBlock>
 			) }
 			<LayoutBlock

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -166,7 +166,7 @@ export default function SiteProfiler( props: Props ) {
 
 			{ showGetReportForm && (
 				<LayoutBlock>
-					<GetReportForm />
+					<GetReportForm url={ url } />
 				</LayoutBlock>
 			) }
 			<LayoutBlock

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -96,7 +96,7 @@ export default function SiteProfiler( props: Props ) {
 	let showGetReportForm = false;
 
 	if ( isEnabled( 'site-profiler/metrics' ) ) {
-		showGetReportForm = true;
+		showGetReportForm = showResultScreen && !! url;
 	}
 
 	const updateDomainRouteParam = ( value: string ) => {

--- a/client/site-profiler/utils/get-valid-url.ts
+++ b/client/site-profiler/utils/get-valid-url.ts
@@ -5,12 +5,12 @@ export function getValidUrl( url?: string ) {
 	try {
 		parsedUrl = parseUrl( url );
 	} catch ( error ) {
-		return null;
+		return undefined;
 	}
 
 	// `isURL` considers `http://a` valid, so check for a top level domain name as well.
 	if ( ! parsedUrl || ! hasTld( parsedUrl.hostname ) ) {
-		return null;
+		return undefined;
 	}
 
 	return parsedUrl.toString();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6908

## Proposed Changes

* Add the initial version of the get user details form
* Adds validation to the name, email and terms fields
* Calls the new `/site-profiler/lead` endpoint passing the `url`, `name`, `email` and `hash` values
* The `url` and `hash` are obtained from the parent component
* Most of the style changes in the figma design have been applied P7Jjk4nbUTahUk8aHkG6NQ-fi-206_24912
* The mobile has not being designed but it should display reasonable well in mobile


![CleanShot 2024-05-09 at 12 58 58@2x](https://github.com/Automattic/wp-calypso/assets/3519124/4ed3111b-ef67-44a2-954e-a36044c6daf5)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The form will be displayed under the following conditions:
  * The basic metrics have been obtained successfully 
  * The `site-profiler/metrics` flag is enabled
* Apply this patch to your environment
* Run the profiler against a valid website
* Check the form is displayed if the `Basic Metrics` are displayed
* Check the style of the form is similar to the figma design P7Jjk4nbUTahUk8aHkG6NQ-fi-206_24912, please note that there will be more iterations on the design so it does not need to be pixel perfect in this version
* Before populating all the values in the form,  press on the `Get my report` button 
* Check the fields are validated
*  Add an invalid email, e.g. `invalid-email` and press the `Get my report` button
* Check the email is validated
* Populate all the fields with valid values
* Check the form is submitted and the following successful message is displayed `Success! Email with the report link will be sent shortly`

#### Things that will be done in other tasks
- Mobile version
- Display the form when clicking a button
- Close the form when clicking the `Close` icon
- Display the form in a fixed position at the bottom of the viewport

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
~~- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~