### PR TITLE
A4A: Fix a typo in the  product feedback form

### DIFF
--- a/client/a8c-for-agencies/components/user-feedback-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-feedback-modal-form/index.tsx
@@ -113,7 +113,7 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 
 				<p className="user-feedback-modal-form__instruction">
 					{ translate(
-						'Your feedback is extremely valuable to us. All feedback is set to our product and program teams, and helps to inform how we evolve our offering.'
+						'Your feedback is extremely valuable to us. All feedback is sent to our product and program teams, and helps to inform how we evolve our offering.'
 					) }
 				</p>
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes a minor typo in the message in the feedback form in A4A.

## Testing Instructions
- Use the A4A live link below and go to /overview page.
- In the Sidebar, click the Shared product feedback button.
- Submit some feedback and verify that the success message is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
