### PR TITLE
A4A: Make sure that WPCOM plan quantity cannot be selected if it is below minimum.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -77,6 +77,14 @@ export default function A4AWPCOMSlider( {
 		setCurrentSliderPos( valueToSliderPos( next, mappedOptions ) );
 	};
 
+	const onNumberSelect = ( value: number ) => {
+		if ( value >= minimum ) {
+			onChange?.( value );
+			setCurrentValue( value );
+			setCurrentSliderPos( valueToSliderPos( value, mappedOptions ) );
+		}
+	};
+
 	const ratio = valueToSliderPos( minimum, mappedOptions ) / total;
 
 	const thumbSize = 14;
@@ -121,10 +129,12 @@ export default function A4AWPCOMSlider( {
 								key={ `slider-option-${ option.value }` }
 								role="button"
 								tabIndex={ -1 }
-								onClick={ () => onChange?.( index ) }
+								onClick={ () => {
+									onNumberSelect( option.value as number );
+								} }
 								onKeyDown={ ( event ) => {
 									if ( event.key === 'Enter' ) {
-										onChange?.( index );
+										onNumberSelect( option.value as number );
 									}
 								} }
 							>


### PR DESCRIPTION
This PR fixes an issue with the WPCOM volume slider, allowing users to select an invalid quantity.


https://github.com/Automattic/wp-calypso/assets/56598660/10137d26-fa82-4c95-a23d-104fc178db93



Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/460

## Proposed Changes

* We are adding a check to ensure that the currently selected quantity does not fall below the minimum required. This is to prevent any potential issues that may arise from negative quantities.

## Testing Instructions

* Use A4A live link and go to `/marketplace/hosting/wpcom`
* Purchase a few WPCOM plans.
* Return to the same page and confirm by clicking the quantity label below the minimum does not trigger selection.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?