### PR TITLE
A4A: The Volume Saving message is not aligned with other Hosting cards

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -180,7 +180,7 @@ export default function HostingCard( {
 					{ highestDiscountPercentage ? (
 						<div className="hosting-card__price-discount">
 							{ translate( 'Volume savings up to %(highestDiscountPercentage)s%', {
-								args: { highestDiscountPercentage },
+								args: { highestDiscountPercentage: Math.trunc( highestDiscountPercentage ) },
 							} ) }
 						</div>
 					) : null }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -32,6 +32,7 @@
 
 	.hosting-card__price {
 		display: flex;
+		flex-direction: column;
 		flex-wrap: wrap;
 		gap: 8px;
 	}


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/486

## Proposed Changes

The Volume Saving message is not aligned with other Hosting cards on horizontal large screens:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/365de4c7-359d-4a7f-878c-deb18c402677)

This PR fixes it, making the `flex-direction: column` of that block:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/bafeda88-4caa-4995-aff8-3d49fc85ea69)

Also it removes the decimal part of the percentage, so you will see 66% instead of 66.6666%:

<img width="415" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/117d4a01-c6e0-47d1-aae5-48434c34aa3d">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Apply this change
- Go to `/marketplace/hosting`
- In a large screen or stretching horizontally the browser:
- In trunk, you will see the "Volume Saving" message not aligned (see screenshot above)
- In this PR, the "Volume Saving" message will be aligned. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
