### PR TITLE
Marketing: Remove Facebook partner promo

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { PLAN_BUSINESS, PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -9,7 +8,6 @@ import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import rocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import earnIllustration from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
 import wordPressLogo from 'calypso/assets/images/icons/wordpress-logo.svg';
-import facebookLogo from 'calypso/assets/images/illustrations/facebook-logo.png';
 import simpletextLogo from 'calypso/assets/images/illustrations/simpletext-logo.png';
 import verblioLogo from 'calypso/assets/images/illustrations/verblio-logo.png';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -17,7 +15,6 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { marketingConnections, pluginsPath } from 'calypso/my-sites/marketing/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
-import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import * as T from 'calypso/types';
 import MarketingToolsFeature from './feature';
@@ -31,10 +28,6 @@ export const MarketingTools: FunctionComponent = () => {
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
-
-	const facebookPluginInstalled = useSelector( ( state ) =>
-		getPluginOnSite( state, siteId, 'official-facebook-pixel' )
-	);
 
 	const handleBusinessToolsClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_business_tools_button_click' );
@@ -54,10 +47,6 @@ export const MarketingTools: FunctionComponent = () => {
 
 	const handleCreateALogoClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_create_a_logo_button_click' );
-	};
-
-	const handleFacebookClick = () => {
-		recordTracksEvent( 'calypso_marketing_tools_facebook_button_click' );
 	};
 
 	const handleVerblioClick = () => {
@@ -119,33 +108,6 @@ export const MarketingTools: FunctionComponent = () => {
 						{ translate( 'Create a logo' ) }
 					</Button>
 				</MarketingToolsFeature>
-
-				{ ! facebookPluginInstalled && (
-					<MarketingToolsFeature
-						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
-						description={ translate(
-							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on %(businessPlanName)s and %(commercePlanName)s plans{{/em}}.',
-							{
-								components: {
-									em: <em />,
-								},
-								args: {
-									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-									commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
-								},
-							}
-						) }
-						imagePath={ facebookLogo }
-						imageAlt={ translate( 'Facebook logo' ) }
-					>
-						<Button
-							onClick={ handleFacebookClick }
-							href={ `/plugins/official-facebook-pixel/${ selectedSiteSlug }` }
-						>
-							{ translate( 'Add Facebook for WordPress.com' ) }
-						</Button>
-					</MarketingToolsFeature>
-				) }
 
 				<MarketingToolsFeature
 					title={ translate( 'Monetize your site' ) }


### PR DESCRIPTION
See p1715069626248319-slack-C072MQW3YM7

## Proposed Changes

Removes the Facebook partner promo:

![CleanShot 2024-05-07 at 03 44 51@2x](https://github.com/Automattic/wp-calypso/assets/36432/333cd9dd-dea1-4446-aa7b-f3184adba3ab)

## Testing Instructions

1. Verify the promo no longer appears.