### PR TITLE
Add check for supported engines to import CaptureStep

### DIFF
--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -4,6 +4,7 @@ import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import React, { useRef, useState } from 'react';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
+import { isSupportedImporterEngine } from 'calypso/lib/importer/importer-config';
 import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser, getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
@@ -99,7 +100,11 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 				break;
 
 			default:
-				stepSectionName = 'preview';
+				if ( ! isSupportedImporterEngine( urlData.platform ) ) {
+					stepSectionName = 'not';
+				} else {
+					stepSectionName = 'preview';
+				}
 				break;
 		}
 

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -327,4 +327,10 @@ export function getImporterByKey(
 	return filter( getImporters( args ), ( importer ) => importer.key === key )[ 0 ];
 }
 
+export function isSupportedImporterEngine( engine: string ): boolean {
+	const allImporters = getImporters();
+
+	return allImporters.some( ( importer ) => importer.engine === engine );
+}
+
 export default getConfig;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR ensures that we support the specified import platform before we redirect to the preview step in import flows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Navigate to `/setup/import-hosted-site`
* On the screen asking for your site address, enter a site built with Godaddy's site builder (which should be hosted at `*.godaddysites.com`)
* Verify that you are taken to a screen that indicates we don't support imports from that platform

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
