### PR TITLE
domains/manage page: restore the plus icon on mobile

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -4,7 +4,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
-import { Icon, search } from '@wordpress/icons';
+import { Icon, plus, search } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -123,7 +123,12 @@ class AddDomainButton extends Component {
 		}
 
 		return (
-			<>{ ! isMobile() && <span className="options-domain-button__desktop">{ label }</span> }</>
+			<>
+				{ isMobile() && (
+					<Icon icon={ plus } className="options-domain-button__add gridicon" viewBox="2 2 20 20" />
+				) }
+				{ ! isMobile() && <span className="options-domain-button__desktop">{ label }</span> }
+			</>
 		);
 	}
 


### PR DESCRIPTION
quick fix for bug where plus icon is hidden on mobile:

https://github.com/Automattic/wp-calypso/assets/22446385/57643c32-1280-4865-b5a7-d8798b6e15f6

Note if you resize the screen you will need to refresh the page to get the new string, I'll leave this as is for now.
### Test instructions
N/A