### PR TITLE
E2E: Revert to draft - close settings panel which was intercepting pointer events

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -764,14 +764,27 @@ export class EditorPage {
 	async unpublish(): Promise< void > {
 		const editorParent = await this.editor.parent();
 		await this.editorToolbarComponent.switchToDraft();
+
+		// For mobiles, we need to dismiss the settings panel before we can click on publish
+		await this.closeSettings();
+
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
 		// Saves the draft
-		await Promise.race( [
-			this.editorToolbarComponent.clickPublish(),
-			editorParent.getByRole( 'button' ).getByText( 'OK' ).click(),
-		] );
+		await Promise.race( [ this.editorToolbarComponent.clickPublish(), this.confirmUnpublish() ] );
 		// @TODO: eventually refactor this out to a EditorToastNotificationComponent.
 		await editorParent.getByRole( 'button', { name: 'Dismiss this notice' } ).waitFor();
+	}
+
+	/**
+	 * Confirms the unpublish action in some views
+	 */
+	async confirmUnpublish(): Promise< void > {
+		const editorParent = await this.editor.parent();
+		const okButtonLocator = editorParent.getByRole( 'button' ).getByText( 'OK' );
+
+		if ( await okButtonLocator.count() ) {
+			okButtonLocator.click();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fix failed switch to draft test, due to the settings panel which overlayed the publish button

This is currently breaking some nightly e2e tests for Gutenberg. This change modifies the e2e's expectations to fit the new realities.

Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

Run the editor schedule flow e2e edge tests, which was failing before this fix:

```bash
cd test/e2e
yarn jest --clearCache && yarn build  # clear build cache before each run


yarn jest specs/editor/editor__post-advanced-flow.ts  
VIEWPORT_NAME=mobile yarn jest specs/editor/editor__post-advanced-flow.ts 
```