### PR TITLE
Nav Redesign v2: remove status filter

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -113,13 +113,8 @@ const DotcomSitesDataViews = ( {
 				id: 'status',
 				header: __( 'Status' ),
 				render: ( { item }: { item: SiteInfo } ) => <SiteStatus site={ item } />,
-				type: 'enumeration',
-				elements: siteStatusGroups,
-				filterBy: {
-					operators: [ 'in' ],
-				},
 				enableHiding: false,
-				enableSorting: false,
+				enableSorting: true,
 			},
 			{
 				id: 'last-publish',


### PR DESCRIPTION
Removes the filter option for status as described in 6960-gh-Automattic/dotcom-forge.

The filter is added within the Gutenberg dataviews component based on the configuration passed in. By changing the column type, status is no longer filterable, since no other columns are filterable, the filter UI is completely removed.

Before:
<img width="1375" alt="Screenshot 2024-05-07 at 1 11 36 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/54752b54-b7b5-40be-a899-dd565d88d734">

After:
<img width="1165" alt="Screenshot 2024-05-07 at 3 29 24 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/5fe219dc-3900-4aaf-a69b-86b2b1fed777">

### Testing instructions:

Go to /sites

The Status column should no longer be filterable but should now be sortable. 
The filter UI should be removed.