### PR TITLE
Hosted site migration: add support for direct import

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -121,8 +121,13 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
-						// siteId/siteSlug wont be defined here if coming from a direct link/signup.
-						// We need to make sure the importer works when no site is available.
+						if ( isHostedSiteMigrationFlow( variantSlug ?? '' ) ) {
+							// siteId/siteSlug wont be defined here if coming from a direct link/signup.
+							// We need to make sure there's a site to import into.
+							if ( ! siteSlugParam ) {
+								return navigate( STEPS.SITE_CREATION_STEP.slug );
+							}
+						}
 						return exitFlow(
 							addQueryArgs(
 								{
@@ -195,6 +200,21 @@ const siteMigration: Flow = {
 
 				case STEPS.PROCESSING.slug: {
 					if ( providedDependencies?.siteCreated ) {
+						if ( ! fromQueryParam ) {
+							// If we get to this point without a fromQueryParam then we are coming from a direct
+							// pick your current platform link. That's why we navigate to the importList step.
+							return exitFlow(
+								addQueryArgs(
+									{
+										siteId,
+										siteSlug,
+										origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+										backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+									},
+									'/setup/site-setup/importList'
+								)
+							);
+						}
 						return navigate(
 							addQueryArgs(
 								{ siteId, siteSlug, from: fromQueryParam },

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -81,6 +81,24 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 		} );
 
+		it( 'redirects to the site creation step when import action is selected', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentURL: '/setup/hosted-site-migration',
+				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+				dependencies: {
+					action: 'skip_platform_identification',
+				},
+			} );
+
+			await waitFor( () => {
+				expect( getFlowLocation() ).toEqual( {
+					path: `/${ STEPS.SITE_CREATION_STEP.slug }`,
+					state: null,
+				} );
+			} );
+		} );
 		it( 'redirects to processing after site creation', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
 
@@ -94,10 +112,26 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'redirects to import/migrate screen after site creation', () => {
+		it( 'redirects to setup/importList after site creation if no from query parameter is set', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
+				currentURL: `/processing?siteSlug=example.wordpress.com`,
+				currentStep: STEPS.PROCESSING.slug,
+				dependencies: {
+					siteCreated: true,
+				},
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'/setup/site-setup/importList?siteSlug=example.wordpress.com&origin=site-migration-identify&backToFlow=%2Fhosted-site-migration%2Fsite-migration-identify'
+			);
+		} );
+		it( 'redirects to import/migrate screen after site creation if a from query parameter is set', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentURL: `/processing?siteSlug=example.wordpress.com&from=https://site-to-be-migrated.com`,
 				currentStep: STEPS.PROCESSING.slug,
 				dependencies: {
 					siteCreated: true,
@@ -105,7 +139,7 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?siteSlug=example.wordpress.com`,
+				path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
 				state: null,
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90665

## Proposed Changes
This adds support for the `pick your current platform from a list` link in the `site-migration-identify` step.
<img width="514" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/16ff8cac-8ce1-4f07-8cac-d39cdca6e8f4">

If a submit with `action=skip_platform_identification` is detected in the `site-migration-identify` step we redirect the user to the create-site step. This will create a simple site for the user and when it gets back to the flow it will redirect the user to the `/setup/site-setup/importList` step in the same way that the current `site-migration` does now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The new `hosted-site-migration` flow should work even if no siteSlug is present in the `site-migration-identify` step, since this is a signupFlow.

paYKcK-4BA-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Two scenarios should be tested:

### Scenario 1
* Navigate to `/setup/hosted-site-migration`
* Click on `pick your current platform from a list`
* Verify you get redirected to the create step and then to the processing step
* Verify you finally get redirected to `/setup/site-setup/importList`

### Scenario 2
* Navigate to `/setup/hosted-site-migration`
* Once you get redirected to the `site-migration-identify` step add `?siteSlug=[VALID_SITE_SLUG]` to the query in the browser and navigate.
* Click on `pick your current platform from a list`
* Verify you get directly redirected to `/setup/site-setup/importList`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?