### PR TITLE
Fix logo animation on sidebar change

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -273,15 +273,11 @@
 			}
 		}
 		.sidebar__header {
-			flex-wrap: wrap;
-			span.dotcom {
+			flex-direction: row !important;
+			transition: none;
+			.dotcom {
+				transition: width 220ms ease-out;
 				background-position: left;
-			}
-			.gap,
-			button.sidebar__item-search,
-			a.sidebar__item-notifications {
-				justify-content: flex-start;
-				flex-basis: 0%;
 			}
 			.sidebar__menu-link {
 				transition: all 220ms ease-out;
@@ -311,14 +307,9 @@
 						}
 					}
 					.sidebar__header {
-						flex-direction: row !important;
 						padding-inline: 19px;
-						.gap {
-							flex-basis: 100%;
-						}
-						button.sidebar__item-search,
-						a.sidebar__item-notifications {
-							flex-basis: 100%;
+						.dotcom {
+							// transition: all 220ms ease-out;
 						}
 					}
 					.sidebar__body {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -308,9 +308,6 @@
 					}
 					.sidebar__header {
 						padding-inline: 19px;
-						.dotcom {
-							// transition: all 220ms ease-out;
-						}
 					}
 					.sidebar__body {
 						.sidebar__menu-link-text {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7138

## Proposed Changes

Fix logo animation when the sidebar opens (leaving a site)

Before:

https://github.com/Automattic/wp-calypso/assets/402286/9e7a98cb-d2a6-4fdc-84c7-90315cebb3cb

After:

https://github.com/Automattic/wp-calypso/assets/402286/a5b2c44a-f377-45a1-8965-b076f066fdc6

## Testing Instructions

* Go to `/sites`
* Click on a site.
* Click on domains or close the site.
* The animation should be smooth.

