### PR TITLE
Reader: Add bottom-line on headers

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -231,6 +231,20 @@
 	}
 }
 
+.is-group-reader {
+	@media screen and (min-width: 782px) {
+		.navigation-header::after {
+			content: "";
+			display: block;
+			position: relative;
+			left: calc(-1 * (100vw - 100%)/2 - 132px);
+			margin: 24px 0;
+			width: 100vw;
+			height: 1px;
+			background: var(--color-border-secondary);
+		}
+	}
+}
 .is-group-reader .reader-notifications__panel {
 	@media only screen and ( min-width: 1114px ) {
 		.wpnc__main {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7065

## Proposed Changes

Add bottom-line on Rearer headers

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/e97edf63-18d1-4b52-8e99-88dcbaf04afa) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/5a6e526e-0a3b-4351-bb3f-fbe3d8bdadec) |

## Testing Instructions

* Go to `/read`
* Check the line at the bottom of the header
* It should show on all reader pages
* Check mobile & desktop screen sizes
* Check if logged-out reader is not broken