### PR TITLE
Show WP Admin on /sites for Jetpack Self-hosted

### DIFF
--- a/client/state/sites/hooks/use-site-admin-interface-data.ts
+++ b/client/state/sites/hooks/use-site-admin-interface-data.ts
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from '../selectors/get-site-admin-url';
 import getSiteHomeUrl from '../selectors/get-site-home-url';
 import getSiteOption from '../selectors/get-site-option';
@@ -13,7 +14,8 @@ const useSiteAdminInterfaceData = ( siteId: number = 0 ) => {
 	const wpcomAdminInterface = useSelector( ( state: AppState ) =>
 		getSiteOption( state, siteId, 'wpcom_admin_interface' )
 	);
-	const isWPAdmin = wpcomAdminInterface === 'wp-admin';
+	const isJetpack = useSelector( ( state: AppState ) => isJetpackSite( state, siteId ) );
+	const isWPAdmin = wpcomAdminInterface === 'wp-admin' || isJetpack;
 	const adminLabel = isWPAdmin ? translate( 'WP Admin' ) : translate( 'My Home' );
 	const adminUrl =
 		useSelector( ( state: AppState ) =>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7207

## Proposed Changes

Show `WP Admin` instead of `My Home` on Jetpack sites in the sites lists.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/08add01f-b231-40b0-abb5-b0e92a198f28) | [image](https://github.com/Automattic/wp-calypso/assets/402286/599679ed-7a97-42fa-be81-122f2115612a) |

## Testing Instructions

* Go to `/sites`
* Search for a Jetpack self-hosted site
* It should show `WP Admin` and link to site's wp-admin
