### PR TITLE
A4A: Marketplace|Products - Make product slider sticky on scroll

### DIFF
--- a/client/a8c-for-agencies/components/layout/top.tsx
+++ b/client/a8c-for-agencies/components/layout/top.tsx
@@ -5,9 +5,10 @@ import LayoutNavigation from './nav';
 type Props = {
 	children: ReactNode;
 	withNavigation?: boolean;
+	className?: string;
 };
 
-export default function LayoutTop( { children, withNavigation }: Props ) {
+export default function LayoutTop( { children, withNavigation, className }: Props ) {
 	const navigation = Children.toArray( children ).find(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( child: any ) => child.type === LayoutNavigation
@@ -15,7 +16,7 @@ export default function LayoutTop( { children, withNavigation }: Props ) {
 
 	return (
 		<div
-			className={ classNames( 'a4a-layout__top-wrapper', {
+			className={ classNames( 'a4a-layout__top-wrapper', className, {
 				'has-navigation': withNavigation || !! navigation,
 			} ) }
 		>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -19,6 +19,8 @@ import { ShoppingCartContext } from '../context';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import ProductListing from './product-listing';
+import { useProductBundleSize } from './product-listing/hooks/use-product-bundle-size';
+import VolumePriceSelector from './product-listing/volume-price-selector';
 import type { AssignLicenseProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -43,6 +45,12 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 	const sites = useSelector( getSites );
 
 	const showStickyContent = useBreakpoint( '>660px' ) && selectedCartItems.length > 0;
+
+	const {
+		selectedSize: quantity,
+		availableSizes: availableBundleSizes,
+		setSelectedSize: setSelectedBundleSize,
+	} = useProductBundleSize();
 
 	useEffect( () => {
 		if ( siteId && sites.length > 0 ) {
@@ -79,6 +87,14 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 					<Actions className="a4a-marketplace__header-actions">
 						<MobileSidebarNavigation />
 
+						{ availableBundleSizes.length > 1 && (
+							<VolumePriceSelector
+								selectedBundleSize={ quantity }
+								availableBundleSizes={ availableBundleSizes }
+								onBundleSizeChange={ setSelectedBundleSize }
+							/>
+						) }
+
 						<ShoppingCart
 							showCart={ showCart }
 							setShowCart={ setShowCart }
@@ -95,7 +111,11 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 
 			<LayoutBody>
 				<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
-					<ProductListing selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
+					<ProductListing
+						selectedSite={ selectedSite }
+						suggestedProduct={ suggestedProduct }
+						setSelectedBundleSize={ setSelectedBundleSize }
+					/>
 				</ShoppingCartContext.Provider>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -80,7 +80,7 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 			wide
 			withBorder
 		>
-			<LayoutTop>
+			<LayoutTop className="a4a-marketplace__products-top-wrapper">
 				<LayoutHeader showStickyContent={ showStickyContent }>
 					<Title>{ translate( 'Marketplace' ) } </Title>
 
@@ -109,7 +109,7 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>
+			<LayoutBody className="a4a-marketplace__products-body">
 				<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
 					<ProductListing
 						selectedSite={ selectedSite }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -296,55 +296,57 @@ export default function ProductListing( {
 					/>
 				</div>
 
-				{ wooExtensions.length > 0 && (
-					<ListingSection
-						id="woocommerce-extensions"
-						icon={ <WooLogo width={ 45 } height={ 28 } /> }
-						title={ translate( 'WooCommerce Extensions' ) }
-						description={ translate(
-							'You must have WooCommerce installed to utilize these paid extensions.'
-						) }
-					>
-						{ getProductCards( wooExtensions ) }
-					</ListingSection>
-				) }
+				<div className="product-listing__product-sections">
+					{ wooExtensions.length > 0 && (
+						<ListingSection
+							id="woocommerce-extensions"
+							icon={ <WooLogo width={ 45 } height={ 28 } /> }
+							title={ translate( 'WooCommerce Extensions' ) }
+							description={ translate(
+								'You must have WooCommerce installed to utilize these paid extensions.'
+							) }
+						>
+							{ getProductCards( wooExtensions ) }
+						</ListingSection>
+					) }
 
-				{ plans.length > 0 && (
-					<ListingSection
-						id="jetpack-plans"
-						icon={ <JetpackLogo size={ 26 } /> }
-						title={ translate( 'Jetpack Plans' ) }
-						description={ translate(
-							'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
-						) } // FIXME: Add proper description for A4A
-					>
-						{ getProductCards( plans ) }
-					</ListingSection>
-				) }
+					{ plans.length > 0 && (
+						<ListingSection
+							id="jetpack-plans"
+							icon={ <JetpackLogo size={ 26 } /> }
+							title={ translate( 'Jetpack Plans' ) }
+							description={ translate(
+								'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
+							) } // FIXME: Add proper description for A4A
+						>
+							{ getProductCards( plans ) }
+						</ListingSection>
+					) }
 
-				{ products.length > 0 && (
-					<ListingSection
-						icon={ <JetpackLogo size={ 26 } /> }
-						title={ translate( 'Jetpack Products' ) }
-						description={ translate(
-							'Mix and match powerful security, performance, and growth tools for your sites.'
-						) }
-					>
-						{ getProductCards( products ) }
-					</ListingSection>
-				) }
+					{ products.length > 0 && (
+						<ListingSection
+							icon={ <JetpackLogo size={ 26 } /> }
+							title={ translate( 'Jetpack Products' ) }
+							description={ translate(
+								'Mix and match powerful security, performance, and growth tools for your sites.'
+							) }
+						>
+							{ getProductCards( products ) }
+						</ListingSection>
+					) }
 
-				{ backupAddons.length > 0 && (
-					<ListingSection
-						icon={ <JetpackLogo size={ 26 } /> }
-						title={ translate( 'Jetpack VaultPress Backup Add-ons' ) }
-						description={ translate(
-							'Add additional storage to your current VaultPress Backup plans.'
-						) }
-					>
-						{ getProductCards( backupAddons ) }
-					</ListingSection>
-				) }
+					{ backupAddons.length > 0 && (
+						<ListingSection
+							icon={ <JetpackLogo size={ 26 } /> }
+							title={ translate( 'Jetpack VaultPress Backup Add-ons' ) }
+							description={ translate(
+								'Add additional storage to your current VaultPress Backup plans.'
+							) }
+						>
+							{ getProductCards( backupAddons ) }
+						</ListingSection>
+					) }
+				</div>
 			</div>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -28,9 +28,14 @@ import './style.scss';
 interface ProductListingProps {
 	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;
+	setSelectedBundleSize: ( value: number ) => void;
 }
 
-export default function ProductListing( { selectedSite, suggestedProduct }: ProductListingProps ) {
+export default function ProductListing( {
+	selectedSite,
+	suggestedProduct,
+	setSelectedBundleSize,
+}: ProductListingProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -38,11 +43,7 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 
 	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
 
-	const {
-		selectedSize: quantity,
-		availableSizes: availableBundleSizes,
-		setSelectedSize: setSelectedBundleSize,
-	} = useProductBundleSize();
+	const { selectedSize: quantity, availableSizes: availableBundleSizes } = useProductBundleSize();
 
 	const {
 		filteredProductsAndBundles,
@@ -273,16 +274,8 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 	}
 
 	return (
-		<div className="product-listing">
-			<QueryProductsList currency="USD" />
-
-			<div className="product-listing__actions">
-				<FilterSearch
-					label={ translate( 'Search plans, products, add-ons, and extensions' ) }
-					onSearch={ onProductSearch }
-					onClick={ trackClickCallback( 'search' ) }
-				/>
-
+		<>
+			<div className="product-listing__volume-price-selector-wrapper">
 				{ availableBundleSizes.length > 1 && (
 					<VolumePriceSelector
 						selectedBundleSize={ quantity }
@@ -292,55 +285,67 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 				) }
 			</div>
 
-			{ wooExtensions.length > 0 && (
-				<ListingSection
-					id="woocommerce-extensions"
-					icon={ <WooLogo width={ 45 } height={ 28 } /> }
-					title={ translate( 'WooCommerce Extensions' ) }
-					description={ translate(
-						'You must have WooCommerce installed to utilize these paid extensions.'
-					) }
-				>
-					{ getProductCards( wooExtensions ) }
-				</ListingSection>
-			) }
+			<div className="product-listing">
+				<QueryProductsList currency="USD" />
 
-			{ plans.length > 0 && (
-				<ListingSection
-					id="jetpack-plans"
-					icon={ <JetpackLogo size={ 26 } /> }
-					title={ translate( 'Jetpack Plans' ) }
-					description={ translate(
-						'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
-					) } // FIXME: Add proper description for A4A
-				>
-					{ getProductCards( plans ) }
-				</ListingSection>
-			) }
+				<div className="product-listing__actions">
+					<FilterSearch
+						label={ translate( 'Search plans, products, add-ons, and extensions' ) }
+						onSearch={ onProductSearch }
+						onClick={ trackClickCallback( 'search' ) }
+					/>
+				</div>
 
-			{ products.length > 0 && (
-				<ListingSection
-					icon={ <JetpackLogo size={ 26 } /> }
-					title={ translate( 'Jetpack Products' ) }
-					description={ translate(
-						'Mix and match powerful security, performance, and growth tools for your sites.'
-					) }
-				>
-					{ getProductCards( products ) }
-				</ListingSection>
-			) }
+				{ wooExtensions.length > 0 && (
+					<ListingSection
+						id="woocommerce-extensions"
+						icon={ <WooLogo width={ 45 } height={ 28 } /> }
+						title={ translate( 'WooCommerce Extensions' ) }
+						description={ translate(
+							'You must have WooCommerce installed to utilize these paid extensions.'
+						) }
+					>
+						{ getProductCards( wooExtensions ) }
+					</ListingSection>
+				) }
 
-			{ backupAddons.length > 0 && (
-				<ListingSection
-					icon={ <JetpackLogo size={ 26 } /> }
-					title={ translate( 'Jetpack VaultPress Backup Add-ons' ) }
-					description={ translate(
-						'Add additional storage to your current VaultPress Backup plans.'
-					) }
-				>
-					{ getProductCards( backupAddons ) }
-				</ListingSection>
-			) }
-		</div>
+				{ plans.length > 0 && (
+					<ListingSection
+						id="jetpack-plans"
+						icon={ <JetpackLogo size={ 26 } /> }
+						title={ translate( 'Jetpack Plans' ) }
+						description={ translate(
+							'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
+						) } // FIXME: Add proper description for A4A
+					>
+						{ getProductCards( plans ) }
+					</ListingSection>
+				) }
+
+				{ products.length > 0 && (
+					<ListingSection
+						icon={ <JetpackLogo size={ 26 } /> }
+						title={ translate( 'Jetpack Products' ) }
+						description={ translate(
+							'Mix and match powerful security, performance, and growth tools for your sites.'
+						) }
+					>
+						{ getProductCards( products ) }
+					</ListingSection>
+				) }
+
+				{ backupAddons.length > 0 && (
+					<ListingSection
+						icon={ <JetpackLogo size={ 26 } /> }
+						title={ translate( 'Jetpack VaultPress Backup Add-ons' ) }
+						description={ translate(
+							'Add additional storage to your current VaultPress Backup plans.'
+						) }
+					>
+						{ getProductCards( backupAddons ) }
+					</ListingSection>
+				) }
+			</div>
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -25,13 +25,42 @@ p.product-listing__description {
 	border-color: transparent;
 }
 
-.product-listing__volume-price-selector-wrapper,
 .product-listing__actions {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 16px;
-	margin: 16px 0 32px;
 	justify-content: space-between;
+	padding-inline: 64px;
+	padding-block-start: 16px;
+	align-items: center;
+	padding-block-end: 16px;
+	margin-block-end: 32px;
+}
+
+.product-listing__volume-price-selector-wrapper {
+	top: 0;
+	margin: 0;
+	z-index: 30;
+	position: sticky;
+	padding-inline: 64px;
+	padding-block-end: 16px;
+	background-color: var(--color-surface);
+	border-block-end: 1px solid var(--color-neutral-5);
+	display: none;
+}
+
+@media ( max-width: $break-xlarge ) {
+	.product-listing__volume-price-selector-wrapper {
+		display: block;
+	}
+
+	.main.a4a-layout.is-with-border .a4a-layout__top-wrapper.a4a-marketplace__products-top-wrapper {
+		border-block-end: 0;
+	}
+}
+
+.product-listing__product-sections {
+	padding-inline: 64px;
 }
 
 .select-dropdown.is-compact.product-listing__product-filter-select {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -25,6 +25,7 @@ p.product-listing__description {
 	border-color: transparent;
 }
 
+.product-listing__volume-price-selector-wrapper,
 .product-listing__actions {
 	display: flex;
 	flex-wrap: wrap;
@@ -88,5 +89,15 @@ p.product-listing__description {
 
 	@include break-medium {
 		min-width: 430px;
+	}
+}
+
+.a4a-layout__header .product-listing__volume-price-selector {
+	margin-inline-end: 50px;
+}
+
+@media ( max-width: $break-xlarge ) {
+	.a4a-layout__header .product-listing__volume-price-selector {
+		display: none;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
@@ -14,6 +14,20 @@
 	}
 }
 
+.a4a-marketplace__products-body.a4a-layout__body {
+	padding-block-start: 0;
+
+	.a4a-layout__body-wrapper {
+		padding-inline: 0;
+	}
+}
+
+.products-overview {
+	.a4a-layout__top-wrapper {
+		padding-block-end: 0 !important;
+	}
+}
+
 .products-overview .assign-license-step-progress {
 	margin-block-start: 16px;
 	margin-block-end: 32px;


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/451

## Proposed Changes

* This PR moves the bundle size selection slider to the page header, as requested in https://github.com/Automattic/automattic-for-agencies-dev/issues/451. The header's position remains unchanged, as it's already sticky, the slider also respects this behavior.

* When the screen size is not big enough to accommodate the slider within the header, it is moved down and remains  sticky.

## Testing Instructions

* Navigate to the products section of the Marketplace (`http://agencies.localhost:3000/marketplace/products`)
* Verify that the slider is positioned according to https://github.com/Automattic/automattic-for-agencies-dev/issues/451
* Verify that the slider is sticky
* Shrink down the page
* Verify that the slider always respects borders and does not overflow
* Verify that both sliders are in sync and always show the same bundle size

![image](https://github.com/Automattic/wp-calypso/assets/37049295/dd8c73e9-7adc-4699-9455-6e515fc44fab)

![image](https://github.com/Automattic/wp-calypso/assets/37049295/63367879-aabc-47ef-bb92-519675e9dd30)

![image](https://github.com/Automattic/wp-calypso/assets/37049295/fcc1a564-87f7-40f0-aaec-701ef90aa490)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
