### PR TITLE
Update the ExPlat instance slug of the trail map language offering test

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
+++ b/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
@@ -23,7 +23,7 @@ function useExperimentForTrailMap( { flowName, isInSignup, intent }: Params ): {
 	isTrailMapStructure: boolean;
 } {
 	const [ isLoading, assignment ] = useExperiment(
-		'calypso_signup_onboarding_plans_trail_map_feature_grid',
+		'calypso_signup_onboarding_plans_trail_map_feature_grid_v2',
 		{
 			isEligible: flowName === 'onboarding' || ( ! isInSignup && intent === 'plans-default-wpcom' ),
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89690 

## Proposed Changes

The trail map experiment has been paused since the team needed to conduct some more post-launch review. This PR updates the ExPlat instance slug in preparation for the relaunch.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The same test plan as in https://github.com/Automattic/wp-calypso/pull/90247

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
