### PR TITLE
Change links pointing to Gravatar from profile.

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -214,7 +214,7 @@ export class EditGravatar extends Component {
 	render() {
 		const { isGravatarProfileHidden, isUploading, translate, user, additionalUploadHtml } =
 			this.props;
-		const gravatarLink = `https://gravatar.com/profile`;
+		const gravatarLink = 'https://gravatar.com';
 		// use imgSize = 400 for caching
 		// it's the popular value for large Gravatars in Calypso
 		const GRAVATAR_IMG_SIZE = 400;

--- a/client/me/profile/updated-gravatar-string.js
+++ b/client/me/profile/updated-gravatar-string.js
@@ -10,12 +10,17 @@ class UpdatedGravatarString extends Component {
 				spanExtra: <span className="profile__link-destination-label-extra" />,
 				profileLink: <a href={ gravatarProfileLink } target="_blank" rel="noreferrer" />,
 				deleteLink: (
-					<a href="https://gravatar.com/profile/disable-account" target="_blank" rel="noreferrer" />
+					<a
+						href="https://support.gravatar.com/account/disable-account/"
+						target="_blank"
+						rel="noreferrer"
+					/>
 				),
+				gravatarLink: <a href="https://gravatar.com/" target="_blank" rel="noreferrer" />,
 			},
 		};
 		return translate(
-			'{{spanLead}}Hide my photo and Gravatar profile.{{/spanLead}} {{spanExtra}}This will prevent your photo and {{profileLink}}Gravatar profile{{/profileLink}} from appearing on any site. It may take some time for the changes to take effect. Gravatar profiles can be deleted at {{deleteLink}}Gravatar.com{{/deleteLink}}.{{/spanExtra}}',
+			'{{spanLead}}Hide my photo and Gravatar profile.{{/spanLead}} {{spanExtra}}This will prevent your photo and {{profileLink}}Gravatar profile{{/profileLink}} from appearing on any site. It may take some time for the changes to take effect. Gravatar profiles {{deleteLink}}can be deleted{{/deleteLink}} at {{gravatarLink}}Gravatar.com{{/gravatarLink}}.{{/spanExtra}}',
 			stringParts
 		);
 	}


### PR DESCRIPTION
Related to 107700-ghe-Automattic/gravatar

## Proposed Changes

* Change delete link to point to documentation.
* Change other links to point directly to Gravatar.com


## Why are these changes being made?

Current links generate a poor experience for users that are not Gravatar users yet. Delete link would login them into Gravatar and actually create an account.

## Testing Instructions

* Go to http://calypso.localhost:3000/me
* Check links are as described in 107700-gh-Automattic/gravatar

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
