### PR TITLE
Nav redesign: fix missing Hosting -> Plans

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -179,7 +179,7 @@ const useSiteMenuItems = () => {
 							type: 'submenu-item',
 							url: `/hosting/${ siteDomain }`,
 						},
-						...children.splice( pos ),
+						...children.splice( pos - 1 ),
 					];
 				}
 


### PR DESCRIPTION

## Proposed Changes

This change restores the missing Hosting -> Plans menu, which is broken by https://github.com/Automattic/wp-calypso/issues/90562.

<img width="280" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/b88c0500-f384-4bad-b14b-2e40508c1379">


## Why are these changes being made?

It was a regression.

## Testing Instructions

1. Go to `/plans/:siteSlug` of an Atomic Classic site.
2. Verify that Hosting -> Plans is there in the sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
