### PR TITLE
E2E tests: Enable updates for breaking schedules

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -269,9 +269,13 @@ export class EditorToolbarComponent {
 	 *
 	 * @returns {Promise<string>} String found on the button.
 	 */
-	async getPostStatusButtonText(): Promise< string > {
+	async getPostStatusButtonText(): Promise< string | null > {
 		const editorParent = await this.editor.parent();
 		const postStatusButtonLocator = editorParent.locator( selectors.postStatusButton );
+
+		if ( ! ( await postStatusButtonLocator.isVisible() ) ) {
+			return null;
+		}
 
 		return await postStatusButtonLocator.innerText();
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -265,6 +265,18 @@ export class EditorToolbarComponent {
 	}
 
 	/**
+	 * Returns the text present for the post status button.
+	 *
+	 * @returns {Promise<string>} String found on the button.
+	 */
+	async getPostStatusButtonText(): Promise< string > {
+		const editorParent = await this.editor.parent();
+		const postStatusButtonLocator = editorParent.locator( selectors.postStatusButton );
+
+		return await postStatusButtonLocator.innerText();
+	}
+
+	/**
 	 * Clicks on the primary button to publish the article.
 	 *
 	 * This is applicable for the following scenarios:

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -700,6 +700,7 @@ export class EditorPage {
 		timeout,
 	}: { visit?: boolean; timeout?: number } = {} ): Promise< URL > {
 		const publishButtonText = await this.editorToolbarComponent.getPublishButtonText();
+		const postStatusButtonText = await this.editorToolbarComponent.getPostStatusButtonText();
 		const actionsArray = [];
 
 		// Every publish action requires at least one click on the EditorToolbarComponent.
@@ -709,7 +710,12 @@ export class EditorPage {
 		// is merely being saved/updated.
 		// If not yet published, a second click on the EditorPublishPanelComponent
 		// is added to the array of actions.
-		if ( ! [ 'save', 'update' ].includes( publishButtonText.toLowerCase() ) ) {
+		const requiresSecondClick =
+			! [ 'save', 'update' ].includes( publishButtonText.toLowerCase() ) ||
+			( publishButtonText.toLowerCase() === 'save' &&
+				postStatusButtonText.toLowerCase() === 'scheduled' );
+
+		if ( requiresSecondClick ) {
 			actionsArray.push( this.editorPublishPanelComponent.publish() );
 		}
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -713,7 +713,7 @@ export class EditorPage {
 		const requiresSecondClick =
 			! [ 'save', 'update' ].includes( publishButtonText.toLowerCase() ) ||
 			( publishButtonText.toLowerCase() === 'save' &&
-				postStatusButtonText.toLowerCase() === 'scheduled' );
+				postStatusButtonText?.toLowerCase() === 'scheduled' );
 
 		if ( requiresSecondClick ) {
 			actionsArray.push( this.editorPublishPanelComponent.publish() );


### PR DESCRIPTION
The new UI for scheduling posts in the Editor now requires a second click to update scheduled posts.

This PR enables a second click which lets schedules be updated  for e2e tests.

This is currently breaking some nightly e2e tests for Gutenberg. This change modifies the e2e's expectations to fit the new realities.

Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

Run the editor schedule flow e2e edge tests, which was failing before this fix:

```bash
cd test/e2e
yarn jest --clearCache && yarn build  # clear build cache before each run


yarn jest specs/editor/editor__schedule.ts  
GUTENBERG_EDGE=1 yarn jest specs/editor/editor__schedule.ts 
GUTENBERG_EDGE=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__schedule.ts 
```