### PR TITLE
Scheduled Updates: implement multi-site design on single site scheduled updates

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -1,0 +1,126 @@
+@import "~@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
+
+$brand-display: "SF Pro Display", sans-serif;
+
+.plugins-update-manager,
+.plugins-update-manager-multisite {
+	@media screen and (max-width: $break-small) {
+		margin: 1rem;
+	}
+
+	h1 {
+		font-size: 2rem;
+		margin-bottom: 1rem;
+	}
+
+	&__header {
+		align-items: center;
+		border-block-end: 1px solid var(--color-border-secondary);
+		display: flex;
+		font-family: $brand-display;
+		justify-content: space-between;
+		padding-bottom: 1.5rem;
+
+		&.no-border {
+			border-block-end: none;
+		}
+
+		h1 {
+			font-size: 1.5rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 1.2;
+			margin-bottom: 0;
+		}
+
+		button {
+			font-size: rem(14px);
+			border-radius: 4px;
+		}
+
+		.buttons {
+			display: flex;
+			align-items: center;
+			justify-content: flex-end;
+			gap: rem(10px);
+		}
+	}
+
+	&-table {
+		th,
+		td {
+			font-size: 0.875rem;
+			padding: 1rem 0.125rem;
+			color: var(--studio-gray-60);
+			border-bottom: solid 1px var(--studio-gray-0);
+		}
+
+		th {
+			font-weight: 500;
+
+			&.expand {
+				width: 4rem;
+			}
+		}
+
+		td {
+			padding: 0.5rem 0.125rem;
+			vertical-align: middle;
+
+			&.last-update {
+				min-width: 200px;
+			}
+
+			.badge-component {
+				line-height: 2;
+			}
+
+			&.expand {
+				text-align: center;
+				line-height: 1;
+
+				button {
+					margin-top: rem(2px);
+				}
+			}
+
+			&.name {
+				width: 300px;
+			}
+
+			&.sites {
+				width: 80px;
+			}
+
+			&.menu {
+				text-align: center;
+			}
+		}
+
+		&__expanded {
+			background-color: var(--studio-gray-0);
+		}
+	}
+
+	.schedule-form {
+		margin-bottom: 1.25rem;
+
+		& > .form-control-container {
+			margin-bottom: 1.25rem;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+
+			& > .components-flex {
+				gap: 2rem;
+
+				& > .components-flex-item {
+					flex-basis: 100%;
+					width: 100%;
+				}
+			}
+		}
+	}
+}

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -18,6 +18,8 @@ $brand-display: "SF Pro Display", sans-serif;
 		align-items: center;
 		border-block-end: 1px solid var(--color-border-secondary);
 		display: flex;
+		flex-wrap: wrap;
+		row-gap: 1rem;
 		font-family: $brand-display;
 		justify-content: space-between;
 		padding-bottom: 1.5rem;
@@ -32,6 +34,7 @@ $brand-display: "SF Pro Display", sans-serif;
 			font-weight: 500;
 			line-height: 1.2;
 			margin-bottom: 0;
