### PR TITLE
A8C For Agencies: Add site tags filter and Refactor of SitesDashboardProvider

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/constants.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/constants.ts
@@ -7,13 +7,13 @@ export const DATAVIEWS_LIST = 'list';
 export const initialDataViewsState: DataViewsState = {
 	filters: [],
 	sort: {
-		field: '',
+		field: 'url',
 		direction: 'asc',
 	},
 	type: DATAVIEWS_TABLE,
 	perPage: 50,
 	page: 1,
 	search: '',
-	hiddenFields: [],
+	hiddenFields: [ 'status', 'site_tags' ],
 	layout: {},
 };

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -1,7 +1,5 @@
-import { Spinner } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
-import ReactDOM from 'react-dom';
 import { DataViews } from 'calypso/components/dataviews';
 import { ItemsDataViewsType, DataViewsColumn } from './interfaces';
 
@@ -57,6 +55,11 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 
 	// Until the DataViews package is updated to support the spinner, we need to manually add the (loading) spinner to the table wrapper for now.
 	// todo: The DataViews v0.9 has the spinner support. Remove this once we upgrade the package.
+	// Disabling this for now, as manipulating the DOM on the React tree completely breaks the point of using React.
+	// This generates mismatches and React has to re-render the whole application to recover.
+	// When the mismatch happens, the page might break on a unrecoverable state.
+
+	/*
 	const SpinnerWrapper = () => {
 		return (
 			<div className="spinner-wrapper">
@@ -64,20 +67,20 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 			</div>
 		);
 	};
-	const dataviewsWrapper = document.getElementsByClassName( 'dataviews-wrapper' )[ 0 ];
-	if ( dataviewsWrapper ) {
-		// Remove any existing spinner if present
-		const existingSpinner = dataviewsWrapper.querySelector( '.spinner-wrapper' );
-		if ( existingSpinner ) {
-			existingSpinner.remove();
-		}
+  const dataviewsWrapper = document.getElementsByClassName( 'dataviews-wrapper' )[ 0 ];
+    if ( dataviewsWrapper ) {
+        // Remove any existing spinner if present
+        const existingSpinner = dataviewsWrapper.querySelector( '.spinner-wrapper' );
+        if ( existingSpinner ) {
+            existingSpinner.remove();
+        }
 
-		const spinnerWrapper = dataviewsWrapper.appendChild( document.createElement( 'div' ) );
-		spinnerWrapper.classList.add( 'spinner-wrapper' );
-		// Render the SpinnerWrapper component inside the spinner wrapper
-		ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
-	}
-
+        const spinnerWrapper = dataviewsWrapper.appendChild( document.createElement( 'div' ) );
+        spinnerWrapper.classList.add( 'spinner-wrapper' );
+        // Render the SpinnerWrapper component inside the spinner wrapper
+        ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
+  }
+ */
 	return (
 		<div className={ className }>
 			<DataViews

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
@@ -17,7 +17,7 @@ export interface DataViewsColumn {
 	enableHiding?: boolean;
 	enableSorting?: boolean;
 	elements?: {
-		value: number;
+		value: number | string;
 		label: string;
 	}[];
 	filterBy?: {
@@ -26,7 +26,7 @@ export interface DataViewsColumn {
 	};
 	type?: string;
 	header: ReactNode;
-	getValue?: ( item: any ) => string | boolean | number | undefined;
+	getValue?: ( item: any ) => string | boolean | number | any[] | undefined;
 	render?: ( item: any ) => ReactNode | null;
 }
 
@@ -55,7 +55,7 @@ export interface DataViewsSort {
 export interface DataViewsFilter {
 	field: string;
 	operator: string;
-	value: number;
+	value: number | string | undefined;
 }
 
 export interface DataViewsState {

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
@@ -53,7 +53,7 @@ export interface DataViewsSort {
 }
 
 export interface DataViewsFilter {
-	field: string;
+	field: string | number;
 	operator: string;
 	value: number | string | undefined;
 }

--- a/client/a8c-for-agencies/data/sites.ts
+++ b/client/a8c-for-agencies/data/sites.ts
@@ -2,6 +2,7 @@ import { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-over
 
 export const mockedSites: Site[] = [
 	{
+		a4a_site_tags: [],
 		url: 'elegantsuperbly.wpcomstaging.com',
 		url_with_scheme: 'https://elegantsuperbly.wpcomstaging.com',
 		blog_id: 230552437,
@@ -58,6 +59,7 @@ export const mockedSites: Site[] = [
 		multisite: false,
 	},
 	{
+		a4a_site_tags: [],
 		url: 'instantdelightfully.wpcomstaging.com',
 		url_with_scheme: 'https://instantdelightfully.wpcomstaging.com',
 		blog_id: 230520819,
@@ -114,6 +116,7 @@ export const mockedSites: Site[] = [
 		multisite: false,
 	},
 	{
+		a4a_site_tags: [],
 		url: 'jetpackcrm.com',
 		url_with_scheme: 'https://jetpackcrm.com',
 		blog_id: 177696842,
@@ -185,6 +188,7 @@ export const mockedSites: Site[] = [
 		multisite: false,
 	},
 	{
+		a4a_site_tags: [],
 		url: 'kb.jetpackcrm.com',
 		url_with_scheme: 'https://kb.jetpackcrm.com',
 		blog_id: 177445055,

--- a/client/a8c-for-agencies/hooks/use-no-active-site.ts
+++ b/client/a8c-for-agencies/hooks/use-no-active-site.ts
@@ -11,6 +11,7 @@ export default function useNoActiveSite() {
 		currentPage: 1,
 		filter: {
 			issueTypes: [],
+			siteTags: [],
 			showOnlyFavorites: false,
 		},
 		sort: {

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -12,7 +12,6 @@ import {
 import NeedSetup from './needs-setup-sites';
 import SitesDashboard from './sites-dashboard';
 import { SitesDashboardProvider } from './sites-dashboard-provider';
-import type { DashboardSortInterface } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
 function configureSitesContext( context: Context ) {
 	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;
@@ -20,45 +19,30 @@ function configureSitesContext( context: Context ) {
 	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
 	const hideListingInitialState = !! siteUrl;
 
-	const {
-		s: search,
-		page: contextPage,
-		issue_types,
-		sort_field,
-		sort_direction,
-		is_favorite,
-		site_tags,
-	} = context.query;
-
-	const sort: DashboardSortInterface = {
-		field: sort_field || DEFAULT_SORT_FIELD,
-		direction: sort_direction || DEFAULT_SORT_DIRECTION,
-	};
-	const currentPage = parseInt( contextPage ) || 1;
-
 	context.primary = (
 		<SitesDashboardProvider
 			categoryInitialState={ category }
 			siteUrlInitialState={ siteUrl }
 			siteFeatureInitialState={ siteFeature }
 			hideListingInitialState={ hideListingInitialState }
-			showOnlyFavoritesInitialState={
-				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
-			}
+			showOnlyFavoritesInitialState={ context.dashboardSitesQuery?.showOnlyFavorites }
 			path={ context.path }
-			searchQuery={ search }
-			currentPage={ currentPage }
-			filters={ { status: issue_types, siteTags: site_tags } }
-			sort={ sort }
+			searchQuery={ context.dashboardSitesQuery.searchQuery }
+			currentPage={ context.dashboardSitesQuery.currentPage }
+			filters={ {
+				status: context.dashboardSitesQuery.filter.issueTypes,
+				siteTags: context.dashboardSitesQuery.filter.siteTags,
+			} }
+			sort={ context.dashboardSitesQuery.sort }
 			{ ...( context.featurePreview ? { featurePreview: context.featurePreview } : {} ) }
 		>
 			<PageViewTracker
 				title="Sites"
 				path={ context.path }
 				properties={ {
-					category: context.params.category,
-					siteUrl: context.params.siteUrl,
-					feature: context.params.feature,
+					category,
+					siteUrl,
+					feature: siteFeature,
 				} }
 			/>
 
@@ -82,6 +66,7 @@ export const dashboardSitesContext: Callback = ( context: Context, next ) => {
 		sort_direction,
 		issue_types,
 		is_favorite,
+		site_tags,
 	} = context.query;
 	const state = context.store.getState();
 	const agency = getActiveAgency( state );
@@ -91,13 +76,14 @@ export const dashboardSitesContext: Callback = ( context: Context, next ) => {
 		searchQuery: search || '',
 		currentPage: contextPage || 1,
 		sort: {
-			field: sort_field || '',
-			direction: sort_direction || '',
+			field: sort_field || DEFAULT_SORT_FIELD,
+			direction: sort_direction || DEFAULT_SORT_DIRECTION,
 		},
 		perPage: 100,
 		agencyId: agency?.id,
 		filter: {
-			issueTypes: [ issue_types ],
+			issueTypes: issue_types,
+			siteTags: site_tags,
 			showOnlyFavorites: !! is_favorite,
 		},
 	};

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -17,14 +17,13 @@ function configureSitesContext( context: Context ) {
 	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
-	const hideListingInitialState = !! siteUrl;
 
 	context.primary = (
 		<SitesDashboardProvider
 			selectedCategory={ category }
 			siteUrl={ siteUrl }
 			siteFeature={ siteFeature }
-			hideListing={ hideListingInitialState }
+			showPreviewPane={ context.sitePreviewPane }
 			showOnlyFavorites={ context.dashboardSitesQuery?.showOnlyFavorites }
 			path={ context.path }
 			searchQuery={ context.dashboardSitesQuery.searchQuery }
@@ -88,6 +87,11 @@ export const dashboardSitesContext: Callback = ( context: Context, next ) => {
 		},
 	};
 
+	next();
+};
+
+export const sitePreviewPaneContext: Callback = ( context: Context, next ) => {
+	context.sitePreviewPane = true;
 	next();
 };
 

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -91,7 +91,7 @@ export const dashboardSitesContext: Callback = ( context: Context, next ) => {
 };
 
 export const sitePreviewPaneContext: Callback = ( context: Context, next ) => {
-	context.sitePreviewPane = true;
+	context.sitePreviewPane = !! context.params.siteUrl;
 	next();
 };
 

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -24,7 +24,7 @@ function configureSitesContext( context: Context ) {
 			siteUrl={ siteUrl }
 			siteFeature={ siteFeature }
 			showPreviewPane={ context.sitePreviewPane }
-			showOnlyFavorites={ context.dashboardSitesQuery?.showOnlyFavorites }
+			showOnlyFavorites={ context.dashboardSitesQuery.filter.showOnlyFavorites }
 			path={ context.path }
 			searchQuery={ context.dashboardSitesQuery.searchQuery }
 			currentPage={ context.dashboardSitesQuery.currentPage }
@@ -83,7 +83,7 @@ export const dashboardSitesContext: Callback = ( context: Context, next ) => {
 		filter: {
 			issueTypes: issue_types,
 			siteTags: site_tags,
-			showOnlyFavorites: !! is_favorite,
+			showOnlyFavorites: is_favorite === '' || !! is_favorite,
 		},
 	};
 

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -21,11 +21,11 @@ function configureSitesContext( context: Context ) {
 
 	context.primary = (
 		<SitesDashboardProvider
-			categoryInitialState={ category }
-			siteUrlInitialState={ siteUrl }
-			siteFeatureInitialState={ siteFeature }
-			hideListingInitialState={ hideListingInitialState }
-			showOnlyFavoritesInitialState={ context.dashboardSitesQuery?.showOnlyFavorites }
+			selectedCategory={ category }
+			siteUrl={ siteUrl }
+			siteFeature={ siteFeature }
+			hideListing={ hideListingInitialState }
+			showOnlyFavorites={ context.dashboardSitesQuery?.showOnlyFavorites }
 			path={ context.path }
 			searchQuery={ context.dashboardSitesQuery.searchQuery }
 			currentPage={ context.dashboardSitesQuery.currentPage }

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -27,6 +27,7 @@ function configureSitesContext( context: Context ) {
 		sort_field,
 		sort_direction,
 		is_favorite,
+		site_tags,
 	} = context.query;
 
 	const sort: DashboardSortInterface = {
@@ -47,7 +48,7 @@ function configureSitesContext( context: Context ) {
 			path={ context.path }
 			searchQuery={ search }
 			currentPage={ currentPage }
-			issueTypes={ issue_types }
+			filters={ { status: issue_types, siteTags: site_tags } }
 			sort={ sort }
 			{ ...( context.featurePreview ? { featurePreview: context.featurePreview } : {} ) }
 		>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/backup/routes.ts
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/backup/routes.ts
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Context, type Callback } from '@automattic/calypso-router';
 import {
+	sitePreviewPaneContext,
 	dashboardSitesContext,
 	sitesContext,
 } from 'calypso/a8c-for-agencies/sections/sites/controller';
@@ -89,6 +90,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
@@ -107,6 +109,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
@@ -125,6 +128,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
@@ -144,6 +148,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/backup/routes.ts
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/backup/routes.ts
@@ -1,6 +1,9 @@
 import page from '@automattic/calypso-router';
 import { Context, type Callback } from '@automattic/calypso-router';
-import { sitesContext } from 'calypso/a8c-for-agencies/sections/sites/controller';
+import {
+	dashboardSitesContext,
+	sitesContext,
+} from 'calypso/a8c-for-agencies/sections/sites/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { JETPACK_BACKUP_ID } from '../../features';
 import {
@@ -50,6 +53,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
 		//notFoundIfNotEnabled,
@@ -67,6 +71,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
 		//notFoundIfNotEnabled,
@@ -84,6 +89,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
 		//notFoundIfNotEnabled,
@@ -101,6 +107,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
 		//notFoundIfNotEnabled,
@@ -118,6 +125,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
 		//notFoundIfNotEnabled,
@@ -136,6 +144,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMUpsellPage ),
 		//notFoundIfNotEnabled,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -24,7 +24,6 @@ import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/s
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { AllowedTypes, Site, SiteData } from '../../types';
-import SiteTag from 'calypso/a8c-for-agencies/types/site-tag';
 
 export const JetpackSitesDataViews = ( {
 	data,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -24,6 +24,7 @@ import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/s
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { AllowedTypes, Site, SiteData } from '../../types';
+import SiteTag from 'calypso/a8c-for-agencies/types/site-tag';
 
 export const JetpackSitesDataViews = ( {
 	data,
@@ -126,6 +127,26 @@ export const JetpackSitesDataViews = ( {
 					{ value: 5, label: translate( 'Site Disconnected' ) },
 					{ value: 6, label: translate( 'Site Down' ) },
 					{ value: 7, label: translate( 'Plugins Needing Updates' ) },
+				],
+				filterBy: {
+					operators: [ 'in' ],
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'site_tags',
+				header: translate( 'Site Tags' ),
+				getValue: ( { item }: { item: SiteInfo } ) => item.site.value.a4a_site_tags,
+				/* render: ( { item } ) =>
+                    item.site.value.a4a_site_tags.map( ( siteTag: SiteTag ) => siteTag.label ).join( ', ' ), */
+				render: () => null,
+				type: 'enumeration',
+				elements: [
+					{ value: 'game', label: 'Game' },
+					{ value: 'retro', label: 'Retro' },
+					{ value: 'some', label: 'Some' },
+					{ value: 'tags', label: 'Tags' },
 				],
 				filterBy: {
 					operators: [ 'in' ],
@@ -488,20 +509,22 @@ export const JetpackSitesDataViews = ( {
 
 	// Update the data packet
 	useEffect( () => {
-		setItemsData( ( prevState: ItemsDataViewsType< SiteData > ) => ( {
-			...prevState,
-			items: sites,
-			fields: fields,
-			//actions: actions,
-			pagination: {
-				totalItems: totalSites,
-				totalPages: totalPages,
-			},
-			setDataViewsState: setDataViewsState,
-			dataViewsState: dataViewsState,
-			selectedItem: dataViewsState.selectedItem,
-		} ) );
-	}, [ fields, dataViewsState, setDataViewsState, data ] ); // add actions when implemented
+		setItemsData( ( prevState: ItemsDataViewsType< SiteData > ) => {
+			return {
+				...prevState,
+				items: sites,
+				fields: fields,
+				//actions: actions,
+				pagination: {
+					totalItems: totalSites,
+					totalPages: totalPages,
+				},
+				setDataViewsState: setDataViewsState,
+				dataViewsState: dataViewsState,
+				selectedItem: dataViewsState.selectedItem,
+			};
+		} );
+	}, [ fields, dataViewsState, setDataViewsState ] ); // add actions when implemented
 
 	return <ItemsDataViews data={ itemsData } isLoading={ isLoading } className={ className } />;
 };

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -66,6 +67,7 @@ export const JetpackSitesDataViews = ( {
 					selectedItem: site,
 					type: DATAVIEWS_LIST,
 				} ) );
+				page.show( `/sites/overview/${ site.url }` );
 			}
 		},
 		[ setDataViewsState ]

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/scan/routes.ts
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/scan/routes.ts
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { Context, type Callback } from '@automattic/calypso-router';
 import {
 	dashboardSitesContext,
+	sitePreviewPaneContext,
 	sitesContext,
 } from 'calypso/a8c-for-agencies/sections/sites/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
@@ -52,6 +53,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMScanUpsellPage ),
@@ -71,6 +73,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		//notFoundIfNotEnabled,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/scan/routes.ts
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/scan/routes.ts
@@ -1,6 +1,9 @@
 import page from '@automattic/calypso-router';
 import { Context, type Callback } from '@automattic/calypso-router';
-import { sitesContext } from 'calypso/a8c-for-agencies/sections/sites/controller';
+import {
+	dashboardSitesContext,
+	sitesContext,
+} from 'calypso/a8c-for-agencies/sections/sites/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { JETPACK_SCAN_ID } from '../../features';
 import {
@@ -49,6 +52,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		dashboardSitesContext,
 		sitesContext,
 		//wpcomAtomicTransfer( WPCOMScanUpsellPage ),
 		//notFoundIfNotEnabled,
@@ -67,6 +71,7 @@ export default function ( basePath: string ) {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
+		dashboardSitesContext,
 		sitesContext,
 		//notFoundIfNotEnabled,
 		//wpcomAtomicTransfer( WPCOMScanUpsellPage ),

--- a/client/a8c-for-agencies/sections/sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/index.tsx
@@ -35,11 +35,33 @@ export default function () {
 	page(
 		'/sites/:category/:siteUrl/:feature',
 		requireAccessContext,
+		dashboardSitesContext,
 		sitesContext,
 		makeLayout,
 		clientRender
 	);
-	page( '/sites/:category/:siteUrl', requireAccessContext, sitesContext, makeLayout, clientRender );
-	page( '/sites/:category', requireAccessContext, sitesContext, makeLayout, clientRender );
-	page( '/sites', requireAccessContext, sitesContext, makeLayout, clientRender );
+	page(
+		'/sites/:category/:siteUrl',
+		requireAccessContext,
+		dashboardSitesContext,
+		sitesContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/sites/:category',
+		requireAccessContext,
+		dashboardSitesContext,
+		sitesContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/sites',
+		requireAccessContext,
+		dashboardSitesContext,
+		sitesContext,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/a8c-for-agencies/sections/sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/index.tsx
@@ -7,6 +7,7 @@ import {
 	sitesContext,
 	needsSetupContext,
 	dashboardSitesContext,
+	sitePreviewPaneContext,
 } from './controller';
 import { FeatureRoutes as loadFeatureRoutes } from './features/routes';
 
@@ -35,6 +36,7 @@ export default function () {
 	page(
 		'/sites/:category/:siteUrl/:feature',
 		requireAccessContext,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		makeLayout,
@@ -43,6 +45,7 @@ export default function () {
 	page(
 		'/sites/:category/:siteUrl',
 		requireAccessContext,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		makeLayout,
@@ -51,6 +54,7 @@ export default function () {
 	page(
 		'/sites/:category',
 		requireAccessContext,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		makeLayout,
@@ -59,6 +63,7 @@ export default function () {
 	page(
 		'/sites',
 		requireAccessContext,
+		sitePreviewPaneContext,
 		dashboardSitesContext,
 		sitesContext,
 		makeLayout,

--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -35,13 +35,15 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 	const { dataViewsState, showOnlyFavorites, currentPage } = useContext( SitesDashboardContext );
 	const [ filter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
 		issueTypes: [],
+		siteTags: [],
 		showOnlyFavorites: showOnlyFavorites || false,
 	} );
 	useEffect( () => {
 		const selectedFilters = getSelectedFilters( dataViewsState.filters );
 
 		setAgencyDashboardFilter( {
-			issueTypes: selectedFilters,
+			issueTypes: selectedFilters.status,
+			siteTags: selectedFilters.siteTags,
 			showOnlyFavorites: showOnlyFavorites || false,
 		} );
 	}, [ dataViewsState.filters, showOnlyFavorites ] );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -9,8 +9,8 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	selectedSiteFeature: undefined,
 	setSelectedSiteFeature: () => {},
 
-	hideListing: undefined,
-	setHideListing: () => {},
+	showPreviewPane: false,
+	closePreviewPane: () => {},
 
 	showOnlyFavorites: undefined,
 	setShowOnlyFavorites: () => {},
@@ -18,7 +18,7 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	dataViewsState: initialDataViewsState,
 	setDataViewsState: () => {},
 
-	initialSelectedSiteUrl: '',
+	siteUrl: '',
 	currentPage: 1,
 	path: '',
 	featurePreview: null,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -129,7 +129,9 @@ export const SitesDashboardProvider = ( {
 		},
 		selectedSiteFeature: siteFeature,
 		setSelectedSiteFeature: ( feature: string | undefined ) => {
-			page.show( `/sites/${ selectedCategory }/${ siteUrl }/${ feature || '' }` );
+			if ( feature ) {
+				page.show( `/sites/${ selectedCategory }/${ siteUrl }/${ feature || '' }` );
+			}
 		},
 		showPreviewPane,
 		closePreviewPane: onClosePreviewPane,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,8 +1,5 @@
-import { ReactNode, useEffect, useMemo, useState } from 'react';
-import {
-	DATAVIEWS_TABLE,
-	initialDataViewsState,
-} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import { ReactNode, useMemo, useState } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { SitesDashboardContextInterface } from 'calypso/a8c-for-agencies/sections/sites/types';
 import {
@@ -86,8 +83,17 @@ export const SitesDashboardProvider = ( {
 	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
 	const [ mostRecentConnectedSite, setMostRecentConnectedSite ] = useState< string | null >( null );
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
-	const [ initialSelectedSiteUrl, setInitialSelectedSiteUrl ] = useState( siteUrlInitialState );
 
+	const dataViewsFilters = useMemo( () => buildFilters( filters ), [ filters ] );
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		page: currentPage,
+		search: searchQuery,
+		sort,
+		filters: dataViewsFilters,
+	} );
+
+	// Callbacks
 	const handleSetBulkManagementActive = ( isActive: boolean ) => {
 		setIsBulkManagementActive( isActive );
 		if ( ! isActive ) {
@@ -103,49 +109,6 @@ export const SitesDashboardProvider = ( {
 		setCurrentLicenseInfo( null );
 	};
 
-	/* initialDataViewsState.sort.field = DEFAULT_SORT_FIELD; */
-	/* initialDataViewsState.sort.direction = DEFAULT_SORT_DIRECTION; */
-	// initialDataViewsState.hiddenFields = [ 'status', 'site_tags' ];
-
-	const dataViewsFilters = useMemo( () => buildFilters( filters ), [ filters ] );
-
-	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
-		...initialDataViewsState,
-		page: currentPage,
-		search: searchQuery,
-		sort,
-		filters: dataViewsFilters,
-	} );
-
-	useEffect( () => {
-		setInitialSelectedSiteUrl( siteUrlInitialState );
-		if ( ! siteUrlInitialState ) {
-			setShowOnlyFavorites( showOnlyFavoritesInitialState );
-			setHideListing( false );
-		}
-
-		setDataViewsState( ( previousState ) => ( {
-			...previousState,
-			...( siteUrlInitialState
-				? {}
-				: {
-						filters: dataViewsFilters,
-				  } ),
-			...( siteUrlInitialState ? {} : { search: searchQuery } ),
-			...( siteUrlInitialState ? {} : { sort } ),
-			...( siteUrlInitialState ? {} : { selectedItem: undefined } ),
-			...( siteUrlInitialState ? {} : { type: DATAVIEWS_TABLE } ),
-		} ) );
-	}, [
-		setDataViewsState,
-		showOnlyFavoritesInitialState,
-		searchQuery,
-		sort,
-		dataViewsFilters,
-		siteUrlInitialState,
-		setInitialSelectedSiteUrl,
-	] );
-
 	const sitesDashboardContextValue: SitesDashboardContextInterface = {
 		selectedCategory: selectedCategory,
 		setSelectedCategory: setSelectedCategory,
@@ -158,7 +121,7 @@ export const SitesDashboardProvider = ( {
 		path,
 		currentPage,
 		isBulkManagementActive,
-		initialSelectedSiteUrl: initialSelectedSiteUrl,
+		initialSelectedSiteUrl: siteUrlInitialState,
 		setIsBulkManagementActive: handleSetBulkManagementActive,
 		selectedSites,
 		setSelectedSites,
@@ -173,6 +136,7 @@ export const SitesDashboardProvider = ( {
 		setDataViewsState,
 		featurePreview,
 	};
+
 	return (
 		<SitesDashboardContext.Provider value={ sitesDashboardContextValue }>
 			{ children }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { ReactNode, useMemo, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -11,7 +12,7 @@ import SitesDashboardContext from './sites-dashboard-context';
 
 interface Props {
 	showOnlyFavorites?: boolean;
-	hideListing?: boolean;
+	showPreviewPane?: boolean;
 	selectedCategory: string;
 	siteUrl?: string;
 	siteFeature?: string;
@@ -61,7 +62,7 @@ const buildFilters = ( { status, siteTags }: { status: string; siteTags: string 
 };
 
 export const SitesDashboardProvider = ( {
-	hideListing = false,
+	showPreviewPane = false,
 	showOnlyFavorites = false,
 	selectedCategory,
 	siteUrl,
@@ -109,15 +110,19 @@ export const SitesDashboardProvider = ( {
 		selectedCategory,
 		setSelectedCategory: () => {},
 		selectedSiteFeature: siteFeature,
-		setSelectedSiteFeature: () => {},
-		hideListing,
-		setHideListing: () => {},
+		setSelectedSiteFeature: ( feature: string | undefined ) => {
+			page.show( `/sites/${ selectedCategory }/${ siteUrl }/${ feature || '' }` );
+		},
+		showPreviewPane,
+		closePreviewPane: () => {
+			page.show( `/sites/${ selectedCategory }` );
+		},
 		showOnlyFavorites,
 		setShowOnlyFavorites: () => {},
 		path,
 		currentPage,
 		isBulkManagementActive,
-		initialSelectedSiteUrl: siteUrl,
+		siteUrl,
 		setIsBulkManagementActive: handleSetBulkManagementActive,
 		selectedSites,
 		setSelectedSites,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -141,7 +141,7 @@ export const SitesDashboardProvider = ( {
 		showOnlyFavoritesInitialState,
 		searchQuery,
 		sort,
-		issueTypes,
+		dataViewsFilters,
 		siteUrlInitialState,
 		setInitialSelectedSiteUrl,
 	] );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -10,11 +10,11 @@ import { filtersMap } from './constants';
 import SitesDashboardContext from './sites-dashboard-context';
 
 interface Props {
-	showOnlyFavoritesInitialState?: boolean;
-	hideListingInitialState?: boolean;
-	categoryInitialState?: string;
-	siteUrlInitialState?: string;
-	siteFeatureInitialState?: string;
+	showOnlyFavorites?: boolean;
+	hideListing?: boolean;
+	selectedCategory: string;
+	siteUrl?: string;
+	siteFeature?: string;
 	searchQuery: string;
 	children: ReactNode;
 	path: string;
@@ -61,11 +61,11 @@ const buildFilters = ( { status, siteTags }: { status: string; siteTags: string 
 };
 
 export const SitesDashboardProvider = ( {
-	hideListingInitialState = false,
-	showOnlyFavoritesInitialState = false,
-	categoryInitialState,
-	siteUrlInitialState,
-	siteFeatureInitialState,
+	hideListing = false,
+	showOnlyFavorites = false,
+	selectedCategory,
+	siteUrl,
+	siteFeature,
 	children,
 	path,
 	searchQuery,
@@ -74,10 +74,6 @@ export const SitesDashboardProvider = ( {
 	sort,
 	featurePreview,
 }: Props ) => {
-	const [ hideListing, setHideListing ] = useState( hideListingInitialState );
-	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
-	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
-	const [ showOnlyFavorites, setShowOnlyFavorites ] = useState( showOnlyFavoritesInitialState );
 	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
 	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
 	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
@@ -110,18 +106,18 @@ export const SitesDashboardProvider = ( {
 	};
 
 	const sitesDashboardContextValue: SitesDashboardContextInterface = {
-		selectedCategory: selectedCategory,
-		setSelectedCategory: setSelectedCategory,
-		selectedSiteFeature: selectedSiteFeature,
-		setSelectedSiteFeature: setSelectedSiteFeature,
-		hideListing: hideListing,
-		setHideListing: setHideListing,
-		showOnlyFavorites: showOnlyFavorites,
-		setShowOnlyFavorites: setShowOnlyFavorites,
+		selectedCategory,
+		setSelectedCategory: () => {},
+		selectedSiteFeature: siteFeature,
+		setSelectedSiteFeature: () => {},
+		hideListing,
+		setHideListing: () => {},
+		showOnlyFavorites,
+		setShowOnlyFavorites: () => {},
 		path,
 		currentPage,
 		isBulkManagementActive,
-		initialSelectedSiteUrl: siteUrlInitialState,
+		initialSelectedSiteUrl: siteUrl,
 		setIsBulkManagementActive: handleSetBulkManagementActive,
 		selectedSites,
 		setSelectedSites,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -9,9 +9,8 @@ import {
 	DashboardSortInterface,
 	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
-import { DEFAULT_SORT_DIRECTION, DEFAULT_SORT_FIELD, filtersMap } from './constants';
+import { filtersMap } from './constants';
 import SitesDashboardContext from './sites-dashboard-context';
-import SiteTag from 'calypso/a8c-for-agencies/types/site-tag';
 
 interface Props {
 	showOnlyFavoritesInitialState?: boolean;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,6 +1,9 @@
 import page from '@automattic/calypso-router';
 import { ReactNode, useMemo, useState } from 'react';
-import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import {
+	DATAVIEWS_TABLE,
+	initialDataViewsState,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { SitesDashboardContextInterface } from 'calypso/a8c-for-agencies/sections/sites/types';
 import {
@@ -62,7 +65,7 @@ const buildFilters = ( { status, siteTags }: { status: string; siteTags: string 
 };
 
 export const SitesDashboardProvider = ( {
-	showPreviewPane = false,
+	showPreviewPane,
 	showOnlyFavorites = false,
 	selectedCategory,
 	siteUrl,
@@ -106,17 +109,30 @@ export const SitesDashboardProvider = ( {
 		setCurrentLicenseInfo( null );
 	};
 
+	const onClosePreviewPane = () => {
+		setDataViewsState( {
+			...dataViewsState,
+			type: DATAVIEWS_TABLE,
+			selectedItem: undefined,
+		} );
+		page.show( `/sites` );
+	};
+
 	const sitesDashboardContextValue: SitesDashboardContextInterface = {
 		selectedCategory,
-		setSelectedCategory: () => {},
+		setSelectedCategory: ( category: string | undefined ) => {
+			if ( siteUrl ) {
+				page.show( `/sites/${ category }/${ siteUrl }` );
+			}
+
+			page.show( `/sites/${ category }` );
+		},
 		selectedSiteFeature: siteFeature,
 		setSelectedSiteFeature: ( feature: string | undefined ) => {
 			page.show( `/sites/${ selectedCategory }/${ siteUrl }/${ feature || '' }` );
 		},
 		showPreviewPane,
-		closePreviewPane: () => {
-			page.show( `/sites/${ selectedCategory }` );
-		},
+		closePreviewPane: onClosePreviewPane,
 		showOnlyFavorites,
 		setShowOnlyFavorites: () => {},
 		path,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import {
 	DATAVIEWS_TABLE,
 	initialDataViewsState,
@@ -92,6 +92,16 @@ export const SitesDashboardProvider = ( {
 		sort,
 		filters: dataViewsFilters,
 	} );
+
+	// Effects
+
+	// When the sidebar menu items are clicked
+	// The URL gets updated out of the SitesDashboardContext
+	// which causes the SitesDashboard not to refetch the sites
+	// Updating the dataViews state triggers the dashboard sites refetch
+	useEffect( () => {
+		setDataViewsState( ( prevState ) => ( { ...prevState } ) );
+	}, [ showOnlyFavorites ] );
 
 	// Callbacks
 	const handleSetBulkManagementActive = ( isActive: boolean ) => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters.tsx
@@ -2,13 +2,33 @@ import { DataViewsFilter } from 'calypso/a8c-for-agencies/components/items-dashb
 import { filtersMap } from '../constants';
 
 export function getSelectedFilters( filters: DataViewsFilter[] = [] ) {
-	return (
-		filters?.map( ( filter ) => {
+	const statusFilter = filters
+		.filter( ( filter: DataViewsFilter ) => filter.field === 'status' )
+		.map( ( filter: DataViewsFilter ) => {
 			const filterType =
 				filtersMap.find( ( filterMap ) => filterMap.ref === filter.value )?.filterType ||
 				'all_issues';
+			return filterType;
+		} );
+
+	const siteTagsFilter = filters
+		.filter( ( filter: DataViewsFilter ) => filter.field === 'site_tags' )
+		.map( ( filter: DataViewsFilter ) => {
+			const filterType =
+				[
+					{ value: 'game', label: 'Game' },
+					{ value: 'retro', label: 'Retro' },
+					{ value: 'some', label: 'Some' },
+					{ value: 'tags', label: 'Tags' },
+				].find( ( tagFilter ) => {
+					return tagFilter.value === filter.value;
+				} )?.value || '';
 
 			return filterType;
-		} ) || []
-	);
+		} );
+
+	return {
+		status: statusFilter,
+		siteTags: siteTagsFilter,
+	};
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -80,6 +80,7 @@ export default function SitesDashboard() {
 
 	const [ agencyDashboardFilter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
 		issueTypes: [],
+		siteTags: [],
 		showOnlyFavorites: showOnlyFavorites || false,
 	} );
 
@@ -87,7 +88,8 @@ export default function SitesDashboard() {
 		const selectedFilters = getSelectedFilters( dataViewsState.filters );
 
 		setAgencyDashboardFilter( {
-			issueTypes: selectedFilters,
+			issueTypes: selectedFilters.status,
+			siteTags: selectedFilters.siteTags,
 			showOnlyFavorites: showOnlyFavorites || false,
 		} );
 	}, [ dataViewsState.filters, setAgencyDashboardFilter, showOnlyFavorites ] );
@@ -152,6 +154,7 @@ export default function SitesDashboard() {
 			sort: dataViewsState.sort,
 			showOnlyFavorites,
 		} );
+
 		if ( page.current !== updatedUrl && updatedUrl !== undefined ) {
 			page.show( updatedUrl );
 		}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -118,9 +118,11 @@ export default function SitesDashboard() {
 		if ( dataViewsState.selectedItem ) {
 			dispatch( setSelectedSiteId( dataViewsState.selectedItem.blog_id ) );
 		}
+	}, [ dispatch, setSelectedSiteId, dataViewsState.selectedItem ] );
 
+	useEffect( () => {
 		const updatedUrl = updateSitesDashboardUrl( {
-			category: category,
+			category,
 			filters: dataViewsState.filters,
 			selectedSite: dataViewsState.selectedItem,
 			selectedSiteFeature: selectedSiteFeature,
@@ -136,13 +138,13 @@ export default function SitesDashboard() {
 	}, [
 		selectedSiteFeature,
 		category,
-		dispatch,
 		dataViewsState.filters,
 		dataViewsState.search,
 		dataViewsState.page,
+		dataViewsState.selectedItem,
 		showOnlyFavorites,
 		dataViewsState.sort,
-		showPreviewPane,
+		updateSitesDashboardUrl,
 	] );
 
 	useEffect( () => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -3,7 +3,7 @@ import { isWithinBreakpoint } from '@automattic/viewport';
 import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect } from 'react';
 import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
 import { DATAVIEWS_TABLE } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -72,27 +72,17 @@ export default function SitesDashboard() {
 		isError: fetchContactFailed,
 	} = useFetchMonitorVerifiedContacts( false, agencyId );
 
-	const [ agencyDashboardFilter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
-		issueTypes: [],
-		siteTags: [],
+	const agencyDashboardFilters: AgencyDashboardFilter = {
+		issueTypes: getSelectedFilters( dataViewsState.filters ).status,
+		siteTags: getSelectedFilters( dataViewsState.filters ).siteTags,
 		showOnlyFavorites: showOnlyFavorites || false,
-	} );
-
-	useEffect( () => {
-		const selectedFilters = getSelectedFilters( dataViewsState.filters );
-
-		setAgencyDashboardFilter( {
-			issueTypes: selectedFilters.status,
-			siteTags: selectedFilters.siteTags,
-			showOnlyFavorites: showOnlyFavorites || false,
-		} );
-	}, [ dataViewsState.filters, setAgencyDashboardFilter, showOnlyFavorites ] );
+	};
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded: false,
 		searchQuery: dataViewsState.search,
 		currentPage: dataViewsState.page,
-		filter: agencyDashboardFilter,
+		filter: agencyDashboardFilters,
 		sort: dataViewsState.sort,
 		perPage: dataViewsState.perPage,
 		agencyId,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -56,7 +56,6 @@ export default function SitesDashboard() {
 		setDataViewsState,
 		selectedSiteFeature,
 		selectedCategory: category,
-		setSelectedCategory: setCategory,
 		siteUrl,
 		showOnlyFavorites,
 		showPreviewPane,
@@ -122,7 +121,6 @@ export default function SitesDashboard() {
 
 		const updatedUrl = updateSitesDashboardUrl( {
 			category: category,
-			setCategory: setCategory,
 			filters: dataViewsState.filters,
 			selectedSite: dataViewsState.selectedItem,
 			selectedSiteFeature: selectedSiteFeature,
@@ -138,7 +136,6 @@ export default function SitesDashboard() {
 	}, [
 		selectedSiteFeature,
 		category,
-		setCategory,
 		dispatch,
 		dataViewsState.filters,
 		dataViewsState.search,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -42,8 +42,13 @@ const buildQueryString = ( {
 
 	if ( filters && filters.length > 0 ) {
 		const selectedFilters = getSelectedFilters( filters );
-		urlQuery.set( 'issue_types', selectedFilters.status.join( ',' ) );
-		urlQuery.set( 'site_tags', selectedFilters.siteTags.join( ',' ) );
+		if ( selectedFilters.status.length ) {
+			urlQuery.set( 'issue_types', selectedFilters.status.join( ',' ) );
+		}
+
+		if ( selectedFilters.siteTags.length ) {
+			urlQuery.set( 'site_tags', selectedFilters.siteTags.join( ',' ) );
+		}
 	}
 
 	if ( showOnlyFavorites ) {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -16,7 +16,7 @@ const buildQueryString = ( {
 	sort,
 	showOnlyFavorites,
 }: {
-	filters: Filter[];
+	filters: DataViewsFilter[];
 	search: string;
 	currentPage: number;
 	sort: DashboardSortInterface;
@@ -43,7 +43,10 @@ const buildQueryString = ( {
 
 	if ( filters && filters.length > 0 ) {
 		const selectedFilters = getSelectedFilters( filters );
-		urlQuery.set( 'issue_types', selectedFilters.join( ',' ) );
+		console.log( filters );
+		console.log( selectedFilters );
+		urlQuery.set( 'issue_types', selectedFilters.status.join( ',' ) );
+		urlQuery.set( 'site_tags', selectedFilters.siteTags.join( ',' ) );
 	}
 
 	if ( showOnlyFavorites ) {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -1,5 +1,4 @@
 import { DataViewsFilter } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
-import { Filter } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces';
 import {
 	A4A_SITES_DASHBOARD_DEFAULT_CATEGORY,
 	A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
@@ -43,8 +42,6 @@ const buildQueryString = ( {
 
 	if ( filters && filters.length > 0 ) {
 		const selectedFilters = getSelectedFilters( filters );
-		console.log( filters );
-		console.log( selectedFilters );
 		urlQuery.set( 'issue_types', selectedFilters.status.join( ',' ) );
 		urlQuery.set( 'site_tags', selectedFilters.siteTags.join( ',' ) );
 	}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -62,7 +62,6 @@ const buildQueryString = ( {
 
 export const updateSitesDashboardUrl = ( {
 	category,
-	setCategory,
 	filters,
 	selectedSite,
 	selectedSiteFeature,
@@ -72,7 +71,6 @@ export const updateSitesDashboardUrl = ( {
 	showOnlyFavorites,
 }: {
 	category?: string;
-	setCategory: ( category: string ) => void;
 	filters: DataViewsFilter[];
 	selectedSite?: Site;
 	selectedSiteFeature?: string;
@@ -81,12 +79,6 @@ export const updateSitesDashboardUrl = ( {
 	sort: DashboardSortInterface;
 	showOnlyFavorites?: boolean;
 } ) => {
-	// We need a category in the URL if we have a selected site
-	if ( selectedSite && ! category ) {
-		setCategory( A4A_SITES_DASHBOARD_DEFAULT_CATEGORY );
-		return;
-	}
-
 	const baseUrl = '/sites';
 	let url = baseUrl;
 	let shouldAddQueryArgs = true;

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
@@ -1,11 +1,10 @@
+import page from '@automattic/calypso-router';
 import { Button, Gridicon, Spinner } from '@automattic/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
-import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
-import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import SiteSetFavorite from 'calypso/a8c-for-agencies/sections/sites/site-set-favorite';
 import SiteSort from 'calypso/a8c-for-agencies/sections/sites/site-sort';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
@@ -36,16 +35,9 @@ const SitesDataViews = ( {
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );
 
-	const openSitePreviewPane = useCallback(
-		( site: Site ) => {
-			setDataViewsState( ( prevState: DataViewsState ) => ( {
-				...prevState,
-				selectedItem: site,
-				type: DATAVIEWS_LIST,
-			} ) );
-		},
-		[ setDataViewsState ]
-	);
+	const openSitePreviewPane = useCallback( ( site: Site ) => {
+		page.show( `/sites/overview/${ site.url }` );
+	}, [] );
 
 	const renderField = useCallback(
 		( column: AllowedTypes, item: SiteInfo ) => {

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -14,13 +14,13 @@ export interface SitesDashboardContextInterface {
 	dataViewsState: DataViewsState;
 	setDataViewsState: React.Dispatch< React.SetStateAction< DataViewsState > >;
 
-	hideListing?: boolean;
-	setHideListing: ( hideListing: boolean ) => void;
+	showPreviewPane?: boolean;
+	closePreviewPane: () => void;
 
 	showOnlyFavorites?: boolean;
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 
-	initialSelectedSiteUrl?: string;
+	siteUrl?: string;
 	path: string;
 	currentPage: number;
 

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -17,7 +17,12 @@ const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => 
 			} ),
 			{}
 		),
-		...( filter.showOnlyFavorites && { show_only_favorites: true } ),
+		...filter?.siteTags?.reduce( ( curr, acc ) => {
+			return {
+				...curr,
+				[ acc ]: true,
+			};
+		}, {} ),
 		...( filter.isNotMultisite && { not_multisite: true } ),
 		...( filter?.showOnlyFavorites && { show_only_favorites: true } ),
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -16,12 +16,14 @@ export const agencyDashboardContext: Callback = ( context, next ) => {
 		s: search,
 		page: contextPage,
 		issue_types,
+		site_tags,
 		sort_field,
 		sort_direction,
 		origin,
 	} = context.query;
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
+		siteTags: site_tags?.split( ',' ),
 		showOnlyFavorites: context.params.filter === 'favorites',
 	};
 	const sort = {

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -35,7 +35,7 @@ export default function useToggleActivateMonitor(
 				dataViewsState.search,
 				dataViewsState.page,
 				{
-					issueTypes: getSelectedFilters( dataViewsState.filters ),
+					issueTypes: getSelectedFilters( dataViewsState.filters ).status,
 					showOnlyFavorites: showOnlyFavorites || false,
 				},
 				dataViewsState.sort,

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
@@ -38,7 +38,7 @@ export default function useUpdateMonitorSettings(
 				dataViewsState.search,
 				dataViewsState.page,
 				{
-					issueTypes: getSelectedFilters( dataViewsState.filters ),
+					issueTypes: getSelectedFilters( dataViewsState.filters ).status,
 					showOnlyFavorites: showOnlyFavorites || false,
 				},
 				dataViewsState.sort,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
@@ -5,7 +5,7 @@ const SitesOverviewContext = createContext< SitesOverviewContextInterface >( {
 	currentPage: 1,
 	path: '',
 	search: '',
-	filter: { issueTypes: [], showOnlyFavorites: false },
+	filter: { issueTypes: [], siteTags: [], showOnlyFavorites: false },
 	isBulkManagementActive: false,
 	showSitesDashboardV2: false,
 	setIsBulkManagementActive: () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -48,7 +48,7 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 						dataViewsState?.search,
 						dataViewsState?.page,
 						{
-							issueTypes: getSelectedFilters( dataViewsState?.filters ),
+							issueTypes: getSelectedFilters( dataViewsState?.filters ).status,
 							showOnlyFavorites: showOnlyFavorites || false,
 						},
 						dataViewsState.sort,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -1,6 +1,6 @@
 import { TranslateResult } from 'i18n-calypso';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import SiteTag from 'calypso/a8c-for-agencies/types/site-tag';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 // All types based on which the data is populated on the agency dashboard table rows
 export type AllowedTypes =

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -237,7 +237,11 @@ export interface DashboardOverviewContextInterface {
 	path: string;
 	search: string;
 	currentPage: number;
-	filter: { issueTypes: Array< AgencyDashboardFilterOption >; showOnlyFavorites: boolean };
+	filter: {
+		issueTypes: Array< AgencyDashboardFilterOption >;
+		siteTags: any[];
+		showOnlyFavorites: boolean;
+	};
 	sort: DashboardSortInterface;
 	showSitesDashboardV2: boolean;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -1,5 +1,6 @@
 import { TranslateResult } from 'i18n-calypso';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import SiteTag from 'calypso/a8c-for-agencies/types/site-tag';
 
 // All types based on which the data is populated on the agency dashboard table rows
 export type AllowedTypes =
@@ -83,6 +84,7 @@ export interface BoostData {
 }
 
 export interface Site {
+	a4a_site_tags: SiteTag[];
 	sticker: string[];
 	blog_id: number;
 	blogname: string;
@@ -280,6 +282,7 @@ export interface AgencyDashboardFilterMap {
 
 export type AgencyDashboardFilter = {
 	issueTypes: Array< AgencyDashboardFilterOption >;
+	siteTags: string[];
 	showOnlyFavorites: boolean;
 	isNotMultisite?: boolean;
 };

--- a/client/jetpack-cloud/sections/onboarding-tours/constants.ts
+++ b/client/jetpack-cloud/sections/onboarding-tours/constants.ts
@@ -16,6 +16,7 @@ export const JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE: SiteData[] = [
 	{
 		site: {
 			value: {
+				a4a_site_tags: [],
 				url: 'example.jetpack.com',
 				url_with_scheme: 'https://example.jetpack.com',
 				blogname: 'Example WordPress Site',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Refactors a lot of the SitesDashboardProvider component to abolish use of `useEffect` and remove unnecessary props derivation to state variables
* Add site tags filter capability

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
