### PR TITLE
Onboarding: lazily load mshots and external images

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -46,7 +46,14 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 		const themeImgSrc = photon( design.screenshot, { fit } ) || design.screenshot;
 		// const themeImgSrcDoubleDpi = photon( design.screenshot, { fit, zoom: 2 } ) || design.screenshot;
 
-		return <img src={ themeImgSrc } srcSet={ `${ themeImgSrc }` } alt={ design.description } />;
+		return (
+			<img
+				loading="lazy"
+				src={ themeImgSrc }
+				srcSet={ `${ themeImgSrc }` }
+				alt={ design.description }
+			/>
+		);
 	}
 
 	return (

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -35,16 +35,14 @@ export function mshotsUrl( targetUrl: string, options: MShotsOptions, count = 0 
 
 const MAXTRIES = 10;
 
-// This custom react hook returns undefined while the image is loading and
-// a HTMLImageElement (i.e. the class you get from `new Image()`) once loading
-// is complete.
+// This custom react hook returns null while the image is loading and the page
+// (not image) URL once loading is complete.
 //
 // It also triggers a re-render (via setState()) when the value changes, so just
-// check if it's truthy and then treat it like any other Image.
+// check that the requested URL matches the returned URL.
 //
-// Note the loading may occur immediately and synchronously if the image is
-// already or may take up to several seconds if mshots has to generate and cache
-// new images.
+// Note the loading may occur immediately if the image is already available, or
+// may take several seconds if mshots has to generate and cache new images.
 //
 // The calling code doesn't need to worry about the details except that you'll
 // want some sort of loading display.
@@ -112,9 +110,6 @@ const useMshotsImg = (
 				// don't get the request through an img element so we'd need to
 				// take a completely different approach using ajax.
 				if ( imgRef.current?.naturalWidth !== 400 || imgRef.current?.naturalHeight !== 300 ) {
-					// Note we're using the naked object here, not the ref, because
-					// this is the callback on the image itself. We'd never want
-					// the image to finish loading and set some other image.
 					setLoadedImg( src );
 				} else if ( count < MAXTRIES ) {
 					// Only refresh 10 times

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -177,7 +177,12 @@ const MShotsImage = ( {
 	return scrollable || ! visible ? (
 		<div className={ className } style={ style } aria-labelledby={ labelledby } />
 	) : (
-		<img { ...{ className, style, src, alt } } aria-labelledby={ labelledby } alt={ alt } />
+		<img
+			loading="lazy"
+			{ ...{ className, style, src, alt } }
+			aria-labelledby={ labelledby }
+			alt={ alt }
+		/>
 	);
 };
 

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -50,7 +50,11 @@ const MAXTRIES = 10;
 // want some sort of loading display.
 //
 // Inspired by https://stackoverflow.com/a/60458593
-const useMshotsImg = ( src: string, options: MShotsOptions ): HTMLImageElement | undefined => {
+const useMshotsImg = (
+	src: string,
+	options: MShotsOptions,
+	handleImageLoad: boolean
+): HTMLImageElement | undefined => {
 	const [ loadedImg, setLoadedImg ] = useState< HTMLImageElement >();
 	const [ count, setCount ] = useState( 0 );
 	const previousSrc = useRef( src );
@@ -68,6 +72,13 @@ const useMshotsImg = ( src: string, options: MShotsOptions ): HTMLImageElement |
 	// to browser caching. Getting this wrong looks like the url resolving
 	// before the image is ready.
 	useEffect( () => {
+		// Ignore all this work if we don't want the hook to handle the image load.
+		// Since hooks can't be inside conditions, we need to handle that logic here,
+		// once all hooks are in place...
+		if ( ! handleImageLoad ) {
+			return;
+		}
+
 		// If there's been a "props" change we need to reset everything:
 		if (
 			options !== previousOptions.current ||
@@ -147,8 +158,8 @@ const MShotsImage = ( {
 	options,
 	scrollable = false,
 }: MShotsImageProps ) => {
-	const maybeImage = useMshotsImg( url, options );
-	const src: string = maybeImage?.src || '';
+	const maybeImage = useMshotsImg( url, options, scrollable );
+	const src: string = ( scrollable ? maybeImage?.src : mshotsUrl( url, options ) ) || '';
 	const visible = !! src;
 	const backgroundImage = maybeImage?.src && `url( ${ maybeImage?.src } )`;
 

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -54,8 +54,8 @@ const useMshotsImg = (
 	src: string,
 	options: MShotsOptions,
 	imgRef: React.MutableRefObject< HTMLImageElement | null >
-): HTMLImageElement | null => {
-	const [ loadedImg, setLoadedImg ] = useState< HTMLImageElement | null >( null );
+): string | null => {
+	const [ loadedImg, setLoadedImg ] = useState< string | null >( null );
 	const [ count, setCount ] = useState( 0 );
 	const previousSrc = useRef( src );
 
@@ -115,7 +115,7 @@ const useMshotsImg = (
 					// Note we're using the naked object here, not the ref, because
 					// this is the callback on the image itself. We'd never want
 					// the image to finish loading and set some other image.
-					setLoadedImg( imgRef.current );
+					setLoadedImg( src );
 				} else if ( count < MAXTRIES ) {
 					// Only refresh 10 times
 					// Triggers a target.src change with increasing timeouts
@@ -156,14 +156,14 @@ const MShotsImage = ( {
 	scrollable = false,
 }: MShotsImageProps ) => {
 	const imgRef = useRef< HTMLImageElement | null >( null );
-	const maybeImage = useMshotsImg( url, options, imgRef );
-	const src: string = maybeImage?.src || '';
-	const visible = !! src;
-	const backgroundImage = maybeImage?.src && `url( ${ maybeImage?.src } )`;
+	const currentlyLoadedUrl = useMshotsImg( url, options, imgRef );
+	const src: string = imgRef.current?.src || '';
+	const visible = src && url === currentlyLoadedUrl;
+	const backgroundImage = src && `url( ${ src } )`;
 
 	const animationScrollSpeedInPixelsPerSecond = 400;
 	const animationDuration =
-		( maybeImage?.naturalHeight || 600 ) / animationScrollSpeedInPixelsPerSecond;
+		( imgRef.current?.naturalHeight || 600 ) / animationScrollSpeedInPixelsPerSecond;
 
 	const scrollableStyles = {
 		backgroundImage,

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -92,7 +92,6 @@ const useMshotsImg = (
 				}
 			}
 
-			setLoadedImg( null );
 			setCount( 0 );
 			if ( previousImg.current !== imgRef.current ) {
 				previousImg.current = imgRef.current;

--- a/packages/onboarding/src/mshots-image/style.scss
+++ b/packages/onboarding/src/mshots-image/style.scss
@@ -24,6 +24,15 @@
 	animation: fadein 300ms;
 }
 
+// Increase specificity by repeating class name.
+.mshots-dummy-image.mshots-dummy-image {
+	position: absolute;
+	display: block;
+	visibility: hidden;
+	height: 0;
+	width: 0;
+}
+
 @keyframes fadein {
 	from {
 		opacity: 0;


### PR DESCRIPTION
Images in the "pick a design" step of onboarding are currently all being loaded at once, which causes contention on bandwidth-restricted connections. This contention means that the most important images (the ones inside the viewport) take longer to load, and in some cases only load after some of the ones below the viewport.

This PR changes that, via native image lazy loading, thereby ensuring that images outside of the viewport aren't part of the initial salvo of requests, and only get requested once the user scrolls down closer to them.

Related to #88786

## Proposed Changes

* Add `loading="lazy"` to dynamically-generated image tags from mshots

## Why are these changes being made?

* To improve loading performance on the "pick a design" step of onboarding; vital metrics such as LCP benefit from visible content being loaded sooner.

## Testing Instructions

* Navigate to the "pick a design" step of onboarding
* Smoke-test theme images and ensure nothing breaks

To validate performance changes:
- Open DevTools
- Click to open a different category (e.g. Business or About) than the one you're currently on
- Make note of which URLs load and whether they're for images that are visible in the viewport, or close enough to it that the browser decides to fetch them anyway
- Scroll down and ensure that more images get loaded as the viewport gets closer to them

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
