### PR TITLE
Automattic for Agencies: Improve Unassigned WPCOM license flow

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -5,6 +5,7 @@ import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext } from 'react';
+import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
 	isPressableHostingProduct,
 	isWPCOMHostingProduct,
@@ -89,7 +90,9 @@ export default function LicensePreview( {
 	const domain = siteUrl && ! isPressableLicense ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
 	const assign = useCallback( () => {
-		const redirectUrl = addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
+		const redirectUrl = isWPCOMLicense
+			? A4A_SITES_LINK_NEEDS_SETUP
+			: addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
 		if ( paymentMethodRequired ) {
 			const noticeLinkHref = addQueryArgs(
 				{
@@ -113,7 +116,7 @@ export default function LicensePreview( {
 		}
 
 		page.redirect( redirectUrl );
-	}, [ paymentMethodRequired, translate, dispatch, licenseKey ] );
+	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, translate, dispatch ] );
 
 	useEffect( () => {
 		if ( isHighlighted ) {
@@ -192,7 +195,7 @@ export default function LicensePreview( {
 											compact
 											onClick={ assign }
 										>
-											{ translate( 'Assign' ) }
+											{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign' ) }
 										</Button>
 									) }
 								</span>

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-return-url.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-return-url.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import {
 	A4A_PURCHASES_LINK,
 	A4A_MARKETPLACE_CHECKOUT_LINK,
+	A4A_SITES_LINK_NEEDS_SETUP,
 } from '../../../../components/sidebar-menu/lib/constants';
 
 type Props = {
@@ -17,7 +18,8 @@ export function useReturnUrl( { redirect }: Props ) {
 			const returnUrl =
 				returnQuery &&
 				( returnQuery.startsWith( A4A_PURCHASES_LINK ) ||
-					returnQuery.startsWith( A4A_MARKETPLACE_CHECKOUT_LINK ) )
+					returnQuery.startsWith( A4A_MARKETPLACE_CHECKOUT_LINK ) ||
+					returnQuery.startsWith( A4A_SITES_LINK_NEEDS_SETUP ) )
 					? returnQuery
 					: A4A_PURCHASES_LINK;
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/449

## Proposed Changes

This PR improves the unassigned WPCOM license flow

## Testing Instructions

1. Open the A4A live link.
2. Go to /purchases/payment-methods > Delete all the existing payment methods 
3. Go to /marketplace/hosting/wpcom > Purchase  a WPCOM product 
4. Go to /purchases/licenses > Verify you can now see a `Create site` button next to the WPCOM Site license > Verify you are redirected to add a payment method > Add the payment method and verify you are redirected to Needs Setup page 

<img width="642" alt="Screenshot 2024-05-09 at 4 20 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8c6ada37-5304-4701-bcc1-ef97d4204006">

5. Go to /purchases/licenses > Click the `Create site` button next to any WPCOM Site license >  Verify you are redirected to Needs Setup page 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
