### PR TITLE
Sites list - update copy on launch checklist nag

### DIFF
--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useInView } from 'react-intersection-observer';
@@ -85,7 +86,8 @@ const recordNagView = () => {
 };
 
 export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
+	const locale = useLocale();
 	const { ref } = useInView( {
 		onChange: ( inView ) => inView && recordNagView(),
 	} );
@@ -107,7 +109,11 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const link = validSiteIntent
 		? getLaunchpadUrl( site.slug, validSiteIntent )
 		: getDashboardUrl( site.slug );
-	const text = validSiteIntent ? __( 'Launch guide' ) : __( 'Checklist' );
+	const checklistTranslation =
+		hasTranslation( 'Checklist' ) || englishLocales.includes( locale )
+			? __( 'Checklist' )
+			: __( 'Launch checklist' );
+	const text = validSiteIntent ? __( 'Launch guide' ) : checklistTranslation;
 
 	return (
 		<SiteLaunchNagLink

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -107,7 +107,7 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const link = validSiteIntent
 		? getLaunchpadUrl( site.slug, validSiteIntent )
 		: getDashboardUrl( site.slug );
-	const text = validSiteIntent ? __( 'Launch guide' ) : __( 'Launch checklist' );
+	const text = validSiteIntent ? __( 'Launch guide' ) : __( 'Checklist' );
 
 	return (
 		<SiteLaunchNagLink


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7041 

## Proposed Changes

* Updates the copy on the sites list for the "Launch checklist" nag to read "Checklist" instead.
* Checks the locale and translation status to continue serving the old translation to non english locales until the new one is ready.

NOTE - this effects both versions of the sites dashboard, but this seems ideal as the design and implementation of this field column is the same on both.


BEFORE
<img width="179" alt="Screenshot 2024-05-09 at 10 16 22 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/65812d6d-ccf7-4e60-9945-e5449badbfff">


AFTER
<img width="150" alt="Screenshot 2024-05-09 at 10 18 07 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/6ce5dcad-4321-4894-9d4d-b20cfbe3c956">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit the sites dashboard, filter by "coming soon"
* verify the "Launch checklist" nag now reads "Checklist"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
