### PR TITLE
Tracking: Fix hosting flow related issues

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -38,7 +38,9 @@ To create a flow, you only have to implement `useSteps` and `useStepNavigation`.
 
 There is also an optional `useSideEffect` hook. You can implement this hook to run any side-effects to the flow. You can prefetch information, send track events when something changes, etc...
 
-There is a required `isSignupFlow` flag that _MUST be `true` for signup flows_ (generally where a new site may be created), and should be `false` for other flows. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts. For signup flows, you can also supply additional event props to the `calypso_signup_start` event by implementing the optional `useSignupStartEventProps()` hook on the flow.
+### Tracking Config
+
+A configuration `trackingConfig` object which controls how tracking works inside the stepper frameworks
 
 ```tsx
 // prettier-ignore

--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -29,7 +29,10 @@ const SiteIntent = Onboard.SiteIntent;
 
 const withAIAssemblerFlow: Flow = {
 	name: AI_ASSEMBLER_FLOW,
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSideEffect() {
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),

--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -30,8 +30,8 @@ const SiteIntent = Onboard.SiteIntent;
 const withAIAssemblerFlow: Flow = {
 	name: AI_ASSEMBLER_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSideEffect() {
 		const selectedDesign = useSelect(

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -29,8 +29,8 @@ const SiteIntent = Onboard.SiteIntent;
 const assemblerFirstFlow: Flow = {
 	name: ASSEMBLER_FIRST_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSideEffect() {
 		const selectedDesign = useSelect(

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -28,7 +28,10 @@ const SiteIntent = Onboard.SiteIntent;
 
 const assemblerFirstFlow: Flow = {
 	name: ASSEMBLER_FIRST_FLOW,
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSideEffect() {
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),

--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -18,8 +18,8 @@ const Blog: Flow = {
 		return translate( 'Blog' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -17,7 +17,10 @@ const Blog: Flow = {
 	get title() {
 		return translate( 'Blog' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -15,8 +15,8 @@ const build: Flow = {
 		return 'WordPress';
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -14,7 +14,10 @@ const build: Flow = {
 	get title() {
 		return 'WordPress';
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [
 			{ slug: 'launchpad', component: LaunchPad },

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -30,7 +30,10 @@ const connectDomain: Flow = {
 	get title() {
 		return translate( 'Connect your domain' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useAssertConditions: () => {
 		const { domain, provider } = useDomainParams();
 		const flowName = CONNECT_DOMAIN_FLOW;

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -31,8 +31,8 @@ const connectDomain: Flow = {
 		return translate( 'Connect your domain' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useAssertConditions: () => {
 		const { domain, provider } = useDomainParams();

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -75,7 +75,10 @@ const copySite: Flow = {
 	get title() {
 		return '';
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -76,8 +76,8 @@ const copySite: Flow = {
 		return '';
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -26,7 +26,10 @@ const designFirst: Flow = {
 	get title() {
 		return translate( 'Blog' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -27,8 +27,8 @@ const designFirst: Flow = {
 		return translate( 'Blog' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -26,8 +26,8 @@ const domainTransfer: Flow = {
 		return translate( 'Bulk domain transfer' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -25,7 +25,10 @@ const domainTransfer: Flow = {
 	get title() {
 		return translate( 'Bulk domain transfer' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -16,7 +16,10 @@ const domainUpsell: Flow = {
 	get title() {
 		return translate( 'Domain Upsell' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -17,8 +17,8 @@ const domainUpsell: Flow = {
 		return translate( 'Domain Upsell' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -19,8 +19,8 @@ import DomainContactInfo from './internals/steps-repository/domain-contact-info'
 const domainUserTransfer: Flow = {
 	name: 'domain-user-transfer',
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [ { slug: 'domain-contact-info', component: DomainContactInfo } ];

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -18,7 +18,10 @@ import DomainContactInfo from './internals/steps-repository/domain-contact-info'
 
 const domainUserTransfer: Flow = {
 	name: 'domain-user-transfer',
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [ { slug: 'domain-contact-info', component: DomainContactInfo } ];
 	},

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -17,8 +17,8 @@ const SEGMENTATION_SURVEY_SLUG = 'start';
 const entrepreneurFlow: Flow = {
 	name: ENTREPRENEUR_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -3,8 +3,6 @@ import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { anonIdCache } from 'calypso/data/segmentaton-survey';
-import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useFlowLocale } from '../hooks/use-flow-locale';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { getLoginUrl } from '../utils/path';
@@ -18,8 +16,10 @@ const SEGMENTATION_SURVEY_SLUG = 'start';
 
 const entrepreneurFlow: Flow = {
 	name: ENTREPRENEUR_FLOW,
-
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 
 	useSteps() {
 		return [
@@ -142,8 +142,6 @@ const entrepreneurFlow: Flow = {
 	},
 
 	useSideEffect() {
-		const isLoggedIn = useSelector( isUserLoggedIn );
-
 		useEffect( () => {
 			// We need to store the anonymous user ID in localStorage because
 			// we need to pass it to the server on site creation, i.e. after the user signs up or logs in.

--- a/client/landing/stepper/declarative-flow/free-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/free-post-setup.ts
@@ -12,8 +12,8 @@ const freePostSetup: Flow = {
 		return translate( 'Free' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [ STEPS.FREE_POST_SETUP ];

--- a/client/landing/stepper/declarative-flow/free-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/free-post-setup.ts
@@ -11,7 +11,10 @@ const freePostSetup: Flow = {
 	get title() {
 		return translate( 'Free' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [ STEPS.FREE_POST_SETUP ];
 	},

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -34,8 +34,8 @@ const free: Flow = {
 		return translate( 'Free' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -33,7 +33,10 @@ const free: Flow = {
 	get title() {
 		return translate( 'Free' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -20,7 +20,10 @@ const HundredYearPlanFlow: Flow = {
 	get title() {
 		return translate( '100-year Plan' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		const currentUser = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),

--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -21,8 +21,8 @@ const HundredYearPlanFlow: Flow = {
 		return translate( '100-year Plan' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		const currentUser = useSelect(

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -43,7 +43,10 @@ import type { SiteExcerptData } from '@automattic/sites';
 
 const importFlow: Flow = {
 	name: IMPORT_FOCUSED_FLOW,
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -44,8 +44,8 @@ import type { SiteExcerptData } from '@automattic/sites';
 const importFlow: Flow = {
 	name: IMPORT_FOCUSED_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -33,7 +33,10 @@ import type { SiteExcerptData } from '@automattic/sites';
 
 const importHostedSiteFlow: Flow = {
 	name: IMPORT_HOSTED_SITE_FLOW,
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 
 	useSteps() {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -34,8 +34,8 @@ import type { SiteExcerptData } from '@automattic/sites';
 const importHostedSiteFlow: Flow = {
 	name: IMPORT_HOSTED_SITE_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -163,7 +163,11 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	useEffect( () => {
-		if ( flow.trackingConfig?.isRecordSignupStart && isFlowStart() ) {
+		let isSignupStartTracked = flow.trackingConfig?.isSignupStartTracked;
+		if ( typeof isSignupStartTracked === 'function' ) {
+			isSignupStartTracked = isSignupStartTracked( { isLoggedIn } );
+		}
+		if ( isSignupStartTracked && isFlowStart() ) {
 			recordSignupStart( flow.name, ref, flow.trackingConfig?.signupStartProps );
 		}
 	}, [ flow, ref, isFlowStart, isLoggedIn ] );
@@ -171,11 +175,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	useEffect( () => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed
 		if ( ! currentStepRoute || ! hasRequestedSelectedSite ) {
-			return;
-		}
-
-		// We do not log stats if the user is not logged in and if this is a signup flow.
-		if ( flow.trackingConfig?.isSignupFlow && ! isLoggedIn ) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -160,20 +160,13 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		window.scrollTo( 0, 0 );
 	}, [ location ] );
 
-	// Get any flow-specific event props to include in the
-	// `calypso_signup_start` Tracks event triggerd in the effect below.
-	const signupStartEventProps = useMemo( () => flow.useSignupStartEventProps?.() ?? {}, [ flow ] );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	useEffect( () => {
-		if ( flow.isSignupFlow && ! isLoggedIn ) {
-			return;
+		if ( flow.trackingConfig?.isRecordSignupStart && isFlowStart() ) {
+			recordSignupStart( flow.name, ref, flow.trackingConfig?.signupStartProps );
 		}
-
-		if ( flow.isSignupFlow && isFlowStart() ) {
-			recordSignupStart( flow.name, ref, signupStartEventProps );
-		}
-	}, [ flow, ref, isFlowStart, isLoggedIn, signupStartEventProps ] );
+	}, [ flow, ref, isFlowStart, isLoggedIn ] );
 
 	useEffect( () => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed
@@ -182,7 +175,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		}
 
 		// We do not log stats if the user is not logged in and if this is a signup flow.
-		if ( flow.isSignupFlow && ! isLoggedIn ) {
+		if ( flow.trackingConfig?.isSignupFlow && ! isLoggedIn ) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -20,7 +20,6 @@ import {
 	getSignupCompleteStepNameAndClear,
 } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSite, isRequestingSite } from 'calypso/state/sites/selectors';
 import { useQuery } from '../../hooks/use-query';
 import { useSaveQueryParams } from '../../hooks/use-save-query-params';
@@ -160,17 +159,14 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		window.scrollTo( 0, 0 );
 	}, [ location ] );
 
-	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isSignupStartTracked = flow.trackingConfig?.useIsSignupStartTracked?.();
+	const signupEventProps = flow.trackingConfig?.useSignupStartEventProps?.();
 
 	useEffect( () => {
-		let isSignupStartTracked = flow.trackingConfig?.isSignupStartTracked;
-		if ( typeof isSignupStartTracked === 'function' ) {
-			isSignupStartTracked = isSignupStartTracked( { isLoggedIn } );
-		}
 		if ( isSignupStartTracked && isFlowStart() ) {
-			recordSignupStart( flow.name, ref, flow.trackingConfig?.signupStartProps );
+			recordSignupStart( flow.name, ref, signupEventProps );
 		}
-	}, [ flow, ref, isFlowStart, isLoggedIn ] );
+	}, [ flow, ref, isFlowStart, isSignupStartTracked, signupEventProps ] );
 
 	useEffect( () => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -103,7 +103,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
 			if ( availableFlows[ flow ] ) {
 				availableFlows[ flow ]().then( ( flowExport ) => {
-					if ( flowExport.default.trackingConfig?.isRecordSignupComplete ) {
+					if ( flowExport.default.trackingConfig?.isSignupCompleteTracked ) {
 						recordSignupComplete( flowExport.default.trackingConfig?.signupStartProps );
 					}
 				} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -103,8 +103,8 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
 			if ( availableFlows[ flow ] ) {
 				availableFlows[ flow ]().then( ( flowExport ) => {
-					if ( flowExport.default.isSignupFlow ) {
-						recordSignupComplete();
+					if ( flowExport.default.trackingConfig?.isRecordSignupComplete ) {
+						recordSignupComplete( flowExport.default.trackingConfig?.signupStartProps );
 					}
 				} );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -25,7 +25,7 @@ import { ProcessingResult } from './constants';
 import { useProcessingLoadingMessages } from './hooks/use-processing-loading-messages';
 import HundredYearPlanFlowProcessingScreen from './hundred-year-plan-flow-processing-screen';
 import TailoredFlowPreCheckoutScreen from './tailored-flow-precheckout-screen';
-import type { StepProps } from '../../types';
+import type { Flow, StepProps } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './style.scss';
 interface ProcessingStepProps extends StepProps {
@@ -43,6 +43,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
 	const [ destinationState, setDestinationState ] = useState( {} );
+	const [ flowDefinition, setFlowDefinition ] = useState< Flow >();
 
 	const recordSignupComplete = useRecordSignupComplete( flow );
 
@@ -73,6 +74,12 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const captureFlowException = useCaptureFlowException( props.flow, 'ProcessingStep' );
 
 	useEffect( () => {
+		availableFlows[ flow ]().then( ( flowExport ) => {
+			setFlowDefinition( flowExport.default );
+		} );
+	}, [ flow ] );
+
+	useEffect( () => {
 		( async () => {
 			if ( typeof action === 'function' ) {
 				try {
@@ -97,16 +104,15 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ action ] );
 
+	const isSignupCompleteTracked = flowDefinition?.trackingConfig?.useIsSignupCompleteTracked?.();
+	const signupStartEventProps = flowDefinition?.trackingConfig?.useSignupStartEventProps?.();
+
 	// When the hasActionSuccessfullyRun flag turns on, run submit() and fire the sign-up completion event.
 	useEffect( () => {
 		if ( hasActionSuccessfullyRun ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
-			if ( availableFlows[ flow ] ) {
-				availableFlows[ flow ]().then( ( flowExport ) => {
-					if ( flowExport.default.trackingConfig?.isSignupCompleteTracked ) {
-						recordSignupComplete( flowExport.default.trackingConfig?.signupStartProps );
-					}
-				} );
+			if ( isSignupCompleteTracked ) {
+				recordSignupComplete( signupStartEventProps );
 			}
 
 			if ( isNewSiteMigrationFlow( flow ) ) {
@@ -119,7 +125,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		}
 		// A change in submit() doesn't cause this effect to rerun.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ hasActionSuccessfullyRun, recordSignupComplete, flow ] );
+	}, [ hasActionSuccessfullyRun, recordSignupComplete, flowDefinition ] );
 
 	const getSubtitle = () => {
 		return props.subtitle || loadingMessages[ currentMessageIndex ]?.subtitle;

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -94,6 +94,34 @@ export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (
 	navigate: Navigate< FlowSteps >
 ) => void;
 
+type IsSignupStartTrackedParams = {
+	/**
+	 * Is the current user already logged in.
+	 */
+	isLoggedIn: boolean;
+};
+
+// Tracking Config
+type TrackingConfig = {
+	/**
+	 * Should signup start be tracked at the start of the flow, Can provide either a boolean or callback that resolves to a boolean.
+	 * The callback will inject some key parameters.
+	 */
+	isSignupStartTracked: boolean | ( ( params: IsSignupStartTrackedParams ) => boolean );
+	/**
+	 * Should signup complete be tracked at the end of the flow
+	 */
+	isSignupCompleteTracked: boolean;
+	/**
+	 * Supply additional event props to the `calypso_signup_start` event
+	 */
+	signupStartProps?: Record< string, string | number >;
+	/**
+	 * Supply additional event props to the `calypso_signup_complete` event
+	 */
+	signupCompleteProps?: Record< string, string | number >;
+};
+
 export type Flow = {
 	name: string;
 	/**
@@ -109,24 +137,7 @@ export type Flow = {
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
 	useSideEffect?: UseSideEffectHook< ReturnType< Flow[ 'useSteps' ] > >;
-	trackingConfig?: {
-		/**
-		 * Should signup start be tracked at the start of the flow
-		 */
-		isRecordSignupStart: boolean;
-		/**
-		 * Should signup complete be tracked at the end of the flow
-		 */
-		isRecordSignupComplete: boolean;
-		/**
-		 * Supply additional event props to the `calypso_signup_start` event
-		 */
-		signupStartProps?: Record< string, string | number >;
-		/**
-		 * Supply additional event props to the `calypso_signup_complete` event
-		 */
-		signupCompleteProps?: Record< string, string | number >;
-	};
+	trackingConfig?: TrackingConfig;
 };
 
 export type StepProps = {

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -94,32 +94,28 @@ export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (
 	navigate: Navigate< FlowSteps >
 ) => void;
 
-type IsSignupStartTrackedParams = {
-	/**
-	 * Is the current user already logged in.
-	 */
-	isLoggedIn: boolean;
-};
-
 // Tracking Config
 type TrackingConfig = {
 	/**
-	 * Should signup start be tracked at the start of the flow, Can provide either a boolean or callback that resolves to a boolean.
+	 * Should signup start be tracked at the start of the flow, Provide wnnnCan provide either a boolean or callback that resolves to a boolean.
 	 * The callback will inject some key parameters.
 	 */
-	isSignupStartTracked: boolean | ( ( params: IsSignupStartTrackedParams ) => boolean );
+	useIsSignupStartTracked: () => boolean;
+
 	/**
 	 * Should signup complete be tracked at the end of the flow
 	 */
-	isSignupCompleteTracked: boolean;
+	useIsSignupCompleteTracked: () => boolean;
+
 	/**
 	 * Supply additional event props to the `calypso_signup_start` event
 	 */
-	signupStartProps?: Record< string, string | number >;
+	useSignupStartEventProps?: () => Record< string, string | number >;
+
 	/**
 	 * Supply additional event props to the `calypso_signup_complete` event
 	 */
-	signupCompleteProps?: Record< string, string | number >;
+	useSignupCompleteEventProps?: () => Record< string, string | number >;
 };
 
 export type Flow = {

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -102,11 +102,6 @@ export type Flow = {
 	variantSlug?: string;
 	title?: string;
 	classnames?: string | [ string ];
-	/**
-	 * Required flag to indicate if the flow is a signup flow.
-	 */
-	isSignupFlow: boolean;
-	useSignupStartEventProps?: () => Record< string, string | number >;
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;
 	useAssertConditions?: UseAssertConditionsHook< ReturnType< Flow[ 'useSteps' ] > >;
@@ -114,6 +109,24 @@ export type Flow = {
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
 	useSideEffect?: UseSideEffectHook< ReturnType< Flow[ 'useSteps' ] > >;
+	trackingConfig?: {
+		/**
+		 * Should signup start be tracked at the start of the flow
+		 */
+		isRecordSignupStart: boolean;
+		/**
+		 * Should signup complete be tracked at the end of the flow
+		 */
+		isRecordSignupComplete: boolean;
+		/**
+		 * Supply additional event props to the `calypso_signup_start` event
+		 */
+		signupStartProps?: Record< string, string | number >;
+		/**
+		 * Supply additional event props to the `calypso_signup_complete` event
+		 */
+		signupCompleteProps?: Record< string, string | number >;
+	};
 };
 
 export type StepProps = {

--- a/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
@@ -29,8 +29,8 @@ const linkInBioDomain: Flow = {
 		return translate( 'Link in Bio' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	variantSlug: LINK_IN_BIO_DOMAIN_FLOW,
 	useAssertConditions: () => {

--- a/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
@@ -28,7 +28,10 @@ const linkInBioDomain: Flow = {
 	get title() {
 		return translate( 'Link in Bio' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	variantSlug: LINK_IN_BIO_DOMAIN_FLOW,
 	useAssertConditions: () => {
 		const { domain } = useDomainParams();

--- a/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
@@ -11,7 +11,10 @@ const linkInBioPostSetup: Flow = {
 	get title() {
 		return translate( 'Link in Bio' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [ { slug: 'linkInBioPostSetup', component: LinkInBioPostSetup } ];
 	},

--- a/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
@@ -12,8 +12,8 @@ const linkInBioPostSetup: Flow = {
 		return translate( 'Link in Bio' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [ { slug: 'linkInBioPostSetup', component: LinkInBioPostSetup } ];

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -31,8 +31,8 @@ const linkInBio: Flow = {
 		return translate( 'Link in Bio' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -30,7 +30,10 @@ const linkInBio: Flow = {
 	get title() {
 		return translate( 'Link in Bio' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		return [
 			{ slug: 'domains', component: DomainsStep },

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -25,8 +25,8 @@ const linkInBio: Flow = {
 		return translate( 'Link in Bio' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -24,7 +24,10 @@ const linkInBio: Flow = {
 	get title() {
 		return translate( 'Link in Bio' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		return [
 			{ slug: 'intro', asyncComponent: () => import( './internals/steps-repository/intro' ) },

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -23,7 +23,10 @@ const FLOW_NAME = MIGRATION_SIGNUP_FLOW;
 
 const migrationSignup: Flow = {
 	name: FLOW_NAME,
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 
 	useSteps() {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -24,8 +24,8 @@ const FLOW_NAME = MIGRATION_SIGNUP_FLOW;
 const migrationSignup: Flow = {
 	name: FLOW_NAME,
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -21,7 +21,10 @@ import './internals/new-hosted-site-flow.scss';
 
 const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW,
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		return [
 			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -10,6 +10,7 @@ import {
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
@@ -22,8 +23,11 @@ import './internals/new-hosted-site-flow.scss';
 const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW,
 	trackingConfig: {
-		isSignupStartTracked: ( { isLoggedIn } ) => isLoggedIn,
-		isSignupCompleteTracked: true,
+		useIsSignupStartTracked: () => {
+			const userLoggedIn = useSelector( isUserLoggedIn );
+			return userLoggedIn;
+		},
+		useIsSignupCompleteTracked: () => true,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -22,7 +22,7 @@ import './internals/new-hosted-site-flow.scss';
 const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW,
 	trackingConfig: {
-		isSignupStartTracked: true,
+		isSignupStartTracked: ( { isLoggedIn } ) => isLoggedIn,
 		isSignupCompleteTracked: true,
 	},
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -22,8 +22,8 @@ import './internals/new-hosted-site-flow.scss';
 const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
@@ -12,8 +12,8 @@ const newsletterPostSetup: Flow = {
 		return translate( 'Newsletter' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [ { slug: 'newsletterPostSetup', component: NewsletterPostSetup } ];

--- a/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
@@ -11,7 +11,10 @@ const newsletterPostSetup: Flow = {
 	get title() {
 		return translate( 'Newsletter' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [ { slug: 'newsletterPostSetup', component: NewsletterPostSetup } ];
 	},

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -27,8 +27,8 @@ const newsletter: Flow = {
 		return translate( 'Newsletter' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		const query = useQuery();

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -26,7 +26,10 @@ const newsletter: Flow = {
 	get title() {
 		return translate( 'Newsletter' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		const query = useQuery();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -39,7 +39,10 @@ const SiteIntent = Onboard.SiteIntent;
 
 const pluginBundleFlow: Flow = {
 	name: 'plugin-bundle',
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 
 	useSteps() {
 		const pluginSlug = useSitePluginSlug();

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -40,8 +40,8 @@ const SiteIntent = Onboard.SiteIntent;
 const pluginBundleFlow: Flow = {
 	name: 'plugin-bundle',
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/podcasts.ts
+++ b/client/landing/stepper/declarative-flow/podcasts.ts
@@ -11,8 +11,8 @@ const podcasts: Flow = {
 		return translate( 'Podcasting' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/podcasts.ts
+++ b/client/landing/stepper/declarative-flow/podcasts.ts
@@ -10,7 +10,10 @@ const podcasts: Flow = {
 	get title() {
 		return translate( 'Podcasting' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [
 			{ slug: 'letsGetStarted', component: LetsGetStarted },

--- a/client/landing/stepper/declarative-flow/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/reblogging.ts
@@ -21,8 +21,8 @@ const reblogging: Flow = {
 		return translate( 'Reblogging' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/reblogging.ts
@@ -20,7 +20,10 @@ const reblogging: Flow = {
 	get title() {
 		return translate( 'Reblogging' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		return [
 			{ slug: 'domains', asyncComponent: () => import( './internals/steps-repository/domains' ) },

--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -27,8 +27,8 @@ const sensei: Flow = {
 		return translate( 'Course Creator' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -26,7 +26,10 @@ const sensei: Flow = {
 	get title() {
 		return translate( 'Course Creator' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [
 			{ slug: 'intro', component: Intro },

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -23,7 +23,10 @@ const FLOW_NAME = 'site-migration';
 
 const siteMigration: Flow = {
 	name: FLOW_NAME,
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -24,8 +24,8 @@ const FLOW_NAME = 'site-migration';
 const siteMigration: Flow = {
 	name: FLOW_NAME,
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -46,8 +46,8 @@ function isLaunchpadIntent( intent: string ) {
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 
 	useSideEffect( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -45,7 +45,10 @@ function isLaunchpadIntent( intent: string ) {
 
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 
 	useSideEffect( currentStep, navigate ) {
 		const selectedDesign = useSelect(

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -26,8 +26,8 @@ const startWriting: Flow = {
 		return translate( 'Blog' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -25,7 +25,10 @@ const startWriting: Flow = {
 	get title() {
 		return translate( 'Blog' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -49,8 +49,8 @@ function getPlanFromRecurType( recurType: string ) {
 const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 		useSignupStartEventProps() {
 			const recur = useSelect(
 				( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -48,14 +48,17 @@ function getPlanFromRecurType( recurType: string ) {
 
 const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
-	isSignupFlow: true,
-	useSignupStartEventProps() {
-		const recur = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
-			[]
-		);
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+		useSignupStartEventProps() {
+			const recur = useSelect(
+				( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
+				[]
+			);
 
-		return { recur };
+			return { recur };
+		},
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -13,7 +13,10 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 const transferringHostedSite: Flow = {
 	name: TRANSFERRING_HOSTED_SITE_FLOW,
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -14,8 +14,8 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 const transferringHostedSite: Flow = {
 	name: TRANSFERRING_HOSTED_SITE_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -20,7 +20,10 @@ import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-sto
 
 const wooexpress: Flow = {
 	name: 'wooexpress',
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -21,8 +21,8 @@ import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-sto
 const wooexpress: Flow = {
 	name: 'wooexpress',
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -23,8 +23,8 @@ const updateDesign: Flow = {
 		return translate( 'Choose Design' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [ STEPS.DESIGN_SETUP, STEPS.PATTERN_ASSEMBLER, STEPS.PROCESSING, STEPS.ERROR ];

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -22,7 +22,10 @@ const updateDesign: Flow = {
 	get title() {
 		return translate( 'Choose Design' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [ STEPS.DESIGN_SETUP, STEPS.PATTERN_ASSEMBLER, STEPS.PROCESSING, STEPS.ERROR ];
 	},

--- a/client/landing/stepper/declarative-flow/update-options.ts
+++ b/client/landing/stepper/declarative-flow/update-options.ts
@@ -8,7 +8,10 @@ import type { Flow } from './internals/types';
 
 const updateOptions: Flow = {
 	name: 'update-options',
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [ STEPS.OPTIONS, STEPS.PROCESSING, STEPS.ERROR ];
 	},

--- a/client/landing/stepper/declarative-flow/update-options.ts
+++ b/client/landing/stepper/declarative-flow/update-options.ts
@@ -9,8 +9,8 @@ import type { Flow } from './internals/types';
 const updateOptions: Flow = {
 	name: 'update-options',
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [ STEPS.OPTIONS, STEPS.PROCESSING, STEPS.ERROR ];

--- a/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
@@ -25,7 +25,10 @@ const videopressTvPurchase: Flow = {
 	get title() {
 		return translate( 'VideoPress TV' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [
 			{ slug: 'processing', component: ProcessingStep },

--- a/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
@@ -26,8 +26,8 @@ const videopressTvPurchase: Flow = {
 		return translate( 'VideoPress TV' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -18,7 +18,10 @@ const videopressTv: Flow = {
 	get title() {
 		return translate( 'VideoPress TV' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -19,8 +19,8 @@ const videopressTv: Flow = {
 		return translate( 'VideoPress TV' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -32,8 +32,8 @@ const videopress: Flow = {
 		return translate( 'Video' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: true,
-		isRecordSignupComplete: true,
+		isSignupStartTracked: true,
+		isSignupCompleteTracked: true,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -31,7 +31,10 @@ const videopress: Flow = {
 	get title() {
 		return translate( 'Video' );
 	},
-	isSignupFlow: true,
+	trackingConfig: {
+		isRecordSignupStart: true,
+		isRecordSignupComplete: true,
+	},
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -19,8 +19,8 @@ const SiteIntent = Onboard.SiteIntent;
 const withThemeAssemblerFlow: Flow = {
 	name: WITH_THEME_ASSEMBLER_FLOW,
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSideEffect() {
 		const selectedDesign = useSelect(

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -18,7 +18,10 @@ const SiteIntent = Onboard.SiteIntent;
 
 const withThemeAssemblerFlow: Flow = {
 	name: WITH_THEME_ASSEMBLER_FLOW,
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSideEffect() {
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -27,7 +27,10 @@ const write: Flow = {
 	get title() {
 		return translate( 'Write' );
 	},
-	isSignupFlow: false,
+	trackingConfig: {
+		isRecordSignupStart: false,
+		isRecordSignupComplete: false,
+	},
 	useSteps() {
 		return [
 			{ slug: 'launchpad', component: LaunchPad },

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -28,8 +28,8 @@ const write: Flow = {
 		return translate( 'Write' );
 	},
 	trackingConfig: {
-		isRecordSignupStart: false,
-		isRecordSignupComplete: false,
+		isSignupStartTracked: false,
+		isSignupCompleteTracked: false,
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -19,52 +19,56 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 		};
 	}, [] );
 
-	return useCallback( () => {
-		// FIXME: once moving to the Stepper version of User step,
-		// wire the value of `isNewUser()` from the user store.
-		const isNewUser = ! siteCount;
+	return useCallback(
+		( customProps?: Record< string, string | number > ) => {
+			// FIXME: once moving to the Stepper version of User step,
+			// wire the value of `isNewUser()` from the user store.
+			const isNewUser = ! siteCount;
 
-		// FIXME:
-		// currently it's impossible to derive this data since it requires
-		// the length of registration, so I use isNewUser here as an approximation
-		const isNew7DUserSite = isNewUser;
+			// FIXME:
+			// currently it's impossible to derive this data since it requires
+			// the length of registration, so I use isNewUser here as an approximation
+			const isNew7DUserSite = isNewUser;
 
-		// Domain product slugs can be a domain purchases like dotcom_domain or dotblog_domain or a mapping like domain_mapping
-		// When purchasing free subdomains the product_slugs is empty (since there is no actual produce being purchased)
-		// so we avoid capturing the product slug in these instances.
-		const domainProductSlug = domainCartItem?.product_slug ?? undefined;
+			// Domain product slugs can be a domain purchases like dotcom_domain or dotblog_domain or a mapping like domain_mapping
+			// When purchasing free subdomains the product_slugs is empty (since there is no actual produce being purchased)
+			// so we avoid capturing the product slug in these instances.
+			const domainProductSlug = domainCartItem?.product_slug ?? undefined;
 
-		// Domain cart items can sometimes be included when free. So the selected domain is explicitly checked to see if it's free.
-		// For mappings and transfers this attribute should be empty but it needs to be checked.
-		const hasCartItems = !! ( domainProductSlug || planCartItem ); // see the function `dependenciesContainCartItem()
+			// Domain cart items can sometimes be included when free. So the selected domain is explicitly checked to see if it's free.
+			// For mappings and transfers this attribute should be empty but it needs to be checked.
+			const hasCartItems = !! ( domainProductSlug || planCartItem ); // see the function `dependenciesContainCartItem()
 
