### PR TITLE
Entrepreneur My Home: Fix incorrect link for "Add a product" and "View orders" on quick links.

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites/index.jsx
@@ -49,7 +49,7 @@ const QuickLinksForEcommerceSites = ( props ) => {
 		<div className="quick-links-for-hosted-sites__boxes quick-links__boxes">
 			{ isAtomic && (
 				<ActionBox
-					href={ `https://${ siteSlug }/wp-admin/edit.php?post_type=shop_order` }
+					href={ `https://${ siteSlug }/wp-admin/post-new.php?post_type=product` }
 					hideLinkIndicator
 					label={ translate( 'Add a product' ) }
 					iconComponent={
@@ -62,7 +62,7 @@ const QuickLinksForEcommerceSites = ( props ) => {
 			) }
 			{ isAtomic && (
 				<ActionBox
-					href={ `https://${ siteSlug }/wp-admin/post-new.php?post_type=product` }
+					href={ `https://${ siteSlug }/wp-admin/edit.php?post_type=shop_order` }
 					hideLinkIndicator
 					label={ translate( 'View orders' ) }
 					iconComponent={


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The "Add a product" and "View orders" quick links were swapped. This PR swaps it back.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site via `/setup/entrepreneur".
* Once it lands in My Home, click "Add a product" and "View orders" on the quick links panel on the right side of My Home.
* It should go to the correct pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
