### PR TITLE
Revert "Automattic for Agencies: Implement download action for unattached licenses"

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -70,11 +70,17 @@ export default function LicenseDetailsActions( {
 
 	return (
 		<div className="license-details__actions">
-			{ hasDownloads && licenseType === LicenseType.Partner && (
-				<Button compact { ...( status === 'pending' ? { busy: true } : {} ) } onClick={ download }>
-					{ translate( 'Download' ) }
-				</Button>
-			) }
+			{ hasDownloads &&
+				licenseState === LicenseState.Attached &&
+				licenseType === LicenseType.Partner && (
+					<Button
+						compact
+						{ ...( status === 'pending' ? { busy: true } : {} ) }
+						onClick={ download }
+					>
+						{ translate( 'Download' ) }
+					</Button>
+				) }
 
 			{ ! isPressableLicense && licenseState === LicenseState.Attached && siteUrl && (
 				<Button compact href={ siteUrl } target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Reverts Automattic/wp-calypso#90366