### PR TITLE
New instructions: add siteId to return checkout url

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -250,6 +250,7 @@ const siteMigration: Flow = {
 						const destination = addQueryArgs(
 							{
 								siteSlug,
+								siteId,
 								// don't use from query param if the user takes the migration deal.
 								// This is to avoid the user being redirected to the wrong page after checkout.
 								...( ! providedDependencies?.userAcceptedDeal ? { from: fromQueryParam } : {} ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

I found that navigating through the site-migration flow doesn't trigger `calypso_signup_step_start` track event when it gets to the instructions screen. This is because the `useSite` hook (`client/landing/stepper/hooks/use-site.ts`) doesn't work in this context with only the siteSlug.
This was is probably surfaced by https://github.com/Automattic/wp-calypso/pull/90433/, before the redirection was to the bundleTransfer step that added the siteId to URL before moving to instructions.

## Testing Instructions
### Reproduce the bug
1. Go trough the flow until checkout
2. Select Free Trial (though this might happen with paid plans too)
3. Once redirected to the instructions screen verify that:
   1. The `calypso_signup_step_start` step is not triggered for this step
   2. The URL doesn't contain a `siteId` query param

### Test the fix
Do the same, but run this branch and in the last step verify that:
1. The `calypso_signup_step_start` step is triggered for this step
2. The URL does contain a `siteId` query param

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
