### PR TITLE
Nav redesign: Hide the “Site” and “Last Publish” under the Sort By option on the larger screen

### DIFF
--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -40,7 +40,11 @@ import { DOTCOM_OVERVIEW, FEATURE_TO_ROUTE_MAP } from './site-preview-pane/const
 import DotcomPreviewPane from './site-preview-pane/dotcom-preview-pane';
 import SitesDashboardHeader from './sites-dashboard-header';
 import DotcomSitesDataViews, { siteStatusGroups } from './sites-dataviews';
-import { getSitesPagination } from './sites-dataviews/utils';
+import {
+	getSitesPagination,
+	addDummyDataViewPrefix,
+	removeDummyDataViewPrefix,
+} from './sites-dataviews/utils';
 import type { SiteDetails } from '@automattic/data-stores';
 
 // todo: we are using A4A styles until we extract them as common styles in the ItemsDashboard component
@@ -57,6 +61,8 @@ interface SitesDashboardProps {
 }
 
 const siteSortingKeys = [
+	{ dataView: addDummyDataViewPrefix( 'site' ), sortKey: 'alphabetically' },
+	{ dataView: addDummyDataViewPrefix( 'last-publish' ), sortKey: 'updatedAt' },
 	{ dataView: 'site', sortKey: 'alphabetically' },
 	{ dataView: 'magic', sortKey: 'lastInteractedWith' },
 	{ dataView: 'last-publish', sortKey: 'updatedAt' },
@@ -98,6 +104,7 @@ const SitesDashboardV2 = ( {
 		page,
 		perPage,
 		search: search ?? '',
+		hiddenFields: [ addDummyDataViewPrefix( 'site' ), addDummyDataViewPrefix( 'last-publish' ) ],
 		filters:
 			status === 'all'
 				? []
@@ -193,9 +200,9 @@ const SitesDashboardV2 = ( {
 	// Update site sorting preference on change
 	useEffect( () => {
 		if ( dataViewsState.sort.field ) {
+			const field = removeDummyDataViewPrefix( dataViewsState.sort.field );
 			onSitesSortingChange( {
-				sortKey: siteSortingKeys.find( ( key ) => key.dataView === dataViewsState.sort.field )
-					?.sortKey as SitesSortKey,
+				sortKey: siteSortingKeys.find( ( key ) => key.dataView === field )?.sortKey as SitesSortKey,
 				sortOrder: dataViewsState.sort.direction || 'asc',
 			} );
 		}

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -61,6 +61,7 @@ interface SitesDashboardProps {
 }
 
 const siteSortingKeys = [
+	// Put the dummy data view at the beginning for searching the sort key.
 	{ dataView: addDummyDataViewPrefix( 'site' ), sortKey: 'alphabetically' },
 	{ dataView: addDummyDataViewPrefix( 'last-publish' ), sortKey: 'updatedAt' },
 	{ dataView: 'site', sortKey: 'alphabetically' },

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -64,8 +64,8 @@ const siteSortingKeys = [
 	// Put the dummy data view at the beginning for searching the sort key.
 	{ dataView: addDummyDataViewPrefix( 'site' ), sortKey: 'alphabetically' },
 	{ dataView: addDummyDataViewPrefix( 'last-publish' ), sortKey: 'updatedAt' },
+	{ dataView: addDummyDataViewPrefix( 'last-interacted' ), sortKey: 'lastInteractedWith' },
 	{ dataView: 'site', sortKey: 'alphabetically' },
-	{ dataView: 'magic', sortKey: 'lastInteractedWith' },
 	{ dataView: 'last-publish', sortKey: 'updatedAt' },
 ];
 
@@ -105,7 +105,11 @@ const SitesDashboardV2 = ( {
 		page,
 		perPage,
 		search: search ?? '',
-		hiddenFields: [ addDummyDataViewPrefix( 'site' ), addDummyDataViewPrefix( 'last-publish' ) ],
+		hiddenFields: [
+			addDummyDataViewPrefix( 'site' ),
+			addDummyDataViewPrefix( 'last-publish' ),
+			addDummyDataViewPrefix( 'last-interacted' ),
+		],
 		filters:
 			status === 'all'
 				? []

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -98,7 +98,6 @@ const SitesDashboardV2 = ( {
 		page,
 		perPage,
 		search: search ?? '',
-		hiddenFields: [ 'magic' ],
 		filters:
 			status === 'all'
 				? []

--- a/client/sites-dashboard-v2/sites-dataviews/constants.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/constants.tsx
@@ -1,0 +1,1 @@
+export const DUMMY_DATA_VIEW_PREFIX = 'dummy-';

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -15,6 +15,7 @@ import { SiteInfo } from './interfaces';
 import { SiteSort } from './sites-site-sort';
 import { SiteStats } from './sites-site-stats';
 import { SiteStatus } from './sites-site-status';
+import { addDummyDataViewPrefix } from './utils';
 import type { SiteExcerptData } from '@automattic/sites';
 import type {
 	DataViewsColumn,
@@ -174,18 +175,25 @@ const DotcomSitesDataViews = ( {
 			},
 			// Dummy fields to allow people to sort by them on mobile.
 			{
-				id: 'dummy-site',
+				id: addDummyDataViewPrefix( 'site' ),
 				header: <span>{ __( 'Site' ) }</span>,
 				render: () => null,
 				enableHiding: false,
 				enableSorting,
 			},
 			{
-				id: 'dummy-last-publish',
+				id: addDummyDataViewPrefix( 'last-publish' ),
 				header: <span>{ __( 'Last Publish' ) }</span>,
 				render: () => null,
 				enableHiding: false,
 				enableSorting,
+			},
+			{
+				id: addDummyDataViewPrefix( 'last-interacted' ),
+				header: __( 'Last Interacted' ),
+				render: () => null,
+				enableHiding: false,
+				enableSorting: true,
 			},
 		],
 		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState, enableSorting ]

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -167,6 +167,21 @@ const DotcomSitesDataViews = ( {
 				enableHiding: false,
 				enableSorting: false,
 			},
+			// Dummy fields to allow people to sort by them on mobile.
+			{
+				id: 'dummy-site',
+				header: <span>{ __( 'Site' ) }</span>,
+				render: () => null,
+				enableHiding: false,
+				enableSorting: true,
+			},
+			{
+				id: 'dummy-last-publish',
+				header: <span>{ __( 'Last Publish' ) }</span>,
+				render: () => null,
+				enableHiding: false,
+				enableSorting: true,
+			},
 		],
 		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState ]
 	);

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -133,11 +133,20 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'last-publish',
-				header: <span>{ __( 'Last Publish' ) }</span>,
+				header: (
+					<SiteSort
+						isSortable={ true }
+						columnKey="last-publish"
+						dataViewsState={ dataViewsState }
+						setDataViewsState={ setDataViewsState }
+					>
+						<span>{ __( 'Last Publish' ) }</span>
+					</SiteSort>
+				),
 				render: ( { item }: { item: SiteInfo } ) =>
 					item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
 				enableHiding: false,
-				enableSorting: true,
+				enableSorting: false,
 			},
 			{
 				id: 'stats',
@@ -157,13 +166,6 @@ const DotcomSitesDataViews = ( {
 				render: ( { item }: { item: SiteInfo } ) => <ActionsField site={ item } />,
 				enableHiding: false,
 				enableSorting: false,
-			},
-			{
-				id: 'magic',
-				header: __( 'Magic' ),
-				render: () => <></>,
-				enableHiding: false,
-				enableSorting: true,
 			},
 		],
 		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState ]

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -1,3 +1,4 @@
+import { useBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -50,6 +51,10 @@ const DotcomSitesDataViews = ( {
 }: Props ) => {
 	const { __ } = useI18n();
 	const userId = useSelector( getCurrentUserId );
+
+	// Display the `Sort By` option only when the fields are hidden on smaller viewport.
+	const isSmallScreen = useBreakpoint( '<1180px' );
+	const enableSorting = isSmallScreen || dataViewsState.type === 'list';
 
 	const openSitePreviewPane = useCallback(
 		( site: SiteExcerptData ) => {
@@ -173,17 +178,17 @@ const DotcomSitesDataViews = ( {
 				header: <span>{ __( 'Site' ) }</span>,
 				render: () => null,
 				enableHiding: false,
-				enableSorting: true,
+				enableSorting,
 			},
 			{
 				id: 'dummy-last-publish',
 				header: <span>{ __( 'Last Publish' ) }</span>,
 				render: () => null,
 				enableHiding: false,
-				enableSorting: true,
+				enableSorting,
 			},
 		],
-		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState ]
+		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState, enableSorting ]
 	);
 
 	// Create the itemData packet state

--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
@@ -13,11 +13,6 @@ import 'calypso/a8c-for-agencies/sections/sites/site-sort/style.scss';
 const SORT_DIRECTION_ASC = 'asc';
 const SORT_DIRECTION_DESC = 'desc';
 
-// Mapping the columns to the site data keys
-const SITE_COLUMN_KEY_MAP: { [ key: string ]: string } = {
-	site: 'site',
-};
-
 interface SiteSortProps {
 	columnKey: string;
 	isLargeScreen?: boolean;
@@ -37,12 +32,12 @@ export const SiteSort = ( {
 }: SiteSortProps ) => {
 	const { field, direction } = dataViewsState.sort;
 
-	const isDefault = field !== SITE_COLUMN_KEY_MAP?.[ columnKey ] || ! field || ! direction;
+	const isDefault = field !== columnKey || ! field || ! direction;
 
 	const setSort = () => {
 		const updatedSort = { ...dataViewsState.sort };
 		if ( isDefault ) {
-			updatedSort.field = SITE_COLUMN_KEY_MAP?.[ columnKey ];
+			updatedSort.field = columnKey;
 			updatedSort.direction = SORT_DIRECTION_ASC;
 		} else if ( direction === SORT_DIRECTION_ASC ) {
 			updatedSort.direction = SORT_DIRECTION_DESC;

--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
@@ -6,6 +6,7 @@ import {
 	ascendingSortIcon,
 	descendingSortIcon,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/icons';
+import { addDummyDataViewPrefix, removeDummyDataViewPrefix } from './utils';
 import type { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 
 import 'calypso/a8c-for-agencies/sections/sites/site-sort/style.scss';
@@ -32,12 +33,12 @@ export const SiteSort = ( {
 }: SiteSortProps ) => {
 	const { field, direction } = dataViewsState.sort;
 
-	const isDefault = field !== columnKey || ! field || ! direction;
+	const isDefault = removeDummyDataViewPrefix( field ) !== columnKey || ! field || ! direction;
 
 	const setSort = () => {
 		const updatedSort = { ...dataViewsState.sort };
 		if ( isDefault ) {
-			updatedSort.field = columnKey;
+			updatedSort.field = addDummyDataViewPrefix( columnKey );
 			updatedSort.direction = SORT_DIRECTION_ASC;
 		} else if ( direction === SORT_DIRECTION_ASC ) {
 			updatedSort.direction = SORT_DIRECTION_DESC;

--- a/client/sites-dashboard-v2/sites-dataviews/utils.ts
+++ b/client/sites-dashboard-v2/sites-dataviews/utils.ts
@@ -1,4 +1,5 @@
 import { DataViewsPaginationInfo } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DUMMY_DATA_VIEW_PREFIX } from './constants';
 import type { SiteExcerptData } from '@automattic/sites';
 
 const SORT_KEY_MAP = {
@@ -18,4 +19,12 @@ export function getSitesPagination(
 	const totalPages = Math.ceil( totalItems / perPage );
 
 	return { totalItems, totalPages };
+}
+
+export function addDummyDataViewPrefix( dataView: string ) {
+	return `${ DUMMY_DATA_VIEW_PREFIX }${ dataView }`;
+}
+
+export function removeDummyDataViewPrefix( dataView: string ) {
+	return dataView.replace( DUMMY_DATA_VIEW_PREFIX, '' );
 }

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -99,6 +99,7 @@ const mediaQueryOptions: Record< string, QueryOption > = {
 	'<800px': { max: 800 },
 	'<960px': { max: 960 },
 	'<1040px': { max: 1040 },
+	'<1180px': { max: 1180 },
 	'<1280px': { max: 1280 },
 	'<1400px': { max: 1400 },
 	'>480px': { min: 480 },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6961

## Proposed Changes

* The current way is a bit hacky as we want to show the sorting icon on the header of the column to let the user sort by the column with just a single click. See https://github.com/Automattic/wp-calypso/pull/90353. As a result, we have to disable the sorting feature provided by the DataViews component to avoid the dropdown option being shown when the user clicks the header of the column. So, I add the dummy fields to the DataViews to display them on the Sort By option.
* To hide the “Site” and “Last Publish” under the `Sort By` option on the larger screen, I use the viewport to determine whether to enable the sorting feature on those dummy fields.
* Rename the “Magic” to “Last Interacted”

Any thoughts?


| Small Screen | Large Screen |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/2839c9fb-2045-410c-b5a9-04851cafbd81) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/9c82fb3d-aaa4-4b83-bf69-39e0f65e6693) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Make sure the `Sort By` option has only the “Last Interacted” option when the vw is greater than 1180px. The value of `1180px` is the threshold to hide the `Last Published` column.
* Resize your window to 1180px below
* Make sure you can see the `Sort By` option
* Select any site
* Make sure you can see the Sort By option on any viewport as the `Last Published` column is not visible on the list view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
