### PR TITLE
Nav redesign: show Hosting -> Overview submenu in Calypso

### DIFF
--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -93,10 +93,12 @@ export const MySitesSidebarUnifiedMenu = ( {
 	};
 
 	const shouldForceShowExternalIcon = ( item ) => {
+		if ( ! isUnifiedSiteSidebarVisible ) {
+			return false;
+		}
 		return (
-			isUnifiedSiteSidebarVisible &&
-			item?.parent === 'jetpack' &&
-			item?.url?.startsWith( 'https://jetpack.com' )
+			( item?.parent === 'jetpack' && item?.url?.startsWith( 'https://jetpack.com' ) ) ||
+			( item?.parent === 'wpcom-hosting-menu' && item?.url?.startsWith( '/hosting/' ) )
 		);
 	};
 

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -153,16 +153,39 @@ const useSiteMenuItems = () => {
 	const result = menuItemsWithNewsletterSettings ?? buildFallbackResponse( fallbackDataOverrides );
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		// TODO: After the flag is enabled, the following logic can be reimplemented in jetpack-mu-wpcom
+		// and removed from Calypso.
+		// See: https://github.com/Automattic/dotcom-forge/issues/7066
+
 		return result.map( ( menu ) => {
 			if ( menu.slug === 'wpcom-hosting-menu' && Array.isArray( menu.children ) ) {
+				// Remove Hosting -> {Configuration, Monitoring}
+				let children = menu.children.filter(
+					( menuItem ) =>
+						! [ '/hosting-config/', '/site-monitoring' ].some( ( path ) =>
+							menuItem.url.startsWith( path )
+						)
+				);
+
+				// Insert Hosting -> Overview
+				const pos = 1;
+				if ( children.length > pos && ! children[ pos ].url.startsWith( '/hosting/' ) ) {
+					children = [
+						...children.splice( 0, pos ),
+						{
+							parent: menu.slug,
+							slug: 'hosting-overview',
+							title: translate( 'Overview' ),
+							type: 'submenu-item',
+							url: `/hosting/${ siteDomain }`,
+						},
+						...children.splice( pos ),
+					];
+				}
+
 				return {
 					...menu,
-					children: menu.children.filter(
-						( menuItem ) =>
-							! [ '/hosting-config/', '/site-monitoring' ].some( ( path ) =>
-								menuItem.url.startsWith( path )
-							)
-					),
+					children,
 				};
 			}
 			return menu;


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6874

## Proposed Changes

This PR adds the new Hosting -> Overview submenu on Calypso side.

This logic will not be necessary after we remove the proxy check in:

- https://github.com/Automattic/wpcomsh/pull/1850

, and should be migrated to `jetpack-mu-wpcom`. See:

- https://github.com/Automattic/dotcom-forge/issues/7066

## Testing Instructions

1. Open `/home/:site` of an early classic Atomic site.
2. Verify you can see the `Overview` submenu under `Hosting`:

<img width="136" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/349575f5-b8b6-4d04-ba51-c02d553e07b2">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
