### PR TITLE
Fix issue where sidebar is collapsed in calypso with site selected

### DIFF
--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -56,8 +56,7 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	sectionGroup: string,
 	sectionName: string
 ) => {
-	const isAllowedRegion =
-		sectionGroup === 'sites-dashboard' || sectionGroup === 'sites' || sectionName === 'plugins';
+	const isAllowedRegion = sectionGroup === 'sites-dashboard' || sectionName === 'plugins';
 	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
 	const pluginsScheduledUpdatesEditMode =

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -56,12 +56,17 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	sectionGroup: string,
 	sectionName: string
 ) => {
-	const isAllowedRegion = sectionGroup === 'sites-dashboard' || sectionName === 'plugins';
+	const isAllowedRegion =
+		sectionGroup === 'sites-dashboard' || sectionGroup === 'sites' || sectionName === 'plugins';
 	const siteSelected = sectionGroup === 'sites-dashboard' && !! siteId;
 	const siteLoaded = getShouldShowGlobalSiteSidebar( state, siteId, sectionGroup, sectionName );
 	const pluginsScheduledUpdatesEditMode =
 		state.route.path?.current?.includes( 'scheduled-updates/edit' ) ||
 		state.route.path?.current?.includes( 'scheduled-updates/create' );
+	const isBulkDomainsDashboard = state.route.path?.current?.endsWith( 'domains/manage' );
+	const isSmallScreenDashboard =
+		( sectionGroup === 'sites-dashboard' || isBulkDomainsDashboard ) &&
+		isWithinBreakpoint( '<782px' );
 
 	return (
 		isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
@@ -69,7 +74,7 @@ export const getShouldShowCollapsedGlobalSidebar = (
 		( siteSelected ||
 			siteLoaded ||
 			( ! siteId && pluginsScheduledUpdatesEditMode ) ||
-			isWithinBreakpoint( '<782px' ) )
+			isSmallScreenDashboard )
 	);
 };
 

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -63,7 +63,7 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	const pluginsScheduledUpdatesEditMode =
 		state.route.path?.current?.includes( 'scheduled-updates/edit' ) ||
 		state.route.path?.current?.includes( 'scheduled-updates/create' );
-	const isBulkDomainsDashboard = state.route.path?.current?.endsWith( 'domains/manage' );
+	const isBulkDomainsDashboard = state.route.path?.current === '/domains/manage';
 	const isSmallScreenDashboard =
 		( sectionGroup === 'sites-dashboard' || isBulkDomainsDashboard ) &&
 		isWithinBreakpoint( '<782px' );


### PR DESCRIPTION
The collapsed state for the global sidebar bleeds into other areas on smaller screen widths (<782px) where they should not. Such as the sites sidebar on my-home when opening the sidebar at about 700-780px range.

This PR adds more conditioning to the breakpoint check that determines collapsing the sidebar to limit this to the two global overview pages that require this functionality of collapsing the sidebar under no conditions other than screen width. 

More context in comment below https://github.com/Automattic/wp-calypso/pull/90785#discussion_r1603380758

BEFORE
<img width="135" alt="Screenshot 2024-05-16 at 10 31 08 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/3b757573-e4c0-4819-b488-8a3f2bfae191">


AFTER
<img width="279" alt="Screenshot 2024-05-16 at 10 31 39 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/9ddcd342-47d3-4244-b19d-07475753f139">



### Testing instructions

* Run this branch of calypso.
* In a browser width of ~ 780px, Visit my home for a site.
* Open the sidebar, verify it isnt collapsed and is the expected width.
* Go to the sites dashboard, verify opening the sidebar at 780px and verify it is still compact.
* Click the domains section. Verify the sidebar is still compact. Clicking through to the site specific domains page should have a sidebar of expected wider width.
* Visit the sites dashboard at a wider screen width. 
* Select a site and verify the sidebar collapses when the site overview pane pops out.