### PR TITLE
Storybook: Use `satisfies` operator to get helpful errors about missing props

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
@@ -4,12 +4,12 @@ import {
 	getPlanFeaturesGrouped,
 	setTrailMapExperiment,
 } from '@automattic/calypso-products';
-import { Meta, StoryObj } from '@storybook/react';
 import { ComparisonGrid, ComparisonGridExternalProps, useGridPlansForComparisonGrid } from '../..';
+import type { Meta, StoryObj } from '@storybook/react';
 
 const ComponentWrapper = (
-	props: ComparisonGridExternalProps & {
-		trailMapVariant: TrailMapVariantType;
+	props: Omit< ComparisonGridExternalProps, 'gridPlans' > & {
+		trailMapVariant?: TrailMapVariantType;
 	}
 ) => {
 	const gridPlans = useGridPlansForComparisonGrid( {
@@ -45,7 +45,7 @@ const ComponentWrapper = (
 	);
 };
 
-const defaultProps: Omit< ComparisonGridExternalProps, 'gridPlans' > = {
+const defaultProps = {
 	allFeaturesList: getFeaturesList(),
 	coupon: undefined,
 	currentSitePlanSlug: undefined,
@@ -67,61 +67,61 @@ const defaultProps: Omit< ComparisonGridExternalProps, 'gridPlans' > = {
 		primary: {
 			text: 'test',
 			callback: () => {},
-			status: 'enabled',
+			status: 'enabled' as const,
 		},
 		postButtonText: '',
 	} ),
 };
 
-type Story = StoryObj< typeof ComponentWrapper >;
+const meta = {
+	title: 'ComparisonGrid',
+	component: ComponentWrapper,
+	decorators: [
+		( Story, { args: { trailMapVariant } } ) => {
+			trailMapVariant && setTrailMapExperiment( trailMapVariant );
+			return <Story />;
+		},
+	],
+} satisfies Meta< typeof ComponentWrapper >;
 
-export const Start: Story = {
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const Start = {
 	name: '/start',
 	args: {
 		...defaultProps,
 		intent: 'plans-default-wpcom',
 	},
-};
+} satisfies Story;
 
-export const TrailMapControl: Story = {
+export const TrailMapControl = {
 	args: {
 		...Start.args,
 		trailMapVariant: 'control',
 	},
-};
+} satisfies Story;
 
-export const TrailMapStructure: Story = {
+export const TrailMapStructure = {
 	args: {
 		...TrailMapControl.args,
 		trailMapVariant: 'treatment_structure',
 		hideUnsupportedFeatures: true,
 	},
-};
+} satisfies Story;
 
-export const TrailMapCopy: Story = {
+export const TrailMapCopy = {
 	args: {
 		...TrailMapControl.args,
 		trailMapVariant: 'treatment_copy',
 	},
-};
+} satisfies Story;
 
-export const TrailMapCopyAndStructure: Story = {
+export const TrailMapCopyAndStructure = {
 	args: {
 		...TrailMapControl.args,
 		trailMapVariant: 'treatment_copy_and_structure',
 		hideUnsupportedFeatures: true,
 	},
-};
-
-const meta: Meta< typeof ComponentWrapper > = {
-	title: 'ComparisonGrid',
-	component: ComponentWrapper,
-	decorators: [
-		( Story, storyContext ) => {
-			setTrailMapExperiment( storyContext.args.trailMapVariant );
-			return <Story />;
-		},
-	],
-};
-
-export default meta;
+} satisfies Story;

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -4,17 +4,17 @@ import {
 	getPlanFeaturesGrouped,
 	setTrailMapExperiment,
 } from '@automattic/calypso-products';
-import { Meta, StoryObj } from '@storybook/react';
 import {
 	FeaturesGrid,
 	FeaturesGridExternalProps,
 	useGridPlanForSpotlight,
 	useGridPlansForFeaturesGrid,
 } from '../..';
+import type { Meta, StoryObj } from '@storybook/react';
 
 const ComponentWrapper = (
-	props: FeaturesGridExternalProps & {
-		trailMapVariant: TrailMapVariantType;
+	props: Omit< FeaturesGridExternalProps, 'gridPlans' > & {
+		trailMapVariant?: TrailMapVariantType;
 	}
 ) => {
 	const gridPlans = useGridPlansForFeaturesGrid( {
@@ -60,7 +60,7 @@ const ComponentWrapper = (
 	);
 };
 
-const defaultProps: Omit< FeaturesGridExternalProps, 'gridPlans' > = {
+const defaultProps = {
 	allFeaturesList: getFeaturesList(),
 	coupon: undefined,
 	currentSitePlanSlug: undefined,
@@ -87,15 +87,28 @@ const defaultProps: Omit< FeaturesGridExternalProps, 'gridPlans' > = {
 		primary: {
 			text: 'test',
 			callback: () => {},
-			status: 'enabled',
+			status: 'enabled' as const,
 		},
 		postButtonText: '',
 	} ),
 };
 
-type Story = StoryObj< typeof ComponentWrapper >;
+const meta = {
+	title: 'FeaturesGrid',
+	component: ComponentWrapper,
+	decorators: [
+		( Story, { args: { trailMapVariant } } ) => {
+			trailMapVariant && setTrailMapExperiment( trailMapVariant );
+			return <Story />;
+		},
+	],
+} satisfies Meta< typeof ComponentWrapper >;
 
-export const Plans: Story = {
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const Plans = {
 	name: '/plans',
 	args: {
 		...defaultProps,
@@ -104,55 +117,43 @@ export const Plans: Story = {
 		isInAdmin: true,
 		isInSignup: false,
 	},
-};
+} satisfies Story;
 
-export const Newsletter: Story = {
+export const Newsletter = {
 	name: '/setup/newsletter',
 	args: {
 		...defaultProps,
 		intent: 'plans-newsletter',
 	},
-};
+} satisfies Story;
 
-export const TrailMapControl: Story = {
+export const TrailMapControl = {
 	args: {
 		...Plans.args,
 		trailMapVariant: 'control',
 		gridPlanForSpotlight: undefined,
 	},
-};
+} satisfies Story;
 
-export const TrailMapStructure: Story = {
+export const TrailMapStructure = {
 	args: {
 		...TrailMapControl.args,
 		trailMapVariant: 'treatment_structure',
 		enableCategorisedFeatures: true,
 	},
-};
+} satisfies Story;
 
-export const TrailMapCopy: Story = {
+export const TrailMapCopy = {
 	args: {
 		...TrailMapControl.args,
 		trailMapVariant: 'treatment_copy',
 	},
-};
-export const TrailMapCopyAndStructure: Story = {
+} satisfies Story;
+
+export const TrailMapCopyAndStructure = {
 	args: {
 		...TrailMapControl.args,
 		trailMapVariant: 'treatment_copy_and_structure',
 		enableCategorisedFeatures: true,
 	},
-};
-
-const meta: Meta< typeof ComponentWrapper > = {
-	title: 'FeaturesGrid',
-	component: ComponentWrapper,
-	decorators: [
-		( Story, storyContext ) => {
-			setTrailMapExperiment( storyContext.args.trailMapVariant );
-			return <Story />;
-		},
-	],
-};
-
-export default meta;
+} satisfies Story;


### PR DESCRIPTION
## Proposed Changes

As we expand our usage of Storybook and our components continue to evolve, it's important that we render components within Storybook with the correct props to avoid inadvertently breaking stories or introducing bugs.

Currently, if we add a new required prop or rename an existing required prop in a component, and we don't update the corresponding stories, the TypeScript compiler won't raise any errors. This can lead to stories being in an incorrect state, which can be difficult to catch.

This change adopts the TS `satisfies` operator to address this issue. It allows us to ensure that the props passed to a component in a story conform to the expected shape defined by the component's props interface. If a story is missing a required prop or has an incorrect prop, the TypeScript compiler will now catch the issue and provide a clear error message.

Eg. we add a new required prop:

![CleanShot 2024-05-13 at 17 30 54@2x](https://github.com/Automattic/wp-calypso/assets/69198925/fa2ce8e8-b0a5-43a3-b242-662dfa879a57)

TS will now helpfully detect that we haven't yet added this prop to our story:

![CleanShot 2024-05-13 at 17 16 00@2x](https://github.com/Automattic/wp-calypso/assets/69198925/b244ab33-19ef-40a5-8c8a-4abb46fd3004)

![CleanShot 2024-05-13 at 17 23 51@2x](https://github.com/Automattic/wp-calypso/assets/69198925/85931b42-a39b-452a-a1c9-915ab0654e98)


## Testing Instructions

Try adding a new required prop to `FeaturesGridProps` or `ComparisonGridProps` (or rename an existing required prop) and check that you can see a TS warning in the relevant `.stories.tsx` files.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?