### PR TITLE
Fix chevron color on sidebar

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -208,7 +208,7 @@ $font-size: rem(14px);
 		}
 
 		.gridicons-chevron-right {
-			color: var(--studio-gray-20);
+			fill: var(--color-sidebar-text);
 		}
 
 		.sidebar__expandable-content {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7137

## Proposed Changes

Update the sidebar chevron color to match the text.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/e8a18096-46dc-46a3-861d-dd92938f731c) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/61b0ffde-a99d-4099-b01e-a079bd66a48d) |

## Testing Instructions
* Check the chevron color on the sidebar
