### PR TITLE
Reload the Plans List experiment after log in

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -16,7 +16,7 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
-import { useExperiment } from 'calypso/lib/explat';
+import { loadExperimentAssignment, useExperiment } from 'calypso/lib/explat';
 import { createAccountUrl, login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -36,6 +36,7 @@ import { hydrate, render } from './web-util.js';
 export { setLocaleMiddleware, setSectionMiddleware } from './shared.js';
 export { hydrate, render } from './web-util.js';
 
+const PLAN_NAME_EXPERIMENT = 'wpcom_plan_name_change_starter_to_beginner_v5';
 export const ProviderWrappedLayout = ( {
 	store,
 	queryClient,
@@ -50,18 +51,19 @@ export const ProviderWrappedLayout = ( {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
 
-	const [ isLoading, experimentAssignment ] = useExperiment(
-		'wpcom_plan_name_change_starter_to_beginner_v5'
-	);
+	const [ isLoading, experimentAssignment ] = useExperiment( PLAN_NAME_EXPERIMENT );
 
 	useEffect( () => {
 		if ( ! isLoading ) {
-			setPlansListExperiment(
-				'wpcom_plan_name_change_starter_to_beginner_v5',
-				experimentAssignment?.variationName
-			);
+			setPlansListExperiment( PLAN_NAME_EXPERIMENT, experimentAssignment?.variationName );
 		}
 	}, [ isLoading, experimentAssignment?.variationName ] );
+
+	useEffect( () => {
+		// TODO: Implement a proper way to reset the experiment assignment
+		localStorage.removeItem( `explat-experiment--${ PLAN_NAME_EXPERIMENT }` );
+		loadExperimentAssignment( PLAN_NAME_EXPERIMENT );
+	}, [ userLoggedIn ] );
 
 	const layout = userLoggedIn ? (
 		<Layout primary={ primary } secondary={ secondary } />

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { setPlansListExperiment } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { localStorageExperimentAssignmentKey } from '@automattic/explat-client/src/internal/experiment-assignment-store';
 import {
 	getLanguage,
 	getLanguageSlugs,
@@ -61,7 +62,7 @@ export const ProviderWrappedLayout = ( {
 
 	useEffect( () => {
 		// TODO: Implement a proper way to reset the experiment assignment
-		localStorage.removeItem( `explat-experiment--${ PLAN_NAME_EXPERIMENT }` );
+		localStorage.removeItem( localStorageExperimentAssignmentKey( PLAN_NAME_EXPERIMENT ) );
 		loadExperimentAssignment( PLAN_NAME_EXPERIMENT );
 	}, [ userLoggedIn ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This addresses an issue where users get assigned plan name experiments that they weren't supposed to.
This happens when they land on the `/start` flow while logged out, and they log in afterward. The assignment is fetched while they're logged out and never gets updated.
This fixes this by removing the stored assignment and re-fetches it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Network Tab
* While logged out, go to `/start`
* You should see a request to `/assignments` related to `wpcom_plan_name_change_starter_to_beginner_v5`
* Log in to a current account
* You should see another request 
<img width="380" alt="Screenshot 2024-05-09 at 09 57 03" src="https://github.com/Automattic/wp-calypso/assets/2749938/62fb960a-edb9-4789-a329-f7afa65e38c7">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
