### PR TITLE
Fix Woo login back button navigation

### DIFF
--- a/client/layout/masterbar/woo.jsx
+++ b/client/layout/masterbar/woo.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { createInterpolateElement, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
@@ -8,13 +9,17 @@ import './typekit';
 import './woo.scss';
 
 const WooOauthMasterbar = () => {
+	function onClick() {
+		window.history.back();
+	}
+
 	const backNav = (
 		<li className="masterbar__woo-nav-item">
-			<a className="masterbar__login-back-link" href="https://woocommerce.com">
+			<Button className="masterbar__login-back-link" onClick={ onClick }>
 				{ createInterpolateElement( __( '<arrow/> Back' ), {
 					arrow: <Gridicon icon="chevron-left" size={ 18 } />,
 				} ) }
-			</a>
+			</Button>
 		</li>
 	);
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -221,11 +221,11 @@ $breakpoint-mobile: 660px;
 		width: 100%;
 	}
 
-	.masterbar__woo-nav-item a.masterbar__login-back-link {
+	.masterbar__woo-nav-item button.masterbar__login-back-link {
 		color: var(--studio-gray-100);
-		text-decoration: none;
 		display: flex;
 		font-weight: 500;
+		padding: 0;
 	}
 
 	.masterbar__woo-mobile-nav {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 20362-gh-Automattic/woocommerce.com

## Proposed Changes

This changes the back button in the Woo login flow from an explicit link to `woocommerce.com` to history back navigation.

## Testing Instructions

You should have [a local Calypso installation](https://github.com/Automattic/wp-calypso/blob/trunk/README.md#getting-started) to follow these steps:

* Make sure Calypso is set up with this branch checked out. Do `yarn start` and make sure `http://calypso.localhost:3000/` loads up.
* Spin up any new woocommerce store ([JN can help](https://jurassic.ninja/))
* Go to your store's connection page and connect your store (`/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions`)
* If you get this screen, click Use a different Woocommerce.com account:
![CleanShot 2024-05-07 at 10 40 05](https://github.com/Automattic/wp-calypso/assets/533/415dc995-98a7-4449-af1b-659ddab50395)
* Now replace the first section of the URL `https://wordpress.com/log-in?client_id=` with `http://calypso.localhost:3000/log-in?client_id=`.
* Try hitting the back button. 
* Make sure the styling is the same, and also check the mobile view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?