### PR TITLE
VBE: Rename generated translations files

### DIFF
--- a/packages/verbum-block-editor/bin/build-languages.js
+++ b/packages/verbum-block-editor/bin/build-languages.js
@@ -54,15 +54,14 @@ function buildLanguages( downloadedLanguages ) {
 
 	downloadedLanguages.forEach( ( { langSlug, languageTranslations } ) => {
 		// Keep only used phrases.
-		const filteredTranslations = Object.fromEntries(
+		languageTranslations.locale_data.messages = Object.fromEntries(
 			Object.entries( languageTranslations.locale_data.messages ).filter( ( [ key ] ) =>
 				usedPhrases.includes( key )
 			)
 		);
 
-		filteredTranslations[ '' ].localeSlug = langSlug;
-		const output = resolve( process.cwd(), outputPath, `${ langSlug }-v1.1.json` );
-		fs.writeFileSync( output, JSON.stringify( filteredTranslations ) );
+		const output = resolve( process.cwd(), outputPath, `${ langSlug }-verbum.json` );
+		fs.writeFileSync( output, JSON.stringify( languageTranslations ) );
 	} );
 
 	console.info( 'VBE: Language build completed.' );

--- a/packages/verbum-block-editor/webpack.config.js
+++ b/packages/verbum-block-editor/webpack.config.js
@@ -34,6 +34,9 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			filename: '[name].min.js', // dynamic filename
 			library: 'verbumBlockEditor',
 		},
+		externals: {
+			'@wordpress/i18n': [ 'wp', 'i18n' ],
+		},
 	};
 }
 

--- a/packages/verbum-block-editor/webpack.config.js
+++ b/packages/verbum-block-editor/webpack.config.js
@@ -34,9 +34,6 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			filename: '[name].min.js', // dynamic filename
 			library: 'verbumBlockEditor',
 		},
-		externals: {
-			'@wordpress/i18n': [ 'wp', 'i18n' ],
-		},
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes
This renames the translations files generated by Verbum Block Editor to be `locale-scriptHandle`.

## Why are these changes being made?

Because Gutenberg requires translations to be enqueued before module initialization. This means a JS bundle containing GB cannot translate itself. Something external has to enqueue the translations **_before_** GB is imported, so we need to enqueue the translations on PHP side and thus follow WP standard.
