### PR TITLE
Fix font family for woo social buttons

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1417,6 +1417,7 @@ $breakpoint-mobile: 660px;
 					font-weight: 500;
 					line-height: 24px;
 					color: var(--studio-gray-100);
+					font-family: $woo-inter-font;
 				}
 
 				.social-icons {


### PR DESCRIPTION

## Proposed Changes


* Veronica just spotted that all these secondary buttons are in SF Pro instead of Inter, this PR updates the font to Inter.


<img width="1348" alt="Screenshot 2024-05-10 at 11 16 16" src="https://github.com/Automattic/wp-calypso/assets/4344253/a6af8b6a-8dcf-4ba7-9209-f05826a5704c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



* Log out of your account or use incognito mode
* Use Calypso Live link or a local calypso environment
* Go to `/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D35a1d5759a8c03bfcac64677cc08432a4ac46c3bb69bb66a0195a8bfc53bdcea%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1%26woo-passwordless%3Dyes&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253D35a1d5759a8c03bfcac64677cc08432a4ac46c3bb69bb66a0195a8bfc53bdcea%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1%26woo-passwordless%3Dyes`
* Confirm that the font of the secondary buttons is Inter
* Click on "Sign up"
* Confirm that the font of the secondary buttons is Inter
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
