### PR TITLE
Add variant for hosted-site-migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
@@ -5,6 +5,7 @@ import siteMigration from './site-migration-flow';
 const hostedSiteMigrationFlow: Flow = {
 	...siteMigration,
 	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
+	isSignupFlow: true,
 };
 
 export default hostedSiteMigrationFlow;

--- a/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
@@ -1,0 +1,10 @@
+import { HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { type Flow } from './internals/types';
+import siteMigration from './site-migration-flow';
+
+const hostedSiteMigrationFlow: Flow = {
+	...siteMigration,
+	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
+};
+
+export default hostedSiteMigrationFlow;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -170,6 +170,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			return {
 				siteSlug: getSignupCompleteSlug(),
 				goToCheckout: true,
+				siteCreated: true,
 			};
 		}
 
@@ -203,6 +204,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 				siteId: site.siteId,
 				siteSlug: site.siteSlug,
 				goToCheckout: false,
+				siteCreated: true,
 			};
 		}
 
@@ -224,6 +226,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			siteSlug: site?.siteSlug,
 			goToCheckout: Boolean( planCartItem ),
 			hasSetPreselectedTheme: Boolean( preselectedThemeSlug ),
+			siteCreated: true,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -110,7 +110,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			}
 
 			if ( isNewSiteMigrationFlow( flow ) ) {
-				submit?.( { ...props.data }, ProcessingResult.SUCCESS );
+				submit?.( { ...destinationState, ...props.data }, ProcessingResult.SUCCESS );
 				return;
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -251,6 +251,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-plugin-install' ),
 	},
 
+	PICK_SITE: {
+		slug: 'sitePicker',
+		asyncComponent: () => import( './steps-repository/site-picker' ),
+	},
+
 	SEGMENTATION_SURVEY: {
 		slug: 'segmentation-survey',
 		asyncComponent: () => import( './steps-repository/segmentation-survey' ),

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -16,6 +16,7 @@ import {
 	SITE_MIGRATION_FLOW,
 	MIGRATION_SIGNUP_FLOW,
 	ENTREPRENEUR_FLOW,
+	HOSTED_SITE_MIGRATION_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -168,4 +169,16 @@ const siteMigrationFlow: Record< string, () => Promise< { default: Flow } > > = 
 	  }
 	: {};
 
-export default { ...availableFlows, ...videoPressTvFlows, ...siteMigrationFlow };
+const hostedSiteMigrationFlow: Record< string, () => Promise< { default: Flow } > > = {
+	[ HOSTED_SITE_MIGRATION_FLOW ]: () =>
+		import(
+			/* webpackChunkName: "hosted-site-migration-flow" */ '../declarative-flow/hosted-site-migration-flow'
+		),
+};
+
+export default {
+	...availableFlows,
+	...videoPressTvFlows,
+	...siteMigrationFlow,
+	...hostedSiteMigrationFlow,
+};

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -185,7 +185,7 @@ const siteMigration: Flow = {
 							return navigate(
 								addQueryArgs(
 									{ siteId: newSiteId, siteSlug: newSiteSlug, from: fromQueryParam },
-									STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+									STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
 								)
 							);
 						}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -144,14 +144,7 @@ const siteMigration: Flow = {
 							}
 
 							if ( from ) {
-								// return navigate(
-								// 	addQueryArgs( { from: fromQueryParam }, STEPS.SITE_CREATION_STEP.slug )
-								// );
-								return navigate( STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug, {
-									siteId,
-									siteSlug,
-								} );
-								// return navigate( `createSite?from=${ encodeURIComponent( from ) }` );
+								return navigate( addQueryArgs( { from }, STEPS.SITE_CREATION_STEP.slug ) );
 							}
 							return navigate( 'error' );
 						}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -37,7 +37,7 @@ const siteMigration: Flow = {
 		];
 
 		if ( isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME ) ) {
-			steps.push( STEPS.PICK_SITE, STEPS.SITE_CREATION_STEP );
+			steps.push( STEPS.PICK_SITE, STEPS.SITE_CREATION_STEP, STEPS.PROCESSING );
 		}
 
 		return steps;
