### PR TITLE
Nav Redesign: Hide search and notifications on mobile

### DIFF
--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { LocalizeProps } from 'i18n-calypso';
 import { FC } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
@@ -20,6 +21,7 @@ export const GlobalSidebarFooter: FC< {
 } > = ( { translate, user } ) => {
 	const hasEnTranslation = useHasEnTranslation();
 	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
+	const isDesktop = useBreakpoint( '>=782px' );
 
 	const isMac = window?.navigator.userAgent && window.navigator.userAgent.indexOf( 'Mac' ) > -1;
 	const searchShortcut = isMac ? '⌘ + K' : 'Ctrl + K';
@@ -44,20 +46,24 @@ export const GlobalSidebarFooter: FC< {
 				}
 				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.HELPCENTER_CLICK ) }
 			/>
-			<SidebarSearch
-				tooltip={
-					hasEnTranslation( 'Search (%(shortcut)s)' )
-						? translate( 'Search (%(shortcut)s)', { args: { shortcut: searchShortcut } } )
-						: translate( 'Jump to…' )
-				}
-				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.SEARCH_CLICK ) }
-			/>
-			<SidebarNotifications
-				className="sidebar__item-notifications"
-				tooltip={ translate( 'Notifications' ) }
-				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.NOTIFICATION_CLICK ) }
-				translate={ translate }
-			/>
+			{ isDesktop && (
+				<>
+					<SidebarSearch
+						tooltip={
+							hasEnTranslation( 'Search (%(shortcut)s)' )
+								? translate( 'Search (%(shortcut)s)', { args: { shortcut: searchShortcut } } )
+								: translate( 'Jump to…' )
+						}
+						onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.SEARCH_CLICK ) }
+					/>
+					<SidebarNotifications
+						className="sidebar__item-notifications"
+						tooltip={ translate( 'Notifications' ) }
+						onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.NOTIFICATION_CLICK ) }
+						translate={ translate }
+					/>
+				</>
+			) }
 			{ isInSupportSession && (
 				<QuickLanguageSwitcher className="sidebar__footer-language-switcher" shouldRenderAsButton />
 			) }


### PR DESCRIPTION
## Proposed Changes

We now hide the notifications and search on mobile from the sidebar, since they are already present in the top bar.

Before | After
--- | ---
<img width="359" alt="Screenshot 2024-05-15 at 10 21 51" src="https://github.com/Automattic/wp-calypso/assets/1233880/d8ad4c09-af1f-4568-8d8f-7b44067c9a3a"> | <img width="348" alt="Screenshot 2024-05-15 at 10 21 58" src="https://github.com/Automattic/wp-calypso/assets/1233880/6898c00d-b8fe-4c2a-97a3-dcbd0d001635">


## Why are these changes being made?

Because we have duplicated elements in the UI.

## Testing Instructions

- Use the Calypso live link below
- Switch to a mobile viewport
- Go to `/sites`
- Open the sidebar
- Make sure the search and notifications don't appear in the footer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
