### PR TITLE
Hosting config: add notice that admin interface setting has moved

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_SFTP,
 	FEATURE_SFTP_DATABASE,
@@ -92,6 +91,7 @@ const MainCards = ( {
 	isWpcomStagingSite,
 	isBusinessTrial,
 	siteId,
+	siteSlug,
 } ) => {
 	const mainCards = [
 		{
@@ -140,12 +140,11 @@ const MainCards = ( {
 			content: <CacheCard disabled={ isBasicHostingDisabled } />,
 			type: 'basic',
 		},
-		siteId &&
-			! isEnabled( 'layout/dotcom-nav-redesign-v2' ) && {
-				feature: 'wp-admin',
-				content: <SiteAdminInterface siteId={ siteId } isHosting />,
-				type: 'basic',
-			},
+		siteId && {
+			feature: 'wp-admin',
+			content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
+			type: 'basic',
+		},
 	].filter( ( card ) => card !== null );
 
 	const availableTypes = [
@@ -289,6 +288,7 @@ const Hosting = ( props ) => {
 								isWpcomStagingSite={ isWpcomStagingSite }
 								isBusinessTrial={ isBusinessTrial && ! hasTransfer }
 								siteId={ siteId }
+								siteSlug={ siteSlug }
 							/>
 						</Column>
 						<Column type="sidebar">

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -136,7 +136,22 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 						<CardHeading id="admin-interface-style" size={ 20 }>
 							{ translate( 'Admin interface style' ) }
 						</CardHeading>
-						{ isEnabled( 'layout/dotcom-nav-redesign-v2' ) ? (
+						<p>
+							{ translate(
+								'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
+								{
+									components: {
+										supportLink: (
+											<InlineSupportLink
+												supportContext="admin-interface-style"
+												showIcon={ false }
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+						{ isEnabled( 'layout/dotcom-nav-redesign-v2' ) && (
 							<p className="form-setting-explanation">
 								{ translate( 'This setting has now moved to {{a}}Settings → General{{/a}}.', {
 									components: {
@@ -148,22 +163,6 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 										),
 									},
 								} ) }
-							</p>
-						) : (
-							<p>
-								{ translate(
-									'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
-									{
-										components: {
-											supportLink: (
-												<InlineSupportLink
-													supportContext="admin-interface-style"
-													showIcon={ false }
-												/>
-											),
-										},
-									}
-								) }
 							</p>
 						) }
 					</>

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -150,23 +150,21 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 								} ) }
 							</p>
 						) : (
-							<>
-								<p>
-									{ translate(
-										'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
-										{
-											components: {
-												supportLink: (
-													<InlineSupportLink
-														supportContext="admin-interface-style"
-														showIcon={ false }
-													/>
-												),
-											},
-										}
-									) }
-								</p>
-							</>
+							<p>
+								{ translate(
+									'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
+									{
+										components: {
+											supportLink: (
+												<InlineSupportLink
+													supportContext="admin-interface-style"
+													showIcon={ false }
+												/>
+											),
+										},
+									}
+								) }
+							</p>
 						) }
 					</>
 				) }

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 /* eslint-disable wpcalypso/jsx-gridicon-size */
 import { Card, FormLabel, MaterialIcon } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
@@ -34,7 +35,7 @@ const FormRadioStyled = styled( FormRadio )( {
 	},
 } );
 
-const SiteAdminInterface = ( { siteId, isHosting } ) => {
+const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const dispatch = useDispatch();
@@ -135,57 +136,78 @@ const SiteAdminInterface = ( { siteId, isHosting } ) => {
 						<CardHeading id="admin-interface-style" size={ 20 }>
 							{ translate( 'Admin interface style' ) }
 						</CardHeading>
-						<p>
-							{ translate(
-								'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
-								{
+						{ isEnabled( 'layout/dotcom-nav-redesign-v2' ) ? (
+							<p className="form-setting-explanation">
+								{ translate( 'This setting has now moved to {{a}}Settings → General{{/a}}.', {
 									components: {
-										supportLink: (
-											<InlineSupportLink
-												supportContext="admin-interface-style"
-												showIcon={ false }
+										a: (
+											<a
+												href={ `/settings/general/${ siteSlug }#admin-interface-style` }
+												rel="noreferrer"
 											/>
 										),
 									},
-								}
-							) }
-						</p>
+								} ) }
+							</p>
+						) : (
+							<>
+								<p>
+									{ translate(
+										'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
+										{
+											components: {
+												supportLink: (
+													<InlineSupportLink
+														supportContext="admin-interface-style"
+														showIcon={ false }
+													/>
+												),
+											},
+										}
+									) }
+								</p>
+							</>
+						) }
 					</>
 				) }
-				<FormFieldset>
-					<FormLabel>
-						<FormRadioStyled
-							label={ translate( 'Classic style' ) }
-							name="wpcom_admin_interface"
-							value="wp-admin"
-							checked={ selectedAdminInterface === 'wp-admin' }
-							onChange={ ( event ) => handleInputChange( event.target.value ) }
-							disabled={ isUpdating }
-						/>
-					</FormLabel>
-					<FormSettingExplanation>
-						{ hasEnTranslation( 'Use WP-Admin to manage your site.' )
-							? translate( 'Use WP-Admin to manage your site.' )
-							: translate( 'The classic WP-Admin WordPress interface.' ) }
-					</FormSettingExplanation>
-				</FormFieldset>
-				<FormFieldset>
-					<FormLabel>
-						<FormRadioStyled
-							label={ translate( 'Default style' ) }
-							name="wpcom_admin_interface"
-							value="calypso"
-							checked={ selectedAdminInterface === 'calypso' }
-							onChange={ ( event ) => handleInputChange( event.target.value ) }
-							disabled={ isUpdating }
-						/>
-					</FormLabel>
-					<FormSettingExplanation>
-						{ hasEnTranslation( 'Use WordPress.com’s legacy dashboard to manage your site.' )
-							? translate( 'Use WordPress.com’s legacy dashboard to manage your site.' )
-							: translate( 'The WordPress.com redesign for a better experience.' ) }
-					</FormSettingExplanation>
-				</FormFieldset>
+				{ ( ! isHosting || ! isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) && (
+					<>
+						<FormFieldset>
+							<FormLabel>
+								<FormRadioStyled
+									label={ translate( 'Classic style' ) }
+									name="wpcom_admin_interface"
+									value="wp-admin"
+									checked={ selectedAdminInterface === 'wp-admin' }
+									onChange={ ( event ) => handleInputChange( event.target.value ) }
+									disabled={ isUpdating }
+								/>
+							</FormLabel>
+							<FormSettingExplanation>
+								{ hasEnTranslation( 'Use WP-Admin to manage your site.' )
+									? translate( 'Use WP-Admin to manage your site.' )
+									: translate( 'The classic WP-Admin WordPress interface.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+						<FormFieldset>
+							<FormLabel>
+								<FormRadioStyled
+									label={ translate( 'Default style' ) }
+									name="wpcom_admin_interface"
+									value="calypso"
+									checked={ selectedAdminInterface === 'calypso' }
+									onChange={ ( event ) => handleInputChange( event.target.value ) }
+									disabled={ isUpdating }
+								/>
+							</FormLabel>
+							<FormSettingExplanation>
+								{ hasEnTranslation( 'Use WordPress.com’s legacy dashboard to manage your site.' )
+									? translate( 'Use WordPress.com’s legacy dashboard to manage your site.' )
+									: translate( 'The WordPress.com redesign for a better experience.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+					</>
+				) }
 			</Card>
 		</>
 	);


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6942

## Proposed Changes

This PR proposes to add a notice when the admin interface style has moved to Settings -> General under the `layout/dotcom-nav-redesign-v2` feature flag. This applies to Atomic sites only (of course).

This is to reduce the potential confusion after we launch nav redesign v2. With this, the setting can still be found under Hosting Config, but we redirect them to the correct new location.

Note that currently we're also using the `layout/wpcom-admin-interface` to control the new setting location in Settings -> General. See: https://github.com/Automattic/wp-calypso/pull/90337

||without `layout/dotcom-nav-redesign-v2`|with `layout/dotcom-nav-redesign-v2`|
|-|-|-|
|Settings -> General|`/settings/general/:site?flags=-layout/dotcom-nav-redesign-v2,-layout/wpcom-admin-interface`<br><br>N/A|`/settings/general/:site`<br><br><img width="729" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/1add1960-4bdf-4990-99ed-a863c6768185">|
|Settings -> Hosting Configuration|`/hosting-config/:site?flags=-layout/dotcom-nav-redesign-v2,-layout/wpcom-admin-interface`<br><br><img width="727" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/168c1d66-9875-441b-9ad7-991b0312e377">|`/hosting-config/:site`<br><br><img width="794" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/78f4465b-ea73-4271-b263-4180a66faf9b">|


## Testing Instructions

1. Prepare an Atomic site.
1. Visit each URL from each cell in the above table (2 x 2) and verify that you see the correct setting.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?