### PR TITLE
Monetize: Add tracking fot the "Add a new payment plan" button click

### DIFF
--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -15,7 +15,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SectionHeader from 'calypso/components/section-header';
 import { useDispatch, useSelector } from 'calypso/state';
-import { bumpStat } from 'calypso/state/analytics/actions';
+import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -83,6 +83,11 @@ function ProductsList() {
 				</PopoverMenuItem>
 			</EllipsisMenu>
 		);
+	}
+
+	function onAddNewPaymentPlanButtonClick() {
+		dispatch( recordTracksEvent( 'calypso_memberships_add_payment_plan_click' ) );
+		openAddEditDialog();
 	}
 
 	function openAddEditDialog( productId?: number ) {
@@ -160,7 +165,7 @@ function ProductsList() {
 
 			{ hasLoadedFeatures && hasStripeFeature && (
 				<SectionHeader label={ translate( 'Manage plans' ) }>
-					<Button primary compact onClick={ () => openAddEditDialog() }>
+					<Button primary compact onClick={ onAddNewPaymentPlanButtonClick }>
 						{ translate( 'Add a new payment plan' ) }
 					</Button>
 				</SectionHeader>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/90496
Part of https://github.com/Automattic/jetpack/issues/36958

## Proposed Changes

It adds tracking to the "Add a new payment plan" button click so we can create a funnel that allows us to check how many users access Cloud > Monetize and create and save a plan.

## Testing Instructions

Code review should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
