### PR TITLE
Verbum Block Editor: externalize wp.i18n since Jetpack will enqueue it anyways

### DIFF
--- a/packages/verbum-block-editor/README.md
+++ b/packages/verbum-block-editor/README.md
@@ -26,6 +26,8 @@ This package can be utilized in two primary ways:
   1. Navigate to the package's directory: `cd package/verbum-block-editor`.
   2. Execute `yarn dev --sync`.
   3. Changes are synchronized to `/home/wpcom/public_html/widgets.wp.com/verbum-block-editor` on your sandbox.
+  4. **This this version, `wp.i18n` global is expected to be present**.
+
 
 ### Deploying Changes
 

--- a/packages/verbum-block-editor/webpack.config.js
+++ b/packages/verbum-block-editor/webpack.config.js
@@ -34,6 +34,9 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			filename: '[name].min.js', // dynamic filename
 			library: 'verbumBlockEditor',
 		},
+		externals: {
+			'@wordpress/i18n': [ 'wp', 'i18n' ],
+		},
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

This makes the `@wordpress/i18n` package as an external package.

## Why are these changes being made?
Jetpack will be included in the global anyway when we call `wp_set_script_translations`. And if we don't, VBE will have its own instance of i18n that doesn't share locale data with the Jetpack instance.
