### PR TITLE
Mulstisite Scheduled Updates: Adapt global style layout

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -39,7 +39,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 		<MultisitePluginUpdateManagerContextProvider>
 			<Layout title={ title } wide>
 				{ context === 'create' || context === 'edit' ? (
-					<LayoutColumn className="schedules-list">
+					<LayoutColumn className="scheduled-updates-list-compact">
 						<ScheduleList
 							compact={ true }
 							previewMode="card"
@@ -49,7 +49,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 						/>
 					</LayoutColumn>
 				) : null }
-				<LayoutColumn wide>
+				<LayoutColumn className={ `scheduled-updates-${ context }` } wide>
 					{ ( () => {
 						switch ( context ) {
 							case 'create':

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -39,7 +39,15 @@ export const PluginsScheduledUpdatesMultisite = ( {
 		<MultisitePluginUpdateManagerContextProvider>
 			<Layout title={ title } wide>
 				{ context === 'create' || context === 'edit' ? (
-					<LayoutColumn className="schedules-list">List of schedules</LayoutColumn>
+					<LayoutColumn className="schedules-list">
+						<ScheduleList
+							compact={ true }
+							previewMode="card"
+							onCreateNewSchedule={ onCreateNewSchedule }
+							onEditSchedule={ onEditSchedule }
+							onShowLogs={ onShowLogs }
+						/>
+					</LayoutColumn>
 				) : null }
 				<LayoutColumn wide>
 					{ ( () => {

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,10 +1,13 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { MultisitePluginUpdateManagerContextProvider } from 'calypso/blocks/plugins-scheduled-updates-multisite/context';
-import DocumentHead from 'calypso/components/data/document-head';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
+import { MultisitePluginUpdateManagerContextProvider } from './context';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleEdit } from './schedule-edit';
 import { ScheduleList } from './schedule-list';
 
+import 'calypso/sites-dashboard-v2/dotcom-style.scss';
 import './styles.scss';
 
 type Props = {
@@ -24,6 +27,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 	onEditSchedule,
 	onShowLogs,
 }: Props ) => {
+	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();
 	const title = {
 		create: translate( 'New schedule' ),
@@ -33,24 +37,31 @@ export const PluginsScheduledUpdatesMultisite = ( {
 
 	return (
 		<MultisitePluginUpdateManagerContextProvider>
-			<DocumentHead title={ title } />
-			{ ( () => {
-				switch ( context ) {
-					case 'create':
-						return <ScheduleCreate onNavBack={ onNavBack } />;
-					case 'edit':
-						return <ScheduleEdit id={ id! } onNavBack={ onNavBack } />;
-					case 'list':
-					default:
-						return (
-							<ScheduleList
-								onCreateNewSchedule={ onCreateNewSchedule }
-								onEditSchedule={ onEditSchedule }
-								onShowLogs={ onShowLogs }
-							/>
-						);
-				}
-			} )() }
+			<Layout title={ title } wide>
+				{ context === 'create' || context === 'edit' ? (
+					<LayoutColumn className="schedules-list">List of schedules</LayoutColumn>
+				) : null }
+				<LayoutColumn wide>
+					{ ( () => {
+						switch ( context ) {
+							case 'create':
+								return <ScheduleCreate onNavBack={ onNavBack } />;
+							case 'edit':
+								return <ScheduleEdit id={ id! } onNavBack={ onNavBack } />;
+							case 'list':
+							default:
+								return (
+									<ScheduleList
+										previewMode={ isMobile ? 'card' : 'table' }
+										onCreateNewSchedule={ onCreateNewSchedule }
+										onEditSchedule={ onEditSchedule }
+										onShowLogs={ onShowLogs }
+									/>
+								);
+						}
+					} )() }
+				</LayoutColumn>
+			</Layout>
 		</MultisitePluginUpdateManagerContextProvider>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,4 +1,4 @@
-import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
@@ -29,7 +29,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 	onShowLogs,
 }: Props ) => {
 	const { schedule: selectedSchedule } = useLoadScheduleFromId( id! );
-	const isMobile = useMobileBreakpoint();
+	const isSmallScreen = useBreakpoint( '<660px' );
 	const translate = useTranslate();
 	const title = {
 		create: translate( 'New schedule' ),
@@ -64,7 +64,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 							default:
 								return (
 									<ScheduleList
-										previewMode={ isMobile ? 'card' : 'table' }
+										previewMode={ isSmallScreen ? 'card' : 'table' }
 										onCreateNewSchedule={ onCreateNewSchedule }
 										onEditSchedule={ onEditSchedule }
 										onShowLogs={ onShowLogs }

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -2,6 +2,7 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
+import { useLoadScheduleFromId } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-load-schedule-from-id';
 import { MultisitePluginUpdateManagerContextProvider } from './context';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleEdit } from './schedule-edit';
@@ -27,6 +28,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 	onEditSchedule,
 	onShowLogs,
 }: Props ) => {
+	const { schedule: selectedSchedule } = useLoadScheduleFromId( id! );
 	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();
 	const title = {
@@ -43,6 +45,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 						<ScheduleList
 							compact={ true }
 							previewMode="card"
+							selectedScheduleId={ selectedSchedule?.schedule_id }
 							onCreateNewSchedule={ onCreateNewSchedule }
 							onEditSchedule={ onEditSchedule }
 							onShowLogs={ onShowLogs }

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -45,6 +45,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 						<ScheduleList
 							compact={ true }
 							previewMode="card"
+							showNewScheduleBtn={ context === 'edit' }
 							selectedScheduleId={ selectedSchedule?.schedule_id }
 							onCreateNewSchedule={ onCreateNewSchedule }
 							onEditSchedule={ onEditSchedule }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const ScheduleCreate = ( { onNavBack }: Props ) => {
 	const translate = useTranslate();
 	return (
-		<div className="plugins-update-manager plugins-update-manager-multisite">
+		<div className="plugins-update-manager plugins-update-manager-multisite plugins-update-manager-multisite-create">
 			<div className="plugins-update-manager-multisite__header no-border">
 				<h1 className="wp-brand-font">{ translate( 'New schedule' ) }</h1>
 				<Button onClick={ onNavBack }>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
@@ -37,7 +37,7 @@ export const ScheduleEdit = ( { id, onNavBack }: Props ) => {
 				</Button>
 			</div>
 			{ schedule && scheduleLoaded ? (
-				<ScheduleForm onNavBack={ onNavBack } scheduleForEdit={ schedule } />
+				<ScheduleForm key={ id } onNavBack={ onNavBack } scheduleForEdit={ schedule } />
 			) : (
 				<Spinner />
 			) }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
@@ -25,7 +25,7 @@ export const ScheduleEdit = ( { id, onNavBack }: Props ) => {
 	}, [ scheduleNotFound, onNavBack ] );
 
 	return (
-		<div className="plugins-update-manager plugins-update-manager-multisite">
+		<div className="plugins-update-manager plugins-update-manager-multisite plugins-update-manager-multisite-edit">
 			<div className="plugins-update-manager-multisite__header no-border">
 				<h1 className="wp-brand-font">
 					{ schedule && scheduleLoaded

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card-new.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card-new.tsx
@@ -1,0 +1,23 @@
+import clsx from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	className?: string;
+}
+export const ScheduleListCardNew = ( props: Props ) => {
+	const translate = useTranslate();
+	const { className } = props;
+
+	return (
+		<div
+			className={ clsx(
+				'plugins-update-manager-multisite-card plugins-update-manager-multisite-card__new',
+				className
+			) }
+		>
+			<div className="plugins-update-manager-multisite-card__label  plugins-update-manager-multisite-card__name-label">
+				<strong id="name">{ translate( 'New schedule' ) }</strong>
+			</div>
+		</div>
+	);
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -1,5 +1,6 @@
 import { Button, Tooltip } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon, info } from '@wordpress/icons';
+import clsx from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDateTimeFormat } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-date-time-format';
@@ -14,6 +15,7 @@ import type {
 } from 'calypso/data/plugins/use-update-schedules-query';
 
 type Props = {
+	className?: string;
 	compact?: boolean;
 	schedule: MultisiteSchedulesUpdates;
 	onEditClick: ( id: string ) => void;
@@ -22,7 +24,7 @@ type Props = {
 };
 
 export const ScheduleListCard = ( props: Props ) => {
-	const { compact, schedule, onEditClick, onRemoveClick, onLogsClick } = props;
+	const { className, compact, schedule, onEditClick, onRemoveClick, onLogsClick } = props;
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat();
 	const { preparePluginsTooltipInfo } = usePrepareMultisitePluginsTooltipInfo(
@@ -32,7 +34,7 @@ export const ScheduleListCard = ( props: Props ) => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 
 	return (
-		<div className="plugins-update-manager-multisite-card">
+		<div className={ clsx( 'plugins-update-manager-multisite-card', className ) }>
 			<div className="plugins-update-manager-multisite-card__label  plugins-update-manager-multisite-card__name-label">
 				<strong id="name">
 					<Button

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -14,6 +14,7 @@ import type {
 } from 'calypso/data/plugins/use-update-schedules-query';
 
 type Props = {
+	compact?: boolean;
 	schedule: MultisiteSchedulesUpdates;
 	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
@@ -21,7 +22,7 @@ type Props = {
 };
 
 export const ScheduleListCard = ( props: Props ) => {
-	const { schedule, onEditClick, onRemoveClick, onLogsClick } = props;
+	const { compact, schedule, onEditClick, onRemoveClick, onLogsClick } = props;
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat();
 	const { preparePluginsTooltipInfo } = usePrepareMultisitePluginsTooltipInfo(
@@ -60,17 +61,19 @@ export const ScheduleListCard = ( props: Props ) => {
 				/>
 			</div>
 
-			<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
-				<label htmlFor="last-update">
-					<Button variant="link" onClick={ () => setIsExpanded( ! isExpanded ) }>
-						{ translate( 'Last update' ) }
-						<Icon icon={ isExpanded ? chevronUp : chevronDown } />
-					</Button>
-				</label>
-				<div>
-					<ScheduleListLastRunStatus schedule={ schedule } />
+			{ ! compact && (
+				<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
+					<label htmlFor="last-update">
+						<Button variant="link" onClick={ () => setIsExpanded( ! isExpanded ) }>
+							{ translate( 'Last update' ) }
+							<Icon icon={ isExpanded ? chevronUp : chevronDown } />
+						</Button>
+					</label>
+					<div>
+						<ScheduleListLastRunStatus schedule={ schedule } />
+					</div>
 				</div>
-			</div>
+			) }
 
 			{ isExpanded && (
 				<div className="plugins-update-manager-multisite-card__sites">
@@ -94,10 +97,12 @@ export const ScheduleListCard = ( props: Props ) => {
 				</div>
 			) }
 
-			<div className="plugins-update-manager-multisite-card__label">
-				<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
-				<span id="next-update">{ prepareDateTime( schedule.timestamp ) }</span>
-			</div>
+			{ ! compact && (
+				<div className="plugins-update-manager-multisite-card__label">
+					<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
+					<span id="next-update">{ prepareDateTime( schedule.timestamp ) }</span>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
@@ -3,6 +3,7 @@ import { ScheduleListCard } from './schedule-list-card';
 import type { MultisiteSchedulesUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 
 type Props = {
+	compact?: boolean;
 	schedules: MultisiteSchedulesUpdates[];
 	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
@@ -11,12 +12,13 @@ type Props = {
 };
 
 export const ScheduleListCards = ( props: Props ) => {
-	const { schedules, onEditClick, onLogsClick, onRemoveClick } = props;
+	const { compact, schedules, onEditClick, onLogsClick, onRemoveClick } = props;
 
 	return (
 		<div className="plugins-update-manager-multisite-cards">
 			{ schedules.map( ( schedule ) => (
 				<ScheduleListCard
+					compact={ compact }
 					schedule={ schedule }
 					onEditClick={ onEditClick }
 					onRemoveClick={ onRemoveClick }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
@@ -1,3 +1,4 @@
+import clsx from 'classnames';
 import { SiteSlug } from 'calypso/types';
 import { ScheduleListCard } from './schedule-list-card';
 import type { MultisiteSchedulesUpdates } from 'calypso/data/plugins/use-update-schedules-query';
@@ -5,6 +6,7 @@ import type { MultisiteSchedulesUpdates } from 'calypso/data/plugins/use-update-
 type Props = {
 	compact?: boolean;
 	schedules: MultisiteSchedulesUpdates[];
+	selectedScheduleId?: string;
 	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
 	onLogsClick: ( id: string, siteSlug: SiteSlug ) => void;
@@ -12,12 +14,13 @@ type Props = {
 };
 
 export const ScheduleListCards = ( props: Props ) => {
-	const { compact, schedules, onEditClick, onLogsClick, onRemoveClick } = props;
+	const { compact, schedules, selectedScheduleId, onEditClick, onLogsClick, onRemoveClick } = props;
 
 	return (
 		<div className="plugins-update-manager-multisite-cards">
 			{ schedules.map( ( schedule ) => (
 				<ScheduleListCard
+					className={ clsx( { 'is-selected': selectedScheduleId === schedule.schedule_id } ) }
 					compact={ compact }
 					schedule={ schedule }
 					onEditClick={ onEditClick }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-filter.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-filter.tsx
@@ -29,14 +29,19 @@ const SearchSVG = (
 		/>
 	</svg>
 );
+interface Props {
+	compact?: boolean;
+}
 
-export const ScheduleListFilter = () => {
+export const ScheduleListFilter = ( props: Props ) => {
 	const translate = useTranslate();
+	const { compact } = props;
 	const { searchTerm, handleSearch } = useContext( MultisitePluginUpdateManagerContext );
 
 	return (
 		<div className="plugins-update-manager-multisite-filter">
 			<SearchInput
+				compact={ compact }
 				placeholder={ translate( 'Search by site' ) }
 				searchIcon={ <Icon icon={ SearchSVG } size={ 18 } /> }
 				onSearch={ handleSearch }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -84,7 +84,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 						<Icon className="icon-info" icon={ info } size={ 16 } />
 					</Tooltip>
 				</td>
-				<td style={ { textAlign: 'end' } }>
+				<td className="menu">
 					<ScheduleListTableRowMenu { ...props } />
 				</td>
 			</tr>
@@ -108,7 +108,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 						<td></td>
 
 						<td></td>
-						<td style={ { textAlign: 'end' } }>
+						<td className="menu">
 							<ScheduleListTableRowMenu { ...props } site={ site } />
 						</td>
 					</tr>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
@@ -19,7 +19,7 @@ export const ScheduleListTable = ( props: Props ) => {
 		<table className="plugins-update-manager-multisite-table">
 			<thead>
 				<tr>
-					<th></th>
+					<th className="expand"></th>
 					<th>{ translate( 'Name' ) }</th>
 					<th>{ translate( 'Sites' ) }</th>
 					<th>{ translate( 'Last update' ) }</th>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -1,4 +1,3 @@
-import { useMobileBreakpoint } from '@automattic/viewport-react';
 import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
@@ -19,19 +18,19 @@ import { ScheduleListTable } from './schedule-list-table';
 import './styles.scss';
 
 type Props = {
+	previewMode: 'table' | 'card';
 	onEditSchedule: ( id: string ) => void;
 	onShowLogs: ( id: string, siteSlug: string ) => void;
 	onCreateNewSchedule: () => void;
 };
 
 export const ScheduleList = ( props: Props ) => {
-	const { onEditSchedule, onShowLogs, onCreateNewSchedule } = props;
+	const { previewMode, onEditSchedule, onShowLogs, onCreateNewSchedule } = props;
 	const {
 		data: schedules = [],
 		isLoading: isLoadingSchedules,
 		isFetched,
 	} = useMultisiteUpdateScheduleQuery( true );
-	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();
 	const { searchTerm } = useContext( MultisitePluginUpdateManagerContext );
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
@@ -84,7 +83,7 @@ export const ScheduleList = ( props: Props ) => {
 		.filter( ( schedule ) => schedule.sites.length > 0 );
 
 	const isLoading = isLoadingSchedules;
-	const ScheduleListComponent = isMobile ? ScheduleListCards : ScheduleListTable;
+	const ScheduleListComponent = previewMode === 'table' ? ScheduleListTable : ScheduleListCards;
 	const isScheduleEmpty = schedules.length === 0 && isFetched;
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -18,6 +18,7 @@ import { ScheduleListTable } from './schedule-list-table';
 import './styles.scss';
 
 type Props = {
+	compact?: boolean;
 	previewMode: 'table' | 'card';
 	onEditSchedule: ( id: string ) => void;
 	onShowLogs: ( id: string, siteSlug: string ) => void;
@@ -25,7 +26,7 @@ type Props = {
 };
 
 export const ScheduleList = ( props: Props ) => {
-	const { previewMode, onEditSchedule, onShowLogs, onCreateNewSchedule } = props;
+	const { compact, previewMode, onEditSchedule, onShowLogs, onCreateNewSchedule } = props;
 	const {
 		data: schedules = [],
 		isLoading: isLoadingSchedules,
@@ -92,8 +93,9 @@ export const ScheduleList = ( props: Props ) => {
 				<h1>{ translate( 'Update schedules' ) }</h1>
 				{ ! isScheduleEmpty && (
 					<Button
-						__next40pxDefaultSize
-						variant="primary"
+						__next40pxDefaultSize={ ! compact }
+						isSmall={ compact }
+						variant={ compact ? 'secondary' : 'primary' }
 						onClick={ onCreateNewSchedule }
 						disabled={ false }
 					>
@@ -108,8 +110,9 @@ export const ScheduleList = ( props: Props ) => {
 			{ isScheduleEmpty && <ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } /> }
 			{ ! isScheduleEmpty && ScheduleListComponent ? (
 				<>
-					<ScheduleListFilter />
+					<ScheduleListFilter compact={ compact } />
 					<ScheduleListComponent
+						compact={ compact }
 						schedules={ filteredSchedules }
 						onRemoveClick={ openRemoveDialog }
 						onEditClick={ onEditSchedule }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -10,6 +10,7 @@ import { useBatchDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-u
 import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ScheduleErrors } from './schedule-errors';
+import { ScheduleListCardNew } from './schedule-list-card-new';
 import { ScheduleListCards } from './schedule-list-cards';
 import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListFilter } from './schedule-list-filter';
@@ -120,7 +121,10 @@ export const ScheduleList = ( props: Props ) => {
 			<ScheduleErrors />
 
 			{ schedules.length === 0 && isLoading && <Spinner /> }
-			{ isScheduleEmpty && <ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } /> }
+			{ isScheduleEmpty && ! compact && (
+				<ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } />
+			) }
+			{ isScheduleEmpty && compact && <ScheduleListCardNew className="is-selected" /> }
 			{ ! isScheduleEmpty && ScheduleListComponent ? (
 				<>
 					<ScheduleListFilter compact={ compact } />

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -20,6 +20,7 @@ import './styles.scss';
 type Props = {
 	compact?: boolean;
 	previewMode: 'table' | 'card';
+	showNewScheduleBtn?: boolean;
 	selectedScheduleId?: string;
 	onEditSchedule: ( id: string ) => void;
 	onShowLogs: ( id: string, siteSlug: string ) => void;
@@ -30,6 +31,7 @@ export const ScheduleList = ( props: Props ) => {
 	const {
 		compact,
 		previewMode,
+		showNewScheduleBtn = true,
 		selectedScheduleId: initSelectedScheduleId,
 		onEditSchedule,
 		onShowLogs,
@@ -102,7 +104,7 @@ export const ScheduleList = ( props: Props ) => {
 		<div className="plugins-update-manager plugins-update-manager-multisite">
 			<div className="plugins-update-manager-multisite__header">
 				<h1>{ translate( 'Update schedules' ) }</h1>
-				{ ! isScheduleEmpty && (
+				{ showNewScheduleBtn && ! isScheduleEmpty && (
 					<Button
 						__next40pxDefaultSize={ ! compact }
 						isSmall={ compact }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -20,13 +20,21 @@ import './styles.scss';
 type Props = {
 	compact?: boolean;
 	previewMode: 'table' | 'card';
+	selectedScheduleId?: string;
 	onEditSchedule: ( id: string ) => void;
 	onShowLogs: ( id: string, siteSlug: string ) => void;
 	onCreateNewSchedule: () => void;
 };
 
 export const ScheduleList = ( props: Props ) => {
-	const { compact, previewMode, onEditSchedule, onShowLogs, onCreateNewSchedule } = props;
+	const {
+		compact,
+		previewMode,
+		selectedScheduleId: initSelectedScheduleId,
+		onEditSchedule,
+		onShowLogs,
+		onCreateNewSchedule,
+	} = props;
 	const {
 		data: schedules = [],
 		isLoading: isLoadingSchedules,
@@ -35,13 +43,16 @@ export const ScheduleList = ( props: Props ) => {
 	const translate = useTranslate();
 	const { searchTerm } = useContext( MultisitePluginUpdateManagerContext );
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
-	const [ selectedScheduleId, setSelectedScheduleId ] = useState< string | undefined >();
+	const [ selectedScheduleId, setSelectedScheduleId ] = useState< string | undefined >(
+		initSelectedScheduleId
+	);
 	const [ selectedSiteSlugs, setSelectedSiteSlugs ] = useState< string[] >( [] );
 
 	useEffect( () => {
 		const schedule = schedules?.find( ( schedule ) => schedule.schedule_id === selectedScheduleId );
 		setSelectedSiteSlugs( schedule?.sites?.map( ( site ) => site.slug ) || [] );
 	}, [ selectedScheduleId ] );
+	useEffect( () => setSelectedScheduleId( initSelectedScheduleId ), [ initSelectedScheduleId ] );
 
 	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation( selectedSiteSlugs );
 
@@ -114,6 +125,7 @@ export const ScheduleList = ( props: Props ) => {
 					<ScheduleListComponent
 						compact={ compact }
 						schedules={ filteredSchedules }
+						selectedScheduleId={ selectedScheduleId }
 						onRemoveClick={ openRemoveDialog }
 						onEditClick={ onEditSchedule }
 						onLogsClick={ onShowLogs }

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -102,6 +102,17 @@ $brand-display: "SF Pro Display", sans-serif;
 			border: 1px solid $studio-gray-10;
 			border-radius: 2px;
 
+			&.is-compact {
+				.plugins-update-manager-multisite-filter__search-icon {
+					width: 0.875rem;
+					margin: 0 0.5rem;
+				}
+
+				input {
+					font-size: 0.875rem;
+				}
+			}
+
 			.plugins-update-manager-multisite-filter__search-icon {
 				margin-left: 1rem;
 				margin-right: 0.875rem;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -97,7 +97,6 @@ $brand-display: "SF Pro Display", sans-serif;
 			flex: 1;
 
 			max-width: 30rem;
-			height: 3rem;
 			box-sizing: border-box;
 
 			border: 1px solid $studio-gray-10;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -182,7 +182,7 @@ $brand-display: "SF Pro Display", sans-serif;
 			border-top: solid 1px var(--studio-gray-0);
 		}
 
-		&.selected {
+		&.is-selected {
 			background: #f7faff;
 		}
 

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -174,6 +174,10 @@ $brand-display: "SF Pro Display", sans-serif;
 		text-align: left;
 		padding: 0;
 
+		@media screen and (max-width: $break-large) {
+			max-width: 100%;
+		}
+
 		p {
 			color: var(--studio-gray-100);
 			margin: 1.5rem auto;
@@ -193,6 +197,10 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		&.is-selected {
 			background: #f7faff;
+		}
+
+		&__new {
+			line-height: 2;
 		}
 
 		&__label {

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -76,11 +76,17 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 
 			&.expand {
+				min-width: 2rem;
+				text-align: center;
 				line-height: 1;
 
 				button {
 					margin-top: rem(2px);
 				}
+			}
+
+			&.menu {
+				text-align: center;
 			}
 		}
 

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -8,6 +8,13 @@ $brand-display: "SF Pro Display", sans-serif;
 		margin: 1rem;
 	}
 
+	&.plugins-update-manager-multisite-edit,
+	&.plugins-update-manager-multisite-create {
+		h1 {
+			font-size: 2rem !important;
+		}
+	}
+
 	h1 {
 		font-size: 2rem;
 		margin-bottom: 1rem;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -61,6 +61,10 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		th {
 			font-weight: 500;
+
+			&.expand {
+				width: 4rem;
+			}
 		}
 
 		td {
@@ -76,7 +80,6 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 
 			&.expand {
-				min-width: 2rem;
 				text-align: center;
 				line-height: 1;
 

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -4,7 +4,7 @@
 $brand-display: "SF Pro Display", sans-serif;
 
 .plugins-update-manager-multisite {
-	@media screen and (max-width: $break-small) {
+	@media screen and (max-width: 660px) {
 		margin: 1rem;
 	}
 

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -158,7 +158,11 @@ $brand-display: "SF Pro Display", sans-serif;
 
 	.plugins-update-manager-multisite-card {
 		margin-bottom: 1rem;
-		border-bottom: solid 1px var(--studio-gray-5);
+		border-bottom: solid 1px var(--studio-gray-0);
+
+		&:first-child {
+			border-top: solid 1px var(--studio-gray-0);
+		}
 
 		&__label {
 			font-size: 0.875rem;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -182,6 +182,10 @@ $brand-display: "SF Pro Display", sans-serif;
 			border-top: solid 1px var(--studio-gray-0);
 		}
 
+		&.selected {
+			background: #f7faff;
+		}
+
 		&__label {
 			font-size: 0.875rem;
 			margin-bottom: 0.75rem;

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -1,4 +1,4 @@
-import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { __experimentalText as Text } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
@@ -29,7 +29,7 @@ interface Props {
 export const ScheduleForm = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
-	const isMobile = useMobileBreakpoint();
+	const isSmallScreen = useBreakpoint( '<660px' );
 	const { isEligibleForFeature } = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
 
@@ -175,7 +175,7 @@ export const ScheduleForm = ( props: Props ) => {
 				selectedPlugins={ selectedPlugins }
 				isPluginsFetching={ isPluginsFetching }
 				isPluginsFetched={ isPluginsFetched }
-				borderWrapper={ ! isMobile }
+				borderWrapper={ ! isSmallScreen }
 				error={ validationErrors?.plugins }
 				showError={ fieldTouched?.plugins }
 				onChange={ setSelectedPlugins }

--- a/client/blocks/plugins-scheduled-updates/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list.tsx
@@ -1,4 +1,4 @@
-import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useBreakpoint } from '@automattic/viewport-react';
 import {
 	__experimentalText as Text,
 	__experimentalConfirmDialog as ConfirmDialog,
@@ -37,7 +37,7 @@ interface Props {
 export const ScheduleList = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
-	const isMobile = useMobileBreakpoint();
+	const isSmallScreen = useBreakpoint( '<660px' );
 	const { isEligibleForFeature, loading: isEligibleForFeatureLoading } = useIsEligibleForFeature();
 	const { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading } =
 		useSiteHasEligiblePlugins();
@@ -143,7 +143,7 @@ export const ScheduleList = ( props: Props ) => {
 						schedules.length > 0 &&
 						canCreateSchedules && (
 							<>
-								{ isMobile ? (
+								{ isSmallScreen ? (
 									<ScheduleListCards
 										onRemoveClick={ openRemoveDialog }
 										onEditClick={ onEditSchedule }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -188,30 +188,38 @@ export function scheduledUpdates( context, next ) {
 
 export function scheduledUpdatesMultisite( context, next ) {
 	const goToScheduledUpdatesList = () => page.show( `/plugins/scheduled-updates/` );
+	const goToScheduleEdit = ( id ) => page.show( `/plugins/scheduled-updates/edit/${ id }` );
+	const goToScheduleLogs = ( id, siteSlug ) =>
+		page.show( `/plugins/scheduled-updates/logs/${ siteSlug }/${ id }?multisite` );
+	const goToScheduleCreate = () => page.show( `/plugins/scheduled-updates/create/` );
+
+	const callbackHandlers = {
+		onNavBack: goToScheduledUpdatesList,
+		onShowLogs: goToScheduleLogs,
+		onEditSchedule: goToScheduleEdit,
+		onCreateNewSchedule: goToScheduleCreate,
+	};
+
 	switch ( context.params.action ) {
 		case 'create':
 			context.primary = createElement( PluginsScheduledUpdatesMultisite, {
-				onNavBack: goToScheduledUpdatesList,
 				context: 'create',
+				...callbackHandlers,
 			} );
 			break;
 
 		case 'edit':
 			context.primary = createElement( PluginsScheduledUpdatesMultisite, {
-				onNavBack: goToScheduledUpdatesList,
 				id: context.params.id,
 				context: 'edit',
+				...callbackHandlers,
 			} );
 			break;
 
 		default:
 			context.primary = createElement( PluginsScheduledUpdatesMultisite, {
-				onNavBack: goToScheduledUpdatesList,
 				context: 'list',
-				onEditSchedule: ( id ) => page.show( `/plugins/scheduled-updates/edit/${ id }` ),
-				onShowLogs: ( id, siteSlug ) =>
-					page.show( `/plugins/scheduled-updates/logs/${ siteSlug }/${ id }?multisite` ),
-				onCreateNewSchedule: () => page.show( `/plugins/scheduled-updates/create/` ),
+				...callbackHandlers,
 			} );
 			break;
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -93,14 +93,6 @@ body.is-section-plugins {
 			@include breakpoint-deprecated( "<660px" ) {
 				padding: 1rem 0;
 			}
-
-			@include breakpoint-deprecated( "<660px" ) {
-				padding: 1rem 0;
-			}
-
-			@include breakpoint-deprecated( "<480px" ) {
-				padding: 1rem 0;
-			}
 		}
 
 		.empty-state {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -88,6 +88,10 @@ body.is-section-plugins {
 			@include breakpoint-deprecated( "<600px" ) {
 				padding: 1rem 0;
 			}
+
+			@include breakpoint-deprecated( "<480px" ) {
+				padding: 1rem 0;
+			}
 		}
 	}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -69,6 +69,10 @@ body.is-section-plugins {
 			margin: 0;
 			padding: 0.5rem 1.5rem;
 		}
+
+		@include breakpoint-deprecated( "<960px" ) {
+			display: none;
+		}
 	}
 
 	.a4a-layout-column.scheduled-updates-list {
@@ -76,12 +80,24 @@ body.is-section-plugins {
 		.plugins-update-manager-multisite-filter {
 			margin: 0;
 			padding: 1.5rem 4rem;
+
+			@include breakpoint-deprecated( "<960px" ) {
+				padding: 1rem;
+			}
+
+			@include breakpoint-deprecated( "<600px" ) {
+				padding: 1rem 0;
+			}
 		}
 	}
 
 	.a4a-layout-column.scheduled-updates-edit,
 	.a4a-layout-column.scheduled-updates-create {
 		padding: 3rem;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			padding: 0.5rem;
+		}
 	}
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -47,10 +47,19 @@
 body.is-section-plugins {
 	background: var(--studio-gray-0);
 
-	.schedules-list {
+	.a4a-layout-column {
+		overflow: scroll;
+	}
+
+	.a4a-layout-column.scheduled-updates-list-compact {
 		width: 400px;
 		flex: unset;
 		transition: all 0.2s;
+	}
+
+	.a4a-layout-column.scheduled-updates-edit,
+	.a4a-layout-column.scheduled-updates-create {
+		padding: 3rem;
 	}
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -94,6 +94,10 @@ body.is-section-plugins {
 				padding: 1rem 0;
 			}
 
+			@include breakpoint-deprecated( "<660px" ) {
+				padding: 1rem 0;
+			}
+
 			@include breakpoint-deprecated( "<480px" ) {
 				padding: 1rem 0;
 			}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -90,7 +90,7 @@ body.is-section-plugins {
 				padding: 1rem;
 			}
 
-			@include breakpoint-deprecated( "<600px" ) {
+			@include breakpoint-deprecated( "<660px" ) {
 				padding: 1rem 0;
 			}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -55,6 +55,28 @@ body.is-section-plugins {
 		width: 400px;
 		flex: unset;
 		transition: all 0.2s;
+
+		.plugins-update-manager-multisite__header {
+			padding: 1rem 1.125rem;
+		}
+
+		.plugins-update-manager-multisite-filter {
+			margin: 0;
+			padding: 1rem 1.5rem;
+		}
+
+		.plugins-update-manager-multisite-card {
+			margin: 0;
+			padding: 0.5rem 1.5rem;
+		}
+	}
+
+	.a4a-layout-column.scheduled-updates-list {
+		.plugins-update-manager-multisite__header,
+		.plugins-update-manager-multisite-filter {
+			margin: 0;
+			padding: 1.5rem 4rem;
+		}
 	}
 
 	.a4a-layout-column.scheduled-updates-edit,

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -44,6 +44,16 @@
 	}
 }
 
+body.is-section-plugins {
+	background: var(--studio-gray-0);
+
+	.schedules-list {
+		width: 400px;
+		flex: unset;
+		transition: all 0.2s;
+	}
+}
+
 body.is-section-plugins.theme-default.color-scheme {
 	--color-surface-backdrop: var(--studio-white);
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -73,6 +73,11 @@ body.is-section-plugins {
 		@include breakpoint-deprecated( "<960px" ) {
 			display: none;
 		}
+
+		.empty-state {
+			max-width: 100%;
+			padding: 0 1rem;
+		}
 	}
 
 	.a4a-layout-column.scheduled-updates-list {
@@ -91,6 +96,14 @@ body.is-section-plugins {
 
 			@include breakpoint-deprecated( "<480px" ) {
 				padding: 1rem 0;
+			}
+		}
+
+		.empty-state {
+			padding: 0 4rem;
+
+			@include breakpoint-deprecated( "<960px" ) {
+				padding: 0 1rem;
 			}
 		}
 	}

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -22,6 +22,14 @@ export default function globalSidebarMenu() {
 			type: 'menu-item',
 			url: '/domains/manage',
 		},
+		{
+			icon: 'dashicons-admin-plugins',
+			slug: 'plugins',
+			title: translate( 'Plugins' ),
+			navigationLabel: translate( 'Update schedules' ),
+			type: 'menu-item',
+			url: '/plugins/scheduled-updates',
+		},
 		{ type: 'separator' },
 		{
 			icon: (

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -22,14 +22,6 @@ export default function globalSidebarMenu() {
 			type: 'menu-item',
 			url: '/domains/manage',
 		},
-		{
-			icon: 'dashicons-admin-plugins',
-			slug: 'plugins',
-			title: translate( 'Plugins' ),
-			navigationLabel: translate( 'Update schedules' ),
-			type: 'menu-item',
-			url: '/plugins/scheduled-updates',
-		},
 		{ type: 'separator' },
 		{
 			icon: (

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -182,7 +182,8 @@
 }
 
 .wpcom-site .is-group-sites.is-global-sidebar-collapsed,
-.wpcom-site .is-group-sites.is-global-sidebar-visible:has(.sites-dashboard.sites-dashboard__layout) {
+.wpcom-site .is-group-sites.is-global-sidebar-visible:has(.sites-dashboard.sites-dashboard__layout),
+.wpcom-site .is-group-sites.is-global-sidebar-visible.is-section-plugins {
 	.layout__content {
 		min-height: 100vh;
 
@@ -492,7 +493,8 @@
 
 // Override styles from my-sites/sidebar
 .wpcom-site div.is-group-sites:not(.has-no-masterbar),
-.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) {
+.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar),
+.wpcom-site div.is-section-plugins:not(.has-no-masterbar) {
 	&.focus-content .layout__content,
 	&.focus-sidebar .layout__content {
 		padding-bottom: 0;
@@ -517,7 +519,8 @@
 	}
 }
 
-.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {
+.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper,
+.wpcom-site div.is-section-plugins:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {
 	max-height: calc(100vh - 276px); /* 276px is the size of all the height above and below the dataviews-view-table-wrapper */
 
 	// With 48px padding.

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -56,8 +56,8 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
 	const pluginsScheduledUpdatesEditMode =
-		state.route.path?.current?.includes( 'scheduled-updates/edit' ) ||
-		state.route.path?.current?.includes( 'scheduled-updates/create' );
+		state.route.path?.current?.endsWith( 'scheduled-updates/edit' ) ||
+		state.route.path?.current?.endsWith( 'scheduled-updates/create' );
 
 	return (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -56,15 +56,15 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
 	const pluginsScheduledUpdatesEditMode =
-		state.route.path?.current?.endsWith( 'scheduled-updates/edit' ) ||
-		state.route.path?.current?.endsWith( 'scheduled-updates/create' );
+		state.route.path?.current?.includes( 'scheduled-updates/edit' ) ||
+		state.route.path?.current?.includes( 'scheduled-updates/create' );
 
 	return (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
 		isAllowedRegion &&
 		( siteSelected ||
 			siteLoaded ||
-			pluginsScheduledUpdatesEditMode ||
+			( ! siteSelected && pluginsScheduledUpdatesEditMode ) ||
 			isWithinBreakpoint( '<782px' ) )
 	);
 };

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -64,7 +64,7 @@ export const getShouldShowCollapsedGlobalSidebar = (
 		isAllowedRegion &&
 		( siteSelected ||
 			siteLoaded ||
-			( ! siteSelected && pluginsScheduledUpdatesEditMode ) ||
+			( ! siteId && pluginsScheduledUpdatesEditMode ) ||
 			isWithinBreakpoint( '<782px' ) )
 	);
 };

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -51,14 +51,21 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	sectionGroup: string,
 	sectionName: string
 ) => {
-	const isAllowedRegion = sectionGroup === 'sites-dashboard' || sectionGroup === 'sites';
+	const isAllowedRegion =
+		sectionGroup === 'sites-dashboard' || sectionGroup === 'sites' || sectionName === 'plugins';
 	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
+	const pluginsScheduledUpdatesEditMode =
+		state.route.path?.current?.includes( 'scheduled-updates/edit' ) ||
+		state.route.path?.current?.includes( 'scheduled-updates/create' );
 
 	return (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
 		isAllowedRegion &&
-		( siteSelected || siteLoaded || isWithinBreakpoint( '<782px' ) )
+		( siteSelected ||
+			siteLoaded ||
+			pluginsScheduledUpdatesEditMode ||
+			isWithinBreakpoint( '<782px' ) )
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90151

## Proposed Changes

* Adapt multisite scheduled updates inside the new layout
* Update the `schedule-list` component to support compact version of presentation
* Update CSS to match the Figma proposal
* Update CSS to support mobile resolutions

## Testing Instructions

* Open live link
* Go to `/plugins/scheduled-updates?flags=plugins/multisite-scheduled-updates`
* Check how the feature acts inside the new layout
* Check how existing schedule list works

![Screen Capture on 2024-05-08 at 19-22-05](https://github.com/Automattic/wp-calypso/assets/1241413/06294292-922f-4bc5-894a-3cfdfe9b2ed1)

![Screen Capture on 2024-05-09 at 12-35-58](https://github.com/Automattic/wp-calypso/assets/1241413/9f150e27-3209-4982-94c3-5c80cf7582ba)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
