### PR TITLE
Nav redesign - update reader layout to match new dashboard design

### DIFF
--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -99,3 +99,9 @@
 .accessible-focus .discover-stream-navigation .discover-stream-navigation__right-button {
 	display: none;
 }
+
+.is-global-sidebar-visible.is-section-reader .tag-stream__main.main {
+	&.reader-two-column {
+		max-width: 100%;
+	}
+}

--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -2,7 +2,7 @@
 	margin: 0 auto;
 	max-width: 600px;
 	&.reader-dual-column {
-		max-width: 968px; // Max width of dual column reader stream.
+		max-width: 100%; // Max width of dual column reader stream.
 	}
 }
 
@@ -17,7 +17,7 @@
 	}
 
 	&.reader-dual-column {
-		max-width: 968px; // Max width of dual column reader stream.
+		max-width: 100%; // Max width of dual column reader stream.
 		margin-bottom: 0;
 	}
 	@media only screen and (max-width: 660px) {
@@ -98,10 +98,4 @@
 .accessible-focus .discover-stream-navigation .discover-stream-navigation__left-button,
 .accessible-focus .discover-stream-navigation .discover-stream-navigation__right-button {
 	display: none;
-}
-
-.is-global-sidebar-visible.is-section-reader .tag-stream__main.main {
-	&.reader-two-column {
-		max-width: 100%;
-	}
 }

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -17,16 +17,20 @@ function FollowingStream( { ...props } ) {
 			<Stream
 				{ ...props }
 				className="following"
+				streamHeader={ () => (
+					<div className="stream__top-header">
+						<BloganuaryHeader />
+						<NavigationHeader
+							title={ translate( 'Recent' ) }
+							subtitle={ translate( "Stay current with the blogs you've subscribed to." ) }
+							className={ classNames( 'following-stream-header', {
+								'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
+							} ) }
+						/>
+					</div>
+				) }
 				streamSidebar={ () => <ReaderListFollowedSites path={ window.location.pathname } /> }
 			>
-				<BloganuaryHeader />
-				<NavigationHeader
-					title={ translate( 'Recent' ) }
-					subtitle={ translate( "Stay current with the blogs you've subscribed to." ) }
-					className={ classNames( 'following-stream-header', {
-						'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
-					} ) }
-				/>
 				<FollowingIntro />
 			</Stream>
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -18,6 +18,12 @@
 	}
 }
 
+.is-section-reader .is-global-sidebar-visible .tag-stream__main.main {
+	&.reader-two-column {
+		max-width: 100%;
+	}
+}
+
 .following.main  .section-nav {
 	margin-top: 0;
 

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -3,7 +3,7 @@
 	max-width: 600px;
 	padding: 0;
 	&.reader-dual-column {
-		max-width: 968px; // Max width of dual column reader stream.
+		max-width: 100%; // Max width of dual column reader stream.
 	}
 
 	.navigation-header__main {
@@ -15,12 +15,6 @@
 		.navigation-header__main {
 			min-height: auto;
 		}
-	}
-}
-
-.is-section-reader .is-global-sidebar-visible .tag-stream__main.main {
-	&.reader-two-column {
-		max-width: 100%;
 	}
 }
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -527,8 +527,6 @@ class ReaderStream extends Component {
 		let body;
 		let showingStream;
 
-		console.log( streamHeader );
-
 		// trick an infinite list to showing placeholders
 		if ( forcePlaceholders ) {
 			items = [];

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -527,6 +527,8 @@ class ReaderStream extends Component {
 		let body;
 		let showingStream;
 
+		console.log( streamHeader );
+
 		// trick an infinite list to showing placeholders
 		if ( forcePlaceholders ) {
 			items = [];
@@ -573,13 +575,13 @@ class ReaderStream extends Component {
 				body = <div className="reader__content">{ bodyContent }</div>;
 			} else if ( wideDisplay ) {
 				body = (
-					<div className="stream__two-column">
-						<div className="reader__content">
-							{ streamHeader?.() }
-							{ bodyContent }
+					<>
+						{ streamHeader?.() }
+						<div className="stream__two-column">
+							<div className="reader__content">{ bodyContent }</div>
+							<div className="stream__right-column">{ sidebarContentFn?.() }</div>
 						</div>
-						<div className="stream__right-column">{ sidebarContentFn?.() }</div>
-					</div>
+					</>
 				);
 				baseClassnames = classnames( 'reader-two-column', baseClassnames );
 			} else {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -30,6 +30,12 @@
 	}
 }
 
+.is-section-reader .is-global-sidebar-visible .tag-stream__main.main {
+	&.reader-two-column {
+		max-width: 100%;
+	}
+}
+
 .is-reader-page .reader__card.card.is-placeholder {
 	border-bottom: 1px solid #e9e9ea;
 	box-shadow: none;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -8,7 +8,7 @@
 	max-width: 600px;
 
 	&.reader-two-column {
-		max-width: 968px;
+		max-width: 100%;
 
 		.reader__content,
 		.tag-stream__header {
@@ -27,12 +27,6 @@
 				}
 			}
 		}
-	}
-}
-
-.is-section-reader .is-global-sidebar-visible .tag-stream__main.main {
-	&.reader-two-column {
-		max-width: 100%;
 	}
 }
 
@@ -611,7 +605,8 @@
 	display: flex;
 	flex-wrap: nowrap;
 	gap: 80px;
-	justify-content: flex-start;
+	justify-content: left;
+	padding-left: 64px;
 }
 
 .reader__content {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -15,14 +15,17 @@
 .is-reader-page .following.main,
 .is-reader-page .tag-stream__main.main,
 .is-reader-page .search-stream__with-sites.main {
-	margin: 0 auto;
-	@include breakpoint-deprecated( "<660px" ) {
-		margin: 16px 0;
-	}
+	margin: 0;
 }
 
 .is-reader-page .reader-full-post__story-content {
 	margin-top: 0;
+}
+
+.is-section-reader .stream__top-header {
+	padding: 12px 64px 0 64px;
+	border-block-end: 1px solid var(--color-border-secondary);
+	margin-bottom: 24px;
 }
 
 .reader__content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7065

## Proposed Changes

* TBD

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
