### PR TITLE
Plugins: Make the page background match everywhere else

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -477,91 +477,96 @@ export class PluginsMain extends Component {
 					<QueryJetpackSitesFeatures />
 				) }
 				{ this.renderPageViewTracking() }
-				{ ! isJetpackCloud && (
-					<NavigationHeader
-						navigationItems={ [] }
-						title={ pageTitle }
-						subtitle={
-							this.props.selectedSite
-								? this.props.translate( 'Manage all plugins installed on %(selectedSite)s', {
-										args: {
-											selectedSite: this.props.selectedSite.domain,
-										},
-								  } )
-								: this.props.translate( 'Manage plugins installed on all sites' )
-						}
+				<div className="plugin-management-wrapper">
+					{ ! isJetpackCloud && (
+						<NavigationHeader
+							navigationItems={ [] }
+							title={ pageTitle }
+							subtitle={
+								this.props.selectedSite
+									? this.props.translate( 'Manage all plugins installed on %(selectedSite)s', {
+											args: {
+												selectedSite: this.props.selectedSite.domain,
+											},
+									  } )
+									: this.props.translate( 'Manage plugins installed on all sites' )
+							}
+						>
+							{ ! isJetpackCloud && (
+								<>
+									{ this.renderAddPluginButton() }
+									{ this.renderUploadPluginButton() }
+									<UpdatePlugins isWpCom plugins={ currentPlugins } />
+								</>
+							) }
+						</NavigationHeader>
+					) }
+					<div
+						className={ classNames( 'plugins__top-container', {
+							'plugins__top-container-jc': isJetpackCloud,
+						} ) }
 					>
-						{ ! isJetpackCloud && (
-							<>
-								{ this.renderAddPluginButton() }
-								{ this.renderUploadPluginButton() }
-								<UpdatePlugins isWpCom plugins={ currentPlugins } />
-							</>
-						) }
-					</NavigationHeader>
-				) }
-				<div
-					className={ classNames( 'plugins__top-container', {
-						'plugins__top-container-jc': isJetpackCloud,
-					} ) }
-				>
-					<div className="plugins__content-wrapper">
-						<MissingPaymentNotification />
+						<div className="plugins__content-wrapper">
+							<MissingPaymentNotification />
 
-						{ isJetpackCloud && (
-							<div className="plugins__page-title-container">
-								<div className="plugins__header-left-content">
-									<h2 className="plugins__page-title">{ pageTitle }</h2>
-									<div className="plugins__page-subtitle">
-										{ this.props.selectedSite
-											? this.props.translate( 'Manage all plugins installed on %(selectedSite)s', {
-													args: {
-														selectedSite: this.props.selectedSite.domain,
-													},
-											  } )
-											: this.props.translate( 'Manage plugins installed on all sites' ) }
+							{ isJetpackCloud && (
+								<div className="plugins__page-title-container">
+									<div className="plugins__header-left-content">
+										<h2 className="plugins__page-title">{ pageTitle }</h2>
+										<div className="plugins__page-subtitle">
+											{ this.props.selectedSite
+												? this.props.translate(
+														'Manage all plugins installed on %(selectedSite)s',
+														{
+															args: {
+																selectedSite: this.props.selectedSite.domain,
+															},
+														}
+												  )
+												: this.props.translate( 'Manage plugins installed on all sites' ) }
+										</div>
 									</div>
 								</div>
-							</div>
-						) }
-						<div className="plugins__main plugins__main-updated">
-							<div className="plugins__main-header">
-								<SectionNav
-									applyUpdatedStyles
-									selectedText={ selectedTextContent }
-									className="plugins-section-nav"
-								>
-									<NavTabs selectedText={ title } selectedCount={ count }>
-										{ navItems }
-									</NavTabs>
-								</SectionNav>
+							) }
+							<div className="plugins__main plugins__main-updated">
+								<div className="plugins__main-header">
+									<SectionNav
+										applyUpdatedStyles
+										selectedText={ selectedTextContent }
+										className="plugins-section-nav"
+									>
+										<NavTabs selectedText={ title } selectedCount={ count }>
+											{ navItems }
+										</NavTabs>
+									</SectionNav>
+								</div>
 							</div>
 						</div>
 					</div>
-				</div>
-				<div
-					className={ classNames( 'plugins__main-content', {
-						'plugins__main-content-jc': isJetpackCloud,
-					} ) }
-				>
-					<div className="plugins__content-wrapper">
-						{
-							// Hide the search box only when the request to fetch plugins fail, and there are no sites.
-							! ( this.props.requestPluginsError && ! currentPlugins?.length ) && (
-								<div className="plugins__search">
-									<Search
-										hideFocus
-										isOpen
-										onSearch={ this.props.doSearch }
-										initialValue={ this.props.search }
-										hideClose={ ! this.props.search }
-										analyticsGroup="Plugins"
-										placeholder={ this.props.translate( 'Search plugins' ) }
-									/>
-								</div>
-							)
-						}
-						{ this.renderPluginsContent() }
+					<div
+						className={ classNames( 'plugins__main-content', {
+							'plugins__main-content-jc': isJetpackCloud,
+						} ) }
+					>
+						<div className="plugins__content-wrapper">
+							{
+								// Hide the search box only when the request to fetch plugins fail, and there are no sites.
+								! ( this.props.requestPluginsError && ! currentPlugins?.length ) && (
+									<div className="plugins__search">
+										<Search
+											hideFocus
+											isOpen
+											onSearch={ this.props.doSearch }
+											initialValue={ this.props.search }
+											hideClose={ ! this.props.search }
+											analyticsGroup="Plugins"
+											placeholder={ this.props.translate( 'Search plugins' ) }
+										/>
+									</div>
+								)
+							}
+							{ this.renderPluginsContent() }
+						</div>
 					</div>
 				</div>
 			</>

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -419,7 +419,17 @@ body.is-section-plugins header .select-dropdown__item {
 	padding: 0 0 0 16px !important;
 }
 
