### PR TITLE
Sites dashboard v2 - update last publish label to "Last published" 

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -145,7 +145,7 @@ const DotcomSitesDataViews = ( {
 						dataViewsState={ dataViewsState }
 						setDataViewsState={ setDataViewsState }
 					>
-						<span>{ __( 'Last Publish' ) }</span>
+						<span>{ __( 'Last Published' ) }</span>
 					</SiteSort>
 				),
 				render: ( { item }: { item: SiteInfo } ) =>
@@ -182,7 +182,7 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: addDummyDataViewPrefix( 'last-publish' ),
-				header: <span>{ __( 'Last Publish' ) }</span>,
+				header: <span>{ __( 'Last Published' ) }</span>,
 				render: () => null,
 				enableHiding: false,
 				enableSorting,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1715179018971119/1715176227.307219-slack-C06DN6QQVAQ

## Proposed Changes

* Updates the label from "Last Publish" to "Last Published" on the sites dashboard field and dummy field for sorting:

<img width="347" alt="Screenshot 2024-05-08 at 10 51 24 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d36cf298-a6c1-40e1-8b29-70a709dec551">
<img width="175" alt="Screenshot 2024-05-08 at 10 51 32 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/7b568acd-fbbe-4d89-a3fe-ee4ef797ad86">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Verify "last publish" is now "last published" on the column header as well as in the sorting controls (currently on visible on mobile but that will change in separate PR)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?