### PR TITLE
Nav redesign - update styles to dashboard headers

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -185,7 +185,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			}
 		`;
 	const item = {
-		label: translate( 'All Domains' ),
+		label: translate( 'Domains' ),
 		subtitle: translate(
 			'Manage all your domains. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 			{

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -75,6 +75,10 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					.formatted-header {
 						max-height: 41px;
 					}
+					
+					.navigation-header__main {
+						align-items: center;
+					}
 
 					.formatted-header__title {
 						color: var( --studio-gray-80, #2c3338 );
@@ -138,7 +142,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				@media only screen and ( max-width: 600px ) {
 					.navigation-header__main {
 						justify-content: normal;
-						align-items: center;
 						.formatted-header {
 							flex: none;
 						}
@@ -186,14 +189,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 		`;
 	const item = {
 		label: translate( 'Domains' ),
-		subtitle: translate(
-			'Manage all your domains. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-			{
-				components: {
-					learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
-				},
-			}
-		),
 		helpBubble: translate(
 			'Manage all your domains. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 			{

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -6,6 +6,22 @@
 // Add new Dotcom specific styles to this file.
 .wpcom-site .layout__primary .main {
 	padding-bottom: 0;
+
+	.navigation-header__main {
+		align-items: center !important;
+
+		.formatted-header__subtitle {
+			display: none; // Hide the subtitle on the main site list page.
+		}
+	}
+
+	.a4a-layout__header {
+		align-items: center !important;
+
+		.a4a-layout__header-subtitle {
+			display: none; // Hide the subtitle on the main site list page.
+		}
+	}
 }
 
 .wpcom-site .a4a-layout-with-columns__container {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -6,22 +6,6 @@
 // Add new Dotcom specific styles to this file.
 .wpcom-site .layout__primary .main {
 	padding-bottom: 0;
-
-	.navigation-header__main {
-		align-items: center !important;
-
-		.formatted-header__subtitle {
-			display: none; // Hide the subtitle on the main site list page.
-		}
-	}
-
-	.a4a-layout__header {
-		align-items: center !important;
-
-		.a4a-layout__header-subtitle {
-			display: none; // Hide the subtitle on the main site list page.
-		}
-	}
 }
 
 .wpcom-site .a4a-layout-with-columns__container {
@@ -45,10 +29,7 @@
 	}
 
 	.a4a-layout__header {
-		align-items: initial;
-		@media ( max-width: 660px ) {
-			align-items: center;
-		}
+		align-items: center;
 	}
 
 	.a4a-layout__header-main {

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -20,11 +20,9 @@ import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 	LayoutHeaderTitle as Title,
-	LayoutHeaderSubtitle as Subtitle,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import DocumentHead from 'calypso/components/data/document-head';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import {
 	SitesDashboardQueryParams,
@@ -243,12 +241,6 @@ const SitesDashboardV2 = ( {
 					<LayoutTop withNavigation={ false }>
 						<LayoutHeader>
 							{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
-							<Subtitle>
-								{ translate( 'Manage all your sites' ) }
-								{ '. ' }
-								<InlineSupportLink supportPostId="230679" showIcon={ false } />.
-							</Subtitle>
-
 							<Actions>
 								<SitesDashboardHeader />
 							</Actions>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7068

## Proposed Changes

* Updates "All Domains" -> "Domains"
* Removes the subtitles. 
* Aligns the titles along center

## Before

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/efd41a84-a2c3-4b33-98c7-3a6159a72fe8)

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/d2926423-cbb5-479c-a52f-04c01609dd78)

## After

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/3b8b3612-7f5c-4631-84b9-c7a9ec4a98e5)

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/42da9473-341d-423e-8d69-07fcc249eb22)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check if calypso.live site has the changes noted above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
