### PR TITLE
Nav redesign: Adjust search field width on /sites

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -171,7 +171,7 @@
 .dataviews-filters__view-actions {
 	.components-search-control {
 		@include break-large {
-			flex: 1;
+			min-width: 337px;
 		}
 	}
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -171,7 +171,7 @@
 .dataviews-filters__view-actions {
 	.components-search-control {
 		@include break-large {
-			min-width: 337px;
+			flex: 1;
 		}
 	}
 
@@ -330,6 +330,12 @@
 			> .components-button:has(.preview-hidden) {
 				// Since we changed the original height of the search input, we need to adjust the position of this icon.
 				margin-top: 5px;
+			}
+
+			.components-button.is-compact.has-icon:not(.has-text) {
+				@media ( max-width: 961px ) {
+					margin-inline-end: 8px;
+				}
 			}
 		}
 

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -165,10 +165,6 @@
 				flex: 6;
 			}
 
-			.components-button.is-compact.has-icon {
-				flex: 1;
-				margin-left: -12px;
-			}
 		}
 
 		.sites-overview__stats-trend,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7080

## Proposed Changes

Adjust search field width on `/sites`

Before:

https://github.com/Automattic/wp-calypso/assets/402286/8947b09c-9b4b-47e8-b2fa-815a7f47ca23

After:

https://github.com/Automattic/wp-calypso/assets/402286/f66f4106-69df-4e83-8f65-ae98dbfe9834

## Testing Instructions

* Go to `/sites`
* Check search field width on all screen sizes

