### PR TITLE
Detect when a secondary publish button is available to click it

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -77,6 +77,14 @@ export class EditorPublishPanelComponent {
 	async publish(): Promise< void > {
 		const editorParent = await this.editor.parent();
 		const publishButtonLocator = editorParent.locator( selectors.publishButton );
+
+		// Check if the button is able to be triggered before proceeding
+		if (
+			! ( ( await publishButtonLocator.isVisible() ) || ( await publishButtonLocator.isEnabled() ) )
+		) {
+			return;
+		}
+
 		await publishButtonLocator.click();
 	}
 

--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -79,9 +79,13 @@ export class EditorPublishPanelComponent {
 		const publishButtonLocator = editorParent.locator( selectors.publishButton );
 
 		// Check if the button is able to be triggered before proceeding
-		if (
-			! ( ( await publishButtonLocator.isVisible() ) || ( await publishButtonLocator.isEnabled() ) )
-		) {
+		try {
+			await publishButtonLocator.waitFor( { state: 'attached' } );
+		} catch {
+			return;
+		}
+
+		if ( ! ( await publishButtonLocator.count() ) ) {
 			return;
 		}
 

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -265,22 +265,6 @@ export class EditorToolbarComponent {
 	}
 
 	/**
-	 * Returns the text present for the post status button.
-	 *
-	 * @returns {Promise<string>} String found on the button.
-	 */
-	async getPostStatusButtonText(): Promise< string | null > {
-		const editorParent = await this.editor.parent();
-		const postStatusButtonLocator = editorParent.locator( selectors.postStatusButton );
-
-		if ( ! ( await postStatusButtonLocator.isVisible() ) ) {
-			return null;
-		}
-
-		return await postStatusButtonLocator.innerText();
-	}
-
-	/**
 	 * Clicks on the primary button to publish the article.
 	 *
 	 * This is applicable for the following scenarios:

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -699,25 +699,13 @@ export class EditorPage {
 		visit = false,
 		timeout,
 	}: { visit?: boolean; timeout?: number } = {} ): Promise< URL > {
-		const publishButtonText = await this.editorToolbarComponent.getPublishButtonText();
-		const postStatusButtonText = await this.editorToolbarComponent.getPostStatusButtonText();
 		const actionsArray = [];
 
 		// Every publish action requires at least one click on the EditorToolbarComponent.
 		actionsArray.push( this.editorToolbarComponent.clickPublish() );
 
-		// Determine whether the post/page is yet to be published or the post/page
-		// is merely being saved/updated.
-		// If not yet published, a second click on the EditorPublishPanelComponent
-		// is added to the array of actions.
-		const requiresSecondClick =
-			! [ 'save', 'update' ].includes( publishButtonText.toLowerCase() ) ||
-			( publishButtonText.toLowerCase() === 'save' &&
-				postStatusButtonText?.toLowerCase() === 'scheduled' );
-
-		if ( requiresSecondClick ) {
-			actionsArray.push( this.editorPublishPanelComponent.publish() );
-		}
+		// Trigger a secondary/confirmation click if needed
+		actionsArray.push( this.editorPublishPanelComponent.publish() );
 
 		// Resolve the promises.
 		const [ response ] = await Promise.all( [


### PR DESCRIPTION
Follow-up: #90341

The new UI for scheduling posts in the Editor now requires a second click to publish/update posts. 

This PR enables a second click which lets posts/pages be updated  for e2e tests.


This is currently breaking some nightly e2e tests for Gutenberg. This change modifies the e2e's expectations to fit the new realities.

Unit Tests
---
TC tests should be green.

Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

Run the editor schedule flow e2e edge tests, which was failing before this fix:

```bash
cd test/e2e
yarn jest --clearCache && yarn build  # clear build cache before each run


yarn jest specs/editor/editor__post-advanced-flow.ts  
GUTENBERG_EDGE=1 yarn jest specs/editor/editor__post-advanced-flow.ts 
GUTENBERG_EDGE=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__post-advanced-flow.ts 

yarn jest specs/editor/editor__schedule.ts  
GUTENBERG_EDGE=1 yarn jest specs/editor/editor__schedule.ts 
GUTENBERG_EDGE=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__schedule.ts 
```