### PR TITLE
E2E tests: Ensure the `Add Block` button is depressed when adding inline blocks

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts
@@ -95,6 +95,12 @@ export class LayoutGridBlockFlow implements BlockFlow {
 			// A more stable, viewport-safe approach is to focus and press enter (which is also a real workflow for keyboard users).
 			await addBlockButtonLocator.focus();
 			await addBlockButtonLocator.press( 'Enter' );
+
+			// Sometimes the inserter popover doesn't come-up after the `Enter` press.
+			// We use the `aria-expanded` attribute to further send the missing click event
+			if ( ( await addBlockButtonLocator.getAttribute( 'aria-expanded' ) ) === 'false' ) {
+				await addBlockButtonLocator.click();
+			}
 		};
 
 		await context.editorPage.addBlockInline(

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
@@ -1,4 +1,6 @@
+import { Locator } from 'playwright';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+import { envVariables } from '../../..';
 
 interface ConfigurationData {
 	phoneNumber: number | string;
@@ -9,6 +11,7 @@ const selectors = {
 	// Editor
 	phoneNumberInput: 'input[placeholder="Your phone number…"]',
 	buttonLabel: 'a.whatsapp-block__button',
+	editorSettingsButton: '.editor-header__settings button[aria-label="Settings"]',
 
 	// Published
 	// 'main' needs to be specified due to the debug elements
@@ -35,6 +38,22 @@ export class WhatsAppButtonFlow implements BlockFlow {
 	blockSidebarName = 'WhatsApp Button';
 
 	/**
+	 * Given a Locator, determines whether the target button/toggle is
+	 * in an expanded state.
+	 *
+	 * If the toggle is in the on state or otherwise in an expanded
+	 * state, this method will return true. Otherwise, false.
+	 *
+	 * @param {Locator} target Target button.
+	 * @returns {Promise<boolean>} True if target is in an expanded state. False otherwise.
+	 */
+	private async targetIsOpen( target: Locator ): Promise< boolean > {
+		const pressed = await target.getAttribute( 'aria-pressed' );
+		const expanded = await target.getAttribute( 'aria-expanded' );
+		return pressed === 'true' || expanded === 'true';
+	}
+
+	/**
 	 * Configure the block in the editor with the configuration data from the constructor
 	 *
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
@@ -51,21 +70,44 @@ export class WhatsAppButtonFlow implements BlockFlow {
 		}
 
 		const editorParent = await context.editorPage.getEditorParent();
-		const settingsLocator = editorParent.getByRole( 'button', {
-			name: 'WhatsApp Button Settings',
-		} );
+
+		const editorSettingsButton = editorParent.locator( selectors.editorSettingsButton );
+
+		// This is especially needed in mobile viewport where the settings panel takes up the screen
+		// and needs to be open deliberately
+		if ( ! ( await this.targetIsOpen( editorSettingsButton ) ) ) {
+			await editorSettingsButton.click();
+		}
+
+		// We select the button by text content because `.getByRole('button')` has the potential to select multiple
+		// elements here. WhatsApp block also has a similarly themed settings button
+		const whatsAppSettingsButton = editorParent.locator(
+			'button >> text="WhatsApp Button Settings"'
+		);
 
 		// Open the block settings dialog.
-		await settingsLocator.click();
+		// Check if the settings dialog is already open, otherwise clicking closes it, as the button works as a toggle
+		if ( ! ( await this.targetIsOpen( whatsAppSettingsButton ) ) ) {
+			await whatsAppSettingsButton.click();
+		}
 
 		// Enter phone number.
 		const phoneInputLocator = editorParent.locator( selectors.phoneNumberInput );
 		await phoneInputLocator.fill( this.configurationData.phoneNumber.toString() );
 
 		// Dismiss the block settings dialog.
-		await settingsLocator.click();
+		await whatsAppSettingsButton.click();
 
 		await phoneInputLocator.waitFor( { state: 'detached' } );
+
+		// Close the settings dialog specifically on mobiles
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			return;
+		}
+
+		if ( await this.targetIsOpen( editorSettingsButton ) ) {
+			await editorSettingsButton.click();
+		}
 	}
 
 	/**


### PR DESCRIPTION
This fix addresses the situation where the block inserter popover is not activated due to mouse down events not registering.

This is currently breaking Calypso's atomic nightly e2e tests. 


```
======= Failed test run #1 ==========
  locator.fill: Timeout 10000ms exceeded.
  =========================== logs ===========================
  waiting for locator('body.block-editor-page').locator('.block-editor-inserter__quick-inserter input[type=search]')
  ============================================================
  at EditorInlineBlockInserterComponent.fill [as searchBlockInserter] (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts:35:17)
      at EditorPage.addBlockFromInserter (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/editor-page.ts:389:4)
      at EditorPage.addBlockInline (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/editor-page.ts:368:3)
      at LayoutGridBlockFlow.addTextToColumn (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts:100:3)
      at LayoutGridBlockFlow.configure (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/blocks/block-flows/layout-grid.ts:69:3)
      at Object.<anonymous> (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/blocks/shared/block-smoke-testing.ts:75:7)
======= Failed test run #2 ==========
```

Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)


```bash
cd test/e2e
yarn jest --clearCache && yarn build  # clear build cache before each run


GUTENBERG_NIGHTLY=1 TEST_ON_ATOMIC=true yarn jest specs/blocks/blocks__core.ts
VIEWPORT=mobile GUTENBERG_NIGHTLY=1 TEST_ON_ATOMIC=true yarn jest specs/blocks/blocks__core.ts

GUTENBERG_NIGHTLY=1 TEST_ON_ATOMIC=true yarn jest specs/blocks/blocks__jetpack-grow.ts
VIEWPORT=mobile GUTENBERG_NIGHTLY=1 TEST_ON_ATOMIC=true yarn jest specs/blocks/blocks__jetpack-grow.ts
```