### PR TITLE
Revert "Stats: Release the UTM module to Atomic sites (#90293)"

### DIFF
--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -1,8 +1,6 @@
 import { StatsCard } from '@automattic/components';
 import classNames from 'classnames';
-import { STATS_FEATURE_UTM_STATS } from '../constants';
 import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
-import { useShouldGateStats } from '../hooks/use-should-gate-stats';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import statsStrings from '../stats-strings';
@@ -14,14 +12,11 @@ const StatsModuleUTMWrapper = ( { siteId, period, postId, query, summary, classN
 
 	// Check if blog is internal.
 	const { isPending: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
-	// Check if the UTM stats module is valid by the standalone Stats commercial purchase.
 	const { isLoading: isLoadingFeatureCheck, supportCommercialUse } = useStatsPurchases( siteId );
-	// Check if the UTM stats module should be gated by WPCOM plans.
-	const { isGatedStats: isGatedUTMStats } = useShouldGateStats( STATS_FEATURE_UTM_STATS );
 
 	const isSiteInternal = ! isFetchingUsage && usageData?.is_internal;
 	const isFetching = isFetchingUsage || isLoadingFeatureCheck;
-	const isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse || ! isGatedUTMStats;
+	const isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse;
 
 	// TODO: trigger useUTMMetricsQuery manually once isAdvancedFeatureEnabled === true
 

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -18,9 +18,6 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 	const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {
 		treatAtomicAsJetpackSite: false,
 	} );
-	const isSiteJetpackOrAtomic = isJetpackSite( state, siteId, {
-		treatAtomicAsJetpackSite: true,
-	} );
 
 	return {
 		supportsHighlightsSettings: version_greater_than_or_equal(
@@ -48,8 +45,9 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.16.0-alpha',
 			isOdysseyStats
 		),
-		// UTM stats are only supported for Jetpack and Atomic sites.
-		supportsUTMStats: isSiteJetpackOrAtomic,
+		supportsUTMStats:
+			// UTM stats are only available for Jetpack sites for now.
+			isSiteJetpackNotAtomic,
 		supportsDevicesStats: config.isEnabled( 'stats/devices' ) && isSiteJetpackNotAtomic,
 		supportsOnDemandCommercialClassification: version_greater_than_or_equal(
 			statsAdminVersion,
@@ -57,8 +55,7 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			isOdysseyStats
 		),
 		isOldJetpack:
-			// We consider both Jetpack and Atomic sites since they could be hosted on Jetpack.
-			isSiteJetpackOrAtomic &&
+			isSiteJetpackNotAtomic &&
 			! version_greater_than_or_equal( statsAdminVersion, '0.19.0-alpha', isOdysseyStats ),
 	};
 }


### PR DESCRIPTION
This reverts commit d9e041162fa285ef09d156df844ddb5f9957525f.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1715363097377789/1715348677.970399-slack-C0438NHCLSY
Related to https://github.com/Automattic/red-team/issues/19

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?