### PR TITLE
Nav redesign: unify card styles

### DIFF
--- a/client/components/hosting-card/index.tsx
+++ b/client/components/hosting-card/index.tsx
@@ -1,0 +1,53 @@
+import { Card } from '@automattic/components';
+import classNames from 'classnames';
+import type { ReactNode } from 'react';
+
+import './style.scss';
+
+interface HostingCardProps {
+	className?: string;
+	headingId?: string;
+	title?: string;
+	children: ReactNode;
+}
+
+interface HostingCardHeadingProps {
+	className?: string;
+	id?: string;
+	title?: string;
+	children?: ReactNode;
+}
+
+interface HostingCardDescriptionProps {
+	children: string | ReactNode;
+}
+
+export function HostingCard( { className, headingId, title, children }: HostingCardProps ) {
+	return (
+		<Card className={ classNames( 'hosting-card', className ) }>
+			{ title && (
+				<h3 id={ headingId } className="hosting-card__title">
+					{ title }
+				</h3>
+			) }
+			{ children }
+		</Card>
+	);
+}
+
+export function HostingCardHeading( { id, title, children }: HostingCardHeadingProps ) {
+	return (
+		<div className="hosting-card__heading">
+			{ title && (
+				<h3 id={ id } className="hosting-card__title">
+					{ title }
+				</h3>
+			) }
+			{ children }
+		</div>
+	);
+}
+
+export function HostingCardDescription( { children }: HostingCardDescriptionProps ) {
+	return <p className="hosting-card__description">{ children }</p>;
+}

