### PR TITLE
Jetpack Cloud: fix overlapping button styles

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -117,12 +117,6 @@
 	}
 }
 
-.button .gridicon {
-	color: var(--color-neutral-80);
-	width: 24px;
-	height: 24px;
-}
-
 .select-dropdown__item-text {
 	text-align: start;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -58,6 +58,11 @@ td.site-table__actions-button {
 			margin-inline-start: 0;
 			margin-inline-end: 15px;
 		}
+		.gridicon {
+			color: var(--color-neutral-80);
+			width: 24px;
+			height: 24px;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/90168

## Proposed Changes

Avoiding global styling override reported in the issue.

| Before | After |
| ---- | ---- |
| <img width="245" alt="Screenshot 2024-05-13 at 10 50 28 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/15eba422-8421-429a-9738-c0b08698e369"> | <img width="213" alt="Screenshot 2024-05-13 at 10 50 33 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/b8335728-efcd-45ed-b0df-62a9340316bf"> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to https://jetpack.com/manage/
- Navigat to `[Cloud Jetpack]/dashboard`
- Observe that edit button are still same color as in trunk (`color: var(--color-neutral-80)`)
<img width="201" alt="Screenshot 2024-05-13 at 10 52 33 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/0b9ee9e4-fd90-4862-98ec-a632619fc423">

- Select any non wp site
- Click on "Subscribers" in the left hand menu
- Check `Add subscribers` button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