+			flex: 1;
 		}
 
 		button {

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -34,7 +34,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 	const title = {
 		create: translate( 'New schedule' ),
 		edit: translate( 'Edit schedule' ),
-		list: translate( 'Update schedules' ),
+		list: translate( 'Scheduled Updates' ),
 	}[ context ];
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -112,7 +112,7 @@ export const ScheduleList = ( props: Props ) => {
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
 			<div className="plugins-update-manager-multisite__header">
-				<h1>{ translate( 'Update schedules' ) }</h1>
+				<h1>{ translate( 'Scheduled Updates' ) }</h1>
 				{ showNewScheduleBtn && ! isScheduleEmpty && (
 					<Button
 						__next40pxDefaultSize={ ! compact }

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -1,23 +1,13 @@
-@import "~@automattic/color-studio/dist/color-variables";
-@import "@wordpress/base-styles/breakpoints";
+@import "../plugin-scheduled-updates-common/styles";
 
 $brand-display: "SF Pro Display", sans-serif;
 
 .plugins-update-manager-multisite {
-	@media screen and (max-width: 660px) {
-		margin: 1rem;
-	}
-
 	&.plugins-update-manager-multisite-edit,
 	&.plugins-update-manager-multisite-create {
 		h1 {
 			font-size: 2rem !important;
 		}
-	}
-
-	h1 {
-		font-size: 2rem;
-		margin-bottom: 1rem;
 	}
 
 	.components-notice {
@@ -26,84 +16,6 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		ul {
 			margin-top: 1.25rem;
-		}
-	}
-
-	.schedule-form {
-		margin-bottom: 1.25rem;
-
-		& > .form-control-container {
-			margin-bottom: 1.25rem;
-
-			&:last-child {
-				margin-bottom: 0;
-			}
-
-			& > .components-flex {
-				gap: 2rem;
-
-				& > .components-flex-item {
-					flex-basis: 100%;
-					width: 100%;
-				}
-			}
-		}
-	}
-
-	.plugins-update-manager-multisite-table {
-		th,
-		td {
-			font-size: 0.875rem;
-			padding: 1rem 0.125rem;
-			color: var(--studio-gray-60);
-			border-bottom: solid 1px var(--studio-gray-0);
-		}
-
-		th {
-			font-weight: 500;
-
-			&.expand {
-				width: 4rem;
-			}
-		}
-
-		td {
-			padding: 0.5rem 0.125rem;
-			vertical-align: middle;
-
-			&.last-update {
-				min-width: 200px;
-			}
-
-			.badge-component {
-				line-height: 2;
-			}
-
-			&.expand {
-				text-align: center;
-				line-height: 1;
-
-				button {
-					margin-top: rem(2px);
-				}
-			}
-
-			&.name {
-				width: 300px;
-			}
-
-			&.sites {
-				width: 80px;
-			}
-
-			&.menu {
-				text-align: center;
-			}
-		}
-
-
-		&__expanded {
-			background-color: var(--studio-gray-0);
 		}
 	}
 
@@ -149,31 +61,6 @@ $brand-display: "SF Pro Display", sans-serif;
 			.components-spinner {
 				display: none;
 			}
-		}
-	}
-	&__header {
-		align-items: center;
-		border-block-end: 1px solid var(--color-border-secondary);
-		display: flex;
-		font-family: $brand-display;
-		justify-content: space-between;
-		padding-bottom: 1.5rem;
-
-		&.no-border {
-			border-block-end: none;
-		}
-
-		h1 {
-			font-size: 1.5rem;
-			font-style: normal;
-			font-weight: 500;
-			line-height: 1.2;
-			margin-bottom: 0;
-		}
-
-		button {
-			font-size: rem(14px);
-			border-radius: 4px;
 		}
 	}
 

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -168,7 +168,6 @@ $brand-display: "SF Pro Display", sans-serif;
 				}
 			}
 		}
-
 	}
 
 	.components-card__footer {

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -1,11 +1,10 @@
 import { Button } from '@wordpress/components';
-import { plus } from '@wordpress/icons';
+import { close, Icon } from '@wordpress/icons';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import MainComponent from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import ScheduledUpdatesGate from 'calypso/components/scheduled-updates/scheduled-updates-gate';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -61,16 +60,24 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		} );
 	}, [ context, siteSlug ] );
 
