### PR TITLE
Prevent requesting the checklist when the launchpad is displayed

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -7,6 +7,7 @@ import { memoize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
+import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { getTaskList } from 'calypso/lib/checklist';
@@ -385,4 +386,21 @@ const ConnectedSiteSetupList = connect( ( state, props ) => {
 	};
 } )( SiteSetupList );
 
-export default withIsFSEActive( ConnectedSiteSetupList );
+const WithIsFSEActiveSiteSetupList = withIsFSEActive( ConnectedSiteSetupList );
+export default WithIsFSEActiveSiteSetupList;
+
+const SiteSetupListWrapper = ( { siteId } ) => {
+	if ( ! siteId ) {
+		return null;
+	}
+	return (
+		<>
+			<QuerySiteChecklist siteId={ siteId } />
+			<WithIsFSEActiveSiteSetupList />
+		</>
+	);
+};
+
+export const ConnectedSiteSetupListWrapper = connect( ( state ) => ( {
+	siteId: getSelectedSiteId( state ),
+} ) )( SiteSetupListWrapper );

--- a/client/my-sites/customer-home/locations/card-components.ts
+++ b/client/my-sites/customer-home/locations/card-components.ts
@@ -80,7 +80,7 @@ import PromotePost from 'calypso/my-sites/customer-home/cards/tasks/promote-post
 import Renew from 'calypso/my-sites/customer-home/cards/tasks/renew';
 import { ReviveAutoRevertedAtomic } from 'calypso/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic';
 import SiteResumeCopy from 'calypso/my-sites/customer-home/cards/tasks/site-resume-copy';
-import SiteSetupList from 'calypso/my-sites/customer-home/cards/tasks/site-setup-list';
+import { ConnectedSiteSetupListWrapper } from 'calypso/my-sites/customer-home/cards/tasks/site-setup-list';
 import TitanBanner from 'calypso/my-sites/customer-home/cards/tasks/titan-banner';
 import UseBuiltBy from 'calypso/my-sites/customer-home/cards/tasks/use-built-by';
 import VerifyEmail from 'calypso/my-sites/customer-home/cards/tasks/verify-email';
@@ -120,7 +120,7 @@ const PRIMARY_CARD_COMPONENTS: CardComponentMap = {
 	[ TASK_REACTIVATE_EXPIRED_PLAN ]: ReviveAutoRevertedAtomic,
 	[ TASK_REACTIVATE_RESTORE_BACKUP ]: ReviveAutoRevertedAtomic,
 	[ TASK_SITE_RESUME_COPY ]: SiteResumeCopy,
-	[ TASK_SITE_SETUP_CHECKLIST ]: SiteSetupList,
+	[ TASK_SITE_SETUP_CHECKLIST ]: ConnectedSiteSetupListWrapper,
 	[ TASK_UPSELL_TITAN ]: TitanBanner,
 	[ TASK_USE_BUILT_BY ]: UseBuiltBy,
 	[ TASK_VERIFY_EMAIL ]: VerifyEmail,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -10,7 +10,6 @@ import { connect, useSelector } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
-import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import EmptyContent from 'calypso/components/empty-content';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
@@ -277,7 +276,6 @@ const Home = ( {
 		<Main wideLayout className="customer-home__main">
 			<PageViewTracker path="/home/:site" title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
-			{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 			{ siteId && isJetpack && isPossibleJetpackConnectionProblem && (
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #87955

## Proposed Changes

* The checklist endpoint is being called even when the Launchpad is displayed. The checklist endpoint should be invoked only when we display the Checklist.
* This PR moves the query to a new wrapper of the SiteSetupList component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live link or apply this PR to your local environment.
* Sandbox the public-api.
* Edit the file `wp-content/lib/home/views.php`  and make the `maybe_enable_launchpad_legacy_site_setup` function always return the views:
```
function maybe_enable_launchpad_legacy_site_setup( $views ) {
    return $views;
}
```
* Create a new site through the `/setup/free` flow
* Launch your site once you reach the fullscreen Launchpad step
* You should land at the Customer Home. Click on the "Show site setup" button on the banner.
* Make sure you see the Checklist and that it works properly.
* Now, undo the changes in `wp-content/lib/home/views.php` file.
* Refresh the Customer Home page and confirm that `/checklist` endpoint is not called anymore and you see the launchpad.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
