### PR TITLE
Nav redesign - update site dashboard min height

### DIFF
--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -257,6 +257,7 @@
 		&.sites-dashboard__layout {
 			.dataviews-view-table-wrapper {
 				overflow-y: auto;
+				min-height: calc(100vh - 277px); /* Set min-height to prevent the table from shrinking when there are few rows. */
 				max-height: calc(100vh - 255px); /* 255px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6965

If you change pagination so that you only have a handful of sites on the last remaining page, the pagination no longer sits at the bottom of the screen. The pagination should always be fixed to the bottom, not floating in the middle of the page.

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/b2f67d74-5cb8-4e23-ac98-895145ffdf6e)

## Proposed Changes

* Add `min-height` to dashboard styles to ensure the pagination is always on the bottom of screen.

## Before

<img width="1381" alt="Screenshot 2024-05-07 at 12 23 24" src="https://github.com/Automattic/wp-calypso/assets/5560595/ac1c0ac9-5dd3-4028-9747-06f80bc5a6ed">

## After

<img width="1382" alt="Screenshot 2024-05-07 at 12 23 37" src="https://github.com/Automattic/wp-calypso/assets/5560595/bb169100-a886-4497-8703-d67729c48c16">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test pagination on calyspo live site
* Use the `?flags=layout/dotcom-nav-redesign-v2` to ensure you enable the new dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?