### PR TITLE
Nav redesign - update reader tags padding

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -24,7 +24,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 			}
 			overflow: hidden;
 		}
-		.layout__primary > div > div {
+		.layout__primary > div > div:not(.tags__header) {
 			height: 100%;
 			overflow-y: auto;
 			overflow-x: hidden;

--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -13,12 +13,14 @@ export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 	const translate = useTranslate();
 	return (
 		<div className="tags__main">
-			<h4>
-				{
-					// translators: The heading of the reader trending tags section
-					translate( 'Trending' )
-				}
-			</h4>
+			<div className="tags__header">
+				<h4>
+					{
+						// translators: The heading of the reader trending tags section
+						translate( 'Trending' )
+					}
+				</h4>
+			</div>
 			<div>
 				<TrendingTags trendingTags={ trendingTags } />
 				<AlphabeticTags alphabeticTags={ alphabeticTags } />

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -73,6 +73,15 @@
 		max-width: none;
 		padding: 24px 0;
 
+		.tags__header h4 {
+			margin: -4px 0 19px;
+		}
+
+		.alphabetic-tags__header {
+			padding-bottom: 24px;
+			padding-top: 24px;
+		}
+
 		@include break-small {
 			.sticky-panel.is-sticky .sticky-panel__content {
 				border-top-left-radius: 4px;

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -61,7 +61,9 @@
 	}
 }
 
-.tags__main {
+.tags__header {
+	border-bottom: 1px solid var(--studio-gray-5);
+	padding: 0 35px;
 	h4 {
 		color: var(--studio-gray-50);
 		margin-bottom: 15px;
@@ -79,8 +81,8 @@
 		display: flex;
 		flex-direction: row;
 		// we need to set the border on the column for mobile and the row for desktop
-		border-top: 1px solid var(--studio-gray-5);
-		&:last-child {
+		//border-top: 1px solid var(--studio-gray-5);
+		&:not(:last-child) {
 			border-bottom: 1px solid var(--studio-gray-5);
 		}
 	}
@@ -88,12 +90,11 @@
 		width: 100%;
 		// we need to set the border on the column for mobile and the row for desktop
 		border-top: 1px solid var(--studio-gray-5);
-		padding: 10px;
+		padding: 10px 35px;
 		box-sizing: border-box;
 		@include break-small {
 			width: 50%;
 			border-top: none;
-			padding: 10px 0;
 		}
 		a:focus {
 			outline: none;
@@ -129,15 +130,10 @@
 
 .alphabetic-tags__header {
 	background-color: var(--studio-white);
-	padding-top: 20px;
-	padding-bottom: 10px;
 	border-bottom: 1px solid var(--studio-gray-5);
 	margin-bottom: 26px;
-	padding-left: 10px;
+	padding: 20px 35px 10px 35px;
 
-	@include break-small {
-		padding-left: 0;
-	}
 	@include break-large {
 		display: flex;
 		flex-direction: row;
@@ -187,7 +183,7 @@
 	.alphabetic-tags__header {
 		border: none;
 		margin: 0;
-		padding: 0;
+		padding: 0 35px;
 
 		.alphabetic-tags__tag-links {
 			align-items: center;
@@ -213,12 +209,11 @@
 
 .alphabetic-tags__table {
 	padding-bottom: 26px;
-	border-bottom: 1px solid var(--studio-gray-5);
-	margin-bottom: 26px;
-	padding-left: 10px;
-	@include break-small {
-		padding-left: 0;
+	&:not(:last-child) {
+		border-bottom: 1px solid var(--studio-gray-5);
 	}
+	margin-bottom: 26px;
+	padding-left: 35px;
 
 	.alphabetic-tags__letter-title {
 		font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -61,6 +61,41 @@
 	}
 }
 
+.is-section-reader .layout.is-global-sidebar-visible .tags__main {
+	max-width: none;
+	padding: 0;
+
+	@include break-small {
+		.tags__header {
+			padding-top: 24px;
+		}
+
+		.sticky-panel.is-sticky .sticky-panel__content {
+			border-top-left-radius: 4px;
+			border-top-right-radius: 4px;
+			margin-top: 24px;
+			overflow: hidden;
+
+			.alphabetic-tags__header {
+				align-items: center;
+				box-sizing: border-box;
+				display: flex;
+				height: 64px;
+
+				h2 {
+					margin: 0;
+				}
+			}
+		}
+	}
+
+	@media ( min-width: 782px ) {
+		.sticky-panel.is-sticky .sticky-panel__content {
+			margin-top: 16px;
+		}
+	}
+}
+
 .tags__header {
 	border-bottom: 1px solid var(--studio-gray-5);
 	padding: 0 35px;

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -61,37 +61,42 @@
 	}
 }
 
-.is-section-reader .layout.is-global-sidebar-visible .tags__main {
-	max-width: none;
-	padding: 0;
-
-	@include break-small {
-		.tags__header {
-			padding-top: 24px;
-		}
-
-		.sticky-panel.is-sticky .sticky-panel__content {
-			border-top-left-radius: 4px;
-			border-top-right-radius: 4px;
-			margin-top: 24px;
-			overflow: hidden;
-
-			.alphabetic-tags__header {
-				align-items: center;
-				box-sizing: border-box;
-				display: flex;
-				height: 64px;
-
-				h2 {
-					margin: 0;
-				}
-			}
+.is-section-reader .layout.is-global-sidebar-visible {
+	@media ( max-width: $break-small ) {
+		.sticky-panel {
+			right: 24px;
 		}
 	}
 
-	@media ( min-width: 782px ) {
-		.sticky-panel.is-sticky .sticky-panel__content {
-			margin-top: 16px;
+	.tags__main {
+		box-sizing: border-box;
+		max-width: none;
+		padding: 24px 0;
+
+		@include break-small {
+			.sticky-panel.is-sticky .sticky-panel__content {
+				border-top-left-radius: 4px;
+				border-top-right-radius: 4px;
+				margin-top: 25px;
+				overflow: hidden;
+
+				.alphabetic-tags__header {
+					align-items: center;
+					box-sizing: border-box;
+					display: flex;
+					height: 64px;
+
+					h2 {
+						margin: 0;
+					}
+				}
+			}
+		}
+
+		@media ( min-width: 782px ) {
+			.sticky-panel.is-sticky .sticky-panel__content {
+				margin-top: 16px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7196

## Proposed Changes

* Updates tags styles to add padding

## Before

<img width="1491" alt="Screenshot 2024-05-15 at 15 20 11" src="https://github.com/Automattic/wp-calypso/assets/5560595/26f46dff-5e0c-4535-9425-11cbcafa2980">

## After
<img width="1490" alt="Screenshot 2024-05-15 at 15 20 27" src="https://github.com/Automattic/wp-calypso/assets/5560595/c4ee5c1c-e306-4e6d-b955-539833d0b995">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/tags` while logged into WPCOM and confirm padding is ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
