### PR TITLE
Site Profiler: Add a blur effect for locked metrics

### DIFF
--- a/client/site-profiler/components/advanced-metrics/index.tsx
+++ b/client/site-profiler/components/advanced-metrics/index.tsx
@@ -1,0 +1,56 @@
+import { useTranslate } from 'i18n-calypso';
+import { MetricsInsightsList } from 'calypso/site-profiler/components/metrics-insights-list';
+import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
+
+interface AdvancedMetricsProps {
+	performanceMetricsRef?: React.RefObject< HTMLObjectElement >;
+	healthScoresRef?: React.RefObject< HTMLObjectElement >;
+}
+
+export const AdvancedMetrics: React.FC< AdvancedMetricsProps > = ( props ) => {
+	const translate = useTranslate();
+	const { performanceMetricsRef, healthScoresRef } = props;
+
+	return (
+		<>
+			<MetricsSection
+				name={ translate( 'Performance Metrics' ) }
+				title={ translate(
+					"Your site {{success}}performs well{{/success}}, but there's always room to be faster and smoother for your visitors.",
+					{
+						components: {
+							success: <span className="success" />,
+							alert: <span className="alert" />,
+						},
+					}
+				) }
+				subtitle={ translate( "Boost your site's performance" ) }
+				ref={ performanceMetricsRef }
+			>
+				<MetricsInsightsList
+					insights={ Array( 10 ).fill( {
+						header:
+							'Your site reveals first content slower than 76% of peers, affecting first impressions.',
+						description: 'This is how you can improve it',
+					} ) }
+				/>
+			</MetricsSection>
+			<MetricsSection
+				name={ translate( 'Health Scores' ) }
+				title={ translate(
+					"Your site's health scores {{alert}}suggest critical area{{/alert}} but need attention to prevent low performance.",
+					{
+						components: {
+							success: <span className="success" />,
+							alert: <span className="alert" />,
+						},
+					}
+				) }
+				subtitle={ translate( "Optimize your site's health" ) }
+				ref={ healthScoresRef }
+			>
+				<MetricsInsightsList locked />
+			</MetricsSection>
+		</>
+	);
+};

--- a/client/site-profiler/components/metrics-insights-list/index.tsx
+++ b/client/site-profiler/components/metrics-insights-list/index.tsx
@@ -3,12 +3,13 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 
 type MetricsInsightsListProps = {
-	insights: Insight[];
+	insights?: Insight[];
+	locked?: boolean;
 };
 
 type Insight = {
 	header: string;
-	description: string;
+	description?: string;
 };
 
 const Container = styled.div`
@@ -18,9 +19,15 @@ const Container = styled.div`
 	letter-spacing: -0.1px;
 `;
 
+type InsightHeaderProps = {
+	locked: boolean;
+	children: React.ReactNode;
+};
 const InsightHeader = styled.div`
 	font-family: 'SF Pro Text';
 	font-size: 16px;
+	filter: ${ ( props: InsightHeaderProps ) => ( props.locked ? 'blur(2px)' : 'none' ) };
+	user-select: ${ ( props: InsightHeaderProps ) => ( props.locked ? 'none' : 'auto' ) };
 `;
 
 const InsightContent = styled.div`
