### PR TITLE
Entrepreneur My Home: Add entrepreneur quick links.

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites/index.jsx
@@ -17,7 +17,7 @@ import { trackAddDomainAction, trackManageAllDomainsAction } from '../quick-link
 import ActionBox from '../quick-links/action-box';
 import '../quick-links/style.scss';
 
-const QuickLinksForHostedSites = ( props ) => {
+const QuickLinksForEcommerceSites = ( props ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -191,4 +191,4 @@ export default connect(
 	mapStateToProps,
 	mapDispatchToProps,
 	mergeProps
-)( QuickLinksForHostedSites );
+)( QuickLinksForEcommerceSites );

--- a/client/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites/index.jsx
@@ -1,0 +1,194 @@
+import { getAllFeaturesForPlan } from '@automattic/calypso-products/';
+import { JetpackLogo, FoldableCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useDispatch, useSelector, connect } from 'react-redux';
+import { useDebouncedCallback } from 'use-debounce';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getSelectedEditor from 'calypso/state/selectors/get-selected-editor';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import { getSitePlanSlug, getSite, getSiteOption } from 'calypso/state/sites/selectors';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { trackAddDomainAction, trackManageAllDomainsAction } from '../quick-links';
+import ActionBox from '../quick-links/action-box';
+import '../quick-links/style.scss';
+
+const QuickLinksForHostedSites = ( props ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const isAtomic = useSelector( ( state ) => isSiteAtomic( state, siteId ) );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const canManageSite = useSelector( ( state ) =>
+		canCurrentUser( state, siteId, 'manage_options' )
+	);
+	const isExpanded = useSelector(
+		( state ) => getPreference( state, 'homeQuickLinksToggleStatus' ) !== 'collapsed'
+	);
+	const currentSitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
+	const site = useSelector( ( state ) => getSite( state, siteId ) );
+	const hasBackups = getAllFeaturesForPlan( currentSitePlanSlug ).includes( 'backups' );
+	const hasBoost = site?.options?.jetpack_connection_active_plugins?.includes( 'jetpack-boost' );
+	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
+
+	const dispatch = useDispatch();
+	const updateToggleStatus = ( status ) => {
+		dispatch( savePreference( 'homeQuickLinksToggleStatus', status ) );
+	};
+	const [
+		debouncedUpdateHomeQuickLinksToggleStatus,
+		,
+		flushDebouncedUpdateHomeQuickLinksToggleStatus,
+	] = useDebouncedCallback( updateToggleStatus, 1000 );
+
+	const quickLinks = (
+		<div className="quick-links-for-hosted-sites__boxes quick-links__boxes">
+			{ isAtomic && (
+				<ActionBox
+					href={ `https://${ siteSlug }/wp-admin/edit.php?post_type=shop_order` }
+					hideLinkIndicator
+					label={ translate( 'Add a product' ) }
+					iconComponent={
+						<span
+							className="quick-links__action-box-icon dashicons dashicons-cart"
+							aria-hidden={ true }
+						/>
+					}
+				/>
+			) }
+			{ isAtomic && (
+				<ActionBox
+					href={ `https://${ siteSlug }/wp-admin/post-new.php?post_type=product` }
+					hideLinkIndicator
+					label={ translate( 'View orders' ) }
+					iconComponent={
+						<span
+							className="quick-links__action-box-icon dashicons dashicons-archive"
+							aria-hidden={ true }
+						/>
+					}
+				/>
+			) }
+			{ isAtomic && (
+				<ActionBox
+					href={ `https://${ siteSlug }/wp-admin/admin.php?page=wc-admin&path=%2Fcustomers` }
+					hideLinkIndicator
+					label={ translate( 'View customers' ) }
+					iconComponent={
+						<span
+							className="quick-links__action-box-icon dashicons dashicons-money"
+							aria-hidden={ true }
+						/>
+					}
+				/>
+			) }
+			{ canManageSite && ! isWpcomStagingSite && (
+				<ActionBox
+					href={ `/domains/add/${ siteSlug }` }
+					hideLinkIndicator
+					onClick={ props.trackAddDomainAction }
+					label={ translate( 'Add a domain' ) }
+					gridicon="add-outline"
+				/>
+			) }
+			{ canManageSite && (
+				<ActionBox
+					href="/domains/manage"
+					hideLinkIndicator
+					onClick={ props.trackManageAllDomainsAction }
+					label={ translate( 'Manage all domains' ) }
+					gridicon="domains"
+				/>
+			) }
+			{ siteAdminUrl && (
+				<ActionBox
+					href={ siteAdminUrl }
+					hideLinkIndicator
+					gridicon="my-sites"
+					label={ translate( 'WP Admin Dashboard' ) }
+				/>
+			) }
+			{ canManageSite && (
+				<ActionBox
+					href={ `/plugins/${ siteSlug }` }
+					hideLinkIndicator
+					label={ translate( 'Explore Plugins' ) }
+					gridicon="plugins"
+				/>
+			) }
+			{ isAtomic && hasBoost && (
+				<ActionBox
+					href={ `https://${ siteSlug }/wp-admin/admin.php?page=jetpack-boost` }
+					hideLinkIndicator
+					label={ translate( 'Speed up your site' ) }
+					iconComponent={ <JetpackLogo monochrome className="quick-links__action-box-icon" /> }
+				/>
+			) }
+			{ isAtomic && hasBackups && (
+				<ActionBox
+					href={ `/backup/${ siteSlug }` }
+					hideLinkIndicator
+					label={ translate( 'Restore a backup' ) }
+					iconComponent={ <JetpackLogo monochrome className="quick-links__action-box-icon" /> }
+				/>
+			) }
+		</div>
+	);
+
+	useEffect( () => {
+		return () => {
+			flushDebouncedUpdateHomeQuickLinksToggleStatus();
+		};
+	}, [] );
+
+	return (
+		<FoldableCard
+			className="quick-links-for-hosted-sites quick-links"
+			header={ translate( 'Quick Links' ) }
+			clickableHeader
+			expanded={ isExpanded }
+			onOpen={ () => debouncedUpdateHomeQuickLinksToggleStatus( 'expanded' ) }
+			onClose={ () => debouncedUpdateHomeQuickLinksToggleStatus( 'collapsed' ) }
+		>
+			{ quickLinks }
+		</FoldableCard>
+	);
+};
+
+const mapStateToProps = ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
+	const isStaticHomePage =
+		! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
+
+	return {
+		isStaticHomePage,
+	};
+};
+
+const mapDispatchToProps = {
+	trackAddDomainAction,
+	trackManageAllDomainsAction,
+};
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const { isStaticHomePage } = stateProps;
+	return {
+		...stateProps,
+		...dispatchProps,
+		trackAddDomainAction: () => dispatchProps.trackAddDomainAction( isStaticHomePage ),
+		trackManageAllDomainsAction: () =>
+			dispatchProps.trackManageAllDomainsAction( isStaticHomePage ),
+		...ownProps,
+	};
+};
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	mergeProps
+)( QuickLinksForHostedSites );

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -67,6 +67,10 @@
 		height: 24px;
 		fill: var(--color-neutral-60);
 		transition: all 0.1s;
