### PR TITLE
Scheduled Updates: Fix passing schedule id to logs

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status.tsx
@@ -25,7 +25,7 @@ export function ScheduleListLastRunStatus( { schedule, site, onLogsClick }: Prop
 					<Button
 						className="schedule-last-run"
 						variant="link"
-						onClick={ () => onLogsClick && onLogsClick( schedule.id, site?.slug ) }
+						onClick={ () => onLogsClick && onLogsClick( schedule.schedule_id, site?.slug ) }
 					>
 						{ site.last_run_status === 'in-progress'
 							? translate( 'In progress' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90371

## Proposed Changes

* When clicking on the status in multi-site level screen, it should redirect you to the site-specific logs. 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates`
* Expand the row and click on the status, make sure it takes you to the log.

![Screen Shot 2024-05-07 at 6 01 07 PM](https://github.com/Automattic/wp-calypso/assets/4074459/f0c75220-0de0-4800-9292-21c551e1c270)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
