### PR TITLE
A4A: Setup Google Analytics.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-page-view-tracker/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-page-view-tracker/index.tsx
@@ -1,0 +1,19 @@
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+type Props = {
+	title: string;
+	path: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	properties?: any;
+};
+
+export default function A4APageViewTracker( { title, path, properties }: Props ) {
+	return (
+		<PageViewTracker
+			title={ title }
+			path={ path }
+			properties={ properties }
+			options={ { useA8CForAgenciesGoogleAnalytics: true } }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -1,7 +1,7 @@
 import { type Callback } from '@automattic/calypso-router';
 import page from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import { A4A_MARKETPLACE_HOSTING_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';

--- a/client/a8c-for-agencies/sections/migrations/controller.tsx
+++ b/client/a8c-for-agencies/sections/migrations/controller.tsx
@@ -1,5 +1,5 @@
 import { type Callback } from '@automattic/calypso-router';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import MainSidebar from '../../components/sidebar-menu/main';
 import MigrationsOverview from './migrations-overview';
 

--- a/client/a8c-for-agencies/sections/overview/controller.tsx
+++ b/client/a8c-for-agencies/sections/overview/controller.tsx
@@ -1,5 +1,5 @@
 import { type Callback } from '@automattic/calypso-router';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import MainSidebar from '../../components/sidebar-menu/main';
 import Overview from './overview';
 

--- a/client/a8c-for-agencies/sections/partner-directory/controller.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/controller.tsx
@@ -1,7 +1,7 @@
 import { type Callback } from '@automattic/calypso-router';
 import page from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PartnerDirectorySideBar from '../../components/sidebar-menu/partner-directory';
 import {
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,

--- a/client/a8c-for-agencies/sections/purchases/controller.tsx
+++ b/client/a8c-for-agencies/sections/purchases/controller.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import PurchasesSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/purchases';
 import {
 	publicToInternalLicenseFilter,
@@ -11,7 +12,6 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BillingDashboard from './billing/billing-dashboard';
 import InvoicesOverview from './invoices/invoices-overview';
 import LicensesOverview from './licenses/licenses-overview';

--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -1,6 +1,6 @@
 import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import ReferralsSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/referrals';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MainSidebar from '../../components/sidebar-menu/main';
 import ReferralsBankDetails from './primary/bank-details';
 import CommissionOverview from './primary/commission-overview';

--- a/client/a8c-for-agencies/sections/settings/controller.tsx
+++ b/client/a8c-for-agencies/sections/settings/controller.tsx
@@ -1,7 +1,7 @@
 import { type Callback } from '@automattic/calypso-router';
 import page from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import { A4A_SETTINGS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MainSidebar from '../../components/sidebar-menu/main';
 import { SETTINGS_AGENCY_PROFILE_TAB } from './constants';
 import Settings from './settings';

--- a/client/a8c-for-agencies/sections/signup/controller.tsx
+++ b/client/a8c-for-agencies/sections/signup/controller.tsx
@@ -1,11 +1,11 @@
 import { Callback, Context } from '@automattic/calypso-router';
 import debug from 'debug';
 import store from 'store';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import {
 	A4A_SIGNUP_FINISH_LINK,
 	A4A_SIGNUP_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { hideMasterbar } from 'calypso/state/ui/actions';
 import AgencySignUp from './primary/agency-signup';
 import AgencySignupFinish from './primary/agency-signup-finish';

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -1,5 +1,5 @@
 import { Context, type Callback } from '@automattic/calypso-router';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import SitesSidebar from '../../components/sidebar-menu/sites';
 import AddSitesFromWPCOM from './add-sites/add-sites-from-wpcom';

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -66,6 +66,7 @@ export const TRACKING_IDS = {
 	akismetGoogleGA4Gtag: 'G-V8X5PZE9F8',
 	akismetGoogleTagManagerId: 'GTM-NLFBXG5',
 	akismetGoogleAdsGtagPurchase: 'AW-10778599042/U-01CImL14MDEIK90ZMo', // "Akismet.com Purchase Gtag"
+	a4aGoogleGA4GTag: 'G-8V8PCRJ142',
 	jetpackLinkedinId: '4537722',
 	jetpackTwitterPixelId: 'odlje',
 	wooGoogleTagManagerId: 'GTM-W64W8Q',

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -66,7 +66,7 @@ export const TRACKING_IDS = {
 	akismetGoogleGA4Gtag: 'G-V8X5PZE9F8',
 	akismetGoogleTagManagerId: 'GTM-NLFBXG5',
 	akismetGoogleAdsGtagPurchase: 'AW-10778599042/U-01CImL14MDEIK90ZMo', // "Akismet.com Purchase Gtag"
-	a4aGoogleGA4GTag: 'G-8V8PCRJ142',
+	a8cForAgenciesGA4Gtag: 'G-8V8PCRJ142',
 	jetpackLinkedinId: '4537722',
 	jetpackTwitterPixelId: 'odlje',
 	wooGoogleTagManagerId: 'GTM-W64W8Q',

--- a/client/lib/analytics/ad-tracking/google-analytics-4.ts
+++ b/client/lib/analytics/ad-tracking/google-analytics-4.ts
@@ -1,3 +1,4 @@
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { GaPurchase } from '../utils/cart-to-ga-purchase';
@@ -11,12 +12,14 @@ export enum Ga4PropertyGtag {
 	JETPACK,
 	WPCOM,
 	AKISMET,
+	A4A,
 }
 
 export const ga4Properties: { [ env in Ga4PropertyGtag ]: string } = {
 	[ Ga4PropertyGtag.WPCOM ]: TRACKING_IDS.wpcomGoogleGA4Gtag,
 	[ Ga4PropertyGtag.JETPACK ]: TRACKING_IDS.jetpackGoogleGA4Gtag,
 	[ Ga4PropertyGtag.AKISMET ]: TRACKING_IDS.akismetGoogleGA4Gtag,
+	[ Ga4PropertyGtag.A4A ]: TRACKING_IDS.a4aGoogleGA4GTag,
 };
 
 export function setup( params: Gtag.ConfigParams ) {
@@ -27,6 +30,9 @@ export function setup( params: Gtag.ConfigParams ) {
 	}
 	if ( isAkismetCheckout() ) {
 		window.gtag( 'config', TRACKING_IDS.akismetGoogleGA4Gtag, params );
+	}
+	if ( isA8CForAgencies() ) {
+		window.gtag( 'config', TRACKING_IDS.a4aGoogleGA4GTag, params );
 	}
 }
 

--- a/client/lib/analytics/ad-tracking/google-analytics-4.ts
+++ b/client/lib/analytics/ad-tracking/google-analytics-4.ts
@@ -12,14 +12,14 @@ export enum Ga4PropertyGtag {
 	JETPACK,
 	WPCOM,
 	AKISMET,
-	A4A,
+	A8C_FOR_AGENCIES,
 }
 
 export const ga4Properties: { [ env in Ga4PropertyGtag ]: string } = {
 	[ Ga4PropertyGtag.WPCOM ]: TRACKING_IDS.wpcomGoogleGA4Gtag,
 	[ Ga4PropertyGtag.JETPACK ]: TRACKING_IDS.jetpackGoogleGA4Gtag,
 	[ Ga4PropertyGtag.AKISMET ]: TRACKING_IDS.akismetGoogleGA4Gtag,
-	[ Ga4PropertyGtag.A4A ]: TRACKING_IDS.a4aGoogleGA4GTag,
+	[ Ga4PropertyGtag.A8C_FOR_AGENCIES ]: TRACKING_IDS.a8cForAgenciesGA4Gtag,
 };
 
 export function setup( params: Gtag.ConfigParams ) {
@@ -32,7 +32,7 @@ export function setup( params: Gtag.ConfigParams ) {
 		window.gtag( 'config', TRACKING_IDS.akismetGoogleGA4Gtag, params );
 	}
 	if ( isA8CForAgencies() ) {
-		window.gtag( 'config', TRACKING_IDS.a4aGoogleGA4GTag, params );
+		window.gtag( 'config', TRACKING_IDS.a8cForAgenciesGA4Gtag, params );
 	}
 }
 

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -39,7 +39,7 @@ export function fireGoogleAnalyticsPageView(
 	pageTitle,
 	useJetpackGoogleAnalytics = false,
 	useAkismetGoogleAnalytics = false,
-	useA4AGoogleAnalytics = false
+	useA8CForAgenciesGoogleAnalytics = false
 ) {
 	const getGa4PropertyGtag = () => {
 		if ( useJetpackGoogleAnalytics ) {
@@ -48,8 +48,8 @@ export function fireGoogleAnalyticsPageView(
 		if ( useAkismetGoogleAnalytics ) {
 			return GA4.Ga4PropertyGtag.AKISMET;
 		}
-		if ( useA4AGoogleAnalytics ) {
-			return GA4.Ga4PropertyGtag.A4A;
+		if ( useA8CForAgenciesGoogleAnalytics ) {
+			return GA4.Ga4PropertyGtag.A8C_FOR_AGENCIES;
 		}
 		return GA4.Ga4PropertyGtag.WPCOM;
 	};

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -38,7 +38,8 @@ export function fireGoogleAnalyticsPageView(
 	urlPath,
 	pageTitle,
 	useJetpackGoogleAnalytics = false,
-	useAkismetGoogleAnalytics = false
+	useAkismetGoogleAnalytics = false,
+	useA4AGoogleAnalytics = false
 ) {
 	const getGa4PropertyGtag = () => {
 		if ( useJetpackGoogleAnalytics ) {
@@ -46,6 +47,9 @@ export function fireGoogleAnalyticsPageView(
 		}
 		if ( useAkismetGoogleAnalytics ) {
 			return GA4.Ga4PropertyGtag.AKISMET;
+		}
+		if ( useA4AGoogleAnalytics ) {
+			return GA4.Ga4PropertyGtag.A4A;
 		}
 		return GA4.Ga4PropertyGtag.WPCOM;
 	};

--- a/client/lib/analytics/ga.js
+++ b/client/lib/analytics/ga.js
@@ -46,7 +46,8 @@ export const gaRecordPageView = makeGoogleAnalyticsTrackingFunction( function re
 	urlPath,
 	pageTitle,
 	useJetpackGoogleAnalytics = false,
-	useAkismetGoogleAnalytics = false
+	useAkismetGoogleAnalytics = false,
+	useA4AGoogleAnalytics = false
 ) {
 	gaDebug(
 		'Recording Page View ~ [URL: ' +
@@ -57,6 +58,8 @@ export const gaRecordPageView = makeGoogleAnalyticsTrackingFunction( function re
 			useJetpackGoogleAnalytics +
 			'] [useAksiemtGoogleAnalytics: ' +
 			useAkismetGoogleAnalytics +
+			'] [useA4AGoogleAnalytics: ' +
+			useA4AGoogleAnalytics +
 			']'
 	);
 
@@ -64,7 +67,8 @@ export const gaRecordPageView = makeGoogleAnalyticsTrackingFunction( function re
 		urlPath,
 		pageTitle,
 		useJetpackGoogleAnalytics,
-		useAkismetGoogleAnalytics
+		useAkismetGoogleAnalytics,
+		useA4AGoogleAnalytics
 	);
 } );
 

--- a/client/lib/analytics/ga.js
+++ b/client/lib/analytics/ga.js
@@ -47,7 +47,7 @@ export const gaRecordPageView = makeGoogleAnalyticsTrackingFunction( function re
 	pageTitle,
 	useJetpackGoogleAnalytics = false,
 	useAkismetGoogleAnalytics = false,
-	useA4AGoogleAnalytics = false
+	useA8CForAgenciesGoogleAnalytics = false
 ) {
 	gaDebug(
 		'Recording Page View ~ [URL: ' +
@@ -58,8 +58,8 @@ export const gaRecordPageView = makeGoogleAnalyticsTrackingFunction( function re
 			useJetpackGoogleAnalytics +
 			'] [useAksiemtGoogleAnalytics: ' +
 			useAkismetGoogleAnalytics +
-			'] [useA4AGoogleAnalytics: ' +
-			useA4AGoogleAnalytics +
+			'] [useA8CForAgenciesGoogleAnalytics: ' +
+			useA8CForAgenciesGoogleAnalytics +
 			']'
 	);
 
@@ -68,7 +68,7 @@ export const gaRecordPageView = makeGoogleAnalyticsTrackingFunction( function re
 		pageTitle,
 		useJetpackGoogleAnalytics,
 		useAkismetGoogleAnalytics,
-		useA4AGoogleAnalytics
+		useA8CForAgenciesGoogleAnalytics
 	);
 } );
 

--- a/client/lib/analytics/page-view.js
+++ b/client/lib/analytics/page-view.js
@@ -24,7 +24,7 @@ export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) 
 			pageTitle,
 			options?.useJetpackGoogleAnalytics,
 			options?.useAkismetGoogleAnalytics,
-			options?.useA4AGoogleAnalytics
+			options?.useA8CForAgenciesGoogleAnalytics
 		);
 		referRecordPageView();
 		saveImpactAffiliateClickId();
@@ -44,7 +44,7 @@ async function safeGoogleAnalyticsPageView(
 	pageTitle,
 	useJetpackGoogleAnalytics = false,
 	useAkismetGoogleAnalytics = false,
-	useA4AGoogleAnalytics = false
+	useA8CForAgenciesGoogleAnalytics = false
 ) {
 	await refreshCountryCodeCookieGdpr();
 	gaRecordPageView(
@@ -52,6 +52,6 @@ async function safeGoogleAnalyticsPageView(
 		pageTitle,
 		useJetpackGoogleAnalytics,
 		useAkismetGoogleAnalytics,
-		useA4AGoogleAnalytics
+		useA8CForAgenciesGoogleAnalytics
 	);
 }

--- a/client/lib/analytics/page-view.js
+++ b/client/lib/analytics/page-view.js
@@ -23,7 +23,8 @@ export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) 
 			urlPath,
 			pageTitle,
 			options?.useJetpackGoogleAnalytics,
-			options?.useAkismetGoogleAnalytics
+			options?.useAkismetGoogleAnalytics,
+			options?.useA4AGoogleAnalytics
 		);
 		referRecordPageView();
 		saveImpactAffiliateClickId();
@@ -42,8 +43,15 @@ async function safeGoogleAnalyticsPageView(
 	urlPath,
 	pageTitle,
 	useJetpackGoogleAnalytics = false,
-	useAkismetGoogleAnalytics = false
+	useAkismetGoogleAnalytics = false,
+	useA4AGoogleAnalytics = false
 ) {
 	await refreshCountryCodeCookieGdpr();
-	gaRecordPageView( urlPath, pageTitle, useJetpackGoogleAnalytics, useAkismetGoogleAnalytics );
+	gaRecordPageView(
+		urlPath,
+		pageTitle,
+		useJetpackGoogleAnalytics,
+		useAkismetGoogleAnalytics,
+		useA4AGoogleAnalytics
+	);
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -28,6 +28,7 @@
 	],
 	"oauth_client_id": 95928,
 	"features": {
+		"ad-tracking": false,
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -33,6 +33,7 @@
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,
 		"always_use_logout_url": true,
+		"cookie-banner": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"oauth": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -25,6 +25,7 @@
 		}
 	],
 	"features": {
+		"ad-tracking": false,
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"oauth": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -28,6 +28,7 @@
 		"ad-tracking": false,
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
+		"cookie-banner": false,
 		"oauth": false,
 		"a4a/site-details-pane": true,
 		"a4a-logged-out-signup": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -30,6 +30,7 @@
 		"ad-tracking": true,
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
+		"cookie-banner": true,
 		"oauth": true,
 		"a4a-logged-out-signup": true
 	},

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -27,6 +27,7 @@
 	],
 	"oauth_client_id": 95932,
 	"features": {
+		"ad-tracking": true,
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"oauth": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -31,6 +31,7 @@
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,
+		"cookie-banner": false,
 		"oauth": true,
 		"a4a/site-details-pane": true,
 		"a4a-logged-out-signup": true

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -27,6 +27,7 @@
 	],
 	"oauth_client_id": 95931,
 	"features": {
+		"ad-tracking": false,
 		"a8c-for-agencies": true,
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,


### PR DESCRIPTION
This PR updates the Google Analytics package to recognize the A4A environment and use the correct Gtag ID. The main goal is for the initial setup. We can track page views.

## Proposed Changes

* Add A4A GTag constant and update Google analytics setup function to recognize A4A environment. 

## Why are these changes being made?

* Google Analytics provides an easy way to track users' journeys and measure user engagement at a high-level visuals. This PR setups GA to work with A4A using A4A-specific properties (Gtag IDs).

## Testing Instructions

* Before testing, sign up for an agency account `/signup`. 
* Use the A4A live link below and go to `/overview?flags=ad-tracking`
* Confirm that the Network request is made to https://www.googletagmanager.com/gtag/js?id=G-8V8PCRJ142

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?