### PR TITLE
eCommerce Signup Flow: Track start and complete survey events

### DIFF
--- a/client/components/segmentation-survey/hooks/use-segmentation-survey-tracks-events.ts
+++ b/client/components/segmentation-survey/hooks/use-segmentation-survey-tracks-events.ts
@@ -1,0 +1,58 @@
+import { useCallback } from 'react';
+import { Answers, Question } from 'calypso/components/survey-container/types';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+const useSegmentationSurveyTracksEvents = ( surveyKey: string ) => {
+	const recordBackEvent = useCallback(
+		( currentQuestion: Question ) => {
+			recordTracksEvent( 'calypso_segmentation_survey_back', {
+				survey_key: surveyKey,
+				question_key: currentQuestion.key,
+			} );
+		},
+		[ surveyKey ]
+	);
+
+	const recordCompleteEvent = useCallback( () => {
+		recordTracksEvent( 'calypso_segmentation_survey_complete', {
+			survey_key: surveyKey,
+		} );
+	}, [ surveyKey ] );
+
+	const recordContinueEvent = useCallback(
+		( currentQuestion: Question, answers: Answers ) => {
+			recordTracksEvent( 'calypso_segmentation_survey_continue', {
+				survey_key: surveyKey,
+				question_key: currentQuestion.key,
+				answer_keys: answers?.[ currentQuestion.key ].join( ',' ) || '',
+			} );
+		},
+		[ surveyKey ]
+	);
+
+	const recordSkipEvent = useCallback(
+		( currentQuestion: Question ) => {
+			recordTracksEvent( 'calypso_segmentation_survey_skip', {
+				survey_key: surveyKey,
+				question_key: currentQuestion.key,
+			} );
+		},
+		[ surveyKey ]
+	);
+
+	const recordStartEvent = useCallback( () => {
+		recordTracksEvent( 'calypso_segmentation_survey_start', {
+			survey_key: surveyKey,
+		} );
+	}, [ surveyKey ] );
+
+	return {
+		recordBackEvent,
+		recordCompleteEvent,
+		recordContinueEvent,
+		recordSkipEvent,
+		recordStartEvent,
+	};
+};
+
+export default useSegmentationSurveyTracksEvents;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import Main from 'calypso/components/main';
 import SegmentationSurvey from 'calypso/components/segmentation-survey';
+import useSegmentationSurveyTracksEvents from 'calypso/components/segmentation-survey/hooks/use-segmentation-survey-tracks-events';
 import { useCachedAnswers } from 'calypso/data/segmentaton-survey';
 import type { ProvidedDependencies, Step } from '../../types';
 import './style.scss';
@@ -29,7 +31,14 @@ const shouldNavigate = (
 };
 
 const SegmentationSurveyStep: Step = ( { navigation } ) => {
+	const { recordStartEvent, recordCompleteEvent } = useSegmentationSurveyTracksEvents( SURVEY_KEY );
 	const { clearAnswers } = useCachedAnswers( SURVEY_KEY );
+
+	// Record Tracks start event on component mount
+	useEffect( () => {
+		recordStartEvent();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const handleNext = ( questionKey: string, answerKeys: string[], isLastQuestion?: boolean ) => {
 		const { proceedWithNavigation, providedDependencies } = shouldNavigate(
@@ -44,6 +53,7 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 				clearAnswers();
 			}
 
+			recordCompleteEvent();
 			navigation.submit?.( providedDependencies );
 		}
 	};


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/7126

## Proposed Changes

* Track start and complete survey events
* Extract the tracking functions to a reusable hook

## Why are these changes being made?

* Start and complete events were missing to build funnels

## Testing Instructions

* Apply this PR to your local
* Open the network tab and filter by the tracking pixel
* Go to http://calypso.localhost:3000/setup/entrepreneur/start
* While using the segmentation survey you should the see following events being tracked:
* When initially loading the page: `calypso_segmentation_survey_start` with survey key
* When clicking continue: `calypso_segmentation_survey_continue` with survey key, question key, and answer keys
* When clicking skip: `calypso_segmentation_survey_skip` with survey key, question key
* When completing the survey: `calypso_segmentation_survey_complete` with survey key

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
