### PR TITLE
Nav Redesign: Add frame around Reader pages like /sites

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -403,6 +403,10 @@ body.is-mobile-app-view {
 // Ensure reader streams have the neutral background.
 .layout.is-section-reader {
 	min-height: 100vh;
+
+	&.has-header-section {
+		background: var(--studio-white);
+	}
 	.section-header.card {
 		box-shadow: none;
 		margin-bottom: 24px;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -402,11 +402,7 @@ body.is-mobile-app-view {
 
 // Ensure reader streams have the neutral background.
 .layout.is-section-reader {
-	background: var(--studio-white); // TODO: Remove after nav-redesign-v2 for reader is done.
 	min-height: 100vh;
-	.layout__content {
-		background: var(--studio-white); // TODO: Remove after nav-redesign-v2 for reader is done.
-	}
 	.section-header.card {
 		box-shadow: none;
 		margin-bottom: 24px;

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -9,7 +9,7 @@
 	bottom: 0;
 	min-width: 400px;
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@media only screen and ( max-width: 600px ) {
 		width: 100%;
 		min-width: 0;
 	}
@@ -176,6 +176,18 @@ div.reader-notifications__panel {
 
 			@media only screen and ( max-width: 783px ) {
 				left: 0;
+			}
+			@media only screen and ( min-width: 783px ) {
+				top: 24px;
+				height: calc(100vh - 40px);
+				border-bottom-left-radius: 8px; /* stylelint-disable-line scales/radii */
+			}
+			@media only screen and ( min-width: 601px ) and ( max-width: 783px ) {
+				top: calc(var(--masterbar-height) + 24px);
+				height: calc(100vh - 48px - var(--masterbar-height));
+				left: 24px;
+				border-top-left-radius: 8px; /* stylelint-disable-line scales/radii */
+				border-bottom-left-radius: 8px; /* stylelint-disable-line scales/radii */
 			}
 		}
 		.wpnc__list-view .wpnc__selected-note {

--- a/client/reader/components/reader-main/index.jsx
+++ b/client/reader/components/reader-main/index.jsx
@@ -44,10 +44,12 @@ export default class ReaderMain extends Component {
 	render() {
 		const { children, ...props } = this.props;
 		return (
-			<Main { ...props }>
-				<SyncReaderFollows key="syncReaderFollows" />
-				{ children }
-			</Main>
+			<div>
+				<Main { ...props }>
+					<SyncReaderFollows key="syncReaderFollows" />
+					{ children }
+				</Main>
+			</div>
 		);
 	}
 }

--- a/client/reader/components/reader-main/style.scss
+++ b/client/reader/components/reader-main/style.scss
@@ -1,8 +1,3 @@
-body.is-reader-page,
-.is-reader-page .layout {
-	background-color: var(--color-surface); // TODO: Remove after nav-redesign-v2 for reader is done.
-}
-
 .is-reader-page .list-end {
 	border-top: none;
 

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -28,11 +28,6 @@ export default function ( props ) {
 
 	return (
 		<>
-			<NavigationHeader
-				title={ translate( 'Conversations' ) }
-				subtitle={ translate( 'Monitor all of your ongoing discussions.' ) }
-				className="conversations__header"
-			/>
 			<Stream
 				key="conversations"
 				streamKey={ props.streamKey }
@@ -44,6 +39,11 @@ export default function ( props ) {
 				intro={ intro }
 			>
 				<ConversationTitle title={ props.title } />
+				<NavigationHeader
+					title={ translate( 'Conversations' ) }
+					subtitle={ translate( 'Monitor all of your ongoing discussions.' ) }
+					className="conversations__header"
+				/>
 			</Stream>
 		</>
 	);

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -2,7 +2,7 @@
 	margin: 0 auto;
 	max-width: 600px;
 	@media only screen and (max-width: 660px) {
-		padding: 30px 16px 0 16px;
+		padding: 0 24px;
 	}
 }
 

--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -12,6 +12,9 @@
 	margin-bottom: -20px;
 	max-width: 600px; // Max width of single column reader stream.
 	overflow: hidden;
+	@media only screen and (max-width: 600px) {
+		padding: 0 24px;
+	}
 
 	&.reader-dual-column {
 		max-width: 968px; // Max width of dual column reader stream.

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -1,6 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
-import { Global, css } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -26,113 +24,6 @@ import {
 } from './helper';
 
 const DiscoverStream = ( props ) => {
-	let navRedesignV2GlobalStyles;
-	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		navRedesignV2GlobalStyles = css`
-			html {
-				overflow-y: auto;
-			}
-			body.is-reader-page,
-			.is-reader-page .layout,
-			.layout.is-section-reader,
-			.layout.is-section-reader .layout__content,
-			.is-section-reader {
-				background: initial;
-			}
-			body.is-section-reader {
-				background: var( --studio-gray-0 );
-
-				&.rtl .layout__content {
-					padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
-				}
-
-				.layout__content {
-					// Add border around everything
-					overflow: hidden;
-					min-height: 100vh;
-					@media only screen and ( min-width: 782px ) {
-						padding: 16px 16px 16px calc( var( --sidebar-width-max ) ) !important;
-					}
-					.layout_primary > div {
-						padding-bottom: 0;
-					}
-				}
-
-				.layout__secondary .global-sidebar {
-					border: none;
-				}
-
-				.has-no-masterbar .layout__content .main {
-					padding-top: 16px;
-				}
-
-				div.layout.is-global-sidebar-visible {
-					.main {
-						@media only screen and ( min-width: 600px ) and ( max-width: 960px ) {
-							padding: 24px;
-						}
-						@media only screen and ( max-width: 660px ) {
-							padding-top: 0;
-						}
-						border-block-end: 1px solid var( --studio-gray-0 );
-					}
-					.layout__primary > div {
-						background: var( --color-surface );
-						border-radius: 8px;
-						box-shadow: none;
-						@media only screen and ( min-width: 600px ) {
-							height: calc( 100vh - var( --masterbar-height ) - 50px );
-						}
-						@media only screen and ( min-width: 782px ) {
-							height: calc( 100vh - 32px );
-						}
-						overflow: hidden;
-					}
-					.layout__primary > div > div {
-						height: 100%;
-						overflow-y: auto;
-						overflow-x: hidden;
-					}
-				}
-
-				@media only screen and ( max-width: 600px ) {
-					.navigation-header__main {
-						justify-content: normal;
-						align-items: center;
-						.formatted-header {
-							flex: none;
-						}
-					}
-				}
-
-				@media only screen and ( max-width: 781px ) {
-					div.layout.is-global-sidebar-visible {
-						.layout__primary {
-							overflow-x: auto;
-						}
-					}
-					.layout__primary > div {
-						background: var( --color-surface );
-						margin: 0;
-						border-radius: 8px;
-						height: calc( 100vh - 32px );
-					}
-				}
-
-				.is-discover-stream {
-					header.navigation-header.discover-stream-header {
-						padding: 0;
-					}
-					@media only screen and ( max-width: 660px ) {
-						.discover-stream-navigation {
-							margin-left: 0;
-							margin-right: 0;
-						}
-					}
-				}
-			}
-		`;
-	}
 	const locale = useLocale();
 	const translate = useTranslate();
 	const followedTags = useSelector( getReaderFollowedTags );
@@ -237,7 +128,6 @@ const DiscoverStream = ( props ) => {
 
 	return (
 		<>
-			<Global styles={ navRedesignV2GlobalStyles } />
 			<Stream { ...streamProps }>
 				{ DiscoverHeader() }
 				<DiscoverNavigation

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,5 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { Global, css } from '@emotion/react';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
@@ -13,109 +11,9 @@ import FollowingIntro from './intro';
 import './style.scss';
 
 function FollowingStream( { ...props } ) {
-	let navRedesignV2GlobalStyles;
-	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		navRedesignV2GlobalStyles = css`
-			html {
-				overflow-y: auto;
-			}
-			body.is-reader-page,
-			.is-reader-page .layout,
-			.layout.is-section-reader,
-			.layout.is-section-reader .layout__content,
-			.is-section-reader {
-				background: initial;
-			}
-			body.is-section-reader {
-				background: var( --studio-gray-0 );
-
-				&.rtl .layout__content {
-					padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
-				}
-
-				.layout__content {
-					// Add border around everything
-					overflow: hidden;
-					min-height: 100vh;
-					@media only screen and ( min-width: 782px ) {
-						padding: 16px 16px 16px calc( var( --sidebar-width-max ) ) !important;
-					}
-					.layout_primary > div {
-						padding-bottom: 0;
-					}
-				}
-
-				.layout__secondary .global-sidebar {
-					border: none;
-				}
-
-				.has-no-masterbar .layout__content .main {
-					padding-top: 16px;
-				}
-
-				div.layout.is-global-sidebar-visible {
-					.main {
-						@media only screen and ( min-width: 600px ) and ( max-width: 960px ) {
-							padding: 24px;
-						}
-						@media only screen and ( max-width: 660px ) {
-							padding-top: 0;
-						}
-						border-block-end: 1px solid var( --studio-gray-0 );
-					}
-					.layout__primary > div {
-						background: var( --color-surface );
-						border-radius: 8px;
-						box-shadow: none;
-						@media only screen and ( min-width: 600px ) {
-							height: calc( 100vh - var( --masterbar-height ) - 50px );
-						}
-						@media only screen and ( min-width: 782px ) {
-							height: calc( 100vh - 32px );
-						}
-						overflow: hidden;
-					}
-					.layout__primary > div > div {
-						height: 100%;
-						overflow-y: auto;
-						overflow-x: hidden;
-					}
-				}
-
-				@media only screen and ( max-width: 600px ) {
-					.navigation-header__main {
-						justify-content: normal;
-						align-items: center;
-						.formatted-header {
-							flex: none;
-						}
-					}
-				}
-
-				@media only screen and ( max-width: 781px ) {
-					div.layout.is-global-sidebar-visible {
-						.layout__primary {
-							overflow-x: auto;
-						}
-					}
-					.layout__primary > div {
-						background: var( --color-surface );
-						margin: 0;
-						border-radius: 8px;
-						height: calc( 100vh - 32px );
-					}
-					header.navigation-header {
-						padding-inline: 16px;
-						padding-bottom: 0;
-					}
-				}
-			}
-		`;
-	}
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<>
-			<Global styles={ navRedesignV2GlobalStyles } />
 			<Stream
 				{ ...props }
 				className="following"

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -20,6 +20,14 @@
 
 .following.main  .section-nav {
 	margin-top: 0;
+
+	.section-nav-tabs__list {
+		.section-nav-tab__link {
+			&:hover {
+				background-color: transparent;
+			}
+		}
+	}
 }
 
 .following .search {

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -10,7 +10,7 @@
 		margin-bottom: 24px;
 	}
 
-	@media (max-width: 660px) {
+	@media (max-width: 600px) {
 		margin: 0 16px;
 		.navigation-header__main {
 			min-height: auto;

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -18,18 +18,22 @@ const exported = {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		context.primary = createElement( LikedPostsStream, {
-			key: 'liked',
-			streamKey,
-			trackScrollPage: trackScrollPage.bind(
-				null,
-				basePath,
-				fullAnalyticsPageTitle,
-				analyticsPageTitle,
-				mcKey
-			),
-			onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-		} );
+		context.primary = (
+			<div>
+				{ createElement( LikedPostsStream, {
+					key: 'liked',
+					streamKey,
+					trackScrollPage: trackScrollPage.bind(
+						null,
+						basePath,
+						fullAnalyticsPageTitle,
+						analyticsPageTitle,
+						mcKey
+					),
+					onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+				} ) }
+			</div>
+		);
 		next();
 	},
 };

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -18,11 +18,6 @@ class LikedStream extends Component {
 	render() {
 		return (
 			<>
-				<NavigationHeader
-					title={ translate( 'Likes' ) }
-					subtitle={ translate( 'Rediscover content that you liked.' ) }
-					className="liked-stream-header"
-				/>
 				<Stream
 					{ ...this.props }
 					listName={ title }
@@ -30,6 +25,11 @@ class LikedStream extends Component {
 					showFollowInHeader={ true }
 				>
 					<DocumentHead title={ documentTitle } />
+					<NavigationHeader
+						title={ translate( 'Likes' ) }
+						subtitle={ translate( 'Rediscover content that you liked.' ) }
+						className="liked-stream-header"
+					/>
 				</Stream>
 			</>
 		);

--- a/client/reader/liked-stream/style.scss
+++ b/client/reader/liked-stream/style.scss
@@ -2,7 +2,7 @@
 	margin: 0 auto;
 	max-width: 600px;
 	@media only screen and (max-width: 660px) {
-		padding: 30px 16px 0;
+		padding: 0 16px;
 
 		.navigation-header__main {
 			min-height: auto;

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -44,7 +44,7 @@ const SpacerDiv = withDimensions( ( { width, height } ) => (
 	<div
 		style={ {
 			width: `${ width }px`,
-			height: `${ height - 38 }px`,
+			height: `${ height - 16 }px`,
 		} }
 	/>
 ) );

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -40,15 +40,6 @@ const updateQueryArg = ( params ) =>
 
 const pickSort = ( sort ) => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
 
-const SpacerDiv = withDimensions( ( { width, height } ) => (
-	<div
-		style={ {
-			width: `${ width }px`,
-			height: `${ height - 16 }px`,
-		} }
-	/>
-) );
-
 class SearchStream extends React.Component {
 	static propTypes = {
 		query: PropTypes.string,
@@ -221,7 +212,7 @@ class SearchStream extends React.Component {
 						/>
 					) }
 				</div>
-				{ isLoggedIn && <SpacerDiv domTarget={ this.fixedAreaRef } /> }
+				{ /* { isLoggedIn && <SpacerDiv domTarget={ this.fixedAreaRef } /> } */ }
 				{ ! hidePostsAndSites && wideDisplay && (
 					<div className={ searchStreamResultsClasses }>
 						<div className="search-stream__post-results">

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -8,9 +8,6 @@
 		margin: 0 auto;
 		padding: 16px 0 16px 0;
 	}
-	@include breakpoint-deprecated( "<660px" ) {
-		padding: 0 16px; // Intentionally padding, not margin
-	}
 }
 
 // .has-header-section only applies for logged out views
@@ -69,11 +66,11 @@
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
 
-	@media only screen and (max-width: 600px) {
-		width: calc(100% - 80px);
-	}
+	// @media only screen and (max-width: 600px) {
+	// 	width: calc(100% - 80px);
+	// }
 	@media only screen and (min-width: 601px) and (max-width: 781px) {
-		margin-top: calc(var(--masterbar-height) + 32px);
+		margin-top: calc(var(--masterbar-height) + 25px);
 	}
 	@media only screen and (min-width: 601px) and (max-width: 660px) {
 		width: calc(100% - 128px);

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -66,9 +66,6 @@
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
 
-	// @media only screen and (max-width: 600px) {
-	// 	width: calc(100% - 80px);
-	// }
 	@media only screen and (min-width: 601px) and (max-width: 781px) {
 		margin-top: calc(var(--masterbar-height) + 25px);
 	}

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -70,7 +70,7 @@
 		margin-top: calc(var(--masterbar-height) + 25px);
 	}
 	@media only screen and (min-width: 601px) and (max-width: 660px) {
-		width: calc(100% - 128px);
+		width: calc(100% - 96px);
 	}
 	@media only screen and (min-width: 782px) {
 		margin-top: 16px;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -25,6 +25,8 @@
 
 .is-reader-page .main.search-stream {
 	max-width: 905px;
+	margin: 0 auto;
+	padding-inline: 24px;
 }
 
 .search-stream__intro {
@@ -67,11 +69,17 @@
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
 
-	@include breakpoint-deprecated( "<660px" ) {
-		width: calc(100% - 32px);
+	@media only screen and (max-width: 600px) {
+		width: calc(100% - 80px);
 	}
-	@include breakpoint-deprecated( ">660px" ) {
-		padding-top: 30px;
+	@media only screen and (min-width: 601px) and (max-width: 781px) {
+		margin-top: calc(var(--masterbar-height) + 32px);
+	}
+	@media only screen and (min-width: 601px) and (max-width: 660px) {
+		width: calc(100% - 128px);
+	}
+	@media only screen and (min-width: 782px) {
+		margin-top: 16px;
 	}
 }
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -19,11 +19,22 @@
 	margin-bottom: 4px;
 }
 
+.layout.has-header-section.is-section-reader {
+
+	.layout__content {
+		background: var(--studio-white);
+	}
+	.main.search-stream {
+		padding-inline: 0;
+	}
+}
+
 
 .is-reader-page .main.search-stream {
 	max-width: 905px;
 	margin: 0 auto;
 	padding-inline: 24px;
+	padding-top: 0 !important;
 }
 
 .search-stream__intro {
@@ -60,20 +71,13 @@
 
 .is-reader-page .search-stream__fixed-area {
 	background: var(--studio-white);
-	position: fixed;
+	position: sticky;
 	top: 0;
-	margin-top: var(--masterbar-height);
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
 
-	@media only screen and (min-width: 601px) and (max-width: 781px) {
-		margin-top: calc(var(--masterbar-height) + 25px);
-	}
 	@media only screen and (min-width: 601px) and (max-width: 660px) {
 		width: calc(100% - 96px);
-	}
-	@media only screen and (min-width: 782px) {
-		margin-top: 16px;
 	}
 }
 

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -65,28 +65,34 @@ const exported = {
 		context.renderHeaderSection = renderHeaderSection;
 
 		context.primary = (
-			<AsyncLoad
-				require="calypso/reader/search-stream"
-				key="search"
-				streamKey={ streamKey }
-				isSuggestion={ isQuerySuggestion }
-				query={ searchSlug }
-				sort={ sort }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				showBack={ false }
-				autoFocusInput={ autoFocusInput }
-				onQueryChange={ reportQueryChange }
-				onSortChange={ reportSortChange }
-				searchType={ show }
-				trendingTags={ context.params.trendingTags }
-			/>
+			<>
+				<div>
+					<div>
+						<AsyncLoad
+							require="calypso/reader/search-stream"
+							key="search"
+							streamKey={ streamKey }
+							isSuggestion={ isQuerySuggestion }
+							query={ searchSlug }
+							sort={ sort }
+							trackScrollPage={ trackScrollPage.bind(
+								null,
+								basePath,
+								fullAnalyticsPageTitle,
+								analyticsPageTitle,
+								mcKey
+							) }
+							onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+							showBack={ false }
+							autoFocusInput={ autoFocusInput }
+							onQueryChange={ reportQueryChange }
+							onSortChange={ reportSortChange }
+							searchType={ show }
+							trendingTags={ context.params.trendingTags }
+						/>
+					</div>
+				</div>
+			</>
 		);
 		next();
 	},

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -59,10 +59,10 @@ body.is-reader-page,
 .is-reader-page .layout,
 .layout.is-section-reader,
 .layout.is-section-reader .layout__content,
-.is-section-reader {
+.is-section-reader:not(.is-reader-full-post) {
 	background: initial;
 }
-body.is-section-reader {
+body.is-section-reader:not(.is-reader-full-post) {
 	background: var(--studio-gray-0);
 
 	&.rtl .layout__content {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -145,6 +145,9 @@ body.is-section-reader {
 	.is-discover-stream {
 		header.navigation-header.discover-stream-header {
 			padding: 0;
+			@media only screen and (max-width: 600px) {
+				padding: 0 24px;
+			}
 		}
 		@media only screen and (max-width: 660px) {
 			.discover-stream-navigation {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -52,6 +52,109 @@
 	}
 }
 
+html {
+	overflow-y: auto;
+}
+body.is-reader-page,
+.is-reader-page .layout,
+.layout.is-section-reader,
+.layout.is-section-reader .layout__content,
+.is-section-reader {
+	background: initial;
+}
+body.is-section-reader {
+	background: var(--studio-gray-0);
+
+	&.rtl .layout__content {
+		padding: 16px calc(var(--sidebar-width-max)) 16px 16px;
+	}
+
+	.layout__content {
+		// Add border around everything
+		overflow: hidden;
+		min-height: 100vh;
+		@media only screen and (min-width: 782px) {
+			padding: 16px 16px 16px calc(var(--sidebar-width-max)) !important;
+		}
+		.layout_primary > div {
+			padding-bottom: 0;
+		}
+	}
+
+	.layout__secondary .global-sidebar {
+		border: none;
+	}
+
+	.has-no-masterbar .layout__content .main {
+		padding-top: 16px;
+	}
+
+	div.layout.is-global-sidebar-visible {
+		.main {
+			@media only screen and (min-width: 600px) and (max-width: 960px) {
+				padding: 24px;
+			}
+			@media only screen and (max-width: 660px) {
+				padding-top: 0;
+			}
+			border-block-end: 1px solid var(--studio-gray-0);
+		}
+		.layout__primary > div {
+			background: var(--color-surface);
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			box-shadow: none;
+			@media only screen and (min-width: 600px) {
+				height: calc(100vh - var(--masterbar-height) - 50px);
+			}
+			@media only screen and (min-width: 782px) {
+				height: calc(100vh - 32px);
+			}
+			overflow: hidden;
+		}
+		.layout__primary > div > div {
+			height: 100%;
+			overflow-y: auto;
+			overflow-x: hidden;
+		}
+	}
+
+	@media only screen and (max-width: 600px) {
+		.navigation-header__main {
+			justify-content: normal;
+			align-items: center;
+			.formatted-header {
+				flex: none;
+			}
+		}
+	}
+
+	@media only screen and (max-width: 781px) {
+		div.layout.is-global-sidebar-visible {
+			.layout__primary {
+				overflow-x: auto;
+			}
+		}
+		.layout__primary > div {
+			background: var(--color-surface);
+			margin: 0;
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			height: calc(100vh - 32px);
+		}
+	}
+
+	.is-discover-stream {
+		header.navigation-header.discover-stream-header {
+			padding: 0;
+		}
+		@media only screen and (max-width: 660px) {
+			.discover-stream-navigation {
+				margin-left: 0;
+				margin-right: 0;
+			}
+		}
+	}
+}
+
 .is-section-reader {
 	.sidebar__menu {
 		user-select: none;

--- a/client/reader/site-subscriptions-manager/comment-subscriptions-manager/comment-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/comment-subscriptions-manager/comment-subscriptions-manager.tsx
@@ -6,12 +6,18 @@ const CommentSubscriptionsManager = () => {
 	const translate = useTranslate();
 
 	return (
-		<SubscriptionsManagerWrapper
-			headerText={ translate( 'Manage subscribed posts' ) }
-			subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
-		>
-			<Comments />
-		</SubscriptionsManagerWrapper>
+		<>
+			<div>
+				<div>
+					<SubscriptionsManagerWrapper
+						headerText={ translate( 'Manage subscribed posts' ) }
+						subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
+					>
+						<Comments />
+					</SubscriptionsManagerWrapper>
+				</div>
+			</div>
+		</>
 	);
 };
 

--- a/client/reader/site-subscriptions-manager/pending-subscriptions-manager/pending-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/pending-subscriptions-manager/pending-subscriptions-manager.tsx
@@ -6,12 +6,18 @@ const PendingSubscriptionsManager = () => {
 	const translate = useTranslate();
 
 	return (
-		<SubscriptionsManagerWrapper
-			headerText={ translate( 'Manage pending subscriptions' ) }
-			subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
-		>
-			<Pending />
-		</SubscriptionsManagerWrapper>
+		<>
+			<div>
+				<div>
+					<SubscriptionsManagerWrapper
+						headerText={ translate( 'Manage pending subscriptions' ) }
+						subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
+					>
+						<Pending />
+					</SubscriptionsManagerWrapper>
+				</div>
+			</div>
+		</>
 	);
 };
 

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -12,23 +12,29 @@ const SiteSubscriptionsManager = () => {
 	const translate = useTranslate();
 
 	return (
-		<SubscriptionsManagerWrapper
-			actionButton={ <AddSitesButton /> }
-			ellipsisMenuItems={
-				<VStack spacing={ 1 }>
-					<ReaderImportButton icon={ uploadCloud } iconSize={ 20 } />
-					<ReaderExportButton
-						icon={ downloadCloud }
-						iconSize={ 20 }
-						exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS }
-					/>
-				</VStack>
-			}
-			headerText={ translate( 'Manage subscribed sites' ) }
-			subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
-		>
-			<ReaderSiteSubscriptions />
-		</SubscriptionsManagerWrapper>
+		<>
+			<div>
+				<div>
+					<SubscriptionsManagerWrapper
+						actionButton={ <AddSitesButton /> }
+						ellipsisMenuItems={
+							<VStack spacing={ 1 }>
+								<ReaderImportButton icon={ uploadCloud } iconSize={ 20 } />
+								<ReaderExportButton
+									icon={ downloadCloud }
+									iconSize={ 20 }
+									exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS }
+								/>
+							</VStack>
+						}
+						headerText={ translate( 'Manage subscribed sites' ) }
+						subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
+					>
+						<ReaderSiteSubscriptions />
+					</SubscriptionsManagerWrapper>
+				</div>
+			</div>
+		</>
 	);
 };
 

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -1,10 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.is-section-reader {
-	background: var(--studio-white); // TODO: Remove after nav-redesign-v2 for reader is done.
-}
-
 .layout.has-header-section.is-section-reader .layout__header-section-content {
 	box-sizing: border-box;
 	max-width: 1140px;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6856

## Proposed Changes

Nav Redesign: Add frame around Reader pages like /sites, and remove the `layout/dotcom-nav-redesign-v2` flag applied on https://github.com/Automattic/wp-calypso/pull/90275#top

![image](https://github.com/Automattic/wp-calypso/assets/402286/7a1c88ff-2973-47dd-acc8-f887fbbe27e2)

#### Pages to check
- [x] /read https://github.com/Automattic/wp-calypso/pull/90275#top
- [x] /discover https://github.com/Automattic/wp-calypso/pull/90275#top
- [x] /read/search
- [x] /activities/likes
- [x] /read/conversations
- [x] /read/list/:feed
- [x] /tag
- [x] /read/feeds
- [x] /read/notifications
- [x] /read/subscriptions

## Testing Instructions

* Navigate to all the Reader pages and check the border on the primary view.
* Also check if the scrollbar works in all pages.
* Also check `/read` while logged-out
