### PR TITLE
Site Migration: Use sentry to log error from the site migration preparation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -1,3 +1,4 @@
+import { captureException } from '@automattic/calypso-sentry';
 import { StepContainer } from '@automattic/onboarding';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -31,7 +32,7 @@ const getMigrateGuruPageURL = ( siteURL: string ) =>
 
 const DoNotTranslateIt: FC< { value: string } > = ( { value } ) => <>{ value }</>;
 
-const SiteMigrationInstructions: Step = function () {
+const SiteMigrationInstructions: Step = function ( { flow } ) {
 	const translate = useTranslate();
 	const site = useSite();
 	const siteId = site?.ID;
@@ -40,6 +41,7 @@ const SiteMigrationInstructions: Step = function () {
 		detailedStatus,
 		migrationKey,
 		completed: isSetupCompleted,
+		error: setupError,
 	} = usePrepareSiteForMigration( siteId );
 
 	const hasErrorGetMigrationKey = detailedStatus.migrationKey === 'error';
@@ -62,6 +64,20 @@ const SiteMigrationInstructions: Step = function () {
 			recordTracksEvent( 'calypso_site_migration_instructions_preparation_complete' );
 		}
 	}, [ isSetupCompleted ] );
+
+	useEffect( () => {
+		if ( setupError ) {
+			captureException( setupError, {
+				tags: {
+					blog_id: siteId,
+					calypso_section: 'setup',
+					flow,
+					stepName: 'site-migration-instructions',
+					context: 'failed_to_prepare_site_for_migration',
+				},
+			} );
+		}
+	}, [ flow, setupError, siteId ] );
 
 	const stepContent = (
 		<div className="site-migration-instructions__content">

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -27,7 +27,7 @@ const getMigrationKeyStatus = (
 };
 
 const getError = ( original: Error ) => {
-	return new Error( 'Error to prepare a site for migration', { cause: original } );
+	return new Error( 'Failed to prepare a site for migration', { cause: original } );
 };
 
 /**

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -26,6 +26,10 @@ const getMigrationKeyStatus = (
 	return status as Status;
 };
 
+const getError = ( original: Error ) => {
+	return new Error( 'Error to prepare a site for migration', { cause: original } );
+};
+
 /**
  *  Hook to manage the site to prepare a site for migration using Migrate Guru plugin.
  *  This hook manages the site transfer, plugin installation and migration key fetching.
@@ -58,7 +62,7 @@ export const usePrepareSiteForMigration = ( siteId?: number ) => {
 	return {
 		detailedStatus,
 		completed,
-		error,
+		error: error ? getError( error ) : null,
 		migrationKey: migrationKey ?? null,
 	};
 };

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -26,10 +26,6 @@ const getMigrationKeyStatus = (
 	return status as Status;
 };
 
-const getError = ( original: Error ) => {
-	return new Error( 'Failed to prepare a site for migration', { cause: original } );
-};
-
 /**
  *  Hook to manage the site to prepare a site for migration using Migrate Guru plugin.
  *  This hook manages the site transfer, plugin installation and migration key fetching.
@@ -62,7 +58,7 @@ export const usePrepareSiteForMigration = ( siteId?: number ) => {
 	return {
 		detailedStatus,
 		completed,
-		error: error ? getError( error ) : null,
+		error,
 		migrationKey: migrationKey ?? null,
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes
Considering the `usePrepareSiteForMigration` is a complex flow dependent on multiple API, we need to log properly when we have some error during the process.

## Testing Instructions
- Set up your A8C account. 
- Run this branch in your local env
- Download and apply this [this patch](https://github.com/Automattic/wp-calypso/files/15297047/test.patch)  [`git apply test.patch`]
- Start the migration flow (`/start/`)
- Enable sentry in your local env `sessionStorage.setItem('flags', "always-enable-sentry")`
- Follow the migration flow until you see the instructions step.
- Check the[ Sentry Site Migration](https://a8c.sentry.io/dashboard/90082/?project=6313676) dashboard to see your error. 

More details about sentry here p1715616291198519-slack-C0Q664T29

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?