### PR TITLE
A4A: Add placeholder elements in WPCOM plan page when fetching existing license count.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -11,9 +11,15 @@ type Props = {
 	selectedTier: DiscountTier;
 	onSelectTier: ( value: DiscountTier ) => void;
 	ownedPlans: number;
+	isLoading?: boolean;
 };
 
-export default function WPCOMBulkSelector( { selectedTier, onSelectTier, ownedPlans }: Props ) {
+export default function WPCOMBulkSelector( {
+	selectedTier,
+	onSelectTier,
+	ownedPlans,
+	isLoading,
+}: Props ) {
 	const translate = useTranslate();
 
 	const { data } = useProductsQuery( false, true );
@@ -46,6 +52,14 @@ export default function WPCOMBulkSelector( { selectedTier, onSelectTier, ownedPl
 		onSelectTier( calculateTier( options, minimumQuantity ) );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ ownedPlans, options ] );
+
+	if ( isLoading ) {
+		return (
+			<div className="bulk-selection is-placeholder">
+				<div className="bulk-selection__slider"></div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="bulk-selection">

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -154,6 +154,7 @@ export default function WpcomOverview() {
 					selectedTier={ selectedTier }
 					onSelectTier={ onSelectTier }
 					ownedPlans={ ownedPlans }
+					isLoading={ ! isLicenseCountsReady }
 				/>
 
 				{ creatorPlan && (

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -163,6 +163,7 @@ export default function WpcomOverview() {
 						quantity={ ( selectedTier.value as number ) - ownedPlans } // We only calculate the difference between the selected tier and the owned plans
 						discount={ selectedTier.discount }
 						onSelect={ onAddToCart }
+						isLoading={ ! isLicenseCountsReady }
 					/>
 				) }
 

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
@@ -37,3 +37,13 @@
 	padding: 8px 16px;
 	margin: 0 auto 32px;
 }
+
+
+.bulk-selection.is-placeholder .bulk-selection__slider {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-neutral-10);
+	width: 800px;
+	height: 80px;
+	margin: 0 auto;
+	border-radius: 4px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
@@ -42,7 +42,8 @@
 .bulk-selection.is-placeholder .bulk-selection__slider {
 	animation: loading-fade 1.6s ease-in-out infinite;
 	background: var(--color-neutral-10);
-	width: 800px;
+	max-width: 800px;
+	width: 100%;
 	height: 80.8px;
 	margin: 0 auto;
 	border-radius: 4px;

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/style.scss
@@ -43,7 +43,7 @@
 	animation: loading-fade 1.6s ease-in-out infinite;
 	background: var(--color-neutral-10);
 	width: 800px;
-	height: 80px;
+	height: 80.8px;
 	margin: 0 auto;
 	border-radius: 4px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -12,9 +12,10 @@ type Props = {
 	quantity: number;
 	discount: number;
 	onSelect: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+	isLoading?: boolean;
 };
 
-export default function WPCOMPlanCard( { plan, quantity, discount, onSelect }: Props ) {
+export default function WPCOMPlanCard( { plan, quantity, discount, onSelect, isLoading }: Props ) {
 	const translate = useTranslate();
 
 	const originalPrice = Number( plan.amount ) * quantity;
@@ -28,50 +29,58 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect }: P
 				<div className="wpcom-plan-card__header">
 					<h2 className="wpcom-plan-card__title">{ name }</h2>
 
-					<div className="wpcom-plan-card__price">
-						<b className="wpcom-plan-card__price-actual-value">
-							{ formatCurrency( actualPrice, plan.currency ) }
-						</b>
-						{ !! discount && (
-							<>
-								<b className="wpcom-plan-card__price-original-value">
-									{ formatCurrency( originalPrice, plan.currency ) }
-								</b>
+					{ isLoading && <div className="wpcom-plan-card__price is-placeholder"></div> }
 
-								<span className="wpcom-plan-card__price-discount">
-									{ translate( 'You save %(discount)s%', {
-										args: {
-											discount: Math.floor( discount * 100 ),
-										},
-										comment: '%(discount)s is the discount percentage.',
-									} ) }
-								</span>
-							</>
-						) }
-						<div className="wpcom-plan-card__price-interval">
-							{ plan.price_interval === 'day' && translate( 'USD per day' ) }
-							{ plan.price_interval === 'month' && translate( 'USD per month' ) }
+					{ ! isLoading && (
+						<div className="wpcom-plan-card__price">
+							<b className="wpcom-plan-card__price-actual-value">
+								{ formatCurrency( actualPrice, plan.currency ) }
+							</b>
+							{ !! discount && (
+								<>
+									<b className="wpcom-plan-card__price-original-value">
+										{ formatCurrency( originalPrice, plan.currency ) }
+									</b>
+
+									<span className="wpcom-plan-card__price-discount">
+										{ translate( 'You save %(discount)s%', {
+											args: {
+												discount: Math.floor( discount * 100 ),
+											},
+											comment: '%(discount)s is the discount percentage.',
+										} ) }
+									</span>
+								</>
+							) }
+							<div className="wpcom-plan-card__price-interval">
+								{ plan.price_interval === 'day' && translate( 'USD per day' ) }
+								{ plan.price_interval === 'month' && translate( 'USD per month' ) }
+							</div>
 						</div>
-					</div>
+					) }
 				</div>
 
-				<Button primary onClick={ () => onSelect( plan, quantity ) }>
-					{ quantity > 1
-						? translate( 'Add %(quantity)s %(planName)s sites to cart', {
-								args: {
-									quantity,
-									planName: name,
-								},
-								comment:
-									'%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
-						  } )
-						: translate( 'Add %(planName)s to cart', {
-								args: {
-									planName: name,
-								},
-								comment: '%(planName)s is the name of the plan.',
-						  } ) }
-				</Button>
+				{ isLoading && <div className="wpcom-plan-card__cta is-placeholder"></div> }
+
+				{ ! isLoading && (
+					<Button primary onClick={ () => onSelect( plan, quantity ) }>
+						{ quantity > 1
+							? translate( 'Add %(quantity)s %(planName)s sites to cart', {
+									args: {
+										quantity,
+										planName: name,
+									},
+									comment:
+										'%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
+							  } )
+							: translate( 'Add %(planName)s to cart', {
+									args: {
+										planName: name,
+									},
+									comment: '%(planName)s is the name of the plan.',
+							  } ) }
+					</Button>
+				) }
 
 				<div className="wpcom-plan-card__features">
 					{ !! features1.length && <SimpleList items={ features1 } /> }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/style.scss
@@ -74,3 +74,20 @@
 .wpcom-plan-card__features.is-jetpack .simple-list-icon {
 	fill: var(--color-jetpack);
 }
+
+.wpcom-plan-card__cta.is-placeholder,
+.wpcom-plan-card__price.is-placeholder {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-neutral-10);
+	border-radius: 4px;
+}
+
+.wpcom-plan-card__cta.is-placeholder {
+	width: 208px;
+	height: 40px;
+}
+
+.wpcom-plan-card__price.is-placeholder {
+	width: 154px;
+	height: 47.2px;
+}


### PR DESCRIPTION
Sometimes, the WPCOM plan page experiences brief glitches due to delays in fetching the license count from the backend. This PR updates the page to display placeholder elements, which will provide a better and more seamless experience, and help avoid these glitches.

https://github.com/Automattic/wp-calypso/assets/56598660/c4dbcf7b-6c63-4aaa-8ae2-aba63af0d119


 
 Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/469

## Proposed Changes

* Update the WPCOM plan page to show a placeholder for the volume slider, plan default price, and Add to cart button while fetching the license count.

## Why are these changes being made?
* To fix some UI glitches in the WPCOM plan page.

## Testing Instructions

* Spin up this branch locally and go to `http://agencies.localhost:3000/marketplace/hosting/wpcom`
* Confirm that you see the placeholders before the actual components.
* In case you are having a hard time testing due to caching, my recommendation would be to modify https://github.com/Automattic/wp-calypso/blob/fe01bf13a57dd454c7a0c65c0e2dbfa13979bb09/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts#L7 to include a random number. This will retrigger a refresh when you reload the page.

  ```
  export const getFetchLicenseCountsQueryKey = ( agencyId?: number ) => {
	return [ 'a4a-license-counts', agencyId, 12121214 ]; // e.g.
  };
  ```

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?ar