### PR TITLE
Change label when no plugins are available to update.

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -209,6 +209,7 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit }: Props ) => {
 					onTouch={ ( touched ) => setFieldTouched( { ...fieldTouched, plugins: touched } ) }
 					error={ validationErrors?.plugins }
 					showError={ fieldTouched?.plugins }
+					selectedSites={ selectedSites }
 				/>
 
 				<Text>{ translate( 'Step 3' ) }</Text>

--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -166,7 +166,7 @@ export function ScheduleFormPlugins( props: Props ) {
 						<Text className="validation-msg">
 							<Icon className="icon-info" icon={ info } size={ 16 } />
 							{ translate(
-								'The current site selection does not have any plugins that can be scheduled for updates.'
+								'All installed plugins are provided by WordPress.com and automatically updated for you. Add a plugin from the WordPress.com Marketplace to create a schedule!'
 							) }
 						</Text>
 					);

--- a/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form-plugins.tsx
@@ -22,6 +22,7 @@ interface Props {
 	onTouch?: ( touched: boolean ) => void;
 	onChange?: ( value: string[] ) => void;
 	borderWrapper?: boolean;
+	selectedSites?: number[] | null;
 }
 export function ScheduleFormPlugins( props: Props ) {
 	const {
@@ -33,6 +34,7 @@ export function ScheduleFormPlugins( props: Props ) {
 		onChange,
 		onTouch,
 		borderWrapper = true,
+		selectedSites = null,
 	} = props;
 	const translate = useTranslate();
 	const plugins = useMemo( () => props.plugins || [], [ props.plugins ] );
@@ -147,10 +149,13 @@ export function ScheduleFormPlugins( props: Props ) {
 						</div>
 					</>
 				) }
-				{ ! pluginsAvailable && (
+				{ ! pluginsAvailable && selectedSites && selectedSites.length === 0 && (
 					<p className="placeholder-info">
 						{ translate( 'Please select a site to view available plugins.' ) }
 					</p>
+				) }
+				{ ! pluginsAvailable && selectedSites && selectedSites.length > 0 && (
+					<p className="placeholder-info">{ translate( 'No plugins to update.' ) }</p>
 				) }
 			</div>
 			{ ( () => {


### PR DESCRIPTION
Closes #90356 

## Proposed Changes

![CleanShot 2024-05-08 at 10 32 49@2x](https://github.com/Automattic/wp-calypso/assets/528287/14607bab-81a6-418e-9ead-0be6270a312c)


## Testing Instructions

1. Apply this PR
2. Go to http://calypso.localhost:3000/plugins/scheduled-updates/create
3. Create schedule with a site that has no updatable plugins
4. Verify the result

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
