### PR TITLE
Nav Redesign: No storage add-on when no available

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -1,4 +1,4 @@
-import { PlanSlug } from '@automattic/calypso-products';
+import { PlanSlug, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Button, Card, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
@@ -32,12 +32,10 @@ const PlanCard: FC = () => {
 		useCheckPlanAvailabilityForPurchase,
 	} );
 
-	// Check for storage addons available for purchase
+	// Check for storage addons available for purchase.
 	const addOns = AddOns.useAddOns( { selectedSiteId: site?.ID } );
 	const storageAddons = addOns.filter(
-		( addOn ) =>
-			addOn?.productSlug === 'wordpress_com_1gb_space_addon_yearly' &&
-			! addOn?.exceedsSiteStorageLimits
+		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE && ! addOn?.exceedsSiteStorageLimits
 	);
 
 	const isLoading = ! pricing || ! planData;

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -1,5 +1,6 @@
 import { PlanSlug } from '@automattic/calypso-products';
 import { Button, Card, PlanPrice, LoadingPlaceholder } from '@automattic/components';
+import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
@@ -30,6 +31,14 @@ const PlanCard: FC = () => {
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );
+
+	// Check for storage addons available for purchase
+	const addOns = AddOns.useAddOns( { selectedSiteId: site?.ID } );
+	const storageAddons = addOns.filter(
+		( addOn ) =>
+			addOn?.productSlug === 'wordpress_com_1gb_space_addon_yearly' &&
+			! addOn?.exceedsSiteStorageLimits
+	);
 
 	const isLoading = ! pricing || ! planData;
 
@@ -125,15 +134,17 @@ const PlanCard: FC = () => {
 					siteId={ site?.ID }
 					StorageBarComponent={ PlanStorageBar }
 				>
-					<div className="hosting-overview__plan-storage-footer">
-						<Button
-							className="hosting-overview__link-button"
-							plain
-							href={ `/add-ons/${ site?.slug }` }
-						>
-							{ translate( 'Need more storage?' ) }
-						</Button>
-					</div>
+					{ storageAddons.length > 0 && (
+						<div className="hosting-overview__plan-storage-footer">
+							<Button
+								className="hosting-overview__link-button"
+								plain
+								href={ `/add-ons/${ site?.slug }` }
+							>
+								{ translate( 'Need more storage?' ) }
+							</Button>
+						</div>
+					) }
 				</PlanStorage>
 			</Card>
 		</>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7044

## Proposed Changes

Remove the `Need more storage?` addon from the flyout overview when not available

| Add-on available | Add-on not available |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/fa41acff-7350-4870-b024-5e1e543ee3ea) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/3b700261-c429-4a27-876f-e13dc9c00f3c) |



## Testing Instructions

- Go to `/sites` 
- Open a site with the Storage upgrade option available (you can check it in `/add-ons/:your-site`.
-  You should see the `Need more storage?` under the Storage space
- Check on sites where the option is not available (like FG)
- You should not see the upgrade option.
