### PR TITLE
Sites dashboard v2 - make 'magic' sort the default sort value.

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/sites-site-sort.tsx
@@ -43,8 +43,8 @@ export const SiteSort = ( {
 		} else if ( direction === SORT_DIRECTION_ASC ) {
 			updatedSort.direction = SORT_DIRECTION_DESC;
 		} else if ( direction === SORT_DIRECTION_DESC ) {
-			updatedSort.field = '';
-			updatedSort.direction = '';
+			updatedSort.field = addDummyDataViewPrefix( 'last-interacted' );
+			updatedSort.direction = SORT_DIRECTION_DESC;
 		}
 
 		setDataViewsState( ( sitesViewState ) => ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/90455 

## Proposed Changes

* In the above linked PR I missed a point from design: `Third click: back to the default state (Last Interacted).` I set the default state back to the default returned by the endpoint instead of last interacted.
* This PR updates the 'default' state set by unsetting sort by column headers to be the last interacted sort setting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit the sites dashboard.
* Click the column sort headers to cycle through sorting options (ascending, descending, default). Once you unset sorting in a header, the default sort value shown should be the same as "magic" on the current sites dashboard (descending by last interaction with date).
* With the default set by the third click, the page should show the same 'magic' ordering after reload.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
