### PR TITLE
E2E tests: remove unneeded eCommerce exceptions

### DIFF
--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -70,28 +70,15 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// eCommerce plan sites attempt to load Calypso, but with
-			// third-party cookies disabled the fallback route to WP-Admin
-			// kicks in after some time.
-			await testAccount.authenticate( page, { url: /wp-admin/ } );
-		} else {
-			await testAccount.authenticate( page );
-		}
+		await testAccount.authenticate( page );
 	} );
 
 	it( 'Navigate to Full Site Editor', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page );
 
-		// eCommerce plan loads WP-Admin for home dashboard,
-		// so instead navigate straight to the FSE page.
-		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
-			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
-		} else {
-			// Explicitly doing sidebar navigation to ensure Calypso navigation is intact.
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Appearance', 'Editor' );
-		}
+		// Explicitly doing sidebar navigation to ensure Calypso navigation is intact.
+		const sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.navigate( 'Appearance', 'Editor' );
 	} );
 
 	it( 'Editor endpoint loads', async function () {

--- a/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
+++ b/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
@@ -23,7 +23,7 @@ declare const browser: Browser;
  * Keywords: Settings, Jetpack, Hosting Configuration, phpMyAdmin
  */
 skipDescribeIf( ! envVariables.TEST_ON_ATOMIC )(
-	DataHelper.createSuiteTitle( 'Settings: Accewss phpMyAdmin' ),
+	DataHelper.createSuiteTitle( 'Settings: Access phpMyAdmin' ),
 	function () {
 		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
@@ -37,14 +37,7 @@ skipDescribeIf( ! envVariables.TEST_ON_ATOMIC )(
 
 			testAccount = new TestAccount( accountName );
 
-			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// Switching to or logging into eCommerce plan sites inevitably
-				// loads WP-Admin instead of Calypso, but the rediret occurs
-				// only after Calypso attempts to load.
-				await testAccount.authenticate( page, { url: /wp-admin/ } );
-			} else {
-				await testAccount.authenticate( page );
-			}
+			await testAccount.authenticate( page );
 		} );
 
 		it( 'Navigate to Settings > Hosting Configuration', async function () {

--- a/test/e2e/specs/media/media__edit.ts
+++ b/test/e2e/specs/media/media__edit.ts
@@ -39,14 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// Switching to or logging into eCommerce plan sites inevitably
-			// loads WP-Admin instead of Calypso, but the rediret occurs
-			// only after Calypso attempts to load.
-			await testAccount.authenticate( page, { url: /wp-admin/ } );
-		} else {
-			await testAccount.authenticate( page );
-		}
+		await testAccount.authenticate( page );
 
 		mediaPage = new MediaPage( page );
 	} );

--- a/test/e2e/specs/media/media__upload.ts
+++ b/test/e2e/specs/media/media__upload.ts
@@ -48,27 +48,14 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// Switching to or logging into eCommerce plan sites inevitably
-			// loads WP-Admin instead of Calypso, but the rediret occurs
-			// only after Calypso attempts to load.
-			await testAccount.authenticate( page, { url: /wp-admin/ } );
-		} else {
-			await testAccount.authenticate( page );
-		}
+		await testAccount.authenticate( page );
 
 		mediaPage = new MediaPage( page );
 	} );
 
 	it( 'Navigate to Media', async function () {
-		// eCommerce plan loads WP-Admin for home dashboard,
-		// so instead navigate straight to the Media page.
-		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
-			await mediaPage.visit( testAccount.credentials.testSites?.primary.url as string );
-		} else {
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Media' );
-		}
+		const sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.navigate( 'Media' );
 	} );
 
 	it( 'Upload image and confirm addition to gallery', async function () {

--- a/test/e2e/specs/media/settings__media.ts
+++ b/test/e2e/specs/media/settings__media.ts
@@ -37,14 +37,7 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 
 		testAccount = new TestAccount( accountName );
 
-		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// Switching to or logging into eCommerce plan sites inevitably
-			// loads WP-Admin instead of Calypso, but the rediret occurs
-			// only after Calypso attempts to load.
-			await testAccount.authenticate( page, { url: /wp-admin/ } );
-		} else {
-			await testAccount.authenticate( page );
-		}
+		await testAccount.authenticate( page );
 	} );
 
 	if ( envVariables.JETPACK_TARGET === 'remote-site' ) {
@@ -82,14 +75,8 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 		let wpAdminMediaSettingsPage: WpAdminMediaSettingsPage;
 
 		it( 'Navigate to Settings > Media', async function () {
-			// eCommerce plan loads WP-Admin for home dashboard,
-			// so instead navigate straight to the Media page.
-			if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
-				await page.goto( `${ testAccount.getSiteURL() }wp-admin/options-media.php` );
-			} else {
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Settings', 'Media' );
-			}
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Settings', 'Media' );
 			wpAdminMediaSettingsPage = new WpAdminMediaSettingsPage( page );
 		} );
 

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -107,14 +107,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		let feedbackInboxPage: FeedbackInboxPage;
 
 		beforeAll( async function () {
-			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// eCommerce plan sites attempt to load Calypso, but with
-				// third-party cookies disabled the fallback route to WP-Admin
-				// kicks in after some time.
-				await testAccount.authenticate( page, { url: /wp-admin/ } );
-			} else {
-				await testAccount.authenticate( page );
-			}
+			await testAccount.authenticate( page );
 		} );
 
 		it( 'Navigate to the Jetpack Forms Inbox', async function () {

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -35,14 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// eCommerce plan sites attempt to load Calypso, but with
-			// third-party cookies disabled the fallback route to WP-Admin
-			// kicks in after some time.
-			await testAccount.authenticate( page, { url: /wp-admin/ } );
-		} else {
-			await testAccount.authenticate( page );
-		}
+		await testAccount.authenticate( page );
 	} );
 
 	it( 'Navigate to Stats', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Several E2E tests are failing on the `ecomm-plan` site. This is because there is was some logic to treat that site differently than others, which no longer appears to be relevant.

Only three of the tests were flagged in "Jetpack Atomic Build Smoke E2E Tests", but when run manually, four others failed (perhaps they're flagged elsewhere), so I updated those as well. We addressed this same issue in a specific test in #90709.

Note that one condition remains relating to that site in the `specs/stats/stats.ts` test. This specific one is relevant; there is no "Store" link in the eCommerce site.

Initial alert: p1715772977575099-slack-C034JEXD1RD

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/fse/fse__temp-smoke-test.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/media/media__edit.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/media/media__upload.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/media/settings__media.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/published-content/forms__submissions.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/stats/stats.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?