-		// When there is no plan put in the cart, `planCartItem` is `null` instead of `undefined` like domainCartItem.
-		// It worths a investigation of whether the both should behave the same.
-		const planProductSlug = planCartItem?.product_slug ?? undefined;
-		// To have a paid domain item it has to either be a paid domain or a different domain product like mapping or transfer.
-		const hasPaidDomainItem =
-			( selectedDomain && ! selectedDomain.is_free ) || !! domainProductSlug;
+			// When there is no plan put in the cart, `planCartItem` is `null` instead of `undefined` like domainCartItem.
+			// It worths a investigation of whether the both should behave the same.
+			const planProductSlug = planCartItem?.product_slug ?? undefined;
+			// To have a paid domain item it has to either be a paid domain or a different domain product like mapping or transfer.
+			const hasPaidDomainItem =
+				( selectedDomain && ! selectedDomain.is_free ) || !! domainProductSlug;
 
-		recordSignupComplete(
-			{
-				flow,
-				siteId,
-				isNewUser,
-				hasCartItems,
-				isNew7DUserSite,
-				theme,
-				intent: flow,
-				startingPoint: flow,
-				isBlankCanvas: theme?.includes( 'blank-canvas' ),
-				planProductSlug,
-				domainProductSlug,
-				isMapping:
-					hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
-				isTransfer:
-					hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
-				signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.NOT_SET,
-			},
-			true
-		);
-	}, [ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ] );
+			recordSignupComplete(
+				{
+					flow,
+					siteId,
+					isNewUser,
+					hasCartItems,
+					isNew7DUserSite,
+					theme,
+					intent: flow,
+					startingPoint: flow,
+					isBlankCanvas: theme?.includes( 'blank-canvas' ),
+					planProductSlug,
+					domainProductSlug,
+					isMapping:
+						hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
+					isTransfer:
+						hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
+					signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.NOT_SET,
+					...customProps,
+				},
+				true
+			);
+		},
+		[ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ]
+	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Tracking events generated on hosting flow surfaced an issue in tracking that's related to the stepper framework.

Previously whenever a flow was marked as a signup flow via `isSignupFlow` a `calypso_signup_complete` was logged whenever the flow started. However when the user is not logged in we redirect the user to the signup framework to log them in. This results in a signup start being logged.

Due to this requirement a change in the tracking approach is suggested in more fine grain controls for events logged by the framework. 

https://github.com/Automattic/wp-calypso/blob/e974e3b369ba00ef3d82095c45f27430e2b557f8/client/landing/stepper/declarative-flow/internals/index.tsx#L165-L169

However if the user is not logged in they will be redirected tht e

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?