### PR TITLE
Fix reader inline notifications

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -231,6 +231,17 @@
 	}
 }
 
+.is-group-reader .reader-notifications__panel {
+	@media only screen and ( min-width: 1114px ) {
+		.wpnc__main {
+			width: calc(100vw - 310px);
+			.wpnc__note-list {
+				left: 0;
+			}
+		}
+	}
+}
+
 .reader__post-embed-count {
 	padding: 4px 6px;
 	border-radius: 2px;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7128

## Proposed Changes

Reader notifications pop out to the right on big screens

https://github.com/Automattic/wp-calypso/assets/402286/aa950a51-899f-461e-af52-e76198eaafd9

## Why are these changes being made?
Clicking notifications sometimes does nothing. Sometimes it replaces the notifications list on the left. Both of which are unexpected and bugs.

## Testing Instructions

* Go to `/read/notifications`
* Open a notification
* It should open on the right of the notifications panel on Desktop sizes
* Check if nothing is broken on other screen sizes
