### PR TITLE
Move help center when global sidebar is shown

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -488,3 +488,14 @@ $brand-text: "SF Pro Text", $sans;
 		display: none;
 	}
 }
+
+body.has-global-sidebar .help-center .components-card.help-center__container.is-desktop {
+	top: auto;
+	right: auto;
+	bottom: 34px;
+	left: 116px;
+}
+
+body.has-global-sidebar.has-global-sidebar-collapsed .help-center .components-card.help-center__container.is-desktop {
+	left: 82px;
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -221,6 +221,7 @@ class Layout extends Component {
 		} );
 
 		this.refreshColorScheme( undefined, this.props.colorScheme );
+		this.addSidebarClassToBody();
 	}
 
 	/**
@@ -239,6 +240,21 @@ class Layout extends Component {
 				this.props.colorScheme !== 'modern' )
 		) {
 			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
+		}
+		this.addSidebarClassToBody();
+	}
+
+	addSidebarClassToBody() {
+		if ( this.props.isGlobalSidebarVisible ) {
+			document.querySelector( 'body' ).classList.add( 'has-global-sidebar' );
+		} else {
+			document.querySelector( 'body' ).classList.remove( 'has-global-sidebar' );
+		}
+
+		if ( this.props.isGlobalSidebarCollapsed ) {
+			document.querySelector( 'body' ).classList.add( 'has-global-sidebar-collapsed' );
+		} else {
+			document.querySelector( 'body' ).classList.remove( 'has-global-sidebar-collapsed' );
 		}
 	}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -251,6 +251,10 @@ class Layout extends Component {
 	}
 
 	addSidebarClassToBody() {
+		if ( typeof document === 'undefined' ) {
+			return;
+		}
+
 		if ( this.props.isGlobalSidebarVisible ) {
 			document.querySelector( 'body' ).classList.add( 'has-global-sidebar' );
 		} else {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -241,7 +241,13 @@ class Layout extends Component {
 		) {
 			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
 		}
-		this.addSidebarClassToBody();
+
+		if (
+			prevProps.isGlobalSidebarVisible !== this.props.isGlobalSidebarVisible ||
+			prevProps.isGlobalSidebarCollapsed !== this.props.isGlobalSidebarCollapsed
+		) {
+			this.addSidebarClassToBody();
+		}
 	}
 
 	addSidebarClassToBody() {


### PR DESCRIPTION
Fixes 6995-gh-Automattic/dotcom-forge Moves help center next to the <?> Icon when the global sidebar is shown.

I've used a CSS class to override the default positioning, I've had to add a `has-global-sidebar` to the body, and then removes it if the global sidebar is removed.

### Testing instructions
see 6995-gh-Automattic/dotcom-forge. the help center should show close to the button that openned it in all cases.


There is one edge case that isn't quite working as I would like it to. 
At this large phone resolution ~580px, the `has-global-sidebar-collapsed` class is applied when technically, I think it shouldn't be. I think that it's, in a sense, an existing issue, and very low impact :) 

<img width="578" alt="Screenshot 2024-05-13 at 6 50 00 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/2efeb56b-18f0-4bc3-8a43-bd9ca9fe75f6">
