### PR TITLE
Add frame around /me Profile pages

### DIFF
--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -1,9 +1,12 @@
 @import "@wordpress/base-styles/breakpoints.scss";
 @import "@automattic/typography/styles/variables";
 @import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/mixins";
 
 .navigation-header.developer__header {
-	margin-top: 50px;
+	@include break-small {
+		margin-top: 50px;
+	}
 
 	.formatted-header__title {
 		font-family: $brand-serif;

--- a/client/me/dotcom-nav-redesign-v2.scss
+++ b/client/me/dotcom-nav-redesign-v2.scss
@@ -69,7 +69,7 @@ body.is-section-me {
 			justify-content: normal;
 			align-items: center;
 			.formatted-header {
-				flex: none;
+				flex: 1;
 			}
 		}
 	}

--- a/client/me/dotcom-nav-redesign-v2.scss
+++ b/client/me/dotcom-nav-redesign-v2.scss
@@ -22,7 +22,7 @@ body.is-section-me {
 	}
 
 	.has-no-masterbar .layout__content .main {
-		padding-top: 24px;
+		padding: 24px;
 	}
 
 	div.layout.is-global-sidebar-visible {
@@ -50,15 +50,18 @@ body.is-section-me {
 		}
 	}
 
-	.navigation-header::after {
-		content: "";
-		display: block;
-		position: relative;
-		left: calc(-50%);
-		margin: 24px 0;
-		width: 100vw;
-		height: 1px;
-		background: var(--color-border-secondary);
+
+	@media screen and (min-width: 782px) {
+		.navigation-header::after {
+			content: "";
+			display: block;
+			position: relative;
+			left: calc(-1 * (100vw - 100%)/2 - 132px);
+			margin: 24px 0;
+			width: 100vw;
+			height: 1px;
+			background: var(--color-border-secondary);
+		}
 	}
 
 	@media only screen and (max-width: 600px) {
@@ -74,7 +77,7 @@ body.is-section-me {
 	@media only screen and (max-width: 781px) {
 		div.layout.is-global-sidebar-visible {
 			.layout__primary {
-				overflow-x: auto;
+				overflow-x: hidden;
 			}
 		}
 		.layout__primary > div {

--- a/client/me/dotcom-nav-redesign-v2.scss
+++ b/client/me/dotcom-nav-redesign-v2.scss
@@ -1,0 +1,87 @@
+body.is-section-me {
+	background: var(--studio-gray-0);
+
+	&.rtl .layout__content {
+		padding: 16px calc(var(--sidebar-width-max)) 16px 16px;
+	}
+
+	.layout__content {
+		// Add border around everything
+		overflow: hidden;
+		min-height: 100vh;
+		@media only screen and (min-width: 782px) {
+			padding: 16px 16px 16px calc(var(--sidebar-width-max)) !important;
+		}
+		.layout_primary > div {
+			padding-bottom: 0;
+		}
+	}
+
+	.layout__secondary .global-sidebar {
+		border: none;
+	}
+
+	.has-no-masterbar .layout__content .main {
+		padding-top: 24px;
+	}
+
+	div.layout.is-global-sidebar-visible {
+		.main {
+			@media only screen and (min-width: 600px) and (max-width: 960px) {
+				padding: 24px;
+			}
+			@media only screen and (max-width: 660px) {
+				padding-top: 0;
+			}
+			border-block-end: 1px solid var(--studio-gray-0);
+		}
+		.layout__primary {
+			background: var(--color-surface);
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			box-shadow: none;
+			@media only screen and (min-width: 600px) {
+				height: calc(100vh - var(--masterbar-height) - 50px);
+			}
+			@media only screen and (min-width: 782px) {
+				height: calc(100vh - 32px);
+			}
+			overflow-y: auto;
+			overflow-x: hidden;
+		}
+	}
+
+	.navigation-header::after {
+		content: "";
+		display: block;
+		position: relative;
+		left: calc(-50%);
+		margin: 24px 0;
+		width: 100vw;
+		height: 1px;
+		background: var(--color-border-secondary);
+	}
+
+	@media only screen and (max-width: 600px) {
+		.navigation-header__main {
+			justify-content: normal;
+			align-items: center;
+			.formatted-header {
+				flex: none;
+			}
+		}
+	}
+
+	@media only screen and (max-width: 781px) {
+		div.layout.is-global-sidebar-visible {
+			.layout__primary {
+				overflow-x: auto;
+			}
+		}
+		.layout__primary > div {
+			background: var(--color-surface);
+			margin: 0;
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			height: calc(100vh - 32px);
+		}
+	}
+}

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
-import './dotcom-nav-redesign-v2.scss';
+import './style.scss';
 
 export default function () {
 	page( '/me', controller.sidebar, controller.profile, makeLayout, clientRender );

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -2,6 +2,8 @@ import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
+import './dotcom-nav-redesign-v2.scss';
+
 export default function () {
 	page( '/me', controller.sidebar, controller.profile, makeLayout, clientRender );
 

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -48,7 +48,7 @@ class Profile extends Component {
 		const gravatarProfileLink = 'https://gravatar.com/' + this.props.getSetting( 'user_login' );
 
 		return (
-			<Main className="profile">
+			<Main wideLayout className="profile">
 				<PageViewTracker path="/me" title="Me > My Profile" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<NavigationHeader

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -15,6 +15,7 @@ body.is-section-me {
 		// Add border around everything
 		overflow: hidden;
 		min-height: 100vh;
+		padding-bottom: 0;
 		@media only screen and (min-width: 782px) {
 			padding: 16px 16px 16px calc(var(--sidebar-width-max)) !important;
 		}

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -1,5 +1,7 @@
-html {
-	overflow-y: hidden;
+@media only screen and (min-width: 601px) {
+	html {
+		overflow-y: hidden;
+	}
 }
 
 body.is-section-me {
@@ -34,7 +36,7 @@ body.is-section-me {
 			@media only screen and (min-width: 600px) and (max-width: 960px) {
 				padding: 24px;
 			}
-			@media only screen and (max-width: 660px) {
+			@media only screen and (max-width: 600px) {
 				padding-top: 0;
 			}
 			border-block-end: 1px solid var(--studio-gray-0);

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -1,3 +1,7 @@
+html {
+	overflow-y: hidden;
+}
+
 body.is-section-me {
 	background: var(--studio-gray-0);
 

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -19,6 +19,9 @@ body.is-section-me {
 		@media only screen and (min-width: 782px) {
 			padding: 16px 16px 16px calc(var(--sidebar-width-max)) !important;
 		}
+		@media only screen and (max-width: 600px) {
+			background: var(--studio-white);
+		}
 		.layout_primary > div {
 			padding-bottom: 0;
 		}
@@ -39,6 +42,7 @@ body.is-section-me {
 			}
 			@media only screen and (max-width: 600px) {
 				padding-top: 0;
+				padding-bottom: 0;
 			}
 			border-block-end: 1px solid var(--studio-gray-0);
 		}
@@ -46,7 +50,7 @@ body.is-section-me {
 			background: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
 			box-shadow: none;
-			@media only screen and (min-width: 600px) {
+			@media only screen and (min-width: 601px) {
 				height: calc(100vh - var(--masterbar-height) - 50px);
 			}
 			@media only screen and (min-width: 782px) {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6856

## Proposed Changes

Add frame like /sites to /me pages, using the Privacy page as a demo


https://github.com/Automattic/wp-calypso/assets/6586048/63a3171d-77fb-401e-9e53-4032231f1c4e



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me and check all the pages to see if there are any inconsistencies

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
