### PR TITLE
Nav redesign - fix icon selected/hover colors

### DIFF
--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -53,7 +53,6 @@ export const GlobalSidebarFooter: FC< {
 				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.SEARCH_CLICK ) }
 			/>
 			<SidebarNotifications
-				isActive={ true }
 				className="sidebar__item-notifications"
 				tooltip={ translate( 'Notifications' ) }
 				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.NOTIFICATION_CLICK ) }

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -18,7 +18,6 @@ import './style.scss';
 
 class SidebarNotifications extends Component {
 	static propTypes = {
-		isActive: PropTypes.bool,
 		className: PropTypes.string,
 		title: TranslatableString,
 		onClick: PropTypes.func,
@@ -129,8 +128,7 @@ class SidebarNotifications extends Component {
 
 	render() {
 		const classes = classNames( this.props.className, 'sidebar-notifications', {
-			'is-active':
-				this.props.isNotificationsOpen || window.location.pathname === '/read/notifications',
+			'is-active': this.props.isActive,
 			'has-unread': this.state.newNote,
 			'is-initial-load': this.state.animationState === -1,
 		} );
@@ -164,8 +162,10 @@ class SidebarNotifications extends Component {
 }
 
 const mapStateToProps = ( state ) => {
+	const isPanelOpen = isNotificationsOpen( state );
 	return {
-		isNotificationsOpen: isNotificationsOpen( state ),
+		isActive: isPanelOpen || window.location.pathname === '/read/notifications',
+		isNotificationsOpen: isPanelOpen,
 		hasUnseenNotifications: hasUnseenNotifications( state ),
 	};
 };

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -286,11 +286,16 @@ $brand-text: "SF Pro Text", $sans;
 		.sidebar__footer-language-switcher,
 		.sidebar__footer-link,
 		.sidebar__item-help,
-		.sidebar__item-notifications,
 		.sidebar__item-search {
-			&:hover {
+			&:hover,
+			&.is-active {
 				background-color: var(--color-sidebar-menu-hover-background);
 				border-radius: 4px;
+			}
+			&.is-active {
+				svg path {
+					fill: var(--color-sidebar-gridicon-hover-fill);
+				}
 			}
 		}
 	}
@@ -301,7 +306,16 @@ $brand-text: "SF Pro Text", $sans;
 			path {
 				stroke: var(--color-sidebar-gridicon-fill);
 			}
-			&:hover {
+		}
+		&:hover {
+			.sidebar__menu-icon.sidebar_svg-notifications {
+				fill: var(--color-sidebar-menu-hover-background);
+			}
+		}
+		&.is-active {
+			background-color: var(--color-sidebar-menu-hover-background);
+			.sidebar__menu-icon.sidebar_svg-notifications {
+				fill: var(--color-sidebar-menu-hover-background);
 				path {
 					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
@@ -310,9 +324,6 @@ $brand-text: "SF Pro Text", $sans;
 		&.has-unread .sidebar__menu-icon.sidebar_svg-notifications path {
 			fill: var(--color-sidebar-gridicon-fill);
 			stroke: unset;
-			&:hover {
-				fill: var(--color-sidebar-gridicon-hover-fill);
-			}
 		}
 	}
 

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -294,7 +294,7 @@ $brand-text: "SF Pro Text", $sans;
 			}
 			&.is-active {
 				svg path {
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 		}
@@ -308,6 +308,7 @@ $brand-text: "SF Pro Text", $sans;
 			}
 		}
 		&:hover {
+			background-color: var(--color-sidebar-menu-hover-background);
 			.sidebar__menu-icon.sidebar_svg-notifications {
 				fill: var(--color-sidebar-menu-hover-background);
 			}
@@ -317,7 +318,7 @@ $brand-text: "SF Pro Text", $sans;
 			.sidebar__menu-icon.sidebar_svg-notifications {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 		}

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -25,6 +25,7 @@ $brand-text: "SF Pro Text", $sans;
 	--color-sidebar-text-alternative: #a2aab2;
 	--color-sidebar-gridicon-fill: #a2aab2;
 	--color-sidebar-gridicon-hover-fill: #00b9eb;
+	--color-sidebar-gridicon-selected-fill: #00b9eb;
 	--color-sidebar-notice-background: #3c434a;
 
 	--color-sidebar-submenu-background: #32373c;
@@ -53,7 +54,8 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-submenu-selected-text: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-submenu-hover-text: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-gridicon-fill: var(--color-sidebar-text);
-		--color-sidebar-gridicon-hover-fill: var(--color-sidebar-menu-selected-text);
+		--color-sidebar-gridicon-hover-fill: var(--color-sidebar-text);
+		--color-sidebar-gridicon-selected-fill: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-tooltip-background: var(--color-sidebar-menu-hover-background);
 		--color-sidebar-tooltip-text: var(--color-sidebar-menu-hover-text);
 	}
@@ -474,6 +476,12 @@ $font-size: rem(14px);
 				background-color: var(--color-sidebar-submenu-background);
 				border-bottom-left-radius: 0;
 				border-bottom-right-radius: 0;
+
+				&:not(:hover) {
+					.sidebar_svg-a8c g {
+						fill: var(--color-sidebar-submenu-background);
+					}
+				}
 			}
 			.sidebar__expandable-content {
 				border-top-left-radius: 0;
@@ -893,18 +901,13 @@ $font-size: rem(14px);
 			border-color: var(--color-sidebar-menu-text);
 		}
 
-		.sidebar__menu-link:hover .count {
-			color: var(--color-sidebar-submenu-hover-text);
-			border-color: var(--color-sidebar-submenu-hover-text);
-		}
-
 		.selected .sidebar__menu-link {
 			.count {
 				color: var(--color-sidebar-submenu-selected-text);
 				border-color: var(--color-sidebar-submenu-selected-text);
 			}
 			.sidebar__menu-item-last-updated {
-				color: var(--color-sidebar-text-alternative-selected);
+				color: var(--studio-gray-50);
 			}
 		}
 

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -193,10 +193,6 @@
 					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
-			//.sidebar__menu-icon.sidebar_svg-a8c g {
-			//	stroke: var(--color-sidebar-gridicon-hover-fill);
-			//	fill: var(--color-sidebar-gridicon-hover-fill);
-			//}
 		}
 		/* Default styles */
 		.sidebar__menu-icon.sidebar_svg-add {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -149,23 +149,23 @@
 		&:focus {
 			.sidebar__menu-icon.sidebar_svg-add {
 				g {
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var(--color-sidebar-gridicon-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-				fill: var(--color-sidebar-gridicon-hover-fill);
+				fill: var(--color-sidebar-gridicon-fill);
 				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-conversations {
 				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-fill);
 				}
 				g g {
 					stroke: unset;
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var(--color-sidebar-gridicon-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
@@ -173,13 +173,13 @@
 			.sidebar__menu-icon.sidebar_svg-notifications {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-p2 {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var(--color-sidebar-gridicon-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-a8c,
@@ -190,12 +190,12 @@
 			.sidebar__menu-icon.sidebar_svg-discover {
 				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-a8c g {
-				stroke: var(--color-sidebar-gridicon-hover-fill);
-				fill: var(--color-sidebar-gridicon-hover-fill);
+				stroke: var(--color-sidebar-gridicon-fill);
+				fill: var(--color-sidebar-gridicon-fill);
 			}
 		}
 		/* Default styles */
@@ -205,6 +205,7 @@
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
+			fill: var(--color-sidebar-gridicon-fill);
 			g {
 				stroke: var(--color-sidebar-gridicon-fill);
 			}
@@ -255,12 +256,13 @@
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
+				fill: var(--color-sidebar-gridicon-hover-fill);
 				g {
 					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-conversations {
-				fill: var(--color-sidebar-background);
+				fill: var(--color-sidebar-menu-hover-background);
 				g {
 					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
@@ -278,7 +280,7 @@
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-p2 {
-				fill: var(--color-sidebar-background);
+				fill: var(--color-sidebar-menu-hover-background);
 				path {
 					fill: var(--color-sidebar-gridicon-hover-fill);
 				}
@@ -289,7 +291,7 @@
 			.sidebar__menu-icon.sidebar_svg-search,
 			.sidebar__menu-icon.sidebar_svg-tag,
 			.sidebar__menu-icon.sidebar_svg-discover {
-				fill: var(--color-sidebar-background);
+				fill: var(--color-sidebar-menu-hover-background);
 				g {
 					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -149,23 +149,23 @@
 		&:focus {
 			.sidebar__menu-icon.sidebar_svg-add {
 				g {
-					fill: var(--color-sidebar-gridicon-fill);
+					fill: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-				fill: var(--color-sidebar-gridicon-fill);
+				fill: var(--color-sidebar-gridicon-hover-fill);
 				g {
-					stroke: var(--color-sidebar-gridicon-fill);
+					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-conversations {
 				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var(--color-sidebar-gridicon-fill);
+					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 				g g {
 					stroke: unset;
-					fill: var(--color-sidebar-gridicon-fill);
+					fill: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
@@ -173,13 +173,13 @@
 			.sidebar__menu-icon.sidebar_svg-notifications {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					stroke: var(--color-sidebar-gridicon-fill);
+					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-p2 {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					fill: var(--color-sidebar-gridicon-fill);
+					fill: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-a8c,
@@ -190,13 +190,13 @@
 			.sidebar__menu-icon.sidebar_svg-discover {
 				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var(--color-sidebar-gridicon-fill);
+					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
-			.sidebar__menu-icon.sidebar_svg-a8c g {
-				stroke: var(--color-sidebar-gridicon-fill);
-				fill: var(--color-sidebar-gridicon-fill);
-			}
+			//.sidebar__menu-icon.sidebar_svg-a8c g {
+			//	stroke: var(--color-sidebar-gridicon-hover-fill);
+			//	fill: var(--color-sidebar-gridicon-hover-fill);
+			//}
 		}
 		/* Default styles */
 		.sidebar__menu-icon.sidebar_svg-add {
@@ -252,23 +252,23 @@
 		.sidebar__menu-link {
 			.sidebar__menu-icon.sidebar_svg-add {
 				g {
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-				fill: var(--color-sidebar-gridicon-hover-fill);
+				fill: var(--color-sidebar-gridicon-selected-fill);
 				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-conversations {
 				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
 				g g {
 					stroke: unset;
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
@@ -276,13 +276,13 @@
 			.sidebar__menu-icon.sidebar_svg-notifications {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-p2 {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-a8c,
@@ -293,11 +293,8 @@
 			.sidebar__menu-icon.sidebar_svg-discover {
 				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
-			}
-			.sidebar__menu-icon.sidebar_svg:hover {
-				fill: var(--color-sidebar-gridicon-hover-fill);
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/180

Fixes https://github.com/Automattic/dotcom-forge/issues/7035
Fixes https://github.com/Automattic/dotcom-forge/issues/7037

## Proposed Changes

* Added a new `--color-sidebar-gridicon-selected-fill` CSS color to handle color for sidebar icons when selected.
* Fixed selected Reader sidebar icon's fill color. Was `studio-gray-0` - should be `#e3e8fc`.
* Fixed hover Reader sidebar icon's stroke color. Was `blueberry` - should be `gray-80`.
* Fixed Sidebar footer selected background and icon fill/stroke colors. When help and notifications are active, the icon remained unselected - now when panel is open, the icons will remain selected.
* Fixed issue with `Automattic` submenu icon having incorrect hover color.
* Fixed issue with `Automattic` P2 last updated text with incorrect selected color.

## Before

**Reader Icons**

https://github.com/Automattic/wp-calypso/assets/5560595/7b61c1cf-14d5-4c7a-860e-fe2d29dfff4b

**Sidebar Footer Icons**

https://github.com/Automattic/wp-calypso/assets/5560595/2b89f2f3-f97a-4bb4-bfbd-e86f479c75a9

**Automattic Submenu Issues**

https://github.com/Automattic/wp-calypso/assets/5560595/9ea51c32-ee15-4e61-8dcb-62eb754ce9ab

## After

https://github.com/Automattic/wp-calypso/assets/5560595/f4028765-af43-45d8-8d25-ea6d9edb8dfb

https://github.com/Automattic/wp-calypso/assets/5560595/71d78f9b-2350-449f-b4c3-4555197355e5

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/` in calypso live and the icons in dashboard behave as you would expect and follow the design outlined in kyCC1EHKtv4qsElmlAzp5T-fi-47%3A22033

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?