### PR TITLE
fix reader double scrollbar on mobile

### DIFF
--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -95,7 +95,7 @@ body.is-section-me {
 			background: var(--color-surface);
 			margin: 0;
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			height: calc(100vh - 32px);
+			height: calc(100vh - 46px);
 		}
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1099,7 +1099,8 @@ $font-size: rem(14px);
 		}
 
 		.focus-content:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
-			padding-top: 47px;
+			padding-top: 46px;
+			padding-bottom: 0;
 		}
 
 		// client/layout/sidebar/style.scss

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -104,7 +104,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 			background: var(--color-surface);
 			margin: 0;
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			height: calc(100vh - 32px);
+			height: calc(100vh - 46px);
 		}
 	}
 


### PR DESCRIPTION
On mobile I noticed reader has two scrollbars:

<img width="402" alt="Screenshot 2024-05-16 at 4 06 05 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/7ead2565-cd7c-46d7-a9b6-755928216c66">

### Test instructions
view reader on mobile
test other pages on mobile as well to ensure no regressions.
