### PR TITLE
Domains: Height with few domains & disabled checkboxes

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -75,7 +75,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					.formatted-header {
 						max-height: 41px;
 					}
-					
+
 					.navigation-header__main {
 						align-items: center;
 					}
@@ -135,6 +135,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 							height: calc( 100vh - 32px );
 							overflow: hidden;
 							max-width: none;
+							height: calc( 100vh - 32px );
 						}
 					}
 				}
@@ -155,6 +156,11 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					table {
 						padding-inline: 0 !important;
 					}
+					div.layout.is-global-sidebar-visible {
+						.layout__primary > main {
+							height: calc( 100vh - var(--masterbar-height) );
+						}
+					}
 				}
 
 				@media only screen and ( max-width: 781px ) {
@@ -167,7 +173,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						background: var( --color-surface );
 						margin: 0;
 						border-radius: 8px;
-						height: calc( 100vh - 32px );
 					}
 					header.navigation-header {
 						padding-inline: 16px;
@@ -181,6 +186,11 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						}
 						table {
 							padding-inline: 16px;
+						}
+					}
+					div.layout.is-global-sidebar-visible {
+						.layout__primary > main {
+							height: calc( 100vh - var(--masterbar-height) - 48px );
 						}
 					}
 				}

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -84,17 +84,16 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		<tr key={ domain.domain }>
 			{ canSelectAnyDomains && (
 				<td className="domains-table-checkbox-td">
-					{ canBulkUpdate( domain ) && (
-						<CheckboxControl
-							__nextHasNoMarginBottom
-							checked={ isSelected }
-							onChange={ () => handleSelectDomain( domain ) }
-							/* translators: Label for a checkbox control that selects a domain name.*/
-							aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
-								domain: domain.domain,
-							} ) }
-						/>
-					) }
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ isSelected }
+						onChange={ () => handleSelectDomain( domain ) }
+						/* translators: Label for a checkbox control that selects a domain name.*/
+						aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
+							domain: domain.domain,
+						} ) }
+						disabled={ ! canBulkUpdate( domain ) }
+					/>
 				</td>
 			) }
 

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -117,6 +117,12 @@
 		}
 	}
 
+	.domains-table-checkbox-td {
+		input[type="checkbox"][disabled] {
+			cursor: no-drop;
+		}
+	}
+
 	.domains-table-row__domain {
 		flex-direction: column;
 		align-items: flex-start;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7095, https://github.com/Automattic/dotcom-forge/issues/7096

## Proposed Changes

- [x] Include the disabled checkbox in rows where we don't support the action and change the cursor to `no-drop`
- [x] Fix height where there are few domains.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/b3588403-7f20-4740-b352-59e67cf34350) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/5feb46b5-e764-4a84-848f-adc54142f271) |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/3cc0da00-8263-4e6a-a290-de3775bca434) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/4056c06a-42c6-424b-9edb-708bdbe0e573) |


## Testing Instructions

* Go to `/domains/manage`
* Check the details described above.
