### PR TITLE
Automattic for Agencies: Implement Manual Woo Payments referrals

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
@@ -1,5 +1,6 @@
 import { Button, Badge } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
+import classNames from 'classnames';
 import React from 'react';
 import StatusBadge from './status-badge';
 
@@ -10,9 +11,10 @@ const ICON_SIZE = 24;
 interface StepSectionItemProps {
 	icon: JSX.Element;
 	heading: string;
-	description: string;
+	description: string | JSX.Element;
 	buttonProps?: React.ComponentProps< typeof Button >;
 	statusProps?: React.ComponentProps< typeof Badge > & { tooltip?: string };
+	className?: string;
 }
 
 export default function StepSectionItem( {
@@ -21,11 +23,12 @@ export default function StepSectionItem( {
 	description,
 	buttonProps,
 	statusProps,
+	className,
 }: StepSectionItemProps ) {
 	const status = <StatusBadge statusProps={ statusProps } />;
 
 	return (
-		<div className="step-section-item">
+		<div className={ classNames( 'step-section-item', className ) }>
 			<div className="step-section-item__icon">
 				<Icon
 					className="sidebar__menu-icon"

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -49,6 +49,23 @@ export default function CommissionOverview() {
 						<FoldableCard
 							header={
 								<div className="commission-overview__heading">
+									<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
+									{ translate( 'Woo Payments revenue share' ) }
+								</div>
+							}
+							expanded
+							clickableHeader
+							summary={ false }
+						>
+							{ translate(
+								'You will receive a revenue share of 5 basis points (0.05%) on new WooPayments gross merchandise value (“GMV”) on client sites through June 30, 2025.' +
+									' For example, if your client’s store generates $1M in GMV per year, your revenue share for that year would be $500.'
+							) }
+						</FoldableCard>
+
+						<FoldableCard
+							header={
+								<div className="commission-overview__heading">
 									<img src={ pressableIcon } alt="Pressable" />
 									<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
 									{ translate( 'Hosting revenue share (WordPress.com and Pressable)' ) }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,3 +1,4 @@
+import { Button, WooLogo } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -114,14 +115,21 @@ export default function ReferralsOverview() {
 				</div>
 
 				<div className="referrals-overview__section-subtitle">
-					{ translate(
-						'Earn commissions from client purchases across our products, including WooCommerce, Jetpack, and hosting services from Pressable or WordPress.com. {{a}}How much can I earn?{{/a}}',
-						{
-							components: {
-								a: <a href={ A4A_REFERRALS_COMMISSIONS_LINK } />,
-							},
-						}
-					) }
+					<div>
+						{ translate(
+							'Make money on each product your clients buy from Automattic. They can buy WooCommerce extensions, tools from Jetpack, and hosting services from Pressable or WordPress.com'
+						) }
+					</div>
+					<div>
+						{ translate(
+							'You can also make money when people buy things on your clients’ websites using WooPayments. {{a}}How much can I earn?{{/a}}',
+							{
+								components: {
+									a: <a href={ A4A_REFERRALS_COMMISSIONS_LINK } />,
+								},
+							}
+						) }
+					</div>
 				</div>
 
 				<div className="referrals-overview__section-container">
@@ -173,6 +181,28 @@ export default function ReferralsOverview() {
 										href: A4A_DOWNLOAD_LINK_ON_GITHUB,
 										onClick: onDownloadA4APluginClick,
 									} }
+								/>
+								<StepSectionItem
+									className="referrals-overview__step-section-woo-payments"
+									icon={ <WooLogo /> }
+									heading={ translate( 'Install WooPayments on your clients’ online stores' ) }
+									description={
+										<>
+											{ translate(
+												'Receive a revenue share of 5 basis points (0.05%) on new WooPayments gross merchandise value on clients’ sites.'
+											) }
+											<div>
+												<Button
+													borderless
+													href="https://woocommerce.com/payments/"
+													rel="noreferrer"
+													target="_blank"
+												>
+													{ translate( 'Learn about WooPayments' ) }
+												</Button>
+											</div>
+										</>
+									}
 								/>
 							</StepSection>
 						</>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -9,15 +9,25 @@
 	font-weight: 600;
 }
 .referrals-overview__section-subtitle {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
 	font-size: rem(14px);
 	font-weight: 400;
 	margin-block-end: 48px;
 	color: var(--color-neutral-50);
+}
 
+
+.referrals-overview__step-section-woo-payments {
 	a,
 	a:visited {
 		color: var(--color-neutral-100);
 		text-decoration: underline;
+	}
+
+	.step-section-item__icon {
+		opacity: 1;
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-roadmap/issues/1508

## Proposed Changes

This PR implements Manual Woo Payments referrals

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals > Verify that the page is updated as shown below.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="987" alt="Screenshot 2024-05-08 at 4 23 13 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/cf76cb4c-f8c2-42b2-8a0f-a11e400208f0">
</td>
<td>
<img width="987" alt="Screenshot 2024-05-08 at 4 23 19 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8140d336-4d2c-40cb-a859-a8ebc98b85ad">
</td>
</tr>
<tr>
<td>
<img width="987" alt="Screenshot 2024-05-08 at 4 23 40 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c49f48ed-21ea-4042-a221-b8ffaa25fd1a">
</td>
<td>
<img width="987" alt="Screenshot 2024-05-08 at 4 23 31 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3ad846a3-74e9-4a19-81e5-4cf948f569e4">
</td>
</tr>
</table>

3. Click on the `Learn about WooPayments` link and verify it opens https://woocommerce.com/payments/ in a new tab.
4. Click on the `How much can I earn?` link and verify the page is updated as shown below:


<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="987" alt="Screenshot 2024-05-08 at 4 23 59 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e1e0a88d-9a40-4f65-9bee-4cefc545e14e">
</td>
<td>
<img width="987" alt="Screenshot 2024-05-08 at 4 23 54 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b373e9fb-e898-40d0-912a-61c48c0a20a4">
</td>
</tr>
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
