### PR TITLE
A4A: Update header styles

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -12,7 +12,8 @@ import { ItemData, ItemPreviewPaneHeaderExtraProps } from '../types';
 
 import './style.scss';
 
-const ICON_SIZE = 24;
+const ICON_SIZE_SMALL = 16;
+const ICON_SIZE_REGULAR = 24;
 
 interface Props {
 	closeItemPreviewPane?: () => void;
@@ -77,7 +78,7 @@ export default function ItemPreviewPaneHeader( {
 							<Icon
 								className="sidebar-v2__external-icon"
 								icon={ external }
-								size={ extraProps?.externalIconSize || ICON_SIZE }
+								size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
 							/>
 						</Button>
 					</div>
@@ -107,7 +108,7 @@ export default function ItemPreviewPaneHeader( {
 						aria-label={ translate( 'Close Preview' ) }
 						ref={ focusRef }
 					>
-						<Gridicon icon="cross" size={ ICON_SIZE } />
+						<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
 					</Button>
 				) }
 			</div>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -47,12 +47,19 @@
 
 					.item-preview__header-summary-link {
 						display: flex;
+						gap: 2px;
 						align-items: center;
-						font-size: rem(18px);
+						font-size: rem(16px);
 						font-weight: 400;
 						color: var(--color-accent-70);
-						line-height: 26px;
+						line-height: 24px;
 						width: fit-content;
+						text-decoration: none;
+
+						&:hover {
+							color: var(--color-link-dark);
+							text-decoration: underline;
+						}
 
 						&:focus {
 							box-shadow: none;

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -52,7 +52,7 @@
 						font-size: rem(16px);
 						font-weight: 400;
 						color: var(--color-accent-70);
-						line-height: 24px;
+						line-height: 1.5;
 						width: fit-content;
 						text-decoration: none;
 


### PR DESCRIPTION
## Proposed Changes

This PR aligns A4A header styles with Dotcom. Related to https://github.com/Automattic/dotcom-forge/issues/6977

Here's a full list of changes:

* Reduces font-size to `16px` for the site URL.
* Removes underline when not hovered.
* Adjusts spacing between site URL and external icon to `2px`.
* Changes size of external icon. Adds new icon size in `ICON_SIZE_SMALL`; renames existing one to `ICON_SIZE_REGULAR`.


## Screenshots

Before | After
--|--
![image](https://github.com/Automattic/wp-calypso/assets/390760/a239b431-8052-4858-9a1b-27541ad6b1d8) | ![image](https://github.com/Automattic/wp-calypso/assets/390760/b3a28f53-7ab7-4546-8b54-d38575207b12)
![image](https://github.com/Automattic/wp-calypso/assets/390760/a239b431-8052-4858-9a1b-27541ad6b1d8) | ![image](https://github.com/Automattic/wp-calypso/assets/390760/24f2a749-e67b-46a7-b689-097d9f485f38)



## Testing Instructions

* Fire up this PR.
* Open A4A and click on a site to show details.
* In the preview panel, ensure the new styles are visible and everything works.
