### PR TITLE
Mark PHP 7.4 as deprecated in the hosting configuration

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -202,7 +202,10 @@ const WebServerSettingsCard = ( {
 				disabled: true, // EOL 6th December, 2021
 			},
 			{
-				label: '7.4',
+				label: translate( '%s (deprecated)', {
+					args: '7.4',
+					comment: 'PHP Version for a version switcher',
+				} ),
 				value: '7.4',
 			},
 			{
@@ -233,7 +236,6 @@ const WebServerSettingsCard = ( {
 			disabled || ! selectedPhpVersion || selectedPhpVersion === phpVersion;
 		const selectedPhpVersionValue =
 			selectedPhpVersion || phpVersion || ( disabled && recommendedValue );
-
 		return (
 			<FormFieldset>
 				<FormLabel>{ translate( 'PHP version' ) }</FormLabel>


### PR DESCRIPTION
## Proposed Changes

* Add a `(deprecated)` label to PHP 7.4

![CleanShot 2024-05-16 at 10 48 31@2x](https://github.com/Automattic/wp-calypso/assets/528287/d260b9ba-8dda-4359-a279-1216ca3424f8)

At a later stage we will (probably) add a modal/warning when the users clicks the button

## Why are these changes being made?

* To discourage users from downgrading / selecting PHP 7.4.

## Testing Instructions

- Visit `http://calypso.localhost:3000/hosting-config/<youriste>` 
- Make sure the label is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
