### PR TITLE
Scheduled Updates: Add track events for multisite context

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,8 +1,10 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import { useLoadScheduleFromId } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-load-schedule-from-id';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MultisitePluginUpdateManagerContextProvider } from './context';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleEdit } from './schedule-edit';
@@ -36,6 +38,12 @@ export const PluginsScheduledUpdatesMultisite = ( {
 		edit: translate( 'Edit schedule' ),
 		list: translate( 'Scheduled Updates' ),
 	}[ context ];
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_scheduled_updates_multisite_page_view', {
+			context: context,
+		} );
+	}, [ context ] );
 
 	return (
 		<MultisitePluginUpdateManagerContextProvider>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@wordpress/components';
 import { close, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ScheduleForm } from './schedule-form';
+import type { MultiSiteSuccessParams } from 'calypso/blocks/plugins-scheduled-updates-multisite/types';
 
 type Props = {
 	onNavBack?: () => void;
@@ -9,6 +11,11 @@ type Props = {
 
 export const ScheduleCreate = ( { onNavBack }: Props ) => {
 	const translate = useTranslate();
+
+	const onRecordSuccessEvent = ( params: MultiSiteSuccessParams ) => {
+		recordTracksEvent( 'calypso_scheduled_updates_multisite_create_schedule', params );
+	};
+
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite plugins-update-manager-multisite-create">
 			<div className="plugins-update-manager-multisite__header no-border">
@@ -17,7 +24,7 @@ export const ScheduleCreate = ( { onNavBack }: Props ) => {
 					<Icon icon={ close } />
 				</Button>
 			</div>
-			<ScheduleForm onNavBack={ onNavBack } />
+			<ScheduleForm onNavBack={ onNavBack } onRecordSuccessEvent={ onRecordSuccessEvent } />
 		</div>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-create.tsx
@@ -3,7 +3,10 @@ import { close, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ScheduleForm } from './schedule-form';
-import type { MultiSiteSuccessParams } from 'calypso/blocks/plugins-scheduled-updates-multisite/types';
+import type {
+	MultiSitesResults,
+	MultiSiteBaseParams,
+} from 'calypso/blocks/plugins-scheduled-updates-multisite/types';
 
 type Props = {
 	onNavBack?: () => void;
@@ -12,8 +15,19 @@ type Props = {
 export const ScheduleCreate = ( { onNavBack }: Props ) => {
 	const translate = useTranslate();
 
-	const onRecordSuccessEvent = ( params: MultiSiteSuccessParams ) => {
-		recordTracksEvent( 'calypso_scheduled_updates_multisite_create_schedule', params );
+	const onRecordSuccessEvent = ( sites: MultiSitesResults, params: MultiSiteBaseParams ) => {
+		recordTracksEvent( 'calypso_scheduled_updates_multisite_create_schedule', {
+			sites_count: sites.createdSiteSlugs.length,
+			...params,
+		} );
+
+		// Add track event for each site
+		sites.createdSiteSlugs.forEach( ( siteSlug ) => {
+			recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {
+				site_slug: siteSlug,
+				...params,
+			} );
+		} );
 	};
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
@@ -3,8 +3,10 @@ import { close, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-common/hooks/use-prepare-schedule-name';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useLoadScheduleFromId } from './hooks/use-load-schedule-from-id';
 import { ScheduleForm } from './schedule-form';
+import type { MultiSiteSuccessParams } from 'calypso/blocks/plugins-scheduled-updates-multisite/types';
 import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 
 type Props = {
@@ -24,6 +26,10 @@ export const ScheduleEdit = ( { id, onNavBack }: Props ) => {
 		}
 	}, [ scheduleNotFound, onNavBack ] );
 
+	const onRecordSuccessEvent = ( params: MultiSiteSuccessParams ) => {
+		recordTracksEvent( 'calypso_scheduled_updates_multisite_edit_schedule', params );
+	};
+
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite plugins-update-manager-multisite-edit">
 			<div className="plugins-update-manager-multisite__header no-border">
@@ -37,7 +43,12 @@ export const ScheduleEdit = ( { id, onNavBack }: Props ) => {
 				</Button>
 			</div>
 			{ schedule && scheduleLoaded ? (
-				<ScheduleForm key={ id } onNavBack={ onNavBack } scheduleForEdit={ schedule } />
+				<ScheduleForm
+					key={ id }
+					onNavBack={ onNavBack }
+					scheduleForEdit={ schedule }
+					onRecordSuccessEvent={ onRecordSuccessEvent }
+				/>
 			) : (
 				<Spinner />
 			) }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-edit.tsx
@@ -6,7 +6,10 @@ import { usePrepareScheduleName } from 'calypso/blocks/plugin-scheduled-updates-
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useLoadScheduleFromId } from './hooks/use-load-schedule-from-id';
 import { ScheduleForm } from './schedule-form';
-import type { MultiSiteSuccessParams } from 'calypso/blocks/plugins-scheduled-updates-multisite/types';
+import type {
+	MultiSitesResults,
+	MultiSiteBaseParams,
+} from 'calypso/blocks/plugins-scheduled-updates-multisite/types';
 import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
 
 type Props = {
@@ -26,8 +29,32 @@ export const ScheduleEdit = ( { id, onNavBack }: Props ) => {
 		}
 	}, [ scheduleNotFound, onNavBack ] );
 
-	const onRecordSuccessEvent = ( params: MultiSiteSuccessParams ) => {
-		recordTracksEvent( 'calypso_scheduled_updates_multisite_edit_schedule', params );
+	const onRecordSuccessEvent = ( sites: MultiSitesResults, params: MultiSiteBaseParams ) => {
+		recordTracksEvent( 'calypso_scheduled_updates_multisite_edit_schedule', {
+			sites_count: sites.createdSiteSlugs.length + sites.editedSiteSlugs.length,
+			...params,
+		} );
+
+		// Add track event for each site
+		sites.createdSiteSlugs.forEach( ( siteSlug ) => {
+			recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {
+				site_slug: siteSlug,
+				...params,
+			} );
+		} );
+
+		sites.editedSiteSlugs.forEach( ( siteSlug ) => {
+			recordTracksEvent( 'calypso_scheduled_updates_edit_schedule', {
+				site_slug: siteSlug,
+				...params,
+			} );
+		} );
+
+		sites.deletedSiteSlugs.forEach( ( siteSlug ) => {
+			recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
+				site_slug: siteSlug,
+			} );
+		} );
 	};
 
 	return (

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -86,6 +86,7 @@ export const ScheduleList = ( props: Props ) => {
 			deleteUpdateSchedules.mutate( selectedScheduleId );
 			recordTracksEvent( 'calypso_scheduled_updates_multisite_delete_schedule', {
 				site_slugs: selectedSiteSlugsForMutate.join( ',' ),
+				sites_count: selectedSiteSlugsForMutate.length,
 			} );
 		}
 		closeRemoveConfirm();

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -88,6 +88,12 @@ export const ScheduleList = ( props: Props ) => {
 				site_slugs: selectedSiteSlugsForMutate.join( ',' ),
 				sites_count: selectedSiteSlugsForMutate.length,
 			} );
+
+			selectedSiteSlugsForMutate.forEach( ( siteSlug ) => {
+				recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
+					site_slug: siteSlug,
+				} );
+			} );
 		}
 		closeRemoveConfirm();
 	};

--- a/client/blocks/plugins-scheduled-updates-multisite/types.ts
+++ b/client/blocks/plugins-scheduled-updates-multisite/types.ts
@@ -1,0 +1,7 @@
+export type MultiSiteSuccessParams = {
+	sites_count: number;
+	plugins_number: number;
+	frequency: 'daily' | 'weekly';
+	hours: number;
+	weekday?: number;
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/types.ts
+++ b/client/blocks/plugins-scheduled-updates-multisite/types.ts
@@ -1,7 +1,18 @@
-export type MultiSiteSuccessParams = {
-	sites_count: number;
+import { SiteSlug } from 'calypso/types';
+
+export type MultiSiteBaseParams = {
 	plugins_number: number;
 	frequency: 'daily' | 'weekly';
 	hours: number;
 	weekday?: number;
+};
+
+export type MultiSiteSuccessParams = MultiSiteBaseParams & {
+	sites_count: number;
+};
+
+export type MultiSitesResults = {
+	createdSiteSlugs: SiteSlug[];
+	editedSiteSlugs: SiteSlug[];
+	deletedSiteSlugs: SiteSlug[];
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/types.ts
+++ b/client/blocks/plugins-scheduled-updates-multisite/types.ts
@@ -7,10 +7,6 @@ export type MultiSiteBaseParams = {
 	weekday?: number;
 };
 
-export type MultiSiteSuccessParams = MultiSiteBaseParams & {
-	sites_count: number;
-};
-
 export type MultiSitesResults = {
 	createdSiteSlugs: SiteSlug[];
 	editedSiteSlugs: SiteSlug[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89791

## Proposed Changes

* Add new track events for multisite context:
    * `calypso_scheduled_updates_multisite_page_view`
    * `calypso_scheduled_updates_multisite_create_schedule`
    * `calypso_scheduled_updates_multisite_edit_schedule`
* Add a new `sites_count` property to `calypso_scheduled_updates_multisite_delete_schedule`
* Small variable bug fixes when updating a schedule.
* When events triggering in multisite context, we also need to record it into individual sites too, so these will be fired too:
    * `calypso_scheduled_updates_create_schedule`
    * `calypso_scheduled_updates_edit_schedule`
    * `calypso_scheduled_updates_delete_schedule`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  Gives us a better idea of how users are using our feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates`
* Using Tracks Vigilante to observe if a track event is triggered correctly.
* Make sure `calypso_scheduled_updates_multisite_page_view` is triggered and context is `list`. Try to go through different context (create, edit) and the page view should be recorded. When submitting a schedule, the related events should be triggered correctly too. Look into the properties and make sure they match what you submitted.
* Try to delete a schedule on the multisite context and make sure the sites_count gets recorded correctly. 
* Make sure the events for individual sites also trigger in multisite context. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
