### PR TITLE
A4A: Convert "stats" dataview item to an interactive button

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -678,6 +678,9 @@
 		vertical-align: middle;
 		color: var(--color-accent-5);
 	}
+	.sites-overview__stats-trend {
+		padding: 0 8px 0 4px;
+	}
 	.sites-overview__stats-trend__up,
 	.sites-overview__stats-trend__down {
 		vertical-align: middle;
@@ -707,13 +710,6 @@
 		vertical-align: middle;
 		color: var(--color-accent-80);
 		font-size: 0.75rem;
-	}
-	.sites-overview__stats-trend svg {
-		position: relative;
-		inset-block-start: 0.3rem;
-		@media screen and (max-width: $break-xlarge) {
-			inset-block-start: 0.27rem;
-		}
 	}
 	.sites-overview__disabled {
 		color: var(--color-accent-5);
@@ -819,7 +815,7 @@
 	.sites-overview__stats {
 		color: var(--color-text-black);
 		display: inline-block;
-		line-height: 17px;
+		line-height: 1;
 		height: 18px;
 		padding: 2px 1px;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -66,7 +66,7 @@ export default function SiteStatusContent( {
 	}
 
 	if ( type === 'stats' ) {
-		return <SiteStatsColumn stats={ rows.stats.value } />;
+		return <SiteStatsColumn site={ rows.site.value } stats={ rows.stats.value } />;
 	}
 
 	// We will show a progress icon when the site score is being fetched.

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -1,3 +1,4 @@
+import { ShortenedNumber } from '@automattic/components';
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -6,6 +7,7 @@ import { useCallback, useContext } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { type Site } from '../../sites-overview/types';
 import { SiteStats } from '../types';
 
@@ -29,6 +31,7 @@ export default function SiteStatsColumn( { site, stats }: Props ) {
 	const { setSelectedSiteFeature, setDataViewsState } = useContext( SitesDashboardContext );
 	const { total: totalViews, trend: viewsTrend } = stats.views;
 	const trendIcon = getTrendIcon( viewsTrend );
+	const isA4A = isA8CForAgencies();
 
 	// Open the site's preview pane with the stats tab displayed.
 	const openStats = useCallback( () => {
@@ -40,16 +43,32 @@ export default function SiteStatsColumn( { site, stats }: Props ) {
 		setSelectedSiteFeature( 'jetpack-stats' );
 	}, [ site, setSelectedSiteFeature, setDataViewsState ] );
 
+	// When in A4A, the stats column is a clickable button that opens the preview pane.
+	if ( isA4A ) {
+		return (
+			<button
+				type="button"
+				title={
+					translate( '%(totalViews)s views in the last 7 days', { args: { totalViews } } ) as string
+				}
+				onClick={ openStats }
+				className={ classNames(
+					'sites-overview__stats-trend',
+					`sites-overview__stats-trend__${ viewsTrend }`,
+					{ 'button is-borderless': isA4A }
+				) }
+			>
+				{ trendIcon }
+				<div className="sites-overview__stats">
+					<span className="shortened-number">{ formatNumber( totalViews ) }</span>
+				</div>
+			</button>
+		);
+	}
+
 	return (
-		<button
-			type="button"
-			title={
-				translate( '%(totalViews)s views in the last 7 days', { args: { totalViews } } ) as string
-			}
-			onClick={ openStats }
+		<span
 			className={ classNames(
-				'button',
-				'is-borderless',
 				'sites-overview__stats-trend',
 				`sites-overview__stats-trend__${ viewsTrend }`
 			) }
@@ -57,8 +76,8 @@ export default function SiteStatsColumn( { site, stats }: Props ) {
 			{ trendIcon }
 
 			<div className="sites-overview__stats">
-				<span className="shortened-number">{ formatNumber( totalViews ) }</span>
+				<ShortenedNumber value={ totalViews } />
 			</div>
-		</button>
+		</span>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -12,7 +12,7 @@ import { type Site } from '../../sites-overview/types';
 import { SiteStats } from '../types';
 
 type Props = {
-	site: Site;
+	site?: Site;
 	stats: SiteStats;
 };
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -1,9 +1,16 @@
-import { ShortenedNumber } from '@automattic/components';
+import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { useCallback, useContext } from 'react';
+import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
+import { type Site } from '../../sites-overview/types';
 import { SiteStats } from '../types';
 
 type Props = {
+	site: Site;
 	stats: SiteStats;
 };
 
@@ -18,12 +25,31 @@ const getTrendIcon = ( viewsTrend: 'up' | 'down' | 'same' ) => {
 	}
 };
 
-export default function SiteStatsColumn( { stats }: Props ) {
+export default function SiteStatsColumn( { site, stats }: Props ) {
+	const { setSelectedSiteFeature, setDataViewsState } = useContext( SitesDashboardContext );
 	const { total: totalViews, trend: viewsTrend } = stats.views;
 	const trendIcon = getTrendIcon( viewsTrend );
+
+	// Open the site's preview pane with the stats tab displayed.
+	const openStats = useCallback( () => {
+		setDataViewsState( ( prevState: DataViewsState ) => ( {
+			...prevState,
+			selectedItem: site,
+			type: DATAVIEWS_LIST,
+		} ) );
+		setSelectedSiteFeature( 'jetpack-stats' );
+	}, [ site, setSelectedSiteFeature, setDataViewsState ] );
+
 	return (
-		<span
+		<button
+			type="button"
+			title={
+				translate( '%(totalViews)s views in the last 7 days', { args: { totalViews } } ) as string
+			}
+			onClick={ openStats }
 			className={ classNames(
+				'button',
+				'is-borderless',
 				'sites-overview__stats-trend',
 				`sites-overview__stats-trend__${ viewsTrend }`
 			) }
@@ -31,8 +57,8 @@ export default function SiteStatsColumn( { stats }: Props ) {
 			{ trendIcon }
 
 			<div className="sites-overview__stats">
-				<ShortenedNumber value={ totalViews } />
+				<span className="shortened-number">{ formatNumber( totalViews ) }</span>
 			</div>
-		</span>
+		</button>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/398

## Proposed Changes

* Makes the "stats" value clickable.
  * Opens the site's preview pane with the stats tab auto-selected.
  * Adds a descriptive "title" attribute to the button, i.e. "100 views in the last 7 days".
  * Adds a focus style for keyboard access.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out the `/sites` page and review the stats value. Test click, focus with keyboard, and title on hover.
* Check out the dataview in Jetpack Manage and ensure there is no regression in styles.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

Focus style:

<img width="109" alt="Screenshot 2024-05-08 at 4 25 23 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/01296974-258f-4ea1-81bc-c17cfbab520b">

Descriptive title on hover:

<img width="200" alt="Screenshot 2024-05-08 at 4 23 46 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/016897ef-0a8c-43a2-b613-7f6e4f26644f">

