### PR TITLE
Text transform header to uppercase

### DIFF
--- a/packages/domains-table/src/domains-table-header/style.scss
+++ b/packages/domains-table/src/domains-table-header/style.scss
@@ -38,6 +38,7 @@
 	}
 
 	.list__header-column {
+		text-transform: uppercase;
 		display: flex;
 		align-items: center;
 		&.is-sortable {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7097

## Proposed Changes

* Text-transform the domain header to uppercase. This applies to /domains/manage/ and /domains/manage/[site]

Before
<img width="1338" alt="Screenshot 2024-05-10 at 3 38 09 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/1dd0fe65-5047-4c20-a265-f0d7ce70f876">

After
<img width="1345" alt="Screenshot 2024-05-10 at 3 37 49 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/98208a34-777f-4051-a2ce-dce822d8c3ca">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link and checkout /domains/manage/ and /domains/manage/[site] to see the Domains table header is in all uppercase.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
