### PR TITLE
Plans Grid: Merge Plan Action buttons

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -115,6 +115,7 @@ function useGenerateActionHook( {
 			return {
 				primary: {
 					callback: getActionCallback( { planSlug, cartItemForPlan, selectedStorageAddOn } ),
+					status: 'enabled',
 					text,
 				},
 			};

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -214,7 +214,6 @@ function useGenerateActionHook( {
 			return {
 				primary: {
 					callback: getActionCallback( { planSlug, cartItemForPlan, selectedStorageAddOn } ),
-					// TODO: Revisit status
 					status: 'enabled',
 					text,
 				},

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -256,8 +256,7 @@ function useGenerateActionHook( {
 			text = translate( 'Contact support', { context: 'verb' } );
 			status = 'disabled';
 
-			// TODO: Consider DRYing this up
-			if ( sitePlanSlug === planSlug && plansIntent !== 'plans-p2' ) {
+			if ( current ) {
 				text = translate( 'Manage add-ons', { context: 'verb' } );
 				status = 'enabled';
 			}
@@ -292,7 +291,7 @@ function useGenerateActionHook( {
 			if ( planMatches( planSlug, { term: TERM_ANNUALLY } ) ) {
 				text = textOverride || translate( 'Upgrade to Yearly' );
 			}
-		} else if ( sitePlanSlug === planSlug && plansIntent !== 'plans-p2' ) {
+		} else if ( current ) {
 			// All other actions for a current plan
 			text = translate( 'View plan' );
 

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -148,18 +148,7 @@ const PlanFeatures2023GridActions = ( {
 	)?.checkoutLink;
 	const nonDefaultStorageOptionSelected = defaultStorageOption !== selectedStorageOptionForPlan;
 
-	let actionButton = null;
-
-	if (
-		( isFreePlan( planSlug ) ||
-			( storageAddOnsForPlan && ! canPurchaseStorageAddOns && nonDefaultStorageOptionSelected ) ) &&
-		isP2FreePlan( planSlug ) &&
-		current
-	) {
-		return null;
-	}
-
-	if ( ! availableForPurchase && ! current && ! isWpcomEnterpriseGridPlan( planSlug ) ) {
+	let actionButton = (
 		<Plans2023Tooltip
 			text={ translate( 'Please contact support to downgrade your plan.' ) }
 			setActiveTooltipId={ setActiveTooltipId }
@@ -173,50 +162,66 @@ const PlanFeatures2023GridActions = ( {
 					{ translate( 'Please contact support to downgrade your plan.' ) }
 				</div>
 			) }
-		</Plans2023Tooltip>;
+		</Plans2023Tooltip>
+	);
+
+	if (
+		( isFreePlan( planSlug ) ||
+			( storageAddOnsForPlan && ! canPurchaseStorageAddOns && nonDefaultStorageOptionSelected ) ) &&
+		isP2FreePlan( planSlug ) &&
+		current
+	) {
+		return null;
 	}
 
-	// TODO: Move this condition into the useAction hook
-	if ( current && canPurchaseStorageAddOns && nonDefaultStorageOptionSelected && ! isMonthlyPlan ) {
-		actionButton = (
-			<PlanButton
-				planSlug={ planSlug }
-				classes="is-storage-upgradeable"
-				href={ storageAddOnCheckoutHref }
-			>
-				{ translate( 'Upgrade' ) }
-			</PlanButton>
-		);
-	} else {
-		const hasFreeTrialPlan = isInSignup ? !! freeTrialPlanSlug : false;
-		actionButton = hasFreeTrialPlan ? (
-			<div className="plan-features-2023-grid__multiple-actions-container">
-				<PlanButton planSlug={ planSlug } onClick={ () => freeTrialCallback() } busy={ busy }>
-					{ freeTrialText }
-				</PlanButton>
-				{ ! isStuck && ( // along side with the free trial CTA, we also provide an option for purchasing the plan directly here
-					<PlanButton planSlug={ planSlug } onClick={ callback } borderless>
-						{ text }
-					</PlanButton>
-				) }
-			</div>
-		) : (
-			<>
+	if ( availableForPurchase || current || isWpcomEnterpriseGridPlan( planSlug ) ) {
+		// TODO: Move the condition below into the useAction hook
+		if (
+			current &&
+			canPurchaseStorageAddOns &&
+			nonDefaultStorageOptionSelected &&
+			! isMonthlyPlan
+		) {
+			actionButton = (
 				<PlanButton
 					planSlug={ planSlug }
-					disabled={ ! callback || 'disabled' === status }
-					onClick={ callback }
-					current={ current }
+					classes="is-storage-upgradeable"
+					href={ storageAddOnCheckoutHref }
 				>
-					{ text }
+					{ translate( 'Upgrade' ) }
 				</PlanButton>
-				{ postButtonText && (
-					<span className="plan-features-2023-grid__actions-post-button-text">
-						{ postButtonText }
-					</span>
-				) }
-			</>
-		);
+			);
+		} else {
+			const hasFreeTrialPlan = isInSignup ? !! freeTrialPlanSlug : false;
+			actionButton = hasFreeTrialPlan ? (
+				<div className="plan-features-2023-grid__multiple-actions-container">
+					<PlanButton planSlug={ planSlug } onClick={ () => freeTrialCallback() } busy={ busy }>
+						{ freeTrialText }
+					</PlanButton>
+					{ ! isStuck && ( // along side with the free trial CTA, we also provide an option for purchasing the plan directly here
+						<PlanButton planSlug={ planSlug } onClick={ callback } borderless>
+							{ text }
+						</PlanButton>
+					) }
+				</div>
+			) : (
+				<>
+					<PlanButton
+						planSlug={ planSlug }
+						disabled={ ! callback || 'disabled' === status }
+						onClick={ callback }
+						current={ current }
+					>
+						{ text }
+					</PlanButton>
+					{ postButtonText && (
+						<span className="plan-features-2023-grid__actions-post-button-text">
+							{ postButtonText }
+						</span>
+					) }
+				</>
+			);
+		}
 	}
 
 	return (

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -114,7 +114,6 @@ const PlanFeatureActionButton = ( {
 	}
 
 	if ( current && planSlug !== PLAN_P2_FREE ) {
-		// TODO: this block can be another "exception" that stays
 		if ( canPurchaseStorageAddOns && nonDefaultStorageOptionSelected && ! isMonthlyPlan ) {
 			return (
 				<PlanButton

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -4,6 +4,7 @@ import {
 	isP2FreePlan,
 	isFreePlan,
 	PLAN_FREE,
+	isWpcomEnterpriseGridPlan,
 } from '@automattic/calypso-products';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
@@ -183,9 +184,7 @@ const PlanFeatures2023GridActions = ( {
 				{ translate( 'Upgrade' ) }
 			</PlanButton>
 		);
-	}
-
-	if ( availableForPurchase || current ) {
+	} else if ( availableForPurchase || current || isWpcomEnterpriseGridPlan( planSlug ) ) {
 		const hasFreeTrialPlan = isInSignup ? !! freeTrialPlanSlug : false;
 		actionButton = hasFreeTrialPlan ? (
 			<div className="plan-features-2023-grid__multiple-actions-container">

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -173,22 +173,19 @@ const PlanFeatures2023GridActions = ( {
 		return null;
 	}
 
-	if ( current ) {
-		if ( canPurchaseStorageAddOns && nonDefaultStorageOptionSelected && ! isMonthlyPlan ) {
-			actionButton = (
-				<PlanButton
-					planSlug={ planSlug }
-					classes="is-storage-upgradeable"
-					href={ storageAddOnCheckoutHref }
-				>
-					{ translate( 'Upgrade' ) }
-				</PlanButton>
-			);
-		}
+	if ( current && canPurchaseStorageAddOns && nonDefaultStorageOptionSelected && ! isMonthlyPlan ) {
+		actionButton = (
+			<PlanButton
+				planSlug={ planSlug }
+				classes="is-storage-upgradeable"
+				href={ storageAddOnCheckoutHref }
+			>
+				{ translate( 'Upgrade' ) }
+			</PlanButton>
+		);
 	}
 
 	if ( availableForPurchase || current ) {
-		// TODO: Fix this condition
 		const hasFreeTrialPlan = isInSignup ? !! freeTrialPlanSlug : false;
 		actionButton = hasFreeTrialPlan ? (
 			<div className="plan-features-2023-grid__multiple-actions-container">

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -148,7 +148,18 @@ const PlanFeatures2023GridActions = ( {
 	)?.checkoutLink;
 	const nonDefaultStorageOptionSelected = defaultStorageOption !== selectedStorageOptionForPlan;
 
-	let actionButton = (
+	let actionButton = null;
+
+	if (
+		( isFreePlan( planSlug ) ||
+			( storageAddOnsForPlan && ! canPurchaseStorageAddOns && nonDefaultStorageOptionSelected ) ) &&
+		isP2FreePlan( planSlug ) &&
+		current
+	) {
+		return null;
+	}
+
+	if ( ! availableForPurchase && ! current && ! isWpcomEnterpriseGridPlan( planSlug ) ) {
 		<Plans2023Tooltip
 			text={ translate( 'Please contact support to downgrade your plan.' ) }
 			setActiveTooltipId={ setActiveTooltipId }
@@ -162,18 +173,10 @@ const PlanFeatures2023GridActions = ( {
 					{ translate( 'Please contact support to downgrade your plan.' ) }
 				</div>
 			) }
-		</Plans2023Tooltip>
-	);
-
-	if (
-		( isFreePlan( planSlug ) ||
-			( storageAddOnsForPlan && ! canPurchaseStorageAddOns && nonDefaultStorageOptionSelected ) ) &&
-		isP2FreePlan( planSlug ) &&
-		current
-	) {
-		return null;
+		</Plans2023Tooltip>;
 	}
 
+	// TODO: Move this condition into the useAction hook
 	if ( current && canPurchaseStorageAddOns && nonDefaultStorageOptionSelected && ! isMonthlyPlan ) {
 		actionButton = (
 			<PlanButton
@@ -184,7 +187,7 @@ const PlanFeatures2023GridActions = ( {
 				{ translate( 'Upgrade' ) }
 			</PlanButton>
 		);
-	} else if ( availableForPurchase || current || isWpcomEnterpriseGridPlan( planSlug ) ) {
+	} else {
 		const hasFreeTrialPlan = isInSignup ? !! freeTrialPlanSlug : false;
 		actionButton = hasFreeTrialPlan ? (
 			<div className="plan-features-2023-grid__multiple-actions-container">

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -1,5 +1,4 @@
 import {
-	PLAN_P2_FREE,
 	type PlanSlug,
 	type StorageOption,
 	isP2FreePlan,
@@ -113,7 +112,7 @@ const PlanFeatureActionButton = ( {
 		return null;
 	}
 
-	if ( current && planSlug !== PLAN_P2_FREE ) {
+	if ( current ) {
 		if ( canPurchaseStorageAddOns && nonDefaultStorageOptionSelected && ! isMonthlyPlan ) {
 			return (
 				<PlanButton

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -3,7 +3,6 @@ import {
 	type PlanSlug,
 	type StorageOption,
 	isP2FreePlan,
-	isWpcomEnterpriseGridPlan,
 	isFreePlan,
 	PLAN_FREE,
 } from '@automattic/calypso-products';
@@ -51,74 +50,38 @@ const DummyDisabledButton = styled.div`
 `;
 
 const PlanFeatureActionButton = ( {
-	planSlug,
-	isStuck,
-	hasFreeTrialPlan,
-	onCtaClick,
-	onFreeTrialCtaClick,
-	text,
-	freeTrialText,
-	postButtonText,
-	status,
-}: {
-	planSlug: PlanSlug;
-	isStuck: boolean;
-	hasFreeTrialPlan: boolean;
-	onCtaClick: () => void;
-	onFreeTrialCtaClick: () => void;
-	text: TranslateResult;
-	freeTrialText?: TranslateResult;
-	postButtonText?: TranslateResult;
-	status?: 'disabled' | 'blocked' | 'enabled';
-} ) => {
-	// TODO: Is status ever 'blocked'? We should do some thorough investigation at some point.
-	const busy = isFreePlan( planSlug ) && status === 'blocked';
-
-	return hasFreeTrialPlan ? (
-		<div className="plan-features-2023-grid__multiple-actions-container">
-			<PlanButton planSlug={ planSlug } onClick={ () => onFreeTrialCtaClick() } busy={ busy }>
-				{ freeTrialText }
-			</PlanButton>
-			{ ! isStuck && ( // along side with the free trial CTA, we also provide an option for purchasing the plan directly here
-				<PlanButton planSlug={ planSlug } onClick={ onCtaClick } borderless>
-					{ text }
-				</PlanButton>
-			) }
-		</div>
-	) : (
-		<>
-			<PlanButton planSlug={ planSlug } onClick={ onCtaClick } busy={ busy }>
-				{ text }
-			</PlanButton>
-			{ postButtonText && (
-				<span className="plan-features-2023-grid__actions-post-button-text">
-					{ postButtonText }
-				</span>
-			) }
-		</>
-	);
-};
-
-const LoggedInPlansFeatureActionButton = ( {
 	availableForPurchase,
 	disabled,
+	freeTrialText,
+	hasFreeTrialPlan,
 	isMonthlyPlan,
+	isStuck,
 	onCtaClick,
+	onFreeTrialCtaClick,
 	planSlug,
+	postButtonText,
+	status,
 	storageOptions,
 	text,
 }: {
 	availableForPurchase?: boolean;
-	disabled: boolean;
-	isMonthlyPlan?: boolean;
-	onCtaClick: () => void;
-	planSlug: PlanSlug;
-	currentSitePlanSlug?: string | null;
-	storageOptions?: StorageOption[];
-	text: TranslateResult;
 	billingPeriod?: PlanPricing[ 'billPeriod' ];
 	currentPlanBillingPeriod?: PlanPricing[ 'billPeriod' ];
+	currentSitePlanSlug?: string | null;
+	disabled: boolean;
+	freeTrialText?: TranslateResult;
+	hasFreeTrialPlan: boolean;
+	isMonthlyPlan?: boolean;
+	isStuck: boolean;
+	onCtaClick: () => void;
+	onFreeTrialCtaClick: () => void;
+	planSlug: PlanSlug;
+	postButtonText?: TranslateResult;
+	status?: 'disabled' | 'blocked' | 'enabled';
+	storageOptions?: StorageOption[];
+	text: TranslateResult;
 } ) => {
+	const busy = isFreePlan( planSlug ) && status === 'blocked';
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const translate = useTranslate();
 	const { gridPlansIndex, siteId } = usePlansGridContext();
@@ -162,49 +125,55 @@ const LoggedInPlansFeatureActionButton = ( {
 					{ translate( 'Upgrade' ) }
 				</PlanButton>
 			);
-		} else if ( text ) {
-			// TODO: this can be removed and done in the final single-render call. there's nothing special about it outside of "disabled" status
-			return (
+		}
+	}
+
+	if ( availableForPurchase || current ) {
+		return hasFreeTrialPlan ? (
+			<div className="plan-features-2023-grid__multiple-actions-container">
+				<PlanButton planSlug={ planSlug } onClick={ () => onFreeTrialCtaClick() } busy={ busy }>
+					{ freeTrialText }
+				</PlanButton>
+				{ ! isStuck && ( // along side with the free trial CTA, we also provide an option for purchasing the plan directly here
+					<PlanButton planSlug={ planSlug } onClick={ onCtaClick } borderless>
+						{ text }
+					</PlanButton>
+				) }
+			</div>
+		) : (
+			<>
 				<PlanButton
 					planSlug={ planSlug }
-					disabled={ ! onCtaClick }
+					disabled={ disabled }
 					onClick={ onCtaClick }
 					current={ current }
 				>
 					{ text }
 				</PlanButton>
-			);
-		}
-	}
-
-	if ( ! availableForPurchase ) {
-		return (
-			<Plans2023Tooltip
-				text={ translate( 'Please contact support to downgrade your plan.' ) }
-				setActiveTooltipId={ setActiveTooltipId }
-				activeTooltipId={ activeTooltipId }
-				showOnMobile={ false }
-				id="downgrade"
-			>
-				<DummyDisabledButton>{ text }</DummyDisabledButton>
-				{ isMobile() && (
-					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
-						{ translate( 'Please contact support to downgrade your plan.' ) }
-					</div>
+				{ postButtonText && (
+					<span className="plan-features-2023-grid__actions-post-button-text">
+						{ postButtonText }
+					</span>
 				) }
-			</Plans2023Tooltip>
+			</>
 		);
 	}
 
 	return (
-		<PlanButton
-			planSlug={ planSlug }
-			disabled={ disabled }
-			onClick={ onCtaClick }
-			current={ current }
+		<Plans2023Tooltip
+			text={ translate( 'Please contact support to downgrade your plan.' ) }
+			setActiveTooltipId={ setActiveTooltipId }
+			activeTooltipId={ activeTooltipId }
+			showOnMobile={ false }
+			id="downgrade"
 		>
-			{ text }
-		</PlanButton>
+			<DummyDisabledButton>{ text }</DummyDisabledButton>
+			{ isMobile() && (
+				<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
+					{ translate( 'Please contact support to downgrade your plan.' ) }
+				</div>
+			) }
+		</Plans2023Tooltip>
 	);
 };
 
@@ -259,8 +228,7 @@ const PlanFeatures2023GridActions = ( {
 	} = useAction( {
 		availableForPurchase,
 		billingPeriod,
-		// TODO: Double check that we need to do this boolean coercion
-		isLargeCurrency: !! isLargeCurrency,
+		isLargeCurrency,
 		isStuck,
 		planSlug,
 		planTitle,
@@ -275,8 +243,7 @@ const PlanFeatures2023GridActions = ( {
 	} = useAction( {
 		billingPeriod,
 		isFreeTrialAction: true,
-		// TODO: Double check that we need to do this boolean coercion
-		isLargeCurrency: !! isLargeCurrency,
+		isLargeCurrency,
 		isStuck,
 		// TODO: Unsure about using free plan as a fallback. We should revisit.
 		planSlug: freeTrialPlanSlug ?? PLAN_FREE,
@@ -290,30 +257,22 @@ const PlanFeatures2023GridActions = ( {
 	return (
 		<div className="plan-features-2023-gridrison__actions">
 			<div className="plan-features-2023-gridrison__actions-buttons">
-				{ isInSignup || isWpcomEnterpriseGridPlan( planSlug ) ? (
-					<PlanFeatureActionButton
-						planSlug={ planSlug }
-						isStuck={ isStuck }
-						postButtonText={ postButtonText }
-						status={ status }
-						hasFreeTrialPlan={ isInSignup ? !! freeTrialPlanSlug : false }
-						onCtaClick={ callback }
-						onFreeTrialCtaClick={ freeTrialCallback }
-						text={ text }
-						freeTrialText={ freeTrialText }
-					/>
-				) : (
-					<LoggedInPlansFeatureActionButton
-						disabled={ ! callback || 'disabled' === status }
-						planSlug={ planSlug }
-						availableForPurchase={ availableForPurchase }
-						onCtaClick={ callback }
-						currentSitePlanSlug={ currentSitePlanSlug }
-						isMonthlyPlan={ isMonthlyPlan }
-						storageOptions={ storageOptions }
-						text={ text }
-					/>
-				) }
+				<PlanFeatureActionButton
+					availableForPurchase={ availableForPurchase }
+					currentSitePlanSlug={ currentSitePlanSlug }
+					disabled={ ! callback || 'disabled' === status }
+					freeTrialText={ freeTrialText }
+					hasFreeTrialPlan={ isInSignup ? !! freeTrialPlanSlug : false }
+					isMonthlyPlan={ isMonthlyPlan }
+					isStuck={ isStuck }
+					onCtaClick={ callback }
+					onFreeTrialCtaClick={ freeTrialCallback }
+					planSlug={ planSlug }
+					postButtonText={ postButtonText }
+					status={ status }
+					storageOptions={ storageOptions }
+					text={ text }
+				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/89926

## Proposed Changes

* Merge the `LoggedInPlanFeatureActionButton` and the `PlanFeatureActionButton` into a single component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Onboarding Ctas**
- Navigate to `/start/plans`
- Smoke test plan ctas in the features grid ( free, explorer, creator, etc. ) and ensure that the correct plan is added to the checkout cart
- Smoke test creator or entrepreneur plan ctas with a storage add-on and ensure the correct products are added to the checkout cart
- Repeat for the comparison grid
- Lists of flows with the plans pricing page can be found here PCYsg-RDT-p2
- Repeat for a different signup flow ( Ex. `start/domain` ) 
- Repeat for a stepper flow ( Ex. `setup/newsletter` ) 

**Paid Domain Modal Upsell Ctas**
- Navigate to `/start/onboarding-pm`
- Select a paid, custom domain
- Select a free plan
- Verify that the upsell modal is displayed as expected
- Smoke test the ctas in the upsell modal

<img width="725" alt="Screenshot 2024-04-23 at 4 04 39 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/537ca848-ac0a-4c99-b1fc-d5c4b08dc59c">

**Free Domain Free Plan Modal Upsell Ctas**
- Navigate to `/start/onboarding-pm`
- Select a free domain
- Select a free plan
- Verify that the upsell modal is displayed as expected
- Smoke test the ctas in the upsell modal

<img width="664" alt="Screenshot 2024-04-23 at 4 04 10 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/dc8af121-2e1a-401d-85f6-0e72701faa79">

**Plans Page Ctas**
- Navigate to `/plans` for a specific site Ex. `/plans/testsite123.wordpress.com`
- Smoke test plan ctas ( free, explorer, creator, etc. ) and ensure that the correct plan is added to the checkout cart
- Smoke test creator or entrepreneur plan ctas with a storage add-on and ensure the correct products are added to the checkout cart
- Repeat for the comparison grid
- Smoke test ctas for the spotlight plan ( plan card rendered at the top of the page )
  - Ensure the manage add-ons button redirects to the `/add-ons` page
  - Ensure the manage plan button redirects to the plan management page

**Test Free Trials Plan Ctas**
- Navigate to `/setup/new-hosted-site`
- Verify that the Creator plan free trial CTA behaves as it does in production ( leads to the `/trialAcknowledge` page )
- Verify that a free trial site is created when continuing through onboarding
- Smoke test the other Creator and Entrepreneur plan CTA buttons

<img width="824" alt="Screenshot 2024-04-23 at 4 12 31 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/560b9521-3fb4-4e2d-88f5-a353290df9e8">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
