### PR TITLE
Site Migration: Update migration-signup to use the i2 migration instructions step

### DIFF
--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -34,11 +34,9 @@ const migrationSignup: Flow = {
 		return [
 			STEPS.SITE_MIGRATION_IDENTIFY,
 			STEPS.SITE_CREATION_STEP,
-			STEPS.BUNDLE_TRANSFER,
-			STEPS.SITE_MIGRATION_PLUGIN_INSTALL,
 			STEPS.PROCESSING,
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
-			STEPS.SITE_MIGRATION_INSTRUCTIONS,
+			STEPS.SITE_MIGRATION_INSTRUCTIONS_I2,
 			STEPS.ERROR,
 		];
 	},
@@ -201,14 +199,6 @@ const migrationSignup: Flow = {
 					);
 				}
 
-				case STEPS.BUNDLE_TRANSFER.slug: {
-					return navigate( STEPS.PROCESSING.slug, { bundleProcessing: true } );
-				}
-
-				case STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug: {
-					return navigate( STEPS.PROCESSING.slug );
-				}
-
 				case STEPS.PROCESSING.slug: {
 					// If we just created the site, either go to the upgrade plan step, or the site identification step.
 					if ( providedDependencies?.siteId && providedDependencies?.siteSlug ) {
@@ -231,14 +221,6 @@ const migrationSignup: Flow = {
 					if ( providedDependencies?.error ) {
 						return navigate( STEPS.ERROR.slug );
 					}
-
-					// If the plugin was installed successfully, go to the migration instructions.
-					if ( providedDependencies?.pluginInstalled ) {
-						return navigate( STEPS.SITE_MIGRATION_INSTRUCTIONS.slug );
-					}
-
-					// Otherwise processing has finished from the BundleTransfer step and we need to install the plugin.
-					return navigate( STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug );
 				}
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
@@ -248,7 +230,7 @@ const migrationSignup: Flow = {
 								siteSlug,
 								from: fromQueryParam,
 							},
-							`/setup/${ FLOW_NAME }/${ STEPS.BUNDLE_TRANSFER.slug }`
+							`/setup/${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`
 						);
 						goToCheckout( {
 							flowName: FLOW_NAME,
@@ -264,26 +246,6 @@ const migrationSignup: Flow = {
 						} );
 						return;
 					}
-
-					if ( providedDependencies?.freeTrialSelected ) {
-						return navigate(
-							addQueryArgs(
-								{
-									siteSlug,
-									from: fromQueryParam,
-								},
-								STEPS.BUNDLE_TRANSFER.slug
-							),
-							{
-								siteId,
-								siteSlug,
-							}
-						);
-					}
-				}
-
-				case STEPS.SITE_MIGRATION_INSTRUCTIONS.slug: {
-					return exitFlow( `/home/${ siteSlug }` );
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
@@ -137,7 +137,7 @@ describe( 'Migration Signup Flow', () => {
 			} );
 
 			expect( goToCheckout ).toHaveBeenCalledWith( {
-				destination: `/setup/migration-signup/${ STEPS.BUNDLE_TRANSFER.slug }?siteSlug=example.wordpress.com`,
+				destination: `/setup/migration-signup/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com`,
 				extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 				flowName: 'migration-signup',
 				siteSlug: 'example.wordpress.com',
@@ -160,22 +160,6 @@ describe( 'Migration Signup Flow', () => {
 			} );
 		} );
 
-		it( 'redirects the user to instructions step if the plugin was installed successfully', () => {
-			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.PROCESSING.slug,
-				dependencies: {
-					pluginInstalled: true,
-				},
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }`,
-				state: null,
-			} );
-		} );
-
 		it( 'redirects the user to error step if there was an error during the process', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
 
@@ -189,50 +173,6 @@ describe( 'Migration Signup Flow', () => {
 			expect( getFlowLocation() ).toEqual( {
 				path: `/${ STEPS.ERROR.slug }`,
 				state: null,
-			} );
-		} );
-
-		it( 'redirects the user to the plugin install step from the processing step', () => {
-			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.PROCESSING.slug,
-				dependencies: {
-					bundleTransfer: true,
-				},
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug }`,
-				state: null,
-			} );
-		} );
-
-		it( 'redirects the user to the processing step from the migration plugin install step', () => {
-			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug,
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.PROCESSING.slug }`,
-				state: null,
-			} );
-		} );
-
-		it( 'redirects the user to the processing step from the bundle transfer step', () => {
-			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.BUNDLE_TRANSFER.slug,
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.PROCESSING.slug }`,
-				state: {
-					bundleProcessing: true,
-				},
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #90502

## Proposed Changes

This updates `/setup/migration-signup` to use the new `site-migration-instructions-i2` step instead of going through bungleTransfer, pluginInstall, and processing (though we still have a brief process step at the beginning when the site is created initially).

The Atomic transfer and plugin installation will now happen behind the scenes in the migration instructions step giving the user a more streamlined experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify tests pass
```
yarn test-client client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
```
* Using calypso.live or checking out the branch locally, visit `/setup/migration-signup`.
* You should go through the steps in the following order:
  * Processing (to create the site)
  * "Let's import your content" (`site-migration-identify`)
  * Plan Upgrade (`site-migration-upgrade-plan`)
  * Checkout (regardless of if you're upgrading or doing the free trial)
  * Migration Instructions (`site-migration-instructions-i2`).
* Wait to ensure the site is properly provisioned and the plugins are installed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
