### PR TITLE
A4A: Add the new Settings section with the sidebar menu and the initial blank page

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -1,4 +1,4 @@
-import { category, currencyDollar, home, moveTo, reusableBlock, tag } from '@wordpress/icons';
+import { category, currencyDollar, home, moveTo, reusableBlock, tag, cog } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
@@ -11,6 +11,7 @@ import {
 	A4A_SITES_LINK,
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MIGRATIONS_LINK,
+	A4A_SETTINGS_LINK,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -91,6 +92,19 @@ const useMainMenuItems = ( path: string ) => {
 							title: translate( 'Migrations' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Migrations',
+							},
+						},
+				  ]
+				: [] ),
+			...( isSectionNameEnabled( 'a8c-for-agencies-settings' )
+				? [
+						{
+							icon: cog,
+							path: '/',
+							link: A4A_SETTINGS_LINK,
+							title: translate( 'Settings' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Settings',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -29,3 +29,4 @@ export const A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK = `${ A4A_MARKETPLACE_LINK }
 export const A4A_SIGNUP_LINK = '/signup';
 export const A4A_SIGNUP_FINISH_LINK = '/signup/finish';
 export const A4A_MIGRATIONS_LINK = '/migrations';
+export const A4A_SETTINGS_LINK = '/settings';

--- a/client/a8c-for-agencies/sections/settings/agency-profile/index.tsx
+++ b/client/a8c-for-agencies/sections/settings/agency-profile/index.tsx
@@ -1,0 +1,9 @@
+const AgencyProfile = () => {
+	return (
+		<div>
+			<h2>Agency Profile Form</h2>
+		</div>
+	);
+};
+
+export default AgencyProfile;

--- a/client/a8c-for-agencies/sections/settings/controller.tsx
+++ b/client/a8c-for-agencies/sections/settings/controller.tsx
@@ -1,0 +1,16 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import MainSidebar from '../../components/sidebar-menu/main';
+import Settings from './settings';
+
+export const settingsContext: Callback = ( context, next ) => {
+	context.secondary = <MainSidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Settings" path={ context.path } />
+			<Settings />
+		</>
+	);
+
+	next();
+};

--- a/client/a8c-for-agencies/sections/settings/index.tsx
+++ b/client/a8c-for-agencies/sections/settings/index.tsx
@@ -1,0 +1,8 @@
+import page from '@automattic/calypso-router';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { settingsContext } from './controller';
+
+export default function () {
+	page( '/settings', requireAccessContext, settingsContext, makeLayout, clientRender );
+}

--- a/client/a8c-for-agencies/sections/settings/index.tsx
+++ b/client/a8c-for-agencies/sections/settings/index.tsx
@@ -1,8 +1,9 @@
 import page from '@automattic/calypso-router';
+import { A4A_SETTINGS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { settingsContext } from './controller';
 
 export default function () {
-	page( '/settings', requireAccessContext, settingsContext, makeLayout, clientRender );
+	page( A4A_SETTINGS_LINK, requireAccessContext, settingsContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/settings/settings.tsx
+++ b/client/a8c-for-agencies/sections/settings/settings.tsx
@@ -6,6 +6,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import AgencyProfile from './agency-profile';
 
 export default function Settings() {
 	const translate = useTranslate();
@@ -18,7 +19,10 @@ export default function Settings() {
 					<Title>{ title }</Title>
 				</LayoutHeader>
 			</LayoutTop>
-			<LayoutBody>This is the Settings section (WIP)</LayoutBody>
+			<LayoutBody>
+				<h1>This is the Settings section with tabs (WIP)</h1>
+				<AgencyProfile />
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/settings/settings.tsx
+++ b/client/a8c-for-agencies/sections/settings/settings.tsx
@@ -1,0 +1,24 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+
+export default function Settings() {
+	const translate = useTranslate();
+	const title = translate( 'Settings' );
+
+	return (
+		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>This is the Settings section (WIP)</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -40,7 +40,7 @@ export const itemLinkMatches = ( path, currentPath ) => {
 	}
 
 	if ( pathIncludes( currentPath, 'settings', 1 ) ) {
-		// Jetpack Cloud uses a simpler /settings/:site pattern for the settings page.
+		// Jetpack Cloud uses a simpler /settings/:site pattern, and A4A uses /settings/:tab, for the settings page.
 		if ( isJetpackCloud() || isA8CForAgencies() ) {
 			return fragmentIsEqual( path, currentPath, 1 );
 		}

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -41,7 +41,7 @@ export const itemLinkMatches = ( path, currentPath ) => {
 
 	if ( pathIncludes( currentPath, 'settings', 1 ) ) {
 		// Jetpack Cloud uses a simpler /settings/:site pattern for the settings page.
-		if ( isJetpackCloud() ) {
+		if ( isJetpackCloud() || isA8CForAgencies() ) {
 			return fragmentIsEqual( path, currentPath, 1 );
 		}
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -794,6 +794,12 @@ const sections = [
 		group: 'a8c-for-agencies',
 	},
 	{
+		name: 'a8c-for-agencies-settings',
+		paths: [ '/settings' ],
+		module: 'calypso/a8c-for-agencies/sections/settings',
+		group: 'a8c-for-agencies',
+	},
+	{
 		name: 'a8c-for-agencies-signup',
 		paths: [ '/signup', '/signup/finish', '/signup/oauth/token' ],
 		module: 'calypso/a8c-for-agencies/sections/signup',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -170,6 +170,7 @@
 		"a8c-for-agencies-signup": false,
 		"a8c-for-agencies-referrals": false,
 		"a8c-for-agencies-migrations": false,
+		"a8c-for-agencies-settings": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -49,6 +49,7 @@
 		"a8c-for-agencies-purchases": true,
 		"a8c-for-agencies-signup": true,
 		"a8c-for-agencies-referrals": true,
+		"a8c-for-agencies-settings": true,
 		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -43,6 +43,7 @@
 		"a8c-for-agencies-purchases": true,
 		"a8c-for-agencies-signup": true,
 		"a8c-for-agencies-referrals": true,
+		"a8c-for-agencies-settings": true,
 		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -44,6 +44,7 @@
 		"a8c-for-agencies-purchases": true,
 		"a8c-for-agencies-signup": true,
 		"a8c-for-agencies-referrals": true,
+		"a8c-for-agencies-settings": false,
 		"a8c-for-agencies-migrations": false
 	},
 	"site_filter": [],

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -45,6 +45,7 @@
 		"a8c-for-agencies-purchases": true,
 		"a8c-for-agencies-signup": true,
 		"a8c-for-agencies-referrals": true,
+		"a8c-for-agencies-settings": false,
 		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/489
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/484

## Proposed Changes

This PR adds the new Settings section to A4A. This is the initial code base to implement the different tabs later. We will start with the Agency Profile subsection.

![image](https://github.com/Automattic/wp-calypso/assets/9832440/41fd182e-b492-4108-b14b-eb5851245b86)


The Settings section is active only for `development` and `horizon` contexts. For `stage` and `production` contexts this section will be hidden.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Ensure that the new Settings section will be active only for `development` and `horizon` contexts.
- Click on the Setting sidebar menu, it'll take you to the Setting page (draft)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
