### PR TITLE
Trail Map: Storage section header styling

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -139,14 +139,12 @@ const MobileView = ( {
 					>
 						<PartnerLogos renderedGridPlans={ [ gridPlan ] } />
 						{ enableCategorisedFeatures ? (
-							featureGroups.map( ( featureGroupSlug, featureGroupIndex ) => (
+							featureGroups.map( ( featureGroupSlug ) => (
 								<div
-									className={ classNames( 'plans-grid-next-features-grid__feature-group-row', {
-										'is-first-feature-group': featureGroupIndex === 0,
-									} ) }
+									className="plans-grid-next-features-grid__feature-group-row"
+									key={ featureGroupSlug }
 								>
 									<PlanFeaturesList
-										key={ featureGroupSlug }
 										renderedGridPlans={ [ gridPlan ] }
 										selectedFeature={ selectedFeature }
 										paidDomainName={ paidDomainName }

--- a/packages/plans-grid-next/src/components/features-grid/plan-storage-options.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-storage-options.tsx
@@ -42,12 +42,6 @@ const PlanStorageOptions = ( {
 				return null;
 			}
 
-			const shouldRenderStorageTitle =
-				storageOptions.length > 0 &&
-				( storageOptions.length === 1 ||
-					intervalType !== 'yearly' ||
-					! showUpgradeableStorage ||
-					! availableForPurchase );
 			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
 				intervalType,
 				showUpgradeableStorage,
@@ -56,7 +50,6 @@ const PlanStorageOptions = ( {
 			const storageJSX =
 				canUpgradeStorageForPlan && availableForPurchase ? (
 					<StorageAddOnDropdown
-						label={ translate( 'Storage' ) }
 						planSlug={ planSlug }
 						onStorageAddOnClick={ onStorageAddOnClick }
 						storageOptions={ storageOptions }
@@ -79,9 +72,9 @@ const PlanStorageOptions = ( {
 					className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
 					isTableCell={ options?.isTableCell }
 				>
-					{ shouldRenderStorageTitle ? (
-						<div className="plan-features-2023-grid__storage-title">{ translate( 'Storage' ) }</div>
-					) : null }
+					<h2 className="plan-features-2023-grid__storage-title plans-grid-next-features-grid__feature-group-title">
+						{ translate( 'Storage' ) }
+					</h2>
 					{ storageJSX }
 				</PlanDivOrTdContainer>
 			);

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -152,7 +152,7 @@ const Table = ( {
 				</tr>
 				{ enableCategorisedFeatures ? (
 					<>
-						<tr>
+						<tr className="plans-grid-next-features-grid__feature-group-row is-first-feature-group-row">
 							<PlanStorageOptions
 								renderedGridPlans={ gridPlansWithoutSpotlight }
 								options={ { isTableCell: true } }
@@ -161,11 +161,9 @@ const Table = ( {
 								showUpgradeableStorage={ showUpgradeableStorage }
 							/>
 						</tr>
-						{ featureGroups.map( ( featureGroupSlug, featureGroupIndex ) => (
+						{ featureGroups.map( ( featureGroupSlug ) => (
 							<tr
-								className={ classNames( 'plans-grid-next-features-grid__feature-group-row', {
-									'is-first-feature-group': featureGroupIndex === 0,
-								} ) }
+								className="plans-grid-next-features-grid__feature-group-row"
 								key={ featureGroupSlug }
 							>
 								<PlanFeaturesList

--- a/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
@@ -12,7 +12,6 @@ import type { PlanSlug, StorageOption, WPComStorageAddOnSlug } from '@automattic
 import type { AddOnMeta } from '@automattic/data-stores';
 
 type StorageAddOnDropdownProps = {
-	label?: string;
 	planSlug: PlanSlug;
 	storageOptions: StorageOption[];
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
@@ -74,7 +73,6 @@ const StorageAddOnOption = ( {
 };
 
 export const StorageAddOnDropdown = ( {
-	label = '',
 	planSlug,
 	storageOptions,
 	onStorageAddOnClick,
@@ -159,7 +157,7 @@ export const StorageAddOnDropdown = ( {
 	return (
 		<>
 			<CustomSelectControl
-				label={ label }
+				hideLabelFromVision={ true }
 				options={ selectControlOptions }
 				value={ selectedOption }
 				onChange={ handleOnChange }

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -357,8 +357,27 @@ $mobile-card-max-width: 440px;
 }
 
 .plans-grid-next-features-grid__feature-group-row {
-	&:not(.is-first-feature-group) > .plan-features-2023-grid__table-item {
-		padding-top: 32px;
+	> .plan-features-2023-grid__table-item {
+		padding-top: 24px;
+	}
+
+	/**
+	 * This is only relevant to match the styling for the Enterprise plan's parter logos,
+	 * which should probably be cleaned-up/refactored instead
+	 */
+	&.is-first-feature-group-row > .plan-features-2023-grid__table-item {
+		@include plans-grid-medium-large {
+			padding-top: 14px;
+		}
+	}
+
+	/**
+	 * This is to handle storage row's internal padding
+	 */
+	&.is-first-feature-group-row > .plan-features-2023-grid__storage {
+		@include plans-grid-medium-large {
+			padding-bottom: 12px;
+		}
 	}
 }
 
@@ -397,6 +416,7 @@ $mobile-card-max-width: 440px;
 	}
 
 	.plan-features-2023-grid__item-sub-feature-list {
+		margin-bottom: 0;
 		& > li {
 			margin-top: 8px;
 		}
@@ -618,13 +638,7 @@ $mobile-card-max-width: 440px;
 			padding: 24px 20px 38px 20px;
 
 			.plan-features-2023-grid__storage-title {
-				color: var(--studio-gray-100);
-				font-weight: 500;
-				/* stylelint-disable-next-line */
-				font-size: 0.688rem;
-				line-height: 16px;
 				margin-bottom: 10px;
-				text-transform: uppercase;
 			}
 
 			.plan-features-2023-grid__storage-buttons {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/90478

## Proposed Changes

Fixes the "Storage" section title to what's portrayed in the trail-map designs/mocks, along with a couple of other fixes:

- "Storage" title now bold and not capitalised across all the grid variations.
- "Storage" now being a "first feature group row" in the grid (at the CSS/class level)
    - Per the comment below ( https://github.com/Automattic/wp-calypso/pull/90486#discussion_r1595332266 ), a follow-up from here can be to consolidate "storage" and "feature groups" and even have them rendered unconditionally (so both trail-map and default/current/non-categorised case to map over `featureGroups`)
- Reduces some of the spacing between the features groups (32px seemed a little too much).
- Reduces some of the spacing between sub-features and the next feature-group

## Media

### non-categorised

<img width="600" alt="Screenshot 2024-05-09 at 2 38 11 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/ee6eb2f6-4088-489c-9852-ee2644fc8d9c">


### categorised

<img width="600" alt="Screenshot 2024-05-09 at 2 46 04 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/57f212dd-368c-41f1-9e97-d11df58f42c1">


### mobile

<img width="248" alt="Screenshot 2024-05-09 at 2 39 13 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/3b2f93da-aa1b-4d0a-b4cd-0ab895f20b8e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to 
    * `/start/plans?flags=onboarding/trail-map-feature-grid` (flag enabled)
    * `/start/plans?flags=-onboarding/trail-map-feature-grid` (flag disabled)
    * OR `yarn workspace @automattic/plans-grid-next storybook` and pick the right variation for categorised/non-categorised features
* Confirm the media above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
