### PR TITLE
Plans: Restructure feature-group rendering for the Features Grid - include "storage" and "all features"

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -11,10 +11,12 @@ import {
 	UrlFriendlyTermType,
 	isValidFeatureKey,
 	getFeaturesList,
-	getWooExpressFeaturesGrouped,
-	getPlanFeaturesGrouped,
 	isWooExpressPlan,
 	PLAN_ECOMMERCE,
+	getPlanFeaturesGroupedForFeaturesGrid,
+	getWooExpressFeaturesGroupedForComparisonGrid,
+	getPlanFeaturesGroupedForComparisonGrid,
+	getWooExpressFeaturesGroupedForFeaturesGrid,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -618,6 +620,9 @@ const PlansFeaturesMain = ( {
 		retargetViewPlans();
 	}, [] );
 
+	/**
+	 * TODO: `handleStorageAddOnClick` no longer necessary. Tracking can be done from the grid components directly.
+	 */
 	const handleStorageAddOnClick = useCallback(
 		( addOnSlug: WPComStorageAddOnSlug ) =>
 			recordTracksEvent( 'calypso_signup_storage_add_on_dropdown_option_click', {
@@ -672,9 +677,13 @@ const PlansFeaturesMain = ( {
 	}, [ gridPlansForComparisonGrid ] );
 
 	// If we have a Woo Express plan, use the Woo Express feature groups, otherwise use the regular feature groups.
-	const featureGroupMap = hasWooExpressFeatures
-		? getWooExpressFeaturesGrouped()
-		: getPlanFeaturesGrouped();
+	const featureGroupMapForComparisonGrid = hasWooExpressFeatures
+		? getWooExpressFeaturesGroupedForComparisonGrid()
+		: getPlanFeaturesGroupedForComparisonGrid();
+
+	const featureGroupMapForFeaturesGrid = hasWooExpressFeatures
+		? getWooExpressFeaturesGroupedForFeaturesGrid()
+		: getPlanFeaturesGroupedForFeaturesGrid();
 
 	return (
 		<>
@@ -792,7 +801,7 @@ const PlansFeaturesMain = ( {
 										useAction={ useAction }
 										enableFeatureTooltips={ ! isTrailMapCopy }
 										enableCategorisedFeatures={ isTrailMapStructure }
-										featureGroupMap={ isTrailMapStructure ? featureGroupMap : undefined }
+										featureGroupMap={ featureGroupMapForFeaturesGrid }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && (
@@ -868,7 +877,7 @@ const PlansFeaturesMain = ( {
 														useCheckPlanAvailabilityForPurchase
 													}
 													enableFeatureTooltips={ ! isTrailMapCopy }
-													featureGroupMap={ featureGroupMap }
+													featureGroupMap={ featureGroupMapForComparisonGrid }
 													hideUnsupportedFeatures={ isTrailMapStructure }
 												/>
 											) }

--- a/packages/calypso-products/src/constants/feature-group.ts
+++ b/packages/calypso-products/src/constants/feature-group.ts
@@ -25,3 +25,6 @@ export const FEATURE_GROUP_PAYMENTS = 'feature-group-payments';
 export const FEATURE_GROUP_MARKETING_EMAIL = 'feature-group-marketing-email';
 export const FEATURE_GROUP_SHIPPING = 'feature-group-shipping';
 /* END: Woo Express Feature Groups */
+
+export const FEATURE_GROUP_STORAGE = 'feature-group-storage';
+export const FEATURE_GROUP_ALL_FEATURES = 'feature-group-all-freatures';

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -52,6 +52,7 @@ import {
 	FEATURE_GITHUB_DEPLOYMENTS,
 	FEATURE_GLOBAL_EDGE_CACHING,
 	FEATURE_GOOGLE_ANALYTICS_V3,
+	FEATURE_GROUP_ALL_FEATURES,
 	FEATURE_GROUP_DEVELOPER_TOOLS,
 	FEATURE_GROUP_ECOMMERCE,
 	FEATURE_GROUP_ESSENTIAL_FEATURES,
@@ -64,6 +65,7 @@ import {
 	FEATURE_GROUP_PRODUCTS,
 	FEATURE_GROUP_SECURITY_AND_SAFETY,
 	FEATURE_GROUP_SHIPPING,
+	FEATURE_GROUP_STORAGE,
 	FEATURE_GROUP_SUPERIOR_COMMERCE_SOLUTIONS,
 	FEATURE_GROUP_SUPPORT,
 	FEATURE_GROUP_THEMES_AND_CUSTOMIZATION,
@@ -172,6 +174,16 @@ import {
 import { FeatureGroupMap } from './types';
 
 export const featureGroups: Partial< FeatureGroupMap > = {
+	[ FEATURE_GROUP_ALL_FEATURES ]: {
+		slug: FEATURE_GROUP_ALL_FEATURES,
+		getTitle: () => null, // Intentionally null, as this is a placeholder for all features.
+		getFeatures: () => [], // This is a placeholder for now. It will not be processed, but theoretically a reference to all the features.
+	},
+	[ FEATURE_GROUP_STORAGE ]: {
+		slug: FEATURE_GROUP_STORAGE,
+		getTitle: () => i18n.translate( 'Storage' ),
+		getFeatures: () => [], // Intentionally empty for now. We will include a fixed list of feature slugs in a follow-up.
+	},
 	/* START: Plans 2023 Feature Group (To be deleted after pau2Xa-5Ol-P2 if trail map wins) */
 	[ FEATURE_GROUP_ESSENTIAL_FEATURES ]: {
 		slug: FEATURE_GROUP_ESSENTIAL_FEATURES,
@@ -585,9 +597,28 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 	/* START: WooExpress Feature Groups */
 };
 
-export function resolvePlansGridFeatureGroups(): Partial< FeatureGroupMap > {
+export function resolveFeatureGroupsForFeaturesGrid(): Partial< FeatureGroupMap > {
 	if ( isTrailMapAnyVariant() ) {
 		return {
+			[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
+			[ FEATURE_GROUP_WEBSITE_BUILDING ]: featureGroups[ FEATURE_GROUP_WEBSITE_BUILDING ],
+			[ FEATURE_GROUP_MANAGED_WP_HOSTING ]: featureGroups[ FEATURE_GROUP_MANAGED_WP_HOSTING ],
+			[ FEATURE_GROUP_DEVELOPER_TOOLS ]: featureGroups[ FEATURE_GROUP_DEVELOPER_TOOLS ],
+			[ FEATURE_GROUP_ECOMMERCE ]: featureGroups[ FEATURE_GROUP_ECOMMERCE ],
+			[ FEATURE_GROUP_SUPPORT ]: featureGroups[ FEATURE_GROUP_SUPPORT ],
+		};
+	}
+
+	return {
+		[ FEATURE_GROUP_ALL_FEATURES ]: featureGroups[ FEATURE_GROUP_ALL_FEATURES ],
+		[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
+	};
+}
+
+export function resolveFeatureGroupsForComparisonGrid(): Partial< FeatureGroupMap > {
+	if ( isTrailMapCopyVariant() ) {
+		return {
+			[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
 			[ FEATURE_GROUP_WEBSITE_BUILDING ]: featureGroups[ FEATURE_GROUP_WEBSITE_BUILDING ],
 			[ FEATURE_GROUP_MANAGED_WP_HOSTING ]: featureGroups[ FEATURE_GROUP_MANAGED_WP_HOSTING ],
 			[ FEATURE_GROUP_DEVELOPER_TOOLS ]: featureGroups[ FEATURE_GROUP_DEVELOPER_TOOLS ],
@@ -608,10 +639,11 @@ export function resolvePlansGridFeatureGroups(): Partial< FeatureGroupMap > {
 			featureGroups[ FEATURE_GROUP_SUPERIOR_COMMERCE_SOLUTIONS ],
 		[ FEATURE_GROUP_MARKETING_GROWTH_AND_MONETIZATION_TOOLS ]:
 			featureGroups[ FEATURE_GROUP_MARKETING_GROWTH_AND_MONETIZATION_TOOLS ],
+		[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
 	};
 }
 
-export function resolveWooExpressFeaturesGrouped(): Partial< FeatureGroupMap > {
+export function resolveWooExpressFeatureGroupsForComparisonGrid(): Partial< FeatureGroupMap > {
 	return {
 		[ FEATURE_GROUP_YOUR_STORE ]: featureGroups[ FEATURE_GROUP_YOUR_STORE ],
 		[ FEATURE_GROUP_PRODUCTS ]: featureGroups[ FEATURE_GROUP_PRODUCTS ],

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -598,7 +598,7 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 };
 
 export function resolveFeatureGroupsForFeaturesGrid(): Partial< FeatureGroupMap > {
-	if ( isTrailMapAnyVariant() ) {
+	if ( isTrailMapStructureVariant() ) {
 		return {
 			[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
 			[ FEATURE_GROUP_WEBSITE_BUILDING ]: featureGroups[ FEATURE_GROUP_WEBSITE_BUILDING ],

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -616,7 +616,7 @@ export function resolveFeatureGroupsForFeaturesGrid(): Partial< FeatureGroupMap 
 }
 
 export function resolveFeatureGroupsForComparisonGrid(): Partial< FeatureGroupMap > {
-	if ( isTrailMapCopyVariant() ) {
+	if ( isTrailMapAnyVariant() ) {
 		return {
 			[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
 			[ FEATURE_GROUP_WEBSITE_BUILDING ]: featureGroups[ FEATURE_GROUP_WEBSITE_BUILDING ],

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -45,8 +45,9 @@ import {
 	WOO_EXPRESS_PLANS,
 } from './constants';
 import {
-	resolvePlansGridFeatureGroups,
-	resolveWooExpressFeaturesGrouped,
+	resolveFeatureGroupsForComparisonGrid,
+	resolveFeatureGroupsForFeaturesGrid,
+	resolveWooExpressFeatureGroupsForComparisonGrid,
 } from './feature-group-plan-map';
 import { FEATURES_LIST } from './features-list';
 import { PLANS_LIST } from './plans-list';
@@ -77,12 +78,21 @@ export function getPlans(): Record< string, Plan > {
 	return PLANS_LIST;
 }
 
-export function getPlanFeaturesGrouped(): Partial< FeatureGroupMap > {
-	return resolvePlansGridFeatureGroups();
+export function getPlanFeaturesGroupedForFeaturesGrid(): Partial< FeatureGroupMap > {
+	return resolveFeatureGroupsForFeaturesGrid();
 }
 
-export function getWooExpressFeaturesGrouped(): Partial< FeatureGroupMap > {
-	return resolveWooExpressFeaturesGrouped();
+export function getPlanFeaturesGroupedForComparisonGrid(): Partial< FeatureGroupMap > {
+	return resolveFeatureGroupsForComparisonGrid();
+}
+
+export function getWooExpressFeaturesGroupedForFeaturesGrid(): Partial< FeatureGroupMap > {
+	// Same as getPlanFeaturesGroupedForFeaturesGrid() for now
+	return getPlanFeaturesGroupedForFeaturesGrid();
+}
+
+export function getWooExpressFeaturesGroupedForComparisonGrid(): Partial< FeatureGroupMap > {
+	return resolveWooExpressFeatureGroupsForComparisonGrid();
 }
 
 export function getPlansSlugs(): string[] {

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -37,6 +37,8 @@ import {
 	FEATURE_GROUP_MANAGED_WP_HOSTING,
 	FEATURE_GROUP_ECOMMERCE,
 	FEATURE_GROUP_SUPPORT,
+	FEATURE_GROUP_STORAGE,
+	FEATURE_GROUP_ALL_FEATURES,
 } from './constants';
 import { PriceTierEntry } from './get-price-tier-for-units';
 import type { TranslateResult } from 'i18n-calypso';
@@ -240,7 +242,9 @@ export type FeatureGroupSlug =
 	| typeof FEATURE_GROUP_PRODUCTS
 	| typeof FEATURE_GROUP_PAYMENTS
 	| typeof FEATURE_GROUP_MARKETING_EMAIL
-	| typeof FEATURE_GROUP_SHIPPING;
+	| typeof FEATURE_GROUP_SHIPPING
+	| typeof FEATURE_GROUP_STORAGE
+	| typeof FEATURE_GROUP_ALL_FEATURES;
 
 export interface FeatureFootnotes {
 	[ key: string ]: Feature[];
@@ -248,7 +252,7 @@ export interface FeatureFootnotes {
 
 export type FeatureGroup = {
 	slug: FeatureGroupSlug;
-	getTitle: () => string;
+	getTitle: () => string | null;
 	getFeatures: () => Feature[];
 	/**
 	 * This optionally returns an object containing footnotes and the features that should display the footnote.

--- a/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
@@ -1,7 +1,7 @@
 import {
 	TrailMapVariantType,
 	getFeaturesList,
-	getPlanFeaturesGrouped,
+	getPlanFeaturesGroupedForComparisonGrid,
 	setTrailMapExperiment,
 } from '@automattic/calypso-products';
 import { ComparisonGrid, ComparisonGridExternalProps, useGridPlansForComparisonGrid } from '../..';
@@ -39,7 +39,7 @@ const ComponentWrapper = (
 			<ComparisonGrid
 				{ ...props }
 				gridPlans={ gridPlans }
-				featureGroupMap={ getPlanFeaturesGrouped() }
+				featureGroupMap={ getPlanFeaturesGroupedForComparisonGrid() }
 			/>
 		)
 	);
@@ -49,7 +49,7 @@ const defaultProps = {
 	allFeaturesList: getFeaturesList(),
 	coupon: undefined,
 	currentSitePlanSlug: undefined,
-	featureGroupMap: getPlanFeaturesGrouped(),
+	featureGroupMap: getPlanFeaturesGroupedForComparisonGrid(),
 	hideUnavailableFeatures: false,
 	intervalType: 'yearly',
 	isInAdmin: false,

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -1,7 +1,7 @@
 import {
 	TrailMapVariantType,
 	getFeaturesList,
-	getPlanFeaturesGrouped,
+	getPlanFeaturesGroupedForFeaturesGrid,
 	setTrailMapExperiment,
 } from '@automattic/calypso-products';
 import {
@@ -54,7 +54,7 @@ const ComponentWrapper = (
 				gridPlanForSpotlight={
 					'gridPlanForSpotlight' in props ? props.gridPlanForSpotlight : gridPlanForSpotlight
 				}
-				featureGroupMap={ props.enableCategorisedFeatures ? getPlanFeaturesGrouped() : undefined }
+				featureGroupMap={ getPlanFeaturesGroupedForFeaturesGrid() }
 			/>
 		)
 	);

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -4,6 +4,7 @@ import {
 	isFreePlan,
 	type WPComStorageAddOnSlug,
 	type FeatureGroupSlug,
+	FEATURE_GROUP_STORAGE,
 } from '@automattic/calypso-products';
 import { FoldableCard } from '@automattic/components';
 import { useMemo } from '@wordpress/element';
@@ -76,8 +77,10 @@ const MobileView = ( {
 	const { enableCategorisedFeatures, featureGroupMap } = usePlansGridContext();
 	const featureGroups = useMemo(
 		() =>
-			enableCategorisedFeatures ? ( Object.keys( featureGroupMap ) as FeatureGroupSlug[] ) : [],
-		[ enableCategorisedFeatures, featureGroupMap ]
+			Object.keys( featureGroupMap ).filter(
+				( key ) => FEATURE_GROUP_STORAGE !== key
+			) as FeatureGroupSlug[],
+		[ featureGroupMap ]
 	);
 
 	return renderedGridPlans
@@ -111,7 +114,7 @@ const MobileView = ( {
 					{ isNotFreePlan && <BillingTimeframes renderedGridPlans={ [ gridPlan ] } /> }
 					<MobileFreeDomain gridPlan={ gridPlan } paidDomainName={ paidDomainName } />
 					<PlanStorageOptions
-						renderedGridPlans={ [ gridPlan ] }
+						planSlug={ gridPlan.planSlug }
 						intervalType={ intervalType }
 						onStorageAddOnClick={ onStorageAddOnClick }
 						showUpgradeableStorage={ showUpgradeableStorage }
@@ -135,26 +138,14 @@ const MobileView = ( {
 						}
 					>
 						<PartnerLogos renderedGridPlans={ [ gridPlan ] } />
-						{ enableCategorisedFeatures ? (
-							featureGroups.map( ( featureGroupSlug ) => (
-								<div
-									className="plans-grid-next-features-grid__feature-group-row"
-									key={ featureGroupSlug }
-								>
-									<PlanFeaturesList
-										renderedGridPlans={ [ gridPlan ] }
-										selectedFeature={ selectedFeature }
-										paidDomainName={ paidDomainName }
-										hideUnavailableFeatures={ hideUnavailableFeatures }
-										generatedWPComSubdomain={ generatedWPComSubdomain }
-										isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-										featureGroupSlug={ featureGroupSlug }
-									/>
-								</div>
-							) )
-						) : (
-							<>
-								<PreviousFeaturesIncludedTitle renderedGridPlans={ [ gridPlan ] } />
+						{ ! enableCategorisedFeatures && (
+							<PreviousFeaturesIncludedTitle renderedGridPlans={ [ gridPlan ] } />
+						) }
+						{ featureGroups.map( ( featureGroupSlug ) => (
+							<div
+								className="plans-grid-next-features-grid__feature-group-row"
+								key={ featureGroupSlug }
+							>
 								<PlanFeaturesList
 									renderedGridPlans={ [ gridPlan ] }
 									selectedFeature={ selectedFeature }
@@ -162,9 +153,13 @@ const MobileView = ( {
 									hideUnavailableFeatures={ hideUnavailableFeatures }
 									generatedWPComSubdomain={ generatedWPComSubdomain }
 									isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+									featureGroupSlug={ featureGroupSlug }
+									intervalType={ intervalType }
+									onStorageAddOnClick={ onStorageAddOnClick }
+									showUpgradeableStorage={ showUpgradeableStorage }
 								/>
-							</>
-						) }
+							</div>
+						) ) }
 					</CardContainer>
 				</div>
 			);

--- a/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
@@ -21,7 +21,7 @@ type PlanFeaturesListProps = {
 	/**
 	 * Used to show a wpcom free domain in the Free plan column when a paid domain is picked.
 	 */
-	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
+	generatedWPComSubdomain?: DataResponse< { domain_name: string } >;
 	/**
 	 * Used to hide features that are not available, instead of strike-through as explained in #76206
 	 */
@@ -29,7 +29,7 @@ type PlanFeaturesListProps = {
 	/**
 	 * Indicates when a custom domain is allowed to be used with the Free plan.
 	 */
-	isCustomDomainAllowedOnFreePlan: boolean;
+	isCustomDomainAllowedOnFreePlan?: boolean;
 	paidDomainName?: string;
 	renderedGridPlans: GridPlan[];
 	selectedFeature?: string;

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -1,11 +1,16 @@
-import { WPComStorageAddOnSlug, getPlanClass, isFreePlan } from '@automattic/calypso-products';
+import {
+	FEATURE_GROUP_STORAGE,
+	WPComStorageAddOnSlug,
+	getPlanClass,
+	isFreePlan,
+} from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { GridPlan, PlanActionOverrides } from '../../types';
 import BillingTimeframes from './billing-timeframes';
+import PlanFeaturesList from './plan-features-list';
 import PlanHeaders from './plan-headers';
 import PlanLogos from './plan-logos';
 import PlanPrice from './plan-price';
-import PlanStorageOptions from './plan-storage-options';
 import PlanTagline from './plan-tagline';
 import TopButtons from './top-buttons';
 
@@ -57,8 +62,9 @@ const SpotlightPlan = ( {
 				/>
 			) }
 			{ isNotFreePlan && <BillingTimeframes renderedGridPlans={ [ gridPlanForSpotlight ] } /> }
-			<PlanStorageOptions
-				planSlug={ gridPlanForSpotlight.planSlug }
+			<PlanFeaturesList
+				renderedGridPlans={ [ gridPlanForSpotlight ] }
+				featureGroupSlug={ FEATURE_GROUP_STORAGE }
 				intervalType={ intervalType }
 				onStorageAddOnClick={ onStorageAddOnClick }
 				showUpgradeableStorage={ showUpgradeableStorage }

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -58,7 +58,7 @@ const SpotlightPlan = ( {
 			) }
 			{ isNotFreePlan && <BillingTimeframes renderedGridPlans={ [ gridPlanForSpotlight ] } /> }
 			<PlanStorageOptions
-				renderedGridPlans={ [ gridPlanForSpotlight ] }
+				planSlug={ gridPlanForSpotlight.planSlug }
 				intervalType={ intervalType }
 				onStorageAddOnClick={ onStorageAddOnClick }
 				showUpgradeableStorage={ showUpgradeableStorage }

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -10,7 +10,6 @@ import PlanFeaturesList from './plan-features-list';
 import PlanHeaders from './plan-headers';
 import PlanLogos from './plan-logos';
 import PlanPrice from './plan-price';
-import PlanStorageOptions from './plan-storage-options';
 import PlanTagline from './plan-tagline';
 import PreviousFeaturesIncludedTitle from './previous-features-included-title';
 import TopButtons from './top-buttons';
@@ -59,9 +58,8 @@ const Table = ( {
 	const translate = useTranslate();
 	const { enableCategorisedFeatures, featureGroupMap } = usePlansGridContext();
 	const featureGroups = useMemo(
-		() =>
-			enableCategorisedFeatures ? ( Object.keys( featureGroupMap ) as FeatureGroupSlug[] ) : [],
-		[ enableCategorisedFeatures, featureGroupMap ]
+		() => Object.keys( featureGroupMap ) as FeatureGroupSlug[],
+		[ featureGroupMap ]
 	);
 	// Do not render the spotlight plan if it exists
 	const gridPlansWithoutSpotlight = useMemo(
@@ -147,65 +145,36 @@ const Table = ( {
 						options={ { isTableCell: true } }
 					/>
 				</tr>
-				{ enableCategorisedFeatures ? (
-					<>
-						<tr className="plans-grid-next-features-grid__feature-group-row is-first-feature-group-row">
-							<PlanStorageOptions
-								renderedGridPlans={ gridPlansWithoutSpotlight }
-								options={ { isTableCell: true } }
-								intervalType={ intervalType }
-								onStorageAddOnClick={ onStorageAddOnClick }
-								showUpgradeableStorage={ showUpgradeableStorage }
-							/>
-						</tr>
-						{ featureGroups.map( ( featureGroupSlug ) => (
-							<tr
-								className="plans-grid-next-features-grid__feature-group-row"
-								key={ featureGroupSlug }
-							>
-								<PlanFeaturesList
-									renderedGridPlans={ gridPlansWithoutSpotlight }
-									options={ { isTableCell: true } }
-									paidDomainName={ paidDomainName }
-									hideUnavailableFeatures={ hideUnavailableFeatures }
-									selectedFeature={ selectedFeature }
-									generatedWPComSubdomain={ generatedWPComSubdomain }
-									isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-									featureGroupSlug={ featureGroupSlug }
-								/>
-							</tr>
-						) ) }
-					</>
-				) : (
-					<>
-						<tr>
-							<PreviousFeaturesIncludedTitle
-								renderedGridPlans={ gridPlansWithoutSpotlight }
-								options={ { isTableCell: true } }
-							/>
-						</tr>
-						<tr>
-							<PlanFeaturesList
-								renderedGridPlans={ gridPlansWithoutSpotlight }
-								options={ { isTableCell: true } }
-								paidDomainName={ paidDomainName }
-								hideUnavailableFeatures={ hideUnavailableFeatures }
-								selectedFeature={ selectedFeature }
-								generatedWPComSubdomain={ generatedWPComSubdomain }
-								isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-							/>
-						</tr>
-						<tr>
-							<PlanStorageOptions
-								renderedGridPlans={ gridPlansWithoutSpotlight }
-								options={ { isTableCell: true } }
-								intervalType={ intervalType }
-								onStorageAddOnClick={ onStorageAddOnClick }
-								showUpgradeableStorage={ showUpgradeableStorage }
-							/>
-						</tr>
-					</>
+				{ ! enableCategorisedFeatures && (
+					<tr>
+						<PreviousFeaturesIncludedTitle
+							renderedGridPlans={ gridPlansWithoutSpotlight }
+							options={ { isTableCell: true } }
+						/>
+					</tr>
 				) }
+				{ featureGroups.map( ( featureGroupSlug, featureGroupIndex ) => (
+					<tr
+						className={ classNames( 'plans-grid-next-features-grid__feature-group-row', {
+							'is-first-feature-group-row': featureGroupIndex === 0,
+						} ) }
+						key={ featureGroupSlug }
+					>
+						<PlanFeaturesList
+							renderedGridPlans={ gridPlansWithoutSpotlight }
+							options={ { isTableCell: true } }
+							paidDomainName={ paidDomainName }
+							hideUnavailableFeatures={ hideUnavailableFeatures }
+							selectedFeature={ selectedFeature }
+							generatedWPComSubdomain={ generatedWPComSubdomain }
+							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+							featureGroupSlug={ featureGroupSlug }
+							intervalType={ intervalType }
+							onStorageAddOnClick={ onStorageAddOnClick }
+							showUpgradeableStorage={ showUpgradeableStorage }
+						/>
+					</tr>
+				) ) }
 			</tbody>
 		</table>
 	);

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -24,11 +24,11 @@ const SubdomainSuggestion = styled.div`
 
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
-	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
-	isCustomDomainAllowedOnFreePlan: boolean;
+	generatedWPComSubdomain?: DataResponse< { domain_name: string } >;
+	isCustomDomainAllowedOnFreePlan?: boolean;
 } > = ( { paidDomainName, generatedWPComSubdomain, isCustomDomainAllowedOnFreePlan } ) => {
 	const translate = useTranslate();
-	const isLoading = generatedWPComSubdomain.isLoading;
+	const isLoading = generatedWPComSubdomain?.isLoading;
 	return (
 		<SubdomainSuggestion>
 			{ isLoading && <LoadingPlaceholder /> }
@@ -43,7 +43,7 @@ const FreePlanCustomDomainFeature: React.FC< {
 				) : (
 					<>
 						<div className="is-domain-name">{ paidDomainName }</div>
-						<div>{ generatedWPComSubdomain.result?.domain_name }</div>
+						<div>{ generatedWPComSubdomain?.result?.domain_name }</div>
 					</>
 				) ) }
 		</SubdomainSuggestion>
@@ -54,10 +54,10 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planSlug: string;
 	paidDomainName?: string;
-	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
+	generatedWPComSubdomain?: DataResponse< { domain_name: string } >;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
-	isCustomDomainAllowedOnFreePlan: boolean;
+	isCustomDomainAllowedOnFreePlan?: boolean;
 	activeTooltipId: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 } > = ( {

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -22,10 +22,6 @@ interface PlansGridContext {
 	 * for rendering features with categories based on available/associated feature group map.
 	 */
 	enableCategorisedFeatures?: boolean;
-	/**
-	 * `featureGroupMap` is relevant for rendering features with categories.
-	 * This is necessary for Comparison Grid and optional for Features Grid (i.e. applicable when `enableCategorisedFeatures` is set).
-	 */
 	featureGroupMap: Partial< FeatureGroupMap >;
 	hideUnsupportedFeatures?: boolean;
 }

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -370,15 +370,6 @@ $mobile-card-max-width: 440px;
 			padding-top: 14px;
 		}
 	}
-
-	/**
-	 * This is to handle storage row's internal padding
-	 */
-	&.is-first-feature-group-row > .plan-features-2023-grid__storage {
-		@include plans-grid-medium-large {
-			padding-bottom: 12px;
-		}
-	}
 }
 
 .plan-features-2023-grid__item-info {
@@ -450,6 +441,9 @@ $mobile-card-max-width: 440px;
 
 		& .plan-features-2023-grid__item-info-container {
 			display: flex;
+			.plan-features-2023-grid__storage & {
+				display: block;
+			}
 		}
 	}
 
@@ -634,13 +628,7 @@ $mobile-card-max-width: 440px;
 			padding: 24px 0 6px 20px;
 		}
 
-		&.plan-features-2023-grid__storage {
-			padding: 24px 20px 38px 20px;
-
-			.plan-features-2023-grid__storage-title {
-				margin-bottom: 10px;
-			}
-
+		.plan-features-2023-grid__storage {
 			.plan-features-2023-grid__storage-buttons {
 				background: #f2f2f2;
 				/* stylelint-disable-next-line */
@@ -660,7 +648,6 @@ $mobile-card-max-width: 440px;
 			font-weight: 600;
 			font-size: $font-body-small;
 			padding: 0 20px;
-			margin-bottom: 12px;
 
 			&.is-personal-plan {
 				color: var(--studio-blue-60);

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -191,17 +191,13 @@ export type GridContextProps = {
 	children: React.ReactNode;
 	coupon?: string;
 	enableFeatureTooltips?: boolean;
-	/**
-	 * `enableCategorisedFeatures` relevant to Features Grid (and omitted from Comparison Grid)
-	 * for rendering features with categories based on available/associated feature group map.
-	 */
-	enableCategorisedFeatures?: boolean;
-	/**
-	 * `featureGroupMap` is relevant for rendering features with categories.
-	 * This is necessary for Comparison Grid and optional for Features Grid (i.e. applicable when `enableCategorisedFeatures` is set).
-	 */
 	featureGroupMap: Partial< FeatureGroupMap >;
 	hideUnsupportedFeatures?: boolean;
+	/**
+	 * `enableCategorisedFeatures` is no longer exact, and probably best to rename.
+	 * It is only used for showing "Everything in [previous] plus".
+	 */
+	enableCategorisedFeatures?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit<


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89682
Follow-up to https://github.com/Automattic/wp-calypso/pull/90486

## Proposed Changes

This PR does a couple of things to shape up the features rendering in the `FeaturesGrid` component. 
- Makes everything render within the context of a "feature group". Introduces "storage" and "all features" groups.
- The grid component is less data-gnostic with more control passed to the data layer (`calypso-products` for now).
- Follow-ups from here will aim to bring even more unity e.g. introduce storage feature slugs, define a "FeatureSlug" type, etc.
- `enableCategorisedFeatures` becomes less applicable except for rendering `Everything in [previous] plus`. We will explore renaming in a follow-up.

Some TODOs left in code to be done in follow-ups or here (they are separate but minor stuff)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is a fairly critical refactor of the Feature Grid for separating concerns (data layer being more in control) and more consistent rendering of features (not needing to treat "storage" separately, less conditioning within the grid)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- In `/start/plans` (confirm across Desktop & Mobile):
    - Trail map variants render according to design (enabled flag via `?flags=onboarding/trail-map-feature-grid[-copy, -structure]`)
    - Default/control variant renders like previously (disabled flag via `?flags=-onboarding/trail-map-feature-grid[-copy, -structure]`)
- In `/plans/[ woo express ]` (grab from `/setup/wooexpress`):
    - Confirm default/control renders like previously (should be the only variation)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
