### PR TITLE
Increase timeout for unit tests to 10 mins

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -481,7 +481,7 @@ object RunAllUnitTests : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 8
+		executionTimeoutMin = 10
 	}
 	features {
 		feature {


### PR DESCRIPTION
With the recent changes and memory limiting for Jest, the tests are a bit slower.