### PR TITLE
Add WP Admin link in each row

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -62,7 +62,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	}
 
 	const title = __( 'View Site Details' );
-	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site.ID ) );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site.ID ) ?? '' );
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -16,6 +16,7 @@ import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link
 import { displaySiteUrl, isStagingSite, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import type { SiteExcerptData } from '@automattic/sites';
 
 type Props = {
@@ -48,27 +49,12 @@ const ListTileTitle = styled.div`
 	align-items: center;
 `;
 
-const ListTileSubtitle = styled.div`
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	font-size: 14px;
-	color: var( --studio-gray-60 ) !important;
-	svg {
-		flex-shrink: 0;
-	}
-
-	&:not( :last-child ) {
-		margin-block-end: 2px;
-	}
-`;
-
 const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const { __ } = useI18n();
-	// todo: This hook is used by the SiteItemThumbnail component below, in a prop showPlaceholder={ ! inView }. It does not work as expected. Fix it.
-	//const { inView } = useInView( { triggerOnce: true } );
+
+	// Todo: This hook is used by the SiteItemThumbnail component below, in a prop showPlaceholder={ ! inView }.
+	// It does not work as expected. Fix it.
+	// const { inView } = useInView( { triggerOnce: true } );
 
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
@@ -76,6 +62,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	}
 
 	const title = __( 'View Site Details' );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site.ID ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
@@ -87,7 +74,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	};
 
 	return (
-		<Button className="sites-dataviews__site" onClick={ onSiteClick } borderless={ true }>
+		<div className="sites-dataviews__site">
 			<SiteListTile
 				contentClassName={ classnames(
 					'sites-dataviews__site-name',
@@ -97,23 +84,25 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 					`
 				) }
 				leading={
-					<ListTileLeading title={ title }>
-						<SiteItemThumbnail
-							className="sites-site-thumbnail"
-							displayMode="list"
-							showPlaceholder={ false }
-							site={ site }
-						/>
-						<SiteFavicon
-							className="sites-site-favicon"
-							blogId={ site.ID }
-							isDotcomSite={ site.is_wpcom_atomic }
-						/>
-					</ListTileLeading>
+					<Button className="sites-dataviews__preview-trigger" onClick={ onSiteClick } borderless>
+						<ListTileLeading title={ title }>
+							<SiteItemThumbnail
+								className="sites-site-thumbnail"
+								displayMode="list"
+								showPlaceholder={ false }
+								site={ site }
+							/>
+							<SiteFavicon
+								className="sites-site-favicon"
+								blogId={ site.ID }
+								isDotcomSite={ site.is_wpcom_atomic }
+							/>
+						</ListTileLeading>
+					</Button>
 				}
 				title={
 					<ListTileTitle>
-						<SiteName title={ title }>
+						<SiteName as="div" title={ title }>
 							<Truncated>{ site.title }</Truncated>
 						</SiteName>
 						{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
@@ -130,14 +119,17 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 						</>
 					) : (
 						<>
-							<ListTileSubtitle className="sites-dataviews__site-url">
+							<div className="sites-dataviews__site-url">
 								<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
-							</ListTileSubtitle>
+							</div>
+							<a className="sites-dataviews__site-wp-admin-url" href={ siteAdminUrl }>
+								<Truncated>{ __( 'WP Admin' ) }</Truncated>
+							</a>
 						</>
 					)
 				}
 			/>
-		</Button>
+		</div>
 	);
 };
 

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -69,7 +69,9 @@ const DotcomSitesDataViews = ( {
 			if ( row ) {
 				const isButtonOrLink = target.closest( 'button, a' );
 				if ( ! isButtonOrLink ) {
-					const button = row.querySelector( '.sites-dataviews__site' ) as HTMLButtonElement;
+					const button = row.querySelector(
+						'.sites-dataviews__preview-trigger'
+					) as HTMLButtonElement;
 					if ( button ) {
 						button.click();
 					}

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -4,29 +4,47 @@
 .sites-dataviews__site {
 	display: flex;
 	flex-direction: row;
+	padding-bottom: 8px;
+	padding-top: 8px;
 
 	.button {
+		margin: 0;
 		padding: 0;
 	}
 }
 
 .sites-dataviews__site-name {
+	align-self: center;
 	display: inline-block;
 	text-align: left;
 	text-overflow: ellipsis;
 	overflow: hidden;
+	padding-left: 20px;
 	white-space: nowrap;
 	font-weight: 500;
 	font-size: rem(14px);
 }
 
-.sites-dataviews__site-url {
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
+.sites-dataviews__site-url,
+.sites-dataviews__site-wp-admin-url {
+	color: var(--color-neutral-70);
 	font-size: rem(12px);
-	color: var(--color-neutral-60);
 	font-weight: 400;
+}
+
+.sites-dataviews__site-wp-admin-url {
+	&:focus {
+		border-radius: 2px;
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+	}
+
+	&:hover {
+		text-decoration: underline;
+	}
+
+	&:visited {
+		color: var(--color-neutral-70);
+	}
 }
 
 .preview-hidden {
@@ -62,6 +80,14 @@
 }
 
 .sites-dashboard__layout:not(.preview-hidden) {
+	.sites-dataviews__site-wp-admin-url {
+		display: none;
+	}
+
+	.sites-dataviews__site button {
+		cursor: default;
+	}
+
 	.dataviews-pagination {
 		.components-base-control {
 			width: unset !important;

--- a/client/sites-dashboard/components/sites-site-name.ts
+++ b/client/sites-dashboard/components/sites-site-name.ts
@@ -9,7 +9,7 @@ export const SiteName = styled.a< { fontSize?: number } >`
 	font-size: ${ ( props ) => `${ props.fontSize }px` };
 	letter-spacing: -0.4px;
 
-	&:hover {
+	&:is( a ):hover {
 		text-decoration: underline;
 	}
 

--- a/client/sites-dashboard/components/test/__snapshots__/sites-grid-item.tsx.snap
+++ b/client/sites-dashboard/components/test/__snapshots__/sites-grid-item.tsx.snap
@@ -36,7 +36,7 @@ exports[`<SitesGridItem> Custom render 1`] = `
       className="css-1xtz7v6-primaryContainer"
     >
       <a
-        className="css-6u0p2y-SiteName esmj6c50"
+        className="css-jjnk6s-SiteName esmj6c50"
         fontSize={16}
         href="/home/test_slug"
         title="Visit Dashboard"
@@ -106,7 +106,7 @@ exports[`<SitesGridItem> Custom render 2 1`] = `
       className="css-1xtz7v6-primaryContainer"
     >
       <a
-        className="css-6u0p2y-SiteName esmj6c50"
+        className="css-jjnk6s-SiteName esmj6c50"
         fontSize={16}
       >
         The example site
@@ -178,7 +178,7 @@ exports[`<SitesGridItem> Default render 1`] = `
       className="css-1xtz7v6-primaryContainer"
     >
       <a
-        className="css-6u0p2y-SiteName esmj6c50"
+        className="css-jjnk6s-SiteName esmj6c50"
         fontSize={16}
         href="/home/test_slug"
         title="Visit Dashboard"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6964

## Proposed Changes

This PR add the WP Admin link to each row in the Sites list. Note that the WP Admin is not displayed when the Site list is collapsed. The HTML structure was updated to avoid having the link inside a button. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that each row has a WP Admin link that works properly.
* Ensure that the "click row" to open the fly-out panel also works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
