### PR TITLE
Plans Grid: Fix comparison grid current plan cta

### DIFF
--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -108,7 +108,7 @@ const AddOnsMain = () => {
 	}
 
 	const handleActionPrimary = ( addOnSlug: string, quantity?: number ) => {
-		page.redirect( `${ checkoutLink( selectedSite?.slug ?? null, addOnSlug, quantity ) }` );
+		page.redirect( `${ checkoutLink( selectedSite?.ID ?? null, addOnSlug, quantity ) }` );
 	};
 
 	const handleActionSelected = () => {

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-checkout-link.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-checkout-link.ts
@@ -8,22 +8,22 @@ import * as Site from '../../site';
  */
 
 const useAddOnCheckoutLink = (): ( (
-	selectedSiteSlug: Site.SiteDetails[ 'slug' ] | null,
+	selectedSiteId: Site.SiteDetails[ 'ID' ] | null,
 	addOnSlug: string,
 	quantity?: number
 ) => string ) => {
 	const checkoutLinkCallback = useCallback(
 		(
-			selectedSiteSlug: Site.SiteDetails[ 'slug' ] | null,
+			selectedSiteId: Site.SiteDetails[ 'ID' ] | null,
 			addOnSlug: string,
 			quantity?: number
 		): string => {
 			// If no site is provided, return the checkout link with the add-on (will render site-selector).
-			if ( ! selectedSiteSlug ) {
+			if ( ! selectedSiteId ) {
 				return `/checkout/${ addOnSlug }`;
 			}
 
-			const checkoutLinkFormat = `/checkout/${ selectedSiteSlug }/${ addOnSlug }`;
+			const checkoutLinkFormat = `/checkout/${ selectedSiteId }/${ addOnSlug }`;
 
 			if ( quantity ) {
 				return checkoutLinkFormat + `:-q-${ quantity }`;

--- a/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
@@ -25,8 +25,6 @@ import type { AddOnMeta } from '../types';
 const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 	const translate = useTranslate();
 	const checkoutLink = useAddOnCheckoutLink();
-	const selectedSite = Site.useSite( { siteIdOrSlug: selectedSiteId } );
-	const selectedSiteSlug = selectedSite.data?.slug;
 
 	/*
 	 * TODO: `useAddOnFeatureSlugs` be refactored instead to return an index of `{ [ slug ]: featureSlug[] }`
@@ -100,7 +98,7 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 					),
 					featured: false,
 					purchased: false,
-					checkoutLink: checkoutLink( selectedSiteSlug ?? null, PRODUCT_1GB_SPACE, 50 ),
+					checkoutLink: checkoutLink( selectedSiteId ?? null, PRODUCT_1GB_SPACE, 50 ),
 				},
 				{
 					productSlug: PRODUCT_1GB_SPACE,
@@ -115,7 +113,7 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 					),
 					featured: false,
 					purchased: false,
-					checkoutLink: checkoutLink( selectedSiteSlug ?? null, PRODUCT_1GB_SPACE, 100 ),
+					checkoutLink: checkoutLink( selectedSiteId ?? null, PRODUCT_1GB_SPACE, 100 ),
 				},
 			] as const,
 		[
@@ -132,7 +130,7 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 			featureSlugsCustomDesign,
 			featureSlugsJetpackAIMonthly,
 			featureSlugsUnlimitedThemes,
-			selectedSiteSlug,
+			selectedSiteId,
 			translate,
 		]
 	);

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -54,6 +54,7 @@ import type {
 	PlanSlug,
 	WPComStorageAddOnSlug,
 	FeatureGroupMap,
+	StorageOption,
 } from '@automattic/calypso-products';
 
 const featureGroupRowTitleCellMaxWidth = 450;
@@ -360,6 +361,7 @@ type ComparisonGridHeaderCellProps = Omit< ComparisonGridHeaderProps, 'planTypeS
 	allVisible: boolean;
 	isLastInRow: boolean;
 	planSlug: PlanSlug;
+	storageOptions: StorageOption[];
 };
 
 type PlanFeatureFootnotes = {
@@ -381,6 +383,7 @@ const ComparisonGridHeaderCell = ( {
 	planUpgradeCreditsApplicable,
 	showRefundPeriod,
 	isStuck,
+	storageOptions,
 }: ComparisonGridHeaderCellProps ) => {
 	const { gridPlansIndex } = usePlansGridContext();
 	const gridPlan = gridPlansIndex[ planSlug ];
@@ -473,6 +476,7 @@ const ComparisonGridHeaderCell = ( {
 				showMonthlyPrice={ false }
 				isStuck={ false }
 				visibleGridPlans={ visibleGridPlans }
+				storageOptions={ storageOptions }
 			/>
 		</Cell>
 	);
@@ -526,7 +530,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 						</PlanTypeSelectorWrapper>
 					) }
 				</RowTitleCell>
-				{ visibleGridPlans.map( ( { planSlug }, index ) => (
+				{ visibleGridPlans.map( ( { planSlug, features: { storageOptions } }, index ) => (
 					<ComparisonGridHeaderCell
 						planSlug={ planSlug }
 						planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
@@ -543,6 +547,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 						selectedPlan={ selectedPlan }
 						showRefundPeriod={ showRefundPeriod }
 						isStuck={ isStuck }
+						storageOptions={ storageOptions }
 					/>
 				) ) }
 			</PlanRow>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/90664#issuecomment-2108831768

## Proposed Changes
This PR fixes 2 distinct bugs with the plans grid:

1. Fixes a bug where the current plan CTA in the comparison grid was always showing the upgrade button ( which, when clicked, would do nothing ).
2. Fixes storage add-on checkout links in the `/plans` page for the current plan. They were previously leading to the site selector page because the selected site slug in the checkout url was never a meaningful value.

## Screenshots

### Before
<img width="1421" alt="Screenshot 2024-05-13 at 5 18 31 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/ed1103a8-8629-42c4-96a0-b0fb63ccb170">

![2024-05-13 17 31 29](https://github.com/Automattic/wp-calypso/assets/5414230/c30f3822-c458-4eec-866e-781fb2ec6a6c)


### After
<img width="1416" alt="Screenshot 2024-05-13 at 5 19 10 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/810b55aa-9642-482e-a680-f3783bd01c99">

![2024-05-13 17 34 50](https://github.com/Automattic/wp-calypso/assets/5414230/1109ebef-b14c-4524-a7b6-cd9f76f0bdaa)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes regressions with the plans grid ctas

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Visit Calypso admin `/plans` page of a site that has a creator or entrepreneur plan ( without storage add-ons )
* Verify that comparison grid current plan cta shows the "Manage Plan" button
* Verify that when selecting a storage add-on for the current plan, the comparison grid cta shows an upgrade button that leads to checkout with the storage add-on in the cart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
