### PR TITLE
Add site filter permissions check

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,3 +1,5 @@
+import { SiteDetails } from '@automattic/data-stores';
+import { SiteExcerptData } from '@automattic/sites';
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
@@ -51,7 +53,11 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit }: Props ) => {
 
 	const translate = useTranslate();
 
-	const { data: sites } = useSiteExcerptsQuery( [ 'atomic' ] );
+	const siteFilter = ( site: SiteExcerptData ): boolean => {
+		return ( site as SiteDetails ).capabilities?.update_plugins;
+	};
+
+	const { data: sites } = useSiteExcerptsQuery( [ 'atomic', 'capabilities' ], siteFilter );
 	const {
 		data: plugins,
 		isInitialLoading: isPluginsFetching,

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,5 +1,3 @@
-import { SiteDetails } from '@automattic/data-stores';
-import { SiteExcerptData } from '@automattic/sites';
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
@@ -17,6 +15,8 @@ import { ScheduleFormPlugins } from '../plugins-scheduled-updates/schedule-form-
 import { validateSites, validatePlugins } from '../plugins-scheduled-updates/schedule-form.helper';
 import { useErrors } from './hooks/use-errors';
 import { ScheduleFormSites } from './schedule-form-sites';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { SiteExcerptData } from '@automattic/sites';
 
 type Props = {
 	scheduleForEdit?: MultisiteSchedulesUpdates;

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -57,7 +57,9 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit }: Props ) => {
 		return ( site as SiteDetails ).capabilities?.update_plugins;
 	};
 
-	const { data: sites } = useSiteExcerptsQuery( [ 'atomic', 'capabilities' ], siteFilter );
+	const { data: sites } = useSiteExcerptsQuery( [ 'atomic' ], siteFilter, 'all', [
+		'capabilities',
+	] );
 	const {
 		data: plugins,
 		isInitialLoading: isPluginsFetching,

--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -14,14 +14,15 @@ export type SiteVisibility = 'all' | 'deleted';
 
 const fetchSites = (
 	site_visibility: SiteVisibility = 'all',
-	siteFilter = config< string[] >( 'site_filter' )
+	siteFilter = config< string[] >( 'site_filter' ),
+	additional_fields: string[] = []
 ): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	return wpcom.me().sites( {
 		apiVersion: '1.2',
 		site_visibility,
 		include_domain_only: true,
 		site_activity: 'active',
-		fields: SITE_EXCERPT_REQUEST_FIELDS.join( ',' ),
+		fields: additional_fields.concat( SITE_EXCERPT_REQUEST_FIELDS ).join( ',' ),
 		options: SITE_EXCERPT_REQUEST_OPTIONS.join( ',' ),
 		filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
 	} );
@@ -30,7 +31,8 @@ const fetchSites = (
 export const useSiteExcerptsQuery = (
 	fetchFilter?: string[],
 	sitesFilterFn?: ( site: SiteExcerptData ) => boolean,
-	site_visibility: SiteVisibility = 'all'
+	site_visibility: SiteVisibility = 'all',
+	additional_fields: string[] = []
 ) => {
 	const store = useStore();
 
@@ -41,8 +43,9 @@ export const useSiteExcerptsQuery = (
 			SITE_EXCERPT_REQUEST_OPTIONS,
 			fetchFilter,
 			site_visibility,
+			additional_fields,
 		],
-		queryFn: () => fetchSites( site_visibility, fetchFilter ),
+		queryFn: () => fetchSites( site_visibility, fetchFilter, additional_fields ),
 		select: ( data ) => {
 			const sites = data?.sites.map( computeFields( data?.sites ) ) || [];
 			return sitesFilterFn ? sites.filter( sitesFilterFn ) : sites;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -207,6 +207,7 @@ export interface SiteDetailsCapabilities {
 	publish_posts: boolean;
 	remove_users: boolean;
 	upload_files: boolean;
+	update_plugins: boolean;
 	view_hosting: boolean;
 	view_stats: boolean;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/89968

## Proposed Changes

* Add `update_plugins` capability check
* Fix: add missing field to store type

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure to have a site where you don't have `update_plugins` capability. You can force it on the `WPCOM_JSON_API_Me_Sites_V1_2_Endpoint` endpoint.
* Go to `http://calypso.localhost:3000/plugins/scheduled-updates/edit/__ID__-...`
* Ensure the site is filtered away from the list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?