### PR TITLE
Nav redesign: Use wpcom_admin_interface to determine the admin label and link

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -5,8 +5,7 @@ import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
-import { useSelector } from 'calypso/state';
-import { getSiteOption, getSiteHomeUrl } from 'calypso/state/sites/selectors';
+import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import SiteFavicon from '../../site-favicon';
 import { ItemData, ItemPreviewPaneHeaderExtraProps } from '../types';
 
@@ -33,20 +32,7 @@ export default function ItemPreviewPaneHeader( {
 
 	const focusRef = useRef< HTMLInputElement >( null );
 
-	const { adminLabel, adminUrl } = useSelector( ( state ) => {
-		const wpcomAdminInterface = getSiteOption( state, itemData.blogId, 'wpcom_admin_interface' );
-		if ( wpcomAdminInterface === 'wp-admin' ) {
-			return {
-				adminLabel: translate( 'WP Admin' ),
-				adminUrl: itemData.adminUrl,
-			};
-		}
-
-		return {
-			adminLabel: translate( 'My Home' ),
-			adminUrl: getSiteHomeUrl( state, itemData.blogId ),
-		};
-	} );
+	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
 
 	// Use useEffect to set the focus when the component mounts
 	useEffect( () => {

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -13,8 +13,7 @@ import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url';
 import getStatsUrl from 'calypso/state/selectors/get-stats-url';
 import getThemeInstallUrl from 'calypso/state/selectors/get-theme-install-url';
-import { getSiteHomeUrl, isSimpleSite } from 'calypso/state/sites/selectors';
-import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 interface ActionProps {
@@ -41,33 +40,25 @@ const QuickActionsCard: FC = () => {
 	const hasEnTranslation = useHasEnTranslation();
 	const site = useSelector( getSelectedSite );
 	const { data: activeThemeData } = useActiveThemeQuery( site?.ID || -1, !! site );
-	const {
-		editorUrl,
-		themeInstallUrl,
-		pluginInstallUrl,
-		statsUrl,
-		siteHomeUrl,
-		isSiteSimple,
-		siteAdminUrl,
-		siteEditorUrl,
-	} = useSelector( ( state ) => ( {
-		editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
-		themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
-		pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
-		statsUrl: getStatsUrl( state, site?.ID ) ?? '',
-		siteAdminUrl: getSiteAdminUrl( state, site?.ID ) ?? '',
-		siteHomeUrl: getSiteHomeUrl( state, site?.ID ) ?? '',
-		isSiteSimple: isSimpleSite( state, site?.ID ),
-		siteEditorUrl:
-			site?.ID && activeThemeData
-				? getCustomizeUrl(
-						state as object,
-						activeThemeData[ 0 ]?.stylesheet,
-						site?.ID,
-						activeThemeData[ 0 ]?.is_block_theme
-				  )
-				: '',
-	} ) );
+	const { editorUrl, themeInstallUrl, pluginInstallUrl, statsUrl, siteEditorUrl } = useSelector(
+		( state ) => ( {
+			editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
+			themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
+			pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
+			statsUrl: getStatsUrl( state, site?.ID ) ?? '',
+			siteEditorUrl:
+				site?.ID && activeThemeData
+					? getCustomizeUrl(
+							state as object,
+							activeThemeData[ 0 ]?.stylesheet,
+							site?.ID,
+							activeThemeData[ 0 ]?.is_block_theme
+					  )
+					: '',
+		} )
+	);
+
+	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( site?.ID );
 
 	return (
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
@@ -82,8 +73,8 @@ const QuickActionsCard: FC = () => {
 			<ul className="hosting-overview__actions-list">
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }
-					href={ isSiteSimple ? siteHomeUrl : siteAdminUrl }
-					text={ isSiteSimple ? translate( 'My Home' ) : translate( 'WP Admin' ) }
+					href={ adminUrl }
+					text={ adminLabel }
 				/>
 				<Action
 					icon={

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -16,7 +16,7 @@ import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link
 import { displaySiteUrl, isStagingSite, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
-import { getSiteHomeUrl, isSimpleSite } from 'calypso/state/sites/selectors';
+import { getSiteHomeUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -67,7 +67,9 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const title = __( 'View Site Details' );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site.ID ) ?? '' );
 	const siteHomeUrl = useSelector( ( state ) => getSiteHomeUrl( state, site.ID ) ?? '' );
-	const isSimple = useSelector( ( state ) => isSimpleSite( state, site.ID ) );
+	const isAdminInterfaceWPAdmin = useSelector(
+		( state ) => getSiteOption( state, site.ID, 'wpcom_admin_interface' ) === 'wp-admin'
+	);
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
@@ -129,9 +131,11 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 							</div>
 							<a
 								className="sites-dataviews__site-wp-admin-url"
-								href={ isSimple ? siteHomeUrl : siteAdminUrl }
+								href={ isAdminInterfaceWPAdmin ? siteAdminUrl : siteHomeUrl }
 							>
-								<Truncated>{ isSimple ? __( 'My Home' ) : __( 'WP Admin' ) }</Truncated>
+								<Truncated>
+									{ isAdminInterfaceWPAdmin ? __( 'WP Admin' ) : __( 'My Home' ) }
+								</Truncated>
 							</a>
 						</>
 					)

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -15,9 +15,8 @@ import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-
 import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link';
 import { displaySiteUrl, isStagingSite, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
+import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
-import { getSiteHomeUrl, getSiteOption } from 'calypso/state/sites/selectors';
-import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import type { SiteExcerptData } from '@automattic/sites';
 
 type Props = {
@@ -65,11 +64,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	}
 
 	const title = __( 'View Site Details' );
-	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site.ID ) ?? '' );
-	const siteHomeUrl = useSelector( ( state ) => getSiteHomeUrl( state, site.ID ) ?? '' );
-	const isAdminInterfaceWPAdmin = useSelector(
-		( state ) => getSiteOption( state, site.ID, 'wpcom_admin_interface' ) === 'wp-admin'
-	);
+	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( site.ID );
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
@@ -129,13 +124,8 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 							<div className="sites-dataviews__site-url">
 								<Truncated>{ displaySiteUrl( siteUrl ) }</Truncated>
 							</div>
-							<a
-								className="sites-dataviews__site-wp-admin-url"
-								href={ isAdminInterfaceWPAdmin ? siteAdminUrl : siteHomeUrl }
-							>
-								<Truncated>
-									{ isAdminInterfaceWPAdmin ? __( 'WP Admin' ) : __( 'My Home' ) }
-								</Truncated>
+							<a className="sites-dataviews__site-wp-admin-url" href={ adminUrl }>
+								<Truncated>{ adminLabel }</Truncated>
 							</a>
 						</>
 					)

--- a/client/state/sites/hooks/index.js
+++ b/client/state/sites/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useSelectedSiteSelector } from './use-selected-site-selector';
 export { default as useSiteOption } from './use-site-option';
+export { default as useSiteAdminInterfaceData } from './use-site-admin-interface-data';

--- a/client/state/sites/hooks/use-site-admin-interface-data.ts
+++ b/client/state/sites/hooks/use-site-admin-interface-data.ts
@@ -1,0 +1,31 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import getSiteAdminUrl from '../selectors/get-site-admin-url';
+import getSiteHomeUrl from '../selectors/get-site-home-url';
+import getSiteOption from '../selectors/get-site-option';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns the site admin interface data
+ */
+const useSiteAdminInterfaceData = ( siteId: number = 0 ) => {
+	const translate = useTranslate();
+	const wpcomAdminInterface = useSelector( ( state: AppState ) =>
+		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	);
+	const isWPAdmin = wpcomAdminInterface === 'wp-admin';
+	const adminLabel = isWPAdmin ? translate( 'WP Admin' ) : translate( 'My Home' );
+	const adminUrl =
+		useSelector( ( state: AppState ) =>
+			isWPAdmin ? getSiteAdminUrl( state, siteId ) : getSiteHomeUrl( state, siteId )
+		) ?? '';
+
+	return {
+		wpcomAdminInterface,
+		isWPAdmin,
+		adminLabel,
+		adminUrl,
+	};
+};
+
+export default useSiteAdminInterfaceData;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7055

## Proposed Changes

* Display `WP Admin` and link to `/wp-admin` if the `wpcom_admin_interface` is configured to `wp-admin`. 
* Otherwise, display `My Home` and link to `/home/:site`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Make sure you can see `WP Admin` below the site URL for the site with `wp-admin` interface and `My Home` for the sites with the `calypso` interface.
* Select the site with the `wp-admin` interface
* Make sure the primary CTA is `WP Admin`
* Make sure the first item under the Dashboard links is `WP Admin`
* Select the site with the `calypso` interface
* Make sure the primary CTA is `My Home`
* Make sure the first item under the Dashboard links is `My Home`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
