### PR TITLE
Automattic for Agencies: Implement download action for unattached licenses

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -70,17 +70,11 @@ export default function LicenseDetailsActions( {
 
 	return (
 		<div className="license-details__actions">
-			{ hasDownloads &&
-				licenseState === LicenseState.Attached &&
-				licenseType === LicenseType.Partner && (
-					<Button
-						compact
-						{ ...( status === 'pending' ? { busy: true } : {} ) }
-						onClick={ download }
-					>
-						{ translate( 'Download' ) }
-					</Button>
-				) }
+			{ hasDownloads && licenseType === LicenseType.Partner && (
+				<Button compact { ...( status === 'pending' ? { busy: true } : {} ) } onClick={ download }>
+					{ translate( 'Download' ) }
+				</Button>
+			) }
 
 			{ ! isPressableLicense && licenseState === LicenseState.Attached && siteUrl && (
 				<Button compact href={ siteUrl } target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/429

## Proposed Changes

This PR implements download action for unattached licenses

## Testing Instructions

1) Open the A4A live link.
2) Go to the Marketplace > Issue a WooCommerce license.
3) Visit the Licenses page > Expand the license details for the previously issued WooCommerce license.
4) Verify you can now see a Download button & it works as expected.
5) Assign this license to a site > Verify that the button is still available and works as expected. 

<img width="898" alt="Screenshot 2024-05-07 at 12 38 57 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/773c831b-40b5-4817-b502-2fa85f8924f3">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
