### PR TITLE
A4A: Update site provisioning notice copy

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -13,6 +14,8 @@ export default function ProvisioningSiteNotification( { siteId }: Props ) {
 
 	const translate = useTranslate();
 
+	const wpHomeUrl = `https://wordpress.com/home/${ site?.url?.replace( /(^\w+:|^)\/\//, '' ) }`;
+
 	return (
 		showBanner && (
 			<NoticeBanner
@@ -21,27 +24,30 @@ export default function ProvisioningSiteNotification( { siteId }: Props ) {
 				onClose={ () => setShowBanner( false ) }
 				title={
 					isReady
-						? translate( 'Congratulations on your new WordPress.com site!' )
+						? translate( 'Your WordPress.com site is ready!' )
 						: translate( 'Setting up your new WordPress.com site' )
+				}
+				actions={
+					isReady
+						? [
+								<Button href={ wpHomeUrl } target="_blank" rel="noreferrer">
+									{ translate( 'Set up your site' ) }
+								</Button>,
+						  ]
+						: undefined
 				}
 			>
 				{ isReady
-					? translate( 'Your {{a}}%(siteURL)s{{/a}} is now ready.', {
-							args: { siteURL: site?.url ?? '' },
-							components: {
-								a: (
-									<a
-										href={ `https://wordpress.com/home/${ site?.url?.replace(
-											/(^\w+:|^)\/\//,
-											''
-										) }` }
-										target="_blank"
-										rel="noreferrer"
-									/>
-								),
-							},
-							comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
-					  } )
+					? translate(
+							'{{a}}%(siteURL)s{{/a}} is now ready. Get started by configuring your new site. It may take a few minutes for it to show up in the site list below.',
+							{
+								args: { siteURL: site?.url ?? '' },
+								components: {
+									a: <a href={ wpHomeUrl } target="_blank" rel="noreferrer" />,
+								},
+								comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
+							}
+					  )
 					: translate(
 							"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
 					  ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/452

## Proposed Changes

* Updates the copy for the "site provisioning" notice displayed on the "/sites" page immediately after creating a new WordPress.com site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy a WordPress.com Creator plan through the A4A platform.
* Click the "Create new site" button on the "/sites/need-setup" screen.
* Navigate to "/sites" and wait for the site to provision.
* Review the success notice, ensure the URL is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1034" alt="Screenshot 2024-05-07 at 11 10 56 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/fb04b660-b80c-4bee-ac6e-1d1f286d5ed4">