-	const { component, title } = {
+	const [ navigationTitle, setNavigationTitle ] = useState< string | null >( null );
+
+	const { component, title, showClose } = {
 		logs: {
-			component: <ScheduleLogs scheduleId={ scheduleId as string } onNavBack={ onNavBack } />,
+			component: (
+				<ScheduleLogs
+					scheduleId={ scheduleId as string }
+					onNavBack={ onNavBack }
+					setNavigationTitle={ setNavigationTitle }
+				/>
+			),
 			title: translate( 'Scheduled Updates Logs' ),
+			showClose: true,
 		},
 		list: {
 			component: (
 				<ScheduleList
 					siteId={ siteId }
-					onNavBack={ onNavBack }
 					onCreateNewSchedule={ onCreateNewSchedule }
 					onEditSchedule={ onEditSchedule }
 					onShowLogs={ onShowLogs }
@@ -81,58 +88,74 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		create: {
 			component: <ScheduleCreate onNavBack={ onNavBack } />,
 			title: translate( 'New schedule' ),
+			showClose: true,
 		},
 		edit: {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
 			title: translate( 'Edit schedule' ),
+			showClose: true,
 		},
 		notifications: {
 			component: <NotificationSettings onNavBack={ onNavBack } />,
 			title: translate( 'Notification settings' ),
+			showClose: true,
 		},
 	}[ context ];
+
+	useEffect( () => {
+		setNavigationTitle( title );
+	}, [ title ] );
 
 	return (
 		<PluginUpdateManagerContextProvider siteSlug={ siteSlug }>
 			<DocumentHead title={ title } />
 			{ ! isSitePlansLoaded && <QuerySitePlans siteId={ siteId } /> }
-			<MainComponent wideLayout>
-				<NavigationHeader
-					className="plugins-update-manager-header"
-					navigationItems={ [] }
-					title={ translate( 'Plugin Update Manager' ) }
-					subtitle={ translate(
-						'Streamline your workflow with scheduled updates, timed to suit your needs.'
+			<div className="plugins-update-manager">
+				<div
+					className={ classnames(
+						'plugins-update-manager__header',
+						context !== 'list' ? 'no-border' : null
 					) }
 				>
-					{ context === 'list' && (
-						<>
-							{ onNotificationManagement && (
-								<Button
-									__next40pxDefaultSize
-									variant="secondary"
-									onClick={ onNotificationManagement }
-								>
-									{ translate( 'Notification settings' ) }
-								</Button>
-							) }
+					<h1 className={ classnames( context !== 'list' ? 'wp-brand-font' : null ) }>
+						{ navigationTitle }
+					</h1>
+					<div className="buttons">
+						{ context === 'list' && (
+							<>
+								{ onNotificationManagement && (
+									<Button
+										__next40pxDefaultSize
+										variant="secondary"
+										onClick={ onNotificationManagement }
+									>
+										{ translate( 'Notification settings' ) }
+									</Button>
+								) }
 
-							{ onCreateNewSchedule && ! hideCreateButton && (
-								<Button
-									__next40pxDefaultSize
-									icon={ plus }
-									variant={ canCreateSchedules && siteHasEligiblePlugins ? 'primary' : 'secondary' }
-									onClick={ onCreateNewSchedule }
-									disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
-								>
-									{ translate( 'Add new schedule' ) }
-								</Button>
-							) }
-						</>
-					) }
-				</NavigationHeader>
+								{ onCreateNewSchedule && ! hideCreateButton && (
+									<Button
+										__next40pxDefaultSize
+										variant={
+											canCreateSchedules && siteHasEligiblePlugins ? 'primary' : 'secondary'
+										}
+										onClick={ onCreateNewSchedule }
+										disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
+									>
+										{ translate( 'Add new schedule' ) }
+									</Button>
+								) }
+							</>
+						) }
+						{ showClose && (
+							<Button onClick={ onNavBack }>
+								<Icon icon={ close } />
+							</Button>
+						) }
+					</div>
+				</div>
 				<ScheduledUpdatesGate siteId={ siteId as number }>{ component }</ScheduledUpdatesGate>
-			</MainComponent>
+			</div>
 		</PluginUpdateManagerContextProvider>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -140,7 +140,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 										onClick={ onCreateNewSchedule }
 										disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
 									>
-										{ translate( 'Add new schedule' ) }
+										{ translate( 'New Schedule' ) }
 									</Button>
 								) }
 							</>

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -117,9 +117,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 						context !== 'list' ? 'no-border' : null
 					) }
 				>
-					<h1 className={ classnames( context !== 'list' ? 'wp-brand-font' : null ) }>
-						{ navigationTitle }
-					</h1>
+					<h1>{ navigationTitle }</h1>
 					<div className="buttons">
 						{ context === 'list' && (
 							<>

--- a/client/blocks/plugins-scheduled-updates/notification-settings.scss
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.scss
@@ -18,7 +18,7 @@
 		}
 
 		.form-field {
-			margin-bottom: 1rem;
+			margin-bottom: 1.25rem;
 		}
 	}
 }

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -1,13 +1,4 @@
-import {
-	__experimentalText as Text,
-	CheckboxControl,
-	Card,
-	CardHeader,
-	Button,
-	CardBody,
-	CardFooter,
-} from '@wordpress/components';
-import { arrowLeft } from '@wordpress/icons';
+import { __experimentalText as Text, CheckboxControl, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { useScheduledUpdatesNotificationSettingsMutation } from 'calypso/data/plugins/use-scheduled-updates-notification-settings-mutation';
@@ -82,61 +73,47 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 	}, [ formValues, updateNotificationSettings ] );
 
 	return (
-		<Card className="plugins-update-manager">
-			<CardHeader size="extraSmall">
-				<div className="ch-placeholder">
-					{ onNavBack && (
-						<Button icon={ arrowLeft } onClick={ onNavBack }>
-							{ translate( 'Back' ) }
-						</Button>
-					) }
-				</div>
-				<Text>{ translate( 'Notification Settings' ) }</Text>
-				<div className="ch-placeholder"></div>
-			</CardHeader>
-			<CardBody className="notification-settings-form">
-				<label>{ translate( 'Email me' ) }</label>
+		<form className="notification-settings-form">
+			<label>{ translate( 'Email me' ) }</label>
+			<Text className="info-msg">
+				{ translate(
+					'Receive email notifications to stay informed about the performance of the plugin updates.'
+				) }
+			</Text>
+
+			<div className="form-field">
+				<CheckboxControl
+					label={ translate( 'On successful updates' ) }
+					checked={ formValues.success }
+					onChange={ handleCheckboxChange( 'success' ) }
+					disabled={ ! isFetched || hasGlobalNotificationsDisabled }
+				/>
+			</div>
+			<div className="form-field">
+				<CheckboxControl
+					label={ translate( 'On failed updates' ) }
+					checked={ formValues.failure }
+					onChange={ handleCheckboxChange( 'failure' ) }
+					disabled={ ! isFetched || hasGlobalNotificationsDisabled }
+				/>
+			</div>
+
+			{ hasGlobalNotificationsDisabled && (
 				<Text className="info-msg">
 					{ translate(
-						'Receive email notifications to stay informed about the performance of the plugin updates.'
+						"You've opted out of WordPress.com's scheduled update notifications. Head to {{notificationSettingsLink}}Notification Settings{{/notificationSettingsLink}} to re-enable them.",
+						{
+							components: {
+								notificationSettingsLink: <a href="/me/notifications/updates" />,
+							},
+						}
 					) }
 				</Text>
+			) }
 
-				<div className="form-field">
-					<CheckboxControl
-						label={ translate( 'On successful updates' ) }
-						checked={ formValues.success }
-						onChange={ handleCheckboxChange( 'success' ) }
-						disabled={ ! isFetched || hasGlobalNotificationsDisabled }
-					/>
-				</div>
-				<div className="form-field">
-					<CheckboxControl
-						label={ translate( 'On failed updates' ) }
-						checked={ formValues.failure }
-						onChange={ handleCheckboxChange( 'failure' ) }
-						disabled={ ! isFetched || hasGlobalNotificationsDisabled }
-					/>
-				</div>
-
-				{ hasGlobalNotificationsDisabled && (
-					<Text className="info-msg">
-						{ translate(
-							"You've opted out of WordPress.com's scheduled update notifications. Head to {{notificationSettingsLink}}Notification Settings{{/notificationSettingsLink}} to re-enable them.",
-							{
-								components: {
-									notificationSettingsLink: <a href="/me/notifications/updates" />,
-								},
-							}
-						) }
-					</Text>
-				) }
-			</CardBody>
-			<CardFooter>
-				<Button variant="primary" disabled={ isSaving } onClick={ onSave }>
-					{ translate( 'Save' ) }
-				</Button>
-			</CardFooter>
-		</Card>
+			<Button variant="primary" disabled={ isSaving } onClick={ onSave }>
+				{ translate( 'Save' ) }
+			</Button>
+		</form>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-create.tsx
@@ -84,6 +84,7 @@ export const ScheduleCreate = ( props: Props ) => {
 				variant={ canCreateSchedules ? 'primary' : 'secondary' }
 				disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
 				isBusy={ isBusy }
+				className="schedule-form-button"
 			>
 				{ translate( 'Create' ) }
 			</Button>

--- a/client/blocks/plugins-scheduled-updates/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-create.tsx
@@ -1,16 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { useMutationState } from '@tanstack/react-query';
-import {
-	__experimentalText as Text,
-	Button,
-	Card,
-	CardHeader,
-	CardBody,
-	CardFooter,
-	Icon,
-} from '@wordpress/components';
-import { arrowLeft, info } from '@wordpress/icons';
+import { __experimentalText as Text, Button, Icon } from '@wordpress/components';
+import { info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { Banner } from 'calypso/components/banner';
@@ -83,40 +75,25 @@ export const ScheduleCreate = ( props: Props ) => {
 					} }
 				/>
 			) }
