### PR TITLE
A4A: Refetch sites in dashboard on window focus

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -44,6 +44,7 @@ import EmptyState from './empty-state';
 import { getSelectedFilters } from './get-selected-filters';
 import ProvisioningSiteNotification from './provisioning-site-notification';
 import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
+import useRefetchOnFocus from './use-refetch-on-focus';
 
 import './style.scss';
 import './sites-dataviews-style.scss';
@@ -51,7 +52,6 @@ import './sites-dataviews-style.scss';
 export default function SitesDashboard() {
 	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
 	const dispatch = useDispatch();
-
 	const agencyId = useSelector( getActiveAgencyId );
 
 	const recentlyCreatedSite = getQueryArg( window.location.href, 'created_site' ) ?? null;
@@ -101,6 +101,8 @@ export default function SitesDashboard() {
 		perPage: dataViewsState.perPage,
 		agencyId,
 	} );
+
+	useRefetchOnFocus( refetch );
 
 	const noActiveSite = useNoActiveSite();
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/use-refetch-on-focus.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/use-refetch-on-focus.ts
@@ -1,0 +1,80 @@
+import debugFactory from 'debug';
+import { useEffect, useState } from 'react';
+
+const debug = debugFactory( 'calypso:a4a:sites-dashboard:use-refetch-on-focus' );
+
+// The number of seconds within that must have passed before we allow an
+// automatic refetch on focus.
+const minimumFetchInterval = 60;
+
+function convertMsToSecs( ms: number ): number {
+	return Math.floor( ms / 1000 );
+}
+
+function isFocused(): boolean {
+	return [ undefined, 'visible', 'prerender' ].includes( document.visibilityState );
+}
+
+function isOffline(): boolean {
+	try {
+		return ! window.navigator.onLine;
+	} catch ( err ) {
+		debug( 'failed to check onLine status; ignoring check', err );
+		return false;
+	}
+}
+
+export default function useRefetchOnFocus< T = any >( refetch: () => Promise< T > ): void {
+	if ( isFocused() && isOffline() && convertMsToSecs( 1000 ) > minimumFetchInterval ) {
+		refetch();
+	}
+	const [ lastRefreshTime, setLastRefreshTime ] = useState< number >(
+		convertMsToSecs( Date.now() )
+	);
+
+	useEffect( () => {
+		if ( ! refetch ) {
+			debug( 'refetch falsy; not listening' );
+			return;
+		}
+
+		function wasLastFetchRecent(): boolean {
+			const nowInSeconds = convertMsToSecs( Date.now() );
+			const secondsSinceLastFetch = nowInSeconds - lastRefreshTime;
+			debug( 'last fetch was', secondsSinceLastFetch, 'seconds ago' );
+			return secondsSinceLastFetch < minimumFetchInterval;
+		}
+
+		function handleFocusChange(): void {
+			if ( ! isFocused() ) {
+				debug( 'window was made invisible; ignoring' );
+				return;
+			}
+			if ( wasLastFetchRecent() ) {
+				debug( 'last fetch was quite recent; ignoring' );
+				return;
+			}
+			if ( isOffline() ) {
+				debug( 'network is offline; ignoring' );
+				return;
+			}
+
+			debug( 'window was refocused; refetching' );
+			const nowInSeconds = convertMsToSecs( Date.now() );
+			setLastRefreshTime( nowInSeconds );
+			refetch();
+		}
+
+		debug( 'adding focus listeners' );
+		window.addEventListener( 'visibilitychange', handleFocusChange );
+		window.addEventListener( 'focus', handleFocusChange );
+		window.addEventListener( 'online', handleFocusChange );
+
+		return () => {
+			debug( 'removing focus listeners' );
+			window.removeEventListener( 'visibilitychange', handleFocusChange );
+			window.removeEventListener( 'focus', handleFocusChange );
+			window.removeEventListener( 'online', handleFocusChange );
+		};
+	}, [ lastRefreshTime, refetch ] );
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/440

## Proposed Changes

* This PR implements a refetch whenever the sites dashboard window is refocused, maintaining a minimum interval of 60 seconds between fetches.

## Testing Instructions

* Open up your browser's network console (usually using the F12 key) 
* Navigate to the sites dashboard (`http://agencies.localhost:3000/sites`)
* Filter network calls by the keyword `sites`
* Take the focus away from the window for 60+ seconds
* Return the focus to the window (make sure to click on the page, and not on the network monitor)
* Verify that a new call to the `sites` endpoint was made. 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?