### PR TITLE
Fix: Update the offset calculation method to use a fixed menu height

### DIFF
--- a/client/site-profiler/utils/calculate-metrics-section-scroll-offset.ts
+++ b/client/site-profiler/utils/calculate-metrics-section-scroll-offset.ts
@@ -1,7 +1,7 @@
 export function calculateMetricsSectionScrollOffset() {
 	let offset = 0;
 	const headerEl = document.getElementById( 'header' );
-	const menuNavbarEl = document.querySelector( '.metrics-menu-navbar' );
+	const menuHeight = 50;
 
 	// Offset to account for Masterbar if it is fixed position
 	offset +=
@@ -10,7 +10,7 @@ export function calculateMetricsSectionScrollOffset() {
 			: 0;
 
 	// Offset to account for the metrics menu navbar
-	offset += menuNavbarEl ? menuNavbarEl.getBoundingClientRect().height : 0;
+	offset += menuHeight;
 
 	const padding = 20;
 


### PR DESCRIPTION

## Proposed Changes

Use a fixed value for menu height instead of calculate it from the rendered component.
Sometimes when this calculation is made on the styled component, the menu component is not rendered yet, causing this height to be `0`.

## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/wordpress.com`
* Scroll down until you get to the menu displayed on the images
* Click on the option and check if the section title is shown

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-10 at 19 24 17@2x](https://github.com/Automattic/wp-calypso/assets/5039531/deb01923-e075-4e98-9cf9-7d2c1ddd8032)|![CleanShot 2024-05-10 at 19 23 35@2x](https://github.com/Automattic/wp-calypso/assets/5039531/a182d3a2-a5dd-4b26-8c78-81e2a5d02b68)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?