### PR TITLE
Sites dashboard v2 - site sort headers - enabled 'third click' to reset to default sort.

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
@@ -43,7 +43,8 @@ export const SiteSort = ( {
 		} else if ( direction === SORT_DIRECTION_ASC ) {
 			updatedSort.direction = SORT_DIRECTION_DESC;
 		} else if ( direction === SORT_DIRECTION_DESC ) {
-			updatedSort.direction = SORT_DIRECTION_ASC;
+			updatedSort.field = '';
+			updatedSort.direction = '';
 		}
 
 		setDataViewsState( ( sitesViewState ) => ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  6980-gh-Automattic/dotcom-forge-issuecomment-2100516068

## Proposed Changes

* Adds a "third click" to the site sort headers allowing to cycle between ascending, descending, and default sort. Previously this would only toggle between ascending and descending and never unset the sort field.

BEFORE
![site-sort-before](https://github.com/Automattic/wp-calypso/assets/28742426/3708f9f3-58af-48b4-a3c9-2ea9723e54d9)



AFTER

![site-sort-after](https://github.com/Automattic/wp-calypso/assets/28742426/28ea31a9-f161-4d79-8426-8fd70ba8c81a)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit the sites dashboard.
* Click the headers for sorting by site or last publish.
* Verify the third click unsets the sorting to its default state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
