### PR TITLE
Nav Redesign v2: fix horizontal table scrolling

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -116,6 +116,13 @@
 		}
 	}
 
+	table.dataviews-view-table {
+		table-layout: fixed;
+		@include break-large {
+			width: auto;
+		}
+	}
+
 	table.dataviews-view-table thead .dataviews-view-table__row th {
 		border-bottom-color: var(--color-border-secondary);
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -118,13 +118,18 @@
 
 	table.dataviews-view-table {
 		table-layout: fixed;
-		@include break-large {
-			width: auto;
-		}
 	}
 
 	table.dataviews-view-table thead .dataviews-view-table__row th {
 		border-bottom-color: var(--color-border-secondary);
+		@include break-large {
+			padding-left: 26px;
+		}
+		@include break-huge {
+			&:first-child {
+				padding-left: 64px;
+			}
+		}
 
 		span,
 		.dataviews-view-table-header-button {
@@ -134,6 +139,14 @@
 
 	table.dataviews-view-table .dataviews-view-table__row td {
 		border-bottom-color: var(--color-border-secondary);
+		@include break-large {
+			padding-left: 26px;
+		}
+		@include break-huge {
+			&:first-child {
+				padding-left: 64px;
+			}
+		}
 	}
 
 	table.dataviews-view-table th,

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -122,6 +122,7 @@
 
 	table.dataviews-view-table thead .dataviews-view-table__row th {
 		border-bottom-color: var(--color-border-secondary);
+		padding-left: 16px;
 		@include break-large {
 			padding-left: 26px;
 		}

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -1,3 +1,5 @@
+import { DESKTOP_BREAKPOINT, WIDE_BREAKPOINT } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -51,6 +53,17 @@ const DotcomSitesDataViews = ( {
 }: Props ) => {
 	const { __ } = useI18n();
 	const userId = useSelector( getCurrentUserId );
+	const isWide = useBreakpoint( WIDE_BREAKPOINT );
+	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
+	const getSiteNameColWidth = ( isDesktop: boolean, isWide: boolean ) => {
+		if ( isWide ) {
+			return '40%';
+		}
+		if ( isDesktop ) {
+			return '50%';
+		}
+		return '70%';
+	};
 
 	const openSitePreviewPane = useCallback(
 		( site: SiteExcerptData ) => {
@@ -110,7 +123,7 @@ const DotcomSitesDataViews = ( {
 						<span>{ __( 'Site' ) }</span>
 					</SiteSort>
 				),
-				width: '45%',
+				width: getSiteNameColWidth( isDesktop, isWide ),
 				getValue: ( { item }: { item: SiteInfo } ) => item.URL,
 				render: ( { item }: { item: SiteInfo } ) => {
 					return <SiteField site={ item } openSitePreviewPane={ openSitePreviewPane } />;
@@ -124,6 +137,7 @@ const DotcomSitesDataViews = ( {
 				render: ( { item }: { item: SiteInfo } ) => <SitePlan site={ item } userId={ userId } />,
 				enableHiding: false,
 				enableSorting: false,
+				width: '5%',
 			},
 			{
 				id: 'status',
@@ -149,6 +163,7 @@ const DotcomSitesDataViews = ( {
 					item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
 				enableHiding: false,
 				enableSorting: false,
+				width: '100px',
 			},
 			{
 				id: 'stats',
@@ -205,7 +220,7 @@ const DotcomSitesDataViews = ( {
 				enableSorting: false,
 			},
 		],
-		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState ]
+		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState, isWide, isDesktop ]
 	);
 
 	// Create the itemData packet state

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -110,6 +110,7 @@ const DotcomSitesDataViews = ( {
 						<span>{ __( 'Site' ) }</span>
 					</SiteSort>
 				),
+				width: '45%',
 				getValue: ( { item }: { item: SiteInfo } ) => item.URL,
 				render: ( { item }: { item: SiteInfo } ) => {
 					return <SiteField site={ item } openSitePreviewPane={ openSitePreviewPane } />;
@@ -130,6 +131,7 @@ const DotcomSitesDataViews = ( {
 				render: ( { item }: { item: SiteInfo } ) => <SiteStatus site={ item } />,
 				enableHiding: false,
 				enableSorting: false,
+				width: '116px',
 			},
 			{
 				id: 'last-publish',
@@ -166,6 +168,7 @@ const DotcomSitesDataViews = ( {
 				render: ( { item }: { item: SiteInfo } ) => <ActionsField site={ item } />,
 				enableHiding: false,
 				enableSorting: false,
+				width: '48px',
 			},
 			// Dummy fields to allow people to sort by them on mobile.
 			{

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -176,6 +176,7 @@ const DotcomSitesDataViews = ( {
 				render: ( { item }: { item: SiteInfo } ) => <SiteStats site={ item } />,
 				enableHiding: false,
 				enableSorting: false,
+				width: '80px',
 			},
 			{
 				id: 'actions',

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -55,9 +55,9 @@
 		width: 180px;
 	}
 
-	@media (min-width: 2040px) {
+	@include break-wide {
 		.sites-dataviews__site-name {
-			width: 250px;
+			width: 260px;
 		}
 	}
 }

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -14,7 +14,7 @@
 }
 
 .sites-dataviews__site-name {
-	align-self: center;
+	align-self: flex-start;
 	display: inline-block;
 	text-align: left;
 	text-overflow: ellipsis;
@@ -47,18 +47,6 @@
 
 	&:visited {
 		color: var(--color-neutral-70);
-	}
-}
-
-.preview-hidden {
-	.sites-dataviews__site-name {
-		width: 180px;
-	}
-
-	@include break-wide {
-		.sites-dataviews__site-name {
-			width: 260px;
-		}
 	}
 }
 

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -58,13 +58,23 @@
 
 		.dataviews-view-table tr th:first-child,
 		.dataviews-view-table tr td:first-child {
+			padding-left: 30px;
+		}
+		.dataviews-view-table tr th:last-child,
+		.dataviews-view-table tr td:last-child {
+			padding-right: 30px;
+			width: 20px;
+			white-space: nowrap;
+		}
+	}
+	@media (min-width: $break-huge) {
+		.dataviews-view-table tr th:first-child,
+		.dataviews-view-table tr td:first-child {
 			padding-left: 64px;
 		}
 		.dataviews-view-table tr th:last-child,
 		.dataviews-view-table tr td:last-child {
 			padding-right: 64px;
-			width: 20px;
-			white-space: nowrap;
 		}
 	}
 
@@ -136,7 +146,7 @@
 		}
 		.dataviews-view-table tr td:last-child {
 			padding: 0;
-			padding-inline-end: 8px;
+			padding-inline-end: 16px;
 		}
 
 		.components-button.is-compact.has-icon:not(.has-text).dataviews-filters-button {
@@ -154,7 +164,7 @@
 			padding-bottom: 8px;
 
 			& > :first-child {
-				margin-inline-start: 8px;
+				margin-inline-start: 16px;
 			}
 
 			.components-input-control {
@@ -216,7 +226,7 @@
 			}
 
 			th[data-field-id="actions"] {
-				padding-inline-end: 12px;
+				padding-inline-end: 16px;
 				text-align: end;
 			}
 		}
@@ -562,6 +572,20 @@
 				.sites-overview {
 					padding: 0;
 
+					.dataviews-filters__view-actions {
+						& > :first-child {
+							margin-inline-start: 30px;
+						}
+
+						& > :last-child {
+							margin-inline-end: 30px;
+						}
+					}
+				}
+			}
+
+			@media only screen and (min-width: $break-huge) {
+				.sites-overview {
 					.dataviews-filters__view-actions {
 						& > :first-child {
 							margin-inline-start: 64px;

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -38,6 +38,23 @@
 		padding-block-start: 24px;
 	}
 
+	.sites-dataviews__site {
+		.button {
+			flex-shrink: 0;
+			@include breakpoint-deprecated("<480px") {
+				width: 90px;
+			}
+		}
+		.sites-dataviews__site-name {
+			padding: 0;
+		}
+	}
+	th[data-field-id="actions"] {
+		padding-inline-end: 16px;
+		text-align: end;
+	}
+
+
 	@media (min-width: $break-large) {
 		background: inherit;
 
@@ -142,7 +159,7 @@
 
 		.dataviews-view-table tr th:first-child,
 		.dataviews-view-table tr td:first-child {
-			padding: 8px 24px 8px 16px;
+			padding: 8px 16px 8px 16px;
 		}
 		.dataviews-view-table tr td:last-child {
 			padding: 0;
@@ -225,10 +242,6 @@
 				display: none;
 			}
 
-			th[data-field-id="actions"] {
-				padding-inline-end: 16px;
-				text-align: end;
-			}
 		}
 	}
 

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -42,6 +42,7 @@ const SERVER_WIDTH = 769;
 
 export const MOBILE_BREAKPOINT = '<480px';
 export const DESKTOP_BREAKPOINT = '>960px';
+export const WIDE_BREAKPOINT = '>1280px';
 
 const isServer = typeof window === 'undefined' || ! window.matchMedia;
 


### PR DESCRIPTION
Fixes 6972-gh-Automattic/dotcom-forge, removes horizontal table scrolling by setting widths on certain columns and reducing padding at certain breakpoints.

It's a bit of a balancing act to get everything looking good at various screen widths (and still be aligned properly)

This should prevent any horizontal scroling and ensure the table cells always have enough room. from 1600px+, down to 375px wide.

https://github.com/Automattic/wp-calypso/assets/22446385/fbbc1030-5637-42b6-b519-c6faa97b8c61



### Testing instructions

test /sites page on different screen resolutions and browsers etc.