### PR TITLE
Scheduled updates: Add schedule activation toggle control

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-cards.tsx
@@ -1,6 +1,7 @@
-import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
+import { Button, DropdownMenu, FormToggle, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useScheduledUpdatesActionMutation } from 'calypso/data/plugins/use-scheduled-updates-action-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { Badge } from '../plugin-scheduled-updates-common/badge';
 import { useDateTimeFormat } from '../plugin-scheduled-updates-common/hooks/use-date-time-format';
@@ -25,6 +26,7 @@ export const ScheduleListCards = ( props: Props ) => {
 		usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat( siteSlug );
+	const { activateSchedule } = useScheduledUpdatesActionMutation( siteSlug );
 
 	return (
 		<div className="schedule-list--cards">
@@ -108,6 +110,16 @@ export const ScheduleListCards = ( props: Props ) => {
 							>
 								<Icon className="icon-info" icon={ info } size={ 16 } />
 							</Tooltip>
+						</span>
+					</div>
+
+					<div className="schedule-list--card-label">
+						<label htmlFor="active">{ translate( 'Active' ) }</label>
+						<span id="active">
+							<FormToggle
+								checked={ schedule.active }
+								onChange={ ( e ) => activateSchedule( schedule.id, { active: e.target.checked } ) }
+							/>
 						</span>
 					</div>
 				</div>

--- a/client/blocks/plugins-scheduled-updates/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-cards.tsx
@@ -30,7 +30,7 @@ export const ScheduleListCards = ( props: Props ) => {
 
 	return (
 		<div className="schedule-list--cards">
-			{ schedules.map( ( schedule ) => (
+			{ schedules.map( ( schedule, i ) => (
 				<div className="schedule-list--card" key={ schedule.id }>
 					<DropdownMenu
 						className="schedule-list--card-actions"
@@ -53,8 +53,8 @@ export const ScheduleListCards = ( props: Props ) => {
 					/>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="name">{ translate( 'Name' ) }</label>
-						<strong id="name">
+						<label htmlFor={ `name-${ i }` }>{ translate( 'Name' ) }</label>
+						<strong id={ `name-${ i }` }>
 							<Button
 								className="schedule-name"
 								variant="link"
@@ -66,8 +66,8 @@ export const ScheduleListCards = ( props: Props ) => {
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="last-update">{ translate( 'Last update' ) }</label>
-						<span id="last-update">
+						<label htmlFor={ `last-update-${ i }` }>{ translate( 'Last update' ) }</label>
+						<span id={ `last-update-${ i }` }>
 							{ schedule.last_run_timestamp && (
 								<Button
 									className="schedule-last-run"
@@ -82,13 +82,13 @@ export const ScheduleListCards = ( props: Props ) => {
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
-						<span id="next-update">{ prepareDateTime( schedule.timestamp ) }</span>
+						<label htmlFor={ `next-update-${ i }` }>{ translate( 'Next update' ) }</label>
+						<span id={ `next-update-${ i }` }>{ prepareDateTime( schedule.timestamp ) }</span>
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="frequency">{ translate( 'Frequency' ) }</label>
-						<span id="frequency">
+						<label htmlFor={ `frequency-${ i }` }>{ translate( 'Frequency' ) }</label>
+						<span id={ `frequency-${ i }` }>
 							{
 								{
 									daily: translate( 'Daily' ),
@@ -99,8 +99,8 @@ export const ScheduleListCards = ( props: Props ) => {
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="plugins">{ translate( 'Plugins' ) }</label>
-						<span id="plugins">
+						<label htmlFor={ `plugins-${ i }` }>{ translate( 'Plugins' ) }</label>
+						<span id={ `plugins-${ i }` }>
 							{ countInstalledPlugins( schedule.args ) }
 							<Tooltip
 								text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }
@@ -114,8 +114,8 @@ export const ScheduleListCards = ( props: Props ) => {
 					</div>
 
 					<div className="schedule-list--card-label">
-						<label htmlFor="active">{ translate( 'Active' ) }</label>
-						<span id="active">
+						<label htmlFor={ `active-${ i }` }>{ translate( 'Active' ) }</label>
+						<span id={ `active-${ i }` }>
 							<FormToggle
 								checked={ schedule.active }
 								onChange={ ( e ) => activateSchedule( schedule.id, { active: e.target.checked } ) }

--- a/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
@@ -1,6 +1,7 @@
-import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
+import { Button, DropdownMenu, Tooltip, FormToggle } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useScheduledUpdatesActionMutation } from 'calypso/data/plugins/use-scheduled-updates-action-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { Badge } from '../plugin-scheduled-updates-common/badge';
 import { useDateTimeFormat } from '../plugin-scheduled-updates-common/hooks/use-date-time-format';
@@ -26,6 +27,7 @@ export const ScheduleListTable = ( props: Props ) => {
 		usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat( siteSlug );
+	const { activateSchedule } = useScheduledUpdatesActionMutation( siteSlug );
 
 	/**
 	 * NOTE: If you update the table structure,
@@ -40,6 +42,7 @@ export const ScheduleListTable = ( props: Props ) => {
 					<th>{ translate( 'Next update' ) }</th>
 					<th>{ translate( 'Frequency' ) }</th>
 					<th>{ translate( 'Plugins' ) }</th>
+					<th>{ translate( 'Active' ) }</th>
 					<th></th>
 				</tr>
 			</thead>
@@ -98,6 +101,12 @@ export const ScheduleListTable = ( props: Props ) => {
 									<Icon className="icon-info" icon={ info } size={ 16 } />
 								</Tooltip>
 							) }
+						</td>
+						<td>
+							<FormToggle
+								checked={ schedule.active }
+								onChange={ ( e ) => activateSchedule( schedule.id, { active: e.target.checked } ) }
+							/>
 						</td>
 						<td style={ { textAlign: 'end' } }>
 							<DropdownMenu

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -103,6 +103,17 @@
 		color: var(--studio-gray-60);
 	}
 
+	.components-form-toggle {
+		.components-form-toggle__track {
+			border-color: var(--color-text) !important;
+			background-color: var(--color-text) !important;
+		}
+
+		.components-form-toggle__thumb {
+			background-color: #fff !important;
+		}
+	}
+
 	table {
 		th,
 		td {

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -164,6 +164,10 @@
 		.badge-component {
 			margin-inline-start: 0.5rem;
 		}
+
+		.components-form-toggle {
+			margin-top: 0.125rem;
+		}
 	}
 
 	.components-card__footer {

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -106,12 +106,18 @@
 	.components-form-toggle {
 		.components-form-toggle__track {
 			border-color: var(--color-text) !important;
-			background-color: var(--color-text) !important;
 		}
 
-		.components-form-toggle__thumb {
-			background-color: #fff !important;
+		&.is-checked {
+			.components-form-toggle__track {
+				background-color: var(--color-text) !important;
+			}
+
+			.components-form-toggle__thumb {
+				background-color: #fff !important;
+			}
 		}
+
 	}
 
 	table {

--- a/client/data/plugins/use-scheduled-updates-action-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-action-mutation.ts
@@ -1,0 +1,63 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
+import type { SiteSlug } from 'calypso/types';
+
+export type ActiveRequestParams = {
+	active: boolean;
+};
+
+export function useScheduledUpdatesActionMutation( siteSlug: SiteSlug, queryOptions = {} ) {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation( {
+		mutationKey: [ 'scheduled-updates-active', siteSlug ],
+		mutationFn: ( data: { scheduleId: string; params: ActiveRequestParams } ) => {
+			const { scheduleId, params } = data;
+
+			return wpcomRequest( {
+				path: `/sites/${ siteSlug }/update-schedules/${ scheduleId }/active`,
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+				body: params,
+			} );
+		},
+		onMutate: async ( data: { scheduleId: string; params: ActiveRequestParams } ) => {
+			const { scheduleId, params } = data;
+			// cancel in-flight queries because we don't want them to overwrite our optimistic update.
+			await queryClient.cancelQueries( {
+				queryKey: [ 'schedule-updates', siteSlug ],
+			} );
+
+			const prevSchedules: ScheduleUpdates[] =
+				queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
+
+			const newSchedules = prevSchedules.map( ( x ) => {
+				if ( x.id === scheduleId ) {
+					return { ...x, active: params.active };
+				}
+				return x;
+			} );
+
+			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], newSchedules );
+
+			return { prevSchedules };
+		},
+		onError: ( err, params, context ) =>
+			// Set previous value on error
+			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], context?.prevSchedules ),
+		onSettled: () =>
+			// Re-fetch after error or success
+			queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } ),
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const activateSchedule = useCallback(
+		( scheduleId: string, params: ActiveRequestParams ) => mutate( { scheduleId, params } ),
+		[ mutate ]
+	);
+
+	return { activateSchedule, ...mutation };
+}

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -25,6 +25,7 @@ export type ScheduleUpdates = {
 	last_run_status: LastRunStatus;
 	last_run_timestamp: number | null;
 	health_check_paths?: string[];
+	active: boolean;
 };
 
 export type MultisiteSiteDetails = SiteDetails & {

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -120,8 +120,15 @@ export const useMultisiteUpdateScheduleQuery = (
 
 			for ( const site_id in data.sites ) {
 				for ( const scheduleId in data.sites[ site_id ] ) {
-					const { timestamp, schedule, args, interval, last_run_timestamp, last_run_status } =
-						data.sites[ site_id ][ scheduleId ];
+					const {
+						timestamp,
+						schedule,
+						args,
+						interval,
+						last_run_timestamp,
+						last_run_status,
+						active,
+					} = data.sites[ site_id ][ scheduleId ];
 
 					const id = generateId( scheduleId, timestamp, schedule, interval );
 
@@ -145,6 +152,7 @@ export const useMultisiteUpdateScheduleQuery = (
 							schedule,
 							args,
 							interval,
+							active,
 							sites: [
 								{
 									...site,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90264

## Proposed Changes

* Adds FormToggle control for the schedule activation and deactivation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to site specific scheduled updates page `/plugins/scheduled-updates/{SITE_SLUG}`
* Toggle active toggle form control
* Check if it activates/deactivates

![Screen Capture on 2024-05-10 at 11-03-04](https://github.com/Automattic/wp-calypso/assets/1241413/dda61863-03b0-401f-99d2-1894705e10c4)

<img width="421" alt="Screenshot 2024-05-10 at 12 09 06" src="https://github.com/Automattic/wp-calypso/assets/1241413/2032ff5f-6282-4500-be21-2b318e522bad">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
