### PR TITLE
Patterns: Implement `PatternsContext` in more places

### DIFF
--- a/client/my-sites/patterns/components/category-gallery/client.tsx
+++ b/client/my-sites/patterns/components/category-gallery/client.tsx
@@ -79,10 +79,8 @@ function CategoryGalleryItem( { category, patternTypeFilter }: CategoryGalleryIt
 			>
 				<div className="patterns-category-gallery__item-preview-inner">
 					<PatternPreview
-						category={ category.name }
 						className="pattern-preview--category-gallery"
 						pattern={ pattern }
-						patternTypeFilter={ patternTypeFilter }
 						viewportWidth={ GRID_VIEW_VIEWPORT_WIDTH }
 					/>
 				</div>

--- a/client/my-sites/patterns/components/category-not-found/index.tsx
+++ b/client/my-sites/patterns/components/category-not-found/index.tsx
@@ -7,15 +7,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 import './style.scss';
 
-type PatternsCategoryNotFoundProps = {
-	category: string;
-	referrer?: string;
-};
-
-export const PatternsCategoryNotFound = ( {
-	category,
-	referrer,
-}: PatternsCategoryNotFoundProps ) => {
+export const PatternsCategoryNotFound = () => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const translate = useTranslate();
 
@@ -36,11 +28,7 @@ export const PatternsCategoryNotFound = ( {
 
 	return (
 		<>
-			<PatternsPageViewTracker
-				category={ category }
-				referrer={ referrer }
-				error="category-not-found"
-			/>
+			<PatternsPageViewTracker error="category-not-found" />
 
 			<EmptyContent
 				title={ title }

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -3,33 +3,27 @@ import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
-import { PatternTypeFilter, PatternView } from 'calypso/my-sites/patterns/types';
+import { PatternView } from 'calypso/my-sites/patterns/types';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { usePatternsContext } from '../context';
 import type { AppState } from 'calypso/types';
 
 type PatternsPageViewTrackerProps = {
-	category?: string;
-	searchTerm?: string;
 	patternPermalinkName?: string;
-	patternTypeFilter?: PatternTypeFilter;
 	view?: PatternView;
-	referrer?: string;
 	error?: string;
 	patternsCount?: number;
 };
 
 export function PatternsPageViewTracker( {
-	category,
-	searchTerm,
 	patternPermalinkName,
-	patternTypeFilter,
 	view,
-	referrer,
 	error,
 	patternsCount,
 }: PatternsPageViewTrackerProps ) {
+	const { category, searchTerm, patternTypeFilter, referrer } = usePatternsContext();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	// Default to `undefined` while user settings are loading

--- a/client/my-sites/patterns/components/page-view-tracker.tsx
+++ b/client/my-sites/patterns/components/page-view-tracker.tsx
@@ -2,12 +2,12 @@ import { useEffect } from 'react';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
 import { PatternView } from 'calypso/my-sites/patterns/types';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import { usePatternsContext } from '../context';
 import type { AppState } from 'calypso/types';
 
 type PatternsPageViewTrackerProps = {

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -181,17 +181,14 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 					{ patternsToDisplay.map( ( pattern ) => (
 						<PatternPreview
 							canCopy={ isLoggedIn || pattern.can_be_copied_without_account }
-							category={ category }
 							className={ classNames( {
 								'pattern-preview--grid': isGridView,
 								'pattern-preview--list': ! isGridView,
 							} ) }
 							getPatternPermalink={ getPatternPermalink }
-							isGridView={ isGridView }
 							isResizable={ ! isGridView }
 							key={ pattern.ID }
 							pattern={ pattern }
-							patternTypeFilter={ patternTypeFilter }
 							viewportWidth={ isGridView ? GRID_VIEW_VIEWPORT_WIDTH : undefined }
 						/>
 					) ) }

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -11,11 +11,11 @@ import {
 } from 'calypso/my-sites/patterns/components/pattern-preview';
 import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview/placeholder';
 import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/constants';
+import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
 import { PatternTypeFilter, type PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { usePatternsContext } from '../../context';
 
 import './style.scss';
 

--- a/client/my-sites/patterns/components/pattern-gallery/client.tsx
+++ b/client/my-sites/patterns/components/pattern-gallery/client.tsx
@@ -15,6 +15,7 @@ import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-p
 import { PatternTypeFilter, type PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { usePatternsContext } from '../../context';
 
 import './style.scss';
 
@@ -113,15 +114,20 @@ const PATTERNS_PER_PAGE_COUNT = 9;
 
 export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 	const {
-		category,
 		displayPlaceholder = false,
 		getPatternPermalink,
 		isGridView = false,
 		patterns = [],
-		patternTypeFilter,
-		searchTerm,
 	} = props;
 
+	const {
+		category,
+		patternTypeFilter: patternTypeFilterFromContext,
+		searchTerm,
+	} = usePatternsContext();
+	// For search results, we want a non-masonry display and also some specific
+	// tracks data, so we always treat search results as  "regular" patterns
+	const patternTypeFilter = searchTerm ? PatternTypeFilter.REGULAR : patternTypeFilterFromContext;
 	const translate = useTranslate();
 	const [ currentPage, setCurrentPage ] = useState( () => {
 		if ( /#pattern-/.test( window.location.hash ) ) {
@@ -172,7 +178,6 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 							title=""
 						/>
 					) }
-
 					{ patternsToDisplay.map( ( pattern ) => (
 						<PatternPreview
 							canCopy={ isLoggedIn || pattern.can_be_copied_without_account }
@@ -190,7 +195,6 @@ export const PatternGalleryClient: PatternGalleryFC = ( props ) => {
 							viewportWidth={ isGridView ? GRID_VIEW_VIEWPORT_WIDTH : undefined }
 						/>
 					) ) }
-
 					{ shouldDisplayPaginationButton && (
 						<div className="pattern-gallery__pagination-button-wrapper">
 							<Button

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -326,8 +326,6 @@ export const PatternLibrary = ( {
 							isGridView={ isGridView }
 							key={ `pattern-gallery-${ patternGalleryKey }` }
 							patterns={ patterns }
-							patternTypeFilter={ searchTerm ? PatternTypeFilter.REGULAR : patternTypeFilter }
-							searchTerm={ searchTerm }
 						/>
 
 						{ searchTerm && ! patterns.length && category && (

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -80,7 +80,7 @@ export const PatternLibrary = ( {
 	const navRef = useRef< HTMLDivElement >( null );
 
 	const { recordPatternsEvent } = useRecordPatternsEvent();
-	const { category, searchTerm, isGridView, patternTypeFilter, referrer, patternPermalinkId } =
+	const { category, searchTerm, isGridView, patternTypeFilter, patternPermalinkId } =
 		usePatternsContext();
 
 	const { data: categories = [] } = usePatternCategories( locale );
@@ -223,18 +223,12 @@ export const PatternLibrary = ( {
 		<>
 			{ isHomePage ? (
 				<PatternsPageViewTracker
-					searchTerm={ searchTerm }
-					referrer={ referrer }
 					patternsCount={ ! isFetchingPatterns ? patterns.length : undefined }
 				/>
 			) : (
 				<PatternsPageViewTracker
-					category={ category }
 					patternPermalinkName={ patternPermalinkName }
-					patternTypeFilter={ patternTypeFilter }
 					view={ currentView }
-					searchTerm={ searchTerm }
-					referrer={ referrer }
 					patternsCount={ ! isFetchingPatterns ? patterns.length : undefined }
 				/>
 			) }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -21,11 +21,8 @@ import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-p
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import type {
-	Pattern,
-	PatternGalleryProps,
-	PatternTypeFilter,
-} from 'calypso/my-sites/patterns/types';
+import { usePatternsContext } from '../../context';
+import type { Pattern, PatternGalleryProps } from 'calypso/my-sites/patterns/types';
 import type { Dispatch, SetStateAction } from 'react';
 
 import './style.scss';
@@ -85,26 +82,22 @@ function useTimeoutToResetBoolean(
 
 type PatternPreviewProps = {
 	canCopy?: boolean;
-	category?: string;
 	className?: string;
 	getPatternPermalink?: PatternGalleryProps[ 'getPatternPermalink' ];
 	isResizable?: boolean;
 	pattern: Pattern | null;
-	patternTypeFilter?: PatternTypeFilter;
-	isGridView?: boolean;
 	viewportWidth?: number;
 };
 
 function PatternPreviewFragment( {
 	canCopy = true,
-	category,
 	className,
 	getPatternPermalink = () => '',
 	pattern,
-	patternTypeFilter,
-	isGridView,
 	viewportWidth: fixedViewportWidth,
 }: PatternPreviewProps ) {
+	const { category, patternTypeFilter, isGridView } = usePatternsContext();
+
 	const { recordPatternsEvent } = useRecordPatternsEvent();
 	const ref = useRef< HTMLDivElement >( null );
 	const hasScrolledToAnchorRef = useRef< boolean >( false );
@@ -392,7 +385,9 @@ function PatternPreviewFragment( {
 }
 
 export function PatternPreview( props: PatternPreviewProps ) {
-	const { category, isResizable, pattern, patternTypeFilter } = props;
+	const { isResizable, pattern } = props;
+	const { category, patternTypeFilter } = usePatternsContext();
+
 	const isMobile = useMobileBreakpoint();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -16,12 +16,12 @@ import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/intern
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { PatternsGetAccessModal } from 'calypso/my-sites/patterns/components/get-access-modal';
 import { patternFiltersClassName } from 'calypso/my-sites/patterns/components/pattern-library';
+import { usePatternsContext } from 'calypso/my-sites/patterns/context';
 import { useRecordPatternsEvent } from 'calypso/my-sites/patterns/hooks/use-record-patterns-event';
 import { getTracksPatternType } from 'calypso/my-sites/patterns/lib/get-tracks-pattern-type';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import { usePatternsContext } from '../../context';
 import type { Pattern, PatternGalleryProps } from 'calypso/my-sites/patterns/types';
 import type { Dispatch, SetStateAction } from 'react';
 

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -24,10 +24,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 function renderCategoryNotFound( context: RouterContext, next: RouterNext ) {
 	context.primary = (
 		<PatternsWrapper>
-			<PatternsCategoryNotFound
-				category={ context.params.category }
-				referrer={ context.query.ref }
-			/>
+			<PatternsCategoryNotFound />
 		</PatternsWrapper>
 	);
 

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -55,8 +55,6 @@ export type PatternGalleryProps = {
 	getPatternPermalink?( pattern: Pattern ): string;
 	isGridView?: boolean;
 	patterns?: Pattern[];
-	patternTypeFilter: PatternTypeFilter;
-	searchTerm?: string;
 };
 
 export type PatternGalleryFC = React.FC< PatternGalleryProps >;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6560-gh-Automattic/dotcom-forge

## Proposed Changes

Because `PatternsContext` was introduced later in the project, it wasn't used everywhere it could be. This PR aims to implement it in more places that make sense, hopefully without over-optimizing.

## Testing Instructions

- Confirm that patterns, categories, and search result behaviors all match `trunk`
- Confirm that for search results, a masonry-like grid view is never rendered.
- Confirm that for search results pages, the `calypso_pattern_library_load_more` when clicking the pagination link always carries a `type` argument value of `pattern`, even if you were viewing page layouts when you initiated the search
