### PR TITLE
Add/highlight on includes limits for ai and stats

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/quantity-dropdown.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/quantity-dropdown.tsx
@@ -50,8 +50,27 @@ const QuantityDropdown: FC< QuantityDropdownProps > = ( { product, siteId, onCha
 		} );
 	}, [ listPrices.priceTierList, product.productSlug ] );
 
+	const triggerHighlightedIncludes = useCallback( () => {
+		const highlightedIncludes = document.getElementsByClassName( 'highlight-on-render' );
+
+		if ( highlightedIncludes.length > 0 ) {
+			for ( const element of highlightedIncludes ) {
+				element.classList.add( 'trigger-highlight' );
+			}
+		}
+
+		setTimeout( () => {
+			if ( highlightedIncludes.length > 0 ) {
+				for ( const element of highlightedIncludes ) {
+					element.classList.remove( 'trigger-highlight' );
+				}
+			}
+		}, 500 );
+	}, [] );
+
 	const onDropdownTierSelect = useCallback(
 		( { value: slug }: { value: string } ) => {
+			triggerHighlightedIncludes();
 			onChangeProduct( slugToSelectorProduct( slug ) );
 			const { slug: productSlug, quantity } = getProductPartsFromAlias( slug );
 
@@ -63,7 +82,7 @@ const QuantityDropdown: FC< QuantityDropdownProps > = ( { product, siteId, onCha
 				} )
 			);
 		},
