### PR TITLE
Dashboard v2 - refactor item-preview-pane-header overrides, use Automattic button for dotcom override.

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -5,7 +5,6 @@ import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
-import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import SiteFavicon from '../../site-favicon';
 import { ItemData, ItemPreviewPaneHeaderExtraProps } from '../types';
 
@@ -30,9 +29,7 @@ export default function ItemPreviewPaneHeader( {
 	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
 	const size = isLargerThan960px ? 64 : 50;
 
-	const focusRef = useRef< HTMLInputElement >( null );
-
-	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
+	const focusRef = useRef< HTMLButtonElement >( null );
 
 	// Use useEffect to set the focus when the component mounts
 	useEffect( () => {
@@ -76,24 +73,12 @@ export default function ItemPreviewPaneHeader( {
 						</div>
 					</div>
 					<div className="item-preview__header-actions">
-						{ itemData.adminUrl ? (
-							<>
-								<Button
-									onClick={ closeItemPreviewPane }
-									className="item-preview__close-preview-button"
-									variant="secondary"
-								>
-									{ translate( 'Close' ) }
-								</Button>
-								<Button
-									variant="primary"
-									className="item-preview__admin-button"
-									href={ `${ adminUrl }` }
-									ref={ focusRef }
-								>
-									{ adminLabel }
-								</Button>
-							</>
+						{ extraProps?.headerButtons ? (
+							<extraProps.headerButtons
+								focusRef={ focusRef }
+								itemData={ itemData }
+								closeSitePreviewPane={ closeItemPreviewPane || ( () => {} ) }
+							/>
 						) : (
 							<Button
 								onClick={ closeItemPreviewPane }

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -43,4 +43,9 @@ export interface PreviewPaneProps {
 export interface ItemPreviewPaneHeaderExtraProps {
 	externalIconSize?: number;
 	siteIconFallback?: 'color' | 'wordpress-logo' | 'first-grapheme';
+	headerButtons?: React.ComponentType< {
+		focusRef: React.RefObject< HTMLButtonElement >;
+		itemData: ItemData;
+		closeSitePreviewPane: () => void;
+	} >;
 }

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -432,6 +432,7 @@
 			padding: 0 8px;
 		}
 	}
+
 	.item-preview__header {
 		.item-preview__header-title {
 			font-family: Recoleta, sans-serif;
@@ -458,6 +459,10 @@
 					color: var(--color-accent, #3858e9);
 				}
 			}
+		}
+
+		.item-preview__header-actions .button {
+			border-radius: 4px;
 		}
 
 		.item-preview__header-content .item-preview__close-preview {

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -15,6 +15,7 @@ import {
 	DOTCOM_GITHUB_DEPLOYMENTS,
 	DOTCOM_DEVELOPER_TOOLS_PROMO,
 } from './constants';
+import PreviewPaneHeaderButtons from './preview-pane-header-buttons';
 
 type Props = {
 	site: SiteExcerptData;
@@ -151,6 +152,7 @@ const DotcomPreviewPane = ( {
 			itemPreviewPaneHeaderExtraProps={ {
 				externalIconSize: 16,
 				siteIconFallback: 'first-grapheme',
+				headerButtons: PreviewPaneHeaderButtons,
 			} }
 		/>
 	);

--- a/client/sites-dashboard-v2/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/preview-pane-header-buttons.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
+import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
+
+type Props = {
+	focusRef: React.RefObject< HTMLButtonElement >;
+	itemData: ItemData;
+	closeSitePreviewPane?: () => void;
+};
+
+const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane, itemData }: Props ) => {
+	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
+	const { __ } = useI18n();
+	return (
+		<>
+			<Button onClick={ closeSitePreviewPane } className="item-preview__close-preview-button">
+				{ __( 'Close' ) }
+			</Button>
+			<Button
+				primary
+				className="item-preview__admin-button"
+				href={ `${ adminUrl }` }
+				ref={ focusRef }
+			>
+				{ adminLabel }
+			</Button>
+		</>
+	);
+};
+
+export default PreviewPaneHeaderButtons;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7104 and https://github.com/Automattic/wp-calypso/pull/90166 

## Proposed Changes

* Refactors our conditional overrides for the item-preview-pane-header component using the approach discussed in https://github.com/Automattic/wp-calypso/pull/90166#issuecomment-2104362600 cc @cleacos 
* Changes to using the `@automattic/components` Button instead of the `@wordpress/components` button within our dotcom override to better match the surrounding interface as described in Automattic/dotcom-forge#7104 
* Adds 4px border radius to the buttons used here within the dotcom-style file, to match the rest of the buttons in this area.

BEFORE
<img width="214" alt="Screenshot 2024-05-13 at 2 03 40 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/2ad310c0-3fc0-4e7f-b7a4-192d1623076c">
(36px height, 0 radius, `.components-button` class)

AFTER

<img width="280" alt="Screenshot 2024-05-13 at 2 03 22 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/fe0f0c73-653a-4a8e-8b3d-3823df1fcb9e">

(40px height, 4px radius, `.button` class)



<img width="1485" alt="Screenshot 2024-05-13 at 2 28 52 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/40c522a9-949c-4f42-ac38-6bc712adbfe4">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Described above and in linked PR/issues.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit the sites dashboard, select a site to see GSV (click a row).
* In the header area, you should see the buttons are now a little taller and have border radius. The style should match the primary buttons used on the domains page, as well as the main sites list without GSV open.
* Visit the a4a build and verify there are no changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
