### PR TITLE
Sites sidebar: Improve responsiveness of tooltips

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -134,6 +134,7 @@ $brand-text: "SF Pro Text", $sans;
 		}
 
 		.sidebar {
+			overflow: visible;
 			&:first-child {
 				margin-top: 4px;
 			}
@@ -475,5 +476,11 @@ $brand-text: "SF Pro Text", $sans;
 				}
 			}
 		}
+	}
+}
+
+@media ( max-width: 660px ) {
+	.global-sidebar .tooltip:hover::after {
+		display: none;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/90619

## Proposed Changes

Fixes a couple of regressions introduced in https://github.com/Automattic/wp-calypso/pull/90429 which caused the tooltips to be slightly broken at certain viewports.

Before | After
--- | ---
<img width="630" alt="Screenshot 2024-05-13 at 13 08 30" src="https://github.com/Automattic/wp-calypso/assets/1233880/95732027-4f90-443b-b86a-312bf3b24c34"> | <img width="632" alt="Screenshot 2024-05-13 at 13 08 36" src="https://github.com/Automattic/wp-calypso/assets/1233880/f9b7245f-cd49-4cf1-980d-657a37157a35">
<img width="533" alt="Screenshot 2024-05-13 at 13 08 57" src="https://github.com/Automattic/wp-calypso/assets/1233880/60be3a66-e756-4abd-a073-36cc7b5418a1"> | <img width="471" alt="Screenshot 2024-05-13 at 13 24 05" src="https://github.com/Automattic/wp-calypso/assets/1233880/c6a0fd19-30c2-4a55-a187-7af8afaaeab9">



## Testing Instructions

- Use the Calypso live link below
- Go to `/sites` and select a site
- Check that the tooltips are no longer displayed at viewports below 660px
- Check that the tooltips are displayed correctly at viewports between 661px and 782px