### PR TITLE
Fix hosting-config staging/produciton site switch button

### DIFF
--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -21,10 +21,12 @@ function shouldNavigateWithinSamePage( path: string ): boolean {
 	return currentPath === targetUrl.pathname && !! targetUrl.hash;
 }
 
-export function navigate( path: string, openInNewTab = false ): void {
+export function navigate( path: string, openInNewTab = false, forceReload = false ): void {
 	if ( isSameOrigin( path ) ) {
 		if ( openInNewTab ) {
 			window.open( path, '_blank' );
+		} else if ( forceReload ) {
+			window.location.href = path;
 		} else if ( isCurrentPathOutOfScope( window.location.pathname ) ) {
 			const state = { path };
 			window.history.pushState( state, '', path );

--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -128,7 +129,17 @@ export const ManageStagingSiteCardContent = ( {
 			return (
 				<Button
 					primary
-					onClick={ () => navigate( `/hosting-config/${ urlToSlug( stagingSite.url ) }` ) }
+					onClick={ () => {
+						if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+							navigate(
+								`/hosting-config/${ urlToSlug( stagingSite.url ) }?search=${ stagingSite.url }`,
+								false,
+								true
+							);
+						} else {
+							navigate( `/hosting-config/${ urlToSlug( stagingSite.url ) }` );
+						}
+					} }
 					disabled={ isButtonDisabled }
 				>
 					<span>{ translate( 'Manage staging site' ) }</span>

--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -132,7 +132,9 @@ export const ManageStagingSiteCardContent = ( {
 					onClick={ () => {
 						if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
 							navigate(
-								`/hosting-config/${ urlToSlug( stagingSite.url ) }?search=${ stagingSite.url }`,
+								`/hosting-config/${ urlToSlug( stagingSite.url ) }?search=${ urlToSlug(
+									stagingSite.url
+								) }`,
 								false,
 								true
 							);

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -144,9 +144,9 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 						onClick={ () => {
 							if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
 								navigate(
-									`/hosting-config/${ urlToSlug( productionSite.url ) }?search=${
+									`/hosting-config/${ urlToSlug( productionSite.url ) }?search=${ urlToSlug(
 										productionSite.url
-									}`,
+									) }`,
 									false,
 									true
 								);

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
@@ -140,7 +141,19 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 				<ActionButtons>
 					<Button
 						primary
-						onClick={ () => navigate( `/hosting-config/${ urlToSlug( productionSite.url ) }` ) }
+						onClick={ () => {
+							if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+								navigate(
+									`/hosting-config/${ urlToSlug( productionSite.url ) }?search=${
+										productionSite.url
+									}`,
+									false,
+									true
+								);
+							} else {
+								navigate( `/hosting-config/${ urlToSlug( productionSite.url ) }` );
+							}
+						} }
 						disabled={ disabled || isSyncInProgress }
 					>
 						<span>{ __( 'Switch to production site' ) }</span>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7175

## Proposed Changes

* Reloads the page when the staging/production site is switched
* Adds `?search={siteURL}` to the end so that the site list sidebar shows the site highlighted


More context on why this approach is proposed: https://github.com/Automattic/dotcom-forge/issues/7175#issuecomment-2112299803

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  See https://github.com/Automattic/dotcom-forge/issues/7175, when clicking on the go to staging/production button under /hosting-config/:site, it will not update the entire site management dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prereq: have an atomic site with staging site enabled, the staging site also needs /hosting-config to be enabled to test the "Switch to production site" button as well
* Go to /sites and select the site and select the tab "Hosting Config", locate the button
![staging site](https://github.com/Automattic/wp-calypso/assets/6586048/15c58a1b-ec63-42a7-8fae-7f5b9f2f678e)
* Page will refresh and load the staging site's site management panel with the sidebar having filtered so that we can see the site being highlighted
* Locate the button to switch to production site and see if it behaves the same way (reloads, highlights the site in the sidebar and shows the prod site's site management panel
![prod](https://github.com/Automattic/wp-calypso/assets/6586048/64d4dbe9-1a02-41ca-aa8e-6cdffff9eee1)


https://github.com/Automattic/wp-calypso/assets/6586048/be8cfdb2-562a-414a-8227-f2a4806f56d1



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
