### PR TITLE
Scheduled Updates: Pluralize sites in error message

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status.tsx
@@ -72,7 +72,10 @@ export function ScheduleListLastRunStatus( { schedule, site, onLogsClick }: Prop
 		return (
 			<>
 				<Badge type="failure" />
-				{ translate( 'Errors on %d sites', { args: [ failureCount ] } ) }
+				{ translate( 'Errors on %d site', 'Errors on %d sites', {
+					count: failureCount,
+					args: [ failureCount ],
+				} ) }
 			</>
 		);
 	}


### PR DESCRIPTION


## Proposed Changes

* Adds a plural case for when scheduled updates encountered an error on one site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a schedule and downgrade a plugin.
* Run the schedule with a failure.
* Make sure it shows the correct string when viewing the scheduled updates list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
