### PR TITLE
Update dev-tools-promo buttons design and order

### DIFF
--- a/client/dev-tools-promo/components/dev-tools-promo.tsx
+++ b/client/dev-tools-promo/components/dev-tools-promo.tsx
@@ -76,11 +76,11 @@ const DevToolsPromo = () => {
 						'Upgrade to the Creator plan or higher to get access to all developer tools'
 					) }
 				</p>
-				<Button variant="primary" className="dev-tools-promo__button" href={ upgradeLink }>
-					{ translate( 'Upgrade now' ) }
-				</Button>
 				<Button variant="secondary" className="dev-tools-promo__button" href={ pluginsLink }>
 					{ translate( 'Browse plugins' ) }
+				</Button>
+				<Button variant="primary" className="dev-tools-promo__button" href={ upgradeLink }>
+					{ translate( 'Upgrade now' ) }
 				</Button>
 			</div>
 			<div className="dev-tools-promo__cards">

--- a/client/dev-tools-promo/components/style.scss
+++ b/client/dev-tools-promo/components/style.scss
@@ -20,7 +20,10 @@
 		font-size: rem(18px);
 	}
 	.dev-tools-promo__button {
-		margin: 6px;
+		margin: 0 5px;
+		padding: 10px 14px;
+		font-size: rem(14px);
+		height: 40px;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7111

## Proposed Changes

* Update button order and styles to match Figma design (see issue)

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/0be53190-44bb-4e39-86e1-338130656823">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/875e6f89-b702-41b4-b3e4-330fbc0a6cd3">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure nav redesign is enabled `?flags=layout/dotcom-nav-redesign-v2`
* Go to a Simple site > Dev Tools (`/dev-tools-promo/:site`) 
* Check if there're any layout issues

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
