### PR TITLE
Automattic for Agencies: Update the Activate Monitor API endpoint for non-Jetpack sites

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -17,7 +17,7 @@ const NOTIFICATION_DURATION = 3000;
 const DEFAULT_CHECK_INTERVAL = 5;
 
 export default function useToggleActivateMonitor(
-	sites: Array< { blog_id: number; url: string } >
+	sites: Array< Site >
 ): ( isEnabled: boolean ) => void {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -104,7 +104,11 @@ export default function useToggleActivateMonitor(
 			sites.forEach( ( site ) =>
 				requests.push( {
 					site,
-					mutation: toggleActivateMonitoring.mutateAsync( { siteId: site.blog_id, params } ),
+					mutation: toggleActivateMonitoring.mutateAsync( {
+						siteId: site.blog_id,
+						params,
+						hasJetpackPluginInstalled: site?.enabled_plugin_slugs?.includes( 'jetpack' ) ?? false,
+					} ),
 				} )
 			);
 			const promises = await Promise.allSettled(

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -107,6 +107,7 @@ export interface Site {
 	latest_scan_has_threats_found: boolean;
 	active_paid_subscription_slugs: Array< string >;
 	site_color?: string;
+	enabled_plugin_slugs?: Array< string >;
 }
 export interface SiteNode {
 	value: Site;
@@ -337,6 +338,8 @@ export interface ToggleActivaateMonitorAPIResponse {
 export interface ToggleActivateMonitorArgs {
 	siteId: number;
 	params: { monitor_active: boolean };
+	hasJetpackPluginInstalled: boolean;
+	agencyId?: number;
 }
 
 export interface Backup {

--- a/client/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation.ts
@@ -1,5 +1,7 @@
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import type {
 	APIError,
 	ToggleActivaateMonitorAPIResponse as APIResponse,
@@ -9,18 +11,33 @@ import type {
 function mutationToggleActivateMonitor( {
 	siteId,
 	params,
+	hasJetpackPluginInstalled,
+	agencyId,
 }: ToggleActivateMonitorArgs ): Promise< APIResponse > {
-	return wpcom.req.post( `/jetpack-blogs/${ siteId }/rest-api`, {
-		path: '/jetpack/v4/module/monitor/active/',
-		body: JSON.stringify( { active: params.monitor_active } ),
+	if ( hasJetpackPluginInstalled ) {
+		return wpcom.req.post( `/jetpack-blogs/${ siteId }/rest-api`, {
+			path: '/jetpack/v4/module/monitor/active/',
+			body: JSON.stringify( { active: params.monitor_active } ),
+		} );
+	}
+	// For A4A: If the site doesn't have the Jetpack plugin installed, we need to use the agency endpoint
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required for this operation' );
+	}
+	return wpcom.req.put( {
+		method: 'PUT',
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/sites/${ siteId }/monitor`,
+		body: { monitor_active: params.monitor_active },
 	} );
 }
 
 export default function useToggleActivateMonitorMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, APIError, ToggleActivateMonitorArgs, TContext >
 ): UseMutationResult< APIResponse, APIError, ToggleActivateMonitorArgs, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
 	return useMutation< APIResponse, APIError, ToggleActivateMonitorArgs, TContext >( {
 		...options,
-		mutationFn: mutationToggleActivateMonitor,
+		mutationFn: ( args ) => mutationToggleActivateMonitor( { ...args, agencyId } ),
 	} );
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/12

## Proposed Changes

This PR updates the `useToggleActivateMonitorMutation ` to use a different API to Activate/Deactivate Monitor if a site doesn't have the Jetpack plugin installed. 

## Testing Instructions

1. Open the A4A live link.
2. Create a new JN site > Connect this site using Jetpack > Activate monitor > Verify the API call is successful and monitor status is updated. Also, check the API endpoint. It should be `
POST https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{siteId}/rest-api`

3. Create a new JN Site > Connect this using the A4A plugin (download + install this) > Activate monitor > Verify the API call is successful and monitor status is updated.  Also, check the API endpoint. It should be `PUT https://public-api.wordpress.com/wpcom/v2/agency/${agencyId}/sites/${siteId}/monitor`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
