### PR TITLE
Site Profiler: removes feature flag that's already enabled in all envs.

### DIFF
--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -1,17 +1,8 @@
-import config from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import Main from 'calypso/components/main';
 import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-
-export const featureFlagFirewall: Callback = ( _context, next ) => {
-	if ( config.isEnabled( 'site-profiler' ) ) {
-		next();
-	} else {
-		page.redirect( '/' );
-	}
-};
 
 export const handleDomainQueryParam: Callback = ( context, next ) => {
 	const { querystring } = context;

--- a/client/site-profiler/index.web.ts
+++ b/client/site-profiler/index.web.ts
@@ -7,7 +7,6 @@ import {
 } from 'calypso/controller/index.web';
 import {
 	siteProfilerContext,
-	featureFlagFirewall,
 	handleDomainQueryParam,
 	redirectToBaseSiteProfilerRoute,
 	siteProfilerReportContext,
@@ -15,26 +14,16 @@ import {
 
 export default function ( router: typeof clientRouter ) {
 	const lang = getAnyLanguageRouteParam();
-	const langSiteProfilerMiddleware = [
-		featureFlagFirewall,
-		setLocaleMiddleware(),
-		redirectToBaseSiteProfilerRoute,
-	];
+	const langSiteProfilerMiddleware = [ setLocaleMiddleware(), redirectToBaseSiteProfilerRoute ];
 
 	const siteProfilerMiddleware = [
-		featureFlagFirewall,
 		handleDomainQueryParam,
 		siteProfilerContext,
 		makeLayout,
 		clientRender,
 	];
 
-	const siteProfilerReportMiddleware = [
-		featureFlagFirewall,
-		siteProfilerReportContext,
-		makeLayout,
-		clientRender,
-	];
+	const siteProfilerReportMiddleware = [ siteProfilerReportContext, makeLayout, clientRender ];
 
 	router( '/site-profiler/report/:hash/:domain', ...siteProfilerReportMiddleware );
 	router( '/site-profiler/report/:hash/:domain/*', ...siteProfilerReportMiddleware );

--- a/config/development.json
+++ b/config/development.json
@@ -203,7 +203,6 @@
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,
-		"site-profiler": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": false,
 		"stats/checkout-flows-v2": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -128,7 +128,6 @@
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,
-		"site-profiler": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
 		"stats/checkout-flows-v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -170,7 +170,6 @@
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,
-		"site-profiler": true,
 		"site-profiler/metrics": false,
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -166,7 +166,6 @@
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,
-		"site-profiler": true,
 		"site-profiler/metrics": false,
 		"ssr/prefetch-timebox": true,
 		"stats/checkout-flows-v2": true,

--- a/config/test.json
+++ b/config/test.json
@@ -115,7 +115,6 @@
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,
-		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -165,7 +165,6 @@
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,
-		"site-profiler": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
 		"stats/checkout-flows-v2": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* `site-profiler` is already enabled in all envs, thus it can be safely removed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* make sure that `/site-profiler` is still accessible in all envs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?