@@ -29,18 +36,21 @@ const InsightContent = styled.div`
 
 export const MetricsInsightsList = ( props: MetricsInsightsListProps ) => {
 	const translate = useTranslate();
-	const { insights } = props;
+	const { insights = [], locked = false } = props;
+	const lockedInsights = useLockedInsights();
 
+	const itemsToRender = locked ? lockedInsights : insights;
 	return (
 		<Container className="metrics-insights-list">
-			{ insights.map( ( insight, index ) => (
+			{ itemsToRender.map( ( insight ) => (
 				<FoldableCard
-					header={ <InsightHeader>{ insight.header }</InsightHeader> }
+					header={ <InsightHeader locked={ locked }>{ insight.header }</InsightHeader> }
 					screenReaderText={ translate( 'More' ) }
 					compact
 					clickableHeader
 					smooth
-					key={ `insight-${ index }` }
+					disabled={ locked }
+					icon={ locked ? 'lock' : 'chevron-down' }
 				>
 					<InsightContent>{ insight.description }</InsightContent>
 				</FoldableCard>
@@ -48,3 +58,35 @@ export const MetricsInsightsList = ( props: MetricsInsightsListProps ) => {
 		</Container>
 	);
 };
+
+export function useLockedInsights(): Insight[] {
+	const translate = useTranslate();
+
+	return [
+		{
+			header: translate(
+				'The full report will display all the informations you need to improve your site domain, hosting, performance, health, and security'
+			),
+		},
+		{
+			header: translate(
+				'Click on the "Get full site report - It\'s free" button to unlock the all the information you need to make your site stand out on the web'
+			),
+		},
+		{
+			header: translate(
+				"You'll be asked to provide your name and email, and once you confirm your email, you should be able to view all of your site stats"
+			),
+		},
+		{
+			header: translate(
+				'The full report will display all the information about how your site is perfoming currently among with information about how to improve it'
+			),
+		},
+		{
+			header: translate(
+				'Feel free to use our tool how many times you want, its free, and once you have unlocked all functionalities you can see informations for any site'
+			),
+		},
+	];
+}

--- a/client/site-profiler/components/metrics-menu/index.tsx
+++ b/client/site-profiler/components/metrics-menu/index.tsx
@@ -21,9 +21,9 @@ const SectionNavbar = styled( SectionNav )`
 
 interface MetricsMenuProps {
 	basicMetricsRef?: React.RefObject< HTMLObjectElement >;
-	onCTAClick: () => void;
 	performanceMetricsRef?: React.RefObject< HTMLObjectElement >;
 	healthScoresRef?: React.RefObject< HTMLObjectElement >;
+	onCTAClick: () => void;
 }
 
 interface MenuItem {

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -208,7 +208,9 @@ export default function SiteProfiler( props: Props ) {
 								) }
 								subtitle={ translate( "Optimize your site's health" ) }
 								ref={ healthScoresRef }
-							/>
+							>
+								<MetricsInsightsList locked />
+							</MetricsSection>
 						</LayoutBlockSection>
 					) }
 				</LayoutBlock>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -16,6 +16,7 @@ import useScrollToTop from '../hooks/use-scroll-to-top';
 import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
 import { getValidUrl } from '../utils/get-valid-url';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
+import { AdvancedMetrics } from './advanced-metrics';
 import { BasicMetrics } from './basic-metrics';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
@@ -23,9 +24,7 @@ import { GetReportForm } from './get-report-form';
 import HeadingInformation from './heading-information';
 import HostingInformation from './hosting-information';
 import HostingIntro from './hosting-intro';
-import { MetricsInsightsList } from './metrics-insights-list';
 import { MetricsMenu } from './metrics-menu';
-import { MetricsSection } from './metrics-section';
 import './styles.scss';
 
 const debug = debugFactory( 'apps:site-profiler' );
@@ -173,44 +172,10 @@ export default function SiteProfiler( props: Props ) {
 								onCTAClick={ () => setIsGetReportFormOpen( true ) }
 							/>
 							<BasicMetrics ref={ basicMetricsRef } basicMetrics={ basicMetrics.basic } />
-							<MetricsSection
-								name={ translate( 'Performance Metrics' ) }
-								title={ translate(
-									"Your site {{success}}performs well{{/success}}, but there's always room to be faster and smoother for your visitors.",
-									{
-										components: {
-											success: <span className="success" />,
-											alert: <span className="alert" />,
-										},
-									}
-								) }
-								subtitle={ translate( "Boost your site's performance" ) }
-								ref={ performanceMetricsRef }
-							>
-								<MetricsInsightsList
-									insights={ Array( 10 ).fill( {
-										header:
-											'Your site reveals first content slower than 76% of peers, affecting first impressions.',
-										description: 'This is how you can improve it',
-									} ) }
-								/>
-							</MetricsSection>
-							<MetricsSection
-								name={ translate( 'Health Scores' ) }
-								title={ translate(
-									"Your site's health scores {{alert}}suggest critical area{{/alert}} but need attention to prevent low performance.",
-									{
-										components: {
-											success: <span className="success" />,
-											alert: <span className="alert" />,
-										},
-									}
-								) }
-								subtitle={ translate( "Optimize your site's health" ) }
-								ref={ healthScoresRef }
-							>
-								<MetricsInsightsList locked />
-							</MetricsSection>
+							<AdvancedMetrics
+								performanceMetricsRef={ performanceMetricsRef }
+								healthScoresRef={ healthScoresRef }
+							/>
 						</LayoutBlockSection>
 					) }
 				</LayoutBlock>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6676

## Proposed Changes

Add a blurry effect for locked metrics. The icon will also change to a locker.

![CleanShot 2024-05-14 at 13 34 11@2x](https://github.com/Automattic/wp-calypso/assets/5039531/fd73b698-5d8d-4697-8a91-0fbaaa4ab9c0)

## Why are these changes being made?

The list of metrics should show blurred items when on teaser mode.

## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/example.com`
* Scroll down and check if the metrics of the `Health Scores` section is blurred as the image above.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?