### PR TITLE
Nav redesign - fix back button behaviour

### DIFF
--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -59,6 +59,14 @@ const GlobalSidebar = ( {
 		}
 	}, [ previousRoute, section.group ] );
 
+	// If the previous route is the same as the current route, then we are on the same page
+	// To avoid issues with back button, we fallback to the `/sites` route
+	const index = previousLink.current.indexOf( '?' );
+	let route = index >= 0 ? previousLink.current.substring( 0, index ) : previousLink.current;
+	if ( previousRoute.startsWith( route ) ) {
+		route = null;
+	}
+
 	/**
 	 * If there are no menu items and we are currently requesting some,
 	 * then show a spinner. The check for menuItems is necessary because
@@ -70,7 +78,7 @@ const GlobalSidebar = ( {
 	}
 
 	const { requireBackLink, siteTitle, backLinkHref, ...sidebarProps } = props;
-	const sidebarBackLinkHref = backLinkHref || previousLink.current || '/sites';
+	const sidebarBackLinkHref = backLinkHref || route || '/sites';
 
 	return (
 		<div className="global-sidebar" ref={ wrapperRef }>

--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -64,7 +64,7 @@ const GlobalSidebar = ( {
 	// Determine the route to use for the back link.
 	// If there is no previous link, then there is no route to use - fallback to the default.
 	// If the current route is a sub-route of the previous link, then there is no route to use - fallback to the default.
-	const route = useMemo( () => {
+	const previousRouteHref = useMemo( () => {
 		if ( ! previousLink.current ) {
 			return null;
 		}
@@ -85,7 +85,7 @@ const GlobalSidebar = ( {
 	}
 
 	const { requireBackLink, siteTitle, backLinkHref, ...sidebarProps } = props;
-	const sidebarBackLinkHref = backLinkHref || route || '/sites';
+	const sidebarBackLinkHref = backLinkHref || previousRouteHref || '/sites';
 
 	return (
 		<div className="global-sidebar" ref={ wrapperRef }>

--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -63,7 +63,7 @@ const GlobalSidebar = ( {
 
 	// Determine the route to use for the back link.
 	// If there is no previous link, then there is no route to use - fallback to the default.
-	// If the current route is a sub-route of the previous link, then there is no route to use - fallback to the default.
+	// If the previous link is the same as the current route, then there is no route to use - fallback to the default.
 	const previousRouteHref = useMemo( () => {
 		if ( ! previousLink.current ) {
 			return null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/90792

## Proposed Changes

* Adds a check to see if the previous route is the same as the current route and if so, then fallback to using the `/sites` default as the back link URL

## Before

https://github.com/Automattic/wp-calypso/assets/93301/02359e4d-37c8-408d-9326-9eaf7696af8f

## After

https://github.com/Automattic/wp-calypso/assets/5560595/c054653f-ea8b-4c1a-91e4-144854acc6af

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The back button breaks if the page submits a form. From what I can tell, when a page submits a form, like updating account settings, the page gets redirected to `/me/account?updated=success`. The account controller then does a `page.replace( context.pathname );` - this step means the `previousRoute` now will be `/me/account?updated=success` and the current route be ``/me/account`.
* This fix feels a little sloppy so if anyone has a better suggestion, please advise.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me/account' and change the `Interface language` 
* When the `/me/account` page reloads and you click the back chevron icon, it should redirect to the `/sites` page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
