### PR TITLE
Exclude deleted sites from notification settings

### DIFF
--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -9,7 +9,7 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InfiniteList from 'calypso/components/infinite-list';
-import getSites from 'calypso/state/selectors/get-sites';
+import getUndeletedSites from 'calypso/state/selectors/get-undeleted-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import Blog from './blog';
 import Placeholder from './placeholder';
@@ -79,7 +79,7 @@ class BlogsSettings extends Component {
 		const renderBlog = ( site, index, disableToggle = false ) => {
 			const onSave = () => this.props.onSave( site.ID );
 			const onSaveToAll = () => this.props.onSaveToAll( site.ID );
-			const blogSettings = find( this.props.settings, { blog_id: site.ID } ) || {};
+			const blogSettings = find( this.props.settings, { blog_id: site.ID } );
 
 			return (
 				<Blog
@@ -123,7 +123,7 @@ class BlogsSettings extends Component {
 }
 
 const mapStateToProps = ( state ) => ( {
-	sites: getSites( state ),
+	sites: getUndeletedSites( state ),
 	requestingSites: isRequestingSites( state ),
 } );
 

--- a/client/state/selectors/get-undeleted-sites.js
+++ b/client/state/selectors/get-undeleted-sites.js
@@ -1,0 +1,26 @@
+import { createSelector } from '@automattic/state-utils';
+import { partition, sortBy } from 'lodash';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import getSitesItems from 'calypso/state/selectors/get-sites-items';
+import { getSite } from 'calypso/state/sites/selectors';
+
+const sortByNameAndUrl = ( list ) => sortBy( list, [ 'name', 'URL' ] );
+
+/**
+ * Get only sites that are not deleted. Deleted sites cause some issues in some parts of the UI but are still needed in others.
+ * @param {Object} state  Global state tree
+ * @returns {Array}        Sites objects
+ */
+export default createSelector(
+	( state, shouldSort = true ) => {
+		const primarySiteId = getPrimarySiteId( state );
+		const [ primarySite, sites ] = partition( getSitesItems( state ), { ID: primarySiteId } );
+
+		const allSites = shouldSort ? sortByNameAndUrl( sites ) : sites;
+
+		return [ ...primarySite, ...allSites ]
+			.map( ( site ) => getSite( state, site.ID ) )
+			.filter( ( site ) => ! site.is_deleted );
+	},
+	( state ) => [ getSitesItems( state ), state.currentUser.capabilities ]
+);

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -28,6 +28,7 @@ export const SITE_REQUEST_FIELDS = [
 	'was_hosting_trial',
 	'description',
 	'user_interactions',
+	'is_deleted',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [


### PR DESCRIPTION
Related to p1715865934374799-slack-C02FMH4G8

## Proposed Changes

Deleted sites don't have any settings left for them, but they're still part of the user's site history.

Deleted sites appear, as they should, here: https://wordpress.com/sites
But when the user navigates to notification settings, here: https://wordpress.com/me/notifications, deleted sites having no notification settings and throw an error.

This PR excludes deleted sites from notifications settings. 
## Why are these changes being made?
To fix a bug.

## Testing Instructions

1. Delete a testing site.
2. Go to /sites. You should see it, but it should be marked as deleted.
3. Go to notification settings. They should render fine.

