### PR TITLE
A4A: Add "/migrations" section structure

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -1,4 +1,4 @@
-import { category, currencyDollar, home, reusableBlock, tag } from '@wordpress/icons';
+import { category, currencyDollar, home, moveTo, reusableBlock, tag } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
@@ -10,6 +10,7 @@ import {
 	A4A_REFERRALS_LINK,
 	A4A_SITES_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
+	A4A_MIGRATIONS_LINK,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -77,6 +78,19 @@ const useMainMenuItems = ( path: string ) => {
 							title: translate( 'Referrals' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Referrals',
+							},
+						},
+				  ]
+				: [] ),
+			...( isSectionNameEnabled( 'a8c-for-agencies-migrations' )
+				? [
+						{
+							icon: moveTo,
+							path: '/',
+							link: A4A_MIGRATIONS_LINK,
+							title: translate( 'Migrations' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Migrations',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -28,3 +28,4 @@ export const A4A_PAYMENT_METHODS_ADD_LINK = `${ A4A_PURCHASES_LINK }/payment-met
 export const A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK = `${ A4A_MARKETPLACE_LINK }/download-products`;
 export const A4A_SIGNUP_LINK = '/signup';
 export const A4A_SIGNUP_FINISH_LINK = '/signup/finish';
+export const A4A_MIGRATIONS_LINK = '/migrations';

--- a/client/a8c-for-agencies/sections/migrations/controller.tsx
+++ b/client/a8c-for-agencies/sections/migrations/controller.tsx
@@ -1,0 +1,15 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import MainSidebar from '../../components/sidebar-menu/main';
+import MigrationsOverview from './migrations-overview';
+
+export const migrationsContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="Migrations" path={ context.path } />
+			<MigrationsOverview />
+		</>
+	);
+	context.secondary = <MainSidebar path={ context.path } />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/migrations/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/index.tsx
@@ -1,0 +1,15 @@
+import page from '@automattic/calypso-router';
+import { A4A_MIGRATIONS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import * as controller from './controller';
+
+export default function () {
+	page(
+		A4A_MIGRATIONS_LINK,
+		requireAccessContext,
+		controller.migrationsContext,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -1,0 +1,27 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+
+export default function MigrationsOverview() {
+	const translate = useTranslate();
+	const title = translate( 'Migrations' );
+
+	return (
+		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<div />
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -788,6 +788,12 @@ const sections = [
 		group: 'a8c-for-agencies',
 	},
 	{
+		name: 'a8c-for-agencies-migrations',
+		paths: [ '/migrations' ],
+		module: 'calypso/a8c-for-agencies/sections/migrations',
+		group: 'a8c-for-agencies',
+	},
+	{
 		name: 'a8c-for-agencies-signup',
 		paths: [ '/signup', '/signup/finish', '/signup/oauth/token' ],
 		module: 'calypso/a8c-for-agencies/sections/signup',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -169,6 +169,7 @@
 		"a8c-for-agencies-purchases": false,
 		"a8c-for-agencies-signup": false,
 		"a8c-for-agencies-referrals": false,
+		"a8c-for-agencies-migrations": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -48,7 +48,8 @@
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,
 		"a8c-for-agencies-signup": true,
-		"a8c-for-agencies-referrals": true
+		"a8c-for-agencies-referrals": true,
+		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -42,7 +42,8 @@
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,
 		"a8c-for-agencies-signup": true,
-		"a8c-for-agencies-referrals": true
+		"a8c-for-agencies-referrals": true,
+		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -43,7 +43,8 @@
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,
 		"a8c-for-agencies-signup": true,
-		"a8c-for-agencies-referrals": true
+		"a8c-for-agencies-referrals": true,
+		"a8c-for-agencies-migrations": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -44,7 +44,8 @@
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,
 		"a8c-for-agencies-signup": true,
-		"a8c-for-agencies-referrals": true
+		"a8c-for-agencies-referrals": true,
+		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/472

## Proposed Changes

* Adds a new "/migrations" section to the A4A dashboard.
* Adds a Migrations sidebar item.
* Disables the section in production.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/automattic-for-agencies-dev/issues/472

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the A4A live link and check out the new Migrations sidebar item. 
* Open the section and verify an empty page with the "Migrations" heading is displayed.
* Navigate directly to the "/migrations" link and validate you see the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="963" alt="Screenshot 2024-05-13 at 3 57 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10933065/e855a618-1251-4795-9c9a-6a93de15ab0e">


