### PR TITLE
Dashboard v2 - use "My Home" links for simple sites.

### DIFF
--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -13,6 +13,7 @@ import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url';
 import getStatsUrl from 'calypso/state/selectors/get-stats-url';
 import getThemeInstallUrl from 'calypso/state/selectors/get-theme-install-url';
+import { getSiteHomeUrl, isSimpleSite } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -40,23 +41,33 @@ const QuickActionsCard: FC = () => {
 	const hasEnTranslation = useHasEnTranslation();
 	const site = useSelector( getSelectedSite );
 	const { data: activeThemeData } = useActiveThemeQuery( site?.ID || -1, !! site );
-	const { editorUrl, themeInstallUrl, pluginInstallUrl, statsUrl, siteAdminUrl, siteEditorUrl } =
-		useSelector( ( state ) => ( {
-			editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
-			themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
-			pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
-			statsUrl: getStatsUrl( state, site?.ID ) ?? '',
-			siteAdminUrl: getSiteAdminUrl( state, site?.ID ) ?? '',
-			siteEditorUrl:
-				site?.ID && activeThemeData
-					? getCustomizeUrl(
-							state as object,
-							activeThemeData[ 0 ]?.stylesheet,
-							site?.ID,
-							activeThemeData[ 0 ]?.is_block_theme
-					  )
-					: '',
-		} ) );
+	const {
+		editorUrl,
+		themeInstallUrl,
+		pluginInstallUrl,
+		statsUrl,
+		siteHomeUrl,
+		isSiteSimple,
+		siteAdminUrl,
+		siteEditorUrl,
+	} = useSelector( ( state ) => ( {
+		editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
+		themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
+		pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
+		statsUrl: getStatsUrl( state, site?.ID ) ?? '',
+		siteAdminUrl: getSiteAdminUrl( state, site?.ID ) ?? '',
+		siteHomeUrl: getSiteHomeUrl( state, site?.ID ) ?? '',
+		isSiteSimple: isSimpleSite( state, site?.ID ),
+		siteEditorUrl:
+			site?.ID && activeThemeData
+				? getCustomizeUrl(
+						state as object,
+						activeThemeData[ 0 ]?.stylesheet,
+						site?.ID,
+						activeThemeData[ 0 ]?.is_block_theme
+				  )
+				: '',
+	} ) );
 
 	return (
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
@@ -71,8 +82,8 @@ const QuickActionsCard: FC = () => {
 			<ul className="hosting-overview__actions-list">
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }
-					href={ siteAdminUrl }
-					text={ translate( 'WP Admin' ) }
+					href={ isSiteSimple ? siteHomeUrl : siteAdminUrl }
+					text={ isSiteSimple ? translate( 'My Home' ) : translate( 'WP Admin' ) }
 				/>
 				<Action
 					icon={

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -16,6 +16,7 @@ import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link
 import { displaySiteUrl, isStagingSite, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
+import { getSiteHomeUrl, isSimpleSite } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -65,6 +66,8 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 
 	const title = __( 'View Site Details' );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site.ID ) ?? '' );
+	const siteHomeUrl = useSelector( ( state ) => getSiteHomeUrl( state, site.ID ) ?? '' );
+	const isSimple = useSelector( ( state ) => isSimpleSite( state, site.ID ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
@@ -124,8 +127,11 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 							<div className="sites-dataviews__site-url">
 								<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
 							</div>
-							<a className="sites-dataviews__site-wp-admin-url" href={ siteAdminUrl }>
-								<Truncated>{ __( 'WP Admin' ) }</Truncated>
+							<a
+								className="sites-dataviews__site-wp-admin-url"
+								href={ isSimple ? siteHomeUrl : siteAdminUrl }
+							>
+								<Truncated>{ isSimple ? __( 'My Home' ) : __( 'WP Admin' ) }</Truncated>
 							</a>
 						</>
 					)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7043

## Proposed Changes

* Updates "WP Admin" links to "My Home" links for simple sites on the sites dashboard in 2 areas: the sites list rows, and the GSV dashboard links section.

BEFORE
<img width="377" alt="Screenshot 2024-05-09 at 12 28 58 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/dc2db638-c1df-4ee5-9922-b7b393ac0c29">
<img width="299" alt="Screenshot 2024-05-09 at 12 29 04 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/aa7fd29a-0fd9-4a2a-bbe3-2846921d00cb">



AFTER
<img width="376" alt="Screenshot 2024-05-09 at 12 27 44 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/625f863c-db99-4fd5-a227-202735996f3d">
<img width="363" alt="Screenshot 2024-05-09 at 12 28 26 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/69408f18-ab15-448f-bd98-cfc86fd76a65">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this claypso branch
* Visit the sites dashboard
* Verify that simple sites show "My Home" links that lead to my home for the site.
* Verify that atomic/jetpack sites continue to show "WP Admin" links that lead to wp-admin.
* Test the same once selecting a site on the dashboard to see the "overview" in global site view. The "dashboard links" section should also show "My Home" links for simple and "WP Admin" for everything else.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
