### PR TITLE
Entrepreneur Flow: Hide back button on migration flow when redirected from entrepreneur flow

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -113,7 +113,9 @@ const entrepreneurFlow: Flow = {
 						);
 
 						if ( isMigrationFlow ) {
-							return window.location.replace( `/setup/migration-signup?siteSlug=${ stagingUrl }` );
+							return window.location.replace(
+								`/setup/migration-signup?siteSlug=${ stagingUrl }&ref=entrepreneur-signup`
+							);
 						}
 
 						const redirectTo = encodeURIComponent(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -5,6 +5,7 @@ import CaptureInput from 'calypso/blocks/import/capture/capture-input';
 import ScanningStep from 'calypso/blocks/import/scanning';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
@@ -94,6 +95,9 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 		[ navigation, siteSlug ]
 	);
 
+	const urlQueryParams = useQuery();
+	const isEntrepreneurSignup = urlQueryParams.get( 'ref' ) === 'entrepreneur-signup';
+
 	return (
 		<>
 			<DocumentHead title="Site migration instructions" />
@@ -101,6 +105,7 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 				stepName="site-migration-identify"
 				flowName="site-migration"
 				className="import__onboarding-page"
+				hideBack={ isEntrepreneurSignup }
 				hideSkip={ true }
 				hideFormattedHeader={ true }
 				goBack={ navigation.goBack }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6847

## Proposed Changes

* Hide the back button on the migration flow when user selects "Migrate my store" on the entrepreneur flow

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur/start
* Select "Migrate my store" and click "Continue"
* After the site be created, you should be redirected to `/setup/migration-signup?siteSlug=___&ref=entrepreneur-signup`
* The back button should be hidden

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
