### PR TITLE
Automattic for Agencies: Fix site license purchases

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-issue-license-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-issue-license-mutation.ts
@@ -13,7 +13,7 @@ function mutationIssueLicense( {
 	product,
 	quantity,
 	agencyId,
-}: MutationIssueLicenseVariables & { agencyId?: number } ): Promise< APILicense > {
+}: MutationIssueLicenseVariables & { agencyId?: number } ): Promise< APILicense[] > {
 	if ( ! agencyId ) {
 		throw new Error( 'Agency ID is required to issue a license' );
 	}
@@ -25,11 +25,11 @@ function mutationIssueLicense( {
 }
 
 export default function useIssueLicenseMutation< TContext = unknown >(
-	options?: UseMutationOptions< APILicense, APIError, MutationIssueLicenseVariables, TContext >
-): UseMutationResult< APILicense, APIError, MutationIssueLicenseVariables, TContext > {
+	options?: UseMutationOptions< APILicense[], APIError, MutationIssueLicenseVariables, TContext >
+): UseMutationResult< APILicense[], APIError, MutationIssueLicenseVariables, TContext > {
 	const agencyId = useSelector( getActiveAgencyId );
 
-	return useMutation< APILicense, APIError, MutationIssueLicenseVariables, TContext >( {
+	return useMutation< APILicense[], APIError, MutationIssueLicenseVariables, TContext >( {
 		...options,
 		mutationFn: ( args ) => mutationIssueLicense( { ...args, agencyId } ),
 	} );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -34,15 +34,17 @@ const useGetLicenseIssuedMessage = () => {
 			}
 
 			// Only one individual license; let's be more specific
-			if ( licenses.length === 1 && ( licenses[ 0 ].quantity ?? 1 ) === 1 ) {
+			if ( licenses.length === 1 ) {
 				const productName =
 					products?.data?.find?.( ( p ) => p.slug === licenses[ 0 ].slug )?.name ?? '';
 				return translate(
 					'Thanks for your purchase! Below you can view and assign your new {{strong}}%(productName)s{{/strong}} license to a website.',
+					'Thanks for your purchase! Below you can view and assign your new {{strong}}%(productName)s{{/strong}} licenses to a website.',
 					{
 						args: {
 							productName,
 						},
+						count: licenses[ 0 ].licenses.length ?? 1,
 						components: {
 							strong: <strong />,
 						},
@@ -103,7 +105,7 @@ function useIssueAndAssignLicenses(
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_multiple_licenses_issued', {
 					products: issuedLicenses
-						.map( ( license ) => `${ license.slug }:${ license.quantity ?? 1 }` )
+						.map( ( license ) => `${ license.slug }:${ license.licenses.length ?? 1 }` )
 						.join( ',' ),
 				} )
 			);
@@ -111,7 +113,9 @@ function useIssueAndAssignLicenses(
 			// We have issued the licenses successfully so we can now call onSuccess callback regardless if it was able to assign it.
 			options.onSuccess?.();
 
-			const issuedKeys = issuedLicenses.map( ( { license_key } ) => license_key );
+			const issuedKeys = issuedLicenses
+				.map( ( item ) => item.licenses.map( ( lic ) => lic.license_key ) )
+				.flat();
 
 			// TODO: Move dispatch events and redirects outside this function
 			//

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-licenses.tsx
@@ -11,9 +11,10 @@ export type IssueLicenseRequest = {
 	quantity: number;
 };
 
-export type FulfilledIssueLicenseResult = APILicense & {
+export type FulfilledIssueLicenseResult = {
 	status: 'fulfilled';
 	slug: string;
+	licenses: APILicense[];
 };
 export type RejectedIssueLicenseResult = {
 	status: 'rejected';
@@ -51,9 +52,9 @@ const useIssueLicenses = ( options: UseIssueLicensesOptions = {} ) => {
 		const requests: Promise< IssueLicenseResult >[] = selectedLicenses.map(
 			( { slug, quantity } ) =>
 				mutateAsync( { product: slug, quantity } )
-					.then(
-						( value ): FulfilledIssueLicenseResult => ( { slug, status: 'fulfilled', ...value } )
-					)
+					.then( ( value ): FulfilledIssueLicenseResult => {
+						return { slug, status: 'fulfilled', licenses: value };
+					} )
 					.catch( (): RejectedIssueLicenseResult => ( { slug, status: 'rejected' } ) )
 		);
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/466

## Proposed Changes

This PR:

- Fixes an issue that did not assign the licenses to a site after the license was issued.
- Updates the success messages when a new license(s) is issued. 

Context: We changed the [API](https://github.com/Automattic/automattic-for-agencies-dev/issues/403) to assign a license, and the response from that API is now an array instead of an object. 

## Testing Instructions

1. Open the A4A live link.
2. Visit the Sites dashboard > Click on `+ Add` on any site > Checkout > Verify that the license is issued to the selected site.
3. Visit the Marketplace > Purchase any one license without bundle > Verify that the success message is shown below

<img width="924" alt="Screenshot 2024-05-16 at 9 32 33 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/87897c7a-759f-46f0-9704-b21c6fd99685">

5. Visit the Marketplace > Purchase any one license with bundle > Verify that the success message is shown below

<img width="924" alt="Screenshot 2024-05-16 at 9 32 17 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9677cc7d-f3e7-4d4b-ac22-9335694e64af">

7. Visit the Marketplace > Purchase multiple licenses > Verify that the success message is shown below

<img width="924" alt="Screenshot 2024-05-16 at 9 33 36 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ca091744-3cc0-42a9-84be-1d0749a884c4">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
