### PR TITLE
Nav redesign: Close GSV by the Escape key

### DIFF
--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -105,7 +105,7 @@ const DotcomPreviewPane = ( {
 	};
 
 	useEffect( () => {
-		const handleKeydown = ( e: Event ) => {
+		const handleKeydown = ( e: KeyboardEvent ) => {
 			if ( e.key !== 'Escape' ) {
 				return;
 			}

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -1,6 +1,6 @@
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import ItemPreviewPane, {
 	createFeaturePreview,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
@@ -21,6 +21,12 @@ type Props = {
 	selectedSiteFeaturePreview: React.ReactNode;
 	closeSitePreviewPane: () => void;
 };
+
+const OVERLAY_MODAL_SELECTORS = [
+	'body.modal-open',
+	'#wpnc-panel.wpnt-open',
+	'div.help-center__container:not(.is-minimized)',
+];
 
 const DotcomPreviewPane = ( {
 	site,
@@ -97,6 +103,25 @@ const DotcomPreviewPane = ( {
 		isDotcomSite: site.is_wpcom_atomic || site.is_wpcom_staging_site,
 		adminUrl: site.options?.admin_url || `${ site.URL }/wp-admin`,
 	};
+
+	useEffect( () => {
+		const handleKeydown = ( e: Event ) => {
+			if ( e.key !== 'Escape' ) {
+				return;
+			}
+
+			if ( document.querySelector( OVERLAY_MODAL_SELECTORS.join( ',' ) ) ) {
+				return;
+			}
+
+			closeSitePreviewPane();
+		};
+
+		document.addEventListener( 'keydown', handleKeydown, true );
+		return () => {
+			document.removeEventListener( 'keydown', handleKeydown, true );
+		};
+	}, [ closeSitePreviewPane ] );
 
 	return (
 		<ItemPreviewPane

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -73,9 +73,13 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 	// https://github.com/react-grid-layout/react-draggable/blob/781ef77c86be9486400da9837f43b96186166e38/README.md
 	const nodeRef = useRef( null );
 
+	const shouldCloseOnEscapeRef = useRef( false );
+
+	shouldCloseOnEscapeRef.current = show && ! hidden && ! isMinimized;
+
 	useEffect( () => {
 		const handleKeydown = ( e: KeyboardEvent ) => {
-			if ( e.key === 'Escape' ) {
+			if ( e.key === 'Escape' && shouldCloseOnEscapeRef.current ) {
 				onDismiss();
 			}
 		};
@@ -84,7 +88,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 		return () => {
 			document.removeEventListener( 'keydown', handleKeydown );
 		};
-	}, [ onDismiss ] );
+	}, [ shouldCloseOnEscapeRef, onDismiss ] );
 
 	if ( ! show || hidden ) {
 		return null;

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -74,7 +74,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 	const nodeRef = useRef( null );
 
 	useEffect( () => {
-		const handleKeydown = ( e: Event ) => {
+		const handleKeydown = ( e: KeyboardEvent ) => {
 			if ( e.key === 'Escape' ) {
 				onDismiss();
 			}

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -6,7 +6,7 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
-import { useState, useRef, FC } from 'react';
+import { useState, useRef, useEffect, useCallback, FC } from 'react';
 import Draggable, { DraggableProps } from 'react-draggable';
 import { MemoryRouter } from 'react-router-dom';
 /**
@@ -50,10 +50,10 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 		'is-minimized': isMinimized,
 	} );
 
-	const onDismiss = () => {
+	const onDismiss = useCallback( () => {
 		setIsVisible( false );
 		recordTracksEvent( `calypso_inlinehelp_close` );
-	};
+	}, [ setIsVisible, recordTracksEvent ] );
 
 	const toggleVisible = () => {
 		if ( ! isVisible ) {
@@ -72,6 +72,19 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 	// This is a workaround for an issue with Draggable in StrictMode
 	// https://github.com/react-grid-layout/react-draggable/blob/781ef77c86be9486400da9837f43b96186166e38/README.md
 	const nodeRef = useRef( null );
+
+	useEffect( () => {
+		const handleKeydown = ( e: Event ) => {
+			if ( e.key === 'Escape' ) {
+				onDismiss();
+			}
+		};
+
+		document.addEventListener( 'keydown', handleKeydown );
+		return () => {
+			document.removeEventListener( 'keydown', handleKeydown );
+		};
+	}, [ onDismiss ] );
 
 	if ( ! show || hidden ) {
 		return null;

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -75,7 +75,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 
 	const shouldCloseOnEscapeRef = useRef( false );
 
-	shouldCloseOnEscapeRef.current = show && ! hidden && ! isMinimized;
+	shouldCloseOnEscapeRef.current = !! show && ! hidden && ! isMinimized;
 
 	useEffect( () => {
 		const handleKeydown = ( e: KeyboardEvent ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6976

## Proposed Changes

* Close GSV when the user presses the Escape key
* We have the `CloseOnEscape` component to handle closing elements by the ESCAPE key in order but it doesn't apply to every component that is allowed to close by the ESCAPE key. As a result, this PR checks whether the following elements are open to avoid GSV closing together with them by the ESCAPE key
  * Command Palette or any modal that adds the `modal-open` class to the body element
  * Notification
  * Help Center
* The logic might be different between Calypso and A4A, so I don't implement this feature inside the `ItemPreviewPane` component cc @cleacos 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site to open GSV
* Press the ESC to close the GSV
* Select any site to open GSV again
* Open the Notification, Command Palette, Help Center etc
* Press the ESC
* Make sure GSV is not closed because any of the elements opened in the previous step are there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
