### PR TITLE
prevent blank pages when `site.capabilities` are not set.

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -55,7 +55,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const isWpcomStagingSite = site?.is_wpcom_staging_site ?? false;
 
 		return (
-			site.capabilities.manage_options &&
+			site?.capabilities?.manage_options &&
 			! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
 			! isWpcomStagingSite &&
 			! ( site?.options?.is_domain_only ?? false ) &&


### PR DESCRIPTION
### Issue:
* Go to `/domains/manage`
* Select a domain mapped that is not mapped to any site ( a domain-only site )
* Click `Transfer`, then `Transfer to other WordPress.com site`
* Loads a blank white page.

### Testing:

* Repeat the above steps
* Make sure the site selection is loaded
* Select a site you own and try transferring the domain to it

Related #90508