### PR TITLE
Nav redesign: workaround to persist pagination upon page reload

### DIFF
--- a/client/sites-dashboard-v2/hooks/use-initialize-dataviews-page.ts
+++ b/client/sites-dashboard-v2/hooks/use-initialize-dataviews-page.ts
@@ -10,8 +10,8 @@ export function useInitializeDataViewsPage(
 	dataViewsState: DataViewsState,
 	setDataViewsState: ( state: DataViewsState ) => void
 ) {
-	const prevPage = usePrevious( dataViewsState.page );
-	const prevSearch = usePrevious( dataViewsState.search );
+	const prevPage = usePrevious( dataViewsState.page ) as number;
+	const prevSearch = usePrevious( dataViewsState.search ) as string;
 
 	const done = useRef( false );
 

--- a/client/sites-dashboard-v2/hooks/use-initialize-dataviews-page.ts
+++ b/client/sites-dashboard-v2/hooks/use-initialize-dataviews-page.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import type { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+
+// DataViews' pagination always resets when the search component is mounted, even though the search term has not changed.
+// This is a bug which has a fix in https://github.com/WordPress/gutenberg/pull/61307.
+// This is a workaround until the above fix is released.
+// Here, we restore the page to the previous page if it is unintentionally changed by the above bug.
+export function useInitializeDataViewsPage(
+	dataViewsState: DataViewsState,
+	setDataViewsState: ( state: DataViewsState ) => void
+) {
+	const prevPage = useRef( dataViewsState.page );
+	const prevSearch = useRef( dataViewsState.search );
+
+	const done = useRef( false );
+
+	useEffect( () => {
+		if ( prevPage.current === 1 ) {
+			done.current = true;
+		}
+		if ( done.current ) {
+			return;
+		}
+
+		if (
+			dataViewsState.search === prevSearch.current &&
+			dataViewsState.page !== prevPage.current
+		) {
+			setDataViewsState( {
+				...dataViewsState,
+				page: prevPage.current,
+			} );
+			done.current = true;
+		}
+	}, [ dataViewsState.page, dataViewsState.search ] );
+
+	useEffect( () => {
+		prevPage.current = dataViewsState.page;
+	}, [ dataViewsState.page ] );
+
+	useEffect( () => {
+		prevSearch.current = dataViewsState.search;
+	}, [ dataViewsState.search ] );
+}

--- a/client/sites-dashboard-v2/hooks/use-initialize-dataviews-page.ts
+++ b/client/sites-dashboard-v2/hooks/use-initialize-dataviews-page.ts
@@ -1,3 +1,4 @@
+import { usePrevious } from '@wordpress/compose';
 import { useEffect, useRef } from 'react';
 import type { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 
@@ -9,36 +10,25 @@ export function useInitializeDataViewsPage(
 	dataViewsState: DataViewsState,
 	setDataViewsState: ( state: DataViewsState ) => void
 ) {
-	const prevPage = useRef( dataViewsState.page );
-	const prevSearch = useRef( dataViewsState.search );
+	const prevPage = usePrevious( dataViewsState.page );
+	const prevSearch = usePrevious( dataViewsState.search );
 
 	const done = useRef( false );
 
 	useEffect( () => {
-		if ( prevPage.current === 1 ) {
+		if ( prevPage === 1 ) {
 			done.current = true;
 		}
 		if ( done.current ) {
 			return;
 		}
 
-		if (
-			dataViewsState.search === prevSearch.current &&
-			dataViewsState.page !== prevPage.current
-		) {
+		if ( dataViewsState.search === prevSearch && dataViewsState.page !== prevPage ) {
 			setDataViewsState( {
 				...dataViewsState,
-				page: prevPage.current,
+				page: prevPage,
 			} );
 			done.current = true;
 		}
 	}, [ dataViewsState.page, dataViewsState.search ] );
-
-	useEffect( () => {
-		prevPage.current = dataViewsState.page;
-	}, [ dataViewsState.page ] );
-
-	useEffect( () => {
-		prevSearch.current = dataViewsState.search;
-	}, [ dataViewsState.search ] );
 }

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -33,6 +33,7 @@ import {
 	useShowSiteTransferredNotice,
 } from 'calypso/sites-dashboard/components/sites-dashboard';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
+import { useInitializeDataViewsPage } from './hooks/use-initialize-dataviews-page';
 import { useInitializeDataViewsSelectedItem } from './hooks/use-initialize-dataviews-selected-item';
 import { useSyncSelectedSite } from './hooks/use-sync-selected-site';
 import { useSyncSelectedSiteFeature } from './hooks/use-sync-selected-site-feature';
@@ -187,6 +188,7 @@ const SitesDashboardV2 = ( {
 		dataViewsState.page * dataViewsState.perPage
 	);
 
+	useInitializeDataViewsPage( dataViewsState, setDataViewsState );
 	useInitializeDataViewsSelectedItem( { selectedSite, paginatedSites } );
 
 	// Update URL with view control params on change.


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/7176

## Proposed Changes

DataViews' pagination always resets when the search component is mounted, even though the search term has not changed.

This is a bug which has a fix in https://github.com/WordPress/gutenberg/pull/61307.

This is a workaround until the above fix is released. Here, we restore the page to the previous page if it is unintentionally changed by the above bug.

## Why are these changes being made?

We want to persist the pagination on /sites.

## Testing Instructions

1. Go to /sites
2. Go to next page(s) (other than page 1)
3. Refresh the page; verify the current page persists.
4. Select any site
5. Verify that the preview panel opens and the current page persists.
6. Refresh the page; verify the current page persists.
7. Repeat the above steps but this time with a search term.
8. Basically try anything to break it.

## Note 1

If you change the search term, the pagination will reset to 1. This is DataViews' behavior.

## Note 2 (IMPORTANT)

At some point you might see a blinking URL, where page query param disappear and reappear. This is a compromise; this workaround needs this "mechanism".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
