### PR TITLE
site ineligible component

### DIFF
--- a/apps/blaze-dashboard/src/pages/setup/components/blaze-disabled.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/blaze-disabled.jsx
@@ -66,7 +66,7 @@ export default function BlazeDisabled() {
 				<h3 className="setup-pages__title wp-brand-font">
 					{ translate( 'Set up Blaze and start advertising' ) }
 				</h3>
-				<p className="empty-promotion-list__body">
+				<p className="setup-pages__body">
 					{ translate(
 						'To get started, go to the Jetpack settings page and follow the steps below.'
 					) }

--- a/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
@@ -16,7 +16,7 @@ export default function DisconnectedSite() {
 				<h3 className="setup-pages__title wp-brand-font width-fix">
 					{ translate( 'Welcome to Blaze for WooCommerce' ) }
 				</h3>
-				<p className="empty-promotion-list__body">
+				<p className="setup-pages__body">
 					{ translate( 'One-click advertising for your store and products.' ) }
 				</p>
 

--- a/apps/blaze-dashboard/src/pages/setup/components/ineligible-site.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/ineligible-site.jsx
@@ -7,38 +7,7 @@ export default function IneligibleSite() {
 	return (
 		<>
 			<div className="promote-post-i2__inner-container">
-				<div className="promote-post-i2__setup-icon">
-					<svg
-						width="148"
-						height="148"
-						viewBox="0 0 148 148"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<g clipPath="url(#clip0_1610_281)">
-							<rect x="63.5" y="117" width="73" height="7" rx="3.5" fill="#E8E0F2" />
-							<rect x="102.5" y="117" width="34" height="7" rx="3.5" fill="#E8E0F2" />
-							<rect x="63.5" y="129" width="57" height="7" rx="3.5" fill="#E8E0F2" />
-							<circle cx="32.5" cy="126" r="22" fill="#E8E0F2" />
-							<rect x="63.5" y="13" width="75" height="7" rx="3.5" fill="#E8E0F2" />
-							<rect x="63.5" y="25" width="27" height="7" rx="3.5" fill="#E8E0F2" />
-							<rect x="95.5" y="25" width="33" height="7" rx="3.5" fill="#E8E0F2" />
-							<circle cx="32.5" cy="22" r="22" fill="#E8E0F2" />
-							<rect x="62.5" y="52" width="76" height="44" rx="22" fill="#2145E6" />
-							<circle cx="32.5" cy="74" r="22" fill="white" />
-							<path
-								d="M48.5919 72.6789C46.4634 69.6156 40.6349 62.5 32.5 62.5C24.2941 62.5 18.5065 69.6235 16.401 72.689C16.1386 73.076 15.9989 73.5332 16 74.001C16.0012 74.4688 16.1432 74.9253 16.4074 75.311C18.533 78.375 24.3551 85.5 32.5 85.5C40.5704 85.5 46.4362 78.3844 48.5847 75.3196C48.8538 74.9324 48.9987 74.4722 49 74.0004C49.0013 73.5286 48.8589 73.0676 48.5919 72.6789ZM32.5 80.4688C31.2226 80.4688 29.9739 80.0894 28.9118 79.3786C27.8497 78.6678 27.0219 77.6575 26.5331 76.4755C26.0443 75.2935 25.9164 73.9928 26.1656 72.738C26.4148 71.4832 27.0299 70.3306 27.9331 69.4259C28.8364 68.5212 29.9872 67.9051 31.24 67.6555C32.4929 67.4059 33.7915 67.534 34.9716 68.0237C36.1518 68.5133 37.1604 69.3424 37.8701 70.4062C38.5798 71.4699 38.9586 72.7206 38.9586 74C38.9586 75.7156 38.2781 77.361 37.0669 78.5741C35.8557 79.7872 34.2129 80.4688 32.5 80.4688Z"
-								fill="#814BB0"
-							/>
-							<rect x="84" y="71" width="33" height="7" rx="3.5" fill="#F6F7F7" />
-						</g>
-						<defs>
-							<clipPath id="clip0_1610_281">
-								<rect width="148" height="148" fill="white" />
-							</clipPath>
-						</defs>
-					</svg>
-				</div>
+				<div className="promote-post-i2__setup-icon"></div>
 				<h3 className="setup-pages__title wp-brand-font">
 					{ translate( 'Your store is not eligible to Advertise with Blaze' ) }
 				</h3>

--- a/apps/blaze-dashboard/src/pages/setup/components/ineligible-site.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/ineligible-site.jsx
@@ -1,12 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-export default function PrivateSite() {
-	const selectedSiteData = useSelector( getSelectedSite );
-	const siteSlug = selectedSiteData?.slug;
-
+export default function IneligibleSite() {
 	const translate = useTranslate();
 
 	return (
@@ -45,49 +40,23 @@ export default function PrivateSite() {
 					</svg>
 				</div>
 				<h3 className="setup-pages__title wp-brand-font">
-					{ translate( 'Make sure your site is public' ) }
+					{ translate( 'Your store is not eligible to Advertise with Blaze' ) }
 				</h3>
 				<p className="setup-pages__body">
-					{ translate( 'Go to your WordPress.com dashboard and follow the steps below.' ) }
-				</p>
-				<ul className="promote-post-i2__active-steps">
-					<li>
-						<span>1</span>
-						<div>
-							{ translate( "Navigate to your site's {{a}}Privacy settings{{/a}}.", {
-								components: {
-									a: (
-										<a
-											href={ `https://wordpress.com/settings/general/${ siteSlug }#site-privacy-settings` }
-											target="_blank"
-											rel="noreferrer"
-										/>
-									),
-								},
-							} ) }
-						</div>
-					</li>
-					<li>
-						<span>2</span>
-						<div>{ translate( 'Set your site as Public.' ) }</div>
-					</li>
-					<li>
-						<span>3</span>
-						<div>{ translate( 'Refresh this page.' ) }</div>
-					</li>
-				</ul>
-				<p className="promote-post-i2__footer-text">
-					{ translate( 'Read more on how to launch your site {{a}}here{{/a}}. ', {
-						components: {
-							a: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/support/privacy-settings/' ) }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-						},
-					} ) }
+					{ translate(
+						"Unfortunately, your store doesn't qualify for advertising using Blaze. If you have any questions or need assistance, please contact our {{a}}support team{{/a}}.",
+						{
+							components: {
+								a: (
+									<a
+										href={ localizeUrl( 'https://wordpress.com/help/contact' ) }
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+							},
+						}
+					) }
 				</p>
 			</div>
 		</>

--- a/apps/blaze-dashboard/src/pages/setup/main.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/main.jsx
@@ -8,6 +8,7 @@ import { getAdvertisingDashboardPath } from 'calypso/my-sites/promote-post-i2/ut
 import GenericHeader from '../../components/generic-header';
 import BlazeDisabled from './components/blaze-disabled';
 import DisconnectedSite from './components/disconnected-site';
+import IneligibleSite from './components/ineligible-site';
 import PrivateSite from './components/private-site';
 
 const renderSetupComponent = ( setupInfo ) => {
@@ -21,6 +22,8 @@ const renderSetupComponent = ( setupInfo ) => {
 			return <PrivateSite />;
 		case 'disconnected':
 			return <DisconnectedSite />;
+		case 'site_ineligible':
+			return <IneligibleSite />;
 		default:
 			return <BlazeDisabled />;
 	}

--- a/apps/blaze-dashboard/src/pages/setup/style.scss
+++ b/apps/blaze-dashboard/src/pages/setup/style.scss
@@ -52,6 +52,7 @@
 		.promote-post-i2__active-steps {
 			align-self: center;
 			margin: 0;
+			width: 100%;
 
 			li {
 				align-items: center;
@@ -60,11 +61,11 @@
 				box-sizing: border-box;
 				display: flex;
 				font-size: $font-body;
-				margin-bottom: 8px;
-				max-width: 100%;
+				margin: 0 auto 8px;
+				max-width: 520px;
 				padding: 16px;
 				text-align: left;
-				width: 520px;
+				width: 100%;
 
 				span {
 					align-items: center;

--- a/apps/blaze-dashboard/src/pages/setup/style.scss
+++ b/apps/blaze-dashboard/src/pages/setup/style.scss
@@ -21,6 +21,12 @@
 				max-width: 470px;
 			}
 		}
+
+		.setup-pages__body {
+			color: $studio-gray-50;
+			font-size: $font-body;
+			text-wrap: balance;
+		}
 	}
 
 	.promote-post-i2__footer-text {

--- a/apps/blaze-dashboard/src/pages/setup/style.scss
+++ b/apps/blaze-dashboard/src/pages/setup/style.scss
@@ -23,7 +23,6 @@
 		}
 
 		.setup-pages__body {
-			color: $studio-gray-50;
 			font-size: $font-body;
 			text-wrap: balance;
 		}

--- a/client/my-sites/promote-post-i2/components/empty-promotion-list/style.scss
+++ b/client/my-sites/promote-post-i2/components/empty-promotion-list/style.scss
@@ -10,6 +10,7 @@
 			margin-bottom: 20px;
 		}
 		.empty-promotion-list__body {
+			color: $studio-gray-50;
 			font-size: $font-body;
 		}
 	}


### PR DESCRIPTION
site ineligible component
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1164

## Proposed Changes

Added a site ineligible component and the related case in the switch to select the correct view
 - minor fixes in styles in all setup pages components

![Screenshot 2024-05-07 at 16 48 54](https://github.com/Automattic/wp-calypso/assets/1416426/f80198a8-942b-4ec7-b1e4-1b7594ee8fda)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?