### PR TITLE
Revert "Site Migration: Default to hiding the migration trial from unverified users"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -23,7 +23,7 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 	const translate = useTranslate();
 	const queryParams = useQuery();
 	const hideFreeMigrationTrialForNonVerifiedEmail =
-		( data?.hideFreeMigrationTrialForNonVerifiedEmail as boolean | undefined ) ?? true;
+		( data?.hideFreeMigrationTrialForNonVerifiedEmail as boolean | undefined ) ?? false;
 
 	const selectedPlanData = useSelectedPlanUpgradeQuery();
 	const selectedPlanPathSlug = selectedPlanData.data;

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -191,7 +191,11 @@ const migrationSignup: Flow = {
 					}
 
 					return navigate(
-						addQueryArgs( { from: from, siteSlug, siteId }, STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug )
+						addQueryArgs(
+							{ from: from, siteSlug, siteId },
+							STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+						),
+						{ hideFreeMigrationTrialForNonVerifiedEmail: true }
 					);
 				}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#90589

Seeing some weird test failures so I'm reverting to debug.