### PR TITLE
Theme Showcase: Use the screenshot to preview themes without the style variations

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1366,6 +1366,7 @@ class ThemeSheet extends Component {
 			isThemeAllowed,
 			successNotice: showSuccessNotice,
 			themeTier,
+			styleVariations,
 		} = this.props;
 		const analyticsPath = `/theme/${ themeId }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
@@ -1632,7 +1633,7 @@ class ThemeSheet extends Component {
 					</div>
 					{ ! isRemoved && (
 						<div className="theme__sheet-column-right">
-							{ isWpcomTheme && ! isExternallyManagedTheme
+							{ isWpcomTheme && ! isExternallyManagedTheme && styleVariations?.length
 								? this.renderWebPreview()
 								: this.renderScreenshot() }
 						</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/90156

## Proposed Changes

* The `block-previews` endpoint doesn't support themes that have blocks rendered on the frontend very well (e.g.: CORS issue). Hence, it would be better to use the screenshot to preview these themes. Moreover, it doesn't seem to be necessary to render the web preview for themes without the style variations because we don't need to use inline CSS to display the variations.

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/244c4c93-3ca7-4fa7-923d-a4d7d36f5a61) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/450de3f6-7b41-4b9b-8b7f-c9f3bf14cd22) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /theme/kiosko
* Make sure the preview looks well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
