### PR TITLE
Plans 2023: Add legacy storage capacity notice

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -133,9 +133,9 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 					isReskinned={ true }
 				>
 					{ translate(
-						'Your plan currently has a legacy feature that provides 200 GB of space. ' +
+						'Your plan currently has a legacy feature that provides 200GB of space. ' +
 							'You are currently using {{b}}%(usedGigabytes)s{{/b}} of space. ' +
-							'Switching billing plans will lower the amount of default storage to 50GB. ' +
+							'Switching to a different plan or billing interval will lower the amount of available storage to 50GB. ' +
 							'Please keep in mind that the change will be irreversible.',
 						{
 							args: {

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -1,8 +1,10 @@
 import { PlanSlug, isProPlan, isStarterPlan } from '@automattic/calypso-products';
+import { Site, SiteMediaStorage } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
 import { getDiscountByName } from 'calypso/lib/discounts';
@@ -18,6 +20,8 @@ export type PlanNoticeProps = {
 	siteId: number;
 	visiblePlans: PlanSlug[];
 	isInSignup?: boolean;
+	showLegacyStorageFeature?: boolean;
+	mediaStorage?: SiteMediaStorage;
 	discountInformation?: {
 		withDiscount: string;
 		discountEndDate: Date;
@@ -30,6 +34,7 @@ const PLAN_UPGRADE_CREDIT_NOTICE = 'plan-upgrade-credit-notice';
 const MARKETING_NOTICE = 'marketing-notice';
 const PLAN_RETIREMENT_NOTICE = 'plan-retirement-notice';
 const CURRENT_PLAN_IN_APP_PURCHASE_NOTICE = 'current-plan-in-app-purchase-notice';
+const PLAN_LEGACY_STORAGE_NOTICE = 'plan-legacy-storage-notice';
 
 export type PlanNoticeTypes =
 	| typeof NO_NOTICE
@@ -38,10 +43,17 @@ export type PlanNoticeTypes =
 	| typeof PLAN_UPGRADE_CREDIT_NOTICE
 	| typeof MARKETING_NOTICE
 	| typeof PLAN_RETIREMENT_NOTICE
-	| typeof CURRENT_PLAN_IN_APP_PURCHASE_NOTICE;
+	| typeof CURRENT_PLAN_IN_APP_PURCHASE_NOTICE
+	| typeof PLAN_LEGACY_STORAGE_NOTICE;
 
 function useResolveNoticeType(
-	{ siteId, isInSignup, visiblePlans = [], discountInformation }: PlanNoticeProps,
+	{
+		showLegacyStorageFeature,
+		siteId,
+		isInSignup,
+		visiblePlans = [],
+		discountInformation,
+	}: PlanNoticeProps,
 	isNoticeDismissed: boolean
 ): PlanNoticeTypes {
 	const canUserPurchasePlan = useSelector(
@@ -68,6 +80,8 @@ function useResolveNoticeType(
 		return PLAN_RETIREMENT_NOTICE;
 	} else if ( currentPurchase?.isInAppPurchase ) {
 		return CURRENT_PLAN_IN_APP_PURCHASE_NOTICE;
+	} else if ( showLegacyStorageFeature ) {
+		return PLAN_LEGACY_STORAGE_NOTICE;
 	} else if ( activeDiscount ) {
 		return ACTIVE_DISCOUNT_NOTICE;
 	} else if ( planUpgradeCreditsApplicable ) {
@@ -81,6 +95,8 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 	const translate = useTranslate();
 	const [ isNoticeDismissed, setIsNoticeDismissed ] = useState( false );
 	const noticeType = useResolveNoticeType( props, isNoticeDismissed );
+	const { data: mediaStorage } = Site.useSiteMediaStorage( { siteIdOrSlug: siteId } );
+	const usedGigabytes = useStorageText( mediaStorage?.storageUsedBytes ?? 0 );
 	const handleDismissNotice = () => setIsNoticeDismissed( true );
 	let activeDiscount =
 		discountInformation &&
@@ -103,6 +119,32 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 				>
 					{ translate(
 						'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
+					) }
+				</Notice>
+			);
+		case PLAN_LEGACY_STORAGE_NOTICE:
+			return (
+				<Notice
+					className="plan-features-main__notice"
+					showDismiss={ true }
+					onDismissClick={ handleDismissNotice }
+					icon="info-outline"
+					status="is-warning"
+					isReskinned={ true }
+				>
+					{ translate(
+						'Your plan currently has a legacy feature that provides 200 GB of space. ' +
+							'You are currently using {{b}}%(usedGigabytes)s{{/b}} of space. ' +
+							'Switching billing plans will lower the amount of default storage to 50GB. ' +
+							'Please keep in mind that the change will be irreversible.',
+						{
+							args: {
+								usedGigabytes: usedGigabytes ?? '',
+							},
+							components: {
+								b: <strong />,
+							},
+						}
 					) }
 				</Notice>
 			);

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -722,6 +722,7 @@ const PlansFeaturesMain = ( {
 						visiblePlans={ gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ) }
 						siteId={ siteId }
 						isInSignup={ isInSignup }
+						showLegacyStorageFeature={ showLegacyStorageFeature }
 						{ ...( withDiscount &&
 							discountEndDate && {
 								discountInformation: {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2011,12 +2011,15 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 					FEATURE_COMMISSION_FEE_STANDARD_FEATURES,
 					FEATURE_COMMISSION_FEE_WOO_FEATURES,
 			  ],
-	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature ) => {
+	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature, isCurrentPlan ) => {
 		let storageOptionSlugs = [];
 		const storageAddOns = [ FEATURE_50GB_STORAGE_ADD_ON, FEATURE_100GB_STORAGE_ADD_ON ];
 
 		if ( showLegacyStorageFeature ) {
-			storageOptionSlugs = [ FEATURE_200GB_STORAGE ];
+			/* If the user is currently has a legacy plan with 200GB storage space, the capacity will decrease to
+			 * 50GB if they change their billing terms.
+			 */
+			storageOptionSlugs = isCurrentPlan ? [ FEATURE_200GB_STORAGE ] : [ FEATURE_50GB_STORAGE ];
 		} else {
 			storageOptionSlugs = isEnabled( 'plans/updated-storage-labels' )
 				? [ FEATURE_50GB_STORAGE, ...storageAddOns ]

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -199,7 +199,8 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 						jetpackFeatures: jetpackFeaturesTransformed,
 						storageOptions:
 							planConstantObj.get2023PricingGridSignupStorageOptions?.(
-								showLegacyStorageFeature
+								showLegacyStorageFeature,
+								gridPlan.current
 							) ?? [],
 					},
 				};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/90674 and p1715159824482899-slack-C02BEP610

## Proposed Changes

If a user has been grandfathered into the 200GB storage feature, changing billing plans will reset their default storage to 50GB. We add a notice to inform the user of the reset.

The copy for the notice is:

`Your plan currently has a legacy feature that provides 200GB of space. You are currently using 0.1GB of space. Switching billing plans will lower the amount of default storage to 50GB. Please keep in mind that the change will be irreversible.`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1715159824482899-slack-C02BEP610

## Screenshot

<img width="1433" alt="Screenshot 2024-05-13 at 11 57 25 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/0c6e280b-33c9-46a0-a63b-10fd7525e5fe">

![2024-05-13 14 06 28](https://github.com/Automattic/wp-calypso/assets/5414230/53ffbcf3-0411-421e-9e54-5322a6c6289b)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Visit site with legacy 200GB storage creator or entrepreneur plan  ( reach out if need access to one )
* Verify that a notice is displayed that warns the user about resetting their storage if the change billing plans
* Verify that switching billing terms will change the storage label to reflect the new 50GB default storage

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?