### PR TITLE
Reduce number of domains placeholders

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-body.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-body.tsx
@@ -13,15 +13,6 @@ export function DomainsTableBody() {
 			<tbody>
 				<DomainsTableRowLoading />
 				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
-				<DomainsTableRowLoading />
 			</tbody>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7204

## Proposed Changes

Display two domain placeholders rather than eleven.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

While waiting for domains info to load, placeholders for eleven domains were displayed. If the person only had 1-2 domains this caused a small amount of jumping around once they were loaded.

Having 1-2 domains is normal for a given site, and seems like a reasonable default for the global domains list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Go to /domains/manage
4. You should see two placeholders before the real data arrives
5. Go to /sites
6. Click on a site
7. You should see two placeholders before the real data arrives

https://github.com/Automattic/wp-calypso/assets/93301/e361abbb-acb5-41d3-9a38-2a90f654bce2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
