### PR TITLE
Domains: Create flow to buy a domain for Gravatar

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -149,7 +149,7 @@ class DomainProductPrice extends Component {
 			<div className={ className }>
 				<div className="domain-product-price__free-text">
 					<span className="domain-product-price__free-price">
-						{ translate( 'Free domain for one year' ) }
+						{ translate( 'Free for the first year' ) }
 					</span>
 				</div>
 				{ this.renderReskinDomainPrice() }

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -137,7 +137,7 @@ class DomainProductPrice extends Component {
 		);
 	}
 
-	// This method returns "Free domain for one year" text (different from "Free with plan")
+	// This method returns "Free for the first year" text (different from "Free with plan")
 	renderFreeForFirstYear() {
 		const { translate } = this.props;
 

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -137,6 +137,26 @@ class DomainProductPrice extends Component {
 		);
 	}
 
+	// This method returns "Free domain for one year" text (different from "Free with plan")
+	renderFreeForFirstYear() {
+		const { translate } = this.props;
+
+		const className = classnames( 'domain-product-price', 'is-free-domain', {
+			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
+		} );
+
+		return (
+			<div className={ className }>
+				<div className="domain-product-price__free-text">
+					<span className="domain-product-price__free-price">
+						{ translate( 'Free domain for one year' ) }
+					</span>
+				</div>
+				{ this.renderReskinDomainPrice() }
+			</div>
+		);
+	}
+
 	renderFreeWithPlan() {
 		const className = classnames( 'domain-product-price', 'is-free-domain', {
 			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
@@ -261,6 +281,8 @@ class DomainProductPrice extends Component {
 		switch ( this.props.rule ) {
 			case 'FREE_DOMAIN':
 				return this.renderFree();
+			case 'FREE_FOR_FIRST_YEAR':
+				return this.renderFreeForFirstYear();
 			case 'FREE_WITH_PLAN':
 			case 'INCLUDED_IN_HIGHER_PLAN':
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -47,6 +47,7 @@ import {
 	is100Year,
 	PLAN_FREE,
 } from '@automattic/calypso-products';
+import { isDomainForGravatarFlow } from '@automattic/onboarding';
 import { isWpComProductRenewal as isRenewal } from '@automattic/wpcom-checkout';
 import { getTld } from 'calypso/lib/domains';
 import { domainProductSlugs } from 'calypso/lib/domains/constants';
@@ -859,6 +860,10 @@ export function getDomainPriceRule(
 
 	if ( isMonthlyOrFreeFlow( flowName ) ) {
 		return 'PRICE';
+	}
+
+	if ( isDomainForGravatarFlow( flowName ) ) {
+		return 'FREE_FOR_FIRST_YEAR';
 	}
 
 	if ( domainAndPlanUpsellFlow ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -411,11 +411,10 @@ export function generateFlows( {
 			name: 'domain-for-gravatar',
 			steps: [
 				'domain-only',
-				// 'site-or-domain',
-				// 'site-picker',
-				// 'plans-site-selected',
-				// userSocialStep,
-				'user',
+				'site-or-domain',
+				'site-picker',
+				'plans-site-selected',
+				userSocialStep,
 			],
 			destination: getDomainSignupFlowDestination, // TODO: Redirect to Gravatar
 			description: 'Test domain signup flow for Gravatar',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -410,8 +410,8 @@ export function generateFlows( {
 		{
 			name: 'domain-for-gravatar',
 			steps: [ 'domain-only', 'site-or-domain', 'site-picker' ],
-			destination: getDomainSignupFlowDestination, // TODO: Redirect to Gravatar
-			description: 'Test domain signup flow for Gravatar',
+			destination: getDomainSignupFlowDestination,
+			description: 'Checkout flow for domains on Gravatar',
 			disallowResume: true,
 			lastModified: '2024-05-07',
 			showRecaptcha: true,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -409,13 +409,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'domain-for-gravatar',
-			steps: [
-				'domain-only',
-				'site-or-domain',
-				'site-picker',
-				'plans-site-selected',
-				userSocialStep,
-			],
+			steps: [ 'domain-only', 'site-or-domain', 'site-picker' ],
 			destination: getDomainSignupFlowDestination, // TODO: Redirect to Gravatar
 			description: 'Test domain signup flow for Gravatar',
 			disallowResume: true,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -408,6 +408,23 @@ export function generateFlows( {
 			hideProgressIndicator: true,
 		},
 		{
+			name: 'domain-for-gravatar',
+			steps: [
+				'domain-only',
+				// 'site-or-domain',
+				// 'site-picker',
+				// 'plans-site-selected',
+				// userSocialStep,
+				'user',
+			],
+			destination: getDomainSignupFlowDestination, // TODO: Redirect to Gravatar
+			description: 'Test domain signup flow for Gravatar',
+			disallowResume: true,
+			lastModified: '2024-05-07',
+			showRecaptcha: true,
+			hideProgressIndicator: true,
+		},
+		{
 			name: 'site-selected',
 			steps: [ 'plans-site-selected-legacy' ],
 			destination: getSignupDestination,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -22,19 +22,24 @@ function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 		checkoutURL += `/${ localeSlug }`;
 	}
 
+	let checkoutBackUrl = `https://${ config( 'hostname' ) }/start/${ flowName }/domain-only`;
+	if ( config( 'env' ) !== 'production' ) {
+		const protocol = config( 'protocol' ) ?? 'https';
+		const port = config( 'port' ) ? ':' + config( 'port' ) : '';
+
+		checkoutBackUrl = `${ protocol }://${ config(
+			'hostname'
+		) }${ port }/start/${ flowName }/domain-only`;
+	}
+
 	return addQueryArgs(
 		{
 			signup: 1,
 			ref: getQueryArgs()?.ref,
 			...( dependencies.coupon && { coupon: dependencies.coupon } ),
-			...( [ 'domain' ].includes( flowName ) && {
+			...( [ 'domain', 'domain-for-gravatar' ].includes( flowName ) && {
 				isDomainOnly: 1,
-				checkoutBackUrl:
-					config( 'env' ) === 'production'
-						? `https://${ config( 'hostname' ) }/start/domain/domain-only`
-						: `${ config( 'protocol' ) ? config( 'protocol' ) : 'https' }://${ config(
-								'hostname'
-						  ) }${ config( 'port' ) ? ':' + config( 'port' ) : '' }/start/domain/domain-only`,
+				checkoutBackUrl,
 			} ),
 		},
 		checkoutURL

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -26,10 +26,9 @@ function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 	if ( config( 'env' ) !== 'production' ) {
 		const protocol = config( 'protocol' ) ?? 'https';
 		const port = config( 'port' ) ? ':' + config( 'port' ) : '';
+		const hostName = config( 'hostname' );
 
-		checkoutBackUrl = `${ protocol }://${ config(
-			'hostname'
-		) }${ port }/start/${ flowName }/domain-only`;
+		checkoutBackUrl = `${ protocol }://${ hostName }${ port }/start/${ flowName }/domain-only`;
 	}
 
 	return addQueryArgs(

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1423,6 +1423,9 @@ export class RenderDomainsStep extends Component {
 		} else if ( ! previousStepBackUrl && 'domain-transfer' === flowName ) {
 			backUrl = null;
 			backLabelText = null;
+		} else if ( 'domain-for-gravatar' === flowName ) {
+			backUrl = null;
+			backLabelText = null;
 		} else if ( 'with-plugin' === flowName ) {
 			backUrl = '/plugins';
 			backLabelText = translate( 'Back to plugins' );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -465,7 +465,7 @@ export class RenderDomainsStep extends Component {
 				domain: suggestion.domain_name,
 				productSlug: suggestion.product_slug,
 				extra: {
-					domain_for_gravatar: true,
+					is_gravatar_domain: true,
 				},
 			} );
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -476,11 +476,6 @@ export class RenderDomainsStep extends Component {
 				{ stepName: 'site-picker', wasSkipped: true },
 				{ themeSlugWithRepo: 'pub/twentysixteen' }
 			);
-			this.props.submitSignupStep(
-				{ stepName: 'plans-site-selected', wasSkipped: true },
-				{ cartItems: null }
-			);
-			goToStep( config.isEnabled( 'signup/social-first' ) ? 'user-social' : 'user' );
 			return;
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -457,7 +457,7 @@ export class RenderDomainsStep extends Component {
 
 		this.props.setDesignType( this.getDesignType() );
 
-		// For the `domain-for-gravatar` flow, add an extra `domain_for_gravatar` property to the domain registration product,
+		// For the `domain-for-gravatar` flow, add an extra `is_gravatar_domain` property to the domain registration product,
 		// pre-select the "domain" choice in the "site or domain" step and skip the others, going straight to checkout
 		if ( this.props.flowName === 'domain-for-gravatar' ) {
 			const domainForGravatarItem = domainRegistration( {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { PLAN_PERSONAL } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Spinner } from '@automattic/components';
@@ -397,7 +396,7 @@ export class RenderDomainsStep extends Component {
 		signupDomainOrigin,
 		migrateSite = false,
 	} ) => {
-		const { step, goToStep } = this.props;
+		const { step } = this.props;
 		const { suggestion } = step;
 
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -458,19 +458,27 @@ export class RenderDomainsStep extends Component {
 
 		this.props.setDesignType( this.getDesignType() );
 
-		// For the `domain-for-gravatar` flow, pre-select the "domain" choice in the "site or domain" step and
-		// skip the others, going straight to checkout
+		// For the `domain-for-gravatar` flow, add an extra `domain_for_gravatar` property to the domain registration product,
+		// pre-select the "domain" choice in the "site or domain" step and skip the others, going straight to checkout
 		if ( this.props.flowName === 'domain-for-gravatar' ) {
+			const domainForGravatarItem = domainRegistration( {
+				domain: suggestion.domain_name,
+				productSlug: suggestion.product_slug,
+				extra: {
+					domain_for_gravatar: true,
+				},
+			} );
+
 			this.props.submitSignupStep(
 				{
 					stepName: 'site-or-domain',
-					domainItem,
+					domainItem: domainForGravatarItem,
 					designType: 'domain',
-					siteSlug: domainItem.meta,
+					siteSlug: domainForGravatarItem.meta,
 					siteUrl,
 					isPurchasingItem: true,
 				},
-				{ designType: 'domain', domainItem, siteUrl }
+				{ designType: 'domain', domainItem: domainForGravatarItem, siteUrl }
 			);
 			this.props.submitSignupStep(
 				{ stepName: 'site-picker', wasSkipped: true },

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -587,12 +587,13 @@ export class RenderDomainsStep extends Component {
 	}
 
 	shouldHideDomainExplainer = () => {
-		return this.props.flowName === 'domain';
+		const { flowName } = this.props;
+		return [ 'domain', 'domain-for-gravatar' ].includes( flowName );
 	};
 
 	shouldHideUseYourDomain = () => {
 		const { flowName } = this.props;
-		return [ 'domain' ].includes( flowName );
+		return [ 'domain', 'domain-for-gravatar' ].includes( flowName );
 	};
 
 	shouldDisplayDomainOnlyExplainer = () => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { PLAN_PERSONAL } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Spinner } from '@automattic/components';
@@ -396,7 +397,7 @@ export class RenderDomainsStep extends Component {
 		signupDomainOrigin,
 		migrateSite = false,
 	} ) => {
-		const { step } = this.props;
+		const { step, goToStep } = this.props;
 		const { suggestion } = step;
 
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
@@ -456,6 +457,32 @@ export class RenderDomainsStep extends Component {
 		);
 
 		this.props.setDesignType( this.getDesignType() );
+
+		// For the `domain-for-gravatar` flow, pre-select the "domain" choice in the "site or domain" step and
+		// skip the others, going straight to checkout
+		if ( this.props.flowName === 'domain-for-gravatar' ) {
+			this.props.submitSignupStep(
+				{
+					stepName: 'site-or-domain',
+					domainItem,
+					designType: 'domain',
+					siteSlug: domainItem.meta,
+					siteUrl,
+					isPurchasingItem: true,
+				},
+				{ designType: 'domain', domainItem, siteUrl }
+			);
+			this.props.submitSignupStep(
+				{ stepName: 'site-picker', wasSkipped: true },
+				{ themeSlugWithRepo: 'pub/twentysixteen' }
+			);
+			this.props.submitSignupStep(
+				{ stepName: 'plans-site-selected', wasSkipped: true },
+				{ cartItems: null }
+			);
+			goToStep( config.isEnabled( 'signup/social-first' ) ? 'user-social' : 'user' );
+			return;
+		}
 
 		if ( migrateSite ) {
 			this.props.goToNextStep( 'site-migration' );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -250,7 +250,8 @@
 		"onboarding-2023-pricing-grid",
 		"domain-transfer",
 		"site-selected",
-		"guided"
+		"guided",
+		"domain-for-gravatar"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"
 }

--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -4,6 +4,8 @@ import {
 	LINK_IN_BIO_TLD_FLOW,
 	ECOMMERCE_FLOW,
 	WOOEXPRESS_FLOW,
+	DOMAIN_FOR_GRAVATAR_FLOW,
+	isDomainForGravatarFlow,
 } from '@automattic/onboarding';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
@@ -45,7 +47,8 @@ interface DomainSuggestionsVendorOptions {
 		| typeof LINK_IN_BIO_FLOW
 		| typeof LINK_IN_BIO_TLD_FLOW
 		| typeof ECOMMERCE_FLOW
-		| typeof WOOEXPRESS_FLOW;
+		| typeof WOOEXPRESS_FLOW
+		| typeof DOMAIN_FOR_GRAVATAR_FLOW;
 }
 type DomainSuggestionsVendor =
 	| 'variation2_front'
@@ -54,11 +57,15 @@ type DomainSuggestionsVendor =
 	| 'link-in-bio'
 	| 'link-in-bio-tld'
 	| 'newsletter'
-	| 'ecommerce';
+	| 'ecommerce'
+	| 'gravatar';
 
 export function getDomainSuggestionsVendor(
 	options: DomainSuggestionsVendorOptions = {}
 ): DomainSuggestionsVendor {
+	if ( isDomainForGravatarFlow( options.flowName ) ) {
+		return 'gravatar';
+	}
 	if ( options.flowName === LINK_IN_BIO_FLOW ) {
 		return 'link-in-bio';
 	}

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -42,6 +42,7 @@ export const DOMAIN_TRANSFER = 'domain-transfer';
 export const GOOGLE_TRANSFER = 'google-transfer';
 export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
 export const REBLOGGING_FLOW = 'reblogging';
+export const DOMAIN_FOR_GRAVATAR_FLOW = 'domain-for-gravatar';
 
 export const isLinkInBioFlow = ( flowName: string | null | undefined ) => {
 	return Boolean(
@@ -210,4 +211,8 @@ export const isVideoPressTVFlow = ( flowName: string | null | undefined ) => {
 	return Boolean(
 		flowName && [ VIDEOPRESS_TV_FLOW, VIDEOPRESS_TV_PURCHASE_FLOW ].includes( flowName )
 	);
+};
+
+export const isDomainForGravatarFlow = ( flowName: string | null | undefined ) => {
+	return Boolean( flowName && [ DOMAIN_FOR_GRAVATAR_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
## Proposed Changes

This PR creates a new `domain-for-gravatar` onboarding flow that will be used for the Domains on Gravatar project (pcYYhz-24z-p2). This flow lets users select one `.link` domain (domain search is restricted to `.link` domains by the `gravatar` vendor string) and buy it. The 100% discount coupon will abe applied in the backend.

Note: There's some problem when buying `.link` domains in the test environment, so this screen recording uses other TLDs than `.link`.

https://github.com/Automattic/wp-calypso/assets/5324818/b8a6fc17-f2a9-4e0b-be9c-2bc395acf805

## Testing Instructions

- Enable `USE_STORE_SANDBOX` in your backend to prevent buying domains in production
- Open the live Calypso link or build this branch locally
- Navigate to `/start/domain-for-gravatar?search=yes&new=your-test-domain.com` (you can change `your-test-domain.com` by any domain you want)
- Ensure `your-test-domain.com` (or the domain you typed in the `new` parameter) is the default search query and was searched for
- Purchase it
- Ensure a domain-only site is created for it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?