### PR TITLE
Site Management Panel: Revert plan card layout

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -36,11 +36,7 @@ const PlanCard: FC = () => {
 	return (
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
-			<Card
-				className={ classNames( 'hosting-overview__card', 'hosting-overview__plan', {
-					'hosting-overview__plan--is-free': ! isPaidPlan,
-				} ) }
-			>
+			<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__plan' ) }>
 				<div className="hosting-overview__plan-card-header">
 					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
 

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -27,29 +27,19 @@ $card-padding: 24px;
 }
 
 .hosting-overview__plan {
-	&--is-free {
-		grid-column: 1 / -1;
-
-		& + .hosting-overview__quick-actions {
-			grid-column: 1 / -1;
-		}
-	}
-
-	&:not(:has(.plan-storage)) {
-		.hosting-overview__plan-card-header {
-			align-items: center;
-			display: flex;
-			margin-bottom: 0;
-		}
-	}
+	grid-column: 1 / 2;
+	grid-row: 1 / 2;
 }
 
 .hosting-overview__quick-actions {
+	grid-column: 2 / 3;
+	grid-row: 1 / 2;
 	padding-bottom: 10px;
 }
 
 .hosting-overview__active-domains {
-	grid-column: 1 / -1;
+	grid-column: 1 / 3;
+	grid-row: 2 / 3;
 	padding-bottom: 0;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7051

## Proposed Changes

This PR reverts the layout changes of the plan card made in https://github.com/Automattic/wp-calypso/pull/90187 so that it's always side-by-side to the Dashboard links card. I've created the issue https://github.com/Automattic/dotcom-forge/issues/7056 to improve the layout.

| Before | After |
| --- | --- |
| ![Screenshot 2024-05-10 at 10 45 57 AM](https://github.com/Automattic/wp-calypso/assets/797888/2ae6de4e-dce0-48de-ae84-1857c06d25aa) |  ![Screenshot 2024-05-10 at 10 41 27 AM](https://github.com/Automattic/wp-calypso/assets/797888/e31ede1a-f11f-4da1-a7e1-7b7832de0683) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the plan card is side-by-side to the Dashboard links card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
