### PR TITLE
Blaze: Update campaign stats to display cost-per-click

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -153,6 +153,10 @@ export default function CampaignItemDetails( props: Props ) {
 	} = audience_list || {};
 
 	// Formatted labels
+	const cpcFormatted =
+		total_budget_used && clicks_total && clicks_total > 0
+			? `$${ formatCents( total_budget_used / clicks_total, 2 ) }`
+			: '-';
 	const ctrFormatted = clickthrough_rate ? `${ clickthrough_rate.toFixed( 2 ) }%` : '-';
 	const clicksFormatted = clicks_total && clicks_total > 0 ? clicks_total : '-';
 	const weeklyBudget = budget_cents ? ( budget_cents / 100 ) * 7 : 0;
@@ -498,22 +502,17 @@ export default function CampaignItemDetails( props: Props ) {
 										</div>
 										<div>
 											<span className="campaign-item-details__label">
-												{ __( 'Click-through rate' ) }
-												<InfoPopover
-													className="campaign-item-data__info-button"
-													position="bottom right"
-												>
-													{ __( 'Click-through rate:' ) }
-													<br />
-													<span className="popover-title">
-														{ __(
-															'a metric used to measure the ratio of users who click on your ad to the number of total users view it.'
-														) }
-													</span>
-												</InfoPopover>
+												{ __( 'Cost-Per-Click' ) }
 											</span>
 											<span className="campaign-item-details__text wp-brand-font">
-												{ ! isLoading ? ctrFormatted : <FlexibleSkeleton /> }
+												{ ! isLoading ? cpcFormatted : <FlexibleSkeleton /> }
+											</span>
+											<span className="campaign-item-details__details">
+												{ ! isLoading ? (
+													`${ ctrFormatted } ${ __( 'Click-through rate' ) }`
+												) : (
+													<FlexibleSkeleton />
+												) }
 											</span>
 										</div>
 										{ isWooStore && status !== 'created' && (


### PR DESCRIPTION
## Proposed Changes

* Adds cost-per-click metric to campaign stats
* Moves existing click-through rate metric to below the CPC metric

Change:
![f0fd68de-f1b2-491b-8588-17d3e8e93945](https://github.com/Automattic/wp-calypso/assets/1050616/3acb43fa-9ed5-4d09-af84-35f9bf296a09)

To:
![cf530a5d-0827-456a-a1df-328769242b9b](https://github.com/Automattic/wp-calypso/assets/1050616/48ef5294-e2af-4bb2-b05b-1a473ec8ec2e)


## Why are these changes being made?

* We believe this metric will be useful for users to evaluate the health of their campaigns

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the campaign stats for a current or finished campaign
* Verify that the cost-per-click metric is shown and follows the formula: Overall Spend / Total Clicks
* Verify that the click-through rate metric displays below the CPC metric
* Verify if no clicks, that the CPC metric displays "-"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X ] Have you checked for TypeScript, React or other console errors?
- [X ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
