### PR TITLE
A4A: Update the Migration offer 'Chat with us' flow to integrate with the existing contact form.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -1,9 +1,10 @@
+import page from '@automattic/calypso-router';
 import { Button, FoldableCard } from '@automattic/components';
 import { Icon, reusableBlock, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { A4A_OVERVIEW_LINK } from '../sidebar-menu/lib/constants';
 
 import './style.scss';
-
 type Props = {
 	foldable?: boolean;
 };
@@ -30,7 +31,9 @@ const MigrationOfferBody = () => {
 			<p className="a4a-migration-offer__description">{ description }</p>
 			<Button
 				className="a4a-migration-offer__chat-button"
-				href="mailto:partnerships@automattic.com"
+				onClick={ () => {
+					page( `${ A4A_OVERVIEW_LINK }#contact-support-migration-offer` );
+				} }
 				primary
 			>
 				{ translate( 'Chat with us' ) }

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -18,12 +18,17 @@ import './style.scss';
 type Props = {
 	show: boolean;
 	onClose?: () => void;
+	defaultMessage?: string;
 };
 
 const DEFAULT_MESSAGE_VALUE = '';
 const DEFAULT_PRODUCT_VALUE = 'a4a';
 
-export default function UserContactSupportModalForm( { show, onClose }: Props ) {
+export default function UserContactSupportModalForm( {
+	show,
+	onClose,
+	defaultMessage = DEFAULT_MESSAGE_VALUE,
+}: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -33,16 +38,19 @@ export default function UserContactSupportModalForm( { show, onClose }: Props ) 
 	const [ email, setEmail ] = useState( user?.email );
 	const [ product, setProduct ] = useState( DEFAULT_PRODUCT_VALUE );
 	const [ site, setSite ] = useState( '' );
-	const [ message, setMessage ] = useState( DEFAULT_MESSAGE_VALUE );
+	const [ message, setMessage ] = useState( defaultMessage );
 
 	const isPressableSelected = product === 'pressable';
 	const hasCompletedForm = !! message && !! name && !! email && !! product && ! isPressableSelected;
 
 	const { isSubmitting, submit, isSubmissionSuccessful } = useSubmitContactSupport();
 
-	const onModalClose = useCallback( () => {
-		setMessage( DEFAULT_MESSAGE_VALUE );
+	const resetForm = useCallback( () => {
+		setMessage( defaultMessage );
 		setProduct( DEFAULT_PRODUCT_VALUE );
+	}, [ defaultMessage ] );
+
+	const onModalClose = useCallback( () => {
 		onClose?.();
 
 		dispatch( recordTracksEvent( 'calypso_a4a_user_contact_support_form_close' ) );
@@ -59,6 +67,12 @@ export default function UserContactSupportModalForm( { show, onClose }: Props ) 
 			onModalClose();
 		}
 	}, [ dispatch, isSubmissionSuccessful, onModalClose, translate ] );
+
+	useEffect( () => {
+		if ( show ) {
+			resetForm();
+		}
+	}, [ defaultMessage, resetForm, show ] );
 
 	const onNameChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
 		setName( event.currentTarget.value );

--- a/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
@@ -8,13 +8,16 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
 export const CONTACT_URL_HASH_FRAGMENT = '#contact-support';
+export const CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT = '#contact-support-migration-offer';
 
 export default function OverviewSidebarContactSupport() {
 	const translate = useTranslate();
 
-	const [ showUserSupportForm, setShowUserSupportForm ] = useState(
-		window.location.hash === CONTACT_URL_HASH_FRAGMENT
-	);
+	const hashSupportFormHash =
+		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
+		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
+
+	const [ showUserSupportForm, setShowUserSupportForm ] = useState( hashSupportFormHash );
 	const dispatch = useDispatch();
 
 	const toggleContactForm = () => {
@@ -39,6 +42,11 @@ export default function OverviewSidebarContactSupport() {
 		setShowUserSupportForm( false );
 	}, [] );
 
+	// We need make sure to set this to true when we have the support form hash fragment.
+	if ( hashSupportFormHash && ! showUserSupportForm ) {
+		setShowUserSupportForm( true );
+	}
+
 	return (
 		<>
 			<Button className="overview__contact-support-button" onClick={ toggleContactForm }>
@@ -47,6 +55,11 @@ export default function OverviewSidebarContactSupport() {
 			<UserContactSupportModalForm
 				show={ showUserSupportForm }
 				onClose={ onCloseUserSupportForm }
+				defaultMessage={
+					window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT
+						? translate( "I'd like to chat more about the migration offer." )
+						: undefined
+				}
 			/>
 		</>
 	);


### PR DESCRIPTION
This PR updates the Migration offer Chat with us flow to utilize the existing contact form instead of triggering a **mailto** flow.


<img width="1110" alt="Screenshot 2024-05-07 at 11 21 37 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f0376f2a-c53e-4fe8-abd2-89f03d9976f0">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/446

## Proposed Changes

* Update the Migration offer's **'Chat with us'** button href to `${ A4A_OVERVIEW_LINK }#contact-support-migration-offer`.
* Update the Contact support form to monitor hash value changes actively.
* Update the Contact support form to accept the default message as a prop.

## Testing Instructions


* Use the A4A live link and test the Migration Offer Chat with us button on both the **Overview** and **Referrals** pages.
* Confirm that the 'Chat with us' button opens the Contact form with the default message set to 'I'd like to chat more about the migration offer.'
* Also make sure that the existing Contact Support button in the Overview page works exactly the same in production.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?