### PR TITLE
Checkout: Fix checkout line spacing

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -133,6 +133,7 @@ export const Price = styled.span`
 
 export const Variant = styled.div< { shouldUseCheckoutV2: boolean } >`
 	display: flex;
+	align-items: center;
 	font-size: 14px;
 	font-weight: 400;
 	justify-content: space-between;

--- a/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
@@ -60,6 +60,7 @@ const UpsellWrapper = styled.div`
 
 		p {
 			margin-bottom: 1.2em;
+			word-break: break-word;
 		}
 	}
 `;


### PR DESCRIPTION
While working on another issue I spotted two places in Checkout where the line spacing for their text are a bit off.

**Variant picker with long promo text**
| Before | After |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/5ff7d6ed-391e-4c50-b1c3-c184597e3849) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/c60c59a7-afcd-438d-8792-5accacf45340) |

**'Renew your products together' upsell**
| Before | After |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/d4adb63a-574c-40ca-82f4-fef272b71cf7) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/c5c82d20-795e-4d5b-af83-3e7c03116617) |
Related to #

## Testing Instructions

* Go to checkout with a monthly Professional Email in your cart, this should trigger the 3 month promo
* Check that the text is now properly vertically spaced

* Find a site with a subscription that is nearing its renewal date (or set a subscription expiration to closer to todays date)
* Add another product to the cart for the same site, this should then tell checkout to prompt you to renew these two products together

