### PR TITLE
Update border colors

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -86,12 +86,8 @@
 		}
 	}
 
-	table.dataviews-view-table {
-		--color-border-dataviews-view-table: #f1f1f1;
-	}
-
 	table.dataviews-view-table thead .dataviews-view-table__row th {
-		border-bottom-color: var(--color-border-dataviews-view-table);
+		border-bottom-color: var(--color-border-secondary);
 
 		span,
 		.dataviews-view-table-header-button {
@@ -100,7 +96,7 @@
 	}
 
 	table.dataviews-view-table .dataviews-view-table__row td {
-		border-bottom-color: var(--color-border-dataviews-view-table);
+		border-bottom-color: var(--color-border-secondary);
 	}
 
 	table.dataviews-view-table th,

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -206,7 +206,7 @@
 	--color-border-shadow-rgb: var(--color-neutral-0-rgb);
 	--color-border-inverted: var(--studio-white);
 	--color-border-inverted-rgb: var(--studio-white-rgb);
-	--color-border-secondary: #f0f0f0;
+	--color-border-secondary: #f1f1f1;
 
 	--color-link: var(--studio-blue-50);
 	--color-link-rgb: var(--studio-blue-50-rgb);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -206,7 +206,7 @@
 	--color-border-shadow-rgb: var(--color-neutral-0-rgb);
 	--color-border-inverted: var(--studio-white);
 	--color-border-inverted-rgb: var(--studio-white-rgb);
-	--color-border-secondary: #f0f0f0;
+	--color-border-secondary: #f1f1f1;
 
 	--color-link: var(--studio-blue-50);
 	--color-link-rgb: var(--studio-blue-50-rgb);


### PR DESCRIPTION
follow up on 6962-gh-Automattic/dotcom-forge#issuecomment-2099873802

Just update the border colors so that they all use F1F1F1 instead of F0F0F0, the colors are so close that they should be indistinguishable so let's just use one so it will be easier to choose a border color in the future.

### Test instructions
<img width="718" alt="Screenshot 2024-05-09 at 9 07 33 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/8d67a0d8-fe9d-4c16-8a94-eec06834007c">


Go to `/sites?flags=layout/dotcom-nav-redesign-v2`, the borders should look consistent.