### PR TITLE
nav redesign v2: hide 'reset filters' button if not active

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -3,6 +3,10 @@
 
 .dataviews-filters__view-actions {
 	margin-bottom: 8px;
+
+	.components-button.is-compact.is-tertiary:not(.dataviews-filters-button)[aria-disabled="true"] {
+		display: none;
+	}
 }
 
 .dataviews-pagination {

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -38,10 +38,6 @@
 		padding-block-start: 24px;
 	}
 
-	.components-button.is-compact.is-tertiary:not(.dataviews-filters-button)[aria-disabled="true"] {
-		display: none;
-	}
-
 	@media (min-width: $break-large) {
 		background: inherit;
 

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -38,6 +38,10 @@
 		padding-block-start: 24px;
 	}
 
+	.components-button.is-compact.is-tertiary:not(.dataviews-filters-button)[aria-disabled="true"] {
+		display: none;
+	}
+
 	@media (min-width: $break-large) {
 		background: inherit;
 


### PR DESCRIPTION
fixes 7050-gh-Automattic/dotcom-forge

copies an existing complex CSS selector to hide the "Reset Filters" button when no filter is active
<img width="1246" alt="Screenshot 2024-05-10 at 12 43 56 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/c75f10ea-83d7-454d-9bdc-fa3dd09ba610">

### Test instructions

on /sites, reset filters button should be hidden unless a filter has been selected