### PR TITLE
Remove migration assistance feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -202,24 +202,23 @@ const importFlow: Flow = {
 
 				case 'processing': {
 					const processingResult = params[ 0 ] as ProcessingResult;
-					const siteSlug = providedDependencies?.siteSlug || siteSlugParam;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );
 					}
 
-					if ( siteSlug ) {
+					if ( providedDependencies?.siteSlug ) {
 						if ( fromParam ) {
-							urlQueryParams.set( 'siteSlug', siteSlug );
+							const selectedSiteSlug = providedDependencies?.siteSlug as string;
+							urlQueryParams.set( 'siteSlug', selectedSiteSlug );
 							urlQueryParams.set( 'from', fromParam );
 							urlQueryParams.set( 'option', 'everything' );
-							urlQueryParams.delete( 'showModal' );
-							return exitFlow(
-								`/setup/${ IMPORT_FOCUSED_FLOW }/importerWordpress?${ urlQueryParams.toString() }`
-							);
+
+							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 						}
-						return exitFlow( `/setup/${ IMPORT_FOCUSED_FLOW }/import?siteSlug=${ siteSlug }` );
+						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` );
 					}
+
 					// End of Pattern Assembler flow
 					if ( isAssemblerDesign( selectedDesign ) ) {
 						return exitFlow( `/site-editor/${ siteSlugParam }` );

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -202,20 +202,23 @@ const importFlow: Flow = {
 
 				case 'processing': {
 					const processingResult = params[ 0 ] as ProcessingResult;
+					const siteSlug = providedDependencies?.siteSlug || siteSlugParam;
+
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );
 					}
 
-					if ( providedDependencies?.siteSlug ) {
+					if ( siteSlug ) {
 						if ( fromParam ) {
-							const selectedSiteSlug = providedDependencies?.siteSlug as string;
-							urlQueryParams.set( 'siteSlug', selectedSiteSlug );
+							urlQueryParams.set( 'siteSlug', siteSlug );
 							urlQueryParams.set( 'from', fromParam );
 							urlQueryParams.set( 'option', 'everything' );
-
-							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
+							urlQueryParams.delete( 'showModal' );
+							return exitFlow(
+								`/setup/${ IMPORT_FOCUSED_FLOW }/importerWordpress?${ urlQueryParams.toString() }`
+							);
 						}
-						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` );
+						return exitFlow( `/setup/${ IMPORT_FOCUSED_FLOW }/import?siteSlug=${ siteSlug }` );
 					}
 					// End of Pattern Assembler flow
 					if ( isAssemblerDesign( selectedDesign ) ) {

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -321,12 +320,8 @@ const importFlow: Flow = {
 						return navigate( `import?siteSlug=${ siteSlugParam }` );
 					}
 
-					if ( isEnabled( 'migration_assistance_modal' ) ) {
-						urlQueryParams.set( 'showModal', 'true' );
-						return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
-					}
-					return navigate( `import?siteSlug=${ siteSlugParam }` );
-
+					urlQueryParams.set( 'showModal', 'true' );
+					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 				case 'importerWix':
 				case 'importReady':
 				case 'importReadyNot':

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -316,10 +316,7 @@ const importFlow: Flow = {
 						return navigate( `importList?siteSlug=${ siteSlugParam }` );
 					} else if ( isMigrateFromWp && fromParam ) {
 						return navigate( `sitePicker?from=${ fromParam }` );
-					} else if (
-						urlQueryParams.has( 'showModal' ) ||
-						! isEnabled( 'migration_assistance_modal' )
-					) {
+					} else if ( urlQueryParams.has( 'showModal' ) ) {
 						urlQueryParams.delete( 'showModal' );
 						return navigate( `import?siteSlug=${ siteSlugParam }` );
 					}

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -230,7 +230,7 @@ const importHostedSiteFlow: Flow = {
 					return window.location.assign( '/sites?hosting-flow=true' );
 
 				case 'importerWordpress':
-					if ( urlQueryParams.has( 'showModal' ) || ! isEnabled( 'migration_assistance_modal' ) ) {
+					if ( urlQueryParams.has( 'showModal' ) ) {
 						// remove the siteSlug in case they want to change the destination site
 						urlQueryParams.delete( 'siteSlug' );
 						urlQueryParams.delete( 'showModal' );

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useLayoutEffect } from 'react';
@@ -237,9 +236,7 @@ const importHostedSiteFlow: Flow = {
 						return navigate( `sitePicker?${ urlQueryParams.toString() }` );
 					}
 
-					if ( isEnabled( 'migration_assistance_modal' ) ) {
-						urlQueryParams.set( 'showModal', 'true' );
-					}
+					urlQueryParams.set( 'showModal', 'true' );
 					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 
 				case 'sitePicker':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -1,8 +1,9 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, globe, group, shield, backup } from '@wordpress/icons';
-import { useEffect } from 'react';
+import { createElement, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -43,14 +44,19 @@ const ImporterMigrateMessage: Step = () => {
 					{ isPending && <LoadingEllipsis /> }
 					{ ! isPending && (
 						<div className="message">
-							{ sprintf(
-								// translators: %(email)s is the customer's email and %(webSite)s his site.
-								__(
-									'You are all set! Our Happiness Engineers will be reaching out to you shortly at %(email)s to help you migrate %(webSite)s to WordPress.com.'
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %(email)s is the customer's email and %(webSite)s his site.
+									__(
+										'You are all set! Our Happiness Engineers will be reaching out to you shortly at <strong>%(email)s</strong> to help you migrate <strong>%(webSite)s</strong> to WordPress.com.'
+									),
+									{
+										email: user?.email,
+										webSite: siteSlug,
+									}
 								),
 								{
-									email: user?.email,
-									webSite: siteSlug,
+									strong: createElement( 'strong' ),
 								}
 							) }
 						</div>

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -299,9 +299,7 @@ const siteMigration: Flow = {
 							`${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?${ urlQueryParams }`
 						);
 					}
-					if ( isEnabled( 'migration_assistance_modal' ) ) {
-						urlQueryParams.set( 'showModal', 'true' );
-					}
+					urlQueryParams.set( 'showModal', 'true' );
 
 					return navigate( `site-migration-upgrade-plan?${ urlQueryParams.toString() }` );
 				}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -293,7 +293,7 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
-					if ( urlQueryParams.has( 'showModal' ) || ! isEnabled( 'migration_assistance_modal' ) ) {
+					if ( urlQueryParams.has( 'showModal' ) ) {
 						urlQueryParams.delete( 'showModal' );
 						return navigate(
 							`${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?${ urlQueryParams }`

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -531,16 +531,15 @@ const siteSetupFlow: Flow = {
 						return navigate( `importList?siteSlug=${ siteSlug }` );
 					}
 
-					if ( urlQueryParams.has( 'showModal' ) || ! isEnabled( 'migration_assistance_modal' ) ) {
+					if ( urlQueryParams.has( 'showModal' ) ) {
 						// remove the siteSlug in case they want to change the destination site
 						urlQueryParams.delete( 'siteSlug' );
 						urlQueryParams.delete( 'showModal' );
 						return navigate( `import?siteSlug=${ siteSlug }` );
 					}
 
-					if ( isEnabled( 'migration_assistance_modal' ) ) {
-						urlQueryParams.set( 'showModal', 'true' );
-					}
+					urlQueryParams.set( 'showModal', 'true' );
+
 					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 
 				case 'importerWix':

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -301,7 +301,7 @@ describe( 'Site Migration Flow', () => {
 	} );
 
 	describe( 'goBack', () => {
-		it( 'backs to the identify step', async () => {
+		it( 'stays on the same step with showModal:true', async () => {
 			const { runUseStepNavigationGoBack } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationGoBack( {
@@ -309,7 +309,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?siteSlug=example.wordpress.com`,
+				path: `/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&showModal=true`,
 				state: null,
 			} );
 		} );

--- a/config/client.json
+++ b/config/client.json
@@ -17,7 +17,6 @@
 	"login_url",
 	"logout_url",
 	"mc_analytics_enabled",
-	"migration_assistance_modal",
 	"oauth_client_id",
 	"oauth_response_type",
 	"oauth_url",

--- a/config/development.json
+++ b/config/development.json
@@ -140,7 +140,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration-flow/remove-processing-step": true,
-		"migration_assistance_modal": false,
+		"migration_assistance_modal": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,

--- a/config/development.json
+++ b/config/development.json
@@ -140,7 +140,6 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration-flow/remove-processing-step": true,
-		"migration_assistance_modal": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,7 +86,7 @@
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration_assistance_modal": false,
+		"migration_assistance_modal": true,
 		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,7 +86,6 @@
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration_assistance_modal": true,
 		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,

--- a/config/production.json
+++ b/config/production.json
@@ -112,7 +112,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration_assistance_modal": false,
+		"migration_assistance_modal": true,
 		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -112,7 +112,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration_assistance_modal": true,
 		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -104,7 +104,6 @@
 		"marketplace-personal-premium": false,
 		"marketplace-reviews-notification": false,
 		"marketplace-test": true,
-		"migration_assistance_modal": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/test.json
+++ b/config/test.json
@@ -81,7 +81,6 @@
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
-		"migration_assistance_modal": false,
 		"me/account-close": true,
 		"me/vat-details": true,
 		"migration-flow/remove-processing-step": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -103,7 +103,6 @@
 		"marketplace-personal-premium": false,
 		"marketplace-reviews-notification": false,
 		"marketplace-test": true,
-		"migration_assistance_modal": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -25,6 +25,8 @@ const selectors = {
 	setupHeader: 'h1:text("Themes")',
 	startBuildingHeader: ( text: string ) => `h1.onboarding-title:text("${ text }")`,
 
+	importModal: 'div.import__confirm-modal',
+
 	// Buttons
 	checkUrlButton: 'form.capture__input-wrapper button.action-buttons__next',
 	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
@@ -64,6 +66,13 @@ export class StartImportFlow {
 		await this.page.locator(
 			`${ selectors.startImportButton }, ${ selectors.startImportGoalButton }`
 		);
+	}
+
+	/**
+	 * Validates that we show migration modal.
+	 */
+	async validateImportModal(): Promise< void > {
+		await this.page.locator( `${ selectors.importModal }` );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -6,7 +6,7 @@ const selectors = {
 	button: ( text: string ) => `button:text("${ text }")`,
 	backLink: '.navigation-link:text("Back")',
 	dontHaveASiteButton: 'button:text-matches("choose a content platform", "i")',
-
+	migrationModalCancel: 'button.action-buttons__cancel',
 	// Inputs
 	urlInput: 'input.capture__input',
 	goalsCaptureUrlInput: 'input.form-text-input[value]',
@@ -72,7 +72,7 @@ export class StartImportFlow {
 	 * Validates that we show migration modal.
 	 */
 	async validateImportModal(): Promise< void > {
-		await this.page.locator( `${ selectors.importModal }` );
+		await this.page.locator( `${ selectors.importModal }` ).waitFor();
 	}
 
 	/**
@@ -290,9 +290,24 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Click back button of the flow.
+	 */
+	async clickBack(): Promise< void > {
+		await this.page.click( selectors.backLink );
+	}
+
+	/**
+	 * Click migration modal cancel.
+	 */
+	async clickMigrationModalCancel(): Promise< void > {
+		await this.page.click( selectors.migrationModalCancel );
+	}
+
+	/**
 	 * Navigate back one screen in the flow.
 	 */
 	async goBackOneScreen(): Promise< void > {
-		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.backLink ) ] );
+		await this.clickBack();
+		await this.page.waitForNavigation();
 	}
 }

--- a/test/e2e/specs/importer/importer__site-setup.ts
+++ b/test/e2e/specs/importer/importer__site-setup.ts
@@ -123,16 +123,16 @@ describe( DataHelper.createSuiteTitle( 'Importer: Site Setup' ), () => {
 			await startImportFlow.validateUpgradePlanPage();
 		} );
 
-		// Back one page
-		it( 'Back to URL capture page', async () => {
-			await startImportFlow.goBackOneScreen();
-			await startImportFlow.validateURLCapturePage();
-		} );
-
 		// Back one page shows migration modal
 		it( 'Back shows migration modal', async () => {
-			await startImportFlow.goBackOneScreen();
+			await startImportFlow.clickBack();
 			await startImportFlow.validateImportModal();
+		} );
+
+		// Click cancel of migration modal navigates back
+		it( 'Back to URL capture page', async () => {
+			await startImportFlow.clickMigrationModalCancel();
+			await startImportFlow.validateURLCapturePage();
 		} );
 	} );
 

--- a/test/e2e/specs/importer/importer__site-setup.ts
+++ b/test/e2e/specs/importer/importer__site-setup.ts
@@ -129,10 +129,10 @@ describe( DataHelper.createSuiteTitle( 'Importer: Site Setup' ), () => {
 			await startImportFlow.validateURLCapturePage();
 		} );
 
-		// Back one page
-		it( 'Back to Setup page', async () => {
+		// Back one page shows migration modal
+		it( 'Back shows migration modal', async () => {
 			await startImportFlow.goBackOneScreen();
-			await startImportFlow.validateSetupPage();
+			await startImportFlow.validateImportModal();
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR removes the `migration_assistance_modal` feature flag.
This affects the following flows:
- site-setup
- site-migration-flow
- import-hosted-sites
- import-flow


Related to #
https://github.com/Automattic/wp-calypso/pull/89812

## Proposed Changes

* Remove `migration_assistance_modal` ff

## Testing Instructions
- Build the PR or use live link
- Test the affected flows
- You should see the migration modal appear when clicking back
- Test if everything works as expected

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
