### PR TITLE
Domains: Hide site with unknown capabilities from domain-only flow

### DIFF
--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -17,7 +17,7 @@ class SitePicker extends Component {
 	};
 
 	filterSites = ( site ) => {
-		return site.capabilities.manage_options && ! site.jetpack && ! site.options?.is_domain_only;
+		return site.capabilities?.manage_options && ! site.jetpack && ! site.options?.is_domain_only;
 	};
 
 	renderScreen() {


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1715551259319339-slack-C04U5A26MJB

## Proposed Changes

* Use option chaining when accessing the site's `capabilities` field

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR addresses an issue identified by Sentry, see p1715551259319339-slack-C04U5A26MJB.

During the domain-only flow we show a list of existing sites the user can attach their new domain to. If the site details are not loaded correctly, and the `capabilities` field is missing, then we should treat this as if the user doesn't have the required permission to manage the site and hide it from the list.

I don't know how this situation happens in practice, but Sentry identified that it's possible at runtime.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at `/start/domain`
* Add a domain to the cart and continue
* Choose to attach this domain to an existing site
   ![CleanShot 2024-05-15 at 10 51 02@2x](https://github.com/Automattic/wp-calypso/assets/1500769/abaf5acf-4ada-4196-90fa-4ea33fd70627)
* You will see a site list with all your existing sites
* Edit `SITE_REQUEST_FIELDS` in `client/state/sites/constants.js` to comment out `'capabilities'` so Calypso no longer loads the `capabilities` field
* In the dev tools clear your IndexedDB
* Reload the site's list page and go through the flow again
* You now see "No sites found" instead of a site list (you can still go back though)
   ![CleanShot 2024-05-15 at 11 16 27@2x](https://github.com/Automattic/wp-calypso/assets/1500769/54c9fad9-b695-4841-b465-b674061410d5)
* No errors about accessing undefined site properties

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?