### PR TITLE
CheckoutV2 tidying: Show and hide Site Preview in Checkout sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -366,9 +366,7 @@ export default function CheckoutMainContent( {
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
 
-	/*
-	 * Only show the site preview for WPCOM domains that have a site connected to the site id
-	 * */
+	// Only show the site preview for WPCOM domains that have a site connected to the site id
 	const shouldShowSitePreview =
 		showSitePreview && selectedSiteData && wpcomDomain && ! isSignupCheckout && ! isDIFMInCart;
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -357,14 +357,20 @@ export default function CheckoutMainContent( {
 		removeCoupon,
 		couponStatus,
 	} = useShoppingCart( cartKey );
-	const searchParams = new URLSearchParams( window.location.search );
 
+	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const isSignupCheckout = searchParams.get( 'signup' ) === '1';
 	const selectedSiteData = useSelector( getSelectedSite );
 	const wpcomDomain = useSelector( ( state ) =>
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
+
+	/*
+	 * Only show the site preview for WPCOM domains that have a site connected to the site id
+	 * */
+	const shouldShowSitePreview =
+		showSitePreview && selectedSiteData && wpcomDomain && ! isSignupCheckout && ! isDIFMInCart;
 
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const reduxDispatch = useReduxDispatch();
@@ -557,20 +563,13 @@ export default function CheckoutMainContent( {
 								className="checkout__summary-body"
 								shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 							>
-								{ /*
-								 * Only show the site preview for WPCOM domains that have a site connected to the site id
-								 * */ }
-								{ showSitePreview &&
-									selectedSiteData &&
-									wpcomDomain &&
-									! isSignupCheckout &&
-									! isDIFMInCart && (
-										<div className="checkout-site-preview">
-											<SitePreviewWrapper>
-												<SitePreview showEditSite={ false } showSiteDetails={ false } />
-											</SitePreviewWrapper>
-										</div>
-									) }
+								{ shouldShowSitePreview && (
+									<div className="checkout-site-preview">
+										<SitePreviewWrapper>
+											<SitePreview showEditSite={ false } showSiteDetails={ false } />
+										</SitePreviewWrapper>
+									</div>
+								) }
 
 								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
 								<CheckoutSidebarNudge

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -52,12 +52,14 @@ import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/src/hooks/use-val
 import { leaveCheckout } from 'calypso/my-sites/checkout/src/lib/leave-checkout';
 import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout/src/types/wpcom-store-state';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import useOneDollarOfferTrack from 'calypso/my-sites/plans/hooks/use-onedollar-offer-track';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useUpdateCachedContactDetails } from '../hooks/use-cached-contact-details';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
@@ -323,6 +325,7 @@ export default function CheckoutMainContent( {
 	customizedPreviousPath,
 	loadingHeader,
 	onStepChanged,
+	showSitePreview = false,
 }: {
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	changeSelection: OnChangeItemVariant;
@@ -341,7 +344,9 @@ export default function CheckoutMainContent( {
 	isInitialCartLoading: boolean;
 	customizedPreviousPath?: string;
 	loadingHeader?: ReactNode;
+	showSitePreview?: boolean;
 } ) {
+	const translate = useTranslate();
 	const cartKey = useCartKey();
 	const {
 		responseCart,
@@ -352,7 +357,15 @@ export default function CheckoutMainContent( {
 		removeCoupon,
 		couponStatus,
 	} = useShoppingCart( cartKey );
-	const translate = useTranslate();
+	const searchParams = new URLSearchParams( window.location.search );
+
+	const isDIFMInCart = hasDIFMProduct( responseCart );
+	const isSignupCheckout = searchParams.get( 'signup' ) === '1';
+	const selectedSiteData = useSelector( getSelectedSite );
+	const wpcomDomain = useSelector( ( state ) =>
+		getWpComDomainBySiteId( state, selectedSiteData?.ID )
+	);
+
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const reduxDispatch = useReduxDispatch();
 	usePresalesChat( getPresalesChatKey( responseCart ), responseCart?.products?.length > 0 );
@@ -544,19 +557,20 @@ export default function CheckoutMainContent( {
 								className="checkout__summary-body"
 								shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 							>
-								{ shouldUseCheckoutV2 && (
-									<WPCheckoutOrderReview
-										removeProductFromCart={ removeProductFromCart }
-										replaceProductInCart={ replaceProductInCart }
-										couponFieldStateProps={ couponFieldStateProps }
-										removeCouponAndClearField={ removeCouponAndClearField }
-										isCouponFieldVisible={ isCouponFieldVisible }
-										setCouponFieldVisible={ setCouponFieldVisible }
-										onChangeSelection={ changeSelection }
-										siteUrl={ siteUrl }
-										createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-									/>
-								) }
+								{ /*
+								 * Only show the site preview for WPCOM domains that have a site connected to the site id
+								 * */ }
+								{ showSitePreview &&
+									selectedSiteData &&
+									wpcomDomain &&
+									! isSignupCheckout &&
+									! isDIFMInCart && (
+										<div className="checkout-site-preview">
+											<SitePreviewWrapper>
+												<SitePreview showEditSite={ false } showSiteDetails={ false } />
+											</SitePreviewWrapper>
+										</div>
+									) }
 
 								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
 								<CheckoutSidebarNudge
@@ -1207,6 +1221,36 @@ const WPCheckoutSidebarContent = styled.div`
 
 		.rtl & {
 			padding: 144px 64px 0 24px;
+		}
+	}
+`;
+
+const SitePreviewWrapper = styled.div`
+	.home-site-preview {
+		margin-bottom: 1.5em;
+		padding: 0.5em;
+		box-shadow:
+			0 0 0 1px var( --color-border-subtle ),
+			rgba( 0, 0, 0, 0.2 ) 0 7px 30px -10px;
+		border-radius: 6px;
+
+		& .home-site-preview__thumbnail-wrapper {
+			aspect-ratio: 16 / 9;
+			border-radius: 6px;
+			box-shadow: none;
+			min-width: 100%;
+
+			&:hover {
+				box-shadow: unset;
+
+				& .home-site-preview__thumbnail {
+					opacity: unset;
+				}
+			}
+		}
+
+		& home-site-preview__thumbnail {
+			opacity: 1;
 		}
 	}
 `;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -8,14 +8,12 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses, hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
-import { hasDIFMProduct, hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
+import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
@@ -77,36 +75,6 @@ const CouponEnableButton = styled.button< { shouldUseCheckoutV2: boolean } >`
 	}
 `;
 
-const SitePreviewWrapper = styled.div`
-	.home-site-preview {
-		margin-bottom: 1.5em;
-		padding: 0.5em;
-		box-shadow:
-			0 0 0 1px var( --color-border-subtle ),
-			rgba( 0, 0, 0, 0.2 ) 0 7px 30px -10px;
-		border-radius: 6px;
-
-		& .home-site-preview__thumbnail-wrapper {
-			aspect-ratio: 16 / 9;
-			border-radius: 6px;
-			box-shadow: none;
-			min-width: 100%;
-
-			&:hover {
-				box-shadow: unset;
-
-				& .home-site-preview__thumbnail {
-					opacity: unset;
-				}
-			}
-		}
-
-		& home-site-preview__thumbnail {
-			opacity: 1;
-		}
-	}
-`;
-
 export default function WPCheckoutOrderReview( {
 	className,
 	removeProductFromCart,
@@ -164,11 +132,6 @@ export default function WPCheckoutOrderReview( {
 	);
 
 	const selectedSiteData = useSelector( getSelectedSite );
-	const wpcomDomain = useSelector( ( state ) =>
-		getWpComDomainBySiteId( state, selectedSiteData?.ID )
-	);
-	const searchParams = new URLSearchParams( window.location.search );
-	const isSignupCheckout = searchParams.get( 'signup' ) === '1';
 
 	// This is what will be displayed at the top of checkout prefixed by "Site: ".
 	const domainUrl = getDomainToDisplayInCheckoutHeader( responseCart, selectedSiteData, siteUrl );
@@ -179,24 +142,9 @@ export default function WPCheckoutOrderReview( {
 		( state ) =>
 			getCurrentUser( state ) && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 	);
-	const isDIFMInCart = hasDIFMProduct( responseCart );
 
 	return (
 		<>
-			{ /*
-			 * Only show the site preview for WPCOM domains that have a site connected to the site id
-			 * */ }
-			{ shouldUseCheckoutV2 &&
-				selectedSiteData &&
-				wpcomDomain &&
-				! isSignupCheckout &&
-				! isDIFMInCart && (
-					<div className="checkout-site-preview">
-						<SitePreviewWrapper>
-							<SitePreview showEditSite={ false } showSiteDetails={ false } />
-						</SitePreviewWrapper>
-					</div>
-				) }
 			<div
 				className={ joinClasses( [
 					className,


### PR DESCRIPTION
This PR moves the `SitePreview` component from the `WPCheckoutOrderReview` component to the `CheckoutMainContent` component. 

In Checkout V2 we had moved the `WPCheckoutOrderReview` component from the main column to the checkout sidebar and added a number of changes, one of which was a `SitePreview` component. But, this has been reverted and the `SitePreview` still remains in the main column alongside the `WPCheckoutOrderReview` component.

Since we want to retain the `SitePreview` component for Checkout, we needed to lift it out of the `WPCheckoutOrderReview` component into the `WPCheckoutSidebarContent` component found in `CheckoutMainContent`.

By moving this to the `CheckoutMainContent` component we can add a prop to conditionally show or hide the `SitePreview` in `WPCheckoutSidebarContent`.

Additionally, since we make use of a `WPCheckoutOrderSummary` component, a lot of the v2 changes to `WPCheckoutOrderReview` will be moved over to this component to separate their concerns:

- `WPCheckoutOrderReview`: Commit actions on the order such as changing billing terms, remove items, add coupons etc
- `WPCheckoutOrderSummary`: List cart items and their prices alongside discount and the subtotal - may add the option to remove items

This may be a good place to perhaps rename one of these components as they are easily confused.

Related to pbOQVh-45k-p2#comment-5821
[Follow up PR](https://github.com/Automattic/wp-calypso/pull/90534) for Featured List prop

## Testing Instructions

- Open PR locally, and then go to checkout
- There should not be a SitePreview component shown anywhere
- Add the `showSitePreview` prop to `<CheckoutMainContent />`
- Go back to checkout and reload the page, you should now see a SitePreview in the sidebar