### PR TITLE
Notifications: Fix the ensureSelectedNoteVisibility behavior introduced by the Fragment

### DIFF
--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -348,12 +348,7 @@ export class NoteList extends Component {
 
 		return (
 			<>
-				<StatusBar
-					statusClasses={ this.state.statusClasses }
-					statusMessage={ this.state.statusMessage }
-					statusTimeout={ this.state.statusTimeout }
-					statusReset={ this.resetStatusBar }
-				/>
+				{ /* Keep the wpnc__note-list as the first child of the Fragment to ensure the ReactDOM.findDOMNode returns the list element */ }
 				<div className={ classes } id="wpnc__note-list">
 					<FilterBar controller={ this.props.filterController } />
 					<button className="screen-reader-text" onClick={ this.props.closePanel }>
@@ -374,6 +369,12 @@ export class NoteList extends Component {
 						</ol>
 					</div>
 				</div>
+				<StatusBar
+					statusClasses={ this.state.statusClasses }
+					statusMessage={ this.state.statusMessage }
+					statusTimeout={ this.state.statusTimeout }
+					statusReset={ this.resetStatusBar }
+				/>
 			</>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1715755607204209-slack-C06DN6QQVAQ

## Proposed Changes

* The issue was introduced by https://github.com/Automattic/wp-calypso/pull/90695 as it moved the `StatusBar` to the outside of the `wpnc__note-list` and then used the `Fragment` to wrap the `wpnc__note-list` and `StatusBar`. However, it led to the `findDOMNode` getting the wrong element because "[A component may return an array or a Fragment with multiple children. In that case findDOMNode, will return the DOM node corresponding to the first non-empty child](https://react.dev/reference/react-dom/findDOMNode#caveats)".
* As a result, this PR made a quick fix to move the `StatusBar` to the second child of the Fragment so the `findDOMNode` can get the `wpnc__note-list` element as before

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /
* Open the notifications panel
* Select the non-first notification
* Make sure the list won't jump randomly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?