### PR TITLE
Nav Redesign: Add sorting icons to sites table header

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -11,6 +11,7 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import ActionsField from './dataviews-fields/actions-field';
 import SiteField from './dataviews-fields/site-field';
 import { SiteInfo } from './interfaces';
+import { SiteSort } from './sites-site-sort';
 import { SiteStats } from './sites-site-stats';
 import { SiteStatus } from './sites-site-status';
 import type { SiteExcerptData } from '@automattic/sites';
@@ -94,13 +95,22 @@ const DotcomSitesDataViews = ( {
 		() => [
 			{
 				id: 'site',
-				header: <span>{ __( 'Site' ) }</span>,
+				header: (
+					<SiteSort
+						isSortable={ true }
+						columnKey="site"
+						dataViewsState={ dataViewsState }
+						setDataViewsState={ setDataViewsState }
+					>
+						<span>{ __( 'Site' ) }</span>
+					</SiteSort>
+				),
 				getValue: ( { item }: { item: SiteInfo } ) => item.URL,
 				render: ( { item }: { item: SiteInfo } ) => {
 					return <SiteField site={ item } openSitePreviewPane={ openSitePreviewPane } />;
 				},
 				enableHiding: false,
-				enableSorting: true,
+				enableSorting: false,
 			},
 			{
 				id: 'plan',
@@ -156,7 +166,7 @@ const DotcomSitesDataViews = ( {
 				enableSorting: true,
 			},
 		],
-		[ __, openSitePreviewPane, userId ]
+		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState ]
 	);
 
 	// Create the itemData packet state

--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
@@ -1,0 +1,102 @@
+// Copied from client/a8c-for-agencies/sections/sites/site-sort/index.tsx as we don't have SitesDashboardContext here.
+import { Icon } from '@wordpress/icons';
+import classNames from 'classnames';
+import {
+	defaultSortIcon,
+	ascendingSortIcon,
+	descendingSortIcon,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/icons';
+import type { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+
+import 'calypso/a8c-for-agencies/sections/sites/site-sort/style.scss';
+
+const SORT_DIRECTION_ASC = 'asc';
+const SORT_DIRECTION_DESC = 'desc';
+
+// Mapping the columns to the site data keys
+const SITE_COLUMN_KEY_MAP: { [ key: string ]: string } = {
+	site: 'site',
+};
+
+interface SiteSortProps {
+	columnKey: string;
+	isLargeScreen?: boolean;
+	children?: React.ReactNode;
+	isSortable?: boolean;
+	dataViewsState: DataViewsState;
+	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
+}
+
+export const SiteSort = ( {
+	columnKey,
+	isLargeScreen,
+	children,
+	isSortable,
+	dataViewsState,
+	setDataViewsState,
+}: SiteSortProps ) => {
+	const { field, direction } = dataViewsState.sort;
+
+	const isDefault = field !== SITE_COLUMN_KEY_MAP?.[ columnKey ] || ! field || ! direction;
+
+	const setSort = () => {
+		const updatedSort = { ...dataViewsState.sort };
+		if ( isDefault ) {
+			updatedSort.field = SITE_COLUMN_KEY_MAP?.[ columnKey ];
+			updatedSort.direction = SORT_DIRECTION_ASC;
+		} else if ( direction === SORT_DIRECTION_ASC ) {
+			updatedSort.direction = SORT_DIRECTION_DESC;
+		} else if ( direction === SORT_DIRECTION_DESC ) {
+			updatedSort.direction = SORT_DIRECTION_ASC;
+		}
+
+		setDataViewsState( ( sitesViewState ) => ( {
+			...sitesViewState,
+			sort: updatedSort,
+		} ) );
+	};
+
+	const getSortIcon = () => {
+		if ( isDefault ) {
+			return defaultSortIcon;
+		} else if ( direction === SORT_DIRECTION_ASC ) {
+			return ascendingSortIcon;
+		} else if ( direction === SORT_DIRECTION_DESC ) {
+			return descendingSortIcon;
+		}
+		return defaultSortIcon;
+	};
+
+	if ( ! isSortable ) {
+		return <span className="site-sort">{ children }</span>;
+	}
+
+	const handleOnKeyDown = ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			setSort();
+		}
+	};
+
+	return (
+		<span
+			role="button"
+			tabIndex={ 0 }
+			className={ classNames( 'site-sort site-sort__clickable', {
+				'site-sort__icon-large_screen': isLargeScreen,
+			} ) }
+			onKeyDown={ handleOnKeyDown }
+			onClick={ setSort }
+		>
+			{ children }
+			{ isSortable && (
+				<Icon
+					className={ classNames( 'site-sort__icon', {
+						'site-sort__icon-hidden': isLargeScreen && isDefault,
+					} ) }
+					size={ 14 }
+					icon={ getSortIcon() }
+				/>
+			) }
+		</span>
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6959, https://github.com/Automattic/dotcom-forge/issues/6963

## Proposed Changes

* Use the `SiteSort` component to sort the "Site" column as A4A does.
* We disable the `enableSorting` on the "Site" column, so https://github.com/Automattic/dotcom-forge/issues/6963 will be resolved automatically
* There is an issue related to the sort options from settings icon but I think we can address it in the follow-up PR
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a6913117-8eaa-4f07-8593-b05d12fd8ae3)

**Screenshots**

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/90b1de60-91f3-4682-8be0-eca47ac4044e) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/376561ac-dcc6-499d-87a3-492fa5f0790b) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Make sure you can see the sorting icon on the "Site" column
* Click the column to make sure the soring works as expected
* Resize your window to mobile viewport
* Make sure the header of the "Site" column is still visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
