### PR TITLE
E2E tests: Fix opening templates in FSE

### DIFF
--- a/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
@@ -2,8 +2,8 @@ import { Page } from 'playwright';
 import { EditorComponent } from './editor-component';
 
 const selectors = {
-	primaryFieldByText: ( primaryFieldText: string ) =>
-		`.dataviews-view-table__primary-field:has-text("${ primaryFieldText }") a`,
+	primaryFieldByText: ( tableOrGrid: string, primaryFieldText: string ) =>
+		`.dataviews-view-${ tableOrGrid }__primary-field:has-text("${ primaryFieldText }") a`,
 };
 
 /**
@@ -30,6 +30,13 @@ export class FullSiteEditorDataViewsComponent {
 	 */
 	async clickPrimaryFieldByExactText( primaryFieldText: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		await editorParent.locator( selectors.primaryFieldByText( primaryFieldText ) ).click();
+		const primaryFieldInTable = editorParent.locator(
+			selectors.primaryFieldByText( 'table', primaryFieldText )
+		);
+		const primaryFieldInGrid = editorParent.locator(
+			selectors.primaryFieldByText( 'grid', primaryFieldText )
+		);
+
+		await Promise.race( [ primaryFieldInTable.click(), primaryFieldInGrid.click() ] );
 	}
 }


### PR DESCRIPTION
Fixes an e2e error where templates cannot be loaded because a table view is expected rather than a grid.


This is currently breaking some nightly e2e tests for Gutenberg. This change modifies the e2e's expectations to fit the new realities.

Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

Run the editor schedule flow e2e edge tests, which was failing before this fix:

```bash
cd test/e2e
yarn jest --clearCache && yarn build  # clear build cache before each run


yarn jest specs/fse/fse__temp-smoke-test.ts 
GUTENBERG_EDGE=1 yarn jest specs/fse/fse__temp-smoke-test.ts 
GUTENBERG_EDGE=1 TEST_ON_ATOMIC=true yarn jest specs/fse/fse__temp-smoke-test.ts
```