### PR TITLE
Multisite Scheduled Updates: Improve logic for showing global navigation

### DIFF
--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { isWithinBreakpoint } from '@automattic/viewport';
+import isScheduledUpdatesMultisiteRoute from 'calypso/state/selectors/is-scheduled-updates-multisite-route';
 import { isGlobalSiteViewEnabled } from '../sites/selectors';
 import type { AppState } from 'calypso/types';
 
@@ -37,11 +38,14 @@ export const getShouldShowGlobalSidebar = (
 	sectionGroup: string,
 	sectionName: string
 ) => {
+	const pluginsScheduledUpdates = isScheduledUpdatesMultisiteRoute( state );
+
 	return (
 		sectionGroup === 'me' ||
 		sectionGroup === 'reader' ||
 		sectionGroup === 'sites-dashboard' ||
 		( sectionGroup === 'sites' && ! siteId ) ||
+		( sectionGroup === 'sites' && sectionName === 'plugins' && pluginsScheduledUpdates ) ||
 		getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName )
 	);
 };

--- a/client/state/selectors/is-scheduled-updates-multisite-route.js
+++ b/client/state/selectors/is-scheduled-updates-multisite-route.js
@@ -1,0 +1,21 @@
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+
+/**
+ * Returns true if the current route is a scheduled updates multisite route.
+ * @param {Object} state Global state tree
+ * @returns {boolean}
+ */
+export default function isScheduledUpdatesMultisiteRoute( state ) {
+	const route = getCurrentRoute( state );
+
+	if ( ! route ) {
+		return false;
+	}
+
+	const rgxMsBase = /^\/plugins\/scheduled-updates\/?$/;
+	const rgxMsCreate = /^\/plugins\/scheduled-updates\/create\/?$/;
+	const rgxMsEdit =
+		/^\/plugins\/scheduled-updates\/edit\/[a-f0-9]+-(daily|weekly)-\d+-\d{2}:\d{2}\/?$/;
+
+	return rgxMsBase.test( route ) || rgxMsCreate.test( route ) || rgxMsEdit.test( route );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90490

## Proposed Changes

* Fixes navigation style bug when returns from a single site to the multisite context (for more details: https://github.com/Automattic/wp-calypso/issues/90490)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates`
* Select single site logs
* Click Card's navigation back link
* Check if it correctly returns to the multisite context

How it was before the change, you can check the video here: https://github.com/Automattic/wp-calypso/issues/90490

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
