### PR TITLE
Newsletter: use with-site-settings.js

### DIFF
--- a/client/data/site-settings/use-site-settings-query.ts
+++ b/client/data/site-settings/use-site-settings-query.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+
+const useSiteSettingsQuery = ( siteId ) =>
+	useQuery( {
+		queryKey: [ 'site-settings', siteId ],
+		queryFn: () => wp.req.get( `/sites/${ siteId }/settings`, { apiVersion: '1.4' } ),
+		refetchOnWindowFocus: false,
+		enabled: !! siteId,
+		meta: {
+			persist: false,
+		},
+	} );
+
+export default useSiteSettingsQuery;

--- a/client/data/site-settings/use-site-settings-query.ts
+++ b/client/data/site-settings/use-site-settings-query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
-const useSiteSettingsQuery = ( siteId ) =>
+const useSiteSettingsQuery = ( siteId: number | null ) =>
 	useQuery( {
 		queryKey: [ 'site-settings', siteId ],
 		queryFn: () => wp.req.get( `/sites/${ siteId }/settings`, { apiVersion: '1.4' } ),

--- a/client/data/site-settings/use-update-site-settings-mutation.js
+++ b/client/data/site-settings/use-update-site-settings-mutation.js
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+
+function useUpdateSiteSettingsMutation( siteId, queryOptions = {} ) {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: ( { settings } ) =>
+			wp.req.post( '/sites/' + siteId + '/settings', { apiVersion: '1.4' }, settings ),
+		...queryOptions,
+		onSuccess( ...args ) {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'site-settings', siteId ],
+			} );
+			queryOptions.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const updateSiteSettings = useCallback( ( settings ) => mutate( { settings } ), [ mutate ] );
+
+	return { updateSiteSettings, ...mutation };
+}
+
+export default useUpdateSiteSettingsMutation;

--- a/client/data/site-settings/with-site-settings.js
+++ b/client/data/site-settings/with-site-settings.js
@@ -1,0 +1,147 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useCallback, useState } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import useSiteSettingsQuery from 'calypso/data/site-settings/use-site-settings-query';
+import useUpdateSiteSettingsMutation from 'calypso/data/site-settings/use-update-site-settings-mutation';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
+
+const noticeOptions = {
+	duration: 10000,
+	id: 'site-settings-save',
+};
+
+const withSiteSettings = createHigherOrderComponent( ( Wrapped ) => {
+	const WithSiteSettings = ( props ) => {
+		const { siteId } = props;
+		const [ unsavedSettings, setUnsavedSettings ] = useState( {} );
+		const dispatch = useDispatch();
+		const translate = useTranslate();
+		const queryClient = useQueryClient();
+		const path = useSelector( ( state ) => getCurrentRouteParameterized( state, siteId ) );
+
+		const trackEvent = useCallback(
+			( name ) => {
+				dispatch( recordGoogleEvent( 'Site Settings', name ) );
+			},
+			[ dispatch ]
+		);
+
+		const trackTracksEvent = useCallback(
+			( name, eventProps ) => {
+				dispatch( recordTracksEvent( name, eventProps ) );
+			},
+			[ dispatch ]
+		);
+
+		const { data, isLoading: isFetchingSettings } = useSiteSettingsQuery( siteId );
+
+		const updateSettings = useCallback(
+			( fields ) => {
+				return setUnsavedSettings( { ...unsavedSettings, ...fields } );
+			},
+			[ unsavedSettings, setUnsavedSettings ]
+		);
+
+		const {
+			isPending: isSavingSettings,
+			updateSiteSettings: saveSettings,
+			context: mutateContext,
+		} = useUpdateSiteSettingsMutation( siteId, {
+			onMutate: async ( settings ) => {
+				const queryKey = [ 'site-settings', siteId ];
+
+				// Cancel any current refetches, so they don't overwrite our optimistic update
+				await queryClient.cancelQueries( {
+					queryKey,
+				} );
+
+				// Snapshot the previous value
+				const previousSettings = queryClient.getQueryData( queryKey );
+
+				// Optimistically update to the new value
+				queryClient.setQueryData( queryKey, ( { settings: oldSettings } ) => {
+					return { ...oldSettings, ...settings };
+				} );
+
+				// Store previous settings in case of failure
+				return { previousSettings };
+			},
+			onSuccess() {
+				dispatch( successNotice( translate( 'Settings saved successfully!' ), noticeOptions ) );
+				setUnsavedSettings( {} ); // clear dirty fields after successful save.
+				if ( path === '/settings/newsletter/:site' ) {
+					trackTracksEvent( 'calypso_settings_newsletter_saved', unsavedSettings );
+				}
+			},
+			onError( err, newSettings, context ) {
+				// Revert to previous settings on failure
+				queryClient.setQueryData( [ 'site-settings', siteId ], context.previousSettings );
+
+				dispatch(
+					errorNotice(
+						translate( 'There was a problem saving your changes. Please, try again.' ),
+						noticeOptions
+					)
+				);
+			},
+			onSettled: () => {
+				// Refetch settings regardless
+				queryClient.invalidateQueries( {
+					queryKey: [ 'site-settings', siteId ],
+				} );
+			},
+		} );
+
+		const handleSubmitForm = useCallback( () => {
+			trackEvent( 'Clicked Save Settings Button' );
+			saveSettings( unsavedSettings );
+			if ( ! unsavedSettings ) {
+				return;
+			}
+			trackEvent( 'Clicked Save Settings Button' );
+		}, [ saveSettings, unsavedSettings, trackEvent ] );
+
+		const handleToggle = useCallback(
+			( name ) => () => {
+				if ( unsavedSettings[ name ] === undefined ) {
+					unsavedSettings[ name ] = data?.settings[ name ];
+				}
+				updateSettings( { [ name ]: ! unsavedSettings[ name ] } );
+				trackEvent( `Toggled ${ name }` );
+			},
+			[ trackEvent, unsavedSettings, updateSettings, data?.settings ]
+		);
+
+		const settings = Object.assign(
+			{},
+			mutateContext?.previousSettings?.settings,
+			data?.settings,
+			unsavedSettings
+		);
+		return (
+			<Wrapped
+				{ ...props }
+				settings={ settings }
+				isLoadingSettings={ isFetchingSettings }
+				isSavingSettings={ isSavingSettings }
+				updateSettings={ updateSettings }
+				unsavedSettings={ unsavedSettings }
+				handleToggle={ handleToggle }
+				handleSubmitForm={ handleSubmitForm }
+			/>
+		);
+	};
+
+	WithSiteSettings.propTypes = {
+		siteId: PropTypes.number.isRequired,
+	};
+
+	return WithSiteSettings;
+}, 'WithSiteSettings' );
+
+export default withSiteSettings;

