### PR TITLE
Multisite Scheduled Updates: Implement schedule activation toggle control in schedule list

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -34,7 +34,7 @@ export const ScheduleListCard = ( props: Props ) => {
 	);
 	const { activateSchedule } = useScheduledUpdatesActivateBatchMutation();
 	const [ isExpanded, setIsExpanded ] = useState( false );
-	const batchActiveState = schedule.sites.every( ( site ) => site.active );
+	const batchActiveState = schedule.sites.some( ( site ) => site.active );
 
 	return (
 		<div className={ clsx( 'plugins-update-manager-multisite-card', className ) }>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -99,7 +99,7 @@ export const ScheduleListCard = ( props: Props ) => {
 							<div className="plugins-update-manager-multisite-card__label">
 								<label htmlFor="name">{ translate( 'Active' ) }</label>
 								<FormToggle
-									checked={ schedule.active }
+									checked={ site.active }
 									onChange={ ( e ) =>
 										activateSchedule( site.slug, schedule.schedule_id, {
 											active: e.target.checked,

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from '@wordpress/components';
+import { Button, FormToggle, Tooltip } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon, info } from '@wordpress/icons';
 import clsx from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -8,6 +8,7 @@ import { usePrepareMultisitePluginsTooltipInfo } from 'calypso/blocks/plugin-sch
 import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
 import { ScheduleListLastRunStatus } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status';
 import { ScheduleListTableRowMenu } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu';
+import { useScheduledUpdatesActivateMutation } from 'calypso/data/plugins/use-scheduled-updates-activate-mutation';
 import { SiteSlug } from 'calypso/types';
 import type {
 	MultisiteSchedulesUpdates,
@@ -24,13 +25,14 @@ type Props = {
 };
 
 export const ScheduleListCard = ( props: Props ) => {
+	const translate = useTranslate();
 	const { className, compact, schedule, onEditClick, onRemoveClick, onLogsClick } = props;
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat();
 	const { preparePluginsTooltipInfo } = usePrepareMultisitePluginsTooltipInfo(
 		schedule.sites.map( ( site ) => site.ID )
 	);
-	const translate = useTranslate();
+	const { activateSchedule } = useScheduledUpdatesActivateMutation();
 	const [ isExpanded, setIsExpanded ] = useState( false );
 
 	return (
@@ -93,6 +95,17 @@ export const ScheduleListCard = ( props: Props ) => {
 								<div>
 									<ScheduleListLastRunStatus schedule={ schedule } site={ site } />
 								</div>
+							</div>
+							<div className="plugins-update-manager-multisite-card__label">
+								<label htmlFor="name">{ translate( 'Active' ) }</label>
+								<FormToggle
+									checked={ schedule.active }
+									onChange={ ( e ) =>
+										activateSchedule( site.slug, schedule.schedule_id, {
+											active: e.target.checked,
+										} )
+									}
+								/>
 							</div>
 						</div>
 					) ) }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -8,7 +8,7 @@ import { usePrepareMultisitePluginsTooltipInfo } from 'calypso/blocks/plugin-sch
 import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
 import { ScheduleListLastRunStatus } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status';
 import { ScheduleListTableRowMenu } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu';
-import { useScheduledUpdatesActivateMutation } from 'calypso/data/plugins/use-scheduled-updates-activate-mutation';
+import { useScheduledUpdatesActivateBatchMutation } from 'calypso/data/plugins/use-scheduled-updates-activate-batch-mutation';
 import { SiteSlug } from 'calypso/types';
 import type {
 	MultisiteSchedulesUpdates,
@@ -32,7 +32,7 @@ export const ScheduleListCard = ( props: Props ) => {
 	const { preparePluginsTooltipInfo } = usePrepareMultisitePluginsTooltipInfo(
 		schedule.sites.map( ( site ) => site.ID )
 	);
-	const { activateSchedule } = useScheduledUpdatesActivateMutation();
+	const { activateSchedule } = useScheduledUpdatesActivateBatchMutation();
 	const [ isExpanded, setIsExpanded ] = useState( false );
 
 	return (
@@ -101,7 +101,7 @@ export const ScheduleListCard = ( props: Props ) => {
 								<FormToggle
 									checked={ site.active }
 									onChange={ ( e ) =>
-										activateSchedule( site.slug, schedule.schedule_id, {
+										activateSchedule( [ { id: site.ID, slug: site.slug } ], schedule.schedule_id, {
 											active: e.target.checked,
 										} )
 									}

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -69,7 +69,7 @@ export const ScheduleListCard = ( props: Props ) => {
 			{ ! compact && (
 				<>
 					<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
-						<label htmlFor="last-update">
+						<label htmlFor={ `last-update-${ schedule.id }` }>
 							<Button variant="link" onClick={ () => setIsExpanded( ! isExpanded ) }>
 								{ translate( 'Last update' ) }
 								<Icon icon={ isExpanded ? chevronUp : chevronDown } />
@@ -105,17 +105,17 @@ export const ScheduleListCard = ( props: Props ) => {
 							className="plugins-update-manager-multisite-card__sites-site"
 						>
 							<div className="plugins-update-manager-multisite-card__label">
-								<label htmlFor="name">{ translate( 'Name' ) }</label>
-								<strong id="name">{ site.title }</strong>
+								<label htmlFor={ `name-${ site.ID }` }>{ translate( 'Name' ) }</label>
+								<strong id={ `name-${ site.ID }` }>{ site.title }</strong>
 							</div>
 							<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
-								<label htmlFor="last-update">{ translate( 'Last update' ) }</label>
+								<label htmlFor={ `last-update-${ site.ID }` }>{ translate( 'Last update' ) }</label>
 								<div>
 									<ScheduleListLastRunStatus schedule={ schedule } site={ site } />
 								</div>
 							</div>
 							<div className="plugins-update-manager-multisite-card__label">
-								<label htmlFor="name">{ translate( 'Active' ) }</label>
+								<label htmlFor={ `active-${ site.ID }` }>{ translate( 'Active' ) }</label>
 								<FormToggle
 									checked={ site.active }
 									onChange={ ( e ) =>
@@ -132,8 +132,10 @@ export const ScheduleListCard = ( props: Props ) => {
 
 			{ ! compact && (
 				<div className="plugins-update-manager-multisite-card__label">
-					<label htmlFor="next-update">{ translate( 'Next update' ) }</label>
-					<span id="next-update">{ prepareDateTime( schedule.timestamp ) }</span>
+					<label htmlFor={ `next-update-${ schedule.id }` }>{ translate( 'Next update' ) }</label>
+					<span id={ `next-update-${ schedule.id }` }>
+						{ prepareDateTime( schedule.timestamp ) }
+					</span>
 				</div>
 			) }
 		</div>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-card.tsx
@@ -34,6 +34,7 @@ export const ScheduleListCard = ( props: Props ) => {
 	);
 	const { activateSchedule } = useScheduledUpdatesActivateBatchMutation();
 	const [ isExpanded, setIsExpanded ] = useState( false );
+	const batchActiveState = schedule.sites.every( ( site ) => site.active );
 
 	return (
 		<div className={ clsx( 'plugins-update-manager-multisite-card', className ) }>
@@ -66,17 +67,34 @@ export const ScheduleListCard = ( props: Props ) => {
 			</div>
 
 			{ ! compact && (
-				<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
-					<label htmlFor="last-update">
-						<Button variant="link" onClick={ () => setIsExpanded( ! isExpanded ) }>
-							{ translate( 'Last update' ) }
-							<Icon icon={ isExpanded ? chevronUp : chevronDown } />
-						</Button>
-					</label>
-					<div>
-						<ScheduleListLastRunStatus schedule={ schedule } />
+				<>
+					<div className="plugins-update-manager-multisite-card__label plugins-update-manager-multisite-card__last-update-label">
+						<label htmlFor="last-update">
+							<Button variant="link" onClick={ () => setIsExpanded( ! isExpanded ) }>
+								{ translate( 'Last update' ) }
+								<Icon icon={ isExpanded ? chevronUp : chevronDown } />
+							</Button>
+						</label>
+						<div>
+							<ScheduleListLastRunStatus schedule={ schedule } />
+						</div>
 					</div>
-				</div>
+					<div className="plugins-update-manager-multisite-card__label">
+						<label htmlFor={ `active-${ schedule.id }` }>{ translate( 'Active' ) }</label>
+						<span id={ `active-${ schedule.id }` }>
+							<FormToggle
+								checked={ batchActiveState }
+								onChange={ ( e ) =>
+									activateSchedule(
+										schedule.sites.map( ( site ) => ( { id: site.ID, slug: site.slug } ) ),
+										schedule.schedule_id,
+										{ active: e.target.checked }
+									)
+								}
+							/>
+						</span>
+					</div>
+				</>
 			) }
 
 			{ isExpanded && (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
@@ -10,7 +10,7 @@ import type {
 type Props = {
 	schedule: MultisiteSchedulesUpdates;
 	onEditClick: ( id: string ) => void;
-	onRemoveClick: ( id: string ) => void;
+	onRemoveClick: ( id: string, siteSlug?: SiteSlug ) => void;
 	onLogsClick: ( id: string, siteSlug: SiteSlug ) => void;
 };
 
@@ -39,7 +39,7 @@ export const ScheduleListTableRowMenu = ( {
 
 	items.push( {
 		title: translate( 'Remove' ),
-		onClick: () => onRemoveClick( schedule.schedule_id ),
+		onClick: () => onRemoveClick( schedule.schedule_id, site?.slug ),
 	} );
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -33,7 +33,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 	const translate = useTranslate();
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const { activateSchedule } = useScheduledUpdatesActivateBatchMutation();
-	const batchActiveState = schedule.sites.every( ( site ) => site.active );
+	const batchActiveState = schedule.sites.some( ( site ) => site.active );
 
 	return (
 		<>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -33,6 +33,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 	const translate = useTranslate();
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const { activateSchedule } = useScheduledUpdatesActivateBatchMutation();
+	const batchActiveState = schedule.sites.every( ( site ) => site.active );
 
 	return (
 		<>
@@ -86,7 +87,18 @@ export const ScheduleListTableRow = ( props: Props ) => {
 						<Icon className="icon-info" icon={ info } size={ 16 } />
 					</Tooltip>
 				</td>
-				<td className="active"></td>
+				<td className="active">
+					<FormToggle
+						checked={ batchActiveState }
+						onChange={ ( e ) => {
+							activateSchedule(
+								schedule.sites.map( ( site ) => ( { id: site.ID, slug: site.slug } ) ),
+								schedule.schedule_id,
+								{ active: e.target.checked }
+							);
+						} }
+					/>
+				</td>
 				<td className="menu">
 					<ScheduleListTableRowMenu { ...props } />
 				</td>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -7,7 +7,7 @@ import { usePrepareMultisitePluginsTooltipInfo } from 'calypso/blocks/plugin-sch
 import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
 import { usePrepareSitesTooltipInfo } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-prepare-sites-tooltip-info';
 import { ScheduleListLastRunStatus } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status';
-import { useScheduledUpdatesActionMutation } from 'calypso/data/plugins/use-scheduled-updates-action-mutation';
+import { useScheduledUpdatesActivateMutation } from 'calypso/data/plugins/use-scheduled-updates-activate-mutation';
 import { SiteSlug } from 'calypso/types';
 import { ScheduleListTableRowMenu } from './schedule-list-table-row-menu';
 import type {
@@ -32,7 +32,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 		usePrepareMultisitePluginsTooltipInfo( schedule.sites.map( ( site ) => site.ID ) );
 	const translate = useTranslate();
 	const [ isExpanded, setIsExpanded ] = useState( false );
-	const { activateSchedule } = useScheduledUpdatesActionMutation();
+	const { activateSchedule } = useScheduledUpdatesActivateMutation();
 
 	return (
 		<>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from '@wordpress/components';
+import { Button, Tooltip, FormToggle } from '@wordpress/components';
 import { chevronDown, chevronRight, Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -7,6 +7,7 @@ import { usePrepareMultisitePluginsTooltipInfo } from 'calypso/blocks/plugin-sch
 import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
 import { usePrepareSitesTooltipInfo } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-prepare-sites-tooltip-info';
 import { ScheduleListLastRunStatus } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status';
+import { useScheduledUpdatesActionMutation } from 'calypso/data/plugins/use-scheduled-updates-action-mutation';
 import { SiteSlug } from 'calypso/types';
 import { ScheduleListTableRowMenu } from './schedule-list-table-row-menu';
 import type {
@@ -31,6 +32,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 		usePrepareMultisitePluginsTooltipInfo( schedule.sites.map( ( site ) => site.ID ) );
 	const translate = useTranslate();
 	const [ isExpanded, setIsExpanded ] = useState( false );
+	const { activateSchedule } = useScheduledUpdatesActionMutation();
 
 	return (
 		<>
@@ -84,6 +86,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 						<Icon className="icon-info" icon={ info } size={ 16 } />
 					</Tooltip>
 				</td>
+				<td className="active"></td>
 				<td className="menu">
 					<ScheduleListTableRowMenu { ...props } />
 				</td>
@@ -108,6 +111,14 @@ export const ScheduleListTableRow = ( props: Props ) => {
 						<td></td>
 
 						<td></td>
+						<td className="active">
+							<FormToggle
+								checked={ schedule.active }
+								onChange={ ( e ) =>
+									activateSchedule( site.slug, schedule.schedule_id, { active: e.target.checked } )
+								}
+							/>
+						</td>
 						<td className="menu">
 							<ScheduleListTableRowMenu { ...props } site={ site } />
 						</td>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -7,7 +7,7 @@ import { usePrepareMultisitePluginsTooltipInfo } from 'calypso/blocks/plugin-sch
 import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
 import { usePrepareSitesTooltipInfo } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-prepare-sites-tooltip-info';
 import { ScheduleListLastRunStatus } from 'calypso/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status';
-import { useScheduledUpdatesActivateMutation } from 'calypso/data/plugins/use-scheduled-updates-activate-mutation';
+import { useScheduledUpdatesActivateBatchMutation } from 'calypso/data/plugins/use-scheduled-updates-activate-batch-mutation';
 import { SiteSlug } from 'calypso/types';
 import { ScheduleListTableRowMenu } from './schedule-list-table-row-menu';
 import type {
@@ -32,7 +32,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 		usePrepareMultisitePluginsTooltipInfo( schedule.sites.map( ( site ) => site.ID ) );
 	const translate = useTranslate();
 	const [ isExpanded, setIsExpanded ] = useState( false );
-	const { activateSchedule } = useScheduledUpdatesActivateMutation();
+	const { activateSchedule } = useScheduledUpdatesActivateBatchMutation();
 
 	return (
 		<>
@@ -115,7 +115,9 @@ export const ScheduleListTableRow = ( props: Props ) => {
 							<FormToggle
 								checked={ site.active }
 								onChange={ ( e ) =>
-									activateSchedule( site.slug, schedule.schedule_id, { active: e.target.checked } )
+									activateSchedule( [ { id: site.ID, slug: site.slug } ], schedule.schedule_id, {
+										active: e.target.checked,
+									} )
 								}
 							/>
 						</td>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -113,7 +113,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 						<td></td>
 						<td className="active">
 							<FormToggle
-								checked={ schedule.active }
+								checked={ site.active }
 								onChange={ ( e ) =>
 									activateSchedule( site.slug, schedule.schedule_id, { active: e.target.checked } )
 								}

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
@@ -26,6 +26,7 @@ export const ScheduleListTable = ( props: Props ) => {
 					<th>{ translate( 'Next update' ) }</th>
 					<th>{ translate( 'Frequency' ) }</th>
 					<th>{ translate( 'Plugins' ) }</th>
+					<th>{ translate( 'Active' ) }</th>
 					<th></th>
 				</tr>
 			</thead>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -9,6 +9,7 @@ import { MultisitePluginUpdateManagerContext } from 'calypso/blocks/plugins-sche
 import { useBatchDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { SiteSlug } from 'calypso/types';
 import { ScheduleErrors } from './schedule-errors';
 import { ScheduleListCardNew } from './schedule-list-card-new';
 import { ScheduleListCards } from './schedule-list-cards';
@@ -50,7 +51,9 @@ export const ScheduleList = ( props: Props ) => {
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< string | undefined >(
 		initSelectedScheduleId
 	);
+	const [ selectedSiteSlug, setSelectedSiteSlug ] = useState< string | undefined >();
 	const [ selectedSiteSlugs, setSelectedSiteSlugs ] = useState< string[] >( [] );
+	const selectedSiteSlugsForMutate = selectedSiteSlug ? [ selectedSiteSlug ] : selectedSiteSlugs;
 
 	useEffect( () => {
 		const schedule = schedules?.find( ( schedule ) => schedule.schedule_id === selectedScheduleId );
@@ -58,7 +61,7 @@ export const ScheduleList = ( props: Props ) => {
 	}, [ selectedScheduleId ] );
 	useEffect( () => setSelectedScheduleId( initSelectedScheduleId ), [ initSelectedScheduleId ] );
 
-	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation( selectedSiteSlugs, {
+	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation( selectedSiteSlugsForMutate, {
 		onSuccess: () => {
 			// Refetch again after 5 seconds
 			setTimeout( () => {
@@ -67,8 +70,9 @@ export const ScheduleList = ( props: Props ) => {
 		},
 	} );
 
-	const openRemoveDialog = ( id: string ) => {
+	const openRemoveDialog = ( id: string, siteSlug?: SiteSlug ) => {
 		setRemoveDialogOpen( true );
+		setSelectedSiteSlug( siteSlug );
 		setSelectedScheduleId( id );
 	};
 
@@ -81,7 +85,7 @@ export const ScheduleList = ( props: Props ) => {
 		if ( selectedSiteSlugs && selectedScheduleId ) {
 			deleteUpdateSchedules.mutate( selectedScheduleId );
 			recordTracksEvent( 'calypso_scheduled_updates_multisite_delete_schedule', {
-				site_slugs: selectedSiteSlugs.join( ',' ),
+				site_slugs: selectedSiteSlugsForMutate.join( ',' ),
 			} );
 		}
 		closeRemoveConfirm();

--- a/client/blocks/plugins-scheduled-updates/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-cards.tsx
@@ -26,7 +26,7 @@ export const ScheduleListCards = ( props: Props ) => {
 		usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat( siteSlug );
-	const { activateSchedule } = useScheduledUpdatesActivateMutation( siteSlug );
+	const { activateSchedule } = useScheduledUpdatesActivateMutation();
 
 	return (
 		<div className="schedule-list--cards">
@@ -118,7 +118,9 @@ export const ScheduleListCards = ( props: Props ) => {
 						<span id={ `active-${ i }` }>
 							<FormToggle
 								checked={ schedule.active }
-								onChange={ ( e ) => activateSchedule( schedule.id, { active: e.target.checked } ) }
+								onChange={ ( e ) =>
+									activateSchedule( siteSlug, schedule.id, { active: e.target.checked } )
+								}
 							/>
 						</span>
 					</div>

--- a/client/blocks/plugins-scheduled-updates/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-cards.tsx
@@ -1,7 +1,7 @@
 import { Button, DropdownMenu, FormToggle, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useScheduledUpdatesActionMutation } from 'calypso/data/plugins/use-scheduled-updates-action-mutation';
+import { useScheduledUpdatesActivateMutation } from 'calypso/data/plugins/use-scheduled-updates-activate-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { Badge } from '../plugin-scheduled-updates-common/badge';
 import { useDateTimeFormat } from '../plugin-scheduled-updates-common/hooks/use-date-time-format';
@@ -26,7 +26,7 @@ export const ScheduleListCards = ( props: Props ) => {
 		usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat( siteSlug );
-	const { activateSchedule } = useScheduledUpdatesActionMutation( siteSlug );
+	const { activateSchedule } = useScheduledUpdatesActivateMutation( siteSlug );
 
 	return (
 		<div className="schedule-list--cards">

--- a/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
@@ -27,7 +27,7 @@ export const ScheduleListTable = ( props: Props ) => {
 		usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat( siteSlug );
-	const { activateSchedule } = useScheduledUpdatesActionMutation( siteSlug );
+	const { activateSchedule } = useScheduledUpdatesActionMutation();
 
 	/**
 	 * NOTE: If you update the table structure,
@@ -105,7 +105,9 @@ export const ScheduleListTable = ( props: Props ) => {
 						<td>
 							<FormToggle
 								checked={ schedule.active }
-								onChange={ ( e ) => activateSchedule( schedule.id, { active: e.target.checked } ) }
+								onChange={ ( e ) =>
+									activateSchedule( siteSlug, schedule.id, { active: e.target.checked } )
+								}
 							/>
 						</td>
 						<td style={ { textAlign: 'end' } }>

--- a/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
@@ -1,7 +1,7 @@
 import { Button, DropdownMenu, Tooltip, FormToggle } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useScheduledUpdatesActionMutation } from 'calypso/data/plugins/use-scheduled-updates-action-mutation';
+import { useScheduledUpdatesActivateMutation } from 'calypso/data/plugins/use-scheduled-updates-activate-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { Badge } from '../plugin-scheduled-updates-common/badge';
 import { useDateTimeFormat } from '../plugin-scheduled-updates-common/hooks/use-date-time-format';
@@ -27,7 +27,7 @@ export const ScheduleListTable = ( props: Props ) => {
 		usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
 	const { prepareDateTime } = useDateTimeFormat( siteSlug );
-	const { activateSchedule } = useScheduledUpdatesActionMutation();
+	const { activateSchedule } = useScheduledUpdatesActivateMutation();
 
 	/**
 	 * NOTE: If you update the table structure,

--- a/client/data/plugins/use-scheduled-updates-action-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-action-mutation.ts
@@ -8,13 +8,16 @@ export type ActiveRequestParams = {
 	active: boolean;
 };
 
-export function useScheduledUpdatesActionMutation( siteSlug: SiteSlug, queryOptions = {} ) {
+export function useScheduledUpdatesActionMutation( queryOptions = {} ) {
 	const queryClient = useQueryClient();
 
 	const mutation = useMutation( {
-		mutationKey: [ 'scheduled-updates-active', siteSlug ],
-		mutationFn: ( data: { scheduleId: string; params: ActiveRequestParams } ) => {
-			const { scheduleId, params } = data;
+		mutationFn: ( data: {
+			siteSlug: SiteSlug;
+			scheduleId: string;
+			params: ActiveRequestParams;
+		} ) => {
+			const { siteSlug, scheduleId, params } = data;
 
 			return wpcomRequest( {
 				path: `/sites/${ siteSlug }/update-schedules/${ scheduleId }/active`,
@@ -23,8 +26,12 @@ export function useScheduledUpdatesActionMutation( siteSlug: SiteSlug, queryOpti
 				body: params,
 			} );
 		},
-		onMutate: async ( data: { scheduleId: string; params: ActiveRequestParams } ) => {
-			const { scheduleId, params } = data;
+		onMutate: async ( data: {
+			siteSlug: SiteSlug;
+			scheduleId: string;
+			params: ActiveRequestParams;
+		} ) => {
+			const { siteSlug, scheduleId, params } = data;
 			// cancel in-flight queries because we don't want them to overwrite our optimistic update.
 			await queryClient.cancelQueries( {
 				queryKey: [ 'schedule-updates', siteSlug ],
@@ -44,18 +51,24 @@ export function useScheduledUpdatesActionMutation( siteSlug: SiteSlug, queryOpti
 
 			return { prevSchedules };
 		},
-		onError: ( err, params, context ) =>
+		onError: ( err, params, context ) => {
+			const { siteSlug } = params;
 			// Set previous value on error
-			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], context?.prevSchedules ),
-		onSettled: () =>
+			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], context?.prevSchedules );
+		},
+		onSettled: ( data, error, variables ) => {
+			const { siteSlug } = variables;
+
 			// Re-fetch after error or success
-			queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } ),
+			queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
+		},
 		...queryOptions,
 	} );
 
 	const { mutate } = mutation;
 	const activateSchedule = useCallback(
-		( scheduleId: string, params: ActiveRequestParams ) => mutate( { scheduleId, params } ),
+		( siteSlug: SiteSlug, scheduleId: string, params: ActiveRequestParams ) =>
+			mutate( { siteSlug, scheduleId, params } ),
 		[ mutate ]
 	);
 

--- a/client/data/plugins/use-scheduled-updates-action-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-action-mutation.ts
@@ -1,12 +1,37 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
-import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
+import type {
+	ScheduleUpdates,
+	MultisiteSchedulesUpdatesResponse,
+} from 'calypso/data/plugins/use-update-schedules-query';
 import type { SiteSlug } from 'calypso/types';
 
 export type ActiveRequestParams = {
 	active: boolean;
 };
+
+interface IStringIndex extends Record< string, any > {}
+
+function updateMultisiteSchedule(
+	multisiteSchedules: IStringIndex & MultisiteSchedulesUpdatesResponse,
+	updatedSchedule?: ScheduleUpdates
+): MultisiteSchedulesUpdatesResponse {
+	if ( ! updatedSchedule ) {
+		return multisiteSchedules;
+	}
+
+	for ( const key in multisiteSchedules ) {
+		if ( typeof multisiteSchedules[ key ] === 'object' ) {
+			if ( key === updatedSchedule.id ) {
+				multisiteSchedules[ key ] = updatedSchedule;
+			} else {
+				updateMultisiteSchedule( multisiteSchedules[ key ], updatedSchedule );
+			}
+		}
+	}
+	return multisiteSchedules;
+}
 
 export function useScheduledUpdatesActionMutation( queryOptions = {} ) {
 	const queryClient = useQueryClient();
@@ -40,27 +65,40 @@ export function useScheduledUpdatesActionMutation( queryOptions = {} ) {
 			const prevSchedules: ScheduleUpdates[] =
 				queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
 
+			const prevMultisiteSchedules: MultisiteSchedulesUpdatesResponse | undefined =
+				queryClient.getQueryData( [ 'multisite-schedules-update' ] );
+
+			let newSchedule;
 			const newSchedules = prevSchedules.map( ( x ) => {
 				if ( x.id === scheduleId ) {
-					return { ...x, active: params.active };
+					newSchedule = { ...x, active: params.active };
+					return newSchedule;
 				}
 				return x;
 			} );
 
-			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], newSchedules );
+			const newMultisiteSchedules = updateMultisiteSchedule(
+				JSON.parse( JSON.stringify( prevMultisiteSchedules ) ), // deep copy
+				newSchedule
+			);
 
-			return { prevSchedules };
+			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], newSchedules );
+			queryClient.setQueryData( [ 'multisite-schedules-update' ], newMultisiteSchedules );
+
+			return { prevSchedules, prevMultisiteSchedules };
 		},
 		onError: ( err, params, context ) => {
 			const { siteSlug } = params;
 			// Set previous value on error
 			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], context?.prevSchedules );
+			queryClient.setQueryData( [ 'multisite-schedules-update' ], context?.prevMultisiteSchedules );
 		},
 		onSettled: ( data, error, variables ) => {
 			const { siteSlug } = variables;
 
 			// Re-fetch after error or success
 			queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'multisite-schedules-update', siteSlug ] } );
 		},
 		...queryOptions,
 	} );

--- a/client/data/plugins/use-scheduled-updates-activate-batch-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-activate-batch-mutation.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import { ActiveRequestParams } from './use-scheduled-updates-activate-mutation';
+import type { SiteId, SiteSlug } from 'calypso/types';
+
+export function useScheduledUpdatesActivateBatchMutation( mutationOptions = {} ) {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation( {
+		mutationFn: ( data: {
+			sites: { id: SiteId; slug: SiteSlug }[];
+			scheduleId: string;
+			params: ActiveRequestParams;
+		} ) => {
+			const { sites, scheduleId, params } = data;
+			return Promise.all(
+				sites.map( async ( site ) => {
+					try {
+						const response = await wpcomRequest( {
+							path: `/sites/${ site.slug }/update-schedules/${ scheduleId }/active`,
+							apiNamespace: 'wpcom/v2',
+							method: 'POST',
+							body: params,
+						} );
+						return { site, response };
+					} catch ( error ) {
+						return { site, error };
+					}
+				} )
+			);
+		},
+		onMutate: ( data: {
+			sites: { id: SiteId; slug: SiteSlug }[];
+			scheduleId: string;
+			params: ActiveRequestParams;
+		} ) => {
+			const { sites, scheduleId, params } = data;
+			// cancel in-flight queries because we don't want them to overwrite our optimistic update.
+			queryClient.cancelQueries( { queryKey: [ 'multisite-schedules-update' ] } );
+
+			const prevResult = queryClient.getQueryData( [ 'multisite-schedules-update' ] ) || {};
+			const updatedResult = JSON.parse( JSON.stringify( prevResult ) ); // deep copy
+
+			sites.forEach( ( site: { id: SiteId; slug: SiteSlug } ) => {
+				if ( updatedResult?.sites?.[ site.id ]?.[ scheduleId ] ) {
+					updatedResult.sites[ site.id ][ scheduleId ].active = params.active;
+				}
+			} );
+
+			queryClient.setQueryData( [ 'multisite-schedules-update' ], updatedResult );
+			return { prevResult };
+		},
+		onError: ( err, params, context ) => {
+			// Set previous value on error
+			queryClient.setQueryData( [ 'multisite-schedules-update' ], context?.prevResult );
+		},
+		onSettled: () => {
+			// Re-fetch after error or success
+			queryClient.invalidateQueries( { queryKey: [ 'multisite-schedules-update' ] } );
+		},
+		...mutationOptions,
+	} );
+
+	const { mutate } = mutation;
+	const activateSchedule = useCallback(
+		( sites: { id: SiteId; slug: SiteSlug }[], scheduleId: string, params: ActiveRequestParams ) =>
+			mutate( { sites, scheduleId, params } ),
+		[ mutate ]
+	);
+
+	return { activateSchedule, ...mutation };
+}

--- a/client/data/plugins/use-scheduled-updates-activate-batch-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-activate-batch-mutation.ts
@@ -55,10 +55,6 @@ export function useScheduledUpdatesActivateBatchMutation( mutationOptions = {} )
 			// Set previous value on error
 			queryClient.setQueryData( [ 'multisite-schedules-update' ], context?.prevResult );
 		},
-		onSettled: () => {
-			// Re-fetch after error or success
-			queryClient.invalidateQueries( { queryKey: [ 'multisite-schedules-update' ] } );
-		},
 		...mutationOptions,
 	} );
 

--- a/client/data/plugins/use-scheduled-updates-activate-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-activate-mutation.ts
@@ -1,37 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
-import type {
-	ScheduleUpdates,
-	MultisiteSchedulesUpdatesResponse,
-} from 'calypso/data/plugins/use-update-schedules-query';
+import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 import type { SiteSlug } from 'calypso/types';
 
 export type ActiveRequestParams = {
 	active: boolean;
 };
-
-interface IStringIndex extends Record< string, any > {}
-
-function updateMultisiteSchedule(
-	multisiteSchedules: IStringIndex & MultisiteSchedulesUpdatesResponse,
-	updatedSchedule?: ScheduleUpdates
-): MultisiteSchedulesUpdatesResponse {
-	if ( ! updatedSchedule ) {
-		return multisiteSchedules;
-	}
-
-	for ( const key in multisiteSchedules ) {
-		if ( typeof multisiteSchedules[ key ] === 'object' ) {
-			if ( key === updatedSchedule.id ) {
-				multisiteSchedules[ key ] = updatedSchedule;
-			} else {
-				updateMultisiteSchedule( multisiteSchedules[ key ], updatedSchedule );
-			}
-		}
-	}
-	return multisiteSchedules;
-}
 
 export function useScheduledUpdatesActivateMutation( queryOptions = {} ) {
 	const queryClient = useQueryClient();

--- a/client/data/plugins/use-scheduled-updates-activate-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-activate-mutation.ts
@@ -33,7 +33,7 @@ function updateMultisiteSchedule(
 	return multisiteSchedules;
 }
 
-export function useScheduledUpdatesActionMutation( queryOptions = {} ) {
+export function useScheduledUpdatesActivateMutation( queryOptions = {} ) {
 	const queryClient = useQueryClient();
 
 	const mutation = useMutation( {

--- a/client/data/plugins/use-scheduled-updates-activate-mutation.ts
+++ b/client/data/plugins/use-scheduled-updates-activate-mutation.ts
@@ -65,40 +65,27 @@ export function useScheduledUpdatesActivateMutation( queryOptions = {} ) {
 			const prevSchedules: ScheduleUpdates[] =
 				queryClient.getQueryData( [ 'schedule-updates', siteSlug ] ) || [];
 
-			const prevMultisiteSchedules: MultisiteSchedulesUpdatesResponse | undefined =
-				queryClient.getQueryData( [ 'multisite-schedules-update' ] );
-
-			let newSchedule;
 			const newSchedules = prevSchedules.map( ( x ) => {
 				if ( x.id === scheduleId ) {
-					newSchedule = { ...x, active: params.active };
-					return newSchedule;
+					return { ...x, active: params.active };
 				}
 				return x;
 			} );
 
-			const newMultisiteSchedules = updateMultisiteSchedule(
-				JSON.parse( JSON.stringify( prevMultisiteSchedules ) ), // deep copy
-				newSchedule
-			);
-
 			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], newSchedules );
-			queryClient.setQueryData( [ 'multisite-schedules-update' ], newMultisiteSchedules );
 
-			return { prevSchedules, prevMultisiteSchedules };
+			return { prevSchedules };
 		},
 		onError: ( err, params, context ) => {
 			const { siteSlug } = params;
 			// Set previous value on error
 			queryClient.setQueryData( [ 'schedule-updates', siteSlug ], context?.prevSchedules );
-			queryClient.setQueryData( [ 'multisite-schedules-update' ], context?.prevMultisiteSchedules );
 		},
 		onSettled: ( data, error, variables ) => {
 			const { siteSlug } = variables;
 
 			// Re-fetch after error or success
 			queryClient.invalidateQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
-			queryClient.invalidateQueries( { queryKey: [ 'multisite-schedules-update', siteSlug ] } );
 		},
 		...queryOptions,
 	} );

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -29,13 +29,14 @@ export type ScheduleUpdates = {
 };
 
 export type MultisiteSiteDetails = SiteDetails & {
+	active: boolean;
 	last_run_status: LastRunStatus;
 	last_run_timestamp: number | null;
 };
 
 export type MultisiteSchedulesUpdates = Omit<
 	ScheduleUpdates,
-	'last_run_status' | 'last_run_timestamp'
+	'active' | 'last_run_status' | 'last_run_timestamp'
 > & {
 	schedule_id: string;
 	sites: MultisiteSiteDetails[];
@@ -141,6 +142,7 @@ export const useMultisiteUpdateScheduleQuery = (
 					if ( existingSchedule ) {
 						existingSchedule.sites.push( {
 							...site,
+							active,
 							last_run_status,
 							last_run_timestamp,
 						} );
@@ -152,10 +154,10 @@ export const useMultisiteUpdateScheduleQuery = (
 							schedule,
 							args,
 							interval,
-							active,
 							sites: [
 								{
 									...site,
+									active,
 									last_run_status,
 									last_run_timestamp,
 								},

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -41,7 +41,7 @@ export type MultisiteSchedulesUpdates = Omit<
 	sites: MultisiteSiteDetails[];
 };
 
-type MultisiteSchedulesUpdatesResponse = {
+export type MultisiteSchedulesUpdatesResponse = {
 	sites: { [ site_id: string ]: { [ scheduleId: string ]: ScheduleUpdates } };
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90265

## Proposed Changes

* Implement batch activation toggle
* Update label IDs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates`
* Make sure you have a scheduled updates on multiple sites
* Toggle batch activation and check if it works properly
* Toggle single site activation and check if it works properly

![Screen Capture on 2024-05-13 at 23-56-19](https://github.com/Automattic/wp-calypso/assets/1241413/22f58622-203f-4ee6-a6ac-9746b4ef28d9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
