### PR TITLE
Redirect localized /sites links

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -694,6 +694,27 @@ function wpcomPages( app ) {
 		res.redirect( redirectUrl );
 	} );
 
+	app.get( `/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/sites`, function ( req, res, next ) {
+		const locale = req.params?.locale;
+		const queryParams = new URLSearchParams( req.query );
+		const queryString = queryParams.size ? '?' + queryParams.toString() : '';
+
+		if ( ! req.context.isLoggedIn ) {
+			const loginUrl = `/log-in/${ locale }`;
+			const sitesDashboard = `https://wordpress.com/sites/${ queryString }`;
+
+			const redirectUrl = encodeURIComponent( sitesDashboard );
+
+			res.redirect( `${ loginUrl }?redirect_to=${ redirectUrl }` );
+		} else {
+			if ( locale ) {
+				res.redirect( `/sites${ queryString }` );
+				return;
+			}
+			next();
+		}
+	} );
+
 	app.get( `/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/plans`, function ( req, res, next ) {
 		const locale = req.params?.locale;
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -667,6 +667,27 @@ function wpcomPages( app ) {
 		}
 	} );
 
+	app.get( `/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/sites`, function ( req, res, next ) {
+		const locale = req.params?.locale;
+		const queryParams = new URLSearchParams( req.query );
+		const queryString = queryParams.size ? '?' + queryParams.toString() : '';
+
+		if ( locale && ! req.context.isLoggedIn ) {
+			const loginUrl = `/log-in/${ locale }`;
+			const sitesDashboard = `https://wordpress.com/sites/${ queryString }`;
+
+			const redirectUrl = encodeURIComponent( sitesDashboard );
+
+			res.redirect( `${ loginUrl }?redirect_to=${ redirectUrl }` );
+		} else {
+			if ( locale ) {
+				res.redirect( `/sites${ queryString }` );
+				return;
+			}
+			next();
+		}
+	} );
+
 	// redirects to handle old newdash formats
 	app.use( '/sites/:site/:section', function ( req, res, next ) {
 		const redirectedSections = [
@@ -692,27 +713,6 @@ function wpcomPages( app ) {
 			);
 		}
 		res.redirect( redirectUrl );
-	} );
-
-	app.get( `/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/sites`, function ( req, res, next ) {
-		const locale = req.params?.locale;
-		const queryParams = new URLSearchParams( req.query );
-		const queryString = queryParams.size ? '?' + queryParams.toString() : '';
-
-		if ( ! req.context.isLoggedIn ) {
-			const loginUrl = `/log-in/${ locale }`;
-			const sitesDashboard = `https://wordpress.com/sites/${ queryString }`;
-
-			const redirectUrl = encodeURIComponent( sitesDashboard );
-
-			res.redirect( `${ loginUrl }?redirect_to=${ redirectUrl }` );
-		} else {
-			if ( locale ) {
-				res.redirect( `/sites${ queryString }` );
-				return;
-			}
-			next();
-		}
 	} );
 
 	app.get( `/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/plans`, function ( req, res, next ) {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1007,6 +1007,17 @@ describe( 'main app', () => {
 		} );
 	} );
 
+	describe( 'Route /<locale>/sites', () => {
+		it( 'redirects to login if the request contains a locale', async () => {
+			const { response } = await app.run( {
+				request: { url: '/es/sites', query: { status: 'deleted' } },
+			} );
+			expect( response.redirect ).toHaveBeenCalledWith(
+				'/log-in/es?redirect_to=https%3A%2F%2Fwordpress.com%2Fsites%2F%3Fstatus%3Ddeleted'
+			);
+		} );
+	} );
+
 	describe( 'Route /plans', () => {
 		it( 'redirects to login if the request is for jetpack', async () => {
 			const { response } = await app.run( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Automattic/i18n-issues#791

## Proposed Changes

Redirects to localized `/sites` urls, e.g. `/es/sites`, should go to
a localized login page for logged-out users. Logged-in users should be
sent to the `/sites` page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Links in localized emails were broken.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/<locale>/sites` while logged-in, and verify that it redirects to `/sites/`, where `<locale>` is your preferred locale.
* Visit `/<locale>/sites` while logged out, and verify that it redirects to a localized log-in page, and will redirect to `/sites` after logging in.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