--- a/client/components/hosting-card/style.scss
+++ b/client/components/hosting-card/style.scss
@@ -1,0 +1,35 @@
+@import "@automattic/components/src/styles/typography";
+
+.hosting-card {
+	width: 100%;
+	margin: 0;
+	padding: 22px;
+	border: 1px solid var(--studio-gray-5);
+	border-radius: 4px;
+	box-shadow: none;
+	font-family: $font-sf-pro-text;
+}
+
+h3.hosting-card__title {
+	font-size: rem(16px);
+	font-weight: 500;
+	color: var(--studio-gray-80);
+	line-height: 24px;
+	margin-bottom: 12px;
+}
+
+.hosting-card__heading {
+	display: flex;
+	gap: var(--grid-unit-15, 12px);
+
+	h3.hosting-card__title {
+		flex: 1;
+	}
+}
+
+p.hosting-card__description {
+	font-size: rem(14px);
+	font-weight: 400;
+	line-height: 20px;
+	color: var(--studio-gray-100);
+}

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -1,10 +1,11 @@
-import { Button, Card } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable } from '@automattic/domains-table';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
+import { HostingCard, HostingCardHeading } from 'calypso/components/hosting-card';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -18,10 +19,8 @@ const ActiveDomainsCard: FC = () => {
 	const translate = useTranslate();
 
 	return (
-		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__active-domains' ) }>
-			<div className="hosting-overview__card-header">
-				<h3 className="hosting-overview__card-title">{ translate( 'Active domains' ) }</h3>
-
+		<HostingCard className="hosting-overview__active-domains">
+			<HostingCardHeading title={ translate( 'Active domains' ) }>
 				<Button
 					className={ classNames(
 						'hosting-overview__link-button',
@@ -39,7 +38,7 @@ const ActiveDomainsCard: FC = () => {
 				>
 					{ translate( 'Manage domains' ) }
 				</Button>
-			</div>
+			</HostingCardHeading>
 
 			<DomainsTable
 				className="hosting-overview__domains-table"
@@ -50,7 +49,7 @@ const ActiveDomainsCard: FC = () => {
 				useMobileCards={ forceMobile }
 				siteSlug={ site?.slug ?? null }
 			/>
-		</Card>
+		</HostingCard>
 	);
 };
 

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -1,5 +1,5 @@
 import { PlanSlug, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
-import { Button, Card, PlanPrice, LoadingPlaceholder } from '@automattic/components';
+import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { formatCurrency } from '@automattic/format-currency';
@@ -9,6 +9,7 @@ import { FC } from 'react';
 import { useSelector } from 'react-redux';
 import PlanStorage from 'calypso/blocks/plan-storage';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import { HostingCard } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
@@ -43,7 +44,7 @@ const PlanCard: FC = () => {
 	return (
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
-			<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__plan' ) }>
+			<HostingCard className="hosting-overview__plan">
 				<div className="hosting-overview__plan-card-header">
 					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
 
@@ -146,7 +147,7 @@ const PlanCard: FC = () => {
 						</div>
 					) }
 				</PlanStorage>
-			</Card>
+			</HostingCard>
 		</>
 	);
 };

--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -1,10 +1,10 @@
-import { Button, Card } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { chevronRightSmall, Icon } from '@wordpress/icons';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
+import { HostingCard } from 'calypso/components/hosting-card';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { WriteIcon } from 'calypso/layout/masterbar/write-icon';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
@@ -61,15 +61,14 @@ const QuickActionsCard: FC = () => {
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( site?.ID );
 
 	return (
-		<Card className={ classNames( 'hosting-overview__card', 'hosting-overview__quick-actions' ) }>
-			<div className="hosting-overview__card-header">
-				<h3 className="hosting-overview__card-title">
-					{ hasEnTranslation( 'Quick actions' )
-						? translate( 'Quick actions' )
-						: translate( 'WP Admin links' ) }
-				</h3>
-			</div>
-
+		<HostingCard
+			className="hosting-overview__quick-actions"
+			title={
+				hasEnTranslation( 'Quick actions' )
+					? translate( 'Quick actions' )
+					: translate( 'WP Admin links' )
+			}
+		>
 			<ul className="hosting-overview__actions-list">
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }
@@ -102,7 +101,7 @@ const QuickActionsCard: FC = () => {
 					text={ translate( 'See Jetpack Stats' ) }
 				/>
 			</ul>
-		</Card>
+		</HostingCard>
 	);
 };
 

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -16,16 +16,6 @@ $card-padding: 24px;
 	grid-row-gap: 16px;
 }
 
-.hosting-overview__card {
-	border-radius: 4px;
-	border: 1px solid var(--studio-gray-5);
-	box-shadow: none;
-	margin: 0;
-	padding: $card-padding;
-	width: 100%;
-	height: 100%;
-}
-
 .hosting-overview__navigation-header {
 	grid-column: 1 / -1;
 	grid-row: 1 / 2;
@@ -145,17 +135,6 @@ a.hosting-overview__link-button {
 	display: flex;
 	gap: var(--grid-unit-15, 12px);
 	margin-bottom: 16px;
-}
-
-.hosting-overview__card-title {
-	color: var(--studio-gray-100);
-	flex: 1;
-	font-feature-settings: "clig" off, "liga" off;
-	font-family: "SF Pro Display", $sans;
-	font-size: $font-title-small;
-	font-weight: 500;
-	line-height: 26px;
-	letter-spacing: 0.38px;
 }
 
 .hosting-overview__plan-info {
@@ -298,7 +277,7 @@ a.hosting-overview__link-button {
 
 	table {
 		border-top: 1px solid var(--color-border-secondary);
-		margin-bottom: $card-padding;
+		margin-bottom: 0;
 		margin-top: 0;
 
 		tbody tr:last-child::after {

--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -1,10 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button, Card } from '@automattic/components';
+import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import {
 	useEdgeCacheQuery,
@@ -25,11 +25,6 @@ const Hr = styled.hr( {
 	marginTop: '16px',
 	width: '100%',
 	color: '#e0e0e0',
-} );
-
-const EdgeCacheDescription = styled.p( {
-	fontSize: '16px',
-	marginBottom: '16px',
 } );
 
 const EdgeCacheNotice = styled.p( {
@@ -136,18 +131,15 @@ export const CacheCard = ( {
 
 	//autorenew
 	return (
-		<Card className="cache-card">
-			<CardHeading id="cache" size={ 20 }>
-				{ translate( 'Cache' ) }
-			</CardHeading>
+		<HostingCard className="cache-card" headingId="cache" title={ translate( 'Cache' ) }>
 			<CardBody>
-				<EdgeCacheDescription>
+				<HostingCardDescription>
 					{ translate( 'Manage your site’s server-side caching. {{a}}Learn more{{/a}}.', {
 						components: {
 							a: <InlineSupportLink supportContext="hosting-clear-cache" showIcon={ false } />,
 						},
 					} ) }
-				</EdgeCacheDescription>
+				</HostingCardDescription>
 				<ToggleContainer>
 					{ getEdgeCacheInitialLoading ? (
 						<EdgeCacheLoadingPlaceholder />
@@ -181,7 +173,7 @@ export const CacheCard = ( {
 				</ToggleContainer>
 				{ getClearCacheContent() }
 			</CardBody>
-		</Card>
+		</HostingCard>
 	);
 };
 

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -1,9 +1,9 @@
-import { Card, Button, MaterialIcon } from '@automattic/components';
+import { Button, MaterialIcon } from '@automattic/components';
 import { PanelBody } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -65,13 +65,16 @@ export default function PhpMyAdminCard( { disabled } ) {
 	const { openPhpMyAdmin, loading } = useOpenPhpMyAdmin();
 
 	return (
-		<Card className="phpmyadmin-card">
-			<CardHeading id="database-access">{ translate( 'Database access' ) }</CardHeading>
-			<p>
+		<HostingCard
+			className="phpmyadmin-card"
+			headingId="database-access"
+			title={ translate( 'Database access' ) }
+		>
+			<HostingCardDescription>
 				{ translate(
 					'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'
 				) }
-			</p>
+			</HostingCardDescription>
 			<div className="phpmyadmin-card__questions">
 				<PanelBody title={ translate( 'What is phpMyAdmin?' ) } initialOpen={ false }>
 					{ translate(
@@ -117,6 +120,6 @@ export default function PhpMyAdminCard( { disabled } ) {
 				onCancel={ () => setIsRestorePasswordDialogVisible( false ) }
 				onRestore={ () => setIsRestorePasswordDialogVisible( false ) }
 			/>
-		</Card>
+		</HostingCard>
 	);
 }

--- a/client/my-sites/hosting/restore-plan-software-card/index.js
+++ b/client/my-sites/hosting/restore-plan-software-card/index.js
@@ -1,7 +1,7 @@
-import { Button, Card } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import { stripHTML } from 'calypso/lib/formatting/strip-html';
 import wpcom from 'calypso/lib/wp';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
@@ -34,16 +34,18 @@ export default function RestorePlanSoftwareCard() {
 	}
 
 	return (
-		<Card className="restore-plan-software-card">
-			<CardHeading>{ translate( 'Restore plugins and themes' ) }</CardHeading>
-			<p>
+		<HostingCard
+			className="restore-plan-software-card"
+			title={ translate( 'Restore plugins and themes' ) }
+		>
+			<HostingCardDescription>
 				{ translate(
 					'If your website is missing plugins and themes that come with your plan, you may restore them here.'
 				) }
-			</p>
+			</HostingCardDescription>
 			<Button primary onClick={ requestRestore }>
 				{ translate( "Restore plugins and themes for my website's plan" ) }
 			</Button>
-		</Card>
+		</HostingCard>
 	);
 }

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -1,15 +1,15 @@
 import { FEATURE_SFTP, FEATURE_SSH } from '@automattic/calypso-products';
-import { Card, Button, FormLabel, Spinner } from '@automattic/components';
+import { Button, FormLabel, Spinner } from '@automattic/components';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import styled from '@emotion/styled';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -218,14 +218,15 @@ export const SftpCard = ( {
 		  );
 
 	return (
-		<Card className="sftp-card">
-			<CardHeading id="sftp-credentials">
-				{ siteHasSshFeature
-					? translate( 'SFTP/SSH credentials' )
-					: translate( 'SFTP credentials' ) }
-			</CardHeading>
+		<HostingCard
+			className="sftp-card"
+			headingId="sftp-credentials"
+			title={
+				siteHasSshFeature ? translate( 'SFTP/SSH credentials' ) : translate( 'SFTP credentials' )
+			}
+		>
 			{ ! hasSftpFeatureAndIsLoading && (
-				<div className="sftp-card__body">
+				<HostingCardDescription>
 					<p>
 						{ username
 							? translate(
@@ -238,7 +239,7 @@ export const SftpCard = ( {
 							  )
 							: featureExplanation }
 					</p>
-				</div>
+				</HostingCardDescription>
 			) }
 			{ displayQuestionsAndButton && (
 				<SftpQuestionsContainer>
@@ -320,7 +321,7 @@ export const SftpCard = ( {
 			) }
 			{ isLoading && <Spinner /> }
 			{ hasSftpFeatureAndIsLoading && <SftpCardLoadingPlaceholder /> }
-		</Card>
+		</HostingCard>
 	);
 };
 

--- a/client/my-sites/hosting/site-backup-card/index.js
+++ b/client/my-sites/hosting/site-backup-card/index.js
@@ -1,8 +1,7 @@
-import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
+import { HostingCard } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import getLastGoodRewindBackup from 'calypso/state/selectors/get-last-good-rewind-backup';
@@ -36,8 +35,7 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId } ) 
 		: null;
 
 	return (
-		<Card className="site-backup-card">
-			<CardHeading>{ translate( 'Site backup' ) }</CardHeading>
+		<HostingCard className="site-backup-card" title={ translate( 'Site backup' ) }>
 			{ hasRetrievedLastBackup && lastGoodBackup && ! isLoading && ! disabled && (
 				<>
 					<p className="site-backup-card__date">
@@ -61,7 +59,7 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId } ) 
 					<div className="site-backup-card__placeholder is-large"></div>
 				</>
 			) }
-		</Card>
+		</HostingCard>
 	);
 };
 

--- a/client/my-sites/hosting/staging-site-card/card-content/card-content-wrapper.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/card-content-wrapper.tsx
@@ -1,14 +1,16 @@
-import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import CardHeading from 'calypso/components/card-heading';
+import { HostingCard } from 'calypso/components/hosting-card';
 
 export const CardContentWrapper: FunctionComponent< PropsWithChildren > = ( { children } ) => {
 	const translate = useTranslate();
 	return (
-		<Card className="staging-site-card">
-			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
+		<HostingCard
+			className="staging-site-card"
+			headingId="staging-site"
+			title={ translate( 'Staging site' ) }
+		>
 			{ children }
-		</Card>
+		</HostingCard>
 	);
 };

--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { HostingCardDescription } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { ExceedQuotaErrorContent } from './exceed-quota-error-content';
 
@@ -18,7 +19,7 @@ export const NewStagingSiteCardContent = ( {
 		const translate = useTranslate();
 		return (
 			<>
-				<p>
+				<HostingCardDescription>
 					{ translate(
 						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
 						{
@@ -27,7 +28,7 @@ export const NewStagingSiteCardContent = ( {
 							},
 						}
 					) }
-				</p>
+				</HostingCardDescription>
 				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
 					<span>{ translate( 'Add staging site' ) }</span>
 				</Button>

--- a/client/my-sites/hosting/support-card/index.js
+++ b/client/my-sites/hosting/support-card/index.js
@@ -1,8 +1,8 @@
-import { Button, Card } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
 import { HappinessEngineersTray } from 'calypso/components/happiness-engineers-tray';
+import { HostingCard } from 'calypso/components/hosting-card';
 import {
 	composeAnalytics,
 	recordTracksEvent,
@@ -25,8 +25,7 @@ export default function SupportCard() {
 	const dispatch = useDispatch();
 
 	return (
-		<Card className="support-card">
-			<CardHeading>{ translate( 'Support' ) }</CardHeading>
+		<HostingCard className="support-card" title={ translate( 'Support' ) }>
 			<HappinessEngineersTray />
 			<p>
 				{ translate(
@@ -36,6 +35,6 @@ export default function SupportCard() {
 			<Button onClick={ () => dispatch( trackNavigateToContactSupport() ) } href="/help/contact">
 				{ translate( 'Contact us' ) }
 			</Button>
-		</Card>
+		</HostingCard>
 	);
 }

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -1,9 +1,8 @@
-import { Button, Card, FormLabel, LoadingPlaceholder } from '@automattic/components';
+import { Button, FormLabel, LoadingPlaceholder } from '@automattic/components';
 import styled from '@emotion/styled';
 import { localize } from 'i18n-calypso';
 import { useState } from 'react';
 import { connect } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
 import QuerySiteGeoAffinity from 'calypso/components/data/query-site-geo-affinity';
 import QuerySitePhpVersion from 'calypso/components/data/query-site-php-version';
 import QuerySiteStaticFile404 from 'calypso/components/data/query-site-static-file-404';
@@ -12,6 +11,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import {
 	updateAtomicPhpVersion,
 	updateAtomicStaticFile404,
@@ -380,23 +380,26 @@ const WebServerSettingsCard = ( {
 	};
 
 	return (
-		<Card className="web-server-settings-card">
+		<HostingCard
+			className="web-server-settings-card"
+			headingId="web-server-settings"
+			title={ translate( 'Web server settings' ) }
+		>
 			<QuerySiteGeoAffinity siteId={ siteId } />
 			<QuerySitePhpVersion siteId={ siteId } />
 			<QuerySiteWpVersion siteId={ siteId } />
 			<QuerySiteStaticFile404 siteId={ siteId } />
-			<CardHeading id="web-server-settings">{ translate( 'Web server settings' ) }</CardHeading>
-			<p>
+			<HostingCardDescription>
 				{ translate(
 					'For sites with specialized needs, fine-tune how the web server runs your website.'
 				) }
-			</p>
+			</HostingCardDescription>
 			{ ! isLoading && getWpVersionContent() }
 			{ ! isLoading && getGeoAffinityContent() }
 			{ ! isLoading && getPhpVersionContent() }
 			{ ! isLoading && getStaticFile404Content() }
 			{ isLoading && getPlaceholderContent() }
-		</Card>
+		</HostingCard>
 	);
 };
 

--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -5,6 +5,7 @@ import { numberFormat } from 'i18n-calypso';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import { TimeRange } from '../../metrics-tab';
 import { TIME_RANGE_OPTIONS } from '../time-range-picker';
 
@@ -15,7 +16,7 @@ const DEFAULT_DIMENSIONS = {
 
 interface UplotChartProps {
 	title?: string;
-	subtitle?: string | React.ReactNode;
+	subtitle: string;
 	tooltip?: string | React.ReactNode;
 	className?: string;
 	data: uPlot.AlignedData;
@@ -267,11 +268,8 @@ export const SiteMonitoringLineChart = ( {
 	}
 
 	return (
-		<div className={ classnames( classes ) }>
-			<header className="site-monitoring__chart-header">
-				<h2 className="site-monitoring__chart-title">{ title }</h2>
-				{ subtitle && <p className="site-monitoring__chart-subtitle">{ subtitle }</p> }
-			</header>
+		<HostingCard className={ classnames( classes ) } title={ title }>
+			<HostingCardDescription>{ subtitle }</HostingCardDescription>
 			<div ref={ uplotContainer }>
 				{ isLoading && <Spinner /> }
 				<UplotReact
@@ -280,6 +278,6 @@ export const SiteMonitoringLineChart = ( {
 					options={ options }
 				/>
 			</div>
-		</div>
+		</HostingCard>
 	);
 };

--- a/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/index.tsx
@@ -1,5 +1,6 @@
 import { Spinner } from '@wordpress/components';
 import classnames from 'classnames';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import PieChart from 'calypso/components/pie-chart';
 import PieChartLegend from 'calypso/components/pie-chart/legend';
 
@@ -7,7 +8,7 @@ import './style.scss';
 
 type Props = {
 	title: string;
-	subtitle?: string | React.ReactNode;
+	subtitle: string;
 	className?: string;
 	data: Array< {
 		name: string;
@@ -31,16 +32,13 @@ export const SiteMonitoringPieChart = ( {
 	}
 
 	return (
-		<div className={ classnames( classes ) }>
-			<header className="site-monitoring__chart-header">
-				<h2 className="site-monitoring__chart-title">{ title }</h2>
-				{ subtitle && <p className="site-monitoring__chart-subtitle">{ subtitle }</p> }
-			</header>
+		<HostingCard className={ classnames( classes ) } title={ title }>
+			<HostingCardDescription>{ subtitle }</HostingCardDescription>
 			<div className="site-monitoring__chart-container">
 				{ ! data.length ? <Spinner /> : null }
 				<PieChart data={ data } donut startAngle={ 0 } />
 			</div>
 			<PieChartLegend data={ data } onlyPercent fixedOrder={ fixedOrder } />
-		</div>
+		</HostingCard>
 	);
 };

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -70,11 +70,6 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 	.site-monitoring__chart {
 		border: 0;
 		padding: 0;
-		margin: 0 -24px 24px -50px;
-
-		.site-monitoring__chart-header {
-			padding: 0 24px 0 50px;
-		}
 	}
 
 	.u-legend {
@@ -91,11 +86,6 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 			align-items: center;
 		}
 	}
-
-	.site-monitoring__chart-header {
-		margin-bottom: 12px;
-	}
-
 }
 
 .site-monitoring {

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -6,10 +6,10 @@ import styled from '@emotion/styled';
 import { useTranslate, localize } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
@@ -106,105 +106,108 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 		}
 	};
 
-	return (
-		<>
-			{ ! isHosting && (
-				<SettingsSectionHeader
-					id="admin-interface-style"
-					disabled={ isUpdating }
-					isSaving={ isUpdating }
-					onButtonClick={ () => handleSubmitForm( selectedAdminInterface ) }
-					showButton
-					title={ translate(
-						'Admin interface style {{infoPopover}} Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}. {{/infoPopover}}',
+	const renderForm = () => {
+		return (
+			<>
+				<FormFieldset>
+					<FormLabel>
+						<FormRadioStyled
+							label={ translate( 'Classic style' ) }
+							name="wpcom_admin_interface"
+							value="wp-admin"
+							checked={ selectedAdminInterface === 'wp-admin' }
+							onChange={ ( event ) => handleInputChange( event.target.value ) }
+							disabled={ isUpdating }
+						/>
+					</FormLabel>
+					<FormSettingExplanation>
+						{ hasEnTranslation( 'Use WP-Admin to manage your site.' )
+							? translate( 'Use WP-Admin to manage your site.' )
+							: translate( 'The classic WP-Admin WordPress interface.' ) }
+					</FormSettingExplanation>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						<FormRadioStyled
+							label={ translate( 'Default style' ) }
+							name="wpcom_admin_interface"
+							value="calypso"
+							checked={ selectedAdminInterface === 'calypso' }
+							onChange={ ( event ) => handleInputChange( event.target.value ) }
+							disabled={ isUpdating }
+						/>
+					</FormLabel>
+					<FormSettingExplanation>
+						{ hasEnTranslation( 'Use WordPress.com’s legacy dashboard to manage your site.' )
+							? translate( 'Use WordPress.com’s legacy dashboard to manage your site.' )
+							: translate( 'The WordPress.com redesign for a better experience.' ) }
+					</FormSettingExplanation>
+				</FormFieldset>
+			</>
+		);
+	};
+
+	if ( isHosting ) {
+		return (
+			<HostingCard
+				className="admin-interface-style-card"
+				headingId="admin-interface-style"
+				title={ translate( 'Admin interface style' ) }
+			>
+				<HostingCardDescription>
+					{ translate(
+						'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
 						{
 							components: {
 								supportLink: (
 									<InlineSupportLink supportContext="admin-interface-style" showIcon={ false } />
 								),
-								infoPopover: <InfoPopover position="bottom right" />,
 							},
-							comment: 'The header of the Admin interface style setting',
 						}
 					) }
-				/>
-			) }
-			<Card className="admin-interface-style-card">
-				{ isHosting && (
-					<>
-						<CardHeading id="admin-interface-style" size={ 20 }>
-							{ translate( 'Admin interface style' ) }
-						</CardHeading>
-						<p>
-							{ translate(
-								'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
-								{
-									components: {
-										supportLink: (
-											<InlineSupportLink
-												supportContext="admin-interface-style"
-												showIcon={ false }
-											/>
-										),
-									},
-								}
-							) }
-						</p>
-						{ isEnabled( 'layout/dotcom-nav-redesign-v2' ) && (
-							<p className="form-setting-explanation">
-								{ translate( 'This setting has now moved to {{a}}Settings → General{{/a}}.', {
-									components: {
-										a: (
-											<a
-												href={ `/settings/general/${ siteSlug }#admin-interface-style` }
-												rel="noreferrer"
-											/>
-										),
-									},
-								} ) }
-							</p>
-						) }
-					</>
+				</HostingCardDescription>
+				{ isEnabled( 'layout/dotcom-nav-redesign-v2' ) ? (
+					<p className="form-setting-explanation">
+						{ translate( 'This setting has now moved to {{a}}Settings → General{{/a}}.', {
+							components: {
+								a: (
+									<a
+										href={ `/settings/general/${ siteSlug }#admin-interface-style` }
+										rel="noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</p>
+				) : (
+					renderForm()
 				) }
-				{ ( ! isHosting || ! isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) && (
-					<>
-						<FormFieldset>
-							<FormLabel>
-								<FormRadioStyled
-									label={ translate( 'Classic style' ) }
-									name="wpcom_admin_interface"
-									value="wp-admin"
-									checked={ selectedAdminInterface === 'wp-admin' }
-									onChange={ ( event ) => handleInputChange( event.target.value ) }
-									disabled={ isUpdating }
-								/>
-							</FormLabel>
-							<FormSettingExplanation>
-								{ hasEnTranslation( 'Use WP-Admin to manage your site.' )
-									? translate( 'Use WP-Admin to manage your site.' )
-									: translate( 'The classic WP-Admin WordPress interface.' ) }
-							</FormSettingExplanation>
-						</FormFieldset>
-						<FormFieldset>
-							<FormLabel>
-								<FormRadioStyled
-									label={ translate( 'Default style' ) }
-									name="wpcom_admin_interface"
-									value="calypso"
-									checked={ selectedAdminInterface === 'calypso' }
-									onChange={ ( event ) => handleInputChange( event.target.value ) }
-									disabled={ isUpdating }
-								/>
-							</FormLabel>
-							<FormSettingExplanation>
-								{ hasEnTranslation( 'Use WordPress.com’s legacy dashboard to manage your site.' )
-									? translate( 'Use WordPress.com’s legacy dashboard to manage your site.' )
-									: translate( 'The WordPress.com redesign for a better experience.' ) }
-							</FormSettingExplanation>
-						</FormFieldset>
-					</>
+			</HostingCard>
+		);
+	}
+
+	return (
+		<>
+			<SettingsSectionHeader
+				id="admin-interface-style"
+				disabled={ isUpdating }
+				isSaving={ isUpdating }
+				onButtonClick={ () => handleSubmitForm( selectedAdminInterface ) }
+				showButton
+				title={ translate(
+					'Admin interface style {{infoPopover}} Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}. {{/infoPopover}}',
+					{
+						components: {
+							supportLink: (
+								<InlineSupportLink supportContext="admin-interface-style" showIcon={ false } />
+							),
+							infoPopover: <InfoPopover position="bottom right" />,
+						},
+						comment: 'The header of the Admin interface style setting',
+					}
 				) }
-			</Card>
+			/>
+			<Card>{ renderForm() }</Card>
 		</>
 	);
 };


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/7102

## Proposed Changes

This PR updates the styles of the title and description of the cards in the site management panel (except GitHub Deployments) as described in the issue above.

This is done by introducing a new `<HostingCard />` component.

|Before|After|
|-|-|
|Overview<br><br><img width="858" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/60c42dc0-a4ab-4d97-8ae6-70757091f479">|Overview<br><br><img width="897" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/a497961e-fd21-4c51-936a-e42d71a5ff59">|
|Hosting Config<br><br><img width="901" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/44695e33-8c7b-401f-9665-6c7a5886e47e"><br><img width="728" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/e1127632-4081-4a57-944c-3821273ae723"><br><img width="902" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/6406ab35-1b23-4536-9172-6dfa7e944e88">|Hosting Config<br><br><img width="949" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/d16f0857-2798-4be5-94d3-de81c22e1fc9"><br><img width="955" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/945afe7a-60f6-4c7c-a1fd-e55c500010e2"><br><img width="949" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/541296c9-9f3f-40eb-a00b-29bca9f7e325">|
|Monitoring<br><br><img width="689" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/a7798b75-0ee4-4fa9-b1e3-8692dccbd08e"><br><img width="688" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/e32bf455-5790-4e26-9b8c-fdd72379b6e9">|Monitoring<br><br><img width="728" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/451811ae-28a2-47ff-b550-ffbfdf9f2d68"><br><img width="727" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/6d270890-ce59-401b-b0c5-40e9517ba49d">|



## Why are these changes being made?

We want to unify the look of each card in the site management panel.

## Testing Instructions

1. Go to /sites
2. Select an Atomic site
3. Verify the tabs as shown above 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
