### PR TITLE
Fix several e2e test fails for 18.2

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -267,7 +267,7 @@ export class EditorToolbarComponent {
 
 	/**
 	 * Returns whether the current post is a schedule by checking button states
-	 * on the page
+	 * on the post
 	 *
 	 * @returns {Promise<string>} String found on the button.
 	 */

--- a/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
@@ -2,8 +2,8 @@ import { Page } from 'playwright';
 import { EditorComponent } from './editor-component';
 
 const selectors = {
-	primaryFieldByText: ( primaryFieldText: string ) =>
-		`.dataviews-view-table__primary-field:has-text("${ primaryFieldText }") a`,
+	primaryFieldByText: ( tableOrGrid: string, primaryFieldText: string ) =>
+		`.dataviews-view-${ tableOrGrid }__primary-field:has-text("${ primaryFieldText }") a`,
 };
 
 /**
@@ -30,6 +30,14 @@ export class FullSiteEditorDataViewsComponent {
 	 */
 	async clickPrimaryFieldByExactText( primaryFieldText: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		await editorParent.locator( selectors.primaryFieldByText( primaryFieldText ) ).click();
+
+		const primaryFieldInTable = editorParent.locator(
+			selectors.primaryFieldByText( 'table', primaryFieldText )
+		);
+		const primaryFieldInGrid = editorParent.locator(
+			selectors.primaryFieldByText( 'grid', primaryFieldText )
+		);
+
+		await Promise.race( [ primaryFieldInTable.click(), primaryFieldInGrid.click() ] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -700,7 +700,7 @@ export class EditorPage {
 		timeout,
 	}: { visit?: boolean; timeout?: number } = {} ): Promise< URL > {
 		const publishButtonText = await this.editorToolbarComponent.getPublishButtonText();
-		const postStatusButtonText = await this.editorToolbarComponent.getPostStatusButtonText();
+		const isSchedule = await this.editorToolbarComponent.isScheduledPostStatus();
 		const actionsArray = [];
 
 		// Every publish action requires at least one click on the EditorToolbarComponent.
@@ -712,13 +712,12 @@ export class EditorPage {
 		// is added to the array of actions.
 		const requiresSecondClick =
 			! [ 'save', 'update' ].includes( publishButtonText.toLowerCase() ) ||
-			( publishButtonText.toLowerCase() === 'save' &&
-				postStatusButtonText?.toLowerCase() === 'scheduled' );
+			( publishButtonText.toLowerCase() === 'save' && isSchedule );
 
 		if ( requiresSecondClick ) {
 			actionsArray.push( this.editorPublishPanelComponent.publish() );
 		}
-
+		console.log( [ publishButtonText, isSchedule, actionsArray ] );
 		// Resolve the promises.
 		const [ response ] = await Promise.all( [
 			// First URL matches Atomic requests while the second matches Simple requests.


### PR DESCRIPTION
Follow-up from: #90341

Fixes the same issue fixed in #90341 for mobiles.


This is currently breaking some nightly e2e tests for Gutenberg. This change modifies the e2e's expectations to fit the new realities.

Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

Run the editor schedule flow e2e edge tests, which was failing before this fix:

```bash
cd test/e2e
yarn jest --clearCache && yarn build  # clear build cache before each run


yarn jest specs/editor/editor__schedule.ts  
GUTENBERG_EDGE=1 yarn jest specs/editor/editor__schedule.ts 
GUTENBERG_EDGE=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__schedule.ts 
```