### PR TITLE
A4A: Port Jetpack Manage user feedback form to A4A portal.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -1,6 +1,8 @@
 import page from '@automattic/calypso-router';
+import { Icon, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/overview/sidebar/contact-support';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar, {
@@ -13,10 +15,13 @@ import Sidebar, {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { A4A_OVERVIEW_LINK } from '../sidebar-menu/lib/constants';
+import UserFeedbackModalForm from '../user-feedback-modal-form';
 import SidebarHeader from './header';
 import ProfileDropdown from './header/profile-dropdown';
 
 import './style.scss';
+
+const USER_FEEDBACK_FORM_URL_HASH = '#product-feedback';
 
 type Props = {
 	className?: string;
@@ -56,6 +61,22 @@ const A4ASidebar = ( {
 }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	// Determine whether to initially show the user feedback form.
+	const shouldShowUserFeedbackForm = window.location.hash === USER_FEEDBACK_FORM_URL_HASH;
+
+	const [ showUserFeedbackForm, setShowUserFeedbackForm ] = useState( shouldShowUserFeedbackForm );
+
+	const onShareProductFeedback = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_share_product_feedback_click' ) );
+		setShowUserFeedbackForm( true );
+	}, [ dispatch ] );
+
+	const onCloseUserFeedbackForm = useCallback( () => {
+		// Remove any hash from the URL.
+		history.pushState( null, '', window.location.pathname + window.location.search );
+		setShowUserFeedbackForm( false );
+	}, [] );
 
 	return (
 		<Sidebar className={ classNames( 'a4a-sidebar', className ) }>
@@ -107,9 +128,21 @@ const A4ASidebar = ( {
 						/>
 					) }
 
+					<SidebarNavigatorMenuItem
+						title={ translate( 'Share product feedback', {
+							comment: 'A4A sidebar navigation item',
+						} ) }
+						link={ USER_FEEDBACK_FORM_URL_HASH }
+						path=""
+						icon={ <Icon icon={ starEmpty } /> }
+						onClickMenuItem={ onShareProductFeedback }
+					/>
+
 					{ withUserProfileFooter && <ProfileDropdown dropdownPosition="up" /> }
 				</ul>
 			</SidebarFooter>
+
+			<UserFeedbackModalForm show={ showUserFeedbackForm } onClose={ onCloseUserFeedbackForm } />
 		</Sidebar>
 	);
 };

--- a/client/a8c-for-agencies/components/user-feedback-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-feedback-modal-form/index.tsx
@@ -1,0 +1,157 @@
+import { Button, FormLabel } from '@automattic/components';
+import { Modal } from '@wordpress/components';
+import { Icon, close } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import useSubmitProductFeedback from './use-submit-product-feedback';
+
+import './style.scss';
+
+type Props = {
+	show: boolean;
+	onClose?: () => void;
+};
+
+const DEFAULT_FEEDBACK_VALUE = '';
+const DEFAULT_RATING_VALUE = 0;
+
+export default function UserFeedbackModalForm( { show, onClose }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ feedback, setFeedback ] = useState( DEFAULT_FEEDBACK_VALUE );
+	const [ rating, setRating ] = useState( DEFAULT_RATING_VALUE );
+
+	const { isSubmittingFeedback, submitFeedback, isSubmissionSuccessful } =
+		useSubmitProductFeedback();
+
+	const onModalClose = useCallback( () => {
+		setFeedback( DEFAULT_FEEDBACK_VALUE );
+		setRating( DEFAULT_RATING_VALUE );
+		onClose?.();
+
+		dispatch( recordTracksEvent( 'calypso_a4a_user_feedback_form_close' ) );
+	}, [ dispatch, onClose ] );
+
+	useEffect( () => {
+		if ( isSubmissionSuccessful ) {
+			dispatch(
+				successNotice( translate( 'Thank you for your feedback!' ), {
+					id: 'submit-product-feedback-success',
+					duration: 5000,
+				} )
+			);
+			onModalClose();
+		}
+	}, [ dispatch, isSubmissionSuccessful, onModalClose, translate ] );
+
+	const onFeedbackChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
+		setFeedback( event.currentTarget.value );
+	}, [] );
+
+	const onRatingChange = useCallback(
+		( rating: number ) => {
+			dispatch( recordTracksEvent( 'calypso_a4a_user_feedback_form_rating_click' ) );
+			setRating( rating );
+		},
+		[ dispatch ]
+	);
+
+	const hasCompletedForm = !! feedback && !! rating;
+
+	const onSubmit = useCallback( () => {
+		if ( ! hasCompletedForm ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_user_feedback_form_submit', {
+				rating,
+				feedback,
+			} )
+		);
+
+		const sourceUrl = `${ window.location.origin }${ window.location.pathname }`;
+		submitFeedback( { feedback, rating, source_url: sourceUrl } );
+	}, [ dispatch, feedback, hasCompletedForm, rating, submitFeedback ] );
+
+	useEffect( () => {
+		if ( show ) {
+			dispatch( recordTracksEvent( 'calypso_a4a_user_feedback_form_open' ) );
+		}
+	}, [ dispatch, show ] );
+
+	if ( ! show ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="user-feedback-modal-form"
+			onRequestClose={ onModalClose }
+			__experimentalHideHeader
+		>
+			<div className="user-feedback-modal-form__main">
+				<Button
+					className="user-feedback-modal-form__close-button"
+					plain
+					onClick={ onModalClose }
+					aria-label={ translate( 'Close' ) }
+				>
+					<Icon size={ 24 } icon={ close } />
+				</Button>
+
+				<h1 className="user-feedback-modal-form__title">
+					{ translate( 'Help us make Automattic for Agencies even better' ) }
+				</h1>
+
+				<p className="user-feedback-modal-form__instruction">
+					{ translate(
+						'Your product feedback is extremely valuable to us. Our goal is to help you do your work better and more efficiently - all feedback is sent to our product team and helps inform our development roadmap.'
+					) }
+				</p>
+
+				<FormFieldset>
+					<FormLabel htmlFor="textarea">
+						{ translate( 'What can we do to make Automattic for Agencies better for you?' ) }
+					</FormLabel>
+					<FormTextarea
+						name="textarea"
+						id="textarea"
+						placeholder="Add your feedback here"
+						value={ feedback }
+						onChange={ onFeedbackChange }
+						onClick={ () =>
+							dispatch( recordTracksEvent( 'calypso_a4a_user_feedback_form_textarea_click' ) )
+						}
+					/>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="textarea">
+						{ translate( 'How satisfied are you with Automattic for Agencies?' ) }
+					</FormLabel>
+					<ReviewsRatingsStars rating={ rating } onSelectRating={ onRatingChange } />
+				</FormFieldset>
+			</div>
+
+			<div className="user-feedback-modal-form__footer">
+				<Button
+					busy={ isSubmittingFeedback }
+					className="user-feedback-modal-form__footer-submit"
+					primary
+					disabled={ ! hasCompletedForm }
+					onClick={ onSubmit }
+				>
+					{ translate( 'Submit your feedback' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/client/a8c-for-agencies/components/user-feedback-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-feedback-modal-form/index.tsx
@@ -113,7 +113,7 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 
 				<p className="user-feedback-modal-form__instruction">
 					{ translate(
-						'Your product feedback is extremely valuable to us. Our goal is to help you do your work better and more efficiently - all feedback is sent to our product team and helps inform our development roadmap.'
+						'Your feedback is extremely valuable to us. All feedback is set to our product and program teams, and helps to inform how we evolve our offering.'
 					) }
 				</p>
 

--- a/client/a8c-for-agencies/components/user-feedback-modal-form/style.scss
+++ b/client/a8c-for-agencies/components/user-feedback-modal-form/style.scss
@@ -1,0 +1,85 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.user-feedback-modal-form {
+	max-width: 827px;
+	max-height: 100%;
+	margin: 0;
+
+	.components-modal__content {
+		padding: 0;
+
+		> div {
+			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
+			height: 100%;
+		}
+	}
+
+	.reviews-ratings-stars__star:focus {
+		outline: none;
+	}
+
+	.reviews-ratings-stars__star:focus-within {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+		border-radius: 4px;
+	}
+
+	@include break-medium {
+		margin: auto;
+	}
+}
+
+.user-feedback-modal-form .form-fieldset {
+	margin: 0;
+}
+
+.user-feedback-modal-form__main {
+	padding: 40px;
+	gap: 24px;
+	display: flex;
+	flex-direction: column;
+}
+
+.user-feedback-modal-form__title {
+	font-size: 1.5rem;
+	font-weight: 700;
+	line-height: 0.8;
+	margin: 0;
+	padding: 0;
+}
+
+p.user-feedback-modal-form__instruction {
+	font-size: 1rem;
+	font-weight: 400;
+	margin: 0;
+}
+
+.user-feedback-modal-form__footer {
+	padding: 24px 40px;
+	text-align: right;
+	background-color: var(--studio-gray-0);
+	border-radius: 4px;
+}
+
+.user-feedback-modal-form__close-button {
+	position: absolute;
+	inset-inline-end: 1rem;
+	inset-block-start: 1rem;
+	cursor: pointer;
+	transition: scale 0.2s ease-in;
+	max-height: 24px;
+
+	&:hover {
+		scale: 1.2;
+	}
+
+	&:focus-visible {
+		border-color: var(--color-primary);
+		outline: none;
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+		border-radius: 4px;
+	}
+}

--- a/client/a8c-for-agencies/components/user-feedback-modal-form/use-submit-product-feedback.ts
+++ b/client/a8c-for-agencies/components/user-feedback-modal-form/use-submit-product-feedback.ts
@@ -1,0 +1,35 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import useSubmitProductFeedbackMutation from 'calypso/a8c-for-agencies/data/support/use-submit-product-feedback-mutation';
+import { SubmitProductFeedbackParams } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
+
+export default function useSubmitProductFeedback(): {
+	isSubmittingFeedback: boolean;
+	submitFeedback: ( params: SubmitProductFeedbackParams ) => void;
+	isSubmissionSuccessful: boolean;
+} {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const {
+		isError,
+		isSuccess,
+		mutate,
+		isPending: isSubmittingFeedback,
+	} = useSubmitProductFeedbackMutation();
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice( translate( 'Something went wrong. Please try again.' ), {
+					id: 'submit-product-feedback-failure',
+					duration: 5000,
+				} )
+			);
+		}
+	}, [ translate, isError, dispatch ] );
+
+	return { isSubmittingFeedback, submitFeedback: mutate, isSubmissionSuccessful: isSuccess };
+}

