### PR TITLE
Sites list: Update color of P2 badges

### DIFF
--- a/client/sites-dashboard/components/sites-p2-badge.tsx
+++ b/client/sites-dashboard/components/sites-p2-badge.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 
 const SitesP2Badge = styled( SitesLaunchStatusBadge )`
-	color: #fff;
-	background-color: #2b65f6;
+	color: #3858e9;
+	background-color: #e3e8fc;
 `;
 
 export default SitesP2Badge;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7036

## Proposed Changes

Changes the color of the P2 badges in the Sites list screen to a lighter blue so it doesn't compete with CTAs.

Before | After
--- | ---
<img width="327" alt="Screenshot 2024-05-10 at 12 04 59" src="https://github.com/Automattic/wp-calypso/assets/1233880/4a730225-a817-473b-8a77-3cf6bda9d32d"> | <img width="326" alt="Screenshot 2024-05-10 at 12 06 57" src="https://github.com/Automattic/wp-calypso/assets/1233880/0c650cd2-4a1f-4e87-9e93-8875b6762fc6">


## Testing Instructions

- Use the Calypso live link below
- Go to `/sites`
- Make sure the P2 badges use a lighter blue now