### PR TITLE
Reader: Fix the infinite scroll behavior by observing the class list of the body

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -104,6 +104,11 @@ class ReaderStream extends Component {
 
 	isMounted = false;
 
+	/**
+	 * A mutation observer to watch whether the target exists
+	 */
+	observer = null;
+
 	handlePostsSelected = () => {
 		this.setState( { selectedTab: 'posts' } );
 	};
@@ -195,6 +200,25 @@ class ReaderStream extends Component {
 		}
 
 		document.addEventListener( 'keydown', this.handleKeydown, true );
+
+		/**
+		 * Observe the class list of the body element because the scroll container depends on it.
+		 */
+		this.observer = new window.MutationObserver( () => {
+			if ( ! this.listRef.current ) {
+				return;
+			}
+
+			const scrollContainer = this.getScrollContainer(
+				ReactDom.findDOMNode( this.listRef.current )
+			);
+			if ( scrollContainer !== this.state.listContext ) {
+				this.setState( {
+					listContext: scrollContainer,
+				} );
+			}
+		} );
+		this.observer.observe( document.body, { attributeFilter: [ 'class' ] } );
 	}
 
 	componentWillUnmount() {
@@ -204,6 +228,10 @@ class ReaderStream extends Component {
 		}
 
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
+
+		if ( this.observer ) {
+			this.observer.disconnect();
+		}
 	}
 
 	handleKeydown = ( event ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1715774747674879/1715324292.862629-slack-C06DN6QQVAQ

## Proposed Changes

* Fix the infinite scroll behavior by observing the class list of the body. The scroll container depends on the class list of the body as https://github.com/Automattic/wp-calypso/pull/90730 mentioned. However, the styles might not be applied when you go to the reader from sites. The reason is the Reader component mounted first and then the section name changed later. As a result, the scroll container at the beginning might be the `window` but it didn't trigger the scroll event...
  ```css
  .layout__primary > div > div {
    height: 100%;
    overflow-y: auto;
    overflow-x: hidden;
  }
  ```

**Here is the screenshot of the intermediate state**

<img width="400" src="https://github.com/Automattic/wp-calypso/assets/13596067/b85f2a31-b188-4a8f-975c-41f21b480ab7" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the window with 1200px viewport width or smaller
* Go to /sites
* Click Reader on the sidebar
* Scroll to the bottom
* Make sure the infinite scroll works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?