### PR TITLE
A4A: Fix site list when assigning licenses to match sites from the dashboard

### DIFF
--- a/client/a8c-for-agencies/data/sites.ts
+++ b/client/a8c-for-agencies/data/sites.ts
@@ -55,6 +55,7 @@ export const mockedSites: Site[] = [
 		has_paid_agency_monitor: false,
 		has_pending_boost_one_time_score: false,
 		monitor_last_status_change: '',
+		multisite: false,
 	},
 	{
 		url: 'instantdelightfully.wpcomstaging.com',
@@ -110,6 +111,7 @@ export const mockedSites: Site[] = [
 		has_paid_agency_monitor: false,
 		has_pending_boost_one_time_score: false,
 		monitor_last_status_change: '',
+		multisite: false,
 	},
 	{
 		url: 'jetpackcrm.com',
@@ -180,6 +182,7 @@ export const mockedSites: Site[] = [
 		},
 		has_paid_agency_monitor: false,
 		has_pending_boost_one_time_score: false,
+		multisite: false,
 	},
 	{
 		url: 'kb.jetpackcrm.com',
@@ -249,5 +252,6 @@ export const mockedSites: Site[] = [
 		},
 		has_paid_agency_monitor: false,
 		has_pending_boost_one_time_score: false,
+		multisite: false,
 	},
 ];

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -260,7 +260,7 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 					} ) }
 					{ data?.sites.length === 0 && (
 						<div className={ classNames( 'card', 'assign-license__sites-no-results' ) }>
-							No results
+							{ translate( 'No results' ) }
 						</div>
 					) }
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/styles.scss
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/styles.scss
@@ -34,3 +34,9 @@
 .assign-license__site-card-radio.form-radio {
 	margin-inline-end: 1rem;
 }
+
+.assign-license__sites-no-results {
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 24px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -2,7 +2,6 @@ import { type Callback } from '@automattic/calypso-router';
 import page from '@automattic/calypso-router';
 import { A4A_MARKETPLACE_HOSTING_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import getSites from 'calypso/state/selectors/get-sites';
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
@@ -74,15 +73,13 @@ export const checkoutContext: Callback = ( context, next ) => {
 
 export const assignLicenseContext: Callback = ( context, next ) => {
 	const { page, search } = context.query;
-	const state = context.store.getState();
-	const sites = getSites( state );
-	const currentPage = parseInt( page ) || 1;
+	const initialPage = parseInt( page ) || 1;
 
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Assign License" path={ context.path } />
-			<AssignLicense sites={ sites } currentPage={ currentPage } search={ search || '' } />
+			<AssignLicense initialPage={ initialPage } initialSearch={ search || '' } />
 		</>
 	);
 	next();

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -18,6 +18,7 @@ const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => 
 			{}
 		),
 		...( filter.showOnlyFavorites && { show_only_favorites: true } ),
+		...( filter.isNotMultisite && { not_multisite: true } ),
 	};
 };
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -89,6 +89,7 @@ export interface Site {
 	latest_backup_status: string;
 	is_connection_healthy: boolean;
 	awaiting_plugin_updates: Array< string >;
+	multisite: boolean;
 	is_favorite: boolean;
 	monitor_settings: MonitorSettings;
 	monitor_last_status_change: string;
@@ -265,7 +266,7 @@ export interface AgencyDashboardFilterMap {
 export type AgencyDashboardFilter = {
 	issueTypes: Array< AgencyDashboardFilterOption >;
 	showOnlyFavorites: boolean;
-	isMultisite?: boolean;
+	isNotMultisite?: boolean;
 };
 
 export type ProductInfo = { name: string; key: string; status: 'rejected' | 'fulfilled' };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -265,6 +265,7 @@ export interface AgencyDashboardFilterMap {
 export type AgencyDashboardFilter = {
 	issueTypes: Array< AgencyDashboardFilterOption >;
 	showOnlyFavorites: boolean;
+	isMultisite?: boolean;
 };
 
 export type ProductInfo = { name: string; key: string; status: 'rejected' | 'fulfilled' };

--- a/client/jetpack-cloud/sections/onboarding-tours/constants.ts
+++ b/client/jetpack-cloud/sections/onboarding-tours/constants.ts
@@ -74,6 +74,7 @@ export const JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE: SiteData[] = [
 				has_vulnerable_plugins: false,
 				latest_scan_has_threats_found: false,
 				active_paid_subscription_slugs: [],
+				multisite: false,
 			},
 			error: false,
 			status: 'active',


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/465

## Proposed Changes

* This PR makes the site list when assigning licenses match the site list from the sites dashboard.
  * Achieves this by changing the sites fetching source to the same endpoint as the sites dashboard uses.
  * Adds server side pagination.
* This PR also adds user feedback for empty results.

## Testing Instructions

* Apply D148743-code to your sandbox, and point your hosts file to it
  * This diff adds multisite to the sites endpoint results, and also a new filter called `not_multisite` to filter out multisites
* Go to Purchases -> Licenses (`http://agencies.localhost:3000/purchases/licenses`)
* Choose and Unassigned license ( e.g. `Boost` )
* Click over the `Assign` link
* Verify that the sites list matches the sites dashboard list
* Verify that the pagination works
* Verify that multisites are filtered out for products not compatible with multisites (e.g. `Backup`)
* Verify that the search box works
* Verify that there is a a message for empty results
* Verify that the sites dashboard still work ( `http://agencies.localhost:3000/sites` ) 
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
