### PR TITLE
E2E test: Only expand the post summary section if it exists since the summary section will no longer be expansible

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -134,7 +134,7 @@ export class EditorSettingsSidebarComponent {
 	}
 
 	/**
-	 * Expands a collapsed section of the sidebar if the section exists in the first place.
+	 * Expands a collapsed `Summary` section of the sidebar if it exists.
 	 * The `Summary` section is no longer collapsible in recent GB iterations
 	 * @see https://github.com/WordPress/gutenberg/commit/201099408131e2abe3cd094f7a1e7e539a350c12
 	 * @deprecated To discourage the adoption of this function
@@ -144,7 +144,7 @@ export class EditorSettingsSidebarComponent {
 	 *
 	 * @param {string} name Name of section to be expanded.
 	 */
-	async expandSectionIfExists( name: string ): Promise< void > {
+	async expandSummary( name: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
 		const sectionLocator = editorParent.locator( selectors.section( name ) );
 

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -134,6 +134,28 @@ export class EditorSettingsSidebarComponent {
 	}
 
 	/**
+	 * Expands a collapsed section of the sidebar if the section exists in the first place.
+	 * The `Summary` section is no longer collapsible in recent GB iterations
+	 * @see https://github.com/WordPress/gutenberg/commit/201099408131e2abe3cd094f7a1e7e539a350c12
+	 * @deprecated To discourage the adoption of this function
+	 * @todo Remove when all platforms have eventually been migrated
+	 *
+	 * If the section is already open, this method will pass.
+	 *
+	 * @param {string} name Name of section to be expanded.
+	 */
+	async expandSectionIfExists( name: string ): Promise< void > {
+		const editorParent = await this.editor.parent();
+		const sectionLocator = editorParent.locator( selectors.section( name ) );
+
+		if ( ! ( await sectionLocator.isVisible() ) ) {
+			return;
+		}
+
+		this.expandSection( name );
+	}
+
+	/**
 	 * Given a selector, determines whether the target button/toggle is
 	 * in an expanded state.
 	 *

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -580,7 +580,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
 
-		await this.editorSettingsSidebarComponent.expandSectionIfExists( 'Summary' );
+		await this.editorSettingsSidebarComponent.expandSummary( 'Summary' );
 		await this.editorSettingsSidebarComponent.openVisibilityOptions();
 		await this.editorSettingsSidebarComponent.selectVisibility( visibility, {
 			password: password,
@@ -637,7 +637,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
-		await this.editorSettingsSidebarComponent.expandSectionIfExists( 'Summary' );
+		await this.editorSettingsSidebarComponent.expandSummary( 'Summary' );
 		await this.editorSettingsSidebarComponent.enterUrlSlug( slug );
 	}
 
@@ -753,7 +753,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
 
-		await this.editorSettingsSidebarComponent.expandSectionIfExists( 'Summary' );
+		await this.editorSettingsSidebarComponent.expandSummary( 'Summary' );
 		await this.editorSettingsSidebarComponent.openSchedule();
 		await this.editorSettingsSidebarComponent.setScheduleDetails( date );
 		await this.editorSettingsSidebarComponent.closeSchedule();

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -580,7 +580,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
 
-		await this.editorSettingsSidebarComponent.expandSection( 'Summary' );
+		await this.editorSettingsSidebarComponent.expandSectionIfExists( 'Summary' );
 		await this.editorSettingsSidebarComponent.openVisibilityOptions();
 		await this.editorSettingsSidebarComponent.selectVisibility( visibility, {
 			password: password,
@@ -637,7 +637,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
-		await this.editorSettingsSidebarComponent.expandSection( 'Summary' );
+		await this.editorSettingsSidebarComponent.expandSectionIfExists( 'Summary' );
 		await this.editorSettingsSidebarComponent.enterUrlSlug( slug );
 	}
 
@@ -753,7 +753,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
 
-		await this.editorSettingsSidebarComponent.expandSection( 'Summary' );
+		await this.editorSettingsSidebarComponent.expandSectionIfExists( 'Summary' );
 		await this.editorSettingsSidebarComponent.openSchedule();
 		await this.editorSettingsSidebarComponent.setScheduleDetails( date );
 		await this.editorSettingsSidebarComponent.closeSchedule();


### PR DESCRIPTION
GB is making some new adjustments. See this [tracking issue](https://github.com/WordPress/gutenberg/issues/59689) for more context.

At this point, in this [commit](https://github.com/WordPress/gutenberg/commit/201099408131e2abe3cd094f7a1e7e539a350c12) and [PR](https://github.com/WordPress/gutenberg/pull/61624), the `Summary` section has been slightly re-imagined and is no longer expansible.

To this end, the concerned e2e tests will be slightly adjusted as the atomic nightlies are beginning to fail. We'll check the existence of that section before we attempt to expand it. This fixes the issue temporarily. Eventually the line to expand that section should be removed in the future.

```
======= Failed test run #1 ==========
  locator.getAttribute: Timeout 30000ms exceeded.
  =========================== logs ===========================
  waiting for locator('body.block-editor-page').locator('[aria-label="Editor settings"] .components-panel__body-title button:has-text("Summary")')
  ============================================================
  at EditorSettingsSidebarComponent.getAttribute (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts:149:31)
      at EditorSettingsSidebarComponent.expandSection (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts:122:8)
      at EditorPage.schedule (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/editor-page.ts:756:3)
      at Object.<anonymous> (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/editor/editor__schedule.ts:66:4)
```  

---



Testing instructions
---

[Running e2e tests for Calypso](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)


```bash
cd test/e2e
yarn jest --clearCache && yarn build  # clear build cache before each run


GUTENBERG_NIGHTLY=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__schedule.ts
VIEWPORT_NAME=mobile GUTENBERG_NIGHTLY=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__schedule.ts

GUTENBERG_NIGHTLY=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__page-basic-flow.ts
VIEWPORT_NAME=mobile GUTENBERG_NIGHTLY=1 TEST_ON_ATOMIC=true yarn jest specs/editor/editor__page-basic-flow.ts
```

