### PR TITLE
Happy Blocks: Fix missing cats in support

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -134,7 +134,7 @@ function happyblocks_allow_footer_tags( $tags ) {
 	$tags['defs']   = array();
 
 	$tags['footer'] = array_merge(
-		$tags['footer'],
+		$tags['footer'] ?? array(),
 		array(
 			'data-locale' => array(),
 		)


### PR DESCRIPTION
Related to p1715316406620609-slack-C02T4NVL4JJ

## Proposed Changes

The `happyblocks_allow_footer_tags` filter in Happy Blocks assumed the existence of `footer` tag in the `wp_kses_allowed_html` array. I now handle the lack of this tag.


## Testing Instructions

1. In `apps/happy-blocks` run `yarn dev --sync`.
2. Sandbox `en.support.wordpress.com`.
3. Go to `https://en.support.wordpress.com/wp-admin/edit-tags.php?taxonomy=category&post_type=page`.
4. Categories should appear.