### PR TITLE
Sites overview - Plan card - update plans page link copy for free plan case.

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -3,6 +3,7 @@ import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { formatCurrency } from '@automattic/format-currency';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -32,6 +33,7 @@ const PlanCard: FC = () => {
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );
+	const hasEnTranslation = useHasEnTranslation();
 
 	// Check for storage addons available for purchase.
 	const addOns = AddOns.useAddOns( { selectedSiteId: site?.ID } );
@@ -40,6 +42,12 @@ const PlanCard: FC = () => {
 	);
 
 	const isLoading = ! pricing || ! planData;
+
+	const explorePlansLabel = hasEnTranslation( 'Explore paid plans' )
+		? translate( 'Explore paid plans' )
+		: translate( 'Manage plan' );
+
+	const plansPageLinkLabel = isPaidPlan ? translate( 'Manage plan' ) : explorePlansLabel;
 
 	return (
 		<>
@@ -56,7 +64,7 @@ const PlanCard: FC = () => {
 						plain
 						href={ `/plans/${ site?.slug }` }
 					>
-						{ translate( 'Manage plan' ) }
+						{ plansPageLinkLabel }
 					</Button>
 				</div>
 				{ isPaidPlan && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7205

## Proposed Changes

* Updates the copy on the link to the plans page on the plan card in sites overview in the case of it being a free plan.
* Free plans should now say "Explore paid plans" instead of "Manage plan".
* Non-free plans should remain unchanged.

BEFORE

<img width="480" alt="Screenshot 2024-05-15 at 1 33 55 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/ee3dbc56-6e86-405b-853a-e112d2ddcb0e">


AFTER

<img width="527" alt="Screenshot 2024-05-15 at 1 27 46 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/4968a1a5-4797-42ff-aace-fd0c70c15f88">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is already recorded in the issue linked in the "related to" above, as well as the p2 thread it references...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of claypso
* Visit the sites dashboard.
* Select to see the overview for a free site. Verify the copy on the plan card link's top-right has changed to "explore paid plans"
* Verify non-free plans still say "manage plan"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
