### PR TITLE
Notifications: Improve the reply experience

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -17,11 +17,11 @@ $with-sidebar-min-page-width: 1114px;
 
 	.wpnc__note-list {
 		left: auto;
-		width: 410px;
+		width: 400px;
 	}
 
 	.wpnc__single-view {
-		right: 410px;
+		right: 400px;
 		left: 10px;
 		top: 0;
 		bottom: 0;

--- a/apps/notifications/src/panel/templates/action-button.jsx
+++ b/apps/notifications/src/panel/templates/action-button.jsx
@@ -11,7 +11,11 @@ const ActionButton = ( { isActive, hotkey, icon, onToggle, text, title } ) => (
 				'inactive-action': ! isActive,
 			} ) }
 			title={ title }
-			onClick={ onToggle }
+			onClick={ ( event ) => {
+				// Prevent the notification panel from being closed.
+				event.stopPropagation();
+				onToggle();
+			} }
 		>
 			<Gridicon icon={ icon } size={ 24 } />
 			<p>{ text }</p>

--- a/apps/notifications/src/panel/templates/comment-reply-input.jsx
+++ b/apps/notifications/src/panel/templates/comment-reply-input.jsx
@@ -144,6 +144,7 @@ class CommentReplyInput extends Component {
 
 		if ( event ) {
 			event.preventDefault();
+			event.stopPropagation();
 		}
 
 		if ( '' === this.state.value ) {

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -347,28 +347,34 @@ export class NoteList extends Component {
 		};
 
 		return (
-			<div className={ classes } id="wpnc__note-list">
-				<FilterBar controller={ this.props.filterController } />
-				<button className="screen-reader-text" onClick={ this.props.closePanel }>
-					{ this.props.translate( 'Close notifications' ) }
-				</button>
-				<div ref={ this.storeScrollableContainer } className={ listViewClasses }>
-					<ol ref={ this.storeNoteList } className="wpnc__notes" { ...notificationsListAriaProps }>
-						<StatusBar
-							statusClasses={ this.state.statusClasses }
-							statusMessage={ this.state.statusMessage }
-							statusTimeout={ this.state.statusTimeout }
-							statusReset={ this.resetStatusBar }
-						/>
-						{ notes }
-						{ this.props.isLoading && (
-							<div style={ loadingIndicatorVisibility } className="wpnc__loading-indicator">
-								<Spinner />
-							</div>
-						) }
-					</ol>
+			<>
+				<StatusBar
+					statusClasses={ this.state.statusClasses }
+					statusMessage={ this.state.statusMessage }
+					statusTimeout={ this.state.statusTimeout }
+					statusReset={ this.resetStatusBar }
+				/>
+				<div className={ classes } id="wpnc__note-list">
+					<FilterBar controller={ this.props.filterController } />
+					<button className="screen-reader-text" onClick={ this.props.closePanel }>
+						{ this.props.translate( 'Close notifications' ) }
+					</button>
+					<div ref={ this.storeScrollableContainer } className={ listViewClasses }>
+						<ol
+							ref={ this.storeNoteList }
+							className="wpnc__notes"
+							{ ...notificationsListAriaProps }
+						>
+							{ notes }
+							{ this.props.isLoading && (
+								<div style={ loadingIndicatorVisibility } className="wpnc__loading-indicator">
+									<Spinner />
+								</div>
+							) }
+						</ol>
+					</div>
 				</div>
-			</div>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1715689688659609/1715641726.665509-slack-C02FMH4G8

## Proposed Changes

* Prevent the notification panel from closing right after you replied the notification. The reason was the "SEND" button changed to the loading icon so the notification didn't contain that element anymore and then closed like you clicked outside the panel
* Display the status message even when you're reading the notification so the user can see the message on mobile to know they replied successfully

https://github.com/Automattic/wp-calypso/assets/13596067/e7f59c4f-4109-4a2f-82cd-2d9f1c61ccfb

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the notification panel
* Select any mention
* Reply the notification
* Make sure the notification panel won't close right away
* Make sure the "SEND" button becomes loading so you can know the message is sending
* Make sure you can see the success status banner after the message sent successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?