### PR TITLE
Sites dashboard v2 - remove status filtering header popover.

### DIFF
--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -105,6 +105,7 @@ const SitesDashboardV2 = ( {
 			addDummyDataViewPrefix( 'site' ),
 			addDummyDataViewPrefix( 'last-publish' ),
 			addDummyDataViewPrefix( 'last-interacted' ),
+			addDummyDataViewPrefix( 'status' ),
 		],
 		filters:
 			status === 'all'
@@ -155,7 +156,9 @@ const SitesDashboardV2 = ( {
 
 	// Get the status group slug.
 	const statusSlug = useMemo( () => {
-		const statusFilter = dataViewsState.filters.find( ( filter ) => filter.field === 'status' );
+		const statusFilter = dataViewsState.filters.find(
+			( filter ) => filter.field === addDummyDataViewPrefix( 'status' )
+		);
 		const statusNumber = statusFilter?.value || 1;
 		return ( siteStatusGroups.find( ( status ) => status.value === statusNumber )?.slug ||
 			'all' ) as GroupableSiteLaunchStatuses;

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -133,11 +133,6 @@ const DotcomSitesDataViews = ( {
 				id: 'status',
 				header: __( 'Status' ),
 				render: ( { item }: { item: SiteInfo } ) => <SiteStatus site={ item } />,
-				type: 'enumeration',
-				elements: siteStatusGroups,
-				filterBy: {
-					operators: [ 'in' ],
-				},
 				enableHiding: false,
 				enableSorting: false,
 			},
@@ -198,6 +193,18 @@ const DotcomSitesDataViews = ( {
 				render: () => null,
 				enableHiding: false,
 				enableSorting: true,
+			},
+			{
+				id: addDummyDataViewPrefix( 'status' ),
+				header: __( 'Status' ),
+				render: () => null,
+				type: 'enumeration',
+				elements: siteStatusGroups,
+				filterBy: {
+					operators: [ 'in' ],
+				},
+				enableHiding: false,
+				enableSorting: false,
 			},
 		],
 		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState, enableSorting ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # another attempt at https://github.com/Automattic/wp-calypso/pull/90352  / 6960-gh-Automattic/dotcom-forge

## Proposed Changes

* Removes the filtering popover on the 'status' header.
* Since diabling filtering for this column disables both the header and status icon UI controls, we apply a hidden 'dummy' field to continue allow status to be filtered via the icon ui.


REMOVES filtering from the header:

<img width="447" alt="Screenshot 2024-05-08 at 9 32 29 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/749a54d7-27cc-4c0e-9cae-77c333472197">


WHILE KEEPING filtering from the icon:

<img width="545" alt="Screenshot 2024-05-08 at 9 32 37 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/07df1cec-4bc4-4afa-b34c-d0a4852c0c14">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Go to sites dashboard
* Click on the 'status' column header, verify there is no longer a filtering popover.
* verify you can still filter by status in the icon UI next to the search input

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
