### PR TITLE
Swap tracks linker parameters

### DIFF
--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -155,7 +155,7 @@ export function initializeAnalytics(
 	const tracksLinkerId = getUrlParameter( '_tkl' );
 	if ( tracksLinkerId && tracksLinkerId !== getTracksAnonymousUserId() ) {
 		// Link tk_ai anonymous ids if _tkl parameter is present in URL and ids between pages are different (e.g. cross-domain)
-		signalUserFromAnotherProduct( 'anon', tracksLinkerId );
+		signalUserFromAnotherProduct( tracksLinkerId, 'anon' );
 	}
 
 	// Tracks blocked?


### PR DESCRIPTION
## Proposed Changes

Fixes wrong order of params that results in mixed `prevuserid` and `prevuseridtype` attributes.

## Testing Instructions

* Enter Jetpack Cloud Live link (in incognito tab)
* Get `tk_ai` cookie value from there
* Enter Calypso Live link (in incognito tab)
* Using your Calypso Live domain, open `<Calypso Live>/checkout/jetpack/jetpack_ai_yearly?_tkl=<tk_ai>`
* Using Tracks Vigilante, notice `_aliasUserGeneral` event, similar to this one:
![CleanShot 2024-05-08 at 18 02 53@2x](https://github.com/Automattic/wp-calypso/assets/8419292/7ad30d45-061f-477a-9a74-e36354c76837)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?