### PR TITLE
Site Profiler: Fix an error when registrar_url is an array

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -83,7 +83,7 @@ export default function DomainInformation( props: Props ) {
 					<li>
 						<div className="name">{ translate( 'Registrar' ) }</div>
 						<div>
-							{ whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
+							{ normalizeWhoisURL( whois.registrar_url ).toLowerCase().includes( 'automattic' ) && (
 								<VerifiedProvider
 									hostingProvider={ hostingProvider }
 									urlData={ urlData }
@@ -91,7 +91,9 @@ export default function DomainInformation( props: Props ) {
 								/>
 							) }
 							{ whois.registrar_url &&
-								! whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
+								! normalizeWhoisURL( whois.registrar_url )
+									.toLowerCase()
+									.includes( 'automattic' ) && (
 									<a
 										href={ normalizeWhoisURL( whois.registrar_url ) }
 										target="_blank"

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -76,7 +76,7 @@ export default function DomainInformation( props: Props ) {
 				{ filteredWhois.domain_name && (
 					<li>
 						<div className="name">{ translate( 'Domain name' ) }</div>
-						<div>{ whois.domain_name }</div>
+						<div>{ normalizeWhoisField( whois.domain_name ) }</div>
 					</li>
 				) }
 				{ filteredWhois.registrar && (
@@ -99,7 +99,7 @@ export default function DomainInformation( props: Props ) {
 										target="_blank"
 										rel="noopener noreferrer"
 									>
-										{ whois.registrar }
+										{ normalizeWhoisField( whois.registrar ) }
 									</a>
 								) }
 							{ ! whois.registrar_url && <span>{ normalizeWhoisField( whois.registrar ) }</span> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Use `normalizeWhoisURL` method when accessing `whois.registrar_url` as it could be returned as an array instead of string
- Note: I have also tried another approach, creating a boolean flag and using conditions to check if the `registrrar_url` is an array or a string, but I prefer this simpler solution. Leaving it here for clarification: https://github.com/Automattic/wp-calypso/compare/fix/multiple-registrar-url-error-using-flag

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* In Site Profiler, navigate to a site that returns multiple `registrar_url`, e.g. http://calypso.localhost:3000/site-profiler/cap-good.com
* Check the results are displayed and there are no unexpected errors in the console
* Navigate to another site, e.g. http://calypso.localhost:3000/site-profiler/example.com
* Check the results are displayed and there are no unexpected errors in the console


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?