-			<Card className="plugins-update-manager">
-				<CardHeader size="extraSmall">
-					<div className="ch-placeholder">
-						{ onNavBack && (
-							<Button icon={ arrowLeft } onClick={ onNavBack }>
-								{ translate( 'Back' ) }
-							</Button>
-						) }
-					</div>
-					<Text>{ translate( 'New Schedule' ) }</Text>
-					<div className="ch-placeholder"></div>
-				</CardHeader>
-				<CardBody>
-					<ScheduleForm onSyncSuccess={ onSyncSuccess } onSyncError={ setSyncError } />
-				</CardBody>
-				<CardFooter>
-					<Button
-						form="schedule"
-						type="submit"
-						variant={ canCreateSchedules ? 'primary' : 'secondary' }
-						disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
-						isBusy={ isBusy }
-					>
-						{ translate( 'Create' ) }
-					</Button>
-					{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
-						<Text as="p" className="validation-msg">
-							<Icon className="icon-info" icon={ info } size={ 16 } />
-							{ ( eligibilityCheckErrors?.length && eligibilityCheckErrors[ 0 ].message ) || '' }
-							{ syncError }
-						</Text>
-					) }
-				</CardFooter>
-			</Card>
+
+			<ScheduleForm onSyncSuccess={ onSyncSuccess } onSyncError={ setSyncError } />
+
+			<Button
+				form="schedule"
+				type="submit"
+				variant={ canCreateSchedules ? 'primary' : 'secondary' }
+				disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
+				isBusy={ isBusy }
+			>
+				{ translate( 'Create' ) }
+			</Button>
+			{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
+				<Text as="p" className="validation-msg">
+					<Icon className="icon-info" icon={ info } size={ 16 } />
+					{ ( eligibilityCheckErrors?.length && eligibilityCheckErrors[ 0 ].message ) || '' }
+					{ syncError }
+				</Text>
+			) }
 		</>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-edit.tsx
