### PR TITLE
Update Headers for site management panel

### DIFF
--- a/client/hosting-overview/components/hosting-overview.tsx
+++ b/client/hosting-overview/components/hosting-overview.tsx
@@ -1,12 +1,20 @@
+import { translate } from 'i18n-calypso';
 import { FC } from 'react';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ActiveDomainsCard from 'calypso/hosting-overview/components/active-domains-card';
 import PlanCard from 'calypso/hosting-overview/components/plan-card';
 import QuickActionsCard from 'calypso/hosting-overview/components/quick-actions-card';
+
 import './style.scss';
 
 const HostingOverview: FC = () => {
 	return (
 		<div className="hosting-overview">
+			<NavigationHeader
+				className="hosting-overview__navigation-header"
+				title={ translate( 'Overview' ) }
+				subtitle={ translate( 'Get a quick glance at your plans, storage, and domains.' ) }
+			/>
 			<PlanCard />
 			<QuickActionsCard />
 			<ActiveDomainsCard />

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -26,20 +26,25 @@ $card-padding: 24px;
 	height: 100%;
 }
 
+.hosting-overview__navigation-header {
+	grid-column: 1 / -1;
+	grid-row: 1 / 2;
+}
+
 .hosting-overview__plan {
 	grid-column: 1 / 2;
-	grid-row: 1 / 2;
+	grid-row: 2 / 3;
 }
 
 .hosting-overview__quick-actions {
 	grid-column: 2 / 3;
-	grid-row: 1 / 2;
+	grid-row: 2 / 3;
 	padding-bottom: 10px;
 }
 
 .hosting-overview__active-domains {
 	grid-column: 1 / 3;
-	grid-row: 2 / 3;
+	grid-row: 3 / 4;
 	padding-bottom: 0;
 }
 

--- a/client/my-sites/github-deployments/components/page-shell/index.tsx
+++ b/client/my-sites/github-deployments/components/page-shell/index.tsx
@@ -69,7 +69,7 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 				css={ { paddingBottom: '40px !important' } }
 				title={ translate( 'GitHub Deployments' ) }
 				subtitle={ translate(
-					'Effortlessly deploy code from GitHub repositories. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					'Automate updates from GitHub to streamline workflows. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{
 						components: {
 							learnMoreLink: (

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -415,7 +415,7 @@ const Hosting = ( props ) => {
 			<DocumentHead title={ translate( 'Hosting' ) } />
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Hosting' ) }
+				title={ translate( 'Hosting Config' ) }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
 			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -1,7 +1,10 @@
 import { useI18n } from '@wordpress/react-i18n';
+import { translate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteMonitoringLineChart } from './components/site-monitoring-line-chart';
 import {
@@ -536,7 +539,15 @@ export const MetricsTab = () => {
 	return (
 		<div className="site-monitoring-metrics-tab">
 			<div className="site-monitoring-time-controls__container">
-				<div className="site-monitoring-time-controls__title">{ dateRange }</div>
+				<NavigationHeader
+					className="site-monitoring__navigation-header"
+					title={ dateRange }
+					subtitle={ translate( 'Monitor your site’s performance. {{link}}Learn more.{{/link}}', {
+						components: {
+							link: <InlineSupportLink supportContext="site-monitoring" showIcon={ false } />,
+						},
+					} ) }
+				/>
 				<TimeDateChartControls onTimeRangeChange={ handleTimeRangeChange }></TimeDateChartControls>
 			</div>
 			<SiteMonitoringLineChart

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -541,7 +541,12 @@ export const MetricsTab = () => {
 			<div className="site-monitoring-time-controls__container">
 				<NavigationHeader
 					className="site-monitoring__navigation-header"
-					title={ dateRange }
+					title={
+						<>
+							{ translate( 'Monitoring: ' ) }
+							{ dateRange }
+						</>
+					}
 					subtitle={ translate( 'Monitor your site’s performance. {{link}}Learn more.{{/link}}', {
 						components: {
 							link: <InlineSupportLink supportContext="site-monitoring" showIcon={ false } />,

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -277,7 +277,7 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 	}
 }
 
-.site-monitoring__navigation-header {
+.site-monitoring__navigation-header.navigation-header {
 	width: auto;
 	padding-bottom: 0;
 }

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -276,3 +276,8 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 		font-weight: 400;
 	}
 }
+
+.site-monitoring__navigation-header {
+	width: auto;
+	padding-bottom: 0;
+}

--- a/client/site-monitoring/controller.tsx
+++ b/client/site-monitoring/controller.tsx
@@ -22,7 +22,6 @@ export function siteMonitoringPhpLogs( context: PageJSContext, next: () => void 
 		<>
 			<PageViewTracker path="/site-monitoring/:site/php" title="Site Monitoring" />
 			<NavigationHeader
-				className="hosting-overview__navigation-header"
 				title={ translate( 'PHP Logs' ) }
 				subtitle={ translate( 'View and download PHP error logs. {{link}}Learn more.{{/link}}', {
 					components: {
@@ -42,7 +41,6 @@ export function siteMonitoringServerLogs( context: PageJSContext, next: () => vo
 		<>
 			<PageViewTracker path="/site-monitoring/:site/web" title="Site Monitoring" />
 			<NavigationHeader
-				className="hosting-overview__navigation-header"
 				title={ translate( 'Server Logs' ) }
 				subtitle={ translate(
 					'Gain full visibility into server activity. {{link}}Learn more.{{/link}}',

--- a/client/site-monitoring/controller.tsx
+++ b/client/site-monitoring/controller.tsx
@@ -1,3 +1,6 @@
+import { translate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { LogsTab } from 'calypso/my-sites/site-monitoring/logs-tab';
 import { MetricsTab } from 'calypso/my-sites/site-monitoring/metrics-tab';
@@ -18,6 +21,15 @@ export function siteMonitoringPhpLogs( context: PageJSContext, next: () => void 
 	context.primary = (
 		<>
 			<PageViewTracker path="/site-monitoring/:site/php" title="Site Monitoring" />
+			<NavigationHeader
+				className="hosting-overview__navigation-header"
+				title={ translate( 'PHP Logs' ) }
+				subtitle={ translate( 'View and download PHP error logs. {{link}}Learn more.{{/link}}', {
+					components: {
+						link: <InlineSupportLink supportContext="site-monitoring-logs" showIcon={ false } />,
+					},
+				} ) }
+			/>
 			<LogsTab logType="php" />
 		</>
 	);
@@ -29,6 +41,18 @@ export function siteMonitoringServerLogs( context: PageJSContext, next: () => vo
 	context.primary = (
 		<>
 			<PageViewTracker path="/site-monitoring/:site/web" title="Site Monitoring" />
+			<NavigationHeader
+				className="hosting-overview__navigation-header"
+				title={ translate( 'Server Logs' ) }
+				subtitle={ translate(
+					'Gain full visibility into server activity. {{link}}Learn more.{{/link}}',
+					{
+						components: {
+							link: <InlineSupportLink supportContext="site-monitoring-logs" showIcon={ false } />,
+						},
+					}
+				) }
+			/>
 			<LogsTab logType="web" />
 		</>
 	);

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -477,6 +477,8 @@
 		}
 	}
 	.item-preview__content {
+		padding: 32px 48px 48px;
+
 		> * {
 			margin: 0;
 			padding-top: 0;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7083

## Proposed Changes

* Adjust Headers so that all tabs in the site management panel look consistent

### Overview
* Added header and subheader

![overview](https://github.com/Automattic/wp-calypso/assets/6586048/c076c4e3-7760-49b4-ac04-3192448bd3bd)

### Hosting Config
* Updated header from "Hosting" to "Hosting Config"

![hosting config](https://github.com/Automattic/wp-calypso/assets/6586048/34fafc2a-6404-4329-afa6-45409654dcc2)

### Monitoring
* Updated header

![monitoring](https://github.com/Automattic/wp-calypso/assets/6586048/d1815c35-dfbe-429f-874e-d1aa6d7afa52)

### PHP Logs
* Added header and subheader

![php logs](https://github.com/Automattic/wp-calypso/assets/6586048/6efe3c45-3f5f-4df5-ad57-f69d82e24f37)


### Server Logs
* Added header and subheader

![server logs](https://github.com/Automattic/wp-calypso/assets/6586048/4fd6e731-80b2-4177-8089-cb818847e410)

### GitHub Deployments
* Updated copy for subheader

![github deployments](https://github.com/Automattic/wp-calypso/assets/6586048/696982b7-281d-4e31-b512-7c62e865bb06)


## Testing Instructions

* Go to sites dashboard and check the site management screen for atomic sites
* Make sure everything looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
