### PR TITLE
A4A: In the HostingCard style set the padding to 0 and add some specificity to ensure A4A styles.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -1,125 +1,127 @@
+.is-group-a8c-for-agencies {
+	.hosting-card {
+		border: 1px solid var(--color-neutral-10);
+		border-radius: 4px;
+		user-select: none;
+		padding: 0;
 
-.hosting-card {
-	border: 1px solid var(--color-neutral-10);
-	border-radius: 4px;
-	user-select: none;
+		.button {
+			width: 100%;
+		}
 
-	.button {
-		width: 100%;
-	}
+		.woo-logo {
+			margin: 0;
 
-	.woo-logo {
-		margin: 0;
-
-		path {
-			fill: var(--color-woocommerce);
+			path {
+				fill: var(--color-woocommerce);
+			}
 		}
 	}
-}
 
-.hosting-card__section {
-	padding: 24px;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 24px;
-
-	&:last-child:not(:first-child) {
-		border-block-start: 1px solid var(--color-neutral-5);
-	}
-}
-
-.hosting-card__price {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-}
-
-.hosting-card__price-value {
-	display: block;
-	font-size: 1.5rem;
-	font-weight: 600;
-	line-height: 1;
-	margin-bottom: 6px;
-}
-
-.hosting-card__price-interval {
-	font-size: 0.875rem;
-	line-height: 1.1;
-	font-weight: 400;
-	color: var(--studio-gray-60, #50575e);
-}
-
-.hosting-card__price-discount {
-	color: var(--color-green-40, #00a32a);
-	font-size: 0.875rem;
-	line-height: 1.75;
-}
-
-.hosting-card__description {
-	font-size: 1rem;
-	line-height: 1.3;
-	font-weight: 400;
-	min-height: 62px;
-	margin: 0;
-	color: var(--studio-gray-80, #2c3338);
-}
-
-.hosting-card__header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	width: 100%;
-	font-size: 1.5rem;
-	font-weight: 600;
-	line-height: 28px;
-
-	.badge {
+	.hosting-card__section {
+		padding: 24px;
 		display: flex;
-		background-color: #b8e6bf;
-		color: #00450c;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 24px;
 
+		&:last-child:not(:first-child) {
+			border-block-start: 1px solid var(--color-neutral-5);
+		}
 	}
-}
 
-.button .hosting-card__explore-button-content {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 4px;
-
-	.gridicon {
-		width: 16px;
-		height: 16px;
-		top: 0;
-		margin-top: 0;
+	.hosting-card__price {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
 	}
-}
 
-.hosting-card__pressable-dashboard-button {
-	svg {
-		margin-inline-start: 6px;
+	.hosting-card__price-value {
+		display: block;
+		font-size: 1.5rem;
+		font-weight: 600;
+		line-height: 1;
+		margin-bottom: 6px;
 	}
-}
 
-ul.hosting-card__features {
-	display: flex;
-	flex-direction: column;
-	list-style-type: none;
-	margin: 0;
-	padding: 0;
-}
+	.hosting-card__price-interval {
+		font-size: 0.875rem;
+		line-height: 1.1;
+		font-weight: 400;
+		color: var(--studio-gray-60, #50575e);
+	}
 
-.hosting-card__logos {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
-	gap: 16px;
-	max-width: 300px;
-	margin: 0 auto;
+	.hosting-card__price-discount {
+		color: var(--color-green-40, #00a32a);
+		font-size: 0.875rem;
+		line-height: 1.75;
+	}
 
-	svg {
-		flex-basis: 88px;
-		height: 48px;
+	.hosting-card__description {
+		font-size: 1rem;
+		line-height: 1.3;
+		font-weight: 400;
+		min-height: 62px;
+		margin: 0;
+		color: var(--studio-gray-80, #2c3338);
+	}
+
+	.hosting-card__header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+		font-size: 1.5rem;
+		font-weight: 600;
+		line-height: 28px;
+
+		.badge {
+			display: flex;
+			background-color: #b8e6bf;
+			color: #00450c;
+
+		}
+	}
+
+	.button .hosting-card__explore-button-content {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 4px;
+
+		.gridicon {
+			width: 16px;
+			height: 16px;
+			top: 0;
+			margin-top: 0;
+		}
+	}
+
+	.hosting-card__pressable-dashboard-button {
+		svg {
+			margin-inline-start: 6px;
+		}
+	}
+
+	ul.hosting-card__features {
+		display: flex;
+		flex-direction: column;
+		list-style-type: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.hosting-card__logos {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 16px;
+		max-width: 300px;
+		margin: 0 auto;
+
+		svg {
+			flex-basis: 88px;
+			height: 48px;
+		}
 	}
 }


### PR DESCRIPTION
Resolve: https://github.com/Automattic/automattic-for-agencies-dev/issues/480

## Proposed Changes

This PR fixes an issue with the Hosting Card. It seems that the Calypso Hosting Card is interfering with our styles, adding a padding we didn't have at A4A:

The issue:
![image](https://github.com/Automattic/wp-calypso/assets/9832440/6576f4d7-b3a2-47e8-b876-c77ba4313edc)

It fixes setting the padding to 0 and adds a bit of specificity, wrapping the classes around `.is-group-a8c-for-agencies` to ensure that the A4A style is applied.

Fixed in this PR:
<img width="1413" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/e03417db-c0c0-456e-a160-e53ed9713cd2">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Apply this change
- Go to `/marketplace/hosting` page and check the Hosting Cards. You should see a margin between cards

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
