### PR TITLE
Update the Reader item in the Global Sidebar

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -179,13 +179,14 @@ $brand-text: "SF Pro Text", $sans;
 		.sidebar__menu-link {
 			.sidebar__menu-icon {
 				&.dashicons-admin-site-alt3 {
-					margin-right: 10px;
+					margin-right: 9px;
 					margin-left: 1px;
 
 					.is-global-sidebar-collapsed & {
 						margin-left: 2px;
 					}
 				}
+
 				&.svg_all-sites,
 				&.sidebar_svg-reader {
 					.is-global-sidebar-visible:not(.is-global-sidebar-collapsed) & {

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -1,4 +1,5 @@
 import { Count, Badge, Gridicon, MaterialIcon } from '@automattic/components';
+import { Icon, chevronRightSmall } from '@wordpress/icons';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
@@ -89,18 +90,7 @@ export default function SidebarItem( props ) {
 				{ ( showAsExternal || props.forceShowExternalIcon ) && ! sidebarIsCollapsed && (
 					<Gridicon icon="external" size={ 24 } />
 				) }
-				{ props.forceChevronIcon && (
-					<svg
-						ariaHidden="true"
-						focusable="false"
-						height="24"
-						viewBox="0 0 24 24"
-						width="24"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<path d="M10.8622 8.04053L14.2805 12.0286L10.8622 16.0167L9.72327 15.0405L12.3049 12.0286L9.72327 9.01672L10.8622 8.04053Z"></path>
-					</svg>
-				) }
+				{ props.forceChevronIcon && <Icon icon={ chevronRightSmall } size={ 24 } /> }
 				{ props.children }
 			</a>
 		</li>

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -89,7 +89,18 @@ export default function SidebarItem( props ) {
 				{ ( showAsExternal || props.forceShowExternalIcon ) && ! sidebarIsCollapsed && (
 					<Gridicon icon="external" size={ 24 } />
 				) }
-				{ props.forceChevronIcon && <Gridicon icon="chevron-right" size={ 18 } /> }
+				{ props.forceChevronIcon && (
+					<svg
+						ariaHidden="true"
+						focusable="false"
+						height="24"
+						viewBox="0 0 24 24"
+						width="24"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path d="M10.8622 8.04053L14.2805 12.0286L10.8622 16.0167L9.72327 15.0405L12.3049 12.0286L9.72327 9.01672L10.8622 8.04053Z"></path>
+					</svg>
+				) }
 				{ props.children }
 			</a>
 		</li>

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -22,7 +22,6 @@ export default function globalSidebarMenu() {
 			type: 'menu-item',
 			url: '/domains/manage',
 		},
-		{ type: 'separator' },
 		{
 			icon: (
 				<svg


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7170

## Proposed Changes

- The gap between the Domain and the Reader items is removed.
- The chevron icon is updated.

| Before | After |
| --- | --- |
| ![Screenshot 2024-05-15 at 11 23 36 AM](https://github.com/Automattic/wp-calypso/assets/797888/0b42c9ee-93dc-441a-b7da-043b340dbe90) | ![Screenshot 2024-05-15 at 11 23 40 AM](https://github.com/Automattic/wp-calypso/assets/797888/0b81b9ec-bb10-4dfb-aaef-f257f21f601f) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the changes are updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
