### PR TITLE
Remove the notifications link from reader sidebar

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -23,7 +23,6 @@ import ReaderDiscoverIcon from 'calypso/reader/components/icons/discover-icon';
 import ReaderFollowingIcon from 'calypso/reader/components/icons/following-icon';
 import ReaderLikesIcon from 'calypso/reader/components/icons/likes-icon';
 import ReaderManageSubscriptionsIcon from 'calypso/reader/components/icons/manage-subscriptions-icon';
-import ReaderNotificationsIcon from 'calypso/reader/components/icons/notifications-icon';
 import ReaderSearchIcon from 'calypso/reader/components/icons/search-icon';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getTagStreamUrl } from 'calypso/reader/route';
@@ -123,13 +122,6 @@ export class ReaderSidebar extends Component {
 		recordAction( 'clicked_reader_sidebar_conversations' );
 		recordGaEvent( 'Clicked Reader Sidebar Conversations' );
 		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_conversations_clicked' );
-		this.handleGlobalSidebarMenuItemClick( path );
-	};
-
-	handleReaderSidebarNotificationsClicked = ( event, path ) => {
-		recordAction( 'clicked_reader_sidebar_notifications' );
-		recordGaEvent( 'Clicked Reader Sidebar Notifications' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_notifications_clicked' );
 		this.handleGlobalSidebarMenuItemClick( path );
 	};
 
@@ -266,16 +258,6 @@ export class ReaderSidebar extends Component {
 						customIcon={ <ReaderA8cConversationsIcon /> }
 					/>
 				) }
-
-				<SidebarItem
-					className={ ReaderSidebarHelper.itemLinkClass( '/read/notifications', path, {
-						'sidebar-streams__notifications': true,
-					} ) }
-					label={ translate( 'Notifications' ) }
-					onNavigate={ this.handleReaderSidebarNotificationsClicked }
-					customIcon={ <ReaderNotificationsIcon /> }
-					link="/read/notifications"
-				/>
 
 				<SidebarItem
 					className={ ReaderSidebarHelper.itemLinkClass( '/read/subscriptions', path, {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -275,8 +275,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
-			.sidebar__menu-icon.sidebar_svg-likes,
-			.sidebar__menu-icon.sidebar_svg-notifications {
+			.sidebar__menu-icon.sidebar_svg-likes {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
 					stroke: var(--color-sidebar-gridicon-hover-fill);
@@ -323,8 +322,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-following,
-		.sidebar__menu-icon.sidebar_svg-likes,
-		.sidebar__menu-icon.sidebar_svg-notifications {
+		.sidebar__menu-icon.sidebar_svg-likes {
 			fill: var(--color-sidebar-background);
 			path {
 				stroke: var(--color-sidebar-gridicon-fill);
@@ -374,8 +372,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
-			.sidebar__menu-icon.sidebar_svg-likes,
-			.sidebar__menu-icon.sidebar_svg-notifications {
+			.sidebar__menu-icon.sidebar_svg-likes {
 				fill: var(--color-sidebar-menu-hover-background);
 				path {
 					stroke: var(--color-sidebar-gridicon-selected-fill);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/orgs/Automattic/projects/927/views/12?pane=issue&itemId=62535305

## Proposed Changes

Remove the notifications link from the reader.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Go to /read
3. See that the 'Notifications' link is no longer in the sidebar. 
4. Confirm that the notifications icon and keyboard shortcut ('n') still work to show/hide notifications

The already existing popover highlighting the location of the notifications icon will also display, assuming it has not already been dismissed.

Before | After
-------|------
<img width="450" alt="Screenshot 2024-05-14 at 10 44 13" src="https://github.com/Automattic/wp-calypso/assets/93301/86957727-8f3f-4c83-af91-0a799862d9f2"> | <img width="450" alt="Screenshot 2024-05-14 at 10 44 32" src="https://github.com/Automattic/wp-calypso/assets/93301/6bf221ee-b69e-427d-a36f-003717c0cd68">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
