### PR TITLE
Add launchpad_screen check in post-publish redirects

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -1,6 +1,7 @@
 import { dispatch, select, subscribe } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
+import useLaunchpadScreen from './use-launchpad-screen';
 import useSiteIntent from './use-site-intent';
 
 const START_WRITING_FLOW = 'start-writing';
@@ -8,6 +9,7 @@ const DESIGN_FIRST_FLOW = 'design-first';
 
 export function RedirectOnboardingUserAfterPublishingPost() {
 	const { siteIntent: intent } = useSiteIntent();
+	const { launchpad_screen: launchpadScreen } = useLaunchpadScreen();
 
 	useEffect( () => {
 		// We check the URL param along with site intent because the param loads faster and prevents element flashing.
@@ -25,6 +27,10 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 	}, [ intent ] );
 
 	if ( intent !== START_WRITING_FLOW && intent !== DESIGN_FIRST_FLOW ) {
+		return false;
+	}
+
+	if ( [ 'off', 'skipped' ].includes( launchpadScreen ) ) {
 		return false;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -38,7 +38,7 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 		return false;
 	}
 
-	if ( [ 'off', 'skipped' ].includes( launchpadScreen ) ) {
+	if ( 'full' !== launchpadScreen ) {
 		return false;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -26,6 +26,14 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 		}
 	}, [ intent ] );
 
+	// Check the URL parameter first so we can skip later processing ASAP.
+	const hasStartWritingFlowQueryArg =
+		getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+
+	if ( ! hasStartWritingFlowQueryArg ) {
+		return false;
+	}
+
 	if ( intent !== START_WRITING_FLOW && intent !== DESIGN_FIRST_FLOW ) {
 		return false;
 	}

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -48,6 +48,13 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const isCurrentPostScheduled = select( 'core/editor' ).isCurrentPostScheduled();
 		const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
