### PR TITLE
Checkout: Hide edit button when only one payment method exists

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -19,6 +19,7 @@ import { useFormStatus } from '../lib/form-status';
 import joinClasses from '../lib/join-classes';
 import { usePaymentMethod } from '../lib/payment-methods';
 import { SubscriptionManager } from '../lib/subscription-manager';
+import { useAllPaymentMethods } from '../public-api';
 import { CheckoutStepGroupActions, FormStatus } from '../types';
 import Button from './button';
 import CheckoutErrorBoundary from './checkout-error-boundary';
@@ -926,7 +927,29 @@ function CheckoutStepHeader( {
 	editButtonAriaLabel?: string;
 } ) {
 	const { __ } = useI18n();
+
+	const paymentMethods = useAllPaymentMethods();
+	const paymentMethodStepIsActive = id === 'payment-method-step';
 	const shouldShowEditButton = !! onEdit;
+
+	const renderHeaderEditButton = () => {
+		if ( paymentMethodStepIsActive && paymentMethods.length <= 1 ) {
+			return null;
+		}
+
+		if ( shouldShowEditButton ) {
+			return (
+				<HeaderEditButton
+					className="checkout-step__edit-button"
+					buttonType="text-button"
+					onClick={ onEdit }
+					aria-label={ editButtonAriaLabel || __( 'Edit this step' ) }
+				>
+					{ editButtonText || __( 'Edit' ) }
+				</HeaderEditButton>
+			);
+		}
+	};
 
 	return (
 		<StepHeader
@@ -944,16 +967,7 @@ function CheckoutStepHeader( {
 			>
 				{ title }
 			</StepTitle>
-			{ shouldShowEditButton && (
-				<HeaderEditButton
-					className="checkout-step__edit-button"
-					buttonType="text-button"
-					onClick={ onEdit }
-					aria-label={ editButtonAriaLabel || __( 'Edit this step' ) }
-				>
-					{ editButtonText || __( 'Edit' ) }
-				</HeaderEditButton>
-			) }
+			{ renderHeaderEditButton() }
 		</StepHeader>
 	);
 }


### PR DESCRIPTION
This is a follow up PR to #90240

In #90240 we added the credit amount to the `WordPressFreePurchaseSummary` component to make the amount more obvious.

In this PR we are hiding the edit button for the Payment Method step if the step only contains one payment method - because editing a list of one isn't really possible.

Related to #88863
| Before | After |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/e47e612e-ba0a-47e1-81db-4854cf929ef4) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/83bfe5d9-1d47-4cc4-9f44-7a6d6f06c0b5) |

## Proposed Changes

* Hide the stepper's `HeaderEditButton` for the Payment Method step when - 1) the `paymentMethodStepIsActive` 2) the `paymentMethods` array has a length of 1 or less

## Testing Instructions

**Regular purchases**

- Add a renewal to your shopping cart, ensure the cart has valid payment methods
- Go to the Payment Method step and ensure that you see an edit link to change your payment method
- Make sure you can change methods via the edit link

**Credit purchases**

- Next, add enough credit to your account to cover the purchase completely
- Refresh checkout and go to Payment method step, it should show WordPress.com Credits $x.xx
- At this point there should **not** be an edit link next to the payment method step, but, there **should** be an edit link next to Billing Information
- Try to find some combination that breaks this PR