### PR TITLE
Move Admin Interface Style to /settings/general

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_SFTP,
 	FEATURE_SFTP_DATABASE,
@@ -139,11 +140,12 @@ const MainCards = ( {
 			content: <CacheCard disabled={ isBasicHostingDisabled } />,
 			type: 'basic',
 		},
-		siteId && {
-			feature: 'wp-admin',
-			content: <SiteAdminInterface siteId={ siteId } isHosting />,
-			type: 'basic',
-		},
+		siteId &&
+			! isEnabled( 'layout/dotcom-nav-redesign-v2' ) && {
+				feature: 'wp-admin',
+				content: <SiteAdminInterface siteId={ siteId } isHosting />,
+				type: 'basic',
+			},
 	].filter( ( card ) => card !== null );
 
 	const availableTypes = [

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -53,6 +53,7 @@ import {
 	isJetpackSite,
 	isCurrentPlanPaid,
 	getCustomizerUrl,
+	isSimpleSite,
 } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
@@ -551,8 +552,12 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderAdminInterface() {
-		const { site } = this.props;
-		if ( ! isEnabled( 'layout/wpcom-admin-interface' ) ) {
+		const { site, isSimple } = this.props;
+		if (
+			! isEnabled( 'layout/wpcom-admin-interface' ) &&
+			( ! isEnabled( 'layout/dotcom-nav-redesign-v2' ) ||
+				( isEnabled( 'layout/dotcom-nav-redesign-v2' ) && isSimple ) )
+		) {
 			return null;
 		}
 
@@ -695,6 +700,7 @@ const connectComponent = connect( ( state ) => {
 		isSiteOnMigrationTrial: getIsSiteOnMigrationTrial( state, siteId ),
 		isLaunchable:
 			! getIsSiteOnECommerceTrial( state, siteId ) && ! getIsSiteOnMigrationTrial( state, siteId ),
+		isSimple: isSimpleSite( state, siteId ),
 	};
 } );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6942

## Proposed Changes

We want to show the Admin interface style setting in `/settings/general` for Simple and Atomic sites

We are currently using two flags not enabled on production yet but enabled on development, `layout/wpcom-admin-interface` & `layout/dotcom-nav-redesign-v2`

- Remove `Admin interface style` from `/hosting-config` (`layout/dotcom-nav-redesign-v2` flag)
- Add `Admin interface style` to `/settings/general` to Atomic sites (`layout/dotcom-nav-redesign-v2` flag)
- Add `Admin interface style` to `/settings/general` to Simple sites (`layout/wpcom-admin-interface` flag)
- Without any flag (aka `production`), `Admin interface style` should keep showing on `/hosting-config` for Atomic sites only

## Testing Instructions

* Go to `/hosting-config/:your-atomic-site`
* It should not show the `Admin interface style`
* Go to `/settings/general/:your-site`
* It should show for Atomic or Simple sites
* Try using ?flags=-layout/wpcom-admin-interface
* It should show only for Atomic sites

* Try using `?flags=-layout/wpcom-admin-interface,-layout/dotcom-nav-redesign-v2`
* `Admin interface style` should keep showing on `/hosting-config` and not in Settings
