### PR TITLE
Fix diagonal animation from Sites > My home

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -257,7 +257,7 @@
 // Styles collapsed site list.
 .wpcom-site {
 	.layout__content {
-		transition: all 220ms ease-out;
+		transition: padding-left 220ms ease-out;
 	}
 	.layout__secondary {
 		transition: width 220ms ease-out;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7163

## Proposed Changes

This fixes the diagonal animation when clicking `My home` from the sites list.

https://github.com/Automattic/wp-calypso/assets/402286/3e3021b4-4c32-4baf-afdc-3536f9156e75

## Testing Instructions

* Go to `/sites`
* Click on `My Home` on a site without Classic interface enabled
* You should not see a diagonal animation
* It keeps collapsing the sidebar before changing the menu