### PR TITLE
A4A: Hosting: Remove production search and align cards

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -2,13 +2,10 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import FilterSearch from 'calypso/a8c-for-agencies/components/filter-search';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { useDispatch } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamily } from 'calypso/state/partner-portal/types';
 import SimpleList from '../../common/simple-list';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
@@ -25,7 +22,6 @@ interface Props {
 
 export default function HostingList( { selectedSite }: Props ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 	const activeAgency = useSelector( getActiveAgency );
 
 	const { data } = useProductsQuery( false, true );
@@ -45,11 +41,8 @@ export default function HostingList( { selectedSite }: Props ) {
 		);
 	}, [ activeAgency ] );
 
-	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
-
 	const { isLoadingProducts, pressablePlans, wpcomPlans } = useProductAndPlans( {
 		selectedSite,
-		productSearchQuery,
 	} );
 
 	const isWPCOMOptionEnabled = isEnabled( 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' );
@@ -89,16 +82,6 @@ export default function HostingList( { selectedSite }: Props ) {
 		[ translate ]
 	);
 
-	const onProductSearch = useCallback(
-		( value: string ) => {
-			setProductSearchQuery( value );
-			dispatch(
-				recordTracksEvent( 'calypso_a4a_marketplace_hosting_overview_search_submit', { value } )
-			);
-		},
-		[ dispatch ]
-	);
-
 	if ( isLoadingProducts ) {
 		return (
 			<div className="hosting-list">
@@ -109,10 +92,6 @@ export default function HostingList( { selectedSite }: Props ) {
 
 	return (
 		<div className="hosting-list">
-			<div className="hosting-list__actions">
-				<FilterSearch label={ translate( 'Search products' ) } onSearch={ onProductSearch } />
-			</div>
-
 			<ListingSection
 				title={ translate( 'Hosting' ) }
 				description={ translate(

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -82,6 +82,20 @@ export default function HostingList( { selectedSite }: Props ) {
 		[ translate ]
 	);
 
+	// Track the tallest price section across hosting cards, to keep them aligned with each other.
+	const [ minHostingCardPriceHeight, setMinHostingCardPriceHeight ] = useState( 0 );
+	const hostingCardPriceHeightProps = {
+		minPriceHeight: minHostingCardPriceHeight,
+		setPriceHeight: ( height: number ): void => {
+			setMinHostingCardPriceHeight( ( currentHeight ) => {
+				if ( height > currentHeight ) {
+					return height;
+				}
+				return currentHeight;
+			} );
+		},
+	};
+
 	if ( isLoadingProducts ) {
 		return (
 			<div className="hosting-list">
@@ -100,7 +114,11 @@ export default function HostingList( { selectedSite }: Props ) {
 				isTwoColumns
 			>
 				{ creatorPlan && (
-					<HostingCard plan={ creatorPlan } highestDiscountPercentage={ highestDiscountWPCOM } />
+					<HostingCard
+						plan={ creatorPlan }
+						highestDiscountPercentage={ highestDiscountWPCOM }
+						{ ...hostingCardPriceHeightProps }
+					/>
 				) }
 
 				{ cheapestPressablePlan && (
@@ -108,11 +126,16 @@ export default function HostingList( { selectedSite }: Props ) {
 						plan={ cheapestPressablePlan }
 						pressableOwnership={ !! hasPressablePlan }
 						highestDiscountPercentage={ highestDiscountPressable }
+						{ ...hostingCardPriceHeightProps }
 					/>
 				) }
 
 				{ isWPCOMOptionEnabled && (
-					<HostingCard plan={ vipPlan } className="hosting-list__vip-card" />
+					<HostingCard
+						plan={ vipPlan }
+						className="hosting-list__vip-card"
+						{ ...hostingCardPriceHeightProps }
+					/>
 				) }
 			</ListingSection>
 			{ isWPCOMOptionEnabled && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/430

## Proposed Changes

* Removes the product search from the top of the hosting page.
* Syncs height of all pricing cards "price" sections, to keep them aligned.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out "/marketplace/hosting" via the live link.
* Ensure the product search bar is removed.
* Ensure the pricing cards line up.
* Resize the screen or change the content of the pricing cards, ensure they continue to align.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1302" alt="Screenshot 2024-05-07 at 2 13 30 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/6d70028e-ab70-4a37-9a14-b1469ff3bec4">
