### PR TITLE
Add "Why" section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,15 @@ Related to #
 
 *
 
+## Why are these changes being made?
+<!--
+It's easy to see what a PR does but much harder to find out why it was made,
+particularly when researching old changes in history. Record an explanation of
+the motivation behind this change and how it will help.
+-->
+
+*
+
 ## Testing Instructions
 
 <!--


### PR DESCRIPTION
## Proposed Changes

This PR adds a "Why are these changes being made?" section to the PR template.

Related to p7H4VZ-3Hz-p2

## Why are these changes being made?

It's easy to see what a PR does but much harder to find out why it was made, particularly when researching old changes in history. I frequently see PRs which use the "Proposed Changes" section of the template just to list what changes were made, like they were repeating the commit messages of the PR. Sometimes there's also a link to an external issue or post, but those links can get out-of-date quickly and rarely do I see an included explanation of the _motivation_ for a change. I'm hoping this template change will encourage folks to add a "why" and not just "what".

## Testing Instructions

A visual inspection. Does this wording sound right?