### PR TITLE
dashboard v2 - remove site icon shadow in global site view header

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -419,9 +419,6 @@
 		}
 	}
 	.item-preview__header {
-		.site-favicon .site-icon {
-			box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-		}
 		.item-preview__header-title {
 			font-family: Recoleta, sans-serif;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7074

## Proposed Changes

* Removes box shadow from site icon in GSV header

BEFORE
<img width="198" alt="Screenshot 2024-05-10 at 9 29 18 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/89942e5a-5d97-418b-87e6-f3e8d58a6533">


AFTER
<img width="197" alt="Screenshot 2024-05-10 at 9 28 57 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a9c609bb-d94c-4cc1-a979-150618c5b13d">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* visit /sites dashboard
* select a site to see the GSV and overview
* verify the site icon no longer has a box shadow around it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