-		[ onChangeProduct, dispatch, siteId ]
+		[ onChangeProduct, dispatch, siteId, triggerHighlightedIncludes ]
 	);
 
 	if ( ! isJetpackTieredProduct( product.productSlug ) || tierOptions.length < 1 ) {

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -263,3 +263,21 @@
 .popover.product-lightbox__variants-dropdown--popover {
 	z-index: 100200;
 }
+
+.highlight-on-render {
+	display: inline-block;
+	height: 100%;
+
+	&.trigger-highlight {
+		animation: trigger-highlight 500ms ease-out;
+	}
+}
+
+@keyframes trigger-highlight {
+	0% {
+		background-color: var(--studio-yellow-5);
+	}
+	100% {
+		background-color: initial;
+	}
+}

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1,5 +1,7 @@
 import { translate, useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
+// Function is not a hook, should be fine to use here
+// eslint-disable-next-line no-restricted-imports
 import {
 	PRODUCT_JETPACK_ANTI_SPAM_BI_YEARLY,
 	PRODUCT_JETPACK_ANTI_SPAM,
@@ -1248,75 +1250,111 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 
 	return {
 		[ PRODUCT_JETPACK_AI_MONTHLY ]: [
-			translate( '100 monthly requests (upgradeable)' ),
+			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_100 ]: [
-			translate( '100 monthly requests (upgradeable)' ),
+			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_200 ]: [
-			translate( '200 monthly requests (upgradeable)' ),
+			translate( '{{span}}200 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_500 ]: [
-			translate( '500 monthly requests (upgradeable)' ),
+			translate( '{{span}}500 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_750 ]: [
-			translate( '750 monthly requests (upgradeable)' ),
+			translate( '{{span}}750 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_1000 ]: [
-			translate( '1000 monthly requests (upgradeable)' ),
+			translate( '{{span}}1000 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY ]: [
-			translate( '100 monthly requests (upgradeable)' ),
+			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_100 ]: [
-			translate( '100 monthly requests (upgradeable)' ),
+			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_200 ]: [
-			translate( '200 monthly requests (upgradeable)' ),
+			translate( '{{span}}200 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_500 ]: [
-			translate( '500 monthly requests (upgradeable)' ),
+			translate( '{{span}}500 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_750 ]: [
-			translate( '750 monthly requests (upgradeable)' ),
+			translate( '{{span}}750 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_1000 ]: [
-			translate( '1000 monthly requests (upgradeable)' ),
+			translate( '{{span}}1000 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY ]: [
-			translate( '100 monthly requests (upgradeable)' ),
+			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_100 ]: [
-			translate( '100 monthly requests (upgradeable)' ),
+			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_200 ]: [
-			translate( '200 monthly requests (upgradeable)' ),
+			translate( '{{span}}200 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_500 ]: [
-			translate( '500 monthly requests (upgradeable)' ),
+			translate( '{{span}}500 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_750 ]: [
-			translate( '750 monthly requests (upgradeable)' ),
+			translate( '{{span}}750 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_1000 ]: [
-			translate( '1000 monthly requests (upgradeable)' ),
+			translate( '{{span}}1000 monthly requests (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_BACKUP_T0_YEARLY ]: backupIncludesInfoT0,
@@ -1357,75 +1395,111 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedIncludesInfo,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedIncludesInfo,
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: [
-			translate( '10,000 site views (upgradeable)' ),
+			translate( '{{span}}10K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_10K ]: [
-			translate( '10K site views (upgradeable)' ),
+			translate( '{{span}}10K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_100K ]: [
-			translate( '100K site views (upgradeable)' ),
+			translate( '{{span}}100K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_250K ]: [
-			translate( '250K site views (upgradeable)' ),
+			translate( '{{span}}250K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_500K ]: [
-			translate( '500K site views (upgradeable)' ),
+			translate( '{{span}}500K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_1M ]: [
-			translate( '1M site views (upgradeable)' ),
+			translate( '{{span}}1M site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY ]: [
-			translate( '10K site views (upgradeable)' ),
+			translate( '{{span}}10K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_10K ]: [
-			translate( '10K site views (upgradeable)' ),
+			translate( '{{span}}10K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_100K ]: [
-			translate( '100K site views (upgradeable)' ),
+			translate( '{{span}}100K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_250K ]: [
-			translate( '250K site views (upgradeable)' ),
+			translate( '{{span}}250K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_500K ]: [
-			translate( '500K site views (upgradeable)' ),
+			translate( '{{span}}500K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_1M ]: [
-			translate( '1M site views (upgradeable)' ),
+			translate( '{{span}}1M site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY ]: [
-			translate( '10K site views (upgradeable)' ),
+			translate( '{{span}}10K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_10K ]: [
-			translate( '10K site views (upgradeable)' ),
+			translate( '{{span}}10K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_100K ]: [
-			translate( '100K site views (upgradeable)' ),
+			translate( '{{span}}100K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_250K ]: [
-			translate( '250K site views (upgradeable)' ),
+			translate( '{{span}}250K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_500K ]: [
-			translate( '500K site views (upgradeable)' ),
+			translate( '{{span}}500K site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_1M ]: [
-			translate( '1M site views (upgradeable)' ),
+			translate( '{{span}}1M site views (upgradeable){{/span}}', {
+				components: { span: <span className="highlight-on-render" /> },
+			} ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_MONITOR_YEARLY ]: monitorIncludesInfo,

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -120,6 +120,10 @@ import {
 import type { FAQ, SelectorProductFeaturesItem } from './types';
 import type { TranslateResult } from 'i18n-calypso';
 
+const highlightable = ( inner: TranslateResult ): TranslateResult => {
+	return <span className="highlight-on-render">{ inner }</span>;
+};
+
 export const getJetpackProductsShortNames = (): Record< string, React.ReactElement | string > => {
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: (
@@ -1250,111 +1254,75 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 
 	return {
 		[ PRODUCT_JETPACK_AI_MONTHLY ]: [
-			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_100 ]: [
-			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_200 ]: [
-			translate( '{{span}}200 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '200 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_500 ]: [
-			translate( '{{span}}500 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '500 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_750 ]: [
-			translate( '{{span}}750 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '750 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_1000 ]: [
-			translate( '{{span}}1000 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '1000 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY ]: [
-			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_100 ]: [
-			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_200 ]: [
-			translate( '{{span}}200 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '200 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_500 ]: [
-			translate( '{{span}}500 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '500 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_750 ]: [
-			translate( '{{span}}750 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '750 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_1000 ]: [
-			translate( '{{span}}1000 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '1000 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY ]: [
-			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_100 ]: [
-			translate( '{{span}}100 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_200 ]: [
-			translate( '{{span}}200 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '200 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_500 ]: [
-			translate( '{{span}}500 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '500 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_750 ]: [
-			translate( '{{span}}750 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '750 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_1000 ]: [
-			translate( '{{span}}1000 monthly requests (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '1000 monthly requests (upgradeable)' ) ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_BACKUP_T0_YEARLY ]: backupIncludesInfoT0,
@@ -1395,111 +1363,75 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedIncludesInfo,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedIncludesInfo,
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: [
-			translate( '{{span}}10K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '10K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_10K ]: [
-			translate( '{{span}}10K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '10K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_100K ]: [
-			translate( '{{span}}100K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_250K ]: [
-			translate( '{{span}}250K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '250K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_500K ]: [
-			translate( '{{span}}500K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '500K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_1M ]: [
-			translate( '{{span}}1M site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '1M site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY ]: [
-			translate( '{{span}}10K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '10K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_10K ]: [
-			translate( '{{span}}10K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '10K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_100K ]: [
-			translate( '{{span}}100K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_250K ]: [
-			translate( '{{span}}250K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '250K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_500K ]: [
-			translate( '{{span}}500K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '500K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_1M ]: [
-			translate( '{{span}}1M site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '1M site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY ]: [
-			translate( '{{span}}10K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '10K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_10K ]: [
-			translate( '{{span}}10K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '10K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_100K ]: [
-			translate( '{{span}}100K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '100K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_250K ]: [
-			translate( '{{span}}250K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '250K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_500K ]: [
-			translate( '{{span}}500K site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '500K site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_1M ]: [
-			translate( '{{span}}1M site views (upgradeable){{/span}}', {
-				components: { span: <span className="highlight-on-render" /> },
-			} ),
+			highlightable( translate( '1M site views (upgradeable)' ) ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_MONITOR_YEARLY ]: monitorIncludesInfo,

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1,7 +1,5 @@
 import { translate, useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-// Function is not a hook, should be fine to use here
-// eslint-disable-next-line no-restricted-imports
 import {
 	PRODUCT_JETPACK_ANTI_SPAM_BI_YEARLY,
 	PRODUCT_JETPACK_ANTI_SPAM,


### PR DESCRIPTION
## Proposed Changes

* Add a highlight animation on the includes section items that change when a different tier is selected

NOTE: This is an extension of [this PR](https://github.com/Automattic/wp-calypso/pull/90521), this will be rebased when that one is merged

## Testing Instructions

1. Using the Calypso Green live link, go to `/pricing`
2. On the AI or Stats lightbox, switch between tiers and make sure the highlight animation looks good

https://github.com/Automattic/wp-calypso/assets/65001528/de723612-3044-4761-aa3d-c8654bf5ce9a


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
