### PR TITLE
Nav redesign: fix hosting config card gaps

### DIFF
--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -13,6 +13,11 @@ $areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site
 		min-width: 0;
 	}
 
+	.hosting-card {
+		padding-left: 22px;
+		margin-bottom: 12px;
+	}
+
 	&--is-two-columns {
 		.hosting__layout {
 			.card {
@@ -51,11 +56,6 @@ $areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site
 					box-sizing: border-box;
 					flex-basis: 30%;
 					padding-left: 8px;
-
-					.hosting-card {
-						padding-left: 22px;
-						margin-bottom: 12px;
-					}
 
 					&.hosting__main-layout-col {
 						flex-basis: 70%;

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -52,6 +52,11 @@ $areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site
 					flex-basis: 30%;
 					padding-left: 8px;
 
+					.hosting-card {
+						padding-left: 22px;
+						margin-bottom: 12px;
+					}
+
 					&.hosting__main-layout-col {
 						flex-basis: 70%;
 						padding-left: 0;


### PR DESCRIPTION
## Proposed Changes

This PR fixes the regression introduced by the following two PRs to the hosting config page (without nav redesign):

- https://github.com/Automattic/wp-calypso/pull/90671
- https://github.com/Automattic/wp-calypso/pull/90688

|Before|After|
|-|-|
|<img width="730" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/71f16c44-87e6-4461-ae33-e4b1adb65317">|<img width="727" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/72922285-dc5a-4778-b7a6-f4375d89893a">|

## Why are these changes being made?

With this, the cards in the hosting config page (before nav redesign v2 launches) will look good again.

## Testing Instructions

1. Go to `/hosting-config/:siteSlug?flags=-layout/dotcom-nav-redesign-v2`
2. Verify the layout looks good as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
