### PR TITLE
Automattic for Agencies: Update Signup finish page text

### DIFF
--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
@@ -88,9 +88,7 @@ export default function AgencySignupFinish() {
 				size={ 48 }
 			/>
 			<h1 className="agency-signup-finish__text">
-				{ translate(
-					`We're setting up your agency account! This usually takes about 10-30 seconds. Soon you'll manage all your sites from one spot.`
-				) }
+				{ translate( 'Please hold, great things are coming.' ) }
 			</h1>
 		</div>
 	);


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/437

## Proposed Changes

This PR updates the Signup finish page text.

## Testing Instructions

1. Open the A4A live link.
2. Create a new WPCOM account & sign up to A4A > Verify the page text is changed as shown below on the signup finish page.

<img width="857" alt="Screenshot 2024-05-09 at 12 19 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e8320162-dc7b-43c3-841a-e819a187ade6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
