### PR TITLE
Nav redesign - update dashboard search styles

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -122,7 +122,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				flex-direction: row-reverse;
 				padding-inline: 10px 8px;
 				font-size: 14px;
-				color: var( --studio-gray-40 );
+				color: var(--studio-gray-40 );
 				svg {
 					fill: var( --studio-gray-40 );
 					color: var( --studio-gray-40 );
@@ -133,7 +133,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					height: 36px;
 
 					&::placeholder {
-						color: var(--studio-gray-40);
+						color: var( --studio-gray-40 );
 					}
 				}
 				max-width: 245px;

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -122,7 +122,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				flex-direction: row-reverse;
 				padding-inline: 10px 8px;
 				font-size: 14px;
-				color: var(--studio-gray-40 );
+				color: var( --studio-gray-40 );
 				svg {
 					fill: var( --studio-gray-40 );
 					color: var( --studio-gray-40 );

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -98,13 +98,8 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				}
 			}
 
-			.search-component.domains-table-filter__search.is-open.has-open-icon {
-				border-radius: 4px;
-				height: 44px;
-			}
-
 			.domains-table {
-				margin-top: 48px;
+				margin-top: 35px;
 				.domains-table-toolbar {
 					margin-inline: 64px;
 				}
@@ -119,6 +114,30 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					top: 0;
 					z-index: 2;
 				}
+			}
+
+			.search-component.domains-table-filter__search.is-open.has-open-icon {
+				border-radius: 2px;
+				height: 36px;
+				flex-direction: row-reverse;
+				padding-inline: 10px 8px;
+				font-size: 14px;
+				color: var(--studio-gray-40);
+				svg {
+					fill: var(--studio-gray-40);
+					color: var(--studio-gray-40);
+				}
+
+				input.search-component__input[type="search"] {
+					font-size: 14px;
+					height: 36px;
+
+					&::placeholder {
+						color: var(--studio-gray-40);
+					}
+				}
+				max-width: 245px;
+				transition: none;
 			}
 
 			@media only screen and ( min-width: 782px ) {

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -122,13 +122,13 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				flex-direction: row-reverse;
 				padding-inline: 10px 8px;
 				font-size: 14px;
-				color: var(--studio-gray-40);
+				color: var( --studio-gray-40 );
 				svg {
-					fill: var(--studio-gray-40);
-					color: var(--studio-gray-40);
+					fill: var( --studio-gray-40 );
+					color: var( --studio-gray-40 );
 				}
 
-				input.search-component__input[type="search"] {
+				input.search-component__input[type='search'] {
 					font-size: 14px;
 					height: 36px;
 
@@ -150,11 +150,10 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					.layout__primary > main {
 						background: var( --color-surface );
 						border-radius: 8px;
-						box-shadow: 0 0 17.4px 0 rgba( 0, 0, 0, 0.05 );
+						box-shadow: none;
 						height: calc( 100vh - 32px );
 						overflow: hidden;
 						max-width: none;
-						height: calc( 100vh - 32px );
 					}
 				}
 			}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -195,26 +195,24 @@
 // Styles for actions (search, filters).
 .dataviews-filters__view-actions {
 	.components-search-control {
-		@include break-large {
-			min-width: 337px;
-		}
+		min-width: 245px;
 	}
 
 	.components-search-control .components-input-control__container {
 		width: 100%;
-		height: 44px;
+		height: 36px;
 		flex: 1 1 auto;
-		flex-direction: row-reverse;
+		flex-direction: row;
 		align-items: center;
 		// Places search above filters
 		z-index: 1;
-		border-radius: 4px;
+		border-radius: 2px;
 		border: 1px solid var(--color-border-subtle);
 		background-color: var(--color-surface, $white);
 
 		.components-input-control__input {
-			padding-left: 0;
-			font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			padding-left: 10px;
+			font-size: $font-body-small;
 			color: var(--studio-gray-40);
 
 			&::placeholder {
@@ -224,8 +222,7 @@
 
 		// Search icon
 		.components-input-control__suffix {
-			padding-inline-start: 11px;
-			color: var(--studio-black);
+			color: var(--studio-gray-40);
 		}
 	}
 }
@@ -391,10 +388,6 @@
 		.dataviews-filters__view-actions {
 			align-items: center;
 			display: flex;
-
-			.components-search-control {
-				min-width: initial;
-			}
 		}
 
 		ul.dataviews-view-list {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -207,11 +207,11 @@
 		// Places search above filters
 		z-index: 1;
 		border-radius: 2px;
-		border: 1px solid var(--color-border-subtle);
+		border: 1px solid var(--studio-gray-10);
 		background-color: var(--color-surface, $white);
 
 		.components-input-control__input {
-			padding-left: 10px;
+			padding: 0 0 0 10px;
 			font-size: $font-body-small;
 			color: var(--studio-gray-40);
 
@@ -223,6 +223,7 @@
 		// Search icon
 		.components-input-control__suffix {
 			color: var(--studio-gray-40);
+			margin-right: 4px;
 		}
 	}
 }

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -190,6 +190,7 @@
 
 			.components-flex.components-h-stack {
 				flex: 6;
+				padding-left: 8px;
 			}
 
 		}

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -1,7 +1,8 @@
 import { Gridicon, SelectDropdown } from '@automattic/components';
-import SearchControl, { SearchIcon } from '@automattic/search';
+import SearchControl from '@automattic/search';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { DropdownMenu, MenuGroup, MenuItem, ToggleControl } from '@wordpress/components';
+import { Icon, search } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactNode } from 'react';
 import { useDomainsTable } from '../domains-table/domains-table';
@@ -65,7 +66,7 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 	return (
 		<div className="domains-table-filter">
 			<SearchControl
-				searchIcon={ <SearchIcon /> }
+				searchIcon={ <Icon icon={ search } size={ 24 } /> }
 				className="domains-table-filter__search"
 				onSearch={ onSearch }
 				defaultValue={ filter.query }

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -28,8 +28,6 @@
 
 	&__search {
 		--color-surface: var(--studio-white);
-
-		height: var(--domains-table-toolbar-height) !important;
 		box-sizing: border-box;
 		overflow: hidden;
 		border: 1px solid #c3c4c7;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7070

## Proposed Changes

* Moves the search icon to the right
* Update to use same icon for both search inputs
* Update icon color to match placeholder text color
* Adjusts the font size
* Adjusts the input height and width
* Updates margin above search inputs to be match on both sites and domains pages

## Before

**Sites**
<img width="364" alt="Screenshot 2024-05-10 at 15 58 45" src="https://github.com/Automattic/wp-calypso/assets/5560595/5d8d20c3-93e8-4e4d-bde0-2226e74de7a2">

**Domains**
<img width="269" alt="Screenshot 2024-05-10 at 15 59 01" src="https://github.com/Automattic/wp-calypso/assets/5560595/a16aa7e0-a82a-467f-86ab-f12e94958eff">

## After

**Sites**
<img width="270" alt="Screenshot 2024-05-10 at 15 59 20" src="https://github.com/Automattic/wp-calypso/assets/5560595/eef48c98-e381-4adc-af7b-ad74c176eadf">

**Domains**
<img width="275" alt="Screenshot 2024-05-10 at 15 59 26" src="https://github.com/Automattic/wp-calypso/assets/5560595/a4be3c9b-d9ef-4317-8276-1d0eda50889d">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` and the '/domains/manage` pages and confirm search input matches the latest designs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
