### PR TITLE
Sites list: Show consistent icon

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -41,12 +41,15 @@ export default function ItemPreviewPaneHeader( {
 		}
 	}, [] );
 
+	const siteIconFallback =
+		extraProps.siteIconFallback ?? ( itemData.isDotcomSite ? 'wordpress-logo' : 'color' );
+
 	return (
 		<div className={ classNames( 'item-preview__header', className ) }>
 			<div className="item-preview__header-content">
 				<SiteFavicon
 					blogId={ itemData.blogId }
-					fallback={ itemData.isDotcomSite ? 'wordpress-logo' : 'color' }
+					fallback={ siteIconFallback }
 					color={ itemData.color }
 					className="item-preview__header-favicon"
 					size={ size }

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -42,7 +42,7 @@ export default function ItemPreviewPaneHeader( {
 	}, [] );
 
 	const siteIconFallback =
-		extraProps.siteIconFallback ?? ( itemData.isDotcomSite ? 'wordpress-logo' : 'color' );
+		extraProps?.siteIconFallback ?? ( itemData.isDotcomSite ? 'wordpress-logo' : 'color' );
 
 	return (
 		<div className={ classNames( 'item-preview__header', className ) }>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -42,4 +42,5 @@ export interface PreviewPaneProps {
 
 export interface ItemPreviewPaneHeaderExtraProps {
 	externalIconSize?: number;
+	siteIconFallback?: 'color' | 'wordpress-logo' | 'first-grapheme';
 }

--- a/client/a8c-for-agencies/components/items-dashboard/site-favicon/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/site-favicon/index.tsx
@@ -28,6 +28,7 @@ const SiteFavicon = ( {
 	const site = useSelector( ( state ) => getSite( state, blogId ) );
 
 	let defaultFavicon;
+	let defaultFaviconClass = '';
 	switch ( fallback ) {
 		case 'wordpress-logo':
 			defaultFavicon = <WordPressLogo className="wpcom-favicon" size={ size * 0.8 } />;
@@ -38,6 +39,7 @@ const SiteFavicon = ( {
 					{ getFirstGrapheme( site?.title ?? '' ) }
 				</div>
 			);
+			defaultFaviconClass = 'is-first-grapheme';
 			break;
 		case 'color':
 		default:
@@ -46,7 +48,7 @@ const SiteFavicon = ( {
 	}
 
 	return (
-		<div className={ classNames( 'site-favicon', className ) }>
+		<div className={ classNames( 'site-favicon', className, defaultFaviconClass ) }>
 			<SiteIcon siteId={ blogId } size={ size } defaultIcon={ defaultFavicon } />
 		</div>
 	);

--- a/client/a8c-for-agencies/components/items-dashboard/site-favicon/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/site-favicon/style.scss
@@ -17,4 +17,16 @@
 			}
 		}
 	}
+
+	&.is-first-grapheme {
+		.is-blank {
+			font-size: xx-large !important;
+			text-transform: uppercase;
+			background-color: #f5f7f7;
+			border: 1px solid rgb(238, 238, 238);
+			border-radius: 4px;
+			box-sizing: border-box;
+			color: var(--color-link);
+		}
+	}
 }

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -71,6 +71,10 @@
 	@media ( min-width: 782px ) {
 		height: calc(100vh - var(--masterbar-height) - 32px);
 	}
+
+	.sites-site-favicon {
+		margin-right: 0;
+	}
 }
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {
@@ -357,19 +361,6 @@
 				@media ( max-width: 961px ) {
 					margin-inline-end: 8px;
 				}
-			}
-		}
-
-		.sites-site-favicon {
-			margin-right: 0;
-
-			.is-blank {
-				font-size: xx-large !important;
-				text-transform: uppercase;
-				background-color: #f5f7f7;
-				border: 1px solid rgb(238, 238, 238);
-				border-radius: 4px;
-				box-sizing: border-box;
 			}
 		}
 	}

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -150,6 +150,7 @@ const DotcomPreviewPane = ( {
 			features={ features }
 			itemPreviewPaneHeaderExtraProps={ {
 				externalIconSize: 16,
+				siteIconFallback: 'first-grapheme',
 			} }
 		/>
 	);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7132

## Proposed Changes

- Replaces the default site icon of the site management panel with the first grapheme so it's consistent across all views
- Adds some missing styles to the the sites list sidebar so the default site icon looks the same when a site is selected

Before | After
--- | ---
<img width="1728" alt="Screenshot 2024-05-13 at 15 52 19" src="https://github.com/Automattic/wp-calypso/assets/1233880/ba2fd5f0-f63d-49ce-95fc-1563e02c5b92"> | <img width="1728" alt="Screenshot 2024-05-13 at 16 08 12" src="https://github.com/Automattic/wp-calypso/assets/1233880/8f156d6f-bc31-404d-bbdc-7e92a14d4c07">
  

## Testing Instructions

- Use the Calypso live link below
- Go to `/sites`
- Note the default site icon for sites without icon (it should be the first grapheme)
- Select a site
- Make sure the site icon in the sites list remains the same
- Make sure the site icon in the header of the site management panel is the same