### PR TITLE
A4A: Fix typo on site provisioning notification

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -21,7 +21,7 @@ export default function ProvisioningSiteNotification( { siteId }: Props ) {
 				onClose={ () => setShowBanner( false ) }
 				title={
 					isReady
-						? translate( 'Congratulation on your new WordPress.com site!' )
+						? translate( 'Congratulations on your new WordPress.com site!' )
 						: translate( 'Setting up your new WordPress.com site' )
 				}
 			>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/447

## Proposed Changes

* Fix typo introduced in https://github.com/Automattic/wp-calypso/pull/90322 by replacing `Congratulation` with `Congratulations`.

## Testing Instructions

* Open the Live Branch.
* Buy one WordPress.com site.
* Go to the Sites Dashboard.
* Create the site.
* Ensure the success notification says `Congratulations` instead of `Congratulation`.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://github.com/Automattic/wp-calypso/assets/3418513/e3faeb2c-c574-4d94-9292-f106d2e722c1" /></td>
<td><img src="https://github.com/Automattic/wp-calypso/assets/3418513/f46c890d-8fbf-4a6b-8aa5-03ff555e4f01" /></td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
