### PR TITLE
Add large width on `/sites` and `/domains/manage`

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -152,7 +152,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			}
 
 			@media only screen and ( min-width: 782px ) {
-				div.layout.is-global-sidebar-visible {
+				.is-global-sidebar-visible {
 					header.navigation-header {
 						padding-top: 24px;
 						padding-inline: 64px;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -140,10 +140,10 @@
 
 	.main {
 		.navigation-header {
-			@include break-huge {
+			@include break-xhuge {
 				margin: 0 auto;
-				max-width: 1096px;
-				padding-inline: 8px;
+				max-width: 1400px;
+				padding-inline: 64px;
 			}
 		}
 	}
@@ -154,19 +154,19 @@
 		}
 	}
 	.domains-table {
-		@include break-huge {
-			max-width: 1096px;
+		@include break-xhuge {
+			max-width: 1400px;
 			margin-left: auto;
 			margin-right: auto;
 		}
 		.domains-table-toolbar {
 			@include break-huge {
-				margin-inline: 8px;
+				margin-inline: 64px;
 			}
 		}
 		> table {
 			@include break-huge {
-				padding-inline: 8px;
+				padding-inline: 64px;
 			}
 		}
 		.components-base-control {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -134,15 +134,18 @@
 		}
 	}
 }
-
 // Custom layout width for the bulk domains pages
-.is-bulk-domains-page {
-	.layout__content {
-		overflow: auto;
-	}
+.is-bulk-domains-page .layout__content {
+	overflow: auto;
 
-	main {
-		max-width: 1224px;
+	.main {
+		.navigation-header {
+			@include break-large {
+				margin: 0 auto;
+				max-width: 1096px;
+				padding-inline: 8px;
+			}
+		}
 	}
 
 	.empty-domains-list-card {
@@ -150,8 +153,22 @@
 			box-shadow: none;
 		}
 	}
-
 	.domains-table {
+		@include break-huge {
+			max-width: 1096px;
+			margin-left: auto;
+			margin-right: auto;
+		}
+		.domains-table-toolbar {
+			@include break-huge {
+				margin-inline: 8px;
+			}
+		}
+		> table {
+			@include break-huge {
+				padding-inline: 8px;
+			}
+		}
 		.components-base-control {
 			--checkbox-input-size: 16px;
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -140,7 +140,7 @@
 
 	.main {
 		.navigation-header {
-			@include break-large {
+			@include break-huge {
 				margin: 0 auto;
 				max-width: 1096px;
 				padding-inline: 8px;

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -26,8 +26,8 @@
 				padding-inline: 26px;
 			}
 
-			@include breakpoint-deprecated( ">1440px" ) {
-				padding-inline: 8px;
+			@include break-huge {
+				padding-inline: 64px;
 			}
 		}
 	}
@@ -140,9 +140,7 @@
 			padding-left: 26px;
 		}
 		@include break-huge {
-			&:first-child {
-				padding-left: 0;
-			}
+			padding-left: 64px;
 		}
 		&:nth-child(2) {
 			white-space: wrap;
@@ -506,6 +504,14 @@
 				margin: 0;
 				position: relative;
 				width: 100%;
+				@include break-large {
+					padding-left: 26px;
+					padding-right: 26px;
+				}
+				@include break-huge {
+					padding-left: 64px;
+					padding-right: 64px;
+				}
 			}
 		}
 	}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -23,7 +23,11 @@
 			}
 
 			@include breakpoint-deprecated( ">960px" ) {
-				padding-inline: 64px;
+				padding-inline: 26px;
+			}
+
+			@include breakpoint-deprecated( ">1440px" ) {
+				padding-inline: 8px;
 			}
 		}
 	}
@@ -137,7 +141,7 @@
 		}
 		@include break-huge {
 			&:first-child {
-				padding-left: 64px;
+				padding-left: 8px;
 			}
 		}
 		&:nth-child(2) {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -140,7 +140,9 @@
 			padding-left: 26px;
 		}
 		@include break-huge {
-			padding-left: 64px;
+			&:first-child {
+				padding-left: 64px;
+			}
 		}
 		&:nth-child(2) {
 			white-space: wrap;

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -141,7 +141,7 @@
 		}
 		@include break-huge {
 			&:first-child {
-				padding-left: 8px;
+				padding-left: 0;
 			}
 		}
 		&:nth-child(2) {

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -12,14 +12,11 @@ import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { useSitesDashboardImportSiteUrl } from 'calypso/sites-dashboard/hooks/use-sites-dashboard-import-site-url';
 import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 
-const MAX_PAGE_WIDTH = '1224px';
-
 const PageHeader = styled.div( {
 	backgroundColor: 'var( --studio-white )',
 } );
 
 const HeaderControls = styled.div( {
-	maxWidth: MAX_PAGE_WIDTH,
 	marginBlock: 0,
 	marginInline: 'auto',
 	display: 'flex',

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -511,12 +511,17 @@
 		}
 
 		@media (min-width: $break-huge) {
-			.a4a-layout__viewport,
-			.dataviews-wrapper {
-				max-width: 1096px;
-				padding-left: 8px;
-				padding-right: 8px;
+			div.a4a-layout__viewport {
 				margin: 0 auto;
+				max-width: 1096px;
+				box-sizing: border-box;
+				padding-inline: 8px;
+			}
+			.dataviews-wrapper {
+				margin: 0 auto;
+				max-width: 1096px;
+				box-sizing: border-box;
+				padding-inline: 8px;
 			}
 		}
 
@@ -596,11 +601,11 @@
 				.sites-overview {
 					.dataviews-filters__view-actions {
 						& > :first-child {
-							margin-inline-start: 8px;
+							margin-inline-start: 0;
 						}
 
 						& > :last-child {
-							margin-inline-end: 8px;
+							margin-inline-end: 0;
 						}
 					}
 				}

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -54,7 +54,6 @@
 		text-align: end;
 	}
 
-
 	@media (min-width: $break-large) {
 		background: inherit;
 
@@ -87,11 +86,11 @@
 	@media (min-width: $break-huge) {
 		.dataviews-view-table tr th:first-child,
 		.dataviews-view-table tr td:first-child {
-			padding-left: 64px;
+			padding-left: 0;
 		}
 		.dataviews-view-table tr th:last-child,
 		.dataviews-view-table tr td:last-child {
-			padding-right: 64px;
+			padding-right: 0;
 		}
 	}
 
@@ -511,12 +510,13 @@
 			}
 		}
 
-		.a4a-layout__top-wrapper,
-		.a4a-layout__body {
-			> * {
-				@include breakpoint-deprecated(">660px") {
-					max-width: none;
-				}
+		@media (min-width: $break-huge) {
+			.a4a-layout__viewport,
+			.dataviews-wrapper {
+				max-width: 1096px;
+				padding-left: 8px;
+				padding-right: 8px;
+				margin: 0 auto;
 			}
 		}
 
@@ -596,11 +596,11 @@
 				.sites-overview {
 					.dataviews-filters__view-actions {
 						& > :first-child {
-							margin-inline-start: 64px;
+							margin-inline-start: 8px;
 						}
 
 						& > :last-child {
-							margin-inline-end: 64px;
+							margin-inline-end: 8px;
 						}
 					}
 				}

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -74,11 +74,11 @@
 
 		.dataviews-view-table tr th:first-child,
 		.dataviews-view-table tr td:first-child {
-			padding-left: 30px;
+			padding-left: 26px;
 		}
 		.dataviews-view-table tr th:last-child,
 		.dataviews-view-table tr td:last-child {
-			padding-right: 30px;
+			padding-right: 26px;
 			width: 20px;
 			white-space: nowrap;
 		}
@@ -86,11 +86,11 @@
 	@media (min-width: $break-huge) {
 		.dataviews-view-table tr th:first-child,
 		.dataviews-view-table tr td:first-child {
-			padding-left: 0;
+			padding-left: 64px;
 		}
 		.dataviews-view-table tr th:last-child,
 		.dataviews-view-table tr td:last-child {
-			padding-right: 0;
+			padding-right: 64px;
 		}
 	}
 
@@ -510,18 +510,16 @@
 			}
 		}
 
-		@media (min-width: $break-huge) {
+		@media (min-width: $break-xhuge) {
 			div.a4a-layout__viewport {
 				margin: 0 auto;
-				max-width: 1096px;
+				max-width: 1400px;
 				box-sizing: border-box;
-				padding-inline: 8px;
 			}
 			.dataviews-wrapper {
 				margin: 0 auto;
-				max-width: 1096px;
+				max-width: 1400px;
 				box-sizing: border-box;
-				padding-inline: 8px;
 			}
 		}
 
@@ -596,16 +594,15 @@
 					}
 				}
 			}
-
 			@media only screen and (min-width: $break-huge) {
 				.sites-overview {
 					.dataviews-filters__view-actions {
 						& > :first-child {
-							margin-inline-start: 0;
+							margin-inline-start: 64px;
 						}
 
 						& > :last-child {
-							margin-inline-end: 0;
+							margin-inline-end: 64px;
 						}
 					}
 				}


### PR DESCRIPTION
Adds max width to the sites and domains table 

Fixes 7186-gh-Automattic/dotcom-forge

1441px:

<img width="1199" alt="Screenshot 2024-05-16 at 11 49 04 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/6aedb365-0421-4e4a-bf28-f8600c4de04c">

1800px:

<img width="1193" alt="Screenshot 2024-05-16 at 11 49 15 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/8b87a239-4831-4387-9d77-84d0bbaf72cf">

I've also applied a max width to the domains page to max.

I had to jump through a few hoops to implement this, in part this was to maintain the header effect where the line runs right across the page and keep everything lined up properly.

### Testing instructions

Test different widths and page states on the /sites page.

