### PR TITLE
Site Profiler: Show a list of insights inside a section

### DIFF
--- a/client/site-profiler/components/metrics-insights-list/index.tsx
+++ b/client/site-profiler/components/metrics-insights-list/index.tsx
@@ -1,4 +1,4 @@
-import FoldableCard from '@automattic/components/src/foldable-card';
+import { FoldableCard } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 

--- a/client/site-profiler/components/metrics-insights-list/index.tsx
+++ b/client/site-profiler/components/metrics-insights-list/index.tsx
@@ -1,0 +1,49 @@
+import FoldableCard from '@automattic/components/src/foldable-card';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+
+type MetricsInsightsListProps = {
+	insights: Insight[];
+};
+
+type Insight = {
+	header: string;
+	description: string;
+};
+
+const Container = styled.div`
+	font-family: 'SF Pro Text';
+	font-size: 16px;
+	line-height: normal;
+	letter-spacing: -0.1px;
+`;
+
+const InsightHeader = styled.div`
+	font-family: 'SF Pro Text';
+	font-size: 16px;
+`;
+
+const InsightContent = styled.div`
+	padding: 24px;
+`;
+
+export const MetricsInsightsList = ( props: MetricsInsightsListProps ) => {
+	const translate = useTranslate();
+	const { insights } = props;
+
+	return (
+		<Container className="metrics-insights-list">
+			{ insights.map( ( insight ) => (
+				<FoldableCard
+					header={ <InsightHeader>{ insight.header }</InsightHeader> }
+					screenReaderText={ translate( 'More' ) }
+					compact
+					clickableHeader
+					smooth
+				>
+					<InsightContent>{ insight.description }</InsightContent>
+				</FoldableCard>
+			) ) }
+		</Container>
+	);
+};

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -23,9 +23,10 @@ import { GetReportForm } from './get-report-form';
 import HeadingInformation from './heading-information';
 import HostingInformation from './hosting-information';
 import HostingIntro from './hosting-intro';
+import { MetricsInsightsList } from './metrics-insights-list';
 import { MetricsMenu } from './metrics-menu';
-import './styles.scss';
 import { MetricsSection } from './metrics-section';
+import './styles.scss';
 
 const debug = debugFactory( 'apps:site-profiler' );
 
@@ -185,7 +186,15 @@ export default function SiteProfiler( props: Props ) {
 								) }
 								subtitle={ translate( "Boost your site's performance" ) }
 								ref={ performanceMetricsRef }
-							/>
+							>
+								<MetricsInsightsList
+									insights={ Array( 10 ).fill( {
+										header:
+											'Your site reveals first content slower than 76% of peers, affecting first impressions.',
+										description: 'This is how you can improve it',
+									} ) }
+								/>
+							</MetricsSection>
 							<MetricsSection
 								name={ translate( 'Health Scores' ) }
 								title={ translate(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

fixes  https://github.com/Automattic/dotcom-forge/issues/6910
Depends on https://github.com/Automattic/wp-calypso/pull/90662

## Proposed Changes

Show a list of insights inside a section.
There is no layout yet for the expanded version so a simple text is being used.

## Why are these changes being made?
This is part of the effort of the Site Profiler new layout.


## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/example.com`
* Scroll down and check if the sections are displayed as below.

![CleanShot 2024-05-14 at 11 19 31@2x](https://github.com/Automattic/wp-calypso/assets/5039531/bb82e2b8-fd8f-4ae2-abac-b64c11d764a8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?