### PR TITLE
Nav redesign v2: tweak highlight color

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -352,7 +352,7 @@
 
 			li.is-selected,
 			li:hover {
-				background-color: #f7faff;
+				background-color: var(--studio-blue-0);
 			}
 		}
 	}


### PR DESCRIPTION
Part of 6866-gh-Automattic/dotcom-forge#issuecomment-2092031021 changes the colour of the highlight so it is more visible.

@davemart-in suggested `#f0f6ff`, I saw we don't use that color in calypso yet and so I picked the closest named color `--studio-blue-0` which is `#e9f0f5`, just a slightly darker shade of blue, I figure it's not that important as long as it's legible, so we should just pick one that we use already:

**Current** 
<img width="423" alt="Screenshot 2024-05-08 at 11 00 37 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/fcd05e2f-4d18-49bb-b8d2-6a5721ea079a">

**Dave's suggestion** 
<img width="404" alt="Screenshot 2024-05-08 at 11 00 59 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/36157833-4e46-4df0-91c5-28df002912e3">

**--studio-blue-0 **
<img width="406" alt="Screenshot 2024-05-08 at 11 01 16 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/db45580a-db34-4df9-ad37-13aa69554c02">

### Test instructions

Go to `/sites?flags=layout/dotcom-nav-redesign-v2` and select a site