### PR TITLE
A4A: Fix the issue with the WPCOM plan volume slider breaking when currently owned sites are below the minimum discount bracket.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -10,15 +10,29 @@ const wpcomBulkOptions = (
 				value: 1,
 				label: '1',
 				discount: 0,
+				sub: '',
 			},
 		];
 	}
-	return discountOptions.map( ( option ) => ( {
+
+	const options = discountOptions.map( ( option ) => ( {
 		value: option.quantity || 1,
 		label: option.quantity ? `${ option.quantity }` : '1',
 		sub: option.discount_percent ? `${ Math.floor( option.discount_percent * 100 ) }%` : '',
 		discount: option.discount_percent ? option.discount_percent : 0,
 	} ) );
+
+	if ( options[ 0 ].value !== 1 ) {
+		// We need to make sure that the first option is always 1 to allow user to purchase a single site.
+		options.unshift( {
+			value: 1,
+			label: '1',
+			discount: 0,
+			sub: '',
+		} );
+	}
+
+	return options;
 };
 
 export default wpcomBulkOptions;


### PR DESCRIPTION
There is a bug with the volume slider breaking due to the recent change in the discount bracket. It turns out that the endpoint no longer includes quantity 1 in the data, which breaks the volume slider. To prevent this issue and make the slider more robust, we need to make sure quantity 1 is always available as an option.

| Before | After |
|--------|--------|
| <img width="860" alt="Screenshot 2024-05-10 at 7 17 22 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/277a3b7b-2b16-4e61-8497-4586c4365831"> | <img width="865" alt="Screenshot 2024-05-10 at 7 30 57 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9fecf5cc-47b6-4755-8fd1-6bb8e909bc1a"> | 


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/468

## Proposed Changes

* Update the `wpcomBulkOptions` helper function to ensure a quantity of 1 is always an option.

## Testing Instructions

* Make sure that you do not own any WPCOM plan. Please revoke your licenses on the Licenses page before testing.
* Use the A4A live link and go to `/marketplace/hosting/wpcom`.
* Confirm that the slider is not broken. 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?