### PR TITLE
Fix: Add the key prop on the Site Profiler Insights list

### DIFF
--- a/client/site-profiler/components/metrics-insights-list/index.tsx
+++ b/client/site-profiler/components/metrics-insights-list/index.tsx
@@ -33,13 +33,14 @@ export const MetricsInsightsList = ( props: MetricsInsightsListProps ) => {
 
 	return (
 		<Container className="metrics-insights-list">
-			{ insights.map( ( insight ) => (
+			{ insights.map( ( insight, index ) => (
 				<FoldableCard
 					header={ <InsightHeader>{ insight.header }</InsightHeader> }
 					screenReaderText={ translate( 'More' ) }
 					compact
 					clickableHeader
 					smooth
+					key={ `insight-${ index }` }
 				>
 					<InsightContent>{ insight.description }</InsightContent>
 				</FoldableCard>


### PR DESCRIPTION
## Proposed Changes

Add the `key` property to avoid warning.

## Why are these changes being made?

A warning was being raised due to using a map without a key prop.

## Testing Instructions

The Site Profiler should be working as currently.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?