### PR TITLE
Nav Redesign: Update quick links header copy

### DIFF
--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -62,9 +62,9 @@ const QuickActionsCard: FC = () => {
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
 			<div className="hosting-overview__card-header">
 				<h3 className="hosting-overview__card-title">
-					{ hasEnTranslation( 'WP Admin links' )
-						? translate( 'WP Admin links' )
-						: translate( 'Quick actions' ) }
+					{ hasEnTranslation( 'Dashboard links' )
+						? translate( 'Dashboard links' )
+						: translate( 'WP Admin links' ) }
 				</h3>
 			</div>
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6981

## Proposed Changes

* On /sites preview panel, change the links div header copy from "WP Admin links" to "Dashboard links"

Before | After
--|--
<img width="669" alt="Screenshot 2024-05-07 at 9 53 56 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/758d85a6-7077-4193-a958-8164cceb010b">  |  <img width="644" alt="Screenshot 2024-05-07 at 9 54 05 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/f242acb5-94ef-4773-a4e2-0809af6c5bbc">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites and click on any site to see the preview panel. Observe the copy change on the link div box header.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
