### PR TITLE
A4A: fix shopping cart display prices and discount

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -40,7 +40,7 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 					<span className="shopping-cart__menu-list-item-price-discounted">
 						{ formatCurrency( discountedCost, item.currency ) }
 					</span>
-					{ actualCost !== discountedCost && (
+					{ actualCost > discountedCost && (
 						<span className="shopping-cart__menu-list-item-price-actual">
 							{ formatCurrency( actualCost, item.currency ) }
 						</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/457

## Proposed Changes

Small changes to fix Shopping Cart display of prices. We should not show crossed out price when product is not discounted. We also shouldn't show 0 crossed out prices.

<img width="527" alt="Screenshot 2024-05-08 at 4 12 03 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/a509d7a0-e96f-4464-8216-8ebbcf2d1c91">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to `/marketplace/products`
- Add different items and quantities in your cart. Check it's behavior.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
