### PR TITLE
E2E test: Ensure block inserter panel is closed in mobile viewports by waiting for the detached state

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -40,6 +40,11 @@ export class EditorSidebarBlockInserterComponent {
 
 		const editorParent = await this.editor.parent();
 		const blockInserterPanelLocator = editorParent.locator( selectors.closeBlockInserterButton );
+
+		// The panel is expected to auto-close. Let's possible wait for that
+		// detach event before we attempt to use the close button
+		await blockInserterPanelLocator.waitFor( { state: 'detached' } );
+
 		if ( ( await blockInserterPanelLocator.count() ) > 0 ) {
 			await blockInserterPanelLocator.click();
 		}

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -41,11 +41,12 @@ export class EditorSidebarBlockInserterComponent {
 		const editorParent = await this.editor.parent();
 		const blockInserterPanelLocator = editorParent.locator( selectors.closeBlockInserterButton );
 
-		// The panel is expected to auto-close. Let's possible wait for that
-		// detach event before we attempt to use the close button
-		await blockInserterPanelLocator.waitFor( { state: 'detached' } );
-
-		if ( ( await blockInserterPanelLocator.count() ) > 0 ) {
+		try {
+			// The panel is expected to auto-close. Let's possibly wait for that
+			// detach event
+			await blockInserterPanelLocator.waitFor( { state: 'detached' } );
+		} catch {
+			// If not auto-closed, trigger a close
 			await blockInserterPanelLocator.click();
 		}
 


### PR DESCRIPTION
This fix only applies to mobiles, and the test is classified as flaky by TC.

It addresses a situation where the block inserter panel is closed too soon than Playwright's attempt to click it.

This is currently breaking some nightly e2e tests for Gutenberg. 

```
locator.click: Timeout 10000ms exceeded.
=========================== logs ===========================
waiting for locator('body.block-editor-page').locator('button[aria-label="Close block inserter"]')
  locator resolved to <button type="button" aria-label="Close block inserter" …>…</button>
attempting click action
  waiting for element to be visible, enabled and stable
element was detached from the DOM, retrying
============================================================
at EditorSidebarBlockInserterComponent.click [as closeBlockInserter] (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts:44:36)
    at EditorPage.addBlockFromSidebar (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/editor-page.ts:330:4)
    at Object.<anonymous> (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/blocks/blocks__coblocks__blocks.ts:62:23)
```

Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

Run the editor schedule flow e2e edge tests, which was failing before this fix:

```bash
cd test/e2e
yarn jest --clearCache && yarn build  # clear build cache before each run


VIEWPORT=mobile yarn jest specs/blocks/blocks__coblocks__blocks.ts  
VIEWPORT=mobile GUTENBERG_EDGE=1 yarn jest specs/blocks/blocks__coblocks__blocks.ts
VIEWPORT=mobile GUTENBERG_EDGE=1 TEST_ON_ATOMIC=true yarn jest specs/blocks/blocks__coblocks__blocks.ts
```