--- a/client/data/site-settings/with-site-settings.js
+++ b/client/data/site-settings/with-site-settings.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import useSiteSettingsQuery from 'calypso/data/site-settings/use-site-settings-query';
 import useUpdateSiteSettingsMutation from 'calypso/data/site-settings/use-update-site-settings-mutation';
+import { useProtectForm } from 'calypso/lib/protect-form';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
@@ -23,6 +24,7 @@ const withSiteSettings = createHigherOrderComponent( ( Wrapped ) => {
 		const translate = useTranslate();
 		const queryClient = useQueryClient();
 		const path = useSelector( ( state ) => getCurrentRouteParameterized( state, siteId ) );
+		const { markChanged, markSaved } = useProtectForm();
 
 		const trackEvent = useCallback(
 			( name ) => {
@@ -42,6 +44,7 @@ const withSiteSettings = createHigherOrderComponent( ( Wrapped ) => {
 
 		const updateSettings = useCallback(
 			( fields ) => {
+				markChanged();
 				return setUnsavedSettings( { ...unsavedSettings, ...fields } );
 			},
 			[ unsavedSettings, setUnsavedSettings ]
@@ -77,6 +80,7 @@ const withSiteSettings = createHigherOrderComponent( ( Wrapped ) => {
 				if ( path === '/settings/newsletter/:site' ) {
 					trackTracksEvent( 'calypso_settings_newsletter_saved', unsavedSettings );
 				}
+				markSaved();
 			},
 			onError( err, newSettings, context ) {
 				// Revert to previous settings on failure

--- a/client/data/site-settings/with-site-settings.js
+++ b/client/data/site-settings/with-site-settings.js
@@ -47,7 +47,7 @@ const withSiteSettings = createHigherOrderComponent( ( Wrapped ) => {
 				markChanged();
 				return setUnsavedSettings( { ...unsavedSettings, ...fields } );
 			},
-			[ unsavedSettings, setUnsavedSettings ]
+			[ markChanged, unsavedSettings, setUnsavedSettings ]
 		);
 
 		const {

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -45,7 +45,7 @@ type Fields = {
 };
 
 type NewsletterSettingsFormProps = {
-	siteId: number | null;
+	siteId: number;
 	settings: Fields;
 	isLoadingSettings: boolean;
 	isSavingSettings: boolean;
@@ -203,13 +203,13 @@ const NewsletterSettingsForm = withSiteSettings(
 
 const NewsletterSettings = () => {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
+	const siteId = useSelector( getSelectedSiteId ) ?? 0;
 	return (
 		<Main>
 			<DocumentHead title={ translate( 'Newsletter Settings' ) } />
 			<NavigationHeader navigationItems={ [] } title={ translate( 'Newsletter Settings' ) } />
 			<SubscriptionsModuleBanner />
-			<NewsletterSettingsForm siteId={ siteId } />
+			<NewsletterSettingsForm siteId={ Number( siteId ) } />
 		</Main>
 	);
 };

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -154,6 +154,13 @@ const NewsletterSettingsForm = withSiteSettings(
 						value={ settings?.wpcom_subscription_emails_use_excerpt }
 					/>
 				</Card>
+				<Card className="site-settings__card">
+					<ReplyToSetting
+						disabled={ disabled }
+						updateFields={ updateSettings }
+						value={ settings?.jetpack_subscriptions_reply_to }
+					/>
+				</Card>
 				{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 				<SettingsSectionHeader
 					id="newsletter-categories-settings"


### PR DESCRIPTION
This PR is intended to fix https://github.com/Automattic/wp-calypso/issues/89109 issue. 

It does so in a couple of ways. 
1. It creates a more simpler way of managing the unsaved state. 
2. It intrudes a more modern component `with-site-settings` HOC that is intended to replace the current `wrap-settings-form` this new component used the useQuery component instead of the current redux.

## Proposed Changes

* Fixes the current saving of newsletters. 

## Testing Instructions

* Load up this PR. 
* Navigate to /settings/newsletter/example.com for an atomic and simple site. 
* Notice that you can change all the settings and it works as before. 
* Notice that stats works as before. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
