### PR TITLE
Site management panel: Update the Selected site color

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -390,6 +390,9 @@
 			}
 
 			li.is-selected,
+			li.is-selected:hover {
+				background-color: #ebf2fc;
+			}
 			li:hover {
 				background-color: #f7faff;
 			}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7171

## Proposed Changes

Update the selected site color to `#ebf2fc`

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/dec99ea2-68bb-488a-89e0-f70dbcb4bfac) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/c68b3344-1d18-4e46-b937-81dd55055fed) |

## Testing Instructions

* Go to `/sites`
* Select a site
* Check the color of the selected site (it should be darker than the hover color)
