### PR TITLE
Dashboard v2 -  ensure status from url is applied on load.

### DIFF
--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -112,7 +112,7 @@ const SitesDashboardV2 = ( {
 				? []
 				: [
 						{
-							field: 'status',
+							field: addDummyDataViewPrefix( 'status' ),
 							operator: 'in',
 							value: siteStatusGroups.find( ( item ) => item.slug === status )?.value || 1,
 						},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  https://github.com/Automattic/dotcom-forge/issues/7176

## Proposed Changes

* This does not resolve https://github.com/Automattic/dotcom-forge/issues/7176 completely, but fixes a bug with a related case.
* Currently in the sites dashboard (v2) the status filter saved in the URL is not applied on reload. This broke because we (or me 😅 ) moved filtering of this column to a dummy column in order to hide the data-views header filtering popover component, but forgot to update this one initialization param. This fixes the initialization of the url status filter to use the dummy column name so the filter is correctly applied.

After this, search and status filters should (once again) be preserved when reloading, navigating back, or opening and closing GSV:

![status-filter-preserve](https://github.com/Automattic/wp-calypso/assets/28742426/fbf43e92-da52-4019-b6e5-eb95484286db)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Goto the sites dashboard, apply some status filters via the icon/popover to the right of the search input.
* Reload the page, or navigate away (to wp-admin, my home, etc.) and use the browser back button to get back to the sites page.
* The status that was last used (shown in the URL) should be applied on reload.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
