### PR TITLE
Scheduled Updates: Match the empty state between single & multisite

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -50,6 +50,23 @@ $brand-display: "SF Pro Display", sans-serif;
 		}
 	}
 
+	.empty-state {
+		max-width: 50%;
+		text-align: left;
+		padding: 0;
+
+		@media screen and (max-width: $break-large) {
+			max-width: 100%;
+		}
+
+		p {
+			color: var(--studio-gray-100);
+			margin: 1.5rem auto;
+			font-size: rem(18px);
+			line-height: 1.625;
+		}
+	}
+
 	&-table {
 		th,
 		td {

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -64,24 +64,6 @@ $brand-display: "SF Pro Display", sans-serif;
 		}
 	}
 
-	.empty-state {
-		max-width: 50%;
-		text-align: left;
-		padding: 0;
-
-		@media screen and (max-width: $break-large) {
-			max-width: 100%;
-		}
-
-		p {
-			color: var(--studio-gray-100);
-			margin: 1.5rem auto;
-			font-size: rem(18px);
-			line-height: 1.625;
-		}
-	}
-
-
 	.plugins-update-manager-multisite-card {
 		margin-bottom: 1rem;
 		border-bottom: solid 1px var(--studio-gray-0);

--- a/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
@@ -16,7 +16,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 
 	return (
 		<div className="empty-state">
-			<Text as="p" align="center">
+			<Text as="p">
 				{ ( () => {
 					if ( ! siteHasEligiblePlugins && canCreateSchedules ) {
 						return translate(

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -70,15 +70,6 @@
 		font-weight: 500;
 	}
 
-	.empty-state {
-		text-align: center;
-		padding: 0.5rem 0;
-
-		p {
-			margin-bottom: 1.75rem;
-		}
-	}
-
 	button.schedule-name {
 		font-size: 0.875rem;
 		font-weight: 500;


### PR DESCRIPTION
Closes #90623 

## Proposed Changes

Changes the empty state of single site scheduled updates to match multisite.

![CleanShot 2024-05-15 at 14 11 40@2x](https://github.com/Automattic/wp-calypso/assets/528287/aa8a9d5f-2711-46c1-a5c6-d79f4f10e6f4)

## Why are these changes being made?

Because it looks nicer 👨‍🎨

## Testing Instructions

1. Apply the PR
2. Delete all your scheduled updates
3. Ensure that the empty state of individual & multisite matches:
- http://calypso.localhost:3000/plugins/scheduled-updates
- http://calypso.localhost:3000/plugins/scheduled-updates/<siteslug>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
