### PR TITLE
Add quantity to stats and ai in purchases list

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -23,12 +23,14 @@ import {
 	isAkismetProduct,
 	isTieredVolumeSpaceAddon,
 	is100Year,
+	isJetpackAISlug,
+	isJetpackStatsPaidProductSlug,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { formatCurrency } from '@automattic/format-currency';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
-import i18n, { TranslateResult } from 'i18n-calypso';
+import i18n, { numberFormat, type TranslateResult } from 'i18n-calypso';
 import moment from 'moment';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -249,8 +251,26 @@ export function getName( purchase: Purchase ): string {
 
 export function getDisplayName( purchase: Purchase ): TranslateResult {
 	const { productName, productSlug, purchaseRenewalQuantity } = purchase;
-
 	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames( 'full' );
+
+	if ( isJetpackAISlug( purchase.productSlug ) && purchase.purchaseRenewalQuantity ) {
+		return i18n.translate( '%(productName)s (%(quantity)s requests per month)', {
+			args: {
+				productName: jetpackProductsDisplayNames[ productSlug ],
+				quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
+			},
+		} );
+	}
+
+	if ( isJetpackStatsPaidProductSlug( purchase.productSlug ) && purchase.purchaseRenewalQuantity ) {
+		return i18n.translate( '%(productName)s (%(quantity)s views per month)', {
+			args: {
+				productName: jetpackProductsDisplayNames[ productSlug ],
+				quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
+			},
+		} );
+	}
+
 	if ( jetpackProductsDisplayNames[ productSlug ] ) {
 		return jetpackProductsDisplayNames[ productSlug ];
 	}

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1158,10 +1158,10 @@ class ManagePurchase extends Component<
 		}
 
 		if ( isJetpackAISlug( purchase.productSlug ) && purchase.purchaseRenewalQuantity ) {
-			return translate( '%(productName)s (%(quantity)d requests per month)', {
+			return translate( '%(productName)s (%(quantity)s requests per month)', {
 				args: {
 					productName: getDisplayName( purchase ),
-					quantity: purchase.purchaseRenewalQuantity,
+					quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
 				},
 			} );
 		}

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -35,8 +35,6 @@ import {
 	AKISMET_UPGRADES_PRODUCTS_MAP,
 	JETPACK_STARTER_UPGRADE_MAP,
 	is100Year,
-	isJetpackAISlug,
-	isJetpackStatsPaidProductSlug,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import {
@@ -53,7 +51,7 @@ import {
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
 import classNames from 'classnames';
-import { localize, LocalizeProps, numberFormat, useTranslate } from 'i18n-calypso';
+import { localize, LocalizeProps, useTranslate } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -1155,27 +1153,6 @@ class ManagePurchase extends Component<
 
 		if ( ! purchase ) {
 			return '';
-		}
-
-		if ( isJetpackAISlug( purchase.productSlug ) && purchase.purchaseRenewalQuantity ) {
-			return translate( '%(productName)s (%(quantity)s requests per month)', {
-				args: {
-					productName: getDisplayName( purchase ),
-					quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
-				},
-			} );
-		}
-
-		if (
-			isJetpackStatsPaidProductSlug( purchase.productSlug ) &&
-			purchase.purchaseRenewalQuantity
-		) {
-			return translate( '%(productName)s (%(quantity)s views per month)', {
-				args: {
-					productName: getDisplayName( purchase ),
-					quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
-				},
-			} );
 		}
 
 		if ( ! plan || ! isWpComMonthlyPlan( purchase.productSlug ) ) {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -2,6 +2,8 @@ import {
 	isDomainTransfer,
 	isConciergeSession,
 	isAkismetFreeProduct,
+	isJetpackAISlug,
+	isJetpackStatsPaidProductSlug,
 	PLAN_MONTHLY_PERIOD,
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
@@ -14,7 +16,7 @@ import { CALYPSO_CONTACT } from '@automattic/urls';
 import { ExternalLink } from '@wordpress/components';
 import { Icon, warning as warningIcon } from '@wordpress/icons';
 import classNames from 'classnames';
-import { localize, useTranslate } from 'i18n-calypso';
+import { localize, useTranslate, numberFormat } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
@@ -540,6 +542,37 @@ class PurchaseItem extends Component {
 		return <SiteIcon site={ site } size={ 36 } />;
 	};
 
+	getProductDisplayName() {
+		const { purchase, translate } = this.props;
+
+		if ( ! purchase ) {
+			return '';
+		}
+
+		if ( isJetpackAISlug( purchase.productSlug ) && purchase.purchaseRenewalQuantity ) {
+			return translate( '%(productName)s (%(quantity)s requests per month)', {
+				args: {
+					productName: getDisplayName( purchase ),
+					quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
+				},
+			} );
+		}
+
+		if (
+			isJetpackStatsPaidProductSlug( purchase.productSlug ) &&
+			purchase.purchaseRenewalQuantity
+		) {
+			return translate( '%(productName)s (%(quantity)s views per month)', {
+				args: {
+					productName: getDisplayName( purchase ),
+					quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
+				},
+			} );
+		}
+
+		return getDisplayName( purchase );
+	}
+
 	renderPurchaseItemContent = () => {
 		const { purchase, showSite, isBackupMethodAvailable } = this.props;
 
@@ -551,7 +584,7 @@ class PurchaseItem extends Component {
 
 				<div className="purchase-item__information purchases-layout__information">
 					<div className="purchase-item__title">
-						{ getDisplayName( purchase ) }
+						{ this.getProductDisplayName( purchase ) }
 						&nbsp;
 						<OwnerInfo purchase={ purchase } />
 					</div>

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -2,8 +2,6 @@ import {
 	isDomainTransfer,
 	isConciergeSession,
 	isAkismetFreeProduct,
-	isJetpackAISlug,
-	isJetpackStatsPaidProductSlug,
 	PLAN_MONTHLY_PERIOD,
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
@@ -16,7 +14,7 @@ import { CALYPSO_CONTACT } from '@automattic/urls';
 import { ExternalLink } from '@wordpress/components';
 import { Icon, warning as warningIcon } from '@wordpress/icons';
 import classNames from 'classnames';
-import { localize, useTranslate, numberFormat } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
@@ -542,37 +540,6 @@ class PurchaseItem extends Component {
 		return <SiteIcon site={ site } size={ 36 } />;
 	};
 
-	getProductDisplayName() {
-		const { purchase, translate } = this.props;
-
-		if ( ! purchase ) {
-			return '';
-		}
-
-		if ( isJetpackAISlug( purchase.productSlug ) && purchase.purchaseRenewalQuantity ) {
-			return translate( '%(productName)s (%(quantity)s requests per month)', {
-				args: {
-					productName: getDisplayName( purchase ),
-					quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
-				},
-			} );
-		}
-
-		if (
-			isJetpackStatsPaidProductSlug( purchase.productSlug ) &&
-			purchase.purchaseRenewalQuantity
-		) {
-			return translate( '%(productName)s (%(quantity)s views per month)', {
-				args: {
-					productName: getDisplayName( purchase ),
-					quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
-				},
-			} );
-		}
-
-		return getDisplayName( purchase );
-	}
-
 	renderPurchaseItemContent = () => {
 		const { purchase, showSite, isBackupMethodAvailable } = this.props;
 
@@ -584,7 +551,7 @@ class PurchaseItem extends Component {
 
 				<div className="purchase-item__information purchases-layout__information">
 					<div className="purchase-item__title">
-						{ this.getProductDisplayName( purchase ) }
+						{ getDisplayName( purchase ) }
 						&nbsp;
 						<OwnerInfo purchase={ purchase } />
 					</div>


### PR DESCRIPTION
## Proposed Changes

* Add quantity to AI and Stats to the product names in the purchases list
* Add number formatting to AI (already existed for stats)

## Testing Instructions

1. Purchase the highest AI tier plan (https://wordpress.com/checkout/jetpack/jetpack_ai_yearly:-q-1000)
2. Purchase the base stats plan (https://wordpress.com/checkout/jetpack/jetpack_stats_yearly)
3. Use the calypso live link or your local environment to use this branch and go to `/me/purchases`
4. See that the number of requests/views are now visible from the purchases list
![image](https://github.com/Automattic/wp-calypso/assets/65001528/ead40549-c142-4f3b-bbcf-926d5dd352cd)
5. Make sure there is a comma where needed on the numbers on the list and on the individual purchase page
![image](https://github.com/Automattic/wp-calypso/assets/65001528/42cc4ed2-6d20-4422-8cc8-04cd2e89b123)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
