### PR TITLE
Explore: new useFlowLoginUrl() hook for Stepper flows

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -206,7 +206,7 @@ const free: Flow = {
 			if ( ! userIsLoggedIn ) {
 				window.location.assign( logInUrl );
 			}
-		}, [ logInUrl ] );
+		}, [ logInUrl, userIsLoggedIn ] );
 
 		if ( ! userIsLoggedIn ) {
 			result = {

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -204,7 +204,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ flow.name, currentStepRoute, hasRequestedSelectedSite ] );
 
-	const assertCondition = flow.useAssertConditions?.( _navigate ) ?? {
+	const assertCondition = flow.useAssertConditions?.( _navigate, currentStepRoute ) ?? {
 		state: AssertConditionState.SUCCESS,
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -86,7 +86,8 @@ export type UseStepNavigationHook< FlowSteps extends StepperStep[] > = (
 ) => NavigationControls;
 
 export type UseAssertConditionsHook< FlowSteps extends StepperStep[] > = (
-	navigate?: Navigate< FlowSteps >
+	navigate?: Navigate< FlowSteps >,
+	currentStepSlug?: string
 ) => AssertConditionResult;
 
 export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -3,14 +3,13 @@ import { MIGRATION_SIGNUP_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
-import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
+import { useFlowLoginUrl } from 'calypso/landing/stepper/hooks/use-flow-login-url';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSiteData } from '../hooks/use-site-data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
 import { goToCheckout } from '../utils/checkout';
-import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
@@ -50,61 +49,24 @@ const migrationSignup: Flow = {
 
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
-		const flowName = this.name;
-
-		const locale = useFlowLocale();
-
 		const queryParams = new URLSearchParams( window.location.search );
-		const aff = queryParams.get( 'aff' );
-		const vendorId = queryParams.get( 'vid' );
-		const ref = queryParams.get( 'ref' );
-
-		const getStartUrl = () => {
-			let hasFlowParams = false;
-			const flowParams = new URLSearchParams();
-			const queryParams = new URLSearchParams();
-
-			if ( vendorId ) {
-				queryParams.set( 'vid', vendorId );
+		const loginUrlParams: Record< string, string > = {};
+		for ( const [ key, value ] of queryParams.entries() ) {
+			if ( [ 'aff', 'vid', 'ref' ].includes( key ) && value ) {
+				loginUrlParams[ key ] = value;
 			}
+		}
 
-			if ( aff ) {
-				queryParams.set( 'aff', aff );
-			}
-
-			if ( ref ) {
-				queryParams.set( 'ref', ref );
-			}
-
-			if ( locale && locale !== 'en' ) {
-				flowParams.set( 'locale', locale );
-				hasFlowParams = true;
-			}
-
-			const redirectTarget =
-				`/setup/${ FLOW_NAME }` +
-				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
-
-			let queryString = `redirect_to=${ redirectTarget }`;
-
-			if ( queryParams.toString() ) {
-				queryString = `${ queryString }&${ queryParams.toString() }`;
-			}
-
-			const logInUrl = getLoginUrl( {
-				variationName: flowName,
-				locale,
-			} );
-
-			return `${ logInUrl }&${ queryString }`;
-		};
+		const logInUrl = useFlowLoginUrl( {
+			flow: this,
+			loginUrlParams,
+		} );
 
 		useEffect( () => {
 			if ( ! userIsLoggedIn ) {
-				const logInUrl = getStartUrl();
 				window.location.assign( logInUrl );
 			}
-		}, [] );
+		}, [ logInUrl ] );
 
 		if ( ! userIsLoggedIn ) {
 			result = {

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -66,7 +66,7 @@ const migrationSignup: Flow = {
 			if ( ! userIsLoggedIn ) {
 				window.location.assign( logInUrl );
 			}
-		}, [ logInUrl ] );
+		}, [ logInUrl, userIsLoggedIn ] );
 
 		if ( ! userIsLoggedIn ) {
 			result = {

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -4,6 +4,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { useFlowLoginUrl } from 'calypso/landing/stepper/hooks/use-flow-login-url';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
@@ -16,7 +17,6 @@ import {
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
-import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
@@ -86,9 +86,9 @@ const newsletter: Flow = {
 		const isLoadingIntroScreen =
 			! isComingFromMarketingPage && ( 'intro' === _currentStep || undefined === _currentStep );
 
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: `/setup/${ flowName }/newsletterSetup`,
+		const logInUrl = useFlowLoginUrl( {
+			flow: this,
+			returnStepSlug: 'newsletterSetup',
 			pageTitle: translate( 'Newsletter' ),
 		} );
 

--- a/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
@@ -49,7 +49,7 @@ describe( 'Migration Signup Flow', () => {
 			} );
 
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				`/start/account/user-social?variationName=migration-signup&toStepper=true&redirect_to=/setup/migration-signup&vid=vid321&aff=aff123&ref=logged-out-homepage`
+				`/start/account/user-social?variationName=migration-signup&redirect_to=%2Fsetup%2Fmigration-signup&toStepper=true&ref=logged-out-homepage&aff=aff123&vid=vid321`
 			);
 		} );
 
@@ -65,7 +65,7 @@ describe( 'Migration Signup Flow', () => {
 			} );
 
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				`/start/account/user-social/fr?variationName=migration-signup&toStepper=true&redirect_to=/setup/migration-signup%3Flocale%3Dfr&vid=vid321&aff=aff123&ref=logged-out-homepage`
+				`/start/account/user-social/fr?variationName=migration-signup&redirect_to=%2Fsetup%2Fmigration-signup%3Flocale%3Dfr&toStepper=true&ref=logged-out-homepage&aff=aff123&vid=vid321`
 			);
 		} );
 	} );

