### PR TITLE
A4A: update signup flow

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -1,6 +1,4 @@
-import config from '@automattic/calypso-config';
 import { Button, Gridicon, FormLabel } from '@automattic/components';
-import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
 import SearchableDropdown from 'calypso/a8c-for-agencies/components/searchable-dropdown';
@@ -9,8 +7,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import MultiCheckbox, { ChangeList } from 'calypso/components/forms/multi-checkbox';
-import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { Option as CountryOption, useCountriesAndStates } from './hooks/use-countries-and-states';
 import { AgencyDetailsPayload } from './types';
 import type { FormEventHandler } from 'react';
@@ -51,8 +47,6 @@ export default function AgencyDetailsForm( {
 	const translate = useTranslate();
 	const { countryOptions, stateOptionsMap } = useCountriesAndStates();
 	const showCountryFields = countryOptions.length > 0;
-	const userLoggedIn = useSelector( isUserLoggedIn );
-	const isA4ALoggedOutSignup = config.isEnabled( 'a4a-logged-out-signup' );
 
 	const [ countryValue, setCountryValue ] = useState( initialValues?.country ?? '' );
 	const [ city, setCity ] = useState( initialValues?.city ?? '' );
@@ -61,7 +55,6 @@ export default function AgencyDetailsForm( {
 	const [ postalCode, setPostalCode ] = useState( initialValues?.postalCode ?? '' );
 	const [ addressState, setAddressState ] = useState( initialValues?.state ?? '' );
 	const [ agencyName, setAgencyName ] = useState( initialValues?.agencyName ?? '' );
-	const [ email, setEmail ] = useState( initialValues?.email ?? '' );
 	const [ firstName, setFirstName ] = useState( initialValues?.firstName ?? '' );
 	const [ lastName, setLastName ] = useState( initialValues?.lastName ?? '' );
 	const [ agencyUrl, setAgencyUrl ] = useState( initialValues?.agencyUrl ?? '' );
@@ -72,8 +65,6 @@ export default function AgencyDetailsForm( {
 	const country = getCountry( countryValue, countryOptions );
 	const stateOptions = stateOptionsMap[ country ];
 
-	const [ validationError, setValidationError ] = useState< { email?: string } | undefined >( {} );
-
 	useEffect( () => {
 		// Reset the value of state since our options have changed.
 		setAddressState( stateOptions?.length ? stateOptions[ 0 ].value : '' );
@@ -81,7 +72,6 @@ export default function AgencyDetailsForm( {
 
 	const payload: AgencyDetailsPayload = useMemo(
 		() => ( {
-			email,
 			firstName,
 			lastName,
 			agencyName,
@@ -99,7 +89,6 @@ export default function AgencyDetailsForm( {
 			...( includeTermsOfService ? { tos: 'consented' } : {} ),
 		} ),
 		[
-			email,
 			firstName,
 			lastName,
 			agencyName,
@@ -122,32 +111,13 @@ export default function AgencyDetailsForm( {
 		( e: React.SyntheticEvent ) => {
 			e.preventDefault();
 
-			setValidationError( undefined );
-
 			if ( ! showCountryFields || isLoading ) {
 				return;
 			}
 
-			if ( isA4ALoggedOutSignup && ! userLoggedIn ) {
-				if ( ! email || ! emailValidator.validate( email ) ) {
-					return setValidationError( {
-						email: translate( 'Please enter a valid email address.' ),
-					} );
-				}
-			}
-
 			onSubmit( payload );
 		},
-		[
-			showCountryFields,
-			isLoading,
-			isA4ALoggedOutSignup,
-			userLoggedIn,
-			onSubmit,
-			payload,
-			email,
-			translate,
-		]
+		[ showCountryFields, isLoading, onSubmit, payload ]
 	);
 
 	const getServicesOfferedOptions = () => {
@@ -189,26 +159,6 @@ export default function AgencyDetailsForm( {
 	return (
 		<div className="agency-details-form">
 			<form onSubmit={ handleSubmit }>
-				{ isA4ALoggedOutSignup && ! userLoggedIn && (
-					<FormFieldset>
-						<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
-						<FormTextInput
-							id="email"
-							name="email"
-							value={ email || '' }
-							isError={ !! validationError?.email }
-							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-								setEmail( event.target.value );
-								setValidationError( { email: undefined } );
-							} }
-						/>
-						{ validationError?.email && (
-							<div className="agency-details-form__footer-error" role="alert">
-								{ validationError.email }
-							</div>
-						) }
-					</FormFieldset>
-				) }
 				<div className="agency-details-form__fullname-container">
 					<FormFieldset>
 						<FormLabel htmlFor="firstName">{ translate( 'First name' ) }</FormLabel>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -1,5 +1,4 @@
 export interface AgencyDetailsPayload {
-	email?: string | null;
 	firstName: string;
 	lastName: string;
 	agencyName: string;

--- a/client/a8c-for-agencies/sections/signup/signup-form/hooks/use-handle-wpcom-redirect.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/hooks/use-handle-wpcom-redirect.tsx
@@ -1,7 +1,5 @@
 import config from '@automattic/calypso-config';
-import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useCallback } from 'react';
-import wpcom from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -9,53 +7,15 @@ import { AgencyDetailsPayload } from '../../agency-details-form/types';
 
 export function useHandleWPCOMRedirect() {
 	const dispatch = useDispatch();
-	const userLocale = useLocale();
 	const notificationId = 'a4a-agency-signup-form-wpcom-redirect';
 
 	const handleWPCOMRedirect = useCallback(
-		async ( payload: AgencyDetailsPayload ) => {
+		( payload: AgencyDetailsPayload ) => {
 			try {
-				const userValidationResponse = await wpcom.req.post( '/signups/validation/user', {
-					email: payload.email,
-				} );
-
-				const isNewUser = userValidationResponse && userValidationResponse.success;
 				const returnUri = new URL( '/signup/oauth/token', window.location.origin );
 				const authUrl = new URL( config( 'wpcom_authorize_endpoint' ) );
-				authUrl.search = new URLSearchParams( {
-					response_type: 'token',
-					client_id: config( 'oauth_client_id' ),
-					redirect_uri: returnUri.toString(),
-					scope: 'global',
-				} ).toString();
-
-				let wpcomRedirectUrl = undefined;
-				let tracksEventName = undefined;
-
-				if ( isNewUser ) {
-					wpcomRedirectUrl = new URL(
-						localizeUrl( config( 'wpcom_signup_url' ), userLocale ) + 'wpcc'
-					);
-					wpcomRedirectUrl.search = new URLSearchParams( {
-						response_type: 'token',
-						oauth2_client_id: config( 'oauth_client_id' ),
-						oauth2_redirect: authUrl.toString(),
-						email_address: payload.email ?? '',
-					} ).toString();
-					tracksEventName = 'calypso_a4a_create_agency_redirect_to_wpcom_signup';
-				} else {
-					wpcomRedirectUrl = new URL( localizeUrl( config( 'wpcom_login_url' ), userLocale ) );
-					wpcomRedirectUrl.search = new URLSearchParams( {
-						client_id: config( 'oauth_client_id' ),
-						redirect_to: authUrl.toString(),
-						email_address: payload.email ?? '',
-					} ).toString();
-					tracksEventName = 'calypso_a4a_create_agency_redirect_to_wpcom_login';
-				}
-
 				dispatch(
-					recordTracksEvent( tracksEventName, {
-						email: payload.email,
+					recordTracksEvent( 'calypso_a4a_create_agency_redirect_to_wpcom_login', {
 						first_name: payload.firstName,
 						last_name: payload.lastName,
 						name: payload.agencyName,
@@ -72,13 +32,18 @@ export function useHandleWPCOMRedirect() {
 						referer: payload.referer,
 					} )
 				);
-
-				window.location.href = wpcomRedirectUrl.toString();
+				authUrl.search = new URLSearchParams( {
+					response_type: 'token',
+					client_id: config( 'oauth_client_id' ),
+					redirect_uri: returnUri.toString(),
+					scope: 'global',
+				} ).toString();
+				window.location.replace( authUrl.toString() );
 			} catch ( error ) {
 				dispatch( errorNotice( JSON.stringify( error ), { id: notificationId } ) );
 			}
 		},
-		[ dispatch, userLocale ]
+		[ dispatch ]
 	);
 
 	return handleWPCOMRedirect;

--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -47,10 +47,9 @@ export default function SignupForm() {
 	const onSubmit = useCallback(
 		async ( payload: AgencyDetailsPayload ) => {
 			dispatch( removeNotice( notificationId ) );
-
 			if ( shouldRedirectToWPCOM ) {
 				saveSignupDataToLocalStorage( payload );
-				await handleWPCOMRedirect( payload );
+				handleWPCOMRedirect( payload );
 				return;
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/464

## Proposed Changes

Instead of force navigating users to wpcom login/signup we navigate them to auth.
More details: pfunGA-1kl-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check different signup flows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?