### PR TITLE
Notification: Introduce the GlobalNotifications component to share between different entry points

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -944,14 +944,14 @@ $with-sidebar-min-page-width: 1114px;
 	}
 
 	// Check if global-sidebar-visible not present
-	&:not(.global-sidebar-visible) {
+	body:not(:has(.is-global-sidebar-visible)) & {
 		@media only screen and ( min-width: $no-sidebar-min-page-width ) {
 			@include setToggleNoteBehaviour;
 		}
 	}
 
 	// Override the CSS variable value if .global-sidebar-visible is present
-	&.global-sidebar-visible {
+	body:has(.is-global-sidebar-visible) & {
 		@media only screen and ( min-width: $with-sidebar-min-page-width ) {
 			@include setToggleNoteBehaviour;
 		}

--- a/client/layout/global-notifications/index.tsx
+++ b/client/layout/global-notifications/index.tsx
@@ -1,0 +1,92 @@
+import { usePrevious } from '@wordpress/compose';
+import { useCallback, useEffect, useRef } from 'react';
+import AsyncLoad from 'calypso/components/async-load';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
+import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
+import type { AppState } from 'calypso/types';
+import './style.scss';
+
+const GlobalNotifications = () => {
+	const isNotificationsOpen = useSelector( ( state: AppState ) => getIsNotificationsOpen( state ) );
+	const isNotificationsOpenRef = useRef( isNotificationsOpen );
+	const prevIsNotificationsOpen = usePrevious( isNotificationsOpen );
+	const unseenCount = useSelector( ( state: AppState ) => getUnseenCount( state ) );
+	const containerRef = useRef();
+	const dispatch = useDispatch();
+	const toggleNotesFrame = useCallback( ( event: MouseEvent | null ) => {
+		if ( event ) {
+			event.preventDefault && event.preventDefault();
+			event.stopPropagation && event.stopPropagation();
+		}
+		// Get URL and if it matches "/read/notifications", don't open the panel
+		// As it will cause duplicate notification panels to show
+		if ( window.location.pathname === '/read/notifications' ) {
+			return;
+		}
+
+		dispatch( toggleNotificationsPanel() );
+	}, [] );
+
+	// This toggle gets called both on the calypso and panel sides. Throttle it to prevent calls on
+	// both sides from conflicting and cancelling each other out.
+	const checkToggleNotes = useCallback(
+		( event: MouseEvent | null, forceToggle = false, forceOpen = false ) => {
+			const target = event ? event.target : false;
+
+			// Ignore clicks or other events which occur inside of the notification panel.
+			if ( target && containerRef.current.contains( target ) ) {
+				return;
+			}
+
+			// Prevent toggling closed if we are opting to open.
+			if ( forceOpen && isNotificationsOpenRef.current ) {
+				return;
+			}
+
+			if ( isNotificationsOpenRef.current || forceToggle === true || forceOpen === true ) {
+				toggleNotesFrame( event );
+			}
+		},
+		[ containerRef, isNotificationsOpenRef, toggleNotesFrame ]
+	);
+
+	isNotificationsOpenRef.current = isNotificationsOpen;
+
+	/**
+	 * Record the unseen count when the notification opens.
+	 */
+	useEffect( () => {
+		if ( ! prevIsNotificationsOpen && isNotificationsOpen ) {
+			dispatch(
+				recordTracksEvent( 'calypso_notification_open', {
+					unread_notifications: unseenCount,
+				} )
+			);
+		}
+	}, [ prevIsNotificationsOpen, isNotificationsOpen, unseenCount, dispatch ] );
+
+	/**
+	 * Focus on main window if we just closed the notes panel
+	 */
+	useEffect( () => {
+		if ( prevIsNotificationsOpen && ! isNotificationsOpen ) {
+			containerRef.current.ownerDocument.body.focus();
+		}
+	}, [ prevIsNotificationsOpen, isNotificationsOpen, dispatch ] );
+
+	return (
+		<div className="global-notifications" ref={ containerRef }>
+			<AsyncLoad
+				require="calypso/notifications"
+				isShowing={ isNotificationsOpen }
+				checkToggle={ checkToggleNotes }
+				placeholder={ null }
+			/>
+		</div>
+	);
+};
+
+export default GlobalNotifications;

--- a/client/layout/global-notifications/index.tsx
+++ b/client/layout/global-notifications/index.tsx
@@ -14,7 +14,7 @@ const GlobalNotifications = () => {
 	const isNotificationsOpenRef = useRef( isNotificationsOpen );
 	const prevIsNotificationsOpen = usePrevious( isNotificationsOpen );
 	const unseenCount = useSelector( ( state: AppState ) => getUnseenCount( state ) );
-	const containerRef = useRef();
+	const containerRef = useRef< HTMLDivElement >( null );
 	const dispatch = useDispatch();
 	const toggleNotesFrame = useCallback( ( event: MouseEvent | null ) => {
 		if ( event ) {
@@ -37,7 +37,7 @@ const GlobalNotifications = () => {
 			const target = event ? event.target : false;
 
 			// Ignore clicks or other events which occur inside of the notification panel.
-			if ( target && containerRef.current.contains( target ) ) {
+			if ( target && containerRef.current?.contains( target as Node ) ) {
 				return;
 			}
 
@@ -73,7 +73,7 @@ const GlobalNotifications = () => {
 	 */
 	useEffect( () => {
 		if ( prevIsNotificationsOpen && ! isNotificationsOpen ) {
-			containerRef.current.ownerDocument.body.focus();
+			containerRef.current?.ownerDocument.body.focus();
 		}
 	}, [ prevIsNotificationsOpen, isNotificationsOpen, dispatch ] );
 

--- a/client/layout/global-notifications/style.scss
+++ b/client/layout/global-notifications/style.scss
@@ -1,0 +1,4 @@
+.global-notifications {
+	position: relative;
+	z-index: z-index("root", ".layout__secondary") + 1;
+}

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -1,21 +1,17 @@
 import { englishLocales } from '@automattic/i18n-utils';
 import { hasTranslation } from '@wordpress/i18n';
 import classNames from 'classnames';
-import { throttle } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component, createRef } from 'react';
+import { Component } from 'react';
 import { createPortal } from 'react-dom';
 import { connect } from 'react-redux';
-import store from 'store';
 import DismissibleCard from 'calypso/blocks/dismissible-card';
-import AsyncLoad from 'calypso/components/async-load';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import SidebarMenuItem from 'calypso/layout/global-sidebar/menu-items/menu-item';
 import { isE2ETest } from 'calypso/lib/e2e';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
+import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import { BellIcon } from './icon';
@@ -29,70 +25,31 @@ class SidebarNotifications extends Component {
 		onClick: PropTypes.func,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
-		hasUnseenNotifications: PropTypes.bool,
+		unseenCount: PropTypes.number,
 		tooltip: TranslatableString,
 		translate: PropTypes.func,
 		currentUserId: PropTypes.number,
 		locale: PropTypes.string,
 	};
 
-	notificationLink = createRef();
-	notificationPanel = createRef();
-
 	state = {
 		animationState: 0,
-		newNote: this.props.hasUnseenNotifications,
+		newNote: this.props.unseenCount > 0,
 	};
 
 	componentDidUpdate( prevProps ) {
-		if ( ! prevProps.isNotificationsOpen && this.props.isNotificationsOpen ) {
-			this.props.recordTracksEvent( 'calypso_notification_open', {
-				unread_notifications: store.get( 'wpnotes_unseen_count' ),
-			} );
-			this.setNotesIndicator( 0 );
+		if ( ! this.props.isNotificationsOpen && prevProps.unseenCount !== this.props.unseenCount ) {
+			this.setNotesIndicator( this.props.unseenCount, prevProps.unseenCount );
 		}
 
-		// focus on main window if we just closed the notes panel
-		if ( prevProps.isNotificationsOpen && ! this.props.isNotificationsOpen ) {
-			this.notificationLink.current.blur();
-			this.notificationPanel.current.blur();
-			window.focus();
+		if ( ! prevProps.isNotificationsOpen && this.props.isNotificationsOpen ) {
+			this.setNotesIndicator( 0 );
 		}
 	}
 
-	// This toggle gets called both on the calypso and panel sides. Throttle it to prevent calls on
-	// both sides from conflicting and cancelling each other out.
-	checkToggleNotes = throttle(
-		( event, forceToggle, forceOpen = false ) => {
-			const target = event ? event.target : false;
-
-			// Ignore clicks or other events which occur inside of the notification panel.
-			if (
-				target &&
-				( this.notificationLink.current.contains( target ) ||
-					this.notificationPanel.current.contains( target ) )
-			) {
-				return;
-			}
-
-			// Prevent toggling closed if we are opting to open.
-			if ( forceOpen && this.props.isNotificationsOpen ) {
-				return;
-			}
-
-			if ( this.props.isNotificationsOpen || forceToggle === true || forceOpen === true ) {
-				this.toggleNotesFrame( event );
-			}
-		},
-		100,
-		{ leading: true, trailing: false }
-	);
-
 	toggleNotesFrame = ( event ) => {
-		if ( event ) {
-			event.preventDefault && event.preventDefault();
-			event.stopPropagation && event.stopPropagation();
-		}
+		event.preventDefault();
+
 		// Get URL and if it matches "/read/notifications", don't open the panel
 		// As it will cause duplicate notification panels to show
 		if ( window.location.pathname === '/read/notifications' ) {
@@ -109,20 +66,17 @@ class SidebarNotifications extends Component {
 	 * should be in: on, off, or animate-to-on
 	 * @param {number} currentUnseenCount Number of reported unseen notifications
 	 */
-	setNotesIndicator = ( currentUnseenCount ) => {
-		const existingUnseenCount = store.get( 'wpnotes_unseen_count' );
+	setNotesIndicator = ( currentUnseenCount, prevUnseenCount ) => {
 		let newAnimationState = this.state.animationState;
 
 		if ( 0 === currentUnseenCount ) {
 			// If we don't have new notes at load-time, remove the `-1` "init" status
 			newAnimationState = 0;
-		} else if ( currentUnseenCount > existingUnseenCount ) {
+		} else if ( currentUnseenCount > prevUnseenCount ) {
 			// Animate the indicator bubble by swapping CSS classes through the animation state
 			// Note that we could have an animation state of `-1` indicating the initial load
 			newAnimationState = 1 - Math.abs( this.state.animationState );
 		}
-
-		store.set( 'wpnotes_unseen_count', currentUnseenCount );
 
 		this.setState( {
 			newNote: currentUnseenCount > 0,
@@ -177,19 +131,8 @@ class SidebarNotifications extends Component {
 					tooltip={ this.props.tooltip }
 					tooltipPlacement="top"
 					className={ classes }
-					ref={ this.notificationLink }
 					key={ this.state.animationState }
 				/>
-				<div className="sidebar-notifications__panel" ref={ this.notificationPanel }>
-					<AsyncLoad
-						require="calypso/notifications"
-						isShowing={ this.props.isNotificationsOpen }
-						checkToggle={ this.checkToggleNotes }
-						setIndicator={ this.setNotesIndicator }
-						isGlobalSidebarVisible={ true }
-						placeholder={ null }
-					/>
-				</div>
 			</>
 		);
 	}
@@ -200,14 +143,13 @@ const mapStateToProps = ( state ) => {
 	return {
 		isActive: isPanelOpen || window.location.pathname === '/read/notifications',
 		isNotificationsOpen: isPanelOpen,
-		hasUnseenNotifications: hasUnseenNotifications( state ),
+		unseenCount: getUnseenCount( state ),
 		currentUserId: getCurrentUserId( state ),
 		locale: getCurrentLocaleSlug( state ),
 	};
 };
 const mapDispatchToProps = {
 	toggleNotificationsPanel,
-	recordTracksEvent,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( SidebarNotifications );

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -49,6 +49,7 @@ class SidebarNotifications extends Component {
 
 	toggleNotesFrame = ( event ) => {
 		event.preventDefault();
+		event.stopPropagation();
 
 		// Get URL and if it matches "/read/notifications", don't open the panel
 		// As it will cause duplicate notification panels to show

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -62,6 +62,7 @@ import {
 	masterbarIsVisible,
 } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
+import GlobalNotifications from './global-notifications';
 import LayoutLoader from './loader';
 import { handleScroll } from './utils';
 // goofy import for environment badge, which is SSR'd
@@ -436,6 +437,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
+				<GlobalNotifications />
 				{ shouldEnableCommandPalette && (
 					<AsyncLoad
 						require="@automattic/command-palette"

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -38,6 +38,7 @@ class MasterbarItemNotifications extends Component {
 
 	toggleNotesFrame = ( event ) => {
 		event.preventDefault();
+		event.stopPropagation();
 
 		// Get URL and if it matches "/read/notifications", don't open the panel
 		// As it will cause duplicate notification panels to show

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -1,13 +1,9 @@
 import classNames from 'classnames';
-import { throttle } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component, createRef } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-import store from 'store';
-import AsyncLoad from 'calypso/components/async-load';
 import TranslatableString from 'calypso/components/translatable/proptype';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
+import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import MasterbarItem from '../item';
@@ -22,66 +18,27 @@ class MasterbarItemNotifications extends Component {
 		tooltip: TranslatableString,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
-		hasUnseenNotifications: PropTypes.bool,
+		unseenCount: PropTypes.number,
 	};
-
-	notificationLink = createRef();
-	notificationPanel = createRef();
 
 	state = {
 		animationState: 0,
-		newNote: this.props.hasUnseenNotifications,
+		newNote: this.props.unseenCount > 0,
 	};
 
 	componentDidUpdate( prevProps ) {
-		if ( ! prevProps.isNotificationsOpen && this.props.isNotificationsOpen ) {
-			this.props.recordTracksEvent( 'calypso_notification_open', {
-				unread_notifications: store.get( 'wpnotes_unseen_count' ),
-			} );
-			this.setNotesIndicator( 0 );
+		if ( ! this.props.isNotificationsOpen && prevProps.unseenCount !== this.props.unseenCount ) {
+			this.setNotesIndicator( this.props.unseenCount, prevProps.unseenCount );
 		}
 
-		// focus on main window if we just closed the notes panel
-		if ( prevProps.isNotificationsOpen && ! this.props.isNotificationsOpen ) {
-			this.notificationLink.current.blur();
-			this.notificationPanel.current.blur();
-			window.focus();
+		if ( ! prevProps.isNotificationsOpen && this.props.isNotificationsOpen ) {
+			this.setNotesIndicator( 0 );
 		}
 	}
 
-	// This toggle gets called both on the calypso and panel sides. Throttle it to prevent calls on
-	// both sides from conflicting and cancelling each other out.
-	checkToggleNotes = throttle(
-		( event, forceToggle, forceOpen = false ) => {
-			const target = event ? event.target : false;
-
-			// Ignore clicks or other events which occur inside of the notification panel.
-			if (
-				target &&
-				( this.notificationLink.current.contains( target ) ||
-					this.notificationPanel.current.contains( target ) )
-			) {
-				return;
-			}
-
-			// Prevent toggling closed if we are opting to open.
-			if ( forceOpen && this.props.isNotificationsOpen ) {
-				return;
-			}
-
-			if ( this.props.isNotificationsOpen || forceToggle === true || forceOpen === true ) {
-				this.toggleNotesFrame( event );
-			}
-		},
-		100,
-		{ leading: true, trailing: false }
-	);
-
 	toggleNotesFrame = ( event ) => {
-		if ( event ) {
-			event.preventDefault && event.preventDefault();
-			event.stopPropagation && event.stopPropagation();
-		}
+		event.preventDefault();
+
 		// Get URL and if it matches "/read/notifications", don't open the panel
 		// As it will cause duplicate notification panels to show
 		if ( window.location.pathname === '/read/notifications' ) {
@@ -98,20 +55,17 @@ class MasterbarItemNotifications extends Component {
 	 * should be in: on, off, or animate-to-on
 	 * @param {number} currentUnseenCount Number of reported unseen notifications
 	 */
-	setNotesIndicator = ( currentUnseenCount ) => {
-		const existingUnseenCount = store.get( 'wpnotes_unseen_count' );
+	setNotesIndicator = ( currentUnseenCount, prevUnseenCount ) => {
 		let newAnimationState = this.state.animationState;
 
 		if ( 0 === currentUnseenCount ) {
 			// If we don't have new notes at load-time, remove the `-1` "init" status
 			newAnimationState = 0;
-		} else if ( currentUnseenCount > existingUnseenCount ) {
+		} else if ( currentUnseenCount > prevUnseenCount ) {
 			// Animate the indicator bubble by swapping CSS classes through the animation state
 			// Note that we could have an animation state of `-1` indicating the initial load
 			newAnimationState = 1 - Math.abs( this.state.animationState );
 		}
-
-		store.set( 'wpnotes_unseen_count', currentUnseenCount );
 
 		this.setState( {
 			newNote: currentUnseenCount > 0,
@@ -136,18 +90,8 @@ class MasterbarItemNotifications extends Component {
 					isActive={ this.props.isActive }
 					tooltip={ this.props.tooltip }
 					className={ classes }
-					ref={ this.notificationLink }
 					key={ this.state.animationState }
 				/>
-				<div className="masterbar-notifications__panel" ref={ this.notificationPanel }>
-					<AsyncLoad
-						require="calypso/notifications"
-						isShowing={ this.props.isNotificationsOpen }
-						checkToggle={ this.checkToggleNotes }
-						setIndicator={ this.setNotesIndicator }
-						placeholder={ null }
-					/>
-				</div>
 			</>
 		);
 	}
@@ -156,12 +100,11 @@ class MasterbarItemNotifications extends Component {
 const mapStateToProps = ( state ) => {
 	return {
 		isNotificationsOpen: isNotificationsOpen( state ),
-		hasUnseenNotifications: hasUnseenNotifications( state ),
+		unseenCount: getUnseenCount( state ),
 	};
 };
 const mapDispatchToProps = {
 	toggleNotificationsPanel,
-	recordTracksEvent,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( MasterbarItemNotifications );

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -58,9 +58,8 @@ export class Notifications extends Component {
 	};
 
 	componentDidMount() {
-		window.addEventListener( 'mousedown', this.props.checkToggle, { passive: false } );
-		window.addEventListener( 'touchstart', this.props.checkToggle, { passive: false } );
-		window.addEventListener( 'keydown', this.handleKeyPress );
+		document.addEventListener( 'click', this.props.checkToggle );
+		document.addEventListener( 'keydown', this.handleKeyPress );
 
 		if ( typeof document.hidden !== 'undefined' ) {
 			document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
@@ -79,9 +78,8 @@ export class Notifications extends Component {
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'mousedown', this.props.checkToggle, { passive: false } );
-		window.removeEventListener( 'touchstart', this.props.checkToggle, { passive: false } );
-		window.removeEventListener( 'keydown', this.handleKeyPress );
+		document.removeEventListener( 'click', this.props.checkToggle );
+		document.removeEventListener( 'keydown', this.handleKeyPress );
 
 		if ( typeof document.hidden !== 'undefined' ) {
 			document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -18,6 +18,7 @@ import classNames from 'classnames';
 import debugFactory from 'debug';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import localStorageHelper from 'store';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
@@ -57,8 +58,8 @@ export class Notifications extends Component {
 	};
 
 	componentDidMount() {
-		window.addEventListener( 'mousedown', this.props.checkToggle );
-		window.addEventListener( 'touchstart', this.props.checkToggle );
+		window.addEventListener( 'mousedown', this.props.checkToggle, { passive: false } );
+		window.addEventListener( 'touchstart', this.props.checkToggle, { passive: false } );
 		window.addEventListener( 'keydown', this.handleKeyPress );
 
 		if ( typeof document.hidden !== 'undefined' ) {
@@ -78,8 +79,8 @@ export class Notifications extends Component {
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'mousedown', this.props.checkToggle );
-		window.removeEventListener( 'touchstart', this.props.checkToggle );
+		window.removeEventListener( 'mousedown', this.props.checkToggle, { passive: false } );
+		window.removeEventListener( 'touchstart', this.props.checkToggle, { passive: false } );
 		window.removeEventListener( 'keydown', this.handleKeyPress );
 
 		if ( typeof document.hidden !== 'undefined' ) {
@@ -174,7 +175,7 @@ export class Notifications extends Component {
 		const customMiddleware = {
 			APP_RENDER_NOTES: [
 				( store, { newNoteCount } ) => {
-					this.props.setIndicator( newNoteCount );
+					localStorageHelper.set( 'wpnotes_unseen_count', newNoteCount );
 					this.props.setUnseenCount( newNoteCount );
 				},
 			],
@@ -257,7 +258,6 @@ export class Notifications extends Component {
 				className={ classNames( 'wide', 'wpnc__main', {
 					'wpnt-open': this.props.isShowing,
 					'wpnt-closed': ! this.props.isShowing,
-					'global-sidebar-visible': this.props.isGlobalSidebarVisible ?? false,
 				} ) }
 			>
 				<NotificationsPanel

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -46,7 +46,6 @@ export function notifications( context, next ) {
 					require="calypso/notifications"
 					isShowing={ true }
 					checkToggle={ () => {} }
-					setIndicator={ () => {} }
 					placeholder={ null }
 					isGlobalSidebarVisible={ shouldShowGlobalSidebar }
 				/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7133

## Proposed Changes

* There was an issue introduced by https://github.com/Automattic/wp-calypso/pull/90429 that the notification panel was closed while the user wanted to scroll on it. The reason was https://github.com/Automattic/wp-calypso/pull/90429 rendered another `Notification` instance on the sidebar on mobile, so the [checkToggle](https://github.com/Automattic/wp-calypso/blob/bc417b9ee16d58d154e7eaf004a8a49521459407/client/notifications/index.jsx#L81) event binding on the mousedown/touchstart was called twice on both Notification instance and then the notification is closed by the other one.
* As a result, this PR proposes to introduce the `GlobalNotifications` to remove the duplication to resolve the issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites on mobile
* Open the notification
* Touch the notification to scroll down
* Make sure the notification won't be close

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
