### PR TITLE
Update stats values in comparison table

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
@@ -232,7 +232,7 @@ export const useComparisonData = () => {
 									<>
 										{ translate( 'Basic stats' ) }
 										<br data-screen="desktop" />
-										{ /* Space between description and parenthasis on mobile */ }
+										{ /* Space between description and parenthesis on mobile */ }
 										<span data-screen="mobile"> </span>
 										{ translate( '(Personal sites only)' ) }
 									</>
@@ -243,7 +243,7 @@ export const useComparisonData = () => {
 									<>
 										{ translate( 'Basic stats' ) }
 										<br data-screen="desktop" />
-										{ /* Space between description and parenthasis on mobile */ }
+										{ /* Space between description and parenthesis on mobile */ }
 										<span data-screen="mobile"> </span>
 										{ translate( '(Personal sites only)' ) }
 									</>
@@ -255,7 +255,7 @@ export const useComparisonData = () => {
 									<>
 										{ translate( 'Advanced stats' ) }
 										<br data-screen="desktop" />
-										{ /* Space between description and parenthasis on mobile */ }
+										{ /* Space between description and parenthesis on mobile */ }
 										<span data-screen="mobile"> </span>
 										{ translate( '(100k page views)' ) }
 									</>

--- a/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
@@ -228,14 +228,38 @@ export const useComparisonData = () => {
 						icon: StatsIcon,
 						info: {
 							FREE: {
-								content: translate( 'Basic Stats' ),
+								content: (
+									<>
+										{ translate( 'Basic stats' ) }
+										<br data-screen="desktop" />
+										{ /* Space between description and parenthasis on mobile */ }
+										<span data-screen="mobile"> </span>
+										{ translate( '(Personal sites only)' ) }
+									</>
+								),
 							},
 							SECURITY: {
-								content: translate( 'Basic Stats' ),
+								content: (
+									<>
+										{ translate( 'Basic stats' ) }
+										<br data-screen="desktop" />
+										{ /* Space between description and parenthasis on mobile */ }
+										<span data-screen="mobile"> </span>
+										{ translate( '(Personal sites only)' ) }
+									</>
+								),
 							},
 							COMPLETE: {
 								highlight: true,
-								content: translate( 'All Stats' ),
+								content: (
+									<>
+										{ translate( 'Advanced stats' ) }
+										<br data-screen="desktop" />
+										{ /* Space between description and parenthasis on mobile */ }
+										<span data-screen="mobile"> </span>
+										{ translate( '(100k page views)' ) }
+									</>
+								),
 							},
 						},
 					},


### PR DESCRIPTION
## Proposed Changes

* Update stats items in comparison table to be more accurate

## Testing Instructions

1. Use the Calypso Green live link or checkout this branch on your local environment
2. Go to `/features/comparison`
3. Make sure the copy has been updated according to this:
![image](https://github.com/Automattic/wp-calypso/assets/65001528/0675d383-a055-4419-9e90-a713888318ad)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/2c710a54-d6d8-4644-9250-8bdfc6b89502)
4. Make sure mobile looks good too
![image](https://github.com/Automattic/wp-calypso/assets/65001528/f4c62a6c-9b05-4931-b2e2-1572e17bae11)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
