### PR TITLE
Add scheduled update not-run placeholder

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status.tsx
@@ -18,6 +18,10 @@ export function ScheduleListLastRunStatus( { schedule, site, onLogsClick }: Prop
 	const { prepareDateTime } = useDateTimeFormat();
 
 	if ( site ) {
+		if ( ! site.last_run_status ) {
+			return '-';
+		}
+
 		return (
 			<>
 				<Badge type={ site.last_run_status } />
@@ -48,7 +52,7 @@ export function ScheduleListLastRunStatus( { schedule, site, onLogsClick }: Prop
 	).length;
 
 	if ( ! hasRun ) {
-		return null;
+		return '-';
 	}
 
 	if ( isInProgress ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/90549

## Proposed Changes

* Add a placeholder `-` sign when not running statuses are found.



## Testing Instructions

1. Open http://calypso.localhost:3000/plugins/scheduled-updates
2. Create a new scheduler update. It should appear with a `-` sign.
3. Add a new scheduler site to a preexisting scheduler update. It should appear with a `-` sign.

![image](https://github.com/Automattic/wp-calypso/assets/167611/74494b2c-372d-415a-bc3f-56eff424e17a)
![image](https://github.com/Automattic/wp-calypso/assets/167611/bd522ee5-0249-4820-b066-d5ddf7f33145)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?