### PR TITLE
Site Profiler: updates migration cta to new flow.

### DIFF
--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -51,7 +51,7 @@ export default function HeadingInformation( props: Props ) {
 	const onMigrateSite = () => {
 		recordCtaEvent( 'migrateSite' );
 		page(
-			`/setup/new-hosted-site-flow?ref=site-profiler&section=heading-information&from=${ domain }`
+			`/setup/new-hosted-site/plans?ref=site-profiler&section=heading-information&from=${ domain }`
 		);
 	};
 

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -50,7 +50,9 @@ export default function HeadingInformation( props: Props ) {
 
 	const onMigrateSite = () => {
 		recordCtaEvent( 'migrateSite' );
-		page( `/setup/import-hosted-site?from=${ domain }` );
+		page(
+			`/setup/new-hosted-site-flow?ref=site-profiler&section=heading-information&from=${ domain }`
+		);
 	};
 
 	const onLearnMoreHosting = () => {
@@ -152,7 +154,7 @@ export default function HeadingInformation( props: Props ) {
 						finalStatus === 'transfer-domain-hosting-wp' ||
 						finalStatus === 'transfer-google-domain-hosting-wp' ) && (
 						<Button className="button-action" onClick={ onMigrateSite }>
-							{ translate( 'Migrate site' ) }
+							{ translate( 'Get a free assisted website migration' ) }
 						</Button>
 					) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #90506 

## Proposed Changes

* Updated the button text: "Get a free assisted website migration"
* Updated the link:
`https://wordpress.com/setup/new-hosted-site/plans?ref=site-profiler&section=heading-information&from=[DOMAIN]`

![CleanShot 2024-05-10 at 15 42 58@2x](https://github.com/Automattic/wp-calypso/assets/12430020/780742b4-943f-4aeb-b593-46b290262161)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Test a WP site not hosted in WP.com
* Click `Get a free assisted website migration`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
