### PR TITLE
Plans 2023: Change plan upgrade cta messaging if user is not owner

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-can-user-upgrade-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/use-can-user-upgrade-plans.ts
@@ -2,26 +2,12 @@ import { useSelector } from 'react-redux';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-/**
- * TODO: Update docs
- * Returns a dictionary of plan slugs and whether or not they are available for purchase.
- * Note that:
- * - If there is not current-plan or selected-site defined, then plan is marked as purchasable.
- * This would be the equivalent of an Onboarding/Signup context, where no other conditions currently apply.
- * - If a selected site exists, then we check if the plan is available for purchase on that site.
- */
 const useCanUserUpgradePlans = () => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
-	return useSelector( ( state ) => {
-		// TODO: Update this comment
-		// 1. No selected site: plan is in a context-free state and we assume the user is
-		if ( ! selectedSiteId ) {
-			return false;
-		}
-
-		return isCurrentUserCurrentPlanOwner( state, selectedSiteId );
-	} );
+	return useSelector( ( state ) =>
+		selectedSiteId ? isCurrentUserCurrentPlanOwner( state, selectedSiteId ) : false
+	);
 };
 
 export default useCanUserUpgradePlans;

--- a/client/my-sites/plans-features-main/hooks/use-can-user-upgrade-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/use-can-user-upgrade-plans.ts
@@ -1,0 +1,27 @@
+import { useSelector } from 'react-redux';
+import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+/**
+ * TODO: Update docs
+ * Returns a dictionary of plan slugs and whether or not they are available for purchase.
+ * Note that:
+ * - If there is not current-plan or selected-site defined, then plan is marked as purchasable.
+ * This would be the equivalent of an Onboarding/Signup context, where no other conditions currently apply.
+ * - If a selected site exists, then we check if the plan is available for purchase on that site.
+ */
+const useCanUserUpgradePlans = () => {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	return useSelector( ( state ) => {
+		// TODO: Update this comment
+		// 1. No selected site: plan is in a context-free state and we assume the user is
+		if ( ! selectedSiteId ) {
+			return false;
+		}
+
+		return isCurrentUserCurrentPlanOwner( state, selectedSiteId );
+	} );
+};
+
+export default useCanUserUpgradePlans;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -70,6 +70,7 @@ import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
 import PlansPageSubheader from './components/plans-page-subheader';
 import useGenerateActionCallback from './hooks/use-action-callback';
