### PR TITLE
Jest: Fix memory usage issues with Jest

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -151,13 +151,13 @@ open class E2EBuildType(
 					set +o errexit
 
 					# Run suite.
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=$testGroup
 
 					# Restore exit on error.
 					set -o errexit
 
 					# Retry failed tests only.
-					RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup --onlyFailures
+					RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=$testGroup --onlyFailures
 				"""
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --shm-size=4g"

--- a/.teamcity/_self/lib/utils/E2EBuildLibrary.kt
+++ b/.teamcity/_self/lib/utils/E2EBuildLibrary.kt
@@ -116,13 +116,13 @@ fun BuildSteps.runE2eTestsWithRetry(
             set +o errexit
 
             # Run suite.
-            xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup
+            xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=$testGroup
 
             # Restore exit on error.
             set -o errexit
 
             # Retry failed tests only.
-            RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup --onlyFailures
+            RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=$testGroup --onlyFailures
         """.trimIndent()
         dockerImage = "%docker_image_e2e%"
     }

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -75,7 +75,7 @@ object ToSAcceptanceTracking: BuildType ({
 				mkdir temp
 
 				# Run suite.
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=legal
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=legal
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -865,13 +865,13 @@ object PreReleaseE2ETests : BuildType({
 				set +o errexit
 
 				# Run suite.
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=calypso-release
 
 				# Restore exit on error.
 				set -o errexit
 
 				# Retry failed tests only.
-				RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release --onlyFailures --json --outputFile=pre-release-test-results.json
+				RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --workerIdleMemoryLimit=1GB --group=calypso-release --onlyFailures --json --outputFile=pre-release-test-results.json
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -481,7 +481,7 @@ object RunAllUnitTests : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 15
+		executionTimeoutMin = 8
 	}
 	features {
 		feature {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -135,7 +135,7 @@ object BuildDockerImage : BuildType({
 			--label com.a8c.image-builder=teamcity
 			--label com.a8c.build-id=%teamcity.build.id%
 			--build-arg workers=32
-			--build-arg node_memory=8192
+			--build-arg node_memory=16384
 			--build-arg use_cache=true
 			--build-arg base_image=%base_image%
 			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -60,8 +60,8 @@ project {
 		// Force color support in chalk. For some reason it doesn't detect TeamCity
 		// as supported (even though both TeamCity and chalk support that.)
 		param("env.FORCE_COLOR", "1")
-		param("env.NODE_OPTIONS", "--max-old-space-size=8192")
-		text("JEST_E2E_WORKERS", "50%", label = "Jest max workers", description = "Number or percent of cores to use when running E2E tests.", allowEmpty = true)
+		param("env.NODE_OPTIONS", "--max-old-space-size=16384")
+		text("JEST_E2E_WORKERS", "100%", label = "Jest max workers", description = "Number or percent of cores to use when running E2E tests.", allowEmpty = true)
 		password("matticbot_oauth_token", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN)
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)
 		text("docker_image", "registry.a8c.com/calypso/base:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)

--- a/bin/unit-test-suite.mjs
+++ b/bin/unit-test-suite.mjs
@@ -56,10 +56,12 @@ const tscCommands = [
 // runs by itself with 8 cores, and the other tasks run one by one with 4 other
 // cores. This leaves a final 4 cores free for tsc + any other tasks. This seems
 // to result in the fastest overall completion time.
-const testClient = withUnitTestInfo( 'test-client --maxWorkers=4' );
-const testPackages = withUnitTestInfo( 'test-packages --maxWorkers=2' );
-const testServer = withUnitTestInfo( 'test-server --maxWorkers=2' );
-const testBuildTools = withUnitTestInfo( 'test-build-tools --maxWorkers=2' );
+//
+// --workerIdleMemoryLimit=512MB is added because of https://github.com/jestjs/jest/issues/11956
+const testClient = withUnitTestInfo( 'test-client --maxWorkers=8 --workerIdleMemoryLimit=512MB' );
+const testPackages = withUnitTestInfo( 'test-packages --maxWorkers=4 --workerIdleMemoryLimit=512MB' );
+const testServer = withUnitTestInfo( 'test-server --maxWorkers=4 --workerIdleMemoryLimit=512MB' );
+const testBuildTools = withUnitTestInfo( 'test-build-tools --maxWorkers=4 --workerIdleMemoryLimit=512MB' );
 // Includes ETK and Odyssey Stats, migrated here from their individual builds.
 const testApps = withUnitTestInfo( 'test-apps --maxWorkers=1' );
 

--- a/bin/unit-test-suite.mjs
+++ b/bin/unit-test-suite.mjs
@@ -63,7 +63,7 @@ const testPackages = withUnitTestInfo( 'test-packages --maxWorkers=4 --workerIdl
 const testServer = withUnitTestInfo( 'test-server --maxWorkers=4 --workerIdleMemoryLimit=1GB' );
 const testBuildTools = withUnitTestInfo( 'test-build-tools --maxWorkers=4 --workerIdleMemoryLimit=1GB' );
 // Includes ETK and Odyssey Stats, migrated here from their individual builds.
-const testApps = withUnitTestInfo( 'test-apps --maxWorkers=1' );
+const testApps = withUnitTestInfo( 'test-apps --maxWorkers=1 --workerIdleMemoryLimit=1GB' );
 
 const testWorkspaces = {
 	name: 'yarn',

--- a/bin/unit-test-suite.mjs
+++ b/bin/unit-test-suite.mjs
@@ -58,10 +58,10 @@ const tscCommands = [
 // to result in the fastest overall completion time.
 //
 // --workerIdleMemoryLimit=512MB is added because of https://github.com/jestjs/jest/issues/11956
-const testClient = withUnitTestInfo( 'test-client --maxWorkers=8 --workerIdleMemoryLimit=512MB' );
-const testPackages = withUnitTestInfo( 'test-packages --maxWorkers=4 --workerIdleMemoryLimit=512MB' );
-const testServer = withUnitTestInfo( 'test-server --maxWorkers=4 --workerIdleMemoryLimit=512MB' );
-const testBuildTools = withUnitTestInfo( 'test-build-tools --maxWorkers=4 --workerIdleMemoryLimit=512MB' );
+const testClient = withUnitTestInfo( 'test-client --maxWorkers=8 --workerIdleMemoryLimit=1GB' );
+const testPackages = withUnitTestInfo( 'test-packages --maxWorkers=4 --workerIdleMemoryLimit=1GB' );
+const testServer = withUnitTestInfo( 'test-server --maxWorkers=4 --workerIdleMemoryLimit=1GB' );
+const testBuildTools = withUnitTestInfo( 'test-build-tools --maxWorkers=4 --workerIdleMemoryLimit=1GB' );
 // Includes ETK and Odyssey Stats, migrated here from their individual builds.
 const testApps = withUnitTestInfo( 'test-apps --maxWorkers=1' );
 


### PR DESCRIPTION
seems to be fixed in Node v21.1.0, but broken after node v16.11.0...

use `--workerIdleMemoryLimit=1GB` until we upgrade.

https://github.com/jestjs/jest/issues/11956