### PR TITLE
Site Profiler: Wrap logic inside an AdvancedMetrics component

### DIFF
--- a/client/site-profiler/components/advanced-metrics/index.tsx
+++ b/client/site-profiler/components/advanced-metrics/index.tsx
@@ -1,0 +1,56 @@
+import { useTranslate } from 'i18n-calypso';
+import { MetricsInsightsList } from 'calypso/site-profiler/components/metrics-insights-list';
+import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
+
+interface AdvancedMetricsProps {
+	performanceMetricsRef?: React.RefObject< HTMLObjectElement >;
+	healthScoresRef?: React.RefObject< HTMLObjectElement >;
+}
+
+export const AdvancedMetrics: React.FC< AdvancedMetricsProps > = ( props ) => {
+	const translate = useTranslate();
+	const { performanceMetricsRef, healthScoresRef } = props;
+
+	return (
+		<>
+			<MetricsSection
+				name={ translate( 'Performance Metrics' ) }
+				title={ translate(
+					"Your site {{success}}performs well{{/success}}, but there's always room to be faster and smoother for your visitors.",
+					{
+						components: {
+							success: <span className="success" />,
+							alert: <span className="alert" />,
+						},
+					}
+				) }
+				subtitle={ translate( "Boost your site's performance" ) }
+				ref={ performanceMetricsRef }
+			>
+				<MetricsInsightsList
+					insights={ Array( 10 ).fill( {
+						header:
+							'Your site reveals first content slower than 76% of peers, affecting first impressions.',
+						description: 'This is how you can improve it',
+					} ) }
+				/>
+			</MetricsSection>
+			<MetricsSection
+				name={ translate( 'Health Scores' ) }
+				title={ translate(
+					"Your site's health scores {{alert}}suggest critical area{{/alert}} but need attention to prevent low performance.",
+					{
+						components: {
+							success: <span className="success" />,
+							alert: <span className="alert" />,
+						},
+					}
+				) }
+				subtitle={ translate( "Optimize your site's health" ) }
+				ref={ healthScoresRef }
+			>
+				<MetricsInsightsList locked />
+			</MetricsSection>
+		</>
+	);
+};

--- a/client/site-profiler/components/metrics-menu/index.tsx
+++ b/client/site-profiler/components/metrics-menu/index.tsx
@@ -21,9 +21,9 @@ const SectionNavbar = styled( SectionNav )`
 
 interface MetricsMenuProps {
 	basicMetricsRef?: React.RefObject< HTMLObjectElement >;
-	onCTAClick: () => void;
 	performanceMetricsRef?: React.RefObject< HTMLObjectElement >;
 	healthScoresRef?: React.RefObject< HTMLObjectElement >;
+	onCTAClick: () => void;
 }
 
 interface MenuItem {

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -16,6 +16,7 @@ import useScrollToTop from '../hooks/use-scroll-to-top';
 import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
 import { getValidUrl } from '../utils/get-valid-url';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
+import { AdvancedMetrics } from './advanced-metrics';
 import { BasicMetrics } from './basic-metrics';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
@@ -23,9 +24,7 @@ import { GetReportForm } from './get-report-form';
 import HeadingInformation from './heading-information';
 import HostingInformation from './hosting-information';
 import HostingIntro from './hosting-intro';
-import { MetricsInsightsList } from './metrics-insights-list';
 import { MetricsMenu } from './metrics-menu';
-import { MetricsSection } from './metrics-section';
 import './styles.scss';
 
 const debug = debugFactory( 'apps:site-profiler' );
@@ -173,44 +172,10 @@ export default function SiteProfiler( props: Props ) {
 								onCTAClick={ () => setIsGetReportFormOpen( true ) }
 							/>
 							<BasicMetrics ref={ basicMetricsRef } basicMetrics={ basicMetrics.basic } />
-							<MetricsSection
-								name={ translate( 'Performance Metrics' ) }
-								title={ translate(
-									"Your site {{success}}performs well{{/success}}, but there's always room to be faster and smoother for your visitors.",
-									{
-										components: {
-											success: <span className="success" />,
-											alert: <span className="alert" />,
-										},
-									}
-								) }
-								subtitle={ translate( "Boost your site's performance" ) }
-								ref={ performanceMetricsRef }
-							>
-								<MetricsInsightsList
-									insights={ Array( 10 ).fill( {
-										header:
-											'Your site reveals first content slower than 76% of peers, affecting first impressions.',
-										description: 'This is how you can improve it',
-									} ) }
-								/>
-							</MetricsSection>
-							<MetricsSection
-								name={ translate( 'Health Scores' ) }
-								title={ translate(
-									"Your site's health scores {{alert}}suggest critical area{{/alert}} but need attention to prevent low performance.",
-									{
-										components: {
-											success: <span className="success" />,
-											alert: <span className="alert" />,
-										},
-									}
-								) }
-								subtitle={ translate( "Optimize your site's health" ) }
-								ref={ healthScoresRef }
-							>
-								<MetricsInsightsList locked />
-							</MetricsSection>
+							<AdvancedMetrics
+								performanceMetricsRef={ performanceMetricsRef }
+								healthScoresRef={ healthScoresRef }
+							/>
 						</LayoutBlockSection>
 					) }
 				</LayoutBlock>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/90704

## Proposed Changes

Wrap some logic inside an AdvancedMetrics component. 
This component will also be responsible to handle the request to retrieve data for those components.

## Why are these changes being made?
It was a reasonable ask here https://github.com/Automattic/wp-calypso/pull/90662#discussion_r1600315690

## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/example.com`
* Scroll down and check if everything still working as before.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?