### PR TITLE
Reader: Fix manage comment subscriptions pagination

### DIFF
--- a/client/landing/subscriptions/components/virtualized-list/virtualized-list.tsx
+++ b/client/landing/subscriptions/components/virtualized-list/virtualized-list.tsx
@@ -4,7 +4,8 @@ import {
 	List,
 	WindowScroller,
 } from '@automattic/react-virtualized';
-import React, { useCallback, useRef } from 'react';
+import React, { useEffect, useCallback, useRef } from 'react';
+import ReactDOM from 'react-dom';
 import withDimensions from 'calypso/lib/with-dimensions';
 
 type VirtualizedListFunctionProps< T > = {
@@ -34,8 +35,38 @@ type RowRenderProps = {
 	parent: unknown;
 };
 
+const getScrollContainer = ( node: HTMLElement | null ): HTMLElement | Window => {
+	// Default to window if the node is null or it's the root element.
+	if ( ! node || node.ownerDocument === node.parentNode ) {
+		return window;
+	}
+
+	// Return when overflow is defined to either auto or scroll.
+	const { overflowY } = getComputedStyle( node );
+	if ( /(auto|scroll)/.test( overflowY ) ) {
+		return node;
+	}
+
+	// Continue traversing if parentNode is an HTMLElement.
+	const parentNode = node.parentNode;
+	if ( parentNode && parentNode instanceof HTMLElement ) {
+		return getScrollContainer( parentNode );
+	}
+
+	// Default to window if no scroll container is found.
+	return window;
+};
+
 const VirtualizedList = < T, >( { width, items, children }: VirtualizedListProps< T > ) => {
 	const windowScrollerRef = useRef();
+	const scrollContainerRef = useRef< HTMLElement | Window >( window );
+
+	useEffect( () => {
+		if ( windowScrollerRef.current ) {
+			const domNode = ReactDOM.findDOMNode( windowScrollerRef.current ) as HTMLElement;
+			scrollContainerRef.current = getScrollContainer( domNode );
+		}
+	}, [] );
 
 	const rowRenderer = useCallback(
 		( { index, key, style, parent }: RowRenderProps ) => {
@@ -58,7 +89,7 @@ const VirtualizedList = < T, >( { width, items, children }: VirtualizedListProps
 	);
 
 	return (
-		<WindowScroller ref={ windowScrollerRef }>
+		<WindowScroller ref={ windowScrollerRef } scrollElement={ scrollContainerRef.current }>
 			{ ( {
 				height,
 				scrollTop,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7215

## Proposed Changes

Select the correct element with the scroll instead of using the default (`window`)

## Why are these changes being made?
On Manage comment subscriptions, the pagination won't load on scroll

## Testing Instructions

* Go to `/read/subscriptions/comments`
* When scrolling it should load new comments.

