### PR TITLE
Segmentation Survey: Fix Continue button color and options card border-radius

### DIFF
--- a/client/components/survey-container/components/style.scss
+++ b/client/components/survey-container/components/style.scss
@@ -24,7 +24,7 @@ $blueberry-focus-color: #abc0f5;
 	flex-basis: calc(100% - 48px);
 	gap: 16px;
 	align-items: center;
-	border-radius: 2px;
+	border-radius: 4px;
 	border: solid 1px $studio-gray-5;
 	padding: 16px;
 	cursor: pointer;

--- a/client/components/survey-container/components/style.scss
+++ b/client/components/survey-container/components/style.scss
@@ -3,8 +3,8 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "client/components/forms/form-radio/style.scss";
 
-$blueberry-color: #2145e6;
-$blueberry-hover-color: #3858e9;
+$blueberry-color: #3858e9;
+$dark-blueberry-color: #2145e6;
 $blueberry-focus-color: #abc0f5;
 
 @mixin question-options-container {
@@ -61,8 +61,12 @@ $blueberry-focus-color: #abc0f5;
 			&:hover,
 			&:focus,
 			&:active {
-				background-color: $blueberry-hover-color;
-				border-color: $blueberry-hover-color;
+				background-color: $dark-blueberry-color;
+				border-color: $dark-blueberry-color;
+			}
+
+			&:focus {
+				box-shadow: inset 0 0 0 1px $studio-white, 0 0 0 var(--wp-admin-border-width-focus) $blueberry-color;
 			}
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/7090
Closes https://github.com/Automattic/dotcom-forge/issues/7091

## Proposed Changes

* Fix continue button colors (default, focus, and hover colors)
* Set options card border-radius to 4px

## Why are these changes being made?

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur/start
* Check if the Continue button colors were updated
* Check if the options card border-radius was updated to 4px

<img width="814" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/eac89d6b-3889-46e9-a89c-397638d75944">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
