### PR TITLE
Nav Redesign: Add subtitle to sites

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -28,6 +28,10 @@
 		}
 	}
 
+	.a4a-layout__header {
+		align-items: initial;
+	}
+
 	.a4a-layout__header-main {
 		display: block;
 	}
@@ -41,6 +45,10 @@
 		margin: 4px 0 0 0;
 		line-height: 20px;
 		letter-spacing: -0.15px;
+	}
+
+	.a4a-layout__header-actions a {
+		font-weight: normal;
 	}
 
 	height: calc(100vh - var(--masterbar-height));

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -322,7 +322,8 @@
 		}
 
 		.sites-site-thumbnail,
-		.sites-manage-all-domains-button {
+		.sites-manage-all-domains-button,
+		.a4a-layout__header-subtitle {
 			display: none;
 		}
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -30,6 +30,9 @@
 
 	.a4a-layout__header {
 		align-items: initial;
+		@media ( max-width: 660px ) {
+			align-items: center;
+		}
 	}
 
 	.a4a-layout__header-main {
@@ -45,14 +48,21 @@
 		margin: 4px 0 0 0;
 		line-height: 20px;
 		letter-spacing: -0.15px;
+		white-space: nowrap;
 	}
 
-	.a4a-layout__header-actions a {
-		font-weight: normal;
+	.a4a-layout__header-actions {
+		a {
+			font-weight: normal;
+		}
 	}
 
 	.sites-manage-all-domains-button {
 		border-color: var(--color-neutral-10);
+
+		@media (max-width: 959px) {
+			margin-inline-end: 8px !important;
+		}
 	}
 
 	.sites-manage-all-domains-button:hover {
@@ -335,6 +345,10 @@
 		.sites-site-favicon {
 			display: flex;
 			margin-right: 0;
+		}
+
+		.a4a-layout__header {
+			align-items: center !important;
 		}
 
 		.sites-site-thumbnail,

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -48,10 +48,10 @@
 		margin: 4px 0 0 0;
 		line-height: 20px;
 		letter-spacing: -0.15px;
-		white-space: nowrap;
 	}
 
 	.a4a-layout__header-actions {
+		width: auto;
 		a {
 			font-weight: normal;
 		}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -36,6 +36,13 @@
 		display: block;
 	}
 
+	.a4a-layout__header-subtitle {
+		font-size: 0.875rem;
+		margin: 4px 0 0 0;
+		line-height: 20px;
+		letter-spacing: -0.15px;
+	}
+
 	height: calc(100vh - var(--masterbar-height));
 
 	@media ( min-width: 782px ) {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -51,6 +51,14 @@
 		font-weight: normal;
 	}
 
+	.sites-manage-all-domains-button {
+		border-color: var(--color-neutral-10);
+	}
+
+	.sites-manage-all-domains-button:hover {
+		border-color: var(--color-neutral-20);
+	}
+
 	height: calc(100vh - var(--masterbar-height));
 
 	@media ( min-width: 782px ) {

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -26,6 +26,7 @@ const HeaderControls = styled.div( {
 	flexDirection: 'row',
 	alignItems: 'flex-start',
 	fontWeight: 500,
+	justifyContent: 'flex-end',
 } );
 
 export const PageBodyBottomContainer = styled.div( {

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -20,9 +20,11 @@ import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 	LayoutHeaderTitle as Title,
+	LayoutHeaderSubtitle as Subtitle,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import DocumentHead from 'calypso/components/data/document-head';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import {
 	SitesDashboardQueryParams,
@@ -241,6 +243,12 @@ const SitesDashboardV2 = ( {
 					<LayoutTop withNavigation={ false }>
 						<LayoutHeader>
 							{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
+							<Subtitle>
+								{ translate( 'Manage all your sites' ) }
+								{ '. ' }
+								<InlineSupportLink supportPostId="230679" showIcon={ false } />.
+							</Subtitle>
+
 							<Actions>
 								<SitesDashboardHeader />
 							</Actions>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6975

## Proposed Changes

* Adds a subtitle with a "Learn more" modal link to /sites
* Hides the subtitle when the preview panel is open

Before | After
--|--
<img width="1211" alt="Screenshot 2024-05-07 at 5 06 00 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/11dfe47a-a5dd-4094-b996-d975862363a3"> |  <img width="1204" alt="Screenshot 2024-05-07 at 5 03 42 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/13a937eb-92f0-4af2-9809-03210493fb7e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* View the new subtitle.
* Click "Learn more" and see that it opens up the help center modal
* Expand the preview panel and see that the subtitle is hidden
* Close the preview panel and see that the subtitle re-appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
