### PR TITLE
Change /hosting route to /overview

### DIFF
--- a/client/dev-tools-promo/index.tsx
+++ b/client/dev-tools-promo/index.tsx
@@ -10,7 +10,7 @@ const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) =>
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 	if ( site && site.jetpack && ! site.plan?.expired ) {
-		return page.redirect( `/hosting/${ context.params.site }` );
+		return page.redirect( `/overview/${ context.params.site }` );
 	}
 	return next();
 };

--- a/client/hosting-overview/index.tsx
+++ b/client/hosting-overview/index.tsx
@@ -14,9 +14,9 @@ import {
 import { hostingOverview, hostingConfiguration, hostingActivate } from './controller';
 
 export default function () {
-	page( '/hosting', siteSelection, sites, makeLayout, clientRender );
+	page( '/overview', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/hosting/:site',
+		'/overview/:site',
 		siteSelection,
 		navigation,
 		hostingOverview,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -173,7 +173,7 @@ const Home = ( {
 				{ isGlobalSiteViewEnabled ? translate( 'View site' ) : translate( 'Visit site' ) }
 			</Button>
 			{ config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && (
-				<Button primary href={ `/hosting/${ site.slug }` }>
+				<Button primary href={ `/overview/${ site.slug }` }>
 					{ translate( 'Hosting Overview' ) }
 				</Button>
 			) }

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -94,7 +94,7 @@ export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
 		if ( isJetpackNonAtomic ) {
-			context.page.replace( `/hosting/${ site?.slug }` );
+			context.page.replace( `/overview/${ site?.slug }` );
 			return;
 		}
 		next();

--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -42,7 +42,7 @@ export async function handleHostingPanelRedirect( context, next ) {
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
 		if ( isJetpackNonAtomic ) {
-			context.page.replace( `/hosting/${ site?.slug }` );
+			context.page.replace( `/overview/${ site?.slug }` );
 			return;
 		}
 		next();

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -177,7 +177,7 @@ const useSiteMenuItems = () => {
 							slug: 'hosting-overview',
 							title: translate( 'Overview' ),
 							type: 'submenu-item',
-							url: `/hosting/${ siteDomain }`,
+							url: `/overview/${ siteDomain }`,
 						},
 						...children.splice( pos - 1 ),
 					];

--- a/client/my-sites/site-monitoring/controller.tsx
+++ b/client/my-sites/site-monitoring/controller.tsx
@@ -17,7 +17,7 @@ export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
 		if ( ! isAtomicSite ) {
-			context.page.replace( `/hosting/${ site?.slug }` );
+			context.page.replace( `/overview/${ site?.slug }` );
 			return;
 		}
 		next();

--- a/client/sections.js
+++ b/client/sections.js
@@ -217,7 +217,7 @@ const sections = [
 	},
 	{
 		name: 'hosting-overview',
-		paths: [ '/hosting' ],
+		paths: [ '/overview' ],
 		module: 'calypso/hosting-overview',
 		group: 'sites',
 	},

--- a/client/sites-dashboard-v2/site-preview-pane/constants.ts
+++ b/client/sites-dashboard-v2/site-preview-pane/constants.ts
@@ -7,7 +7,7 @@ export const DOTCOM_HOSTING_CONFIG = 'dotcom-hosting-config';
 export const DOTCOM_DEVELOPER_TOOLS_PROMO = 'dotcom-developer-tools-promo';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
-	[ DOTCOM_OVERVIEW ]: 'hosting/:site',
+	[ DOTCOM_OVERVIEW ]: 'overview/:site',
 	[ DOTCOM_MONITORING ]: 'site-monitoring/:site',
 	[ DOTCOM_PHP_LOGS ]: 'site-monitoring/:site/php',
 	[ DOTCOM_SERVER_LOGS ]: 'site-monitoring/:site/web',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7214

## Proposed Changes

* This PR change the URL route from `/hosting` to `/overview`
* It also updates redirects from `/hosting` to `/overview`
* And it updates the Hosting menu link on the Calypso side

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The URL route to the "Overview" tab /hosting is colliding with https://wordpress.com/hosting in production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test the route and Calypso Hosting Menu**
* Using this PR on localhost or Calypso Live
* Go to /plans/[site] on a Classic-early site so you can see the Hosting menu inside Calypso. In the Hosting menu on the left click on the "Overview" menu item. It should take you to /overview/[site]
* Refresh the /overview/[site] page in your browser. It should reload without any issues.
* Click on another site on the /sites page. It should load the Overview tab for that site without issue.

**Test the redirects**
* Using a free Simple site going to the following routes should redirect you to /overview NOT /hosting
  * /site-monitoring/[site]
  * /site-monitoring/[site]/php
  * /site-monitoring/[site]/web

* Using an Atomic site going to the following routes should redirect you to /overview NOT /hosting
  * /dev-tools-promo/[site]

* Using a self-hosted Jetpack site (jurassic.ninja) going to the following routes should redirect you to /overview NOT /hosting
  * /github-deployments/[jetpack-site]
  * /hosting-config/[jetpack-site]

**Test the "Hosting Overview" button**
* Using a Default admin style site
* Go to /home/[site]
* In the upper right corner is a "Hosting Overview" button.
* Click on it and it should take you to /overview/[site]

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
