### PR TITLE
Nav redesign: Don't hide Settings -> Hosting Configuration & Tools -> Site Monitoring

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -154,7 +154,7 @@ const useSiteMenuItems = () => {
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
 		return result.map( ( menu ) => {
-			if ( Array.isArray( menu.children ) ) {
+			if ( menu.slug === 'wpcom-hosting-menu' && Array.isArray( menu.children ) ) {
 				return {
 					...menu,
 					children: menu.children.filter(


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/pull/89981

## Proposed Changes

This PR fixes an error from the above PR, where we should hide the GSV submenus from Hosting menu only, but not Settings / Tools.

GSV submenus will be automatically hidden when we enable the Early Classic flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open `<Calypso Live URL>/home/:site` of an Atomic site with Default admin interface style.
2. Verify you can see Settings -> Hosting Configuration AND Tools -> Site Monitoring.
3. Open `<Calypso Live URL>/home/:site` of an Atomic site with Early Classic admin interface style.
4. Verify you can NOT see Hosting -> {Configuration, Monitoring}

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?