### PR TITLE
Nav redesign - update add domain button text

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -4,7 +4,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
-import { Icon, plus, search } from '@wordpress/icons';
+import { Icon, search } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -119,14 +119,11 @@ class AddDomainButton extends Component {
 
 		let label = translate( 'Other domain options' );
 		if ( specificSiteActions ) {
-			label = translate( 'Add a domain' );
+			label = translate( 'Add new domain' );
 		}
 
 		return (
-			<>
-				<Icon icon={ plus } className="options-domain-button__add gridicon" viewBox="2 2 20 20" />
-				{ ! isMobile() && <span className="options-domain-button__desktop">{ label }</span> }
-			</>
+			<>{ ! isMobile() && <span className="options-domain-button__desktop">{ label }</span> }</>
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7071

## Proposed Changes

* Updates button text from "+ Add a domain" -> "Add new domain"

## Before

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/6d0635ab-afeb-48db-a0ca-0d2124993db5)

## After

![Image](https://github.com/Automattic/dotcom-forge/assets/5634774/8eacdcc7-a7a4-43eb-be38-cc0996ab563f)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage' and confirm button text is as described.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
