### PR TITLE
Sites dashboard v2 - GSV - update copy on quick actions component.

### DIFF
--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -64,8 +64,8 @@ const QuickActionsCard: FC = () => {
 		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
 			<div className="hosting-overview__card-header">
 				<h3 className="hosting-overview__card-title">
-					{ hasEnTranslation( 'Dashboard links' )
-						? translate( 'Dashboard links' )
+					{ hasEnTranslation( 'Quick actions' )
+						? translate( 'Quick actions' )
 						: translate( 'WP Admin links' ) }
 				</h3>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7079

## Proposed Changes

* Renames the header of the quick actions component to read "Quick actions" once again...

BEFORE

<img width="316" alt="Screenshot 2024-05-10 at 9 45 58 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a2231587-f648-4a42-aff1-b2f0b505720e">


AFTER
<img width="230" alt="Screenshot 2024-05-10 at 9 45 53 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/27773ec8-8278-447e-be81-e8b5eaa04223">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Go to /sites dashboard
* Select a site to see global site view
* Verify the quick actions component is labeled "Quick actions"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
