### PR TITLE
Make capabilities optional in site extra data info

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
@@ -14,7 +14,7 @@ type SiteDataExtraInfo = SiteDetails & {
 		is_domain_only: boolean;
 	};
 	title: string;
-	capabilities: Record< string, boolean >;
+	capabilities?: Record< string, boolean >;
 };
 
 // props passed to the component


### PR DESCRIPTION
We made site capabilities optional in https://github.com/Automattic/wp-calypso/pull/90507

This PR just updates the SiteDataExtraInfo definition to make sure it's optional there too.