### PR TITLE
add span around status header

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -126,7 +126,7 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'status',
-				header: __( 'Status' ),
+				header: <span>{ __( 'Status' ) }</span>,
 				render: ( { item }: { item: SiteInfo } ) => <SiteStatus site={ item } />,
 				enableHiding: false,
 				enableSorting: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7099

## Proposed Changes

* Wraps the status header in a `span` tag the way the rest of the column headers are applied. As a result it inherits the intended styles.


BEFORE
<img width="116" alt="Screenshot 2024-05-10 at 1 49 51 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/86ca7b24-be44-45a5-b2ac-4888cdac0888">


AFTER
<img width="109" alt="Screenshot 2024-05-10 at 1 49 37 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/ba6e2dd0-5452-408a-8477-ec90e8b47367">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Go to the sites dashboard
* verify the "status" column header is capitalized like the rest.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
