### PR TITLE
Multisite Scheduled Updates: Set width values for the name and sites columns to prevent jumping during search

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -49,7 +49,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 						{ prepareScheduleName( schedule as unknown as ScheduleUpdates ) }
 					</Button>
 				</td>
-				<td>
+				<td className="sites">
 					{ schedule.sites.length }{ ' ' }
 					<Tooltip
 						text={ prepareSitesTooltipInfo( schedule.sites ) as unknown as string }

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -54,7 +54,7 @@ $brand-display: "SF Pro Display", sans-serif;
 		th,
 		td {
 			font-size: 0.875rem;
-			padding: 1rem 0;
+			padding: 1rem 0.125rem;
 			color: var(--studio-gray-60);
 			border-bottom: solid 1px var(--studio-gray-0);
 		}
@@ -68,7 +68,7 @@ $brand-display: "SF Pro Display", sans-serif;
 		}
 
 		td {
-			padding: 0.5rem 0;
+			padding: 0.5rem 0.125rem;
 			vertical-align: middle;
 
 			&.last-update {
@@ -86,6 +86,14 @@ $brand-display: "SF Pro Display", sans-serif;
 				button {
 					margin-top: rem(2px);
 				}
+			}
+
+			&.name {
+				width: 300px;
+			}
+
+			&.sites {
+				width: 80px;
 			}
 
 			&.menu {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90402

## Proposed Changes

* Set width values for the name and sites columns to prevent jumping during search
* Set missing padding between the heading and data cells

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates`
* Apply some search criteria and check if it jumps (change the size of the name column) check: https://github.com/Automattic/wp-calypso/issues/90402

![Screen Capture on 2024-05-09 at 18-28-34](https://github.com/Automattic/wp-calypso/assets/1241413/2e37ad9a-69a9-4389-9179-666d798770d9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
