### PR TITLE
Remove icons from hosting config sub-headers

### DIFF
--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -2,7 +2,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Card } from '@automattic/components';
 import styled from '@emotion/styled';
 import { ToggleControl } from '@wordpress/components';
-import { Icon, reusableBlock as cacheIcon } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -138,7 +137,6 @@ export const CacheCard = ( {
 	//autorenew
 	return (
 		<Card className="cache-card">
-			<Icon className="card-icon" icon={ cacheIcon } size={ 32 } />
 			<CardHeading id="cache" size={ 20 }>
 				{ translate( 'Cache' ) }
 			</CardHeading>

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -66,7 +66,6 @@ export default function PhpMyAdminCard( { disabled } ) {
 
 	return (
 		<Card className="phpmyadmin-card">
-			<MaterialIcon icon="dns" size={ 32 } />
 			<CardHeading id="database-access">{ translate( 'Database access' ) }</CardHeading>
 			<p>
 				{ translate(

--- a/client/my-sites/hosting/restore-plan-software-card/index.js
+++ b/client/my-sites/hosting/restore-plan-software-card/index.js
@@ -1,4 +1,4 @@
-import { Button, Card, MaterialIcon } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -35,7 +35,6 @@ export default function RestorePlanSoftwareCard() {
 
 	return (
 		<Card className="restore-plan-software-card">
-			<MaterialIcon icon="apps" size={ 32 } />
 			<CardHeading>{ translate( 'Restore plugins and themes' ) }</CardHeading>
 			<p>
 				{ translate(

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -1,5 +1,5 @@
 import { FEATURE_SFTP, FEATURE_SSH } from '@automattic/calypso-products';
-import { Card, Button, FormLabel, Spinner, MaterialIcon } from '@automattic/components';
+import { Card, Button, FormLabel, Spinner } from '@automattic/components';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import styled from '@emotion/styled';
 import { PanelBody, ToggleControl } from '@wordpress/components';
@@ -219,7 +219,6 @@ export const SftpCard = ( {
 
 	return (
 		<Card className="sftp-card">
-			<MaterialIcon icon="key" size={ 32 } />
 			<CardHeading id="sftp-credentials">
 				{ siteHasSshFeature
 					? translate( 'SFTP/SSH credentials' )

--- a/client/my-sites/hosting/staging-site-card/card-content/card-content-wrapper.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/card-content-wrapper.tsx
@@ -1,4 +1,4 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, PropsWithChildren } from 'react';
 import CardHeading from 'calypso/components/card-heading';
@@ -7,10 +7,6 @@ export const CardContentWrapper: FunctionComponent< PropsWithChildren > = ( { ch
 	const translate = useTranslate();
 	return (
 		<Card className="staging-site-card">
-			{
-				// eslint-disable-next-line wpcalypso/jsx-gridicon-size
-				<Gridicon icon="science" size={ 32 } />
-			}
 			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
 			{ children }
 		</Card>

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -1,4 +1,4 @@
-import { Button, Card, FormLabel, LoadingPlaceholder, MaterialIcon } from '@automattic/components';
+import { Button, Card, FormLabel, LoadingPlaceholder } from '@automattic/components';
 import styled from '@emotion/styled';
 import { localize } from 'i18n-calypso';
 import { useState } from 'react';
@@ -385,7 +385,6 @@ const WebServerSettingsCard = ( {
 			<QuerySitePhpVersion siteId={ siteId } />
 			<QuerySiteWpVersion siteId={ siteId } />
 			<QuerySiteStaticFile404 siteId={ siteId } />
-			<MaterialIcon icon="build" size={ 32 } />
 			<CardHeading id="web-server-settings">{ translate( 'Web server settings' ) }</CardHeading>
 			<p>
 				{ translate(

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 /* eslint-disable wpcalypso/jsx-gridicon-size */
-import { Card, FormLabel, MaterialIcon } from '@automattic/components';
+import { Card, FormLabel } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate, localize } from 'i18n-calypso';
@@ -132,7 +132,6 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 			<Card className="admin-interface-style-card">
 				{ isHosting && (
 					<>
-						<MaterialIcon icon="display_settings" style="filled" size={ 32 } />
 						<CardHeading id="admin-interface-style" size={ 20 }>
 							{ translate( 'Admin interface style' ) }
 						</CardHeading>


### PR DESCRIPTION
Addresses: https://github.com/Automattic/dotcom-forge/issues/7142

Select the "Hosting Config" tab for classic view atomic site.

## Before

![before](https://github.com/Automattic/wp-calypso/assets/5634774/6a486e94-c17f-410e-9bf8-4c7a6ea526a1)

## After

![after](https://github.com/Automattic/wp-calypso/assets/5634774/38d12bb3-2f47-47a5-a6f7-c347bc2a3724)
