### PR TITLE
Test pinghub connection

### DIFF
--- a/client/site-profiler/components/pinghub-test/index.tsx
+++ b/client/site-profiler/components/pinghub-test/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 
-const testPath = '/wpcom/me/test';
+const testPath = '/wpcom/pub/test';
 
 export const PinghubTest = () => {
 	const [ connected, setConnected ] = useState( false );

--- a/client/site-profiler/components/pinghub-test/index.tsx
+++ b/client/site-profiler/components/pinghub-test/index.tsx
@@ -11,6 +11,11 @@ export const PinghubTest = () => {
 			if ( error === null && event.response.type === 'open' ) {
 				setConnected( true );
 			}
+
+			if ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Error connecting to pinghub', error );
+			}
 		} );
 	};
 

--- a/client/site-profiler/components/pinghub-test/index.tsx
+++ b/client/site-profiler/components/pinghub-test/index.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+
+const testPath = '/wpcom/me/test';
+
+export const PinghubTest = () => {
+	const [ connected, setConnected ] = useState( false );
+
+	const connect = () => {
+		wpcom.pinghub.connect( testPath, ( error, event ) => {
+			if ( error === null && event.response.type === 'open' ) {
+				setConnected( true );
+			}
+		} );
+	};
+
+	const disconnect = () => {
+		wpcom.pinghub.disconnect( testPath );
+		setConnected( false );
+	};
+
+	useEffect( () => {
+		connect();
+	}, [] );
+
+	return (
+		<>
+			<h2>Pinghub test</h2>
+			{ connected ? (
+				<>
+					<p>Connected to { testPath }</p>
+					<button className="components-button button-action" onClick={ disconnect }>
+						Click to disconnect
+					</button>
+				</>
+			) : (
+				<>
+					<p>Not connected</p>
+					<button className="components-button button-action" onClick={ connect }>
+						Click to connect
+					</button>
+				</>
+			) }
+		</>
+	);
+};

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -24,6 +24,7 @@ import HeadingInformation from './heading-information';
 import HostingInformation from './hosting-information';
 import HostingIntro from './hosting-intro';
 import { MetricsMenu } from './metrics-menu';
+import { PinghubTest } from './pinghub-test';
 import './styles.scss';
 
 const debug = debugFactory( 'apps:site-profiler' );
@@ -124,6 +125,10 @@ export default function SiteProfiler( props: Props ) {
 					/>
 				</LayoutBlock>
 			) }
+
+			<LayoutBlock>
+				<PinghubTest />
+			</LayoutBlock>
 
 			{ showResultScreen && (
 				<LayoutBlock className="domain-result-block">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6673

## Proposed Changes

* DO NOT MERGE
* This diff adds changes to test websocket connections to not user-specific paths

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Both with logged-in and logged-out sessions:
* Go to `/site-profiler`
* On site load, the websocket connection should be successful
* Try clicking the disconnect and re-connect buttons to test the connection
* When the connection is open, open the devtools Networking tab, click the `test` connection, and open the `Messages` tab
* Open a new tab to https://public-api.wordpress.com/pinghub/wpcom/pub/test?action=connect, and send some test messages
* Check that you can see the posted messages on the site-profiler tab devtools

https://github.com/Automattic/wp-calypso/assets/11555574/23aea082-6c8b-4abb-9fc1-5b4d17d4a076

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
