### PR TITLE
Site Migration: Remove migration instruction i2 flag code

### DIFF
--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
 import { waitFor } from '@testing-library/react';
@@ -15,7 +14,6 @@ import siteMigrationFlow from '../site-migration-flow';
 import { getAssertionConditionResult, getFlowLocation, renderFlow } from './helpers';
 // we need to save the original object for later to not affect tests from other files
 const originalLocation = window.location;
-const originalIsEnabled = config.isEnabled;
 
 jest.mock( '../../utils/checkout' );
 jest.mock( '@automattic/data-stores/src/user/selectors' );
@@ -43,11 +41,6 @@ describe( 'Site Migration Flow', () => {
 		const testSettingsEndpoint = '/rest/v1.4/sites/example.wordpress.com/settings';
 		nock( apiBaseUrl ).get( testSettingsEndpoint ).reply( 200, {} );
 		nock( apiBaseUrl ).post( testSettingsEndpoint ).reply( 200, {} );
-		jest
-			.spyOn( config, 'isEnabled' )
-			.mockImplementation( ( key ) =>
-				key === 'migration-flow/remove-processing-step' ? false : originalIsEnabled( key )
-			);
 	} );
 
 	afterEach( () => {
@@ -172,30 +165,8 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'migrate redirects from the import-from page to bundleTransfer step if new instructions not enabled', () => {
-			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.BUNDLE_TRANSFER.slug,
-				dependencies: {
-					destination: 'migrate',
-				},
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.PROCESSING.slug }`,
-				state: {
-					bundleProcessing: true,
-				},
-			} );
-		} );
-
 		it( 'migrate redirects from the import-from page to new instructions if flag enabled', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
-
-			( config.isEnabled as jest.Mock ).mockImplementation( ( key: string ) =>
-				key === 'migration-flow/remove-processing-step' ? true : originalIsEnabled( key )
-			);
 
 			runUseStepNavigationSubmit( {
 				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
@@ -224,7 +195,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( goToCheckout ).toHaveBeenCalledWith( {
-				destination: `/setup/site-migration/${ STEPS.BUNDLE_TRANSFER.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
+				destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
 				extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 				flowName: 'site-migration',
 				siteSlug: 'example.wordpress.com',
@@ -258,7 +229,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: '/bundleTransfer',
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );

--- a/config/development.json
+++ b/config/development.json
@@ -139,7 +139,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,7 +86,6 @@
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -112,7 +112,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -107,7 +107,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/test.json
+++ b/config/test.json
@@ -83,7 +83,6 @@
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2-enabled": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,6 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
-		"migration-flow/remove-processing-step": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90502

## Proposed Changes

We had been using the `migration-flow/remove-processing-step` flag to gate the updates to the migration flow where we skip the Processing and bundleTransfer steps.

We've determined that this change is helping get users through the flow so we're removing the flag.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In #90502, we're going to update the `/setup/migration-signup` flow to behave in the same way as the current `/setup/site-migration` flow. We want to go directly to the Migration Instructions step and have the Atomic transfer and plugin install happen behind the scenes.

As a first step towards making that change, we want to remove all of the `migration-flow/remove-processing-step` flag-specific code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass

```
yarn test-client client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
```
* Using the calypso.live url or running this locally, visit `/start`.
* On the Goals step, select the "Import existing content or website" goal.
* Enter a valid WordPress site on the "Import From" step.
* Chose a Free Trial or upgrade to the Creator plan on the Upgrade Plan step.
* Verify that you're then taken to the new Migration Instructions step.
* Verify that all of the background actions on the instructions step complete successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
