### PR TITLE
Update `material-design-icons` package.json publishConfig to make package public

### DIFF
--- a/packages/material-design-icons/CHANGELOG.md
+++ b/packages/material-design-icons/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial release

--- a/packages/material-design-icons/package.json
+++ b/packages/material-design-icons/package.json
@@ -17,7 +17,9 @@
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
 		"directory": "packages/material-design-icons"
 	},
-	"private": true,
+	"publishConfig": {
+		"access": "public"
+	},
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"files": [
 		"src",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


@automattic/material-design-icons is a dependency of @automattic/components, and it is currently a private package. This PR updates the package.json publishConfig to make the package public.

