### PR TITLE
Site Profiler: Return basic metrics with scores

### DIFF
--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -16,14 +16,21 @@ export const BASIC_METRICS_UNITS: Record< Metrics, string > = {
 };
 
 export const BASIC_METRICS_SCORES: Record< Metrics, [ number, number ] > = {
-	cls: [ 0.1, 0.25 ],
-	fid: [ 100, 300 ],
-	lcp: [ 2500, 4000 ],
-	fcp: [ 1800, 3000 ],
-	ttfb: [ 800, 1800 ],
-	inp: [ 200, 500 ],
+	cls: [ 0.1, 0.25 ], // https://web.dev/articles/cls
+	fid: [ 100, 300 ], // https://web.dev/articles/fid
+	lcp: [ 2500, 4000 ], // https://web.dev/articles/lcp
+	fcp: [ 1800, 3000 ], // https://web.dev/articles/fcp
+	ttfb: [ 800, 1800 ], // https://web.dev/articles/ttfb
+	inp: [ 200, 500 ], // https://web.dev/articles/inp
 };
 
+/**
+ * Get the score of a metric based on its value according to the Google
+ * documentation that has been represented in the BASIC_METRICS_SCORES constant.
+ * @param metric The metric in the Metrics type
+ * @param value The value of the metric
+ * @returns A score based on the value of the metric
+ */
 export function getScore( metric: Metrics, value: number ): Scores {
 	const [ good, poor ] = BASIC_METRICS_SCORES[ metric ];
 	if ( value <= good ) {

--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -1,4 +1,6 @@
-export const BASIC_METRICS_UNITS: Record< string, string > = {
+import { Metrics } from './types';
+
+export const BASIC_METRICS_UNITS: Record< Metrics, string > = {
 	cls: '',
 	fid: 'ms',
 	lcp: 'ms',
@@ -6,3 +8,27 @@ export const BASIC_METRICS_UNITS: Record< string, string > = {
 	ttfb: 'ms',
 	inp: 'ms',
 };
+
+export type Scores = 'good' | 'needs-improvement' | 'poor';
+
+type Range = [ number, number ];
+
+export const BASIC_METRICS_SCORES: Record< Metrics, Range > = {
+	cls: [ 0.1, 0.25 ],
+	fid: [ 100, 300 ],
+	lcp: [ 2500, 4000 ],
+	fcp: [ 1800, 3000 ],
+	ttfb: [ 800, 1800 ],
+	inp: [ 200, 500 ],
+};
+
+export function getScore( metric: Metrics, value: number ): Scores {
+	const [ good, poor ] = BASIC_METRICS_SCORES[ metric ];
+	if ( value <= good ) {
+		return 'good';
+	}
+	if ( value > poor ) {
+		return 'poor';
+	}
+	return 'needs-improvement';
+}

--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -1,4 +1,10 @@
-import { Metrics } from './types';
+import { Metrics, Scores } from './types';
+
+export const SCORES: Record< string, Scores > = {
+	good: 'good',
+	needsImprovement: 'needs-improvement',
+	poor: 'poor',
+};
 
 export const BASIC_METRICS_UNITS: Record< Metrics, string > = {
 	cls: '',
@@ -9,11 +15,7 @@ export const BASIC_METRICS_UNITS: Record< Metrics, string > = {
 	inp: 'ms',
 };
 
-export type Scores = 'good' | 'needs-improvement' | 'poor';
-
-type Range = [ number, number ];
-
-export const BASIC_METRICS_SCORES: Record< Metrics, Range > = {
+export const BASIC_METRICS_SCORES: Record< Metrics, [ number, number ] > = {
 	cls: [ 0.1, 0.25 ],
 	fid: [ 100, 300 ],
 	lcp: [ 2500, 4000 ],
@@ -25,10 +27,10 @@ export const BASIC_METRICS_SCORES: Record< Metrics, Range > = {
 export function getScore( metric: Metrics, value: number ): Scores {
 	const [ good, poor ] = BASIC_METRICS_SCORES[ metric ];
 	if ( value <= good ) {
-		return 'good';
+		return SCORES.good;
 	}
 	if ( value > poor ) {
-		return 'poor';
+		return SCORES.poor;
 	}
-	return 'needs-improvement';
+	return SCORES.needsImprovement;
 }

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -84,7 +84,13 @@ export interface HostingProviderQueryResponse {
 
 export type Metrics = 'cls' | 'fid' | 'lcp' | 'fcp' | 'ttfb' | 'inp';
 
+export type Scores = 'good' | 'needs-improvement' | 'poor';
+
 export type BasicMetrics = Record< Metrics, number >;
+export type BasicMetricsList = [ Metrics, number ][];
+
+export type BasicMetricsScored = Record< Metrics, { value: number; score: Scores } >;
+export type BasicMetricsScoredList = [ Metrics, { value: number; score: Scores } ][];
 
 export interface UrlBasicMetricsQueryResponse {
 	final_url: string;

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -82,14 +82,10 @@ export interface HostingProviderQueryResponse {
 	hosting_provider: HostingProvider;
 }
 
-export type BasicMetrics = {
-	cls: number;
-	fid: number;
-	lcp: number;
-	fcp: number;
-	ttfb: number;
-	inp: number;
-};
+export type Metrics = 'cls' | 'fid' | 'lcp' | 'fcp' | 'ttfb' | 'inp';
+
+export type BasicMetrics = Record< Metrics, number >;
+
 export interface UrlBasicMetricsQueryResponse {
 	final_url: string;
 	basic: BasicMetrics;

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -1,23 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
-import { Metrics, UrlBasicMetricsQueryResponse } from 'calypso/data/site-profiler/types';
+import {
+	BasicMetricsList,
+	BasicMetricsScored,
+	Metrics,
+	UrlBasicMetricsQueryResponse,
+} from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
 import { getScore } from './metrics-dictionaries';
 
 function mapScores( response: UrlBasicMetricsQueryResponse ) {
 	const { basic } = response;
 
-	if ( ! basic ) {
-		return response;
-	}
-
-	const basicMetricsScored = ( Object.entries( basic ) as [ Metrics, number ][] ).reduce<
-		Record< Metrics, { value: number; score: string } >
-	>(
+	const basicMetricsScored = ( Object.entries( basic ) as BasicMetricsList ).reduce(
 		( acc, [ key, value ] ) => {
 			acc[ key ] = { value: value, score: getScore( key as Metrics, value ) };
 			return acc;
 		},
-		{} as Record< Metrics, { value: number; score: string } >
+		{} as BasicMetricsScored
 	);
 
 	return { ...response, basic: basicMetricsScored };

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -1,6 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
-import { UrlBasicMetricsQueryResponse } from 'calypso/data/site-profiler/types';
+import { Metrics, UrlBasicMetricsQueryResponse } from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
+import { getScore } from './metrics-dictionaries';
+
+function mapScores( response: UrlBasicMetricsQueryResponse ) {
+	const { basic } = response;
+
+	if ( ! basic ) {
+		return response;
+	}
+
+	const basicMetricsScored = ( Object.entries( basic ) as [ Metrics, number ][] ).reduce<
+		Record< Metrics, { value: number; score: string } >
+	>(
+		( acc, [ key, value ] ) => {
+			acc[ key ] = { value: value, score: getScore( key as Metrics, value ) };
+			return acc;
+		},
+		{} as Record< Metrics, { value: number; score: string } >
+	);
+
+	return { ...response, basic: basicMetricsScored };
+}
 
 export const useUrlBasicMetricsQuery = ( url?: string ) => {
 	return useQuery( {
@@ -13,6 +34,7 @@ export const useUrlBasicMetricsQuery = ( url?: string ) => {
 				},
 				{ url }
 			),
+		select: mapScores,
 		meta: {
 			persist: false,
 		},

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -42,7 +42,7 @@ export const BasicMetrics = forwardRef(
 						return (
 							showMetric && (
 								<li key={ key }>
-									<div>
+									<div className="name">
 										<a href={ `https://web.dev/articles/${ key }` }>{ key }</a>
 									</div>
 									<div className="basic-metrics__values">{ metricScored.value }</div>

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -1,33 +1,57 @@
+import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { translate } from 'i18n-calypso';
 import { ForwardedRef, forwardRef } from 'react';
-import { BASIC_METRICS_UNITS } from 'calypso/data/site-profiler/metrics-dictionaries';
+import { BASIC_METRICS_UNITS, SCORES } from 'calypso/data/site-profiler/metrics-dictionaries';
 import { calculateMetricsSectionScrollOffset } from 'calypso/site-profiler/utils/calculate-metrics-section-scroll-offset';
-import type { BasicMetrics as BasicMetricsType } from 'calypso/data/site-profiler/types';
+import type {
+	BasicMetricsScored,
+	BasicMetricsScoredList,
+	Scores,
+} from 'calypso/data/site-profiler/types';
+import './styles.scss';
 
 const Container = styled.div`
 	scroll-margin-top: ${ calculateMetricsSectionScrollOffset }px;
 `;
 
+function getIcon( score: Scores ) {
+	switch ( score ) {
+		case SCORES.good:
+			return 'thumbs-up';
+		case SCORES.poor:
+			return 'notice';
+		default:
+			return 'info-outline';
+	}
+}
+
 export const BasicMetrics = forwardRef(
 	(
-		{ basicMetrics }: { basicMetrics: BasicMetricsType },
+		{ basicMetrics }: { basicMetrics: BasicMetricsScored },
 		ref: ForwardedRef< HTMLObjectElement >
 	) => {
 		return (
 			<Container className="basic-metrics" ref={ ref }>
 				<h3>{ translate( 'Basic Performance Metrics' ) }</h3>
 				<ul className="basic-metric-details result-list">
-					{ Object.entries( basicMetrics ).map( ( [ key, value ] ) => {
+					{ ( Object.entries( basicMetrics ) as BasicMetricsScoredList ).map( ( metric ) => {
+						const [ key, metricScored ] = metric;
+						const showMetric = metricScored.value !== undefined && metricScored.value !== null;
+
 						return (
-							<li key={ key }>
-								<div className="name">
-									<a href={ `https://web.dev/articles/${ key }` }>{ key }</a>
-								</div>
-								<div>
-									{ value } { BASIC_METRICS_UNITS[ key ] }
-								</div>
-							</li>
+							showMetric && (
+								<li key={ key }>
+									<div>
+										<a href={ `https://web.dev/articles/${ key }` }>{ key }</a>
+									</div>
+									<div className="basic-metrics__values">{ metricScored.value }</div>
+									<div className="basic-metrics__unit">{ BASIC_METRICS_UNITS[ key ] }</div>
+									<div className={ metricScored.score }>
+										<Gridicon icon={ getIcon( metricScored.score ) } />
+									</div>
+								</li>
+							)
 						);
 					} ) }
 				</ul>

--- a/client/site-profiler/components/basic-metrics/styles.scss
+++ b/client/site-profiler/components/basic-metrics/styles.scss
@@ -1,0 +1,22 @@
+.basic-metric-details {
+	& .good {
+		color: #019c3b;
+
+	}
+	& .needs-improvement {
+		color: #d4bb4c;
+	}
+	& .bad {
+		color: #b24158;
+	}
+
+
+}
+.basic-metrics__values {
+	width: 80px;
+	text-align: right;
+}
+.basic-metrics__unit {
+	width: 20px;
+
+}

--- a/client/site-profiler/components/basic-metrics/styles.scss
+++ b/client/site-profiler/components/basic-metrics/styles.scss
@@ -6,7 +6,7 @@
 	& .needs-improvement {
 		color: #d4bb4c;
 	}
-	& .bad {
+	& .poor {
 		color: #b24158;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7212

## Proposed Changes

* Add a score functionality that appends an score to every Basic metric
* The scores are based on the Google documentation for each metric https://web.dev/articles/vitals
* Add a temporary icon with a color that indicates the score between the three added values: `good`, `needs-improvement` or `poor`

![CleanShot 2024-05-16 at 13 00 08@2x](https://github.com/Automattic/wp-calypso/assets/3519124/6b0bbd93-d2ee-4765-a3cd-bdca3012d285)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Basic metrics needed a way to indicate the result of the metric

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Go to the `site-profiler` and navigate to a site that returns metrics, for example `/site-profiler/example.com`
* Check that the Basic Performance Metrics section contains a column that indicates the rating of the metrics

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
~~- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
~~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~