@@ -190,9 +190,18 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_CREATION_STEP.slug: {
-					return navigate(
-						addQueryArgs( { from: fromQueryParam, siteSlug, siteId }, STEPS.PROCESSING.slug )
-					);
+					return navigate( addQueryArgs( { from: fromQueryParam }, STEPS.PROCESSING.slug ) );
+				}
+
+				case STEPS.PROCESSING.slug: {
+					if ( providedDependencies?.siteCreated ) {
+						return navigate(
+							addQueryArgs(
+								{ siteId, siteSlug, from: fromQueryParam },
+								STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
+							)
+						);
+					}
 				}
 
 				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -1,4 +1,6 @@
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { isHostedSiteMigrationFlow } from '@automattic/onboarding';
+import { SiteExcerptData } from '@automattic/sites';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
@@ -24,7 +26,7 @@ const siteMigration: Flow = {
 	isSignupFlow: false,
 
 	useSteps() {
-		return [
+		const steps = [
 			STEPS.SITE_MIGRATION_IDENTIFY,
 			STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
@@ -33,6 +35,12 @@ const siteMigration: Flow = {
 			STEPS.ERROR,
 			STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
 		];
+
+		if ( isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME ) ) {
+			steps.push( STEPS.PICK_SITE, STEPS.SITE_CREATION_STEP );
+		}
+
+		return steps;
 	},
 	useAssertConditions(): AssertConditionResult {
 		const { siteSlug, siteId } = useSiteData();
@@ -40,7 +48,7 @@ const siteMigration: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const startUrl = useStartUrl( FLOW_NAME );
+		const startUrl = useStartUrl( this.variantSlug ?? FLOW_NAME );
 
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 		const { isOwner } = useIsSiteOwner();
@@ -67,7 +75,7 @@ const siteMigration: Flow = {
 			return result;
 		}
 
-		if ( ! siteSlug && ! siteId ) {
+		if ( ! siteSlug && ! siteId && ! isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME ) ) {
 			window.location.assign( '/start' );
 			result = {
 				state: AssertConditionState.FAILURE,
@@ -80,6 +88,12 @@ const siteMigration: Flow = {
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
+		const variantSlug = this.variantSlug;
+		const flowPath = variantSlug ?? flowName;
+		const siteCount =
+			useSelect( ( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(), [] )
+				?.site_count ?? 0;
+
 		const intent = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 			[]
@@ -94,7 +108,7 @@ const siteMigration: Flow = {
 
 		// TODO - We may need to add `...params: string[]` back once we start adding more steps.
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
+			recordSubmitStep( providedDependencies, intent, flowName, currentStep, variantSlug );
 			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
 			const siteId = getSiteIdBySlug( siteSlug );
 
@@ -107,6 +121,8 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
+						// siteId/siteSlug wont be defined here if coming from a direct link/signup.
+						// We need to make sure the importer works when no site is available.
 						return exitFlow(
 							addQueryArgs(
 								{
@@ -114,11 +130,31 @@ const siteMigration: Flow = {
 									siteSlug,
 									from,
 									origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
-									backToFlow: `/${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+									backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
 								},
 								'/setup/site-setup/importList'
 							)
 						);
+					}
+
+					if ( isHostedSiteMigrationFlow( variantSlug ?? '' ) ) {
+						if ( ! siteSlugParam ) {
+							if ( siteCount > 0 ) {
+								return navigate( `sitePicker?from=${ encodeURIComponent( from ) }` );
+							}
+
+							if ( from ) {
+								// return navigate(
+								// 	addQueryArgs( { from: fromQueryParam }, STEPS.SITE_CREATION_STEP.slug )
+								// );
+								return navigate( STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug, {
+									siteId,
+									siteSlug,
+								} );
+								// return navigate( `createSite?from=${ encodeURIComponent( from ) }` );
+							}
+							return navigate( 'error' );
+						}
 					}
 
 					return navigate(
@@ -128,6 +164,44 @@ const siteMigration: Flow = {
 						)
 					);
 				}
+
+				case STEPS.PICK_SITE.slug: {
+					switch ( providedDependencies?.action ) {
+						case 'update-query': {
+							const newQueryParams =
+								( providedDependencies?.queryParams as { [ key: string ]: string } ) || {};
+
+							Object.keys( newQueryParams ).forEach( ( key ) => {
+								newQueryParams[ key ]
+									? urlQueryParams.set( key, newQueryParams[ key ] )
+									: urlQueryParams.delete( key );
+							} );
+
+							return navigate( `sitePicker?${ urlQueryParams.toString() }` );
+						}
+						case 'select-site': {
+							const { ID: newSiteId, slug: newSiteSlug } =
+								providedDependencies.site as SiteExcerptData;
+							return navigate(
+								addQueryArgs(
+									{ siteId: newSiteId, siteSlug: newSiteSlug, from: fromQueryParam },
+									STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+								)
+							);
+						}
+						case 'create-site':
+							return navigate(
+								addQueryArgs( { from: fromQueryParam }, STEPS.SITE_CREATION_STEP.slug )
+							);
+					}
+				}
+
+				case STEPS.SITE_CREATION_STEP.slug: {
+					return navigate(
+						addQueryArgs( { from: fromQueryParam, siteSlug, siteId }, STEPS.PROCESSING.slug )
+					);
+				}
+
 				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
 					// Switch to the normal Import flow.
 					if ( providedDependencies?.destination === 'import' ) {
@@ -136,7 +210,7 @@ const siteMigration: Flow = {
 								{
 									siteSlug,
 									siteId,
-									backToFlow: `/${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }`,
+									backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }`,
 								},
 								'/setup/site-setup/importList'
 							)
@@ -183,17 +257,17 @@ const siteMigration: Flow = {
 								// This is to avoid the user being redirected to the wrong page after checkout.
 								...( ! providedDependencies?.userAcceptedDeal ? { from: fromQueryParam } : {} ),
 							},
-							`/setup/${ FLOW_NAME }/${ redirectAfterCheckout }`
+							`/setup/${ flowPath }/${ redirectAfterCheckout }`
 						);
 
 						urlQueryParams.delete( 'showModal' );
 						goToCheckout( {
-							flowName: FLOW_NAME,
+							flowName: flowPath,
 							stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
 							siteSlug: siteSlug,
 							destination: destination,
 							plan: providedDependencies.plan as string,
-							cancelDestination: `/setup/${ FLOW_NAME }/${
+							cancelDestination: `/setup/${ flowPath }/${
 								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
 							}?${ urlQueryParams.toString() }`,
 							extraQueryParams:

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -1,0 +1,216 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
+import { waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
+import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
+import { goToCheckout } from '../../utils/checkout';
+import hostedSiteMigrationFlow from '../hosted-site-migration-flow';
+import { STEPS } from '../internals/steps';
+import { getAssertionConditionResult, getFlowLocation, renderFlow } from './helpers';
+// we need to save the original object for later to not affect tests from other files
+const originalLocation = window.location;
+
+jest.mock( '../../utils/checkout' );
+jest.mock( '@automattic/data-stores/src/user/selectors' );
+jest.mock( 'calypso/landing/stepper/hooks/use-is-site-owner' );
+
+describe( 'Hosted site Migration Flow', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+		} );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', originalLocation );
+	} );
+
+	beforeEach( () => {
+		( window.location.assign as jest.Mock ).mockClear();
+		( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( true );
+		( useIsSiteOwner as jest.Mock ).mockReturnValue( {
+			isOwner: true,
+		} );
+
+		const apiBaseUrl = 'https://public-api.wordpress.com';
+		const testSettingsEndpoint = '/rest/v1.4/sites/example.wordpress.com/settings';
+		nock( apiBaseUrl ).get( testSettingsEndpoint ).reply( 200, {} );
+		nock( apiBaseUrl ).post( testSettingsEndpoint ).reply( 200, {} );
+	} );
+
+	afterEach( () => {
+		// Restore the original implementation after each test
+		jest.restoreAllMocks();
+	} );
+
+	describe( 'useAssertConditions', () => {
+		it( 'renders the step succesfully', () => {
+			const { runUseAssertionCondition } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseAssertionCondition( {
+				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+			} );
+
+			expect( getAssertionConditionResult() ).toEqual( { state: 'success' } );
+		} );
+	} );
+
+	describe( 'navigation', () => {
+		it( 'redirects the user to the create site page when the platform is wordpress and no site is set', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentURL: '/setup/hosted-site-migration',
+				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+				dependencies: {
+					action: 'continue',
+					platform: 'wordpress',
+					from: 'https://site-to-be-migrated.com',
+				},
+			} );
+
+			await waitFor( () => {
+				expect( getFlowLocation() ).toEqual( {
+					path: `/${ STEPS.SITE_CREATION_STEP.slug }?from=https%3A%2F%2Fsite-to-be-migrated.com`,
+					state: null,
+				} );
+			} );
+		} );
+
+		it( 'migrate redirects from the import-from page to new instructions if flag enabled', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
+				state: {
+					siteSlug: 'example.wordpress.com',
+				},
+			} );
+		} );
+
+		it( 'redirects the user to the checkout page with the correct destination params', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentURL: `/setup/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https://site-to-be-migrated.com`,
+				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+				dependencies: {
+					goToCheckout: true,
+					plan: PLAN_MIGRATION_TRIAL_MONTHLY,
+					sendIntentWhenCreatingTrial: true,
+				},
+				cancelDestination: `/setup/hosted-site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https://site-to-be-migrated.com`,
+			} );
+
+			expect( goToCheckout ).toHaveBeenCalledWith( {
+				destination: `/setup/hosted-site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
+				extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
+				flowName: 'hosted-site-migration',
+				siteSlug: 'example.wordpress.com',
+				stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+				cancelDestination: `/setup/hosted-site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
+				plan: PLAN_MIGRATION_TRIAL_MONTHLY,
+			} );
+		} );
+
+		it( 'upgrade redirects from the import-from page to site-migration-upgrade-plan page', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
+				dependencies: {
+					destination: 'upgrade',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: '/site-migration-upgrade-plan',
+				state: { siteSlug: 'example.wordpress.com' },
+			} );
+		} );
+
+		it( 'redirects from upgrade-plan to verifyEmail if user is unverified', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+				dependencies: {
+					verifyEmail: true,
+				},
+			} );
+
+			await waitFor( () => {
+				expect( getFlowLocation() ).toEqual( {
+					path: `/${ STEPS.VERIFY_EMAIL.slug }`,
+					state: {
+						pollForEmailVerification: false,
+					},
+				} );
+			} );
+		} );
+
+		it( 'redirects from verifyEmail to site-migration-assign-trial-plan step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.VERIFY_EMAIL.slug,
+				dependencies: {
+					verifyEmail: true,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug }`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects from site-migration-assign-trial-plan step to bundleTransfer step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: '/site-migration-instructions-i2',
+				state: { siteSlug: 'example.wordpress.com' },
+			} );
+		} );
+	} );
+
+	describe( 'goBack', () => {
+		it( 'stays on the same step with showModal:true', async () => {
+			const { runUseStepNavigationGoBack } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationGoBack( {
+				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&showModal=true`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects the user to the goal step when going back from the identify step', async () => {
+			const { runUseStepNavigationGoBack } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationGoBack( {
+				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'/setup/site-setup/goals?siteSlug=example.wordpress.com'
+			);
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -81,6 +81,34 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 		} );
 
+		it( 'redirects to processing after site creation', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_CREATION_STEP.slug,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.PROCESSING.slug }`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirects to import/migrate screen after site creation', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.PROCESSING.slug,
+				dependencies: {
+					siteCreated: true,
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?siteSlug=example.wordpress.com`,
+				state: null,
+			} );
+		} );
 		it( 'migrate redirects from the import-from page to new instructions if flag enabled', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
 
@@ -134,42 +162,6 @@ describe( 'Hosted site Migration Flow', () => {
 			expect( getFlowLocation() ).toEqual( {
 				path: '/site-migration-upgrade-plan',
 				state: { siteSlug: 'example.wordpress.com' },
-			} );
-		} );
-
-		it( 'redirects from upgrade-plan to verifyEmail if user is unverified', async () => {
-			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
-				dependencies: {
-					verifyEmail: true,
-				},
-			} );
-
-			await waitFor( () => {
-				expect( getFlowLocation() ).toEqual( {
-					path: `/${ STEPS.VERIFY_EMAIL.slug }`,
-					state: {
-						pollForEmailVerification: false,
-					},
-				} );
-			} );
-		} );
-
-		it( 'redirects from verifyEmail to site-migration-assign-trial-plan step', () => {
-			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.VERIFY_EMAIL.slug,
-				dependencies: {
-					verifyEmail: true,
-				},
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug }`,
-				state: null,
 			} );
 		} );
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -25,6 +25,7 @@ export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 export const MIGRATION_FLOW = 'import-focused';
 export const SITE_MIGRATION_FLOW = 'site-migration';
 export const MIGRATION_SIGNUP_FLOW = 'migration-signup';
+export const HOSTED_SITE_MIGRATION_FLOW = 'hosted-site-migration';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
@@ -131,6 +132,10 @@ export const isNewSiteMigrationFlow = ( flowName: string | null ) => {
 
 export const isMigrationSignupFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ MIGRATION_SIGNUP_FLOW ].includes( flowName ) );
+};
+
+export const isHostedSiteMigrationFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ HOSTED_SITE_MIGRATION_FLOW ].includes( flowName ) );
 };
 
 export const isBuildFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90654
Closes https://github.com/Automattic/wp-calypso/issues/90655
Related to https://github.com/Automattic/wp-calypso/issues/90694

~I've added the DO NOT MERGE label because~
* ~I still want to add tests for the new variant path.~
* ~I want https://github.com/Automattic/wp-calypso/pull/90663 to be merged before this to handle the potential conflicts before merging~

## Proposed Changes

TLDR, this PR implements the happy path for navigating into the new `/setup/import-hosted-site` flow.

The idea is to create an alternative to `/setup/import-hosted-site` that uses Migrate Guru as underlaying migration tech. This PR adds a variation of the current site migration flow with these basic additions:

* You can navigate to it directly by going to `/setup/hosted-site-migration`.
* You get to pick an existing site to migrate into or create a new one.
* If your source site is not on Wordpress then you are redirected to the import flow (this is not done yet in this PR)
Once you have a destination site, you are redirected straight to the migrate/import screen.
The flow continues in the same way as the site-migration flow does.

**BIG MISSING PIECES**

* Back button handling. Navigating to `/setup/hosted-site-migration` shows a `< Back` button with undefined behavior.
* Redirection to import flow if the source site is not on Wordpress, this is not working yet, we need to figure out what to do when there's no destination site. We can find what the current import-hosted does and mimic that.
* More exhaustive testing on the variant path.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
paYKcK-4BA-p2 

## Testing Instructions
This happy path is ready to test:

* Go to `/setup/hosted-site-migration`
* Select create a new site
* When prompted on the `What do you want to Migrate?` screen, select **Everything**
* See the instructions screen, including your Migrate Guru key

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?