### PR TITLE
New instructions: add tests for both paths

### DIFF
--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -182,7 +182,6 @@ describe( 'Site Migration Flow', () => {
 				},
 			} );
 
-			// Explicitly delegate all calls
 			expect( getFlowLocation() ).toEqual( {
 				path: `/${ STEPS.PROCESSING.slug }`,
 				state: {
@@ -205,7 +204,6 @@ describe( 'Site Migration Flow', () => {
 				},
 			} );
 
-			// Explicitly delegate all calls
 			expect( getFlowLocation() ).toEqual( {
 				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com`,
 				state: null,

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
 import { waitFor } from '@testing-library/react';
@@ -14,6 +15,7 @@ import siteMigrationFlow from '../site-migration-flow';
 import { getAssertionConditionResult, getFlowLocation, renderFlow } from './helpers';
 // we need to save the original object for later to not affect tests from other files
 const originalLocation = window.location;
+const originalIsEnabled = config.isEnabled;
 
 jest.mock( '../../utils/checkout' );
 jest.mock( '@automattic/data-stores/src/user/selectors' );
@@ -41,6 +43,16 @@ describe( 'Site Migration Flow', () => {
 		const testSettingsEndpoint = '/rest/v1.4/sites/example.wordpress.com/settings';
 		nock( apiBaseUrl ).get( testSettingsEndpoint ).reply( 200, {} );
 		nock( apiBaseUrl ).post( testSettingsEndpoint ).reply( 200, {} );
+		jest
+			.spyOn( config, 'isEnabled' )
+			.mockImplementation( ( key ) =>
+				key === 'migration-flow/remove-processing-step' ? false : originalIsEnabled( key )
+			);
+	} );
+
+	afterEach( () => {
+		// Restore the original implementation after each test
+		jest.restoreAllMocks();
 	} );
 
 	describe( 'useAssertConditions', () => {
@@ -160,7 +172,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'migrate redirects from the import-from page to bundleTransfer step', () => {
+		it( 'migrate redirects from the import-from page to bundleTransfer step if new instructions not enabled', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
@@ -170,11 +182,33 @@ describe( 'Site Migration Flow', () => {
 				},
 			} );
 
+			// Explicitly delegate all calls
 			expect( getFlowLocation() ).toEqual( {
 				path: `/${ STEPS.PROCESSING.slug }`,
 				state: {
 					bundleProcessing: true,
 				},
+			} );
+		} );
+
+		it( 'migrate redirects from the import-from page to new instructions if flag enabled', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			( config.isEnabled as jest.Mock ).mockImplementation( ( key: string ) =>
+				key === 'migration-flow/remove-processing-step' ? true : originalIsEnabled( key )
+			);
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.BUNDLE_TRANSFER.slug,
+				dependencies: {
+					destination: 'migrate',
+				},
+			} );
+
+			// Explicitly delegate all calls
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com`,
+				state: null,
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

When I created this pr enabling the new instructions: https://github.com/Automattic/wp-calypso/pull/90335 I realized that doing it would break the flow tests, since now the flow is different.

My approach to fix that was this PR, which tests both paths, with the feature flag on and off.

Overall, I feel this is overly complicated and a time sink, but tests pass 🙍‍♂️ , so I am not sure on wether this is the correct approach or not. I would appreciate comments on this.
More info on this thread: p1715024871796379-slack-C0Q664T29, tldr: we should probably get this merged as is

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?