### PR TITLE
Nav redesign: correctly click the initial selected site

### DIFF
--- a/client/sites-dashboard-v2/hooks/use-initialize-dataviews-selected-item.ts
+++ b/client/sites-dashboard-v2/hooks/use-initialize-dataviews-selected-item.ts
@@ -18,7 +18,7 @@ export function useInitializeDataViewsSelectedItem( {
 		if ( initialized.current || ! selectedSite ) {
 			return;
 		}
-		for ( const site of document.querySelectorAll( 'button.sites-dataviews__site' ) ) {
+		for ( const site of document.querySelectorAll( '.sites-dataviews__site' ) ) {
 			const slug = site.querySelector( '.sites-dataviews__site-url span' );
 			if ( selectedSite.slug === slug?.innerHTML ) {
 				( site as HTMLElement ).click?.();


### PR DESCRIPTION
## Proposed Changes

This PR fixes the expected behavior from:

- https://github.com/Automattic/wp-calypso/pull/90109

which was not working after the following PR:

- https://github.com/Automattic/wp-calypso/pull/90386

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /sites
2. Select a site
3. Verify that the selected site is highlighted after the preview pane is open.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
