### PR TITLE
Fixes a style conflict with the menu in the blaze app

### DIFF
--- a/apps/blaze-dashboard/src/styles/wp-admin.scss
+++ b/apps/blaze-dashboard/src/styles/wp-admin.scss
@@ -20,6 +20,10 @@
 	#wpbody-content {
 		padding-bottom: 0;
 	}
+
+	.site__info {
+		width: inherit;
+	}
 }
 
 .card {


### PR DESCRIPTION
This PR fixes a style conflict we have in atomic sites using the Blaze Dashboard app. The site's information menu section gets shortened, and the name doesn't appear.

<img width="1728" alt="328948085-fea3f0d4-d810-43eb-a98f-bfcf8e1ac21b" src="https://github.com/Automattic/wp-calypso/assets/1258162/905fafcd-5c18-43ea-81d4-fb7a2823d549">

## Proposed Changes

* I am overriding the default width for the site_title class when the user is navigating the Blaze Dashboard page.

## Testing Instructions

You can test this in any atomic site using Woo Blaze (any Woo Express installation with a paid plan)
* Checkout this branch and connect to your sandbox
* In a console, go to `wp-calypso/apps/blaze-dashboard`
* Execute `yarn dev --sync`. This will sync the Blaze dashboard app to your sandbox
* Move all the traffic from `widgets.wp.com` to your sandbox
* Go to Toolsmarketing->Blaze for WooCommerce and verify that the menu site's information is correctly showing your site's name
![Screenshot 2024-05-08 at 2 02 29 PM](https://github.com/Automattic/wp-calypso/assets/1258162/640771b6-0cd4-40de-94f9-dd5719304abb)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
