### PR TITLE
A4A: some refactor of the codebase

### DIFF
--- a/client/a8c-for-agencies/components/content-sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/content-sidebar/index.tsx
@@ -9,12 +9,10 @@ type Props = {
 
 const ContentSidebar = ( { mainContent, rightSidebar }: Props ) => {
 	return (
-		<>
-			<div className="content-sidebar">
-				<div className="content-sidebar__main-content">{ mainContent }</div>
-				<aside className="content-sidebar__right-sidebar">{ rightSidebar }</aside>
-			</div>
-		</>
+		<div className="content-sidebar">
+			<div className="content-sidebar__main-content">{ mainContent }</div>
+			<aside className="content-sidebar__right-sidebar">{ rightSidebar }</aside>
+		</div>
 	);
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -74,8 +74,8 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect }: P
 				</Button>
 
 				<div className="wpcom-plan-card__features">
-					{ features1.length && <SimpleList items={ features1 } /> }
-					{ features2.length && <SimpleList items={ features2 } /> }
+					{ !! features1.length && <SimpleList items={ features1 } /> }
+					{ !! features2.length && <SimpleList items={ features2 } /> }
 				</div>
 			</div>
 			<div className="wpcom-plan-card__section">
@@ -84,8 +84,8 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect }: P
 				</h2>
 
 				<div className="wpcom-plan-card__features is-jetpack">
-					{ features1.length && <SimpleList items={ features1 } /> }
-					{ features2.length && <SimpleList items={ features2 } /> }
+					{ !! features1.length && <SimpleList items={ features1 } /> }
+					{ !! features2.length && <SimpleList items={ features2 } /> }
 				</div>
 			</div>
 		</div>

--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -92,9 +92,10 @@ const OverviewBodyHosting = () => {
 			description={ translate(
 				'Choose the hosting that suits your needs from our best-in-class offerings.'
 			) }
-			children={ migrationOffer }
 			items={ [ pressable, wpcom ] }
-		/>
+		>
+			{ migrationOffer }
+		</Offering>
 	);
 };
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -248,11 +248,11 @@ export default function LicensePreview( {
 				) }
 
 				<div className="license-preview__badge-container">
-					{ isParentLicense && bundleCountContent }
+					{ !! isParentLicense && bundleCountContent }
 				</div>
 
 				<div>
-					{ isParentLicense && ! revokedAt && (
+					{ !! isParentLicense && ! revokedAt && (
 						<LicenseBundleDropDown
 							product={ product }
 							licenseKey={ licenseKey }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

It's a PR to address some small refactor issues pointed out after running Sonar Qube scanner on the codebase.
These are not critical, but good to address.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the changes for this branch and explore the normal behavior of A4A
- Particularly, `sidebar`, `wpcom-hosting` page, `hosting overview` page and `purchases -> licenses`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
