### PR TITLE
Site management panel: Handle plan expiration

### DIFF
--- a/client/dev-tools-promo/index.tsx
+++ b/client/dev-tools-promo/index.tsx
@@ -9,7 +9,7 @@ import { devToolsPromo } from './controller';
 const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) => {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
-	if ( site && site.jetpack ) {
+	if ( site && site.jetpack && ! site.plan?.expired ) {
 		return page.redirect( `/hosting/${ context.params.site }` );
 	}
 	return next();

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -116,10 +116,10 @@ const PlanCard: FC = () => {
 						) : (
 							<div
 								className={ classNames( 'hosting-overview__plan-info', {
-									'is-expired': site.plan?.expired,
+									'is-expired': site?.plan?.expired,
 								} ) }
 							>
-								{ site.plan?.expired
+								{ site?.plan?.expired
 									? translate( 'Expired' )
 									: translate( 'Expires on %s.', {
 											args: moment( planData?.expiryDate ).format( 'LL' ),

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -114,10 +114,16 @@ const PlanCard: FC = () => {
 								height="16px"
 							/>
 						) : (
-							<div className="hosting-overview__plan-info">
-								{ translate( 'Expires on %s.', {
-									args: moment( planData?.expiryDate ).format( 'LL' ),
+							<div
+								className={ classNames( 'hosting-overview__plan-info', {
+									'is-expired': site.plan?.expired,
 								} ) }
+							>
+								{ site.plan?.expired
+									? translate( 'Expired' )
+									: translate( 'Expires on %s.', {
+											args: moment( planData?.expiryDate ).format( 'LL' ),
+									  } ) }
 							</div>
 						) }
 					</>

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -159,6 +159,10 @@ a.hosting-overview__link-button {
 	font-size: $font-body-extra-small;
 	line-height: 16px;
 	margin-bottom: 4px;
+
+	&.is-expired {
+		color: #ea303f;
+	}
 }
 
 .hosting-overview__plan-info-loading-placeholder {

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -41,7 +41,7 @@ const DotcomPreviewPane = ( {
 
 	const isAtomicSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
 	const isSimpleSite = ! site.jetpack;
-	const isPlanExpired = site.plan?.expired;
+	const isPlanExpired = !! site.plan?.expired;
 
 	const features = useMemo(
 		() => [

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -41,6 +41,7 @@ const DotcomPreviewPane = ( {
 
 	const isAtomicSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
 	const isSimpleSite = ! site.jetpack;
+	const isPlanExpired = site.plan?.expired;
 
 	const features = useMemo(
 		() => [
@@ -57,7 +58,7 @@ const DotcomPreviewPane = ( {
 				<span>
 					{ __( 'Dev Tools' ) } <DevToolsIcon />
 				</span>,
-				isSimpleSite,
+				isSimpleSite || isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview
@@ -65,7 +66,7 @@ const DotcomPreviewPane = ( {
 			createFeaturePreview(
 				DOTCOM_HOSTING_CONFIG,
 				__( 'Hosting Config' ),
-				isAtomicSite,
+				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview
@@ -73,7 +74,7 @@ const DotcomPreviewPane = ( {
 			createFeaturePreview(
 				DOTCOM_MONITORING,
 				__( 'Monitoring' ),
-				isAtomicSite,
+				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview
@@ -81,7 +82,7 @@ const DotcomPreviewPane = ( {
 			createFeaturePreview(
 				DOTCOM_PHP_LOGS,
 				__( 'PHP Logs' ),
-				isAtomicSite,
+				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview
@@ -89,7 +90,7 @@ const DotcomPreviewPane = ( {
 			createFeaturePreview(
 				DOTCOM_SERVER_LOGS,
 				__( 'Server Logs' ),
-				isAtomicSite,
+				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview
@@ -97,13 +98,21 @@ const DotcomPreviewPane = ( {
 			createFeaturePreview(
 				DOTCOM_GITHUB_DEPLOYMENTS,
 				__( 'GitHub Deployments' ),
-				isAtomicSite,
+				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview
 			),
 		],
-		[ selectedSiteFeature, setSelectedSiteFeature, selectedSiteFeaturePreview, site ]
+		[
+			__,
+			selectedSiteFeature,
+			setSelectedSiteFeature,
+			selectedSiteFeaturePreview,
+			isSimpleSite,
+			isPlanExpired,
+			isAtomicSite,
+		]
 	);
 
 	const itemData: ItemData = {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7052

## Proposed Changes

Updates the site management panel to better reflect that a plan has expired:
- Show the "Dev tools" tab instead of the dev tabs
- Display a "Expired" text in red in the plan card

Before | After
--- | ---
<img width="1254" alt="Screenshot 2024-05-10 at 12 31 18" src="https://github.com/Automattic/wp-calypso/assets/1233880/2984ee99-3a8f-46d5-ad7c-06fc23888bc9"> | <img width="1244" alt="Screenshot 2024-05-10 at 12 38 05" src="https://github.com/Automattic/wp-calypso/assets/1233880/7e3c1130-6de3-430e-a9c7-2e4a0c47e938">


## Testing Instructions

- Make sure you have an Atomic site with the plan expired (note that you can use the Store Admin to change the plan expiration date)
- Use the Calypso live link below
- Go to `/hosting/:site`
- Make sure the plan card contains a "Expired" note using a red color
- Make sure you no longer see dev tabs such as Hosting Config, Monitoring, etc
- Make sure the "Dev Tools" tab is displayed instead
- Make sure you can access the "Dev Tools" tab