### PR TITLE
Stats: Translate device module screen size labels

### DIFF
--- a/packages/components/src/horizontal-bar-list/sideElements/badge-new/index.tsx
+++ b/packages/components/src/horizontal-bar-list/sideElements/badge-new/index.tsx
@@ -1,11 +1,16 @@
+import { useTranslate } from 'i18n-calypso';
 import { Badge } from '../../../.';
 
 import './style.scss';
 
-const BadgeNew = () => (
-	<Badge type="success" className="stats-card__badge--success">
-		New
-	</Badge>
-);
+const BadgeNew = () => {
+	const translate = useTranslate();
+
+	return (
+		<Badge type="success" className="stats-card__badge--success">
+			{ translate( 'New' ) }
+		</Badge>
+	);
+};
 
 export default BadgeNew;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 796-gh-Automattic/i18n-issues

## Proposed Changes

* Add translatable strings for `mobile`, `tablet`, and `desktop` stat keys.
* Wrap `New` label in `BadgeNew` component in `translate()` call.

**Before:**
![4JfXdk3iZuZhcLk9](https://github.com/Automattic/wp-calypso/assets/2722412/3e631803-db8c-42b9-bc82-cdd01e4b4afb)

**After:**
![CSwrEXkLsXma4c4E](https://github.com/Automattic/wp-calypso/assets/2722412/97833130-4bd0-4efe-a204-7180ed5064d9)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso.live image or checkout the branch locally.
* Change UI to a Mag-16 language.
* Navigate to `/stats/day/[site]` and scroll down to the Devices module.
* Confirm the device screen size labels are translated.
* Confirm the `New` label in the stats module title is translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
