### PR TITLE
A4A: Update the WPCOM license to redirect the user to the WPCOM Purchases page when revoking.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -259,8 +259,6 @@ export default function LicensePreview( {
 					{ isWPCOMLicense && isSiteAtomic ? (
 						<LicenseActions
 							siteUrl={ siteUrl }
-							licenseKey={ licenseKey }
-							product={ product }
 							attachedAt={ attachedAt }
 							revokedAt={ revokedAt }
 							licenseType={ licenseType }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -2,17 +2,10 @@ import { Button, Gridicon } from '@automattic/components';
 import { useState, useRef } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import {
-	LicenseAction,
-	LicenseRole,
-	LicenseType,
-} from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import RevokeLicenseDialog from '../revoke-license-dialog';
+import { LicenseAction, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import useLicenseActions from './use-license-actions';
 
 interface Props {
-	licenseKey: string;
-	product: string;
 	siteUrl: string | null;
 	attachedAt: string | null;
 	revokedAt: string | null;
@@ -22,8 +15,6 @@ interface Props {
 
 export default function LicenseActions( {
 	siteUrl,
-	licenseKey,
-	product,
 	attachedAt,
 	revokedAt,
 	licenseType,
@@ -32,7 +23,6 @@ export default function LicenseActions( {
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 
 	const [ isOpen, setIsOpen ] = useState( false );
-	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
 
 	const licenseActions = useLicenseActions(
 		siteUrl,
@@ -44,9 +34,6 @@ export default function LicenseActions( {
 
 	const handleActionClick = ( action: LicenseAction ) => {
 		action.onClick();
-		if ( action.type === 'revoke' ) {
-			setShowRevokeDialog( true );
-		}
 	};
 
 	return (
@@ -75,16 +62,6 @@ export default function LicenseActions( {
 						</PopoverMenuItem>
 					) ) }
 			</PopoverMenu>
-
-			{ showRevokeDialog && (
-				<RevokeLicenseDialog
-					licenseKey={ licenseKey }
-					product={ product }
-					siteUrl={ siteUrl }
-					onClose={ () => setShowRevokeDialog( false ) }
-					licenseRole={ isChildLicense ? LicenseRole.Child : LicenseRole.Single }
-				/>
-			) }
 		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -70,6 +70,8 @@ export default function useLicenseActions(
 			},
 			{
 				name: translate( 'Revoke' ),
+				href: `https://wordpress.com/purchases/subscriptions/${ siteSlug }`,
+				isExternalLink: true,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_hosting_configuration_click' ),
 				type: 'revoke',
 				isEnabled:


### PR DESCRIPTION
This pull request updates the flow for revoking licenses on WPCOM. The updated flow will now redirect agency users to the WPCOM purchases page.

<img width="290" alt="Screenshot 2024-05-08 at 8 19 19 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a268ca25-6a77-4ab4-a9f4-05384bbec66d">
<img width="1150" alt="Screenshot 2024-05-08 at 8 19 36 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a14f5513-a4cc-4f55-b551-ac1a0b52d4a7">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/445

## Proposed Changes

* Update Revoke button in WPCOM license action to redirect user to `https://wordpress.com/purchases/subscriptions/${ siteSlug }`
* Remove any codes referencing the old flow, which displays the revoke dialog.

## Testing Instructions

* Purchase and Create a WPCOM site in A4A.
* Use the A4A live link and go to `/purchases/licenses`
* Look for the assigned WPCOM license and click the ellipse icon to reveal the site actions.
* Click the 'Revoke' button.
* Confirm that you are redirected to the WPCOM purchases page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?