### PR TITLE
Align back link copy with A4A and Core

### DIFF
--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -69,8 +69,7 @@ const GlobalSidebar = ( {
 		return <Spinner className="sidebar__menu-loading" />;
 	}
 
-	const { requireBackLink, backLinkText, backLinkHref, ...sidebarProps } = props;
-	const sidebarBackLinkText = backLinkText ?? translate( 'Back' );
+	const { requireBackLink, appTitle, backLinkHref, ...sidebarProps } = props;
 	const sidebarBackLinkHref = backLinkHref || previousLink.current || '/sites';
 
 	return (
@@ -82,8 +81,8 @@ const GlobalSidebar = ( {
 						<div className="sidebar__back-link">
 							<a href={ sidebarBackLinkHref } onClick={ handleBackLinkClick }>
 								<Gridicon icon="chevron-left" size={ 24 } />
-								<span className="sidebar__back-link-text">{ sidebarBackLinkText }</span>
 							</a>
+							<span className="sidebar__app-title">{ appTitle || translate( 'Back' ) }</span>
 						</div>
 					) }
 					{ children }

--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -69,7 +69,7 @@ const GlobalSidebar = ( {
 		return <Spinner className="sidebar__menu-loading" />;
 	}
 
-	const { requireBackLink, appTitle, backLinkHref, ...sidebarProps } = props;
+	const { requireBackLink, siteTitle, backLinkHref, ...sidebarProps } = props;
 	const sidebarBackLinkHref = backLinkHref || previousLink.current || '/sites';
 
 	return (
@@ -82,7 +82,7 @@ const GlobalSidebar = ( {
 							<a href={ sidebarBackLinkHref } onClick={ handleBackLinkClick }>
 								<Gridicon icon="chevron-left" size={ 24 } />
 							</a>
-							<span className="sidebar__app-title">{ appTitle || translate( 'Back' ) }</span>
+							<span className="sidebar__site-title">{ siteTitle || translate( 'Back' ) }</span>
 						</div>
 					) }
 					{ children }

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -334,6 +334,7 @@ $brand-text: "SF Pro Text", $sans;
 		margin-bottom: 24px;
 		display: flex;
 		align-items: center;
+		gap: 4px;
 
 		a {
 			color: var(--nav-link);

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -331,16 +331,19 @@ $brand-text: "SF Pro Text", $sans;
 	.sidebar__back-link {
 		padding-left: 12px;
 		margin-top: 4px;
+		margin-bottom: 24px;
+		display: flex;
+		align-items: center;
 
 		a {
 			color: var(--nav-link);
 			text-decoration: none;
 			align-items: center;
-			display: inline-flex;
-			margin-bottom: 24px;
 			padding: 9px;
-			border-radius: 2px;
-			gap: 8px;
+			border-radius: 4px;
+			&:hover {
+				background-color: var(--color-sidebar-menu-hover-background);
+			}
 		}
 
 		svg.gridicons-chevron-left {
@@ -348,7 +351,7 @@ $brand-text: "SF Pro Text", $sans;
 			fill: var(--color-sidebar-gridicon-fill);
 		}
 
-		.sidebar__back-link-text {
+		.sidebar__app-title {
 			font-size: $default-font-size;
 			vertical-align: text-bottom;
 		}

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -79,7 +79,7 @@ class MeSidebar extends Component {
 		const props = {
 			path: context.path,
 			requireBackLink: true,
-			appTitle: this.props.translate( 'Profile' ),
+			siteTitle: this.props.translate( 'Profile' ),
 		};
 		return <GlobalSidebar { ...props }>{ this.renderMenu( { isGlobal: true } ) }</GlobalSidebar>;
 	}

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -79,7 +79,7 @@ class MeSidebar extends Component {
 		const props = {
 			path: context.path,
 			requireBackLink: true,
-			appTitle: this.props.translate( 'My Profile' ),
+			appTitle: this.props.translate( 'Profile' ),
 		};
 		return <GlobalSidebar { ...props }>{ this.renderMenu( { isGlobal: true } ) }</GlobalSidebar>;
 	}

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -79,6 +79,7 @@ class MeSidebar extends Component {
 		const props = {
 			path: context.path,
 			requireBackLink: true,
+			appTitle: this.props.translate( 'My Profile' ),
 		};
 		return <GlobalSidebar { ...props }>{ this.renderMenu( { isGlobal: true } ) }</GlobalSidebar>;
 	}

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -295,7 +295,7 @@ export class ReaderSidebar extends Component {
 			path: this.props.path,
 			onClick: this.handleClick,
 			requireBackLink: true,
-			backLinkText: i18n.translate( 'All sites' ),
+			appTitle: i18n.translate( 'Reader' ),
 			backLinkHref: '/sites',
 		};
 		return (

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -295,7 +295,7 @@ export class ReaderSidebar extends Component {
 			path: this.props.path,
 			onClick: this.handleClick,
 			requireBackLink: true,
-			appTitle: i18n.translate( 'Reader' ),
+			siteTitle: i18n.translate( 'Reader' ),
 			backLinkHref: '/sites',
 		};
 		return (


### PR DESCRIPTION
Fixes 7101-gh-Automattic/dotcom-forge

Makes the site title and back link work the same across calypso, core and a4a

Previously we had a single "Back" _link_. Now we have a site title and a back _arrow_.

**Before** 

https://github.com/Automattic/wp-calypso/assets/22446385/a4ba2cab-a118-437d-9244-dbbcebc1ce08

**After**

https://github.com/Automattic/wp-calypso/assets/22446385/2df7fb5d-470b-4dc5-9dcf-1456e9cf411f

### Testing instructions

The `GlobalSidebar` component is used in:

* Reader: `/read`
* My Profile: `/me`
* My Sites: `/sites` (no effect here as back is hidden anyway)

