### PR TITLE
Scheduled Updates: Add slug beneath site title in site picker

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -69,23 +69,25 @@ export const ScheduleFormSites = ( props: Props ) => {
 				<div className="checkbox-options-container checkbox-options-container__sites">
 					{ sites.map( ( site ) => (
 						<Fragment key={ site.ID }>
-							{ site?.name && site.name.toLowerCase().includes( searchTerm.toLowerCase() ) && (
-								<div>
-									<CheckboxControl
-										key={ site.ID }
-										onChange={ ( isChecked ) => {
-											onSiteSelectionChange( site, isChecked );
-											setFieldTouched( true );
-										} }
-										checked={ selectedSites.includes( site.ID ) }
-									/>
-									<label htmlFor={ `${ site.ID }` }>
-										{ site.name }
-										<br />
-										<span className="site-slug">{ site.slug }</span>
-									</label>
-								</div>
-							) }
+							{ site?.name &&
+								( site.name.toLowerCase().includes( searchTerm.toLowerCase() ) ||
+									site.slug.toLowerCase().includes( searchTerm.toLowerCase() ) ) && (
+									<div>
+										<CheckboxControl
+											key={ site.ID }
+											onChange={ ( isChecked ) => {
+												onSiteSelectionChange( site, isChecked );
+												setFieldTouched( true );
+											} }
+											checked={ selectedSites.includes( site.ID ) }
+										/>
+										<label htmlFor={ `${ site.ID }` }>
+											{ site.name }
+											<br />
+											<span className="site-slug">{ site.slug }</span>
+										</label>
+									</div>
+								) }
 						</Fragment>
 					) ) }
 				</div>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -66,19 +66,25 @@ export const ScheduleFormSites = ( props: Props ) => {
 						feature.
 					</Text>
 				) }
-				<div className="checkbox-options-container">
+				<div className="checkbox-options-container checkbox-options-container__sites">
 					{ sites.map( ( site ) => (
 						<Fragment key={ site.ID }>
 							{ site?.name && site.name.toLowerCase().includes( searchTerm.toLowerCase() ) && (
-								<CheckboxControl
-									key={ site.ID }
-									label={ site.name }
-									onChange={ ( isChecked ) => {
-										onSiteSelectionChange( site, isChecked );
-										setFieldTouched( true );
-									} }
-									checked={ selectedSites.includes( site.ID ) }
-								/>
+								<div>
+									<CheckboxControl
+										key={ site.ID }
+										onChange={ ( isChecked ) => {
+											onSiteSelectionChange( site, isChecked );
+											setFieldTouched( true );
+										} }
+										checked={ selectedSites.includes( site.ID ) }
+									/>
+									<label htmlFor={ `${ site.ID }` }>
+										{ site.name }
+										<br />
+										<span className="site-slug">{ site.slug }</span>
+									</label>
+								</div>
 							) }
 						</Fragment>
 					) ) }

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -228,7 +228,6 @@ $brand-display: "SF Pro Display", sans-serif;
 
 	}
 
-
 	.components-card__footer {
 		display: flex;
 		align-items: baseline;
@@ -237,6 +236,4 @@ $brand-display: "SF Pro Display", sans-serif;
 			width: 100%;
 		}
 	}
-
-
 }

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -115,18 +115,19 @@
 
 		&__sites {
 			> div {
-				.components-checkbox-control {
-					display: inline-block;
-					vertical-align: top;
-				}
+				display: flex;
+				align-items: center;
 
 				label {
-					display: inline-block;
-					vertical-align: top;
-					margin-top: -4px;
+					max-width: calc(100% - 2rem);
 
 					.site-slug {
 						color: var(--studio-gray-50);
+						display: inline-block;
+						white-space: nowrap;
+						overflow: hidden;
+						text-overflow: ellipsis;
+						max-width: 100%;
 					}
 				}
 			}

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -113,6 +113,26 @@
 			box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
 		}
 
+		&__sites {
+			> div {
+				.components-checkbox-control {
+					display: inline-block;
+					vertical-align: top;
+				}
+
+				label {
+					display: inline-block;
+					vertical-align: top;
+					margin-top: -4px;
+
+					.site-slug {
+						color: var(--studio-gray-50);
+					}
+				}
+			}
+
+		}
+
 	}
 
 	.form-field {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/90357

## Proposed Changes

* Adds the domain (slug) beneath site title in site picker

![CleanShot 2024-05-07 at 10 42 30@2x](https://github.com/Automattic/wp-calypso/assets/528287/a71280ba-50cf-499a-90c2-b7b4fef7513b)
![CleanShot 2024-05-07 at 10 41 58@2x](https://github.com/Automattic/wp-calypso/assets/528287/a9a4b29c-365e-407d-9578-f067251a132e)



## Testing Instructions

1. Apply this PR
2. Add schedules in multisite scheduled updates
3. Verify that the slugs render correctly and don't overflow on different viewport sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?