### PR TITLE
Hosting config: Use two equal columns

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_SFTP,
 	FEATURE_SFTP_DATABASE,
@@ -5,6 +6,7 @@ import {
 	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { Fragment, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
@@ -84,34 +86,100 @@ const ShowEnabledFeatureCards = ( { availableTypes, cards, showDisabledCards = t
 	);
 };
 
-const MainCards = ( { isAdvancedHostingDisabled, isBasicHostingDisabled, isBusinessTrial } ) => {
-	const mainCards = [
-		{
-			feature: 'github-deployments',
-			content: <GitHubDeploymentsCard />,
-			type: 'advanced',
-		},
-		{
-			feature: 'sftp',
-			content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
-			type: 'advanced',
-		},
-		{
-			feature: 'phpmyadmin',
-			content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
-			type: 'advanced',
-		},
-		{
-			feature: 'restore-plan-software',
-			content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
-			type: 'basic',
-		},
-		{
-			feature: 'web-server-settings',
-			content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
-			type: 'advanced',
-		},
-	];
+const MainCards = ( {
+	hasStagingSitesFeature,
+	isAdvancedHostingDisabled,
+	isBasicHostingDisabled,
+	isBusinessTrial,
+	isWpcomStagingSite,
+	siteId,
+	siteSlug,
+} ) => {
+	let mainCards = [];
+
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		mainCards = [
+			{
+				feature: 'github-deployments',
+				content: <GitHubDeploymentsCard />,
+				type: 'advanced',
+			},
+			{
+				feature: 'sftp',
+				content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
+				type: 'advanced',
+			},
+			{
+				feature: 'phpmyadmin',
+				content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
+				type: 'advanced',
+			},
+			{
+				feature: 'restore-plan-software',
+				content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
+				type: 'basic',
+			},
+			{
+				feature: 'web-server-settings',
+				content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
+				type: 'advanced',
+			},
+		];
+	} else {
+		mainCards = [
+			{
+				feature: 'github-deployments',
+				content: <GitHubDeploymentsCard />,
+				type: 'advanced',
+			},
+			{
+				feature: 'sftp',
+				content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
+				type: 'advanced',
+			},
+			{
+				feature: 'phpmyadmin',
+				content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
+				type: 'advanced',
+			},
+			! isWpcomStagingSite && hasStagingSitesFeature
+				? {
+						feature: 'staging-site',
+						content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
+						type: 'advanced',
+				  }
+				: null,
+			isWpcomStagingSite && siteId
+				? {
+						feature: 'staging-production-site',
+						content: (
+							<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
+						),
+						type: 'advanced',
+				  }
+				: null,
+			{
+				feature: 'web-server-settings',
+				content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
+				type: 'advanced',
+			},
+			{
+				feature: 'restore-plan-software',
+				content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
+				type: 'basic',
+			},
+			{
+				feature: 'cache',
+				content: <CacheCard disabled={ isBasicHostingDisabled } />,
+				type: 'basic',
+			},
+			siteId && {
+				feature: 'wp-admin',
+				content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
+				type: 'basic',
+			},
+		].filter( ( card ) => card !== null );
+	}
 
 	const availableTypes = [
 		! isAdvancedHostingDisabled ? 'advanced' : null,
@@ -135,43 +203,59 @@ const SidebarCards = ( {
 	siteId,
 	siteSlug,
 } ) => {
-	const sidebarCards = [
-		{
-			feature: 'site-backup',
-			content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
-			type: 'basic',
-		},
-		{
-			feature: 'support',
-			content: <SupportCard />,
-		},
-		! isWpcomStagingSite && hasStagingSitesFeature
-			? {
-					feature: 'staging-site',
-					content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
-					type: 'advanced',
-			  }
-			: null,
-		isWpcomStagingSite && siteId
-			? {
-					feature: 'staging-production-site',
-					content: (
-						<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
-					),
-					type: 'advanced',
-			  }
-			: null,
-		{
-			feature: 'cache',
-			content: <CacheCard disabled={ isBasicHostingDisabled } />,
-			type: 'basic',
-		},
-		siteId && {
-			feature: 'wp-admin',
-			content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
-			type: 'basic',
-		},
-	].filter( ( card ) => card !== null );
+	let sidebarCards = [];
+
+	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		sidebarCards = [
+			{
+				feature: 'site-backup',
+				content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
+				type: 'basic',
+			},
+			{
+				feature: 'support',
+				content: <SupportCard />,
+			},
+			! isWpcomStagingSite && hasStagingSitesFeature
+				? {
+						feature: 'staging-site',
+						content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
+						type: 'advanced',
+				  }
+				: null,
+			isWpcomStagingSite && siteId
+				? {
+						feature: 'staging-production-site',
+						content: (
+							<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
+						),
+						type: 'advanced',
+				  }
+				: null,
+			{
+				feature: 'cache',
+				content: <CacheCard disabled={ isBasicHostingDisabled } />,
+				type: 'basic',
+			},
+			siteId && {
+				feature: 'wp-admin',
+				content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
+				type: 'basic',
+			},
+		].filter( ( card ) => card !== null );
+	} else {
+		sidebarCards = [
+			{
+				feature: 'site-backup',
+				content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
+				type: 'basic',
+			},
+			{
+				feature: 'support',
+				content: <SupportCard />,
+			},
+		];
+	}
 
 	const availableTypes = [
 		! isAdvancedHostingDisabled ? 'advanced' : null,
@@ -284,9 +368,13 @@ const Hosting = ( props ) => {
 					<Layout className="hosting__layout">
 						<Column className="hosting__main-layout-col">
 							<MainCards
+								hasStagingSitesFeature={ hasStagingSitesFeature }
 								isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
 								isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
 								isBusinessTrial={ isBusinessTrial && ! hasTransfer }
+								isWpcomStagingSite={ isWpcomStagingSite }
+								siteId={ siteId }
+								siteSlug={ siteSlug }
 							/>
 						</Column>
 						<Column>
@@ -315,7 +403,12 @@ const Hosting = ( props ) => {
 	const banner = shouldShowUpgradeBanner ? getUpgradeBanner() : getAtomicActivationNotice();
 
 	return (
-		<Main wideLayout className="hosting">
+		<Main
+			wideLayout
+			className={ classnames( 'hosting', {
+				'hosting--is-two-columns': isEnabled( 'layout/dotcom-nav-redesign-v2' ),
+			} ) }
+		>
 			{ ! isLoadingSftpData && <ScrollToAnchorOnMount offset={ HEADING_OFFSET } /> }
 			<PageViewTracker path="/hosting-config/:site" title="Hosting" />
 			<DocumentHead title={ translate( 'Hosting' ) } />

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -84,15 +84,7 @@ const ShowEnabledFeatureCards = ( { availableTypes, cards, showDisabledCards = t
 	);
 };
 
-const MainCards = ( {
-	hasStagingSitesFeature,
-	isAdvancedHostingDisabled,
-	isBasicHostingDisabled,
-	isWpcomStagingSite,
-	isBusinessTrial,
-	siteId,
-	siteSlug,
-} ) => {
+const MainCards = ( { isAdvancedHostingDisabled, isBasicHostingDisabled, isBusinessTrial } ) => {
 	const mainCards = [
 		{
 			feature: 'github-deployments',
@@ -108,6 +100,50 @@ const MainCards = ( {
 			feature: 'phpmyadmin',
 			content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
 			type: 'advanced',
+		},
+		{
+			feature: 'restore-plan-software',
+			content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		{
+			feature: 'web-server-settings',
+			content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+	];
+
+	const availableTypes = [
+		! isAdvancedHostingDisabled ? 'advanced' : null,
+		! isBasicHostingDisabled ? 'basic' : null,
+	].filter( ( type ) => type !== null );
+
+	return (
+		<ShowEnabledFeatureCards
+			cards={ mainCards }
+			availableTypes={ availableTypes }
+			showDisabledCards={ ! isBusinessTrial }
+		/>
+	);
+};
+
+const SidebarCards = ( {
+	hasStagingSitesFeature,
+	isAdvancedHostingDisabled,
+	isBasicHostingDisabled,
+	isWpcomStagingSite,
+	siteId,
+	siteSlug,
+} ) => {
+	const sidebarCards = [
+		{
+			feature: 'site-backup',
+			content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		{
+			feature: 'support',
+			content: <SupportCard />,
 		},
 		! isWpcomStagingSite && hasStagingSitesFeature
 			? {
@@ -126,16 +162,6 @@ const MainCards = ( {
 			  }
 			: null,
 		{
-			feature: 'web-server-settings',
-			content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
-			type: 'advanced',
-		},
-		{
-			feature: 'restore-plan-software',
-			content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
-			type: 'basic',
-		},
-		{
 			feature: 'cache',
 			content: <CacheCard disabled={ isBasicHostingDisabled } />,
 			type: 'basic',
@@ -146,33 +172,6 @@ const MainCards = ( {
 			type: 'basic',
 		},
 	].filter( ( card ) => card !== null );
-
-	const availableTypes = [
-		! isAdvancedHostingDisabled ? 'advanced' : null,
-		! isBasicHostingDisabled ? 'basic' : null,
-	].filter( ( type ) => type !== null );
-
-	return (
-		<ShowEnabledFeatureCards
-			cards={ mainCards }
-			availableTypes={ availableTypes }
-			showDisabledCards={ ! isBusinessTrial }
-		/>
-	);
-};
-
-const SidebarCards = ( { isBasicHostingDisabled } ) => {
-	const sidebarCards = [
-		{
-			feature: 'site-backup',
-			content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
-			type: 'basic',
-		},
-		{
-			feature: 'support',
-			content: <SupportCard />,
-		},
-	];
 
 	const availableTypes = isBasicHostingDisabled ? [] : [ 'basic' ];
 
@@ -280,19 +279,22 @@ const Hosting = ( props ) => {
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<WrapperComponent>
 					<Layout className="hosting__layout">
-						<Column type="main" className="hosting__main-layout-col">
+						<Column className="hosting__main-layout-col">
 							<MainCards
+								isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
+								isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
+								isBusinessTrial={ isBusinessTrial && ! hasTransfer }
+							/>
+						</Column>
+						<Column>
+							<SidebarCards
 								hasStagingSitesFeature={ hasStagingSitesFeature }
 								isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
 								isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
 								isWpcomStagingSite={ isWpcomStagingSite }
-								isBusinessTrial={ isBusinessTrial && ! hasTransfer }
 								siteId={ siteId }
 								siteSlug={ siteSlug }
 							/>
-						</Column>
-						<Column type="sidebar">
-							<SidebarCards isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic } />
 						</Column>
 					</Layout>
 				</WrapperComponent>

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -95,91 +95,59 @@ const MainCards = ( {
 	siteId,
 	siteSlug,
 } ) => {
-	let mainCards = [];
-
-	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		mainCards = [
-			{
-				feature: 'github-deployments',
-				content: <GitHubDeploymentsCard />,
-				type: 'advanced',
-			},
-			{
-				feature: 'sftp',
-				content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-			{
-				feature: 'phpmyadmin',
-				content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-			{
-				feature: 'restore-plan-software',
-				content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-			{
-				feature: 'web-server-settings',
-				content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-		];
-	} else {
-		mainCards = [
-			{
-				feature: 'github-deployments',
-				content: <GitHubDeploymentsCard />,
-				type: 'advanced',
-			},
-			{
-				feature: 'sftp',
-				content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-			{
-				feature: 'phpmyadmin',
-				content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-			! isWpcomStagingSite && hasStagingSitesFeature
-				? {
-						feature: 'staging-site',
-						content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
-						type: 'advanced',
-				  }
-				: null,
-			isWpcomStagingSite && siteId
-				? {
-						feature: 'staging-production-site',
-						content: (
-							<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
-						),
-						type: 'advanced',
-				  }
-				: null,
-			{
-				feature: 'web-server-settings',
-				content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
-				type: 'advanced',
-			},
-			{
-				feature: 'restore-plan-software',
-				content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-			{
-				feature: 'cache',
-				content: <CacheCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-			siteId && {
-				feature: 'wp-admin',
-				content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
-				type: 'basic',
-			},
-		].filter( ( card ) => card !== null );
-	}
+	const mainCards = [
+		{
+			feature: 'github-deployments',
+			content: <GitHubDeploymentsCard />,
+			type: 'advanced',
+		},
+		{
+			feature: 'sftp',
+			content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		{
+			feature: 'phpmyadmin',
+			content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		! isWpcomStagingSite && hasStagingSitesFeature
+			? {
+					feature: 'staging-site',
+					content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
+					type: 'advanced',
+			  }
+			: null,
+		isWpcomStagingSite && siteId
+			? {
+					feature: 'staging-production-site',
+					content: (
+						<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
+					),
+					type: 'advanced',
+			  }
+			: null,
+		{
+			feature: 'web-server-settings',
+			content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		{
+			feature: 'restore-plan-software',
+			content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		{
+			feature: 'cache',
+			content: <CacheCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		siteId && {
+			feature: 'wp-admin',
+			content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
+			type: 'basic',
+		},
+	].filter( ( card ) => card !== null );
 
 	const availableTypes = [
 		! isAdvancedHostingDisabled ? 'advanced' : null,
@@ -195,7 +163,24 @@ const MainCards = ( {
 	);
 };
 
-const SidebarCards = ( {
+const SidebarCards = ( { isBasicHostingDisabled } ) => {
+	const sidebarCards = [
+		{
+			feature: 'site-backup',
+			content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		{
+			feature: 'support',
+			content: <SupportCard />,
+		},
+	];
+
+	const availableTypes = isBasicHostingDisabled ? [] : [ 'basic' ];
+	return <ShowEnabledFeatureCards cards={ sidebarCards } availableTypes={ availableTypes } />;
+};
+
+const AllCards = ( {
 	hasStagingSitesFeature,
 	isAdvancedHostingDisabled,
 	isBasicHostingDisabled,
@@ -203,66 +188,75 @@ const SidebarCards = ( {
 	siteId,
 	siteSlug,
 } ) => {
-	let sidebarCards = [];
-
-	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		sidebarCards = [
-			{
-				feature: 'site-backup',
-				content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-			{
-				feature: 'support',
-				content: <SupportCard />,
-			},
-			! isWpcomStagingSite && hasStagingSitesFeature
-				? {
-						feature: 'staging-site',
-						content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
-						type: 'advanced',
-				  }
-				: null,
-			isWpcomStagingSite && siteId
-				? {
-						feature: 'staging-production-site',
-						content: (
-							<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
-						),
-						type: 'advanced',
-				  }
-				: null,
-			{
-				feature: 'cache',
-				content: <CacheCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-			siteId && {
-				feature: 'wp-admin',
-				content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
-				type: 'basic',
-			},
-		].filter( ( card ) => card !== null );
-	} else {
-		sidebarCards = [
-			{
-				feature: 'site-backup',
-				content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
-				type: 'basic',
-			},
-			{
-				feature: 'support',
-				content: <SupportCard />,
-			},
-		];
-	}
+	const allCards = [
+		{
+			feature: 'github-deployments',
+			content: <GitHubDeploymentsCard />,
+			type: 'advanced',
+		},
+		{
+			feature: 'sftp',
+			content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		{
+			feature: 'phpmyadmin',
+			content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		! isWpcomStagingSite && hasStagingSitesFeature
+			? {
+					feature: 'staging-site',
+					content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
+					type: 'advanced',
+			  }
+			: null,
+		isWpcomStagingSite && siteId
+			? {
+					feature: 'staging-production-site',
+					content: (
+						<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
+					),
+					type: 'advanced',
+			  }
+			: null,
+		{
+			feature: 'web-server-settings',
+			content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
+			type: 'advanced',
+		},
+		{
+			feature: 'restore-plan-software',
+			content: <RestorePlanSoftwareCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		{
+			feature: 'cache',
+			content: <CacheCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		siteId && {
+			feature: 'wp-admin',
+			content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
+			type: 'basic',
+		},
+		{
+			feature: 'site-backup',
+			content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
+			type: 'basic',
+		},
+		{
+			feature: 'support',
+			content: <SupportCard />,
+		},
+	].filter( ( card ) => card !== null );
 
 	const availableTypes = [
 		! isAdvancedHostingDisabled ? 'advanced' : null,
 		! isBasicHostingDisabled ? 'basic' : null,
 	].filter( ( type ) => type !== null );
 
-	return <ShowEnabledFeatureCards cards={ sidebarCards } availableTypes={ availableTypes } />;
+	return <ShowEnabledFeatureCards cards={ allCards } availableTypes={ availableTypes } />;
 };
 
 const Hosting = ( props ) => {
@@ -366,8 +360,8 @@ const Hosting = ( props ) => {
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<WrapperComponent>
 					<Layout className="hosting__layout">
-						<Column className="hosting__main-layout-col">
-							<MainCards
+						{ isEnabled( 'layout/dotcom-nav-redesign-v2' ) ? (
+							<AllCards
 								hasStagingSitesFeature={ hasStagingSitesFeature }
 								isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
 								isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
@@ -376,17 +370,31 @@ const Hosting = ( props ) => {
 								siteId={ siteId }
 								siteSlug={ siteSlug }
 							/>
-						</Column>
-						<Column>
-							<SidebarCards
-								hasStagingSitesFeature={ hasStagingSitesFeature }
-								isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
-								isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
-								isWpcomStagingSite={ isWpcomStagingSite }
-								siteId={ siteId }
-								siteSlug={ siteSlug }
-							/>
-						</Column>
+						) : (
+							<>
+								<Column className="hosting__main-layout-col">
+									<MainCards
+										hasStagingSitesFeature={ hasStagingSitesFeature }
+										isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
+										isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
+										isBusinessTrial={ isBusinessTrial && ! hasTransfer }
+										isWpcomStagingSite={ isWpcomStagingSite }
+										siteId={ siteId }
+										siteSlug={ siteSlug }
+									/>
+								</Column>
+								<Column>
+									<SidebarCards
+										hasStagingSitesFeature={ hasStagingSitesFeature }
+										isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
+										isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
+										isWpcomStagingSite={ isWpcomStagingSite }
+										siteId={ siteId }
+										siteSlug={ siteSlug }
+									/>
+								</Column>
+							</>
+						) }
 					</Layout>
 				</WrapperComponent>
 			</>

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -173,7 +173,10 @@ const SidebarCards = ( {
 		},
 	].filter( ( card ) => card !== null );
 
-	const availableTypes = isBasicHostingDisabled ? [] : [ 'basic' ];
+	const availableTypes = [
+		! isAdvancedHostingDisabled ? 'advanced' : null,
+		! isBasicHostingDisabled ? 'basic' : null,
+	].filter( ( type ) => type !== null );
 
 	return <ShowEnabledFeatureCards cards={ sidebarCards } availableTypes={ availableTypes } />;
 };

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -384,14 +384,7 @@ const Hosting = ( props ) => {
 									/>
 								</Column>
 								<Column>
-									<SidebarCards
-										hasStagingSitesFeature={ hasStagingSitesFeature }
-										isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
-										isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
-										isWpcomStagingSite={ isWpcomStagingSite }
-										siteId={ siteId }
-										siteSlug={ siteSlug }
-									/>
+									<SidebarCards isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic } />
 								</Column>
 							</>
 						) }

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -6,6 +6,11 @@
 		margin-top: 0;
 	}
 
+	.hosting__layout .layout__column,
+	.hosting__layout .layout__column fieldset {
+		min-width: 0;
+	}
+
 	.card > .card-icon,
 	.card > .material-icon,
 	.card > .gridicon {
@@ -66,6 +71,7 @@
 		.layout-wrapper {
 			gap: 16px;
 		}
+
 		&__main-layout-col {
 			.card:not(.github-deployments-card) {
 				padding-left: 72px;
@@ -79,6 +85,7 @@
 				}
 			}
 		}
+
 		.hosting__layout .layout__column {
 			flex-basis: 45%;
 			box-sizing: border-box;
@@ -109,6 +116,12 @@
 		.banner__action {
 			margin-right: 0;
 		}
+	}
+
+	.happiness-engineers-tray {
+		align-items: flex-start;
+		display: flex;
+		justify-content: flex-start;
 	}
 }
 

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -11,6 +11,36 @@
 		min-width: 0;
 	}
 
+	&--is-two-columns {
+		.hosting__layout .layout__column {
+			@include breakpoint-deprecated( ">1280px" ) {
+				box-sizing: border-box;
+				flex-basis: 45%;
+				flex-grow: 1;
+			}
+		}
+	}
+
+	&:not(.hosting--is-two-columns) {
+		@include breakpoint-deprecated( ">1280px" ) {
+			.hosting__layout {
+				gap: 0;
+
+				.layout__column {
+					box-sizing: border-box;
+					flex-basis: 30%;
+					padding-left: 8px;
+
+					&.hosting__main-layout-col {
+						flex-basis: 70%;
+						padding-left: 0;
+						padding-right: 8px;
+					}
+				}
+			}
+		}
+	}
+
 	.card > .card-icon,
 	.card > .material-icon,
 	.card > .gridicon {
@@ -84,12 +114,6 @@
 					left: 24px;
 				}
 			}
-		}
-
-		.hosting__layout .layout__column {
-			flex-basis: 45%;
-			box-sizing: border-box;
-			flex-grow: 1;
 		}
 	}
 

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -63,6 +63,9 @@
 	}
 
 	@include breakpoint-deprecated( ">1280px" ) {
+		.layout-wrapper {
+			gap: 16px;
+		}
 		&__main-layout-col {
 			.card:not(.github-deployments-card) {
 				padding-left: 72px;
@@ -75,6 +78,11 @@
 					left: 24px;
 				}
 			}
+		}
+		.hosting__layout .layout__column {
+			flex-basis: 45%;
+			box-sizing: border-box;
+			flex-grow: 1;
 		}
 	}
 

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -1,5 +1,7 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 
+$areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site, restore-plan-software, cache, web-server-settings, admin-interface-style;
+
 .hosting {
 	/* Rely on the standard spacing for the underlying elements. */
 	.feature-example {
@@ -12,11 +14,30 @@
 	}
 
 	&--is-two-columns {
-		.hosting__layout .layout__column {
+		.hosting__layout {
+			.card {
+				width: 100%;
+			}
+
 			@include breakpoint-deprecated( ">1280px" ) {
+				@each $area in $areas {
+					.#{$area}-card {
+						margin-bottom: 0;
+						grid-area: $area;
+						width: 100%;
+					}
+				}
+
 				box-sizing: border-box;
-				flex-basis: 45%;
-				flex-grow: 1;
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				grid-template-areas:
+					"github-deployments github-deployments"
+					"sftp site-backup"
+					"sftp support"
+					"phpmyadmin staging-site"
+					"restore-plan-software cache"
+					"web-server-settings admin-interface-style";
 			}
 		}
 	}

--- a/client/my-sites/hosting/web-server-settings-card/style.scss
+++ b/client/my-sites/hosting/web-server-settings-card/style.scss
@@ -4,6 +4,10 @@
 	margin-top: 16px;
 }
 
+.web-server-settings-card__static-file-404-select {
+	width: 100%;
+}
+
 .web-server-settings-card__wp-version-description {
 	margin-bottom: 0;
 }

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -129,7 +129,7 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 					) }
 				/>
 			) }
-			<Card>
+			<Card className="admin-interface-style-card">
 				{ isHosting && (
 					<>
 						<MaterialIcon icon="display_settings" style="filled" size={ 32 } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7078

## Proposed Changes

The hosting config cards have been re-sorted into columns and both columns are now displayed with equal widths.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Go to /hosting-config
3. For a browser width >1280px you should see two equal columns, for lower browser widths you should see narrower columns.
4. Essentially it should look like the mock in the linked issue, albeit the order of the boxes may change depending upon what your site has enabled etc


Before | After
-------|------
 <img width="1627" alt="Screenshot 2024-05-10 at 17 05 50" src="https://github.com/Automattic/wp-calypso/assets/93301/fd6e8cfb-7646-4b3c-aba6-eacdb85c0694"> | <img width="1627" alt="Screenshot 2024-05-10 at 17 06 29" src="https://github.com/Automattic/wp-calypso/assets/93301/eb70e2da-2a1b-4566-b852-9f867434945b">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