+import useCanUserUpgradePlans from './hooks/use-can-user-upgrade-plans';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useDeemphasizeFreePlan from './hooks/use-deemphasize-free-plan';
@@ -251,6 +252,7 @@ const PlansFeaturesMain = ( {
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null
 	);
+	const canUserUpgradePlans = useCanUserUpgradePlans();
 	const getPlanTypeDestination = usePlanTypeDestinationCallback();
 
 	const resolveModal = useModalResolutionCallback( {
@@ -821,6 +823,7 @@ const PlansFeaturesMain = ( {
 									<FeaturesGrid
 										allFeaturesList={ getFeaturesList() }
 										className="plans-features-main__features-grid"
+										canUserUpgradePlans={ canUserUpgradePlans }
 										coupon={ coupon }
 										currentSitePlanSlug={ sitePlanSlug }
 										generatedWPComSubdomain={ resolvedSubdomainName }

--- a/client/state/sites/plans/selectors/is-current-user-current-plan-owner.js
+++ b/client/state/sites/plans/selectors/is-current-user-current-plan-owner.js
@@ -1,9 +1,10 @@
 import { get } from 'lodash';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors/get-current-plan';
+import { AppState } from 'calypso/types';
 
 /**
  * Returns true if current user is also a current plan owner.
- * @param  {Object}  state        global state
+ * @param {AppState} state        Global state tree
  * @param  {number}  siteId       the site id
  * @returns {boolean}			  True when user is a plan owner
  */

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -413,7 +413,9 @@ const LoggedInPlansFeatureActionButton = ( {
 			</Plans2023Tooltip>
 		) : (
 			<Plans2023Tooltip
-				text={ translate( 'Please contact support to change your plan.' ) }
+				text={ translate(
+					'The current plan was purchased by a different account. To change plans, please switch to that account or contact the account owner.'
+				) }
 				setActiveTooltipId={ setActiveTooltipId }
 				activeTooltipId={ activeTooltipId }
 				showOnMobile={ false }
@@ -422,7 +424,9 @@ const LoggedInPlansFeatureActionButton = ( {
 				<DummyDisabledButton>{ translate( 'Change', { context: 'verb' } ) }</DummyDisabledButton>
 				{ isMobile() && (
 					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
-						{ translate( 'Please contact support to change your plan.' ) }
+						{ translate(
+							'The current plan was purchased by a different account. To change plans, please switch to that account or contact the account owner.'
+						) }
 					</div>
 				) }
 			</Plans2023Tooltip>

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -225,7 +225,7 @@ const LoggedInPlansFeatureActionButton = ( {
 } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const translate = useTranslate();
-	const { gridPlansIndex, siteId } = usePlansGridContext();
+	const { canUserUpgradePlans, gridPlansIndex, siteId } = usePlansGridContext();
 
 	const selectedStorageOptionForPlan = useSelect(
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, siteId ),
@@ -396,7 +396,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	}
 
 	if ( ! availableForPurchase ) {
-		return (
+		return canUserUpgradePlans ? (
 			<Plans2023Tooltip
 				text={ translate( 'Please contact support to downgrade your plan.' ) }
 				setActiveTooltipId={ setActiveTooltipId }
@@ -408,6 +408,21 @@ const LoggedInPlansFeatureActionButton = ( {
 				{ isMobile() && (
 					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
 						{ translate( 'Please contact support to downgrade your plan.' ) }
+					</div>
+				) }
+			</Plans2023Tooltip>
+		) : (
+			<Plans2023Tooltip
+				text={ translate( 'Please contact support to change your plan.' ) }
+				setActiveTooltipId={ setActiveTooltipId }
+				activeTooltipId={ activeTooltipId }
+				showOnMobile={ false }
+				id="change"
+			>
+				<DummyDisabledButton>{ translate( 'Change', { context: 'verb' } ) }</DummyDisabledButton>
+				{ isMobile() && (
+					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
+						{ translate( 'Please contact support to change your plan.' ) }
 					</div>
 				) }
 			</Plans2023Tooltip>

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -14,6 +14,7 @@ interface PlansGridContext {
 		useActionCallback: UseActionCallback;
 		recordTracksEvent?: GridContextProps[ 'recordTracksEvent' ];
 	};
+	canUserUpgradePlans?: boolean;
 	coupon?: string;
 	enableFeatureTooltips?: boolean;
 	/**
@@ -39,6 +40,7 @@ const PlansGridContextProvider = ( {
 	recordTracksEvent,
 	allFeaturesList,
 	siteId,
+	canUserUpgradePlans,
 	children,
 	coupon,
 	enableFeatureTooltips,
@@ -63,6 +65,7 @@ const PlansGridContextProvider = ( {
 				gridPlansIndex,
 				allFeaturesList,
 				helpers: { useCheckPlanAvailabilityForPurchase, useActionCallback, recordTracksEvent },
+				canUserUpgradePlans,
 				coupon,
 				enableFeatureTooltips,
 				enableCategorisedFeatures,

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -105,6 +105,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		useActionCallback,
 		recordTracksEvent,
 		allFeaturesList,
+		canUserUpgradePlans,
 		coupon,
 		isInAdmin,
 		className,
@@ -135,6 +136,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				intent={ intent }
 				siteId={ siteId }
 				gridPlans={ gridPlans }
+				canUserUpgradePlans={ canUserUpgradePlans }
 				coupon={ coupon }
 				useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 				useActionCallback={ useActionCallback }

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -118,6 +118,7 @@ export interface CommonGridProps {
 	planUpgradeCreditsApplicable?: number | null;
 	gridContainerRef?: React.MutableRefObject< HTMLDivElement | null >;
 	gridSize?: string;
+	canUserUpgradePlans: boolean;
 }
 
 export interface FeaturesGridProps extends CommonGridProps {
@@ -155,6 +156,7 @@ export type GridContextProps = {
 	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
 	useActionCallback: UseActionCallback;
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
+	canUserUpgradePlans?: boolean;
 	children: React.ReactNode;
 	coupon?: string;
 	enableFeatureTooltips?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87479

## Proposed Changes

* Change CTA messaging from "upgrade" + "downgrade" to "change" if current user is not subscription owner

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site with a paid plan
2. Add a non Super User account to a WordPress site as an administrator (This is to trigger the This plan was purchased by a different WordPress.com account state)
3. On the non super user account visit the plans page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?