### PR TITLE
Global pages - add box shadow around content area frames

### DIFF
--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -49,7 +49,7 @@ body.is-section-me {
 		.layout__primary {
 			background: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			box-shadow: none;
+			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
 			@media only screen and (min-width: 601px) {
 				height: calc(100vh - var(--masterbar-height) - 50px);
 			}

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -40,163 +40,162 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	const translate = useTranslate();
 	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
 	const sitesDashboardGlobalStyles = css`
-			html {
-				overflow-y: auto;
+		html {
+			overflow-y: auto;
+		}
+		body.is-section-domains {
+			background: var( --studio-gray-0 );
+
+			&.rtl .layout__content {
+				padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
 			}
-			body.is-section-domains {
-				background: var( --studio-gray-0 );
 
-				&.rtl .layout__content {
-					padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
+			.layout__content {
+				// Add border around everything
+				overflow: hidden;
+				min-height: 100vh;
+				padding: 16px 16px 16px calc( var( --sidebar-width-max ) );
+
+				.layout_primary > main {
+					padding-bottom: 0;
+				}
+			}
+
+			.layout__secondary .global-sidebar {
+				border: none;
+			}
+
+			.has-no-masterbar .layout__content {
+				padding-top: 16px !important;
+			}
+
+			header.navigation-header {
+				padding-top: 24px;
+
+				.formatted-header {
+					max-height: 41px;
 				}
 
-				.layout__content {
-					// Add border around everything
-					overflow: hidden;
-					min-height: 100vh;
-					padding: 16px 16px 16px calc( var( --sidebar-width-max ) );
-
-					.layout_primary > main {
-						padding-bottom: 0;
-					}
+				.navigation-header__main {
+					align-items: center;
 				}
 
-				.layout__secondary .global-sidebar {
-					border: none;
+				.formatted-header__title {
+					color: var( --studio-gray-80, #2c3338 );
+					font-family: 'SF Pro Display', sans-serif;
+					font-size: 1.5rem;
+					font-style: normal;
+					font-weight: 500;
+					line-height: 1.2;
 				}
-
-				.has-no-masterbar .layout__content {
-					padding-top: 16px !important;
-				}
-
-				header.navigation-header {
-					padding-top: 24px;
-
-					.formatted-header {
-						max-height: 41px;
-					}
-
-					.navigation-header__main {
-						align-items: center;
-					}
-
-					.formatted-header__title {
-						color: var( --studio-gray-80, #2c3338 );
-						font-family: 'SF Pro Display', sans-serif;
-						font-size: 1.5rem;
-						font-style: normal;
-						font-weight: 500;
-						line-height: 1.2;
-					}
-					.domain-header__buttons .button {
-						border-radius: 4px;
-						white-space: nowrap;
-						margin-left: 0;
-						&:not( .is-primary ) {
-							margin-inline-end: 1rem;
-						}
-					}
-				}
-
-				.search-component.domains-table-filter__search.is-open.has-open-icon {
+				.domain-header__buttons .button {
 					border-radius: 4px;
-					height: 44px;
-				}
-
-				.domains-table {
-					margin-top: 48px;
-					.domains-table-toolbar {
-						margin-inline: 64px;
+					white-space: nowrap;
+					margin-left: 0;
+					&:not( .is-primary ) {
+						margin-inline-end: 1rem;
 					}
-					table {
-						overflow-y: auto;
-						max-height: calc( 100vh - 235px );
+				}
+			}
+
+			.search-component.domains-table-filter__search.is-open.has-open-icon {
+				border-radius: 4px;
+				height: 44px;
+			}
+
+			.domains-table {
+				margin-top: 48px;
+				.domains-table-toolbar {
+					margin-inline: 64px;
+				}
+				table {
+					overflow-y: auto;
+					max-height: calc( 100vh - 235px );
+					padding-inline: 64px;
+					margin-bottom: 0;
+				}
+				.domains-table-header {
+					position: sticky;
+					top: 0;
+					z-index: 2;
+				}
+			}
+
+			@media only screen and ( min-width: 782px ) {
+				div.layout.is-global-sidebar-visible {
+					header.navigation-header {
+						padding-top: 24px;
 						padding-inline: 64px;
-						margin-bottom: 0;
-					}
-					.domains-table-header {
-						position: sticky;
-						top: 0;
-						z-index: 2;
-					}
-				}
-
-				@media only screen and ( min-width: 782px ) {
-					div.layout.is-global-sidebar-visible {
-						header.navigation-header {
-							padding-top: 24px;
-							padding-inline: 64px;
-							border-block-end: 1px solid var( --studio-gray-0 );
-						}
-						.layout__primary > main {
-							background: var( --color-surface );
-							border-radius: 8px;
-							box-shadow: none
-							height: calc( 100vh - 32px );
-							overflow: hidden;
-							max-width: none;
-							height: calc( 100vh - 32px );
-						}
-					}
-				}
-
-				@media only screen and ( max-width: 600px ) {
-					.navigation-header__main {
-						justify-content: normal;
-						.formatted-header {
-							flex: none;
-						}
-					}
-					.domains-table {
-						padding: 0 8px;
-					}
-					.domains-table-toolbar {
-						margin-inline: 0 !important;
-					}
-					table {
-						padding-inline: 0 !important;
-					}
-					div.layout.is-global-sidebar-visible {
-						.layout__primary > main {
-							height: calc( 100vh - var(--masterbar-height) );
-						}
-					}
-				}
-
-				@media only screen and ( max-width: 781px ) {
-					div.layout.is-global-sidebar-visible {
-						.layout__primary {
-							overflow-x: auto;
-						}
+						border-block-end: 1px solid var( --studio-gray-0 );
 					}
 					.layout__primary > main {
 						background: var( --color-surface );
-						margin: 0;
 						border-radius: 8px;
-					}
-					header.navigation-header {
-						padding-inline: 16px;
-						padding-bottom: 0;
-					}
-				}
-				@media only screen and ( min-width: 601px ) and ( max-width: 781px ) {
-					.domains-table {
-						.domains-table-toolbar {
-							margin-inline: 16px;
-						}
-						table {
-							padding-inline: 16px;
-						}
-					}
-					div.layout.is-global-sidebar-visible {
-						.layout__primary > main {
-							height: calc( 100vh - var(--masterbar-height) - 48px );
-						}
+						box-shadow: 0 0 17.4px 0 rgba( 0, 0, 0, 0.05 );
+						height: calc( 100vh - 32px );
+						overflow: hidden;
+						max-width: none;
+						height: calc( 100vh - 32px );
 					}
 				}
-
 			}
-		`;
+
+			@media only screen and ( max-width: 600px ) {
+				.navigation-header__main {
+					justify-content: normal;
+					.formatted-header {
+						flex: none;
+					}
+				}
+				.domains-table {
+					padding: 0 8px;
+				}
+				.domains-table-toolbar {
+					margin-inline: 0 !important;
+				}
+				table {
+					padding-inline: 0 !important;
+				}
+				div.layout.is-global-sidebar-visible {
+					.layout__primary > main {
+						height: calc( 100vh - var( --masterbar-height ) );
+					}
+				}
+			}
+
+			@media only screen and ( max-width: 781px ) {
+				div.layout.is-global-sidebar-visible {
+					.layout__primary {
+						overflow-x: auto;
+					}
+				}
+				.layout__primary > main {
+					background: var( --color-surface );
+					margin: 0;
+					border-radius: 8px;
+				}
+				header.navigation-header {
+					padding-inline: 16px;
+					padding-bottom: 0;
+				}
+			}
+			@media only screen and ( min-width: 601px ) and ( max-width: 781px ) {
+				.domains-table {
+					.domains-table-toolbar {
+						margin-inline: 16px;
+					}
+					table {
+						padding-inline: 16px;
+					}
+				}
+				div.layout.is-global-sidebar-visible {
+					.layout__primary > main {
+						height: calc( 100vh - var( --masterbar-height ) - 48px );
+					}
+				}
+			}
+		}
+	`;
 	const item = {
 		label: translate( 'Domains' ),
 		helpBubble: translate(

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -102,7 +102,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 		.layout__primary > div {
 			background: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			box-shadow: none;
+			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
 			@media only screen and (min-width: 600px) {
 				height: calc(100vh - var(--masterbar-height) - 50px);
 			}

--- a/client/sites-dashboard-v2/controller.tsx
+++ b/client/sites-dashboard-v2/controller.tsx
@@ -87,7 +87,6 @@ export function sitesDashboard( context: Context, next: () => void ) {
 
 		.main.sites-dashboard.sites-dashboard__layout:has( .dataviews-pagination ) {
 			padding-bottom: 0;
-			box-shadow: none;
 		}
 
 		// Update body margin to account for the sidebar width


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7072

## Proposed Changes

* Adds box shadow to the content frames of /me, /sites, /domains/manage, the reader.

BEFORE
<img width="195" alt="Screenshot 2024-05-10 at 10 27 09 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b96e32a4-83df-4ca8-bfe0-8df7a4004b30">


AFTER
<img width="205" alt="Screenshot 2024-05-10 at 10 27 15 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/075967b5-2358-4eff-ae1f-fd8813a4393b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Visit /sites, verify there is a box shadow around the primary content frame.
* Visit /domains/manage, verify the same.
* Visit /me, verify the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
