### PR TITLE
Nav redesign: fix tab heading margin bottom

### DIFF
--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -19,6 +19,10 @@ $card-padding: 24px;
 .hosting-overview__navigation-header {
 	grid-column: 1 / -1;
 	grid-row: 1 / 2;
+
+	&.navigation-header {
+		margin-bottom: 16px;
+	}
 }
 
 .hosting-overview__plan {

--- a/client/my-sites/github-deployments/components/page-shell/index.tsx
+++ b/client/my-sites/github-deployments/components/page-shell/index.tsx
@@ -66,7 +66,6 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 			<DocumentHead title={ pageTitle } />
 			<NavigationHeader
 				compactBreadcrumb
-				css={ { paddingBottom: '40px !important' } }
 				title={ translate( 'GitHub Deployments' ) }
 				subtitle={ translate(
 					'Automate updates from GitHub to streamline workflows. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',

--- a/client/my-sites/github-deployments/components/page-shell/style.scss
+++ b/client/my-sites/github-deployments/components/page-shell/style.scss
@@ -2,3 +2,7 @@
 	background-color: var(--studio-white);
 	font-size: $font-body-small;
 }
+
+.github-deployments .navigation-header {
+	margin-bottom: 32px;
+}

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -19,6 +19,7 @@ $areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site
 	}
 
 	.navigation-header {
+		padding: 0;
 		margin-bottom: 32px;
 	}
 

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -18,6 +18,10 @@ $areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site
 		margin-bottom: 12px;
 	}
 
+	.navigation-header {
+		margin-bottom: 32px;
+	}
+
 	&--is-two-columns {
 		.hosting__layout {
 			.card {

--- a/client/my-sites/site-monitoring/components/time-range-picker/style.scss
+++ b/client/my-sites/site-monitoring/components/time-range-picker/style.scss
@@ -19,6 +19,7 @@
 .site-monitoring-time-range-picker__container {
 	display: flex;
 	justify-content: flex-end;
+	align-self: flex-start;
 	flex-direction: column;
 	gap: 10px;
 	flex-grow: 1;

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -129,7 +129,6 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: space-between;
-	margin-bottom: 24px;
 }
 
 .site-monitoring-time-controls__title {
@@ -270,4 +269,19 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 .site-monitoring__navigation-header.navigation-header {
 	width: auto;
 	padding-bottom: 0;
+	margin-bottom: 16px;
+
+	@media (max-width: $break-medium) {
+		margin-bottom: 8px;
+	}
+}
+
+.site-logs__navigation-header.navigation-header {
+	margin-bottom: 32px;
+}
+
+.site-logs-container {
+	@media (max-width: $break-small) {
+		margin-top: -12px !important;
+	}
 }

--- a/client/site-monitoring/controller.tsx
+++ b/client/site-monitoring/controller.tsx
@@ -22,6 +22,7 @@ export function siteMonitoringPhpLogs( context: PageJSContext, next: () => void 
 		<>
 			<PageViewTracker path="/site-monitoring/:site/php" title="Site Monitoring" />
 			<NavigationHeader
+				className="site-logs__navigation-header"
 				title={ translate( 'PHP Logs' ) }
 				subtitle={ translate( 'View and download PHP error logs. {{link}}Learn more.{{/link}}', {
 					components: {
@@ -41,6 +42,7 @@ export function siteMonitoringServerLogs( context: PageJSContext, next: () => vo
 		<>
 			<PageViewTracker path="/site-monitoring/:site/web" title="Site Monitoring" />
 			<NavigationHeader
+				className="site-logs__navigation-header"
 				title={ translate( 'Server Logs' ) }
 				subtitle={ translate(
 					'Gain full visibility into server activity. {{link}}Learn more.{{/link}}',

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -461,8 +461,14 @@
 	.item-preview__content {
 		padding: 32px 48px 48px;
 
+		.navigation-header {
+			padding: 0;
+		}
+
 		> * {
-			margin: 0;
+			margin-top: 0;
+			margin-left: 0;
+			margin-right: 0;
 			padding-top: 0;
 			padding-left: 0;
 			padding-right: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/7083

Follow-up of:
- https://github.com/Automattic/wp-calypso/pull/90630

## Proposed Changes

This PR fixes the margin-bottom of the heading in all tabs of the site management panel so that it follows the spec (32 px).

Unfortunately, it's not as easy as setting the margin-bottom of the `.navigation-header` component to 32px, as many pages use CSS grid which specifies `gap` which includes the header 🤦 this is the easiest solution for now without having to refactor the existing components.

## Why are these changes being made?

We missed this in the original PR.

## Testing Instructions

1. Go to /sites
2. Click an Atomic site
3. Click through the tabs, and notice the margin-bottom between the heading and the content stays the same (32 px, no jumping)
4. Test for various screen width as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
