### PR TITLE
Nav Redesign: Add notifications pointer

### DIFF
--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -57,6 +57,7 @@ export const GlobalSidebarFooter: FC< {
 				className="sidebar__item-notifications"
 				tooltip={ translate( 'Notifications' ) }
 				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.NOTIFICATION_CLICK ) }
+				translate={ translate }
 			/>
 			{ isInSupportSession && (
 				<QuickLanguageSwitcher className="sidebar__footer-language-switcher" shouldRenderAsButton />

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -29,7 +29,6 @@ class SidebarNotifications extends Component {
 		hasUnseenNotifications: PropTypes.bool,
 		tooltip: TranslatableString,
 		translate: PropTypes.func,
-		isSidebarCollapsed: PropTypes.bool,
 		currentUserId: PropTypes.number,
 	};
 

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -1,3 +1,5 @@
+import { englishLocales } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { throttle } from 'lodash';
 import PropTypes from 'prop-types';
@@ -11,6 +13,7 @@ import TranslatableString from 'calypso/components/translatable/proptype';
 import SidebarMenuItem from 'calypso/layout/global-sidebar/menu-items/menu-item';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
@@ -30,6 +33,7 @@ class SidebarNotifications extends Component {
 		tooltip: TranslatableString,
 		translate: PropTypes.func,
 		currentUserId: PropTypes.number,
+		locale: PropTypes.string,
 	};
 
 	notificationLink = createRef();
@@ -140,8 +144,13 @@ class SidebarNotifications extends Component {
 		} );
 
 		const shouldShowNotificationsPointer =
-			Date.now() < Date.parse( '23 May 2024' ) && // Show pointer for 2 weeks.
-			this.props.currentUserId < 250450000; // Show pointer to users registered before 08-May-2024 (when we moved the notifications to the footer).
+			// Show pointer for 2 weeks.
+			Date.now() < Date.parse( '23 May 2024' ) &&
+			// Show pointer to users registered before 08-May-2024 (when we moved the notifications to the footer).
+			this.props.currentUserId < 250450000 &&
+			// Show pointer only if translated.
+			( englishLocales.includes( this.props.locale ) ||
+				hasTranslation( 'Looking for your notifications? They have been moved here.' ) );
 
 		return (
 			<>
@@ -190,6 +199,7 @@ const mapStateToProps = ( state ) => {
 		isNotificationsOpen: isNotificationsOpen( state ),
 		hasUnseenNotifications: hasUnseenNotifications( state ),
 		currentUserId: getCurrentUserId( state ),
+		locale: getCurrentLocaleSlug( state ),
 	};
 };
 const mapDispatchToProps = {

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -11,6 +11,7 @@ import DismissibleCard from 'calypso/blocks/dismissible-card';
 import AsyncLoad from 'calypso/components/async-load';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import SidebarMenuItem from 'calypso/layout/global-sidebar/menu-items/menu-item';
+import { isE2ETest } from 'calypso/lib/e2e';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
@@ -150,7 +151,9 @@ class SidebarNotifications extends Component {
 			this.props.currentUserId < 250450000 &&
 			// Show pointer only if translated.
 			( englishLocales.includes( this.props.locale ) ||
-				hasTranslation( 'Looking for your notifications? They have been moved here.' ) );
+				hasTranslation( 'Looking for your notifications? They have been moved here.' ) ) &&
+			// Hide pointer on E2E tests so it doesn't hide menu items that are expected to be visible.
+			! isE2ETest();
 
 		return (
 			<>

--- a/client/layout/global-sidebar/menu-items/notifications/style.scss
+++ b/client/layout/global-sidebar/menu-items/notifications/style.scss
@@ -1,3 +1,71 @@
 .sidebar-notifications__panel {
 	position: absolute;
 }
+
+.sidebar-notifications-pointer {
+	position: absolute;
+	z-index: z-index("root", ".layout__secondary");
+	bottom: 55px;
+	left: 35px;
+	background: var(--studio-black);
+	color: var(--studio-white);
+	/* stylelint-disable-next-line scales/font-sizes */
+	font-size: 0.8125rem;
+	margin: 0;
+	padding: 12px;
+	box-shadow: none;
+	display: flex;
+	flex-direction: column-reverse;
+	width: 250px;
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		margin: 0 auto;
+		width: 0;
+		height: 0;
+		border-top: 8px solid var(--studio-black);
+		border-left: 8px solid transparent;
+		border-right: 8px solid transparent;
+		visibility: visible;
+	}
+
+	.dismissible-card__close-button {
+		position: relative;
+		width: auto;
+		height: auto;
+		top: auto;
+		right: auto;
+		margin-top: 12px;
+		margin-right: 0;
+		background-color: var(--color-accent);
+		border-color: var(--color-accent);
+		color: var(--color-text-inverted);
+		font-size: $font-body-extra-small;
+		line-height: 1;
+		border-radius: 2px;
+		padding: 7px;
+		align-self: flex-end;
+
+		&::before {
+			content: attr(aria-label);
+		}
+
+		svg {
+			display: none;
+		}
+	}
+}
+
+.is-global-sidebar-collapsed .sidebar-notifications-pointer {
+	display: none;
+}
+
+@media ( max-width: 782px ) {
+	.sidebar-notifications-pointer {
+		display: none;
+	}
+}


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/wp-calypso/pull/90429

## Proposed Changes

Adds a pointer to indicate that notifications have been moved to the bottom (as of https://github.com/Automattic/wp-calypso/pull/90429) since users might be confused trying to find it in the previous location (see p1715182058030399-slack-C9EJ7KSGH).

<img width="314" alt="Screenshot 2024-05-09 at 15 02 55" src="https://github.com/Automattic/wp-calypso/assets/1233880/1d280de0-1ee3-4716-86cb-8bb81c095f0a">

The pointer has been designed to only be visible for users registered before we moved the notifications and will remain only visible for two weeks. In a follow-up, we'll need to remove this code.

## Testing Instructions

- Use the Calypso link below
- Go to `/sites`
- Make sure the pointer shows up
- Make sure it is hidden when the sidebar is collapsed (e.g. after selecting a site)
- Dismiss it
- Make sure the pointer no longer shows up