### PR TITLE
Jetpack Backup: improve credentials error message when path has no proper access permissions

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -227,17 +227,15 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 				i18n.translate(
 					'Error saving. ' +
 						'Please ensure that the WordPress installation path has write permissions. ' +
-						'{{LearnMore /}}.',
+						'{{a}}Learn more{{/a}}.',
 					{
 						components: {
-							LearnMore: (
+							a: (
 								<a
 									href="https://jetpack.com/support/backup/ssh-sftp-and-ftp-credentials/#file-access-permission"
 									target="blank"
 									rel="noreferrer"
-								>
-									Learn more
-								</a>
+								/>
 							),
 						},
 					}

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -226,7 +226,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 			dispatchFailure(
 				i18n.translate(
 					'Error saving. ' +
-						'Please ensure that the WordPress installation path has the necessary write permissions. ' +
+						'Please ensure that the WordPress installation path has write permissions. ' +
 						'{{LearnMore /}}.',
 					{
 						components: {

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { ExternalLink } from '@automattic/components';
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
@@ -232,9 +231,13 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 					{
 						components: {
 							LearnMore: (
-								<ExternalLink href="https://jetpack.com/support/backup/ssh-sftp-and-ftp-credentials/#file-access-permission">
+								<a
+									href="https://jetpack.com/support/backup/ssh-sftp-and-ftp-credentials/#file-access-permission"
+									target="blank"
+									rel="noreferrer"
+								>
 									Learn more
-								</ExternalLink>
+								</a>
 							),
 						},
 					}

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { ExternalLink } from '@automattic/components';
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
@@ -222,6 +223,24 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 			);
 			break;
 
+		case 'helper_upload_failed':
+			dispatchFailure(
+				i18n.translate(
+					'Error saving. ' +
+						'Please ensure that the WordPress installation path has the necessary write permissions. ' +
+						'{{LearnMore /}}.',
+					{
+						components: {
+							LearnMore: (
+								<ExternalLink href="https://jetpack.com/support/backup/ssh-sftp-and-ftp-credentials/#file-access-permission">
+									Learn more
+								</ExternalLink>
+							),
+						},
+					}
+				)
+			);
+			break;
 		default:
 			dispatchFailure(
 				i18n.translate( 'Error saving. Please check your credentials and try again.' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/436

## Proposed Changes

* Map `helper_upload_failed` error that occurs when a user enters valid credentials but the WordPress installation path doesn't have the right permissions.
* Add a `Learn more` link on that error, pointing to our support documentation.

![CleanShot 2024-05-07 at 15 40 25@2x](https://github.com/Automattic/wp-calypso/assets/1488641/e7f98599-a86e-472b-bec4-c89e5cc51004)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso or Jetpack Cloud live branch
* Pick a site with Jetpack VaultPress Backup and make your WordPress installation path readonly
  * You can easily reproduce this by executing `chmod -R 555 YOUR_WORDPRESS_PATH` in your server.
* Navigate to the Settings page
* Enter valid credentials
* Given your installation path is readonly, you should see the error shared above
* Ensure clicking on `Learn more` opens https://jetpack.com/support/backup/ssh-sftp-and-ftp-credentials/#file-access-permission

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