--- a/client/a8c-for-agencies/data/support/use-submit-product-feedback-mutation.ts
+++ b/client/a8c-for-agencies/data/support/use-submit-product-feedback-mutation.ts
@@ -1,5 +1,5 @@
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
-import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import type {
 	APIError,
 	SubmitProductFeedbackParams,
@@ -12,7 +12,7 @@ interface APIResponse {
 function mutationSubmitProductFeedback(
 	params: SubmitProductFeedbackParams
 ): Promise< APIResponse > {
-	return wpcomJpl.req.post( {
+	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: '/agency/user-feedback',
 		body: params,

--- a/client/a8c-for-agencies/data/support/use-submit-product-feedback-mutation.ts
+++ b/client/a8c-for-agencies/data/support/use-submit-product-feedback-mutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import type {
+	APIError,
+	SubmitProductFeedbackParams,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+interface APIResponse {
+	success: boolean;
+}
+
+function mutationSubmitProductFeedback(
+	params: SubmitProductFeedbackParams
+): Promise< APIResponse > {
+	return wpcomJpl.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/agency/user-feedback',
+		body: params,
+	} );
+}
+
+export default function useSubmitProductFeedbackMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, SubmitProductFeedbackParams, TContext >
+): UseMutationResult< APIResponse, APIError, SubmitProductFeedbackParams, TContext > {
+	return useMutation< APIResponse, APIError, SubmitProductFeedbackParams, TContext >( {
+		...options,
+		mutationFn: mutationSubmitProductFeedback,
+	} );
+}


### PR DESCRIPTION
This pull request adds a user feedback form to the A4A portal, following a similar design to Jetpack Manage.

<img width="1724" alt="Screenshot 2024-05-08 at 8 30 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7eddee62-195f-4e98-bc56-c1d7232e2203">


Closes https://github.com/Automattic/jetpack-roadmap/issues/1515

## Proposed Changes

* Port the User feedback form from Jetpack Manage to the A4A portal.

## Testing Instructions

* Apply D147857-code patch to your sandbox and point `public-api.wordpress.com` to your sandbox.
* Use the A4A live link below and go to `/overview` page.
* In the Sidebar, click the `Shared product feedback` button.
* Confirm that the User feedback form shows up.
* Fill in the form and submit.
* Confirm that the submission is successful.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?