### PR TITLE
GSV: Adjust the header layout on mobile

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -51,52 +51,56 @@ export default function ItemPreviewPaneHeader( {
 					className="item-preview__header-favicon"
 					size={ size }
 				/>
-				<div className="item-preview__header-title-summary">
-					<div className="item-preview__header-title">{ itemData.title }</div>
-					<div className="item-preview__header-summary">
-						<Button
-							variant="link"
-							className="item-preview__header-summary-link"
-							href={ itemData.url }
-							target="_blank"
-						>
-							<span>{ itemData.subtitle }</span>
-							<Icon
-								className="sidebar-v2__external-icon"
-								icon={ external }
-								size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
-							/>
-						</Button>
+				<div className="item-preview__header-info">
+					<div className="item-preview__header-title-summary">
+						<div className="item-preview__header-title">{ itemData.title }</div>
+						<div className="item-preview__header-summary">
+							<Button
+								variant="link"
+								className="item-preview__header-summary-link"
+								href={ itemData.url }
+								target="_blank"
+							>
+								<span>{ itemData.subtitle }</span>
+								<Icon
+									className="sidebar-v2__external-icon"
+									icon={ external }
+									size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
+								/>
+							</Button>
+						</div>
+					</div>
+					<div className="item-preview__header-actions">
+						{ itemData.adminUrl ? (
+							<>
+								<Button
+									onClick={ closeItemPreviewPane }
+									className="item-preview__close-preview-button"
+									variant="secondary"
+								>
+									{ translate( 'Close' ) }
+								</Button>
+								<Button
+									variant="primary"
+									className="item-preview__admin-button"
+									href={ `${ adminUrl }` }
+									ref={ focusRef }
+								>
+									{ adminLabel }
+								</Button>
+							</>
+						) : (
+							<Button
+								onClick={ closeItemPreviewPane }
+								className="item-preview__close-preview"
+								aria-label={ translate( 'Close Preview' ) }
+								ref={ focusRef }
+							>
+								<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
+							</Button>
+						) }
 					</div>
 				</div>
-				{ itemData.adminUrl ? (
-					<>
-						<Button
-							onClick={ closeItemPreviewPane }
-							className="item-preview__close-preview-button"
-							variant="secondary"
-						>
-							{ translate( 'Close' ) }
-						</Button>
-						<Button
-							variant="primary"
-							className="item-preview__admin-button"
-							href={ `${ adminUrl }` }
-							ref={ focusRef }
-						>
-							{ adminLabel }
-						</Button>
-					</>
-				) : (
-					<Button
-						onClick={ closeItemPreviewPane }
-						className="item-preview__close-preview"
-						aria-label={ translate( 'Close Preview' ) }
-						ref={ focusRef }
-					>
-						<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
-					</Button>
-				) }
 			</div>
 		</div>
 	);

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -61,12 +61,14 @@ export default function ItemPreviewPaneHeader( {
 								href={ itemData.url }
 								target="_blank"
 							>
-								<span>{ itemData.subtitle }</span>
-								<Icon
-									className="sidebar-v2__external-icon"
-									icon={ external }
-									size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
-								/>
+								<span>
+									{ itemData.subtitle }
+									<Icon
+										className="sidebar-v2__external-icon"
+										icon={ external }
+										size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
+									/>
+								</span>
 							</Button>
 						</div>
 					</div>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -3,6 +3,13 @@
 .item-preview__header {
 
 	.item-preview__header-content {
+		.item-preview__header-info {
+			display: flex;
+			flex-direction: row;
+			flex-grow: 1;
+			gap: 10px;
+		}
+
 		.item-preview__header-title-summary {
 			word-wrap: anywhere;
 		}
@@ -82,7 +89,7 @@
 		.item-preview__header-content {
 			flex-grow: 1;
 			display: flex;
-			justify-content: space-between;
+
 			.item-preview__header-title-summary {
 				flex-grow: 1;
 				display: flex;

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -12,6 +12,10 @@
 
 		.item-preview__header-title-summary {
 			word-wrap: anywhere;
+
+			.item-preview__header-summary-link svg {
+				vertical-align: middle;
+			}
 		}
 
 		.item-preview__close-preview,

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -447,6 +447,10 @@
 		}
 
 		.item-preview__header-content {
+			.item-preview__header-info {
+				flex-wrap: wrap;
+			}
+
 			@media (max-width: $break-large) {
 				padding: 0;
 			}

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -563,6 +563,9 @@
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
 			.preview-pane__navigation {
 				box-shadow: 0 0 0 1px var(--color-border-subtle), 0 1px 2px var(--color-border-subtle);
+				// Fix the weird box-shadow on the top when the action buttons are wrapped into the newline;
+				padding-top: 1px;
+				clip-path: inset(2px -1px -1px -1px);
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6936

## Proposed Changes

* Adjust the header layout of the GSV on mobile

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/26a2f426-45ea-4e00-a174-709ed2cb3013) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/db4b5f2f-c72f-462e-b3eb-6be5535a0378) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site
* Resize your window width
* Make sure the action buttons are wrapped into the newline if the width is not enough

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
