### PR TITLE
Updated box-shadow for help center

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -85,7 +85,7 @@ $head-foot-height: 50px;
 			width: 410px;
 			height: 80vh;
 			max-height: 800px;
-			box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.25);
+			box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.12), 0 3px 1px 0 rgba(0, 0, 0, 0.04);
 
 			.help-center__container-header {
 				cursor: move;


### PR DESCRIPTION
Addresses: https://github.com/Automattic/dotcom-forge/issues/7140

The effect is subtle, but there is just a bit more feathering in the box-shadow.

## Before

![before](https://github.com/Automattic/wp-calypso/assets/5634774/c8067068-9b92-4795-ae31-afe8b449aa09)

## After

![after](https://github.com/Automattic/wp-calypso/assets/5634774/b171224f-c3ea-4e18-b1e9-e8a355d3b94b)