### PR TITLE
Scheduled Updates: fix Route already set up warning

### DIFF
--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -155,22 +155,37 @@ export default function ( router ) {
 			makeLayout,
 			clientRender
 		);
-	}
 
-	router(
-		[
-			`/${ langParam }/plugins/scheduled-updates/:site_slug?`,
-			`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?`,
-			`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?/:schedule_id`,
-		],
-		redirectLoggedOut,
-		siteSelection,
-		redirectIfCurrentUserCannot( 'update_plugins' ),
-		navigation,
-		scheduledUpdates,
-		makeLayout,
-		clientRender
-	);
+		router(
+			[
+				`/${ langParam }/plugins/scheduled-updates/:site_slug`,
+				`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?`,
+				`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?/:schedule_id`,
+			],
+			redirectLoggedOut,
+			siteSelection,
+			redirectIfCurrentUserCannot( 'update_plugins' ),
+			navigation,
+			scheduledUpdates,
+			makeLayout,
+			clientRender
+		);
+	} else {
+		router(
+			[
+				`/${ langParam }/plugins/scheduled-updates/:site_slug?`,
+				`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?`,
+				`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?/:schedule_id`,
+			],
+			redirectLoggedOut,
+			siteSelection,
+			redirectIfCurrentUserCannot( 'update_plugins' ),
+			navigation,
+			scheduledUpdates,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	// This rule needs to preceed the one below, to work
 	// when the site_id parameter is omitted.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90434

## Proposed Changes

* Make the site_slug explicitly required for the single site route. 

I opted to do this only when the feature flag is set. When removing the feature flag we can just remove the else completely.


## Testing Instructions

1. Restart Calypso
2. Make sure there are no warning
3. Make sure you can still reach all routes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
