### PR TITLE
Hide the second plan-term selector on mobile

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -828,7 +828,8 @@ const PlansFeaturesMain = ( {
 											</PlanComparisonHeader>
 											{ ! hidePlanSelector &&
 												showPlansComparisonGrid &&
-												gridPlansForPlanTypeSelector && (
+												gridPlansForPlanTypeSelector &&
+												! isMobile && (
 													<PlanTypeSelector
 														{ ...planTypeSelectorProps }
 														plans={ gridPlansForPlanTypeSelector }


### PR DESCRIPTION
Resolves #90362

## Proposed Changes

Fixes the overlapping plan-term selectors on mobile by hiding the second instance. The second selector is redundant anyway, as there's another selector pinned to the top of the viewport. 

## Testing Instructions

1. Load `/start/plans`
2. Enable mobile viewport
3. Scroll down to the comparison grid
4. Check that the second plan-term selector is not displayed
5. Enable desktop viewport
6. Check that the second plan-term selector is displayed

| Desktop (displayed) | Mobile (not displayed) |
| -- | -- |
|![CleanShot 2024-05-08 at 16 36 59@2x](https://github.com/Automattic/wp-calypso/assets/69198925/17badacf-9cdb-4bb3-a979-8dc48bb1d80d)|![CleanShot 2024-05-08 at 16 37 25@2x](https://github.com/Automattic/wp-calypso/assets/69198925/d54c409f-e383-4953-989b-2d014f07cb00)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?