### PR TITLE
Unified sites sidebar - add external icon parity for jetpack links.

### DIFF
--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -21,6 +21,7 @@ export const MySitesSidebarUnifiedBody = ( {
 	path,
 	children,
 	onMenuItemClick,
+	isUnifiedSiteSidebarVisible,
 } ) => {
 	const menuItems = useSiteMenuItems();
 	const sidebarIsCollapsed = useSelector( getSidebarIsCollapsed );
@@ -66,6 +67,7 @@ export const MySitesSidebarUnifiedBody = ( {
 								selected={ isSelected }
 								sidebarCollapsed={ sidebarIsCollapsed }
 								shouldOpenExternalLinksInCurrentTab={ shouldOpenExternalLinksInCurrentTab }
+								isUnifiedSiteSidebarVisible={ isUnifiedSiteSidebarVisible }
 								{ ...item }
 							/>
 						);

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -59,7 +59,10 @@ export const MySitesSidebarUnified = ( { path, isUnifiedSiteSidebarVisible } ) =
 						<CurrentSite forceAllSitesView={ isAllDomainsView } />
 					</SidebarRegion>
 				) }
-				<MySitesSidebarUnifiedBody path={ path } />
+				<MySitesSidebarUnifiedBody
+					path={ path }
+					isUnifiedSiteSidebarVisible={ isUnifiedSiteSidebarVisible }
+				/>
 				<CollapseSidebar
 					key="collapse"
 					title={ translate( 'Collapse menu' ) }

--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -31,6 +31,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 	selected,
 	sidebarCollapsed,
 	shouldOpenExternalLinksInCurrentTab,
+	isUnifiedSiteSidebarVisible,
 	...props
 } ) => {
 	const reduxDispatch = useDispatch();
@@ -91,6 +92,14 @@ export const MySitesSidebarUnifiedMenu = ( {
 		reduxDispatch( toggleSection( sectionId ) );
 	};
 
+	const shouldForceShowExternalIcon = ( item ) => {
+		return (
+			isUnifiedSiteSidebarVisible &&
+			item?.parent === 'jetpack' &&
+			item?.url?.startsWith( 'https://jetpack.com' )
+		);
+	};
+
 	return (
 		<li>
 			<ExpandableSidebarMenu
@@ -110,6 +119,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 						return;
 					}
 					const isSelected = selectedMenuItem?.url === item.url;
+
 					return (
 						<MySitesSidebarUnifiedItem
 							key={ item.title }
@@ -118,6 +128,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 							trackClickEvent={ trackClickEvent }
 							isSubItem={ true }
 							shouldOpenExternalLinksInCurrentTab={ shouldOpenExternalLinksInCurrentTab }
+							forceShowExternalIcon={ shouldForceShowExternalIcon( item ) }
 						/>
 					);
 				} ) }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -67,6 +67,15 @@ $brand-text: "SF Pro Text", $sans;
 
 		.sidebar {
 			padding-top: 12px;
+
+			.sidebar__menu-link-text {
+				flex: none;
+			}
+
+			.sidebar__menu-link .gridicons-external {
+				position: unset;
+				margin-left: 4px;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/6984

## Proposed Changes

* Forces showing the external icon for jetpack.com URL links in the unified site sidebar to have better parity with wp-admin.

BEFORE

<img width="332" alt="Screenshot 2024-05-07 at 2 57 09 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/6aece9ef-7c0a-4fb9-a862-b205743d52fe">


AFTER

<img width="340" alt="Screenshot 2024-05-07 at 2 57 02 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/22995285-7934-47a8-bce7-433335712a6b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Select a site with nav redesign classic enabled and view the unified site sidebar.
* Hover over the jetpack menu, verify the same items have the external link as in the wp-admin version of the jetpack sidebar menu.
* Select sites without the redesign enabled, verify there are no observable changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
