### PR TITLE
Dashboard v2 - update margin above search input

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -111,6 +111,10 @@
 		display: table-cell; /* ensures these cells are always shown */
 	}
 
+	.sites-overview__content {
+		margin-top: 35px;
+	}
+
 	@media (max-width: $break-wide) {
 		table.dataviews-view-table th:nth-child(5),
 		table.dataviews-view-table td:nth-child(5) {
@@ -479,6 +483,7 @@
 			margin-top: 0;
 			overflow: hidden;
 			padding-bottom: 0 !important;
+
 		}
 
 		.dataviews-wrapper {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7042

## Proposed Changes

* Updates the margin above the site overview content area to match design in linked issue (35px instead of 48px)

BEFORE
<img width="419" alt="Screenshot 2024-05-09 at 10 45 54 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/964544a7-478b-4a62-9818-69a2ce9a9d70">


AFTER
<img width="416" alt="Screenshot 2024-05-09 at 10 46 00 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/52cf8f8b-d130-4c48-816b-b6d63f9297ea">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Visit the sites dashboard
* verify the margin is updated to be reduced


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
