### PR TITLE
Woo Express: Fix for box-sizing on Plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -2,6 +2,10 @@
 @import "@wordpress/base-styles/breakpoints";
 
 body.is-section-plans.is-ecommerce-trial-plan {
+	.layout__primary .main {
+		box-sizing: content-box;
+	}
+
 	&.color-scheme {
 		--color-surface-backdrop: var(--color-surface);
 	}

--- a/client/my-sites/plans/woo-express-plans-page/style.scss
+++ b/client/my-sites/plans/woo-express-plans-page/style.scss
@@ -2,6 +2,10 @@
 @import "@wordpress/base-styles/breakpoints";
 
 body.is-section-plans.is-woo-express-plan {
+	.layout__primary .main {
+		box-sizing: content-box;
+	}
+
 	&.color-scheme {
 		--color-surface-backdrop: var(--color-surface);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89939

## Proposed Changes

* #89939 introduced a bug with the Woo Express/Ecommerce trial Plans pages. This adds more specific selectors to those pages to override `box-sizing` change.
* This should probably be a temporary change until we figure out why this layout is so broken. 🤔 
* We may also need to consider making the `.layout__primary .main` box-sizing selector more specific for the navigation redesign. Adding some folks from that PR to start that discussion and make sure this change doesn't break any of their work.

**Before**

<img width="1469" alt="Screenshot 2024-05-07 at 10 30 21 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/12049d69-9987-4e02-8e2c-2ff5ec9b77d4">

**After**

<img width="1481" alt="Screenshot 2024-05-07 at 10 30 06 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/55a4d314-aa8e-4c3d-89bc-aff9503acd61">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/plans/siteSlug` on a site with a Woo Express or Ecommerce Trial plan
* You should be able to view the content at widths greater than 1401px without it collapsing into a narrow column
* Other plans pages for other plans should still look OK

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
