### PR TITLE
Sites dashboard v2 - Show all sorting options in main control always.

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -1,4 +1,3 @@
-import { useBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -52,10 +51,6 @@ const DotcomSitesDataViews = ( {
 }: Props ) => {
 	const { __ } = useI18n();
 	const userId = useSelector( getCurrentUserId );
-
-	// Display the `Sort By` option only when the fields are hidden on smaller viewport.
-	const isSmallScreen = useBreakpoint( '<1180px' );
-	const enableSorting = isSmallScreen || dataViewsState.type === 'list';
 
 	const openSitePreviewPane = useCallback(
 		( site: SiteExcerptData ) => {
@@ -178,14 +173,14 @@ const DotcomSitesDataViews = ( {
 				header: <span>{ __( 'Site' ) }</span>,
 				render: () => null,
 				enableHiding: false,
-				enableSorting,
+				enableSorting: true,
 			},
 			{
 				id: addDummyDataViewPrefix( 'last-publish' ),
 				header: <span>{ __( 'Last Publish' ) }</span>,
 				render: () => null,
 				enableHiding: false,
-				enableSorting,
+				enableSorting: true,
 			},
 			{
 				id: addDummyDataViewPrefix( 'last-interacted' ),
@@ -207,7 +202,7 @@ const DotcomSitesDataViews = ( {
 				enableSorting: false,
 			},
 		],
-		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState, enableSorting ]
+		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState ]
 	);
 
 	// Create the itemData packet state


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1715177886780569/1715176227.307219-slack-C06DN6QQVAQ

## Proposed Changes

* Removes restriction on when to show site and publish fields in main sorting controls. These should now always be available here. These were previously only present on mobile viewports.


BEFORE

<img width="395" alt="Screenshot 2024-05-08 at 10 32 41 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/1c1453a9-45fe-439d-9897-b323496a342f">



AFTER

<img width="415" alt="Screenshot 2024-05-08 at 10 32 22 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a3049096-2b80-4535-9f54-e709b94b60f6">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Go to the sites dashboard at /sites.
* Open the sorting controls in the top right (pictured in description above).
* Verify site and last publish sorting options are listed on desktop as well as mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?