### PR TITLE
Sidebar: Remove max-height from sidebar items to support multiline in some languages

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -833,6 +833,11 @@ $font-size: rem(14px);
 			}
 		}
 
+		.sidebar__expandable-title,
+		.sidebar__menu-link-text {
+			max-height: 34px;
+		}
+
 		.sidebar .notice {
 			.notice__content,
 			.notice__action {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -197,7 +197,6 @@ $font-size: rem(14px);
 		.sidebar__expandable-title,
 		.sidebar__menu-link-text {
 			padding: $sidebar-item-padding;
-			max-height: 34px;
 			box-sizing: border-box;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Remove max-height from sidebar items to support multiline in some languages (like Spanish)

**Expanded sidebar** 
No max-height.

|BEFORE|AFTER|
|-|-|
|<img width="245" alt="Screenshot 2567-05-10 at 12 06 07" src="https://github.com/Automattic/wp-calypso/assets/1881481/ed825617-ed77-4c3e-9708-19cbea911f4d">|<img width="252" alt="Screenshot 2567-05-10 at 12 06 44" src="https://github.com/Automattic/wp-calypso/assets/1881481/6a6cbd0d-1b9a-4306-aa00-101141e2cfb5">|

**Collapsed sidebar** 
No changes.

|BEFORE|AFTER|
|-|-|
|<img width="62" alt="Screenshot 2567-05-14 at 11 25 19" src="https://github.com/Automattic/wp-calypso/assets/1881481/f591ec19-8985-44d7-ab78-fcfe26faf7a8">|<img width="62" alt="Screenshot 2567-05-14 at 11 25 19" src="https://github.com/Automattic/wp-calypso/assets/1881481/f591ec19-8985-44d7-ab78-fcfe26faf7a8">|


> [!Note]
> - It seems to happen only for atomic with `wpcom_classic_early_release`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch the interface language to Spanish from wordpress.com/me/account
* Access https://horizon.wordpress.com/plans/{ SITE } or `/domains/manage/{ SITE }`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
