### PR TITLE
CheckoutV2 tidying: Add prop to show or hide features list in checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -552,7 +552,11 @@ export default function CheckoutMainContent( {
 									</div>
 								) }
 
-								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
+								<WPCheckoutOrderSummary
+									siteId={ siteId }
+									onChangeSelection={ changeSelection }
+									showFeaturesList
+								/>
 								<CheckoutSidebarNudge
 									siteId={ siteId }
 									formStatus={ formStatus }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -233,9 +233,6 @@ function CheckoutSidebarNudge( {
 	addItemToCart,
 	areThereDomainProductsInCart,
 }: {
-	siteId: number | undefined;
-	formStatus: FormStatus;
-	changeSelection: OnChangeItemVariant;
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	areThereDomainProductsInCart: boolean;
 } ) {
@@ -558,9 +555,6 @@ export default function CheckoutMainContent( {
 									showFeaturesList
 								/>
 								<CheckoutSidebarNudge
-									siteId={ siteId }
-									formStatus={ formStatus }
-									changeSelection={ changeSelection }
 									addItemToCart={ addItemToCart }
 									areThereDomainProductsInCart={ areThereDomainProductsInCart }
 								/>

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -86,7 +86,7 @@ import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview, { CouponFieldArea } from './wp-checkout-order-review';
-import { CheckoutSummaryFeaturedList, WPCheckoutOrderSummary } from './wp-checkout-order-summary';
+import { WPCheckoutOrderSummary } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -230,9 +230,6 @@ const getPresalesChatKey = ( responseCart: ObjectWithProducts ) => {
 
 /* Include a condition for your use case here if you want to show a specific nudge in the checkout sidebar */
 function CheckoutSidebarNudge( {
-	siteId,
-	formStatus,
-	changeSelection,
 	addItemToCart,
 	areThereDomainProductsInCart,
 }: {
@@ -247,7 +244,6 @@ function CheckoutSidebarNudge( {
 	const isWcMobile = isWcMobileApp();
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
-	const shouldUseCheckoutV2 = hasCheckoutVersion( '2' );
 	const isPurchaseRenewal = responseCart?.products?.some?.( ( product ) => product.is_renewal );
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 
@@ -266,15 +262,6 @@ function CheckoutSidebarNudge( {
 		return (
 			<CheckoutSidebarNudgeWrapper>
 				<CheckoutNextSteps responseCart={ responseCart } />
-
-				{ shouldUseCheckoutV2 && (
-					<CheckoutSummaryFeaturedList
-						responseCart={ responseCart }
-						siteId={ siteId }
-						isCartUpdating={ FormStatus.VALIDATING === formStatus }
-						onChangeSelection={ changeSelection }
-					/>
-				) }
 			</CheckoutSidebarNudgeWrapper>
 		);
 	}
@@ -297,14 +284,6 @@ function CheckoutSidebarNudge( {
 					responseCart={ responseCart }
 					addItemToCart={ addItemToCart }
 					isPurchaseRenewal={ isPurchaseRenewal }
-				/>
-			) }
-			{ shouldUseCheckoutV2 && (
-				<CheckoutSummaryFeaturedList
-					responseCart={ responseCart }
-					siteId={ siteId }
-					isCartUpdating={ FormStatus.VALIDATING === formStatus }
-					onChangeSelection={ changeSelection }
 				/>
 			) }
 		</CheckoutSidebarNudgeWrapper>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -77,6 +77,7 @@ const StyledIcon = styled( Icon )`
 export function WPCheckoutOrderSummary( {
 	siteId,
 	onChangeSelection,
+	showFeaturesList = true,
 }: {
 	siteId: number | undefined;
 	onChangeSelection: (
@@ -85,6 +86,7 @@ export function WPCheckoutOrderSummary( {
 		productId: number,
 		volume?: number
 	) => void;
+	showFeaturesList?: boolean;
 } ) {
 	const { formStatus } = useFormStatus();
 	const cartKey = useCartKey();
@@ -98,7 +100,7 @@ export function WPCheckoutOrderSummary( {
 			data-e2e-cart-is-loading={ isCartUpdating }
 			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 		>
-			{ ! shouldUseCheckoutV2 && (
+			{ showFeaturesList && (
 				<CheckoutSummaryFeaturedList
 					responseCart={ responseCart }
 					siteId={ siteId }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -77,7 +77,7 @@ const StyledIcon = styled( Icon )`
 export function WPCheckoutOrderSummary( {
 	siteId,
 	onChangeSelection,
-	showFeaturesList = true,
+	showFeaturesList,
 }: {
 	siteId: number | undefined;
 	onChangeSelection: (

--- a/client/my-sites/checkout/src/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/test/wp-checkout-order-summary.tsx
@@ -273,7 +273,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 								defaultCartKey: 123456,
 							} }
 						>
-							<WPCheckoutOrderSummary siteId={ undefined } onChangeSelection={ () => null } />
+							<WPCheckoutOrderSummary
+								siteId={ undefined }
+								onChangeSelection={ () => null }
+								showFeaturesList
+							/>
 						</ShoppingCartProvider>
 					</ThemeProvider>
 				</ReduxProvider>


### PR DESCRIPTION
In CheckoutV2 we moved the `CheckoutSummaryFeaturedList` to the bottom of the sidebar to accommodate the `SitePreview` component and the lengthier use of the sidebar for the `WPCheckoutOrderReview`. 

Since the `SitePreview` is now optional (defaults to off) and the dropdown pickers, pricing, and associated buttons and text from the `WPCheckoutOrderReview` have been removed from the sidebar, we can now show the `CheckoutSummaryFeaturedList` component in its original placement at the top of the sidebar. This can be turned on or off by setting the `showFeaturesList` prop found in `WPCheckoutOrderSummary`.

Related to pbOQVh-45k-p2#comment-5821

## Testing Instructions

* Go to Checkout with a plan in your cart
* Observe the features list in the sidebar, it should only be at the top of the sidebar
* In `client/my-sites/checkout/src/components/checkout-main-content.tsx` remove the `showFeaturesList` prop from the `WPCheckoutOrderSummary` component - this should hide the Features List from the Checkout sidebar