@@ -1,15 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutationState } from '@tanstack/react-query';
-import {
-	__experimentalText as Text,
-	Button,
-	Card,
-	CardHeader,
-	CardBody,
-	CardFooter,
-	Icon,
-} from '@wordpress/components';
-import { arrowLeft, info } from '@wordpress/icons';
+import { __experimentalText as Text, Button, Icon } from '@wordpress/components';
+import { info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
@@ -67,45 +59,31 @@ export const ScheduleEdit = ( props: Props ) => {
 	};
 
 	return (
-		<Card className="plugins-update-manager">
-			<CardHeader size="extraSmall">
-				<div className="ch-placeholder">
-					{ onNavBack && (
-						<Button icon={ arrowLeft } onClick={ onNavBack }>
-							{ translate( 'Back' ) }
-						</Button>
-					) }
-				</div>
-				<Text>{ translate( 'Edit Schedule' ) }</Text>
-				<div className="ch-placeholder"></div>
-			</CardHeader>
-			<CardBody>
-				{ schedule && (
-					<ScheduleForm
-						scheduleForEdit={ schedule }
-						onSyncSuccess={ onSyncSuccess }
-						onSyncError={ setSyncError }
-					/>
-				) }
-			</CardBody>
-			<CardFooter>
-				<Button
-					form="schedule"
-					type="submit"
-					variant={ canCreateSchedules ? 'primary' : 'secondary' }
-					isBusy={ isBusy }
-					disabled={ ! canCreateSchedules }
-				>
-					{ translate( 'Save' ) }
-				</Button>
-				{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
-					<Text as="p" className="validation-msg">
-						<Icon className="icon-info" icon={ info } size={ 16 } />
-						{ ( eligibilityCheckErrors?.length && eligibilityCheckErrors[ 0 ].message ) || '' }
-						{ syncError }
-					</Text>
-				) }
-			</CardFooter>
-		</Card>
+		<>
+			{ schedule && (
+				<ScheduleForm
+					scheduleForEdit={ schedule }
+					onSyncSuccess={ onSyncSuccess }
+					onSyncError={ setSyncError }
+				/>
+			) }
+
+			<Button
+				form="schedule"
+				type="submit"
+				variant={ canCreateSchedules ? 'primary' : 'secondary' }
+				isBusy={ isBusy }
+				disabled={ ! canCreateSchedules }
+			>
+				{ translate( 'Save' ) }
+			</Button>
+			{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
+				<Text as="p" className="validation-msg">
+					<Icon className="icon-info" icon={ info } size={ 16 } />
+					{ ( eligibilityCheckErrors?.length && eligibilityCheckErrors[ 0 ].message ) || '' }
+					{ syncError }
+				</Text>
+			) }
+		</>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-edit.tsx
@@ -74,6 +74,7 @@ export const ScheduleEdit = ( props: Props ) => {
 				variant={ canCreateSchedules ? 'primary' : 'secondary' }
 				isBusy={ isBusy }
 				disabled={ ! canCreateSchedules }
+				className="schedule-form-button"
 			>
 				{ translate( 'Save' ) }
 			</Button>

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -275,3 +275,7 @@
 		}
 	}
 }
+
+.schedule-form-button {
+	margin: 0.5rem 0;
+}

--- a/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
@@ -32,7 +32,7 @@ export const ScheduleListTable = ( props: Props ) => {
 	 * make sure to update the ScheduleListCards component as well
 	 */
 	return (
-		<table>
+		<table className="plugins-update-manager-table">
 			<thead>
 				<tr>
 					<th>{ translate( 'Name' ) }</th>

--- a/client/blocks/plugins-scheduled-updates/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list.tsx
@@ -1,14 +1,5 @@
 import { useBreakpoint } from '@automattic/viewport-react';
-import {
-	__experimentalText as Text,
-	__experimentalConfirmDialog as ConfirmDialog,
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	Spinner,
-} from '@wordpress/components';
-import { arrowLeft } from '@wordpress/icons';
+import { __experimentalConfirmDialog as ConfirmDialog, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
@@ -29,7 +20,6 @@ import { ScheduleListTable } from './schedule-list-table';
 
 interface Props {
 	siteId: number | null;
-	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 	onEditSchedule: ( id: string ) => void;
 	onShowLogs: ( id: string ) => void;
@@ -42,7 +32,7 @@ export const ScheduleList = ( props: Props ) => {
 	const { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading } =
 		useSiteHasEligiblePlugins();
 
-	const { siteId, onNavBack, onCreateNewSchedule, onEditSchedule, onShowLogs } = props;
+	const { siteId, onCreateNewSchedule, onEditSchedule, onShowLogs } = props;
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< undefined | string >();
 
@@ -112,54 +102,40 @@ export const ScheduleList = ( props: Props ) => {
 			>
 				{ translate( 'Are you sure you want to delete this schedule?' ) }
 			</ConfirmDialog>
-			<Card className="plugins-update-manager">
-				<CardHeader size="extraSmall">
-					<div className="ch-placeholder">
-						{ onNavBack && (
-							<Button icon={ arrowLeft } onClick={ onNavBack }>
-								{ translate( 'Back' ) }
-							</Button>
+
+			{ schedules.length === 0 && isLoading && <Spinner /> }
+			{ ! isLoading && showScheduleListEmpty && (
+				<ScheduleListEmpty
+					pluginsUrl={
+						isGlobalSiteViewEnabled
+							? `${ siteAdminUrl }plugin-install.php`
+							: `/plugins/${ siteSlug }`
+					}
+					onCreateNewSchedule={ onCreateNewSchedule }
+					canCreateSchedules={ canCreateSchedules }
+				/>
+			) }
+			{ isFetched &&
+				! isLoadingCanCreateSchedules &&
+				siteHasEligiblePlugins &&
+				schedules.length > 0 &&
+				canCreateSchedules && (
+					<>
+						{ isSmallScreen ? (
+							<ScheduleListCards
+								onRemoveClick={ openRemoveDialog }
+								onEditClick={ onEditSchedule }
+								onShowLogs={ onShowLogs }
+							/>
+						) : (
+							<ScheduleListTable
+								onRemoveClick={ openRemoveDialog }
+								onEditClick={ onEditSchedule }
+								onShowLogs={ onShowLogs }
+							/>
 						) }
-					</div>
-					<Text>{ translate( 'Schedules' ) }</Text>
-					<div className="ch-placeholder"></div>
-				</CardHeader>
-				<CardBody>
-					{ schedules.length === 0 && isLoading && <Spinner /> }
-					{ ! isLoading && showScheduleListEmpty && (
-						<ScheduleListEmpty
-							pluginsUrl={
-								isGlobalSiteViewEnabled
-									? `${ siteAdminUrl }plugin-install.php`
-									: `/plugins/${ siteSlug }`
-							}
-							onCreateNewSchedule={ onCreateNewSchedule }
-							canCreateSchedules={ canCreateSchedules }
-						/>
-					) }
-					{ isFetched &&
-						! isLoadingCanCreateSchedules &&
-						siteHasEligiblePlugins &&
-						schedules.length > 0 &&
-						canCreateSchedules && (
-							<>
-								{ isSmallScreen ? (
-									<ScheduleListCards
-										onRemoveClick={ openRemoveDialog }
-										onEditClick={ onEditSchedule }
-										onShowLogs={ onShowLogs }
-									/>
-								) : (
-									<ScheduleListTable
-										onRemoveClick={ openRemoveDialog }
-										onEditClick={ onEditSchedule }
-										onShowLogs={ onShowLogs }
-									/>
-								) }
-							</>
-						) }
-				</CardBody>
-			</Card>
+					</>
+				) }
 		</>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-logs.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-logs.tsx
@@ -1,15 +1,7 @@
-import {
-	__experimentalText as Text,
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	Tooltip,
-	Spinner,
-} from '@wordpress/components';
-import { arrowLeft, Icon, info } from '@wordpress/icons';
+import { __experimentalText as Text, Tooltip, Spinner } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import Timeline from 'calypso/components/timeline';
 import TimelineEvent from 'calypso/components/timeline/timeline-event';
 import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
@@ -35,11 +27,12 @@ import {
 interface Props {
 	scheduleId: string;
 	onNavBack?: () => void;
+	setNavigationTitle: ( title: string ) => void;
 }
 export const ScheduleLogs = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
-	const { scheduleId, onNavBack } = props;
+	const { scheduleId, onNavBack, setNavigationTitle } = props;
 
 	const siteAdminUrl = useSiteAdminUrl();
 	const {
@@ -68,6 +61,15 @@ export const ScheduleLogs = ( props: Props ) => {
 		window.location.href = `${ siteAdminUrl }plugins.php`;
 	}, [ siteAdminUrl ] );
 
+	useEffect( () => {
+		// a bit hacky, but needed to override the title
+		setTimeout( () => {
+			setNavigationTitle(
+				`${ translate( 'Logs' ) } - ${ prepareScheduleName( schedule as ScheduleUpdates ) }`
+			);
+		} );
+	}, [ setNavigationTitle, schedule ] );
+
 	if ( isPending ) {
 		return <Spinner />;
 	}
@@ -78,18 +80,8 @@ export const ScheduleLogs = ( props: Props ) => {
 	}
 
 	return (
-		<Card className="plugins-update-manager">
-			<CardHeader size="extraSmall">
-				<div className="ch-placeholder">
-					{ onNavBack && (
-						<Button icon={ arrowLeft } onClick={ onNavBack }>
-							{ translate( 'Back' ) }
-						</Button>
-					) }
-				</div>
-				<Text>
-					{ translate( 'Logs' ) } - { prepareScheduleName( schedule as ScheduleUpdates ) }
-				</Text>
+		<>
+			<div>
 				<div className="ch-placeholder">
 					<Text isBlock={ true } align="end" lineHeight={ 2.5 }>
 						{ translate( '%(pluginsNumber)d plugin', '%(pluginsNumber)d plugins', {
@@ -109,20 +101,18 @@ export const ScheduleLogs = ( props: Props ) => {
 						) }
 					</Text>
 				</div>
-			</CardHeader>
-			<CardBody>
-				{ isPendingLogs && <Spinner /> }
-				{ ! isPendingLogs && ! scheduleLogs.length && (
-					<div className="empty-state">
-						<Text align="center">{ translate( 'No logs available at the moment.' ) }</Text>
-					</div>
-				) }
-			</CardBody>
+			</div>
+			{ isPendingLogs && <Spinner /> }
+			{ ! isPendingLogs && ! scheduleLogs.length && (
+				<div className="empty-state">
+					<Text align="center">{ translate( 'No logs available at the moment.' ) }</Text>
+				</div>
+			) }
 			{ scheduleLogs.map( ( logs, i ) => (
 				<Timeline key={ i }>
-					{ logs.reverse().map( ( log ) => (
+					{ logs.reverse().map( ( log, j ) => (
 						<TimelineEvent
-							key={ log.timestamp }
+							key={ `${ log.timestamp }.${ j }` }
 							date={ log.date }
 							dateFormat={
 								log.action === 'PLUGIN_UPDATES_START'
@@ -146,6 +136,6 @@ export const ScheduleLogs = ( props: Props ) => {
 					) ) }
 				</Timeline>
 			) ) }
-		</Card>
+		</>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -1,22 +1,11 @@
-@import "@wordpress/base-styles/breakpoints";
+@import "../plugin-scheduled-updates-common/styles";
+
 
 .tooltip--selected-plugins {
 	text-align: left;
 }
 
-.plugins-update-manager-header {
-	.navigation-header__main {
-		@media screen and (max-width: $break-small) {
-			flex-wrap: wrap;
-			row-gap: 10px;
-		}
-	}
-}
-
 .plugins-update-manager {
-	@media screen and (max-width: $break-small) {
-		margin: 0 1rem;
-	}
 
 	.ch-placeholder {
 		min-width: 60px;
@@ -104,20 +93,7 @@
 	}
 
 	table {
-		th,
 		td {
-			font-size: 0.875rem;
-			padding: 1rem 0;
-			color: var(--studio-gray-60);
-			border-bottom: solid 1px var(--studio-gray-0);
-		}
-
-		th {
-			font-weight: 500;
-		}
-
-		td {
-			padding: 0.5rem 0;
 			vertical-align: middle;
 
 			&.last-update {
@@ -166,13 +142,8 @@
 		}
 	}
 
-	.components-card__footer {
-		display: flex;
-		align-items: baseline;
-
-		.validation-msg {
-			width: 100%;
-		}
+	.validation-msg {
+		width: 100%;
 	}
 
 	.notification-settings__title {


### PR DESCRIPTION
Related to [#90401](https://github.com/Automattic/wp-calypso/issues/90401)

## Proposed Changes

Implements the design language of the multi-site design for single site scheduled updates.

![CleanShot 2024-05-08 at 15 04 46@2x](https://github.com/Automattic/wp-calypso/assets/528287/f7ae2744-f81f-4c0f-9521-3ee7ae21c8b8)
![CleanShot 2024-05-08 at 15 04 57@2x](https://github.com/Automattic/wp-calypso/assets/528287/477c4584-c3ff-45de-b476-95af90634c66)
![CleanShot 2024-05-08 at 15 05 07@2x](https://github.com/Automattic/wp-calypso/assets/528287/1df8bab7-17b6-4b8d-a093-8a7e882276ec)
![CleanShot 2024-05-08 at 15 12 03@2x](https://github.com/Automattic/wp-calypso/assets/528287/3f299e9e-460c-4f32-b7c8-9d292658c2ae)
![CleanShot 2024-05-08 at 15 05 26@2x](https://github.com/Automattic/wp-calypso/assets/528287/8aef68b3-8b34-4533-9bc2-e5b4212f2816)


## Testing Instructions

Try this out  on Calypso Live

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
