### PR TITLE
Reader: Fix the Infinite scroll behavior

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -89,35 +89,6 @@ body.is-section-reader:not(.is-reader-full-post) {
 		padding-top: 16px;
 	}
 
-	div.layout.is-global-sidebar-visible {
-		.main {
-			@media only screen and (min-width: 600px) and (max-width: 960px) {
-				padding: 24px;
-			}
-			@media only screen and (max-width: 660px) {
-				padding-top: 0;
-			}
-			border-block-end: 1px solid var(--studio-gray-0);
-		}
-		.layout__primary > div {
-			background: var(--color-surface);
-			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
-			@media only screen and (min-width: 600px) {
-				height: calc(100vh - var(--masterbar-height) - 50px);
-			}
-			@media only screen and (min-width: 782px) {
-				height: calc(100vh - 32px);
-			}
-			overflow: hidden;
-		}
-		.layout__primary > div > div {
-			height: 100%;
-			overflow-y: auto;
-			overflow-x: hidden;
-		}
-	}
-
 	@media only screen and (max-width: 600px) {
 		.navigation-header__main {
 			justify-content: normal;
@@ -129,11 +100,6 @@ body.is-section-reader:not(.is-reader-full-post) {
 	}
 
 	@media only screen and (max-width: 781px) {
-		div.layout.is-global-sidebar-visible {
-			.layout__primary {
-				overflow-x: auto;
-			}
-		}
 		.layout__primary > div {
 			background: var(--color-surface);
 			margin: 0;

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -502,17 +502,14 @@ class ReaderStream extends Component {
 	};
 
 	getScrollContainer = ( node ) => {
-		if ( ! node ) {
-			return undefined;
+		// Leave it to the default scroll container if we cannot find it or its the root element.
+		if ( ! node || node.ownerDocument === node.parentNode ) {
+			return false;
 		}
 
-		// ...except when overflow is defined to be hidden or visible
+		// Return when overflow is defined to either auto or scroll.
 		const { overflowY } = getComputedStyle( node );
 		if ( /(auto|scroll)/.test( overflowY ) ) {
-			return node;
-		}
-
-		if ( node.ownerDocument === node.parentNode ) {
 			return node;
 		}
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -1,6 +1,45 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+body.is-section-reader:not(.is-reader-full-post) {
+	div.layout.is-global-sidebar-visible {
+		.main {
+			@media only screen and (min-width: 600px) and (max-width: 960px) {
+				padding: 24px;
+			}
+			@media only screen and (max-width: 660px) {
+				padding-top: 0;
+			}
+			border-block-end: 1px solid var(--studio-gray-0);
+		}
+		.layout__primary > div {
+			background: var(--color-surface);
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			@media only screen and (min-width: 600px) {
+				height: calc(100vh - var(--masterbar-height) - 50px);
+			}
+			@media only screen and (min-width: 782px) {
+				height: calc(100vh - 32px);
+			}
+			overflow: hidden;
+		}
+		.layout__primary > div > div {
+			height: 100%;
+			overflow-y: auto;
+			overflow-x: hidden;
+		}
+	}
+
+	@media only screen and (max-width: 781px) {
+		div.layout.is-global-sidebar-visible {
+			.layout__primary {
+				overflow-x: auto;
+			}
+		}
+	}
+}
+
 .is-group-reader .async-load {
 	margin: 30px auto;
 	width: 50%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1715718386206769/1715324292.862629-slack-C06DN6QQVAQ

## Proposed Changes

* The infinite scroll behavior didn't work because we couldn't get the correct scroll container when you landed on the reader page directly. The reason was the following styles were loaded separately by the `ReaderSidebar` component. As a result, when the main component was mounted, the styles might not be applied yet and it led to the scroll container becoming the root element that was not the actual scroll container on the reader page.
  ```css
  .layout__primary > div > div {
    height: 100%;
    overflow-y: auto;
    overflow-x: hidden;
  }
  ```
* This PR moved these styles to the root element of the reader page so the styles will be applied at the beginning and then we can get the correct scroll container while the main component mounts.
* Moreover, I found the infinite scroll behavior didn't work on the logged-out page and it seemed that the scroll event on the `<html>` element won't be triggered. Therefore, this PR also made a change to leave the `listContext` to the default value if it's the root element to avoid this issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Logged-in

* Go to /reader directly
* Scroll down to the bottom
* Make sure the infinite scroll behavior works as expected

### Logged-out

* Go to /discover directly
* Scroll down to the bottom
* Make sure the infinite scroll behavior works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?