### PR TITLE
Command palette: Return after setting locale

### DIFF
--- a/apps/command-palette-wp-admin/src/set-locale.ts
+++ b/apps/command-palette-wp-admin/src/set-locale.ts
@@ -23,6 +23,7 @@ const loadLanguageFile = async ( languageFileName: string ) => {
 				i18n.setLocale( body );
 				// Work with the wordpress i18n `__` etc
 				defaultI18n.setLocaleData( body, __i18n_text_domain__ );
+				return;
 			}
 		}
 		Promise.reject( response );


### PR DESCRIPTION
Once the local has been set, then return rather than rejecting the response. This fixes a noisy warning message in the browser.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To remove a confusing and misleading error message from the browser console. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Use calypso.live or checkout the branch locally
2. Open the browser console
3. Go to /me/account and change language
4. Open the command palette (Cmd + K)
5. Confirm translations work and there are no warnings like this one 
![image](https://github.com/Automattic/wp-calypso/assets/93301/21848503-01c4-4c07-bf52-3fe6d6cbdc4e)
6. Apply the patch on your sandbox with `install-plugin.sh command-palette-wp-admin fix/spurious-cors-warning`
7. Sandbox widgets.wp.com
8. Go to yoursite .wordpress.com/wp-admin
9. Open the command palette (Cmd + K)
10. Confirm translations work and there are no warnings like the above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
