### PR TITLE
Odie: Establish session continuity across Calypso, wp-admin, and Atomic

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
@@ -99,18 +99,20 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/chat/get-last-chat-id',
+			$this->rest_base . '/history/last-chat-id',
 			// Get last chat ID.
 			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_last_chat_id' ),
-				'permission_callback' => array( $this, 'permission_callback' ),
-			),
-			// Set last chat ID.
-			array(
-				'methods'             => \WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'set_last_chat_id' ),
-				'permission_callback' => array( $this, 'permission_callback' ),
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_last_chat_id' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+				// Set last chat ID.
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'set_last_chat_id' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
 			)
 		);
 
@@ -204,8 +206,8 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 
 		$projected_response = array(
 			'calypso_preferences' => array(
-				'chat_id'      => $response->chat_id,
-				'last_chat_id' => $response->last_chat_id,
+				'odie_chat_id'      => $response->odie_chat_id,
+				'odie_last_chat_id' => $response->odie_last_chat_id,
 			),
 		);
 
@@ -220,24 +222,26 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function set_last_chat_id( \WP_REST_Request $request ) {
-		$chat_id      = $request->get_param( 'chat_id' );
-		$last_chat_id = $request->get_param( 'chat_id' );
+		$chat_id      = $request->get_param( 'odie_chat_id' );
+		$last_chat_id = $request->get_param( 'odie_last_chat_id' );
 
-		$body = array();
+		$body = array(
+			'calypso_preferences' => array(),
+		);
 
 		if ( isset( $chat_id ) ) {
-			$body['chat_id'] = $chat_id;
+			$body['calypso_preferences']['odie_chat_id'] = $chat_id;
 		}
 
 		if ( isset( $last_chat_id ) ) {
-			$body['last_chat_id'] = $last_chat_id;
+			$body['calypso_preferences']['odie_last_chat_id'] = $last_chat_id;
 		}
 
 		// Forward the request body to the support chat endpoint.
 		$body = Client::wpcom_json_api_request_as_user(
 			'/me/preferences',
 			2,
-			array( 'method' => 'GET' ),
+			array( 'method' => 'POST' ),
 			$body
 		);
 
@@ -249,8 +253,8 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 
 		$projected_response = array(
 			'calypso_preferences' => array(
-				'chat_id'      => $response->chat_id,
-				'last_chat_id' => $response->last_chat_id,
+				'odie_chat_id'      => $response->odie_chat_id,
+				'odie_last_chat_id' => $response->odie_last_chat_id,
 			),
 		);
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
@@ -99,6 +99,23 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			$this->rest_base . '/chat/get-last-chat-id',
+			// Get last chat ID.
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_last_chat_id' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+			),
+			// Set last chat ID.
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'set_last_chat_id' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			$this->rest_base . '/chat/(?P<bot_id>[a-zA-Z0-9-]+)/(?P<chat_id>\d+)/(?P<message_id>\d+)/feedback',
 			array(
 				array(
@@ -164,6 +181,80 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Get chat_id and last_chat_id from user preferences.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_last_chat_id() {
+		// Forward the request body to the support chat endpoint.
+		$body = Client::wpcom_json_api_request_as_user(
+			'/me/preferences',
+			2,
+			array( 'method' => 'GET' )
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		$projected_response = array(
+			'calypso_preferences' => array(
+				'chat_id'      => $response->chat_id,
+				'last_chat_id' => $response->last_chat_id,
+			),
+		);
+
+		return rest_ensure_response( $projected_response );
+	}
+
+	/**
+	 * Set chat_id or last_chat_id from user preferences.
+	 *
+	 * @param \WP_REST_Request $request The request sent to the API.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function set_last_chat_id( \WP_REST_Request $request ) {
+		$chat_id      = $request->get_param( 'chat_id' );
+		$last_chat_id = $request->get_param( 'chat_id' );
+
+		$body = array();
+
+		if ( isset( $chat_id ) ) {
+			$body['chat_id'] = $chat_id;
+		}
+
+		if ( isset( $last_chat_id ) ) {
+			$body['last_chat_id'] = $last_chat_id;
+		}
+
+		// Forward the request body to the support chat endpoint.
+		$body = Client::wpcom_json_api_request_as_user(
+			'/me/preferences',
+			2,
+			array( 'method' => 'GET' ),
+			$body
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		$projected_response = array(
+			'calypso_preferences' => array(
+				'chat_id'      => $response->chat_id,
+				'last_chat_id' => $response->last_chat_id,
+			),
+		);
+
+		return rest_ensure_response( $projected_response );
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
@@ -235,7 +235,6 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			$data['calypso_preferences']['odie_last_chat_id'] = $last_chat_id;
 		}
 
-		// Forward the request body to the support chat endpoint.
 		$body = Client::wpcom_json_api_request_as_user(
 			'/me/preferences',
 			2,

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
@@ -205,10 +205,8 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		$projected_response = array(
-			'calypso_preferences' => array(
-				'odie_chat_id'      => $response->odie_chat_id,
-				'odie_last_chat_id' => $response->odie_last_chat_id,
-			),
+			'odie_chat_id'      => $response->odie_chat_id,
+			'odie_last_chat_id' => $response->odie_last_chat_id,
 		);
 
 		return rest_ensure_response( $projected_response );
@@ -222,19 +220,19 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function set_last_chat_id( \WP_REST_Request $request ) {
-		$chat_id      = $request->get_param( 'odie_chat_id' );
-		$last_chat_id = $request->get_param( 'odie_last_chat_id' );
+		$chat_id      = $request['odie_chat_id'];
+		$last_chat_id = $request['odie_last_chat_id'];
 
-		$body = array(
+		$data = array(
 			'calypso_preferences' => array(),
 		);
 
-		if ( isset( $chat_id ) ) {
-			$body['calypso_preferences']['odie_chat_id'] = $chat_id;
+		if ( $request->has_param( 'odie_chat_id' ) ) {
+			$data['calypso_preferences']['odie_chat_id'] = $chat_id;
 		}
 
-		if ( isset( $last_chat_id ) ) {
-			$body['calypso_preferences']['odie_last_chat_id'] = $last_chat_id;
+		if ( $request->has_param( 'odie_last_chat_id' ) ) {
+			$data['calypso_preferences']['odie_last_chat_id'] = $last_chat_id;
 		}
 
 		// Forward the request body to the support chat endpoint.
@@ -242,7 +240,7 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			'/me/preferences',
 			2,
 			array( 'method' => 'POST' ),
-			$body
+			$data
 		);
 
 		if ( is_wp_error( $body ) ) {
@@ -253,8 +251,8 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 
 		$projected_response = array(
 			'calypso_preferences' => array(
-				'odie_chat_id'      => $response->odie_chat_id,
-				'odie_last_chat_id' => $response->odie_last_chat_id,
+				'odie_chat_id'      => $response->calypso_preferences->odie_chat_id,
+				'odie_last_chat_id' => $response->calypso_preferences->odie_last_chat_id,
 			),
 		);
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -7,7 +7,7 @@ import config from '@automattic/calypso-config';
 import { getPlan, getPlanTermLabel, isFreePlanProduct } from '@automattic/calypso-products';
 import { FormInputValidation, Popover, Spinner } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
-import { getOdieStorage } from '@automattic/odie-client';
+import { useGetOdieStorage } from '@automattic/odie-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, TextControl, CheckboxControl, Tip } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -133,6 +133,8 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 		'zendesk_support_chat_key',
 		isEligibleForChat || hasActiveChats
 	);
+
+	const wapuuChatId = useGetOdieStorage( 'last_chat_id' );
 
 	useEffect( () => {
 		const supportVariation = getSupportVariationFromMode( mode );
@@ -300,7 +302,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 		const productId = plan?.getProductId();
 		const productName = plan?.getTitle();
 		const productTerm = getPlanTermLabel( productSlug, ( text ) => text );
-		const wapuuChatId = getOdieStorage( 'last_chat_id' );
+
 		const aiChatId = wapuuFlow ? wapuuChatId ?? '' : gptResponse?.answer_id;
 
 		switch ( mode ) {

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -3,7 +3,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import OdieAssistantProvider, { useClearOdieStorage } from '@automattic/odie-client';
+import OdieAssistantProvider, { useSetOdieStorage } from '@automattic/odie-client';
 import { CardBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -79,7 +79,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		[]
 	);
 
-	const clearOdieStorage = useClearOdieStorage( 'chat_id' );
+	const setOdieStorage = useSetOdieStorage( 'chat_id' );
 
 	return (
 		<CardBody ref={ containerRef } className="help-center__container-content">
@@ -94,7 +94,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 				<Route path="/contact-options" element={ <HelpCenterContactPage /> } />
 				<Route
 					path="/contact-form"
-					element={ <HelpCenterContactForm onSubmit={ () => clearOdieStorage( '' ) } /> }
+					element={ <HelpCenterContactForm onSubmit={ () => setOdieStorage( null ) } /> }
 				/>
 				<Route path="/success" element={ <SuccessScreen /> } />
 				<Route

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -3,7 +3,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import OdieAssistantProvider, { clearOdieStorage } from '@automattic/odie-client';
+import OdieAssistantProvider, { useClearOdieStorage } from '@automattic/odie-client';
 import { CardBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -79,6 +79,8 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		[]
 	);
 
+	const clearOdieStorage = useClearOdieStorage( 'chat_id' );
+
 	return (
 		<CardBody ref={ containerRef } className="help-center__container-content">
 			<Routes>
@@ -92,7 +94,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 				<Route path="/contact-options" element={ <HelpCenterContactPage /> } />
 				<Route
 					path="/contact-form"
-					element={ <HelpCenterContactForm onSubmit={ () => clearOdieStorage( 'chat_id' ) } /> }
+					element={ <HelpCenterContactForm onSubmit={ () => clearOdieStorage( '' ) } /> }
 				/>
 				<Route path="/success" element={ <SuccessScreen /> } />
 				<Route

--- a/packages/odie-client/README.md
+++ b/packages/odie-client/README.md
@@ -44,6 +44,8 @@ const MyApp = () => (
 
 ## Odie Storage
 
+Odie stores user's chat ID in Calypso's user preferences. So that the chat continuity works across Calypso, wp-admin, and wp-admin in Atomic sites.
+
 ### Types
 
 ```tsx
@@ -56,15 +58,13 @@ type OdieStorageKey = 'chat_id' | 'last_chat_id';
 import {
 	useGetOdieStorage,
 	useSetOdieStorage,
-	useClearOdieStorage,
-	useOdieStorage,
 } from '@automattic/odie-client';
 
 // Usage examples
-useSetOdieStorage( 'chat_id', 'new_chat_id' );
+const updateChatId = useSetOdieStorage( 'chat_id' )
+updateChatId( 'new_chat_id' );
+
 const chatId = useGetOdieStorage( 'chat_id' );
-useClearOdieStorage( 'chat_id' );
-const chatId = useOdieStorage( 'chat_id' ); // Listen for changes
 ```
 
 _Note: Setting `chat_id` fetches a new chat from the server and also sets `last_chat_id`. Clearing `chat_id` does not clear `last_chat_id`._

--- a/packages/odie-client/README.md
+++ b/packages/odie-client/README.md
@@ -54,16 +54,16 @@ type OdieStorageKey = 'chat_id' | 'last_chat_id';
 
 ```tsx
 import {
-	getOdieStorage,
-	setOdieStorage,
-	clearOdieStorage,
+	useGetOdieStorage,
+	useSetOdieStorage,
+	useClearOdieStorage,
 	useOdieStorage,
 } from '@automattic/odie-client';
 
 // Usage examples
-setOdieStorage( 'chat_id', 'new_chat_id' );
-const chatId = getOdieStorage( 'chat_id' );
-clearOdieStorage( 'chat_id' );
+useSetOdieStorage( 'chat_id', 'new_chat_id' );
+const chatId = useGetOdieStorage( 'chat_id' );
+useClearOdieStorage( 'chat_id' );
 const chatId = useOdieStorage( 'chat_id' ); // Listen for changes
 ```
 

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -1,9 +1,9 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import {
 	broadcastChatClearance,
-	useClearOdieStorage,
+	useSetOdieStorage,
 	useOdieBroadcastWithCallbacks,
-	useOdieStorage,
+	useGetOdieStorage,
 } from '../data';
 import { getOdieInitialMessage } from './get-odie-initial-message';
 import { useLoadPreviousChat } from './use-load-previous-chat';
@@ -115,7 +115,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isNudging, setIsNudging ] = useState( false );
 	const [ lastNudge, setLastNudge ] = useState< Nudge | null >( null );
-	const existingChatIdString = useOdieStorage( 'chat_id' );
+	const existingChatIdString = useGetOdieStorage( 'chat_id' );
 
 	const existingChatId = existingChatIdString ? parseInt( existingChatIdString, 10 ) : null;
 	const existingChat = useLoadPreviousChat( botNameSlug, existingChatId );
@@ -143,17 +143,17 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 		[ botNameSlug, chat?.chat_id, logger, loggerEventNamePrefix ]
 	);
 
-	const clearOdieStorage = useClearOdieStorage( 'chat_id' );
+	const setOdieStorage = useSetOdieStorage( 'chat_id' );
 
 	const clearChat = useCallback( () => {
-		clearOdieStorage( '' );
+		setOdieStorage( null );
 		setChat( {
 			chat_id: null,
 			messages: [ getOdieInitialMessage( botNameSlug ) ],
 		} );
 		trackEvent( 'chat_cleared', {} );
 		broadcastChatClearance( odieClientId );
-	}, [ botNameSlug, trackEvent, clearOdieStorage ] );
+	}, [ botNameSlug, trackEvent, setOdieStorage ] );
 
 	const setMessageLikedStatus = ( message: Message, liked: boolean ) => {
 		setChat( ( prevChat ) => {

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import {
 	broadcastChatClearance,
-	clearOdieStorage,
+	useClearOdieStorage,
 	useOdieBroadcastWithCallbacks,
 	useOdieStorage,
 } from '../data';
@@ -116,6 +116,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	const [ isNudging, setIsNudging ] = useState( false );
 	const [ lastNudge, setLastNudge ] = useState< Nudge | null >( null );
 	const existingChatIdString = useOdieStorage( 'chat_id' );
+
 	const existingChatId = existingChatIdString ? parseInt( existingChatIdString, 10 ) : null;
 	const existingChat = useLoadPreviousChat( botNameSlug, existingChatId );
 
@@ -142,15 +143,17 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 		[ botNameSlug, chat?.chat_id, logger, loggerEventNamePrefix ]
 	);
 
+	const clearOdieStorage = useClearOdieStorage( 'chat_id' );
+
 	const clearChat = useCallback( () => {
-		clearOdieStorage( 'chat_id' );
+		clearOdieStorage( '' );
 		setChat( {
 			chat_id: null,
 			messages: [ getOdieInitialMessage( botNameSlug ) ],
 		} );
 		trackEvent( 'chat_cleared', {} );
 		broadcastChatClearance( odieClientId );
-	}, [ botNameSlug, trackEvent ] );
+	}, [ botNameSlug, trackEvent, clearOdieStorage ] );
 
 	const setMessageLikedStatus = ( message: Message, liked: boolean ) => {
 		setChat( ( prevChat ) => {

--- a/packages/odie-client/src/data/index.ts
+++ b/packages/odie-client/src/data/index.ts
@@ -1,87 +1,74 @@
-import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
+import { useEffect } from 'react';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { Message } from '../types';
 
 type OdieStorageKey = 'chat_id' | 'last_chat_id';
 
 const buildOdieStorageKey = ( key: OdieStorageKey ) => `odie_${ key }`;
 
-const storageEventName = 'odieStorageEvent';
 const messageEventName = 'odieMessageEvent';
 const clearChatEventName = 'clearChatEvent';
 
-export const getOdieStorage = ( key: OdieStorageKey ) => {
+export const useGetOdieStorage = ( key: OdieStorageKey ) => {
 	const storageKey = buildOdieStorageKey( key );
-	return localStorage.getItem( storageKey );
+	const { data } = useQuery( {
+		queryKey: [ storageKey ],
+		queryFn: () => {
+			if ( canAccessWpcomApis() ) {
+				return wpcomRequest< Record< string, string > >( {
+					path: '/me/preferences',
+					apiVersion: 'v2',
+					apiNamespace: 'wpcom/v2',
+				} ).then( ( response ) => response[ storageKey ] );
+			}
+			return apiFetch< { calypso_preferences: Record< string, string > } >( {
+				global: true,
+				path: `/help-center/odie/chat/get-last-chat-id`,
+			} as APIFetchOptions ).then( ( res ) => res.calypso_preferences[ storageKey ] );
+		},
+	} );
+	return data;
 };
 
-export const setOdieStorage = ( key: OdieStorageKey, value: string ) => {
+export const useSetOdieStorage = ( key: OdieStorageKey ) => {
 	const storageKey = buildOdieStorageKey( key );
-	localStorage.setItem( storageKey, value );
-
-	// Duplicate the value to last_chat_id
-	if ( key === 'chat_id' ) {
-		localStorage.setItem( buildOdieStorageKey( 'last_chat_id' ), value );
-		window.dispatchEvent(
-			new CustomEvent( storageEventName, {
-				detail: {
-					key: buildOdieStorageKey( 'last_chat_id' ),
-					value: value,
-				},
-			} )
-		);
-	}
-
-	const event = new CustomEvent( storageEventName, {
-		detail: {
-			key: storageKey,
-			value: value,
+	const client = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: ( value: string ) => {
+			if ( canAccessWpcomApis() ) {
+				return wpcomRequest< { calypso_preferences: Record< string, string > } >( {
+					path: '/me/preferences',
+					apiVersion: 'v2',
+					apiNamespace: 'wpcom/v2',
+					method: 'PUT',
+					body: { calypso_preferences: { [ storageKey ]: value } },
+				} );
+			}
+			return apiFetch< { calypso_preferences: Record< string, string > } >( {
+				global: true,
+				path: `/help-center/odie/chat/get-last-chat-id`,
+				method: 'POST',
+				body: JSON.stringify( { [ storageKey ]: value } ),
+			} as APIFetchOptions );
+		},
+		onSuccess: ( response ) => {
+			client.setQueryData( [ storageKey ], () => {
+				return response.calypso_preferences[ storageKey ];
+			} );
 		},
 	} );
 
-	window.dispatchEvent( event );
+	return mutation.mutate;
 };
 
-export const clearOdieStorage = ( key: OdieStorageKey ) => {
-	const storageKey = buildOdieStorageKey( key );
-	localStorage.removeItem( storageKey );
-
-	const event = new CustomEvent( storageEventName, {
-		detail: {
-			key: storageKey,
-			value: null,
-		},
-	} );
-
-	window.dispatchEvent( event );
+export const useClearOdieStorage = ( key: OdieStorageKey ) => {
+	return useSetOdieStorage( key );
 };
 
 export const useOdieStorage = ( key: OdieStorageKey ) => {
-	const storageKey = buildOdieStorageKey( key );
-	const [ value, setValue ] = useState( getOdieStorage( key ) );
-	useEffect( () => {
-		const storageListener = ( e: StorageEvent ) => {
-			if ( e.key === storageKey ) {
-				setValue( e.newValue );
-			}
-		};
-
-		const customStorageListener = ( e: Event ) => {
-			const detail = ( e as CustomEvent ).detail;
-			if ( detail.key === storageKey ) {
-				setValue( detail.value );
-			}
-		};
-
-		window.addEventListener( 'storage', storageListener );
-		window.addEventListener( storageEventName, customStorageListener );
-
-		return () => {
-			window.removeEventListener( 'storage', storageListener );
-			window.removeEventListener( storageEventName, customStorageListener );
-		};
-	}, [ key, storageKey ] );
-
-	return value;
+	return useGetOdieStorage( key );
 };
 
 export const broadcastOdieMessage = ( message: Message, origin: string ) => {

--- a/packages/odie-client/src/data/index.ts
+++ b/packages/odie-client/src/data/index.ts
@@ -25,7 +25,7 @@ export const useGetOdieStorage = ( key: OdieStorageKey ) => {
 			}
 			return apiFetch< { calypso_preferences: Record< string, string > } >( {
 				global: true,
-				path: `/help-center/odie/chat/get-last-chat-id`,
+				path: `/help-center/odie/history/last-chat-id`,
 			} as APIFetchOptions ).then( ( res ) => res.calypso_preferences[ storageKey ] );
 		},
 	} );
@@ -48,7 +48,7 @@ export const useSetOdieStorage = ( key: OdieStorageKey ) => {
 			}
 			return apiFetch< { calypso_preferences: Record< string, string > } >( {
 				global: true,
-				path: `/help-center/odie/chat/get-last-chat-id`,
+				path: `/help-center/odie/history/last-chat-id`,
 				method: 'POST',
 				body: JSON.stringify( { [ storageKey ]: value } ),
 			} as APIFetchOptions );

--- a/packages/odie-client/src/data/index.ts
+++ b/packages/odie-client/src/data/index.ts
@@ -23,10 +23,10 @@ export const useGetOdieStorage = ( key: OdieStorageKey ) => {
 					apiNamespace: 'wpcom/v2',
 				} ).then( ( response ) => response[ storageKey ] );
 			}
-			return apiFetch< { calypso_preferences: Record< string, string > } >( {
+			return apiFetch< Record< string, string > >( {
 				global: true,
 				path: `/help-center/odie/history/last-chat-id`,
-			} as APIFetchOptions ).then( ( res ) => res.calypso_preferences[ storageKey ] );
+			} as APIFetchOptions ).then( ( res ) => res[ storageKey ] );
 		},
 	} );
 	return data;
@@ -36,7 +36,7 @@ export const useSetOdieStorage = ( key: OdieStorageKey ) => {
 	const storageKey = buildOdieStorageKey( key );
 	const client = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: ( value: string ) => {
+		mutationFn: ( value: string | null ) => {
 			if ( canAccessWpcomApis() ) {
 				return wpcomRequest< { calypso_preferences: Record< string, string > } >( {
 					path: '/me/preferences',
@@ -50,7 +50,7 @@ export const useSetOdieStorage = ( key: OdieStorageKey ) => {
 				global: true,
 				path: `/help-center/odie/history/last-chat-id`,
 				method: 'POST',
-				body: JSON.stringify( { [ storageKey ]: value } ),
+				data: { [ storageKey ]: value },
 			} as APIFetchOptions );
 		},
 		onSuccess: ( response ) => {
@@ -61,14 +61,6 @@ export const useSetOdieStorage = ( key: OdieStorageKey ) => {
 	} );
 
 	return mutation.mutate;
-};
-
-export const useClearOdieStorage = ( key: OdieStorageKey ) => {
-	return useSetOdieStorage( key );
-};
-
-export const useOdieStorage = ( key: OdieStorageKey ) => {
-	return useGetOdieStorage( key );
 };
 
 export const broadcastOdieMessage = ( message: Message, origin: string ) => {

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -106,5 +106,5 @@ export const OdieAssistant: React.FC = () => {
 
 export default OdieAssistantProvider;
 export { useOdieAssistantContext } from './context';
-export { useClearOdieStorage, useSetOdieStorage, useOdieStorage, useGetOdieStorage } from './data';
+export { useSetOdieStorage, useGetOdieStorage } from './data';
 export { EllipsisMenu } from './components/ellipsis-menu';

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -106,5 +106,5 @@ export const OdieAssistant: React.FC = () => {
 
 export default OdieAssistantProvider;
 export { useOdieAssistantContext } from './context';
-export { clearOdieStorage, setOdieStorage, useOdieStorage, getOdieStorage } from './data';
+export { useClearOdieStorage, useSetOdieStorage, useOdieStorage, useGetOdieStorage } from './data';
 export { EllipsisMenu } from './components/ellipsis-menu';

--- a/packages/odie-client/src/query/index.ts
+++ b/packages/odie-client/src/query/index.ts
@@ -6,7 +6,7 @@ import { canAccessWpcomApis } from 'wpcom-proxy-request';
 import wpcom from 'calypso/lib/wp';
 import { WAPUU_ERROR_MESSAGE } from '..';
 import { useOdieAssistantContext } from '../context';
-import { broadcastOdieMessage, setOdieStorage } from '../data';
+import { broadcastOdieMessage, useSetOdieStorage } from '../data';
 import type { Chat, Message, MessageRole, MessageType, OdieAllowedBots } from '../types';
 
 // Either we use wpcom or apiFetch for the request for accessing odie endpoint for atomic or wpcom sites
@@ -88,6 +88,7 @@ export const useOdieSendMessage = (): UseMutationResult<
 	} = useOdieAssistantContext();
 	const queryClient = useQueryClient();
 	const userMessage = useRef< Message | null >( null );
+	const storeChatId = useSetOdieStorage( 'chat_id' );
 
 	return useMutation<
 		{ chat_id: string; messages: Message[] },
@@ -168,7 +169,7 @@ export const useOdieSendMessage = (): UseMutationResult<
 			updateMessage( message );
 
 			broadcastOdieMessage( message, odieClientId );
-			setOdieStorage( 'chat_id', data.chat_id );
+			storeChatId( data.chat_id );
 			const queryKey = [ 'chat', botNameSlug, data.chat_id, 1, 30, true ];
 
 			queryClient.setQueryData( queryKey, ( currentChatCache: Chat ) => {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/90454

## Proposed Changes

This moves the chat_id storage for Wapuu from local storage to user preferences. This allows users to continue their sessions across Calypso, wp-admin, and wp-admin Atomic.

## Testing Instructions

### Simple sites

1. Go to My Home and start a chat.
2. Go to wp-admin of that simple site and re-open the Odie session, chat should continue.
3. Start a new conversation using the three dots on top right.
4. Go to Calypso (My Home).
5. Re-open the Odie session, it should be empty.

### Atomic sites
1. Inside `apps/editing-toolkit` run `yarn build`.
2. In Finder, go inside `apps/editing-toolkit/editing-toolkit-plugin` and select every file and folder then compress them.
3. Go to an Atomic site plugins page.
4. Delete ETK.
5. Upload your own ZIP as ETK.
6. Follow the same steps from simple sites. 
7. Continuity should be perfect across Calypso and wp-admin.
