### PR TITLE
Page Editor: Fix Text global styles for block themes in simple sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -419,7 +419,7 @@ class Starter_Page_Templates {
 	 * Custom styles are safe because they are overwritten by local block styles, global styles, or theme stylesheets.
 	 **/
 	public function add_default_editor_styles_for_classic_themes( $editor_settings, $editor_context ) {
-		$theme = wp_get_theme( normalize_theme_slug( get_stylesheet() ) );
+		$theme = wp_get_theme( get_stylesheet() );
 		if ( $theme->is_block_theme() ) {
 			// Only for classic themes
 			return $editor_settings;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85798 p1715801793910199-slack-C03TY6J1A

## Proposed Changes

* Remove `normalize_theme_slug` from `add_default_editor_styles_for_classic_themes`


>[!Note]
> `normalize_theme_slug()` is not required because `get_stylesheet()` returns the theme directory correctly prefixed for simple `pub/{ theme directory }` and atomic `{ theme directory }`. 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
* To fix a bug reported in p1715801793910199-slack-C03TY6J1A affecting only the page editor for block themes on simple sites
* The bug overwrites the Text font with the default editor font
* After the fix, the page editor sues the font from the theme for Text elements (paragraphs)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a simple site with `bedrock` theme
* Patch this diff with `install-plugin.sh etk fix/default-styles-for-classic-themes-in-simple`
* Go to the Site Editor `Styles > Typography > Text` and set the font family to `Pixeloid mono`
* Edit a page from `https://wordpress.com/pages/{ SITE }`, make sure it has some regular paragraphs 
* Verify the paragraphs use the font as on the screenshot

Test on Atomic:
- Download the ETK plugin from Teamcity
- Deactivate ETK on your atomic site
- Upload and install the ETK you downloaded
* Edit a page from `https://wordpress.com/pages/{ SITE }`, make sure it has some regular paragraphs 
* Verify the paragraphs use the font as on the screenshot

|BEFORE|AFTER|
|-|-|
|<img width="1110" alt="Screenshot 2567-05-16 at 13 10 28" src="https://github.com/Automattic/wp-calypso/assets/1881481/633336ca-ecaf-4a27-a026-119a46d6f8e6">|<img width="1111" alt="Screenshot 2567-05-16 at 13 07 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/a2159258-aef3-4745-871d-cdeef87e2403">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?