### PR TITLE
Sidebar: Hide the notification on mobile to avoid it closed by accident

### DIFF
--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -18,6 +18,7 @@ import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slu
 import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
+import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import { BellIcon } from './icon';
 
 import './style.scss';
@@ -54,8 +55,8 @@ class SidebarNotifications extends Component {
 
 		// focus on main window if we just closed the notes panel
 		if ( prevProps.isNotificationsOpen && ! this.props.isNotificationsOpen ) {
-			this.notificationLink.current.blur();
-			this.notificationPanel.current.blur();
+			this.notificationLink.current?.blur();
+			this.notificationPanel.current?.blur();
 			window.focus();
 		}
 	}
@@ -69,8 +70,8 @@ class SidebarNotifications extends Component {
 			// Ignore clicks or other events which occur inside of the notification panel.
 			if (
 				target &&
-				( this.notificationLink.current.contains( target ) ||
-					this.notificationPanel.current.contains( target ) )
+				( this.notificationLink.current?.contains( target ) ||
+					this.notificationPanel.current?.contains( target ) )
 			) {
 				return;
 			}
@@ -169,27 +170,31 @@ class SidebarNotifications extends Component {
 						</DismissibleCard>,
 						document.querySelector( '.layout' )
 					) }
-				<SidebarMenuItem
-					url="/notifications"
-					icon={ <BellIcon newItems={ this.state.newNote } active={ this.props.isActive } /> }
-					onClick={ this.handleClick }
-					isActive={ this.props.isActive }
-					tooltip={ this.props.tooltip }
-					tooltipPlacement="top"
-					className={ classes }
-					ref={ this.notificationLink }
-					key={ this.state.animationState }
-				/>
-				<div className="sidebar-notifications__panel" ref={ this.notificationPanel }>
-					<AsyncLoad
-						require="calypso/notifications"
-						isShowing={ this.props.isNotificationsOpen }
-						checkToggle={ this.checkToggleNotes }
-						setIndicator={ this.setNotesIndicator }
-						isGlobalSidebarVisible={ true }
-						placeholder={ null }
+				{ this.props.masterbarIsHidden && (
+					<SidebarMenuItem
+						url="/notifications"
+						icon={ <BellIcon newItems={ this.state.newNote } active={ this.props.isActive } /> }
+						onClick={ this.handleClick }
+						isActive={ this.props.isActive }
+						tooltip={ this.props.tooltip }
+						tooltipPlacement="top"
+						className={ classes }
+						ref={ this.notificationLink }
+						key={ this.state.animationState }
 					/>
-				</div>
+				) }
+				{ this.props.masterbarIsHidden && (
+					<div className="sidebar-notifications__panel" ref={ this.notificationPanel }>
+						<AsyncLoad
+							require="calypso/notifications"
+							isShowing={ this.props.isNotificationsOpen }
+							checkToggle={ this.checkToggleNotes }
+							setIndicator={ this.setNotesIndicator }
+							isGlobalSidebarVisible={ true }
+							placeholder={ null }
+						/>
+					</div>
+				) }
 			</>
 		);
 	}
@@ -203,6 +208,7 @@ const mapStateToProps = ( state ) => {
 		hasUnseenNotifications: hasUnseenNotifications( state ),
 		currentUserId: getCurrentUserId( state ),
 		locale: getCurrentLocaleSlug( state ),
+		masterbarIsHidden: ! masterbarIsVisible( state ),
 	};
 };
 const mapDispatchToProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7133

## Proposed Changes

* The issue is introduced by https://github.com/Automattic/wp-calypso/pull/90429. It added another `Notification` instance on the sidebar on mobile. As a result, the [checkToggle](https://github.com/Automattic/wp-calypso/blob/bc417b9ee16d58d154e7eaf004a8a49521459407/client/notifications/index.jsx#L81) event binding on the mousedown/touchstart is called twice on both `Notification` instance and then the notification is closed by the other one.
* The better way is to have a global notifications component, but it might be a bit complicated. So, I'd prefer to resolve this issue first, and then continue on the improvement later.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites on mobile
* Open the notification
* Touch the notification to scroll down
* Make sure the notification won't be close

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
