### PR TITLE
Scheduled Updates: Trigger extra refresh after 5 seconds of submission

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -199,7 +199,7 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit }: Props ) => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'multisite-schedules-update' ],
 			} );
-		}, 5000 ); // 5000 milliseconds = 5 seconds
+		}, 5000 );
 	};
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
@@ -31,6 +32,7 @@ type InitialData = {
 };
 
 export const ScheduleForm = ( { onNavBack, scheduleForEdit }: Props ) => {
+	const queryClient = useQueryClient();
 	const initialData: InitialData = scheduleForEdit
 		? {
 				sites: scheduleForEdit?.sites.map( ( site ) => site.ID ),
@@ -192,6 +194,12 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit }: Props ) => {
 		// Create monitors for sites that have been successfully scheduled
 		createMonitors( successfulSiteSlugs );
 		onNavBack && onNavBack();
+		// Trigger an extra refetch 5 seconds later
+		setTimeout( () => {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'multisite-schedules-update' ],
+			} );
+		}, 5000 ); // 5000 milliseconds = 5 seconds
 	};
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -42,6 +42,7 @@ export const ScheduleList = ( props: Props ) => {
 		data: schedules = [],
 		isLoading: isLoadingSchedules,
 		isFetched,
+		refetch,
 	} = useMultisiteUpdateScheduleQuery( true );
 	const translate = useTranslate();
 	const { searchTerm } = useContext( MultisitePluginUpdateManagerContext );
@@ -57,7 +58,14 @@ export const ScheduleList = ( props: Props ) => {
 	}, [ selectedScheduleId ] );
 	useEffect( () => setSelectedScheduleId( initSelectedScheduleId ), [ initSelectedScheduleId ] );
 
-	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation( selectedSiteSlugs );
+	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation( selectedSiteSlugs, {
+		onSuccess: () => {
+			// Refetch again after 5 seconds
+			setTimeout( () => {
+				refetch();
+			}, 5000 );
+		},
+	} );
 
 	const openRemoveDialog = ( id: string ) => {
 		setRemoveDialogOpen( true );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90542

## Proposed Changes

* On multi-site level, sometimes the list is not up to date after the submission immediately because of Jetpack sync. In the PR, we'll do an extra query 5 seconds after the submission is done to make sure users gets the latest schedules correctly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates`
* Try to create/edit/delete schedules and make sure you get the up-to-date list after the submission. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