--- a/client/landing/stepper/hooks/use-flow-login-url.ts
+++ b/client/landing/stepper/hooks/use-flow-login-url.ts
@@ -12,15 +12,17 @@ type UseFlowLoginUrlProps = {
 };
 
 export function useFlowLoginUrl( {
-	flow,
+	flow: { name: flowName, variantSlug: flowVariantSlug },
 	loginUrlParams = {},
 	pageTitle,
 	returnStepSlug,
 	returnUrlParams = {},
 }: UseFlowLoginUrlProps ): string {
+	// Note: We SHOULD NOT call any hooks on the incoming flow argument.
+	// We accept the argument as a cleaner API to get flow.name and flow.variantSlug.
 	const locale = useFlowLocale();
 
-	const flowPath = flow.variantSlug ?? flow.name;
+	const flowPath = flowVariantSlug ?? flowName;
 	const isNonEnglishLocale = locale && locale !== 'en';
 	const returnQueryParams = {
 		...returnUrlParams,
@@ -33,7 +35,7 @@ export function useFlowLoginUrl( {
 	);
 
 	const loginUrl = useLoginUrl( {
-		variationName: flow.name,
+		variationName: flowName,
 		pageTitle,
 		locale,
 		redirectTo,

--- a/client/landing/stepper/hooks/use-flow-login-url.ts
+++ b/client/landing/stepper/hooks/use-flow-login-url.ts
@@ -1,0 +1,43 @@
+import { addQueryArgs } from '@wordpress/url';
+import { useLoginUrl } from '../utils/path';
+import { useFlowLocale } from './use-flow-locale';
+import type { Flow } from 'calypso/landing/stepper/declarative-flow/internals/types';
+
+type UseFlowLoginUrlProps = {
+	flow: Flow;
+	loginUrlParams?: Record< string, string | number >;
+	pageTitle?: string;
+	returnStepSlug?: string;
+	returnUrlParams?: Record< string, string | number >;
+};
+
+export function useFlowLoginUrl( {
+	flow,
+	loginUrlParams = {},
+	pageTitle,
+	returnStepSlug,
+	returnUrlParams = {},
+}: UseFlowLoginUrlProps ): string {
+	const locale = useFlowLocale();
+
+	const flowPath = flow.variantSlug ?? flow.name;
+	const isNonEnglishLocale = locale && locale !== 'en';
+	const returnQueryParams = {
+		...returnUrlParams,
+		...( isNonEnglishLocale ? { locale } : {} ),
+	};
+
+	const redirectTo = addQueryArgs(
+		`/setup/${ flowPath }${ returnStepSlug ? `/${ returnStepSlug }` : '' }`,
+		returnQueryParams
+	);
+
+	const loginUrl = useLoginUrl( {
+		variationName: flow.name,
+		pageTitle,
+		locale,
+		redirectTo,
+	} );
+
+	return addQueryArgs( loginUrl, loginUrlParams );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
 * https://github.com/Automattic/wp-calypso/pull/90468
 * https://github.com/Automattic/wp-calypso/pull/90323

## Proposed Changes

* This PR explores adding a new `useFlowLoginUrl()` hook to compute a login URL for a Stepper flow, with the goal of centralising the handling and exposing a cleaner API that is more context-aware. If we get this right, we can remove a lot of messy code across Stepper flows _and_ make it easier to write more consistent code in new flows.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As a result of my work on https://github.com/Automattic/wp-calypso/pull/90468, which started using `useFlowLocale()` across various Stepper flows, and on https://github.com/Automattic/wp-calypso/pull/90323, which adds tests for login redirects, I noticed that we have a _lot_ of messy and inconsistent code to build the login URL and the return path.
* The goal of this PR is to push most of that complexity into a single hook so that we can more easily roll out changes that pull in additional URL parameters by default, like affiliate identifiers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This change should have no visual changes, but we will need to test the modified flows while logged in and logged out to verify that login redirects still trigger correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