+		const currentPostType = select( 'core/editor' ).getCurrentPostType();
+
+		// If we're editing anything that is not a post, including pages, templates, and navigation, nothing further needed.
+		if ( currentPostType && currentPostType !== 'post' ) {
+			unsubscribe();
+			return;
+		}
 
 		if (
 			! isSavingPost &&

--- a/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
@@ -8,15 +8,28 @@ beforeAll( () => {} );
 const mockUnSubscribe = jest.fn();
 const mockClosePublishSidebar = jest.fn();
 const mockCloseSidebar = jest.fn();
-const mockSubscribeFunction = [];
+const mockSubscribeFunction = {};
 const mockUseEffectFunctions = [];
+let mockSubscribeFunctionDescriptor = '';
 let mockIsSaving = false;
+let mockPostType = 'post';
+let mockLaunchpadScreen = 'full';
 
 jest.mock( 'react', () => ( {
 	useEffect: ( userFunction ) => {
 		mockUseEffectFunctions.push( userFunction );
 	},
 } ) );
+
+jest.mock( '../use-launchpad-screen', () => ( {
+	__esModule: true,
+	default: () => {
+		return {
+			launchpad_screen: mockLaunchpadScreen,
+		};
+	},
+} ) );
+
 jest.mock( '../use-site-intent', () => ( {
 	__esModule: true,
 	default: () => {
@@ -28,7 +41,7 @@ jest.mock( '../use-site-intent', () => ( {
 
 jest.mock( '@wordpress/data', () => ( {
 	subscribe: ( userFunction ) => {
-		mockSubscribeFunction.push( userFunction );
+		mockSubscribeFunction[ mockSubscribeFunctionDescriptor ] = userFunction;
 
 		return mockUnSubscribe;
 	},
@@ -39,6 +52,7 @@ jest.mock( '@wordpress/data', () => ( {
 				isCurrentPostPublished: () => true,
 				getCurrentPostRevisionsCount: () => 1,
 				isCurrentPostScheduled: () => true,
+				getCurrentPostType: () => mockPostType,
 			};
 		}
 
@@ -61,8 +75,9 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 describe( 'RedirectOnboardingUserAfterPublishingPost', () => {
-	it( 'should NOT redirect while saving the POST', () => {
+	it( 'should NOT redirect while saving the post', () => {
 		mockIsSaving = true;
+		mockSubscribeFunctionDescriptor = 'no_redirect_while_saving_post';
 		delete global.window;
 		global.window = {
 			sessionStorage: {
@@ -79,16 +94,17 @@ describe( 'RedirectOnboardingUserAfterPublishingPost', () => {
 
 		RedirectOnboardingUserAfterPublishingPost();
 
-		expect( mockSubscribeFunction[ 0 ] ).not.toBe( undefined );
-		mockSubscribeFunction[ 0 ]();
+		expect( mockSubscribeFunction[ mockSubscribeFunctionDescriptor ] ).not.toBe( undefined );
+		mockSubscribeFunction[ mockSubscribeFunctionDescriptor ]();
 
-		expect( mockUnSubscribe ).toHaveBeenCalledTimes( 0 );
+		expect( mockUnSubscribe ).not.toHaveBeenCalled();
 		expect( global.window.location.href ).toBe( undefined );
 	} );
 
-	it( 'should redirect the user to the launchpad when a post is published and the start-writing query parameter is present', () => {
+	it( 'should redirect the user to the launchpad when a post is published and the start-writing query parameter is "true"', () => {
 		jest.clearAllMocks();
 		mockIsSaving = false;
+		mockSubscribeFunctionDescriptor = 'redirect_to_launchpad_post';
 		delete global.window;
 
 		global.window = {
@@ -105,9 +121,10 @@ describe( 'RedirectOnboardingUserAfterPublishingPost', () => {
 		};
 
 		RedirectOnboardingUserAfterPublishingPost();
-		mockSubscribeFunction[ 1 ]();
 
-		expect( mockSubscribeFunction ).not.toBe( null );
+		expect( mockSubscribeFunction[ mockSubscribeFunctionDescriptor ] ).not.toBe( null );
+		mockSubscribeFunction[ mockSubscribeFunctionDescriptor ]();
+
 		expect( mockUnSubscribe ).toHaveBeenCalledTimes( 1 );
 		expect( mockClosePublishSidebar ).toHaveBeenCalledTimes( 1 );
 		expect( global.window.location.href ).toBe(
@@ -115,9 +132,127 @@ describe( 'RedirectOnboardingUserAfterPublishingPost', () => {
 		);
 	} );
 
+	it( 'should NOT redirect the user to the launchpad when a post is published and the start-writing query parameter is present but not "true"', () => {
+		jest.clearAllMocks();
+		mockIsSaving = false;
+		mockSubscribeFunctionDescriptor = 'no_redirect_to_launchpad_bad_start_writing_param';
+		delete global.window;
+
+		global.window = {
+			sessionStorage: {
+				getItem: jest.fn( () => 'https://calypso.localhost:3000' ),
+				setItem: jest.fn(),
+				removeItem: jest.fn(),
+				clear: jest.fn(),
+			},
+			location: {
+				search: '?start-writing=test&origin=https://calypso.localhost:3000',
+				hostname: 'wordpress.com',
+			},
+		};
+
+		RedirectOnboardingUserAfterPublishingPost();
+
+		expect( mockSubscribeFunction[ mockSubscribeFunctionDescriptor ] ).toBe( undefined );
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+		expect( global.window.location.href ).toBe( undefined );
+	} );
+
+	it( 'should NOT redirect the user to the launchpad when a post is published, the start-writing query parameter is present, and the launchpad_screen is skipped', () => {
+		jest.clearAllMocks();
+		mockIsSaving = false;
+		mockLaunchpadScreen = 'skipped';
+		mockSubscribeFunctionDescriptor = 'no_redirect_to_launchpad_skipped_launchpad_screen';
+		delete global.window;
+
+		global.window = {
+			sessionStorage: {
+				getItem: jest.fn( () => 'https://calypso.localhost:3000' ),
+				setItem: jest.fn(),
+				removeItem: jest.fn(),
+				clear: jest.fn(),
+			},
+			location: {
+				search: '?start-writing=true&origin=https://calypso.localhost:3000',
+				hostname: 'wordpress.com',
+			},
+		};
+
+		RedirectOnboardingUserAfterPublishingPost();
+
+		expect( mockSubscribeFunction[ mockSubscribeFunctionDescriptor ] ).toBe( undefined );
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+		expect( global.window.location.href ).toBe( undefined );
+
+		mockLaunchpadScreen = 'full';
+	} );
+
+	it( 'should NOT redirect the user to the launchpad when a page is published and the start-writing query parameter is present', () => {
+		jest.clearAllMocks();
+		mockIsSaving = false;
+		mockPostType = 'page';
+		mockSubscribeFunctionDescriptor = 'no_redirect_page_published';
+		delete global.window;
+
+		global.window = {
+			sessionStorage: {
+				getItem: jest.fn( () => 'https://calypso.localhost:3000' ),
+				setItem: jest.fn(),
+				removeItem: jest.fn(),
+				clear: jest.fn(),
+			},
+			location: {
+				search: '?start-writing=true&origin=https://calypso.localhost:3000',
+				hostname: 'wordpress.com',
+			},
+		};
+
+		RedirectOnboardingUserAfterPublishingPost();
+
+		expect( mockSubscribeFunction[ mockSubscribeFunctionDescriptor ] ).not.toBe( null );
+
+		mockSubscribeFunction[ mockSubscribeFunctionDescriptor ]();
+
+		expect( mockUnSubscribe ).toHaveBeenCalledTimes( 1 );
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+		expect( global.window.location.href ).toBe( undefined );
+	} );
+
+	it( 'should NOT redirect the user to the launchpad when a template is published', () => {
+		jest.clearAllMocks();
+		mockIsSaving = false;
+		mockPostType = 'template';
+		mockSubscribeFunctionDescriptor = 'no_redirect_template_published';
+		delete global.window;
+
+		global.window = {
+			sessionStorage: {
+				getItem: jest.fn( () => 'https://calypso.localhost:3000' ),
+				setItem: jest.fn(),
+				removeItem: jest.fn(),
+				clear: jest.fn(),
+			},
+			location: {
+				search: '?start-writing=true&origin=https://calypso.localhost:3000',
+				hostname: 'wordpress.com',
+			},
+		};
+
+		RedirectOnboardingUserAfterPublishingPost();
+
+		expect( mockSubscribeFunction[ mockSubscribeFunctionDescriptor ] ).not.toBe( null );
+
+		mockSubscribeFunction[ mockSubscribeFunctionDescriptor ]();
+
+		expect( mockUnSubscribe ).toHaveBeenCalledTimes( 1 );
+		expect( mockClosePublishSidebar ).not.toHaveBeenCalled();
+		expect( global.window.location.href ).toBe( undefined );
+	} );
+
 	it( 'should close the sidebar once isComplementaryAreaVisible === true', () => {
 		jest.clearAllMocks();
 		mockIsSaving = false;
+		mockSubscribeFunctionDescriptor = 'close_sidebar';
 		delete global.window;
 		global.window = {
 			sessionStorage: {
@@ -133,10 +268,12 @@ describe( 'RedirectOnboardingUserAfterPublishingPost', () => {
 		};
 
 		RedirectOnboardingUserAfterPublishingPost();
-		mockSubscribeFunction[ 0 ]();
+
+		expect( mockSubscribeFunction[ mockSubscribeFunctionDescriptor ] ).not.toBe( null );
+
+		mockSubscribeFunction[ mockSubscribeFunctionDescriptor ]();
 		mockUseEffectFunctions[ 0 ]();
 
 		expect( mockCloseSidebar ).toHaveBeenCalledTimes( 1 );
-		expect( mockSubscribeFunction ).not.toBe( null );
 	} );
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/use-launchpad-screen.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-launchpad-screen.js
@@ -1,0 +1,8 @@
+const useLaunchpadScreen = () => {
+	// We have this data populated, on window.Jetpack_LaunchpadSaveModal, so we should use it.
+	return {
+		launchpad_screen: window.Jetpack_LaunchpadSaveModal?.launchpadScreenOption,
+	};
+};
+
+export default useLaunchpadScreen;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87416

## Proposed Changes

* This PR adds some logic to heavily limit when we redirect to the fullscreen launchpad from the editor. We will now redirect only when _all_ of the following are true, with new restrictions in **bold**:
  - the site has either the `design-first` or the `start-writing` intent (which are created from the `/setup/design-first` and `/setup/start-writing` flows, respectively)
  - **the URL for the editor includes `start-writing=true` as a URL parameter**
  - **the user is editing a post** (and not a template, page, navigation, or any other post type, including custom post types)
  - **the `launchpad_screen` option is specifically set to `'full'`**

Prior to this change, we were redirecting in a number of situations where the redirect was unexpected, including the following:
 * The user was editing the index template for their site via the Site Editor (without starting from the original flow)
 * The user had skipped the launchpad, so the `launchpad_screen` option was set to `'skipped'`

## Why are these changes being made?

* We've seen multiple reports where users continually and unexpectedly get redirected to the fullscreen launchpad. Even after trying to disable the launchpad, however, they are still being redirected. This patch ensures that "normal" approaches to marking the launchpad as disabled or skipped will be honoured, as well as preventing redirects when users are not editing posts specifically from the original onboarding flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Get the site set up to reproduce the issue

For these steps, use the standard Calypso UI, not this code.

* Create a new site via https://wordpress.com/setup/start-writing/
* Work through the flow to publish your first post
* After publishing, you should be taken to the fullscreen launchpad.
  - You may see a congratulatory modal instead -- if so, pick "Next steps" to get taken to the launchpad
* On the fullscreen launchpad, select the "Skip for now" option in the top right corner to take you to Customer Home
* Navigate to the Site Editor via _Appearance_ => _Editor_
* Make one or more changes to the template and save them.
* Reload the site editor.
* You should be redirected to the launchpad screen and then back to Customer Home.
* Keep this tab open -- we'll use it again!

#### Test the launchpad_screen fix

* Follow the instructions in [this comment](https://github.com/Automattic/wp-calypso/pull/90706#issuecomment-2110842096) to apply the changes from this PR to your WordPress.com development sandbox
* Ensure that the `widgets.wp.com` host is pointed at your sandbox
* Ensure that your browser is configured _not_ to cache content - this is easiest if you open up your browsers' development console. (The cache buster for the resources may not have been bumped, so it's simplest to make sure you're loading the files every time.)
* Reload the site editor.
* Verify that you are not redirected to the fullscreen launchpad.
* Keep this tab open.
* Add `?start-writing=true` to the URL, and reload the site editor.
* Verify that you are not redirected to the fullscreen launchpad.

#### Test the redirect applies only to posts

* Use a shell command to reset the `launchpad_screen` option to `full` for your site:
```
> switch_to_blog( 1234567890 ); // replace with your site's blog ID
> update_option( 'launchpad_screen', 'full' );
```
* Reload the site editor above, keeping the `start-writing` URL parameter as `true`.
* Verify that you are not redirected to the fullscreen launchpad.

#### Test the post editor

* Navigate to `/wp-admin/post-new.php?start-writing=true`
* Add some content and then publish the post
* Verify that you are redirected to the fullscreen launchpad

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
