### PR TITLE
Migration assistance: Only show modal if site already on creator plan

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -3,12 +3,14 @@ import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
+import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
 import MigrationError from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/migration-error';
 import { ProcessingResult } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/processing-step/constants';
 import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import CreateSite from './internals/steps-repository/create-site';
@@ -87,6 +89,8 @@ const importFlow: Flow = {
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 		const { addTempSiteToSourceOption } = useAddTempSiteToSourceOptionMutation();
 		const urlQueryParams = useQuery();
+		const site = useSite();
+		const isSitePlanCompatible = site && isTargetSitePlanCompatible( site );
 		const fromParam = urlQueryParams.get( 'from' );
 		const { data: migrationStatus } = useSourceMigrationStatusQuery( fromParam );
 		const siteSlugParam = useSiteSlugParam();
@@ -322,8 +326,13 @@ const importFlow: Flow = {
 						return navigate( `import?siteSlug=${ siteSlugParam }` );
 					}
 
-					urlQueryParams.set( 'showModal', 'true' );
-					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
+					// In this case, it means that we are in the Upgrade Plan page
+					if ( ! isSitePlanCompatible ) {
+						urlQueryParams.set( 'showModal', 'true' );
+						return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
+					}
+
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
 				case 'importerWix':
 				case 'importReady':
 				case 'importReadyNot':

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
+import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
@@ -116,6 +117,7 @@ const siteSetupFlow: Flow = {
 		);
 
 		const { site, siteSlug, siteId } = useSiteData();
+		const isSitePlanCompatible = site && isTargetSitePlanCompatible( site );
 		const currentThemeId = useSelector( ( state ) => getActiveTheme( state, site?.ID || -1 ) );
 		const currentTheme = useSelector( ( state ) =>
 			getCanonicalTheme( state, site?.ID || -1, currentThemeId )
@@ -538,10 +540,12 @@ const siteSetupFlow: Flow = {
 						return navigate( `import?siteSlug=${ siteSlug }` );
 					}
 
-					urlQueryParams.set( 'showModal', 'true' );
+					if ( ! isSitePlanCompatible ) {
+						urlQueryParams.set( 'showModal', 'true' );
+						return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
+					}
 
-					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
-
+					return navigate( `import?siteSlug=${ siteSlug }` );
 				case 'importerWix':
 				case 'importReady':
 				case 'importReadyNot':


### PR DESCRIPTION
We shipped the migration assistance offer modal, when users are clicking back after seeing the plan upgrade

With this PR, we only show the modal if the target site is not on the creator plan.

## Testing

1. `calypso.localhost:3000/setup/import-focused/importerWordpress?siteSlug=[SITE WITHOUT CREATOR PLAN]&from=[EXTERNAL WEBSITE]`, clicking back should show you the modal
2. `calypso.localhost:3000/setup/import-focused/importerWordpress?siteSlug=[SITE WITH CREATOR PLAN]&from=[EXTERNAL WEBSITE]`, clicking back shouldn't show you the modal
3. Do the same thing for `site-setup`