+body.is-section-plugins .is-logged-in {
+	#primary {
+		background-color: var(--color-surface);
+	}
+	.navigation-header {
+		padding-top: 24px;
+	}
+}
+
 body.is-section-plugins #primary {
+
 	.search-box-header::before {
 		box-sizing: border-box;
 		content: "";

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -50,9 +50,13 @@ body.is-section-plugins {
 	}
 
 	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {
-		@include breakpoint-deprecated( ">660px" ) {
-			padding-left: 35px;
-			padding-right: 35px;
+		@include break-small {
+			padding-left: 1rem;
+			padding-right: 1rem;
+		}
+		@include break-small {
+			padding-left: 2rem;
+			padding-right: 2rem;
 		}
 	}
 
@@ -465,6 +469,17 @@ body.is-section-plugins #primary {
 				}
 			}
 		}
+	}
+}
+
+body.is-section-plugins .plugin-management-wrapper {
+	@include break-small {
+		padding-left: 1rem;
+		padding-right: 1rem;
+	}
+	@include break-medium {
+		padding-left: 2rem;
+		padding-right: 2rem;
 	}
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -47,6 +47,15 @@
 body.is-section-plugins {
 	.is-section-plugins.is-global-sidebar-visible {
 		background: var(--studio-gray-0);
+
+		.layout__primary > * {
+			background-color: var(--color-surface);
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			height: calc(100vh - 32px);
+			max-width: none;
+			overflow-y: scroll;
+		}
 	}
 
 	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {
@@ -430,13 +439,8 @@ body.is-section-plugins header .select-dropdown__item {
 	padding: 0 0 0 16px !important;
 }
 
-body.is-section-plugins .is-logged-in {
-	#primary {
-		background-color: var(--color-surface);
-	}
-	.navigation-header {
-		padding-top: 24px;
-	}
+body.is-section-plugins .is-logged-in .navigation-header {
+	padding-top: 24px;
 }
 
 body.is-section-plugins #primary {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -49,13 +49,11 @@ body.is-section-plugins {
 		background: var(--studio-gray-0);
 	}
 
-	.is-logged-in .main {
+	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {
 		@include breakpoint-deprecated( ">660px" ) {
 			padding-left: 35px;
 			padding-right: 35px;
 		}
-
-
 	}
 
 	.a4a-layout-column {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -49,6 +49,15 @@ body.is-section-plugins {
 		background: var(--studio-gray-0);
 	}
 
+	.is-logged-in .main {
+		@include breakpoint-deprecated( ">660px" ) {
+			padding-left: 35px;
+			padding-right: 35px;
+		}
+
+
+	}
+
 	.a4a-layout-column {
 		overflow: scroll;
 	}


### PR DESCRIPTION
With the new navigation system using a grey sidebar it looks weird if the plugins menu uses the same grey, use white instead.

This also highlighted that the page title needed a little more space from the header so that has been adjusted too.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7209

## Proposed Changes

Make bg white on /plugins and /plugins/manage

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

With the new navigation having a grey background, having a grey background on the page itself just blends the two together oddly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use calypso link
 2. Go to /plugins while logged out, note that nothing has changed
 3. Go to /plugins, note it now has a white background
 4. Go to /plugins/manage, note it now has a white background
 5. Go to /plugins/scheduled-updates, note the white background. This page should remain unchanged.


Before | After
-------|---
<img width="1459" alt="Screenshot 2024-05-15 at 17 49 59" src="https://github.com/Automattic/wp-calypso/assets/93301/c1c643e3-2128-4420-b400-9eea69904343"> | <img width="1459" alt="Screenshot 2024-05-15 at 17 49 29" src="https://github.com/Automattic/wp-calypso/assets/93301/bd60df93-f9e1-4fbb-9d5f-d5b29bdcf325">
<img width="1221" alt="Screenshot 2024-05-15 at 22 34 00" src="https://github.com/Automattic/wp-calypso/assets/93301/3f438374-67ba-4d08-84c7-fb8731d65d28"> | <img width="1221" alt="Screenshot 2024-05-15 at 22 30 00" src="https://github.com/Automattic/wp-calypso/assets/93301/1b1f3784-a83a-4516-b1b3-b22c2f2b1a6c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
