### PR TITLE
Multisite Scheduled Updates: Fix bug on removing schedule per site

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
@@ -10,7 +10,7 @@ import type {
 type Props = {
 	schedule: MultisiteSchedulesUpdates;
 	onEditClick: ( id: string ) => void;
-	onRemoveClick: ( id: string ) => void;
+	onRemoveClick: ( id: string, siteSlug?: SiteSlug ) => void;
 	onLogsClick: ( id: string, siteSlug: SiteSlug ) => void;
 };
 
@@ -39,7 +39,7 @@ export const ScheduleListTableRowMenu = ( {
 
 	items.push( {
 		title: translate( 'Remove' ),
-		onClick: () => onRemoveClick( schedule.schedule_id ),
+		onClick: () => onRemoveClick( schedule.schedule_id, site?.slug ),
 	} );
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -9,6 +9,7 @@ import { MultisitePluginUpdateManagerContext } from 'calypso/blocks/plugins-sche
 import { useBatchDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useMultisiteUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { SiteSlug } from 'calypso/types';
 import { ScheduleErrors } from './schedule-errors';
 import { ScheduleListCardNew } from './schedule-list-card-new';
 import { ScheduleListCards } from './schedule-list-cards';
@@ -50,7 +51,9 @@ export const ScheduleList = ( props: Props ) => {
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< string | undefined >(
 		initSelectedScheduleId
 	);
+	const [ selectedSiteSlug, setSelectedSiteSlug ] = useState< string | undefined >();
 	const [ selectedSiteSlugs, setSelectedSiteSlugs ] = useState< string[] >( [] );
+	const selectedSiteSlugsForMutate = selectedSiteSlug ? [ selectedSiteSlug ] : selectedSiteSlugs;
 
 	useEffect( () => {
 		const schedule = schedules?.find( ( schedule ) => schedule.schedule_id === selectedScheduleId );
@@ -58,7 +61,7 @@ export const ScheduleList = ( props: Props ) => {
 	}, [ selectedScheduleId ] );
 	useEffect( () => setSelectedScheduleId( initSelectedScheduleId ), [ initSelectedScheduleId ] );
 
-	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation( selectedSiteSlugs, {
+	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation( selectedSiteSlugsForMutate, {
 		onSuccess: () => {
 			// Refetch again after 5 seconds
 			setTimeout( () => {
@@ -67,8 +70,9 @@ export const ScheduleList = ( props: Props ) => {
 		},
 	} );
 
-	const openRemoveDialog = ( id: string ) => {
+	const openRemoveDialog = ( id: string, siteSlug?: SiteSlug ) => {
 		setRemoveDialogOpen( true );
+		setSelectedSiteSlug( siteSlug );
 		setSelectedScheduleId( id );
 	};
 
@@ -81,7 +85,7 @@ export const ScheduleList = ( props: Props ) => {
 		if ( selectedSiteSlugs && selectedScheduleId ) {
 			deleteUpdateSchedules.mutate( selectedScheduleId );
 			recordTracksEvent( 'calypso_scheduled_updates_multisite_delete_schedule', {
-				site_slugs: selectedSiteSlugs.join( ',' ),
+				site_slugs: selectedSiteSlugsForMutate.join( ',' ),
 			} );
 		}
 		closeRemoveConfirm();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixed bug on removing schedule per site
Before this fix, removing the schedule per site will remove the whole sites batch.

## Testing Instructions

* Go to `/plugins/scheduled-updates`
* Create a schedule for at least two sites
* Remove schedule per schedule
* Check if everything acts properly

<img width="967" alt="Screenshot 2024-05-13 at 15 58 12" src="https://github.com/Automattic/wp-calypso/assets/1241413/32d70d63-e8ae-4e07-8496-0e15c108e66c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