+
+		&.dashicons {
+			color: var(--color-neutral-80);
+		}
 	}
 
 	.quick-links__action-box-text {
@@ -104,6 +108,10 @@
 
 		.quick-links__action-box-icon {
 			fill: var(--color-neutral-80);
+
+			&.dashicons {
+				color: var(--color-neutral-80);
+			}
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -1,5 +1,6 @@
 export const ACTION_QUICK_LINKS = 'home-action-quick-links';
 export const ACTION_QUICK_LINKS_FOR_HOSTED_SITES = 'home-action-quick-links-for-hosted-sites';
+export const ACTION_QUICK_LINKS_FOR_ECOMMERCE_SITES = 'home-action-quick-links-for-ecommerce-sites';
 export const ACTION_QUICK_POST = 'home-action-quick-post';
 export const ACTION_WP_FOR_TEAMS_QUICK_LINKS = 'home-action-wp-for-teams-quick-links';
 export const EDUCATION_FREE_PHOTO_LIBRARY = 'home-education-free-photo-library';

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -2,6 +2,7 @@ import { createElement, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import QuickLinks from 'calypso/my-sites/customer-home/cards/actions/quick-links';
+import QuickLinksForEcommerceSites from 'calypso/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites';
 import QuickLinksForHostedSites from 'calypso/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites';
 import QuickPost from 'calypso/my-sites/customer-home/cards/actions/quick-post';
 import WpForTeamsQuickLinks from 'calypso/my-sites/customer-home/cards/actions/wp-for-teams-quick-links';
@@ -15,6 +16,7 @@ import {
 	FEATURE_SUPPORT,
 	FEATURE_SITE_PREVIEW,
 	FEATURE_STATS,
+	ACTION_QUICK_LINKS_FOR_ECOMMERCE_SITES,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import AppPromo from 'calypso/my-sites/customer-home/cards/features/app-promo';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
@@ -31,6 +33,7 @@ const cardComponents = {
 	[ ACTION_QUICK_LINKS ]: QuickLinks,
 	[ FEATURE_QUICK_START ]: QuickStart,
 	[ ACTION_WP_FOR_TEAMS_QUICK_LINKS ]: WpForTeamsQuickLinks,
+	[ ACTION_QUICK_LINKS_FOR_ECOMMERCE_SITES ]: QuickLinksForEcommerceSites,
 	[ ACTION_QUICK_LINKS_FOR_HOSTED_SITES ]: QuickLinksForHostedSites,
 	[ ACTION_QUICK_POST ]: QuickPost,
 	[ FEATURE_STATS ]: Stats,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6920

## Proposed Changes

* Add entrepreneur quick links.
* Added:
  * Add a product
  * View orders
  * View customers
* Removed:
  * Edit site
  * Write blog post 
  * Manage comments 
  * Add a page 
  * Create a logo with Fiverr 
  * Create a logo with Jetpack AI

Note: The rationale for removed links is based on following what was removed on Hosting plan's quick links.

## Testing Instructions

* Apply patch D148174-code.
* Sandbox `public-api.wordpress.com`.
* Go to My Home `calypso.localhost:3000/home/your-woa-site-here.wpcomstaging.com?flags=entrepreneur-my-home`.
* You should see Entrepreneur quick links. 

<img width="373" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/ecfa6f4e-d12f-4118-b16c-3400b16cd544">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?