### PR TITLE
A4A: Update cards styling in Overview page

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -61,7 +61,7 @@
 		color: var(--studio-gray-80);
 		font-size: rem(16px);
 		font-weight: 400;
-		line-height: 24px;
+		line-height: 1.5;
 		margin-block-start: 16px;
 	}
 

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -33,6 +33,9 @@
 		border: none;
 	}
 
+	.foldable-card__action {
+		right: 8px;
+	}
 	.a4a-migration-offer__title {
 		display: flex;
 		gap: 8px;

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -28,7 +28,7 @@
 	}
 
 	&.foldable-card.is-expanded .foldable-card__content {
-		padding-block: 0 16px;
+		padding-block: 0 24px;
 		padding-inline: 24px;
 		border: none;
 	}

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -23,12 +23,14 @@
 	}
 
 	.foldable-card__content {
+		padding-block-start: 0;
 		border: none;
 	}
 
 	&.foldable-card.is-expanded .foldable-card__content {
+		padding-block: 0 16px;
+		padding-inline: 24px;
 		border: none;
-		padding-block-start: 8px;
 	}
 
 	.a4a-migration-offer__title {

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -36,6 +36,11 @@
 	.foldable-card__action {
 		right: 8px;
 	}
+
+	.foldable-card__expand .gridicon {
+		fill: var(--color-neutral-100);
+	}
+
 	.a4a-migration-offer__title {
 		display: flex;
 		gap: 8px;

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -59,9 +59,9 @@
 
 	.a4a-migration-offer__description {
 		color: var(--studio-gray-80);
-		font-size: 1rem;
+		font-size: rem(16px);
 		font-weight: 400;
-		line-height: 1.65;
+		line-height: 24px;
 		margin-block-start: 16px;
 	}
 

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -62,7 +62,6 @@
 		font-size: rem(16px);
 		font-weight: 400;
 		line-height: 1.5;
-		margin-block-start: 16px;
 	}
 
 	.a4a-migration-offer__details-button {

--- a/client/a8c-for-agencies/components/offering/offering-item.tsx
+++ b/client/a8c-for-agencies/components/offering/offering-item.tsx
@@ -32,7 +32,7 @@ const OfferingItem: React.FC< OfferingItemProps > = ( {
 				{ highlights.map( ( highlightItemText ) => (
 					<li className="a4a-offering-item__card-list-item" key={ highlightItemText }>
 						<div className="a4a-offering-item__icon-container">
-							<Gridicon className="a4a-offering-item__gridicon" icon="checkmark" size={ 24 } />
+							<Gridicon className="a4a-offering-item__gridicon" icon="checkmark" size={ 18 } />
 						</div>
 						<span className="a4a-offering-item__text">{ highlightItemText }</span>
 					</li>

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -52,7 +52,7 @@
 			border: none;
 		}
 		&.foldable-card.is-expanded .foldable-card__content {
-			padding-block: 0 16px;
+			padding-block: 0 24px;
 			padding-inline: 24px;
 			border: none;
 		}

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -56,6 +56,11 @@
 		.foldable-card__action {
 			right: 8px;
 		}
+
+		.foldable-card__expand .gridicon {
+			fill: var(--color-neutral-100);
+		}
+
 		.a4a-offering-item__button {
 			font-weight: 500;
 		}

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -53,6 +53,9 @@
 			border: none;
 		}
 
+		.foldable-card__action {
+			right: 8px;
+		}
 		.a4a-offering-item__button {
 			font-weight: 500;
 		}

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -30,7 +30,8 @@
 			.a4a-offering-item__title {
 				color: var(--color-neutral-100);
 				font-weight: 500;
-				font-size: 1rem;
+				font-size: rem(16px);
+				line-height: 20px;
 				margin-inline-start: 10px;
 			}
 		}
@@ -38,7 +39,10 @@
 		.a4a-offering-item__description {
 			color: var(--color-neutral-60);
 			font-weight: 400;
-			font-size: 0.875rem;
+			font-size: rem(14px);
+			line-height: 20px;
+		}
+
 		.foldable-card__header {
 			padding-inline: 24px;
 		}

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -39,15 +39,18 @@
 			color: var(--color-neutral-60);
 			font-weight: 400;
 			font-size: 0.875rem;
+		.foldable-card__header {
+			padding-inline: 24px;
 		}
 
 		.foldable-card__content {
-			border: none;
 			padding-block-start: 0;
-		}
-		.foldable-card.is-expanded .foldable-card__content {
 			border: none;
-			padding: 0;
+		}
+		&.foldable-card.is-expanded .foldable-card__content {
+			padding-block: 0 16px;
+			padding-inline: 24px;
+			border: none;
 		}
 
 		.a4a-offering-item__button {
@@ -59,7 +62,7 @@
 		display: grid;
 		gap: 16px;
 
-		margin: 8px 0 16px 0;
+		margin: 8px 0 24px 0;
 		padding: 0;
 
 		list-style-type: none;

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -83,7 +83,7 @@
 	.a4a-offering-item__card-list-item {
 		color: var(--color-neutral-80);
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		font-size: 0.875rem;
 		line-height: 20px;
 	}

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -92,7 +92,7 @@
 		margin-inline-end: 10px;
 
 		.a4a-offering-item__gridicon {
-			fill: var(--color-primary-20);
+			fill: var(--color-primary-30);
 			display: flex;
 			align-items: center;
 			justify-content: center;

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -8,14 +8,14 @@
 	.a4a-offering-card__title {
 		font-weight: 500;
 		font-size: 1rem;
-		line-height: 24px;
+		line-height: 1.5;
 		color: var(--color-neutral-100);
 	}
 
 	.a4a-offering-card__description {
 		font-weight: 400;
-		font-size: 0.875rem;
-		line-height: 20px;
+		font-size: rem(14px);
+		line-height: 1.25;
 		color: var(--color-neutral-60);
 		margin-block-end: 16px;
 	}
@@ -31,7 +31,7 @@
 				color: var(--color-neutral-100);
 				font-weight: 500;
 				font-size: rem(16px);
-				line-height: 20px;
+				line-height: 1.25;
 				margin-inline-start: 10px;
 			}
 		}
@@ -40,7 +40,7 @@
 			color: var(--color-neutral-60);
 			font-weight: 400;
 			font-size: rem(14px);
-			line-height: 20px;
+			line-height: 1.25;
 		}
 
 		.foldable-card__header {

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
@@ -10,7 +10,7 @@
 		h1 {
 			font-size: rem(32px);
 			font-weight: 700;
-			line-height: 48px;
+			line-height: 1.25;
 			margin-bottom: 16px;
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Adjust padding of offering cards
* Align expanding card chevrons with other right-aligned icons
* Update chevron color
* Align checkmarks to the top of accompanying text
* Update checkmark size and icon color
* Update font-sizes and line-height values

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/450

## Screenshots

Before | After
--|--
![image](https://github.com/Automattic/wp-calypso/assets/390760/caf32545-00dc-44a2-9c1f-2c345ad136b0) | ![image](https://github.com/Automattic/wp-calypso/assets/390760/ce01629a-73c4-4afa-8b1d-eb5bbdecc760)


## Testing Instructions

* Fire up this PR.
* To go the A4A platform and visit the Overview page.
* Ensure it all looks good and works properly.

