### PR TITLE
Fix importer layout issues

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -153,9 +153,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 				</div>
 			) }
 
-			<UpgradePlanDetails isEligibleForTrialPlan={ isEligibleForTrialPlan }>
-				{ renderCTAs() }
-			</UpgradePlanDetails>
+			<UpgradePlanDetails>{ renderCTAs() }</UpgradePlanDetails>
 		</div>
 	);
 };

--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -19,66 +19,6 @@ $business-plan-color: #7f54b3;
 		@include break-medium {
 			flex-direction: row;
 		}
-
-		&.feature-list-expanded {
-			.import__upgrade-plan-features-container {
-				@include break-medium {
-					height: initial;
-					margin-bottom: 8.5rem;
-				}
-			}
-		}
-
-		&.is-not-eligible-for-trial-plan {
-			.import__upgrade-plan-hosting-details {
-				@include break-medium {
-					margin-top: 0;
-				}
-			}
-		}
-
-		&.is-not-eligible-for-trial-plan.feature-list-expanded {
-
-			.import__upgrade-plan-features-container {
-				@include break-medium {
-					height: initial;
-				}
-			}
-
-			.import__upgrade-plan-hosting-details-card-container {
-				@include break-medium {
-					height: 97.125rem;
-				}
-			}
-		}
-
-		&.feature-list-expanded:not(.is-not-eligible-for-trial-plan) {
-			.import__upgrade-plan-hosting-details-card-container {
-				@include break-medium {
-					height: 94.375rem;
-				}
-			}
-		}
-
-		&.is-not-eligible-for-trial-plan:not(.feature-list-expanded) {
-			.import__upgrade-plan-features-container {
-				@include break-medium {
-					height: 443px;
-				}
-			}
-			.import__upgrade-plan-hosting-details {
-				@include break-medium {
-					height: initial;
-					margin-top: 33px;
-				}
-			}
-
-			.import__upgrade-plan-hosting-details-card-container {
-				@include break-medium {
-					margin-top: 0;
-				}
-			}
-		}
 	}
 
 	.import__upgrade-plan-features-container {
@@ -101,7 +41,6 @@ $business-plan-color: #7f54b3;
 			margin-right: 0;
 			margin-left: 0;
 			width: 352px;
-			height: 400px;
 		}
 	}
 
@@ -308,6 +247,8 @@ $business-plan-color: #7f54b3;
 		margin-bottom: 60px;
 
 		@include break-medium {
+			display: flex;
+			flex-direction: column;
 			margin-bottom: 0;
 			width: 352px;
 		}
@@ -330,6 +271,7 @@ $business-plan-color: #7f54b3;
 			padding: 1.5rem;
 
 			@include break-medium {
+				flex: 1;
 				margin-right: 0;
 				margin-left: 0;
 				margin-top: 0.75rem;
@@ -339,7 +281,6 @@ $business-plan-color: #7f54b3;
 				border-bottom-left-radius: 0;
 				border-bottom: 1px solid #e0e0e0;
 				border-left: 0;
-				height: 376px;
 			}
 
 			.import__upgrade-plan-hosting-details-header {
@@ -512,20 +453,5 @@ $business-plan-color: #7f54b3;
 		.import__upgrade-plan-hosting-details-tooltip-user-info {
 			color: var(--studio-gray-50, #646970);
 		}
-	}
-}
-
-.importer-step {
-	.import__upgrade-plan-container {
-		@media ( min-width: 782px ) and (max-width: 830px) {
-			.import__upgrade-plan-features-container {
-				height: 431px;
-			}
-
-			.import__upgrade-plan-hosting-details-card-container {
-				height: 400px;
-			}
-		}
-
 	}
 }

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -17,7 +17,6 @@ import { UpgradePlanHostingDetails } from './upgrade-plan-hosting-details';
 
 interface Props {
 	children: React.ReactNode;
-	isEligibleForTrialPlan: boolean;
 }
 
 export const UpgradePlanDetails = ( props: Props ) => {
@@ -25,7 +24,7 @@ export const UpgradePlanDetails = ( props: Props ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const [ showFeatures, setShowFeatures ] = useState( false );
 
-	const { children, isEligibleForTrialPlan } = props;
+	const { children } = props;
 	const [ selectedPlan, setSelectedPlan ] = useState<
 		typeof PLAN_BUSINESS | typeof PLAN_BUSINESS_MONTHLY
 	>( PLAN_BUSINESS );
@@ -46,10 +45,10 @@ export const UpgradePlanDetails = ( props: Props ) => {
 	}, [ plan ] );
 
 	return (
-		<div className={ classnames( 'import__upgrade-plan-details' ) }>
+		<div className="import__upgrade-plan-details">
 			<QueryPlans />
 
-			<div className={ classnames( 'import__upgrade-plan-period-switcher' ) }>
+			<div className="import__upgrade-plan-period-switcher">
 				<ButtonGroup>
 					<Button
 						borderless
@@ -68,14 +67,9 @@ export const UpgradePlanDetails = ( props: Props ) => {
 				</ButtonGroup>
 			</div>
 
-			<div
-				className={ classnames( 'import__upgrade-plan-container', {
-					'feature-list-expanded': showFeatures,
-					'is-not-eligible-for-trial-plan': ! isEligibleForTrialPlan,
-				} ) }
-			>
-				<div className={ classnames( 'import__upgrade-plan-features-container' ) }>
-					<div className={ classnames( 'import__upgrade-plan-header' ) }>
+			<div className="import__upgrade-plan-container">
+				<div className="import__upgrade-plan-features-container">
+					<div className="import__upgrade-plan-header">
 						<Plans2023Tooltip
 							text={ __(
 								'WP Cloud gives you the tools you need to add scalable, highly available, extremely fast WordPress hosting.'
@@ -92,17 +86,17 @@ export const UpgradePlanDetails = ( props: Props ) => {
 						<p>{ __( 'Unlock the power of WordPress with plugins and cloud tools.' ) }</p>
 					</div>
 
-					<div className={ classnames( 'import__upgrade-plan-price' ) }>
+					<div className="import__upgrade-plan-price">
 						<PlanPrice rawPrice={ rawPrice ?? undefined } currencyCode={ currencyCode } />
-						<span className={ classnames( 'plan-time-frame' ) }>
+						<span className="plan-time-frame">
 							<small>{ plan?.getBillingTimeFrame() }</small>
 							<small>{ __( 'Refundable within 14 days. No questions asked.' ) }</small>
 						</span>
 					</div>
 
-					<div className={ classnames( 'import__upgrade-plan-cta' ) }>{ children }</div>
+					<div className="import__upgrade-plan-cta">{ children }</div>
 
-					<div className={ classnames( 'import__upgrade-plan-features-list' ) }>
+					<div className="import__upgrade-plan-features-list">
 						<UpgradePlanFeatureList
 							plan={ plan }
 							showFeatures={ showFeatures }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
@@ -39,7 +39,7 @@ const ImporterWordpress: Step = function ( props ) {
 					navigateBack={ props.navigation.goBack }
 				/>
 			) }
-			<Importer importer="wordpress" { ...props } />;
+			<Importer importer="wordpress" { ...props } />
 		</>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90715

## Proposed Changes

* It removes a missing semicolon of the plan step of the importer.
* It cleans up the CSS a bit, and makes sure both sides of the page will have the same height regardless of the content.

<img width="781" alt="Screenshot 2024-05-16 at 18 33 58" src="https://github.com/Automattic/wp-calypso/assets/876340/f0713611-ba97-4878-9256-7f7449f319a7">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the missing semicolon and make sure both sides of the page will keep the same height regardless of the content that is there. So in the next iterations we can add different texts, as needed, and we don't need to worry about the size of the translation texts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use the live link.
* Navigate to both links: `/setup/site-setup/importerWordpress?siteSlug={FREE_SITE_SLUG}&from=https://www.mazdausa.com&option=everything` and `/setup/site-migration/site-migration-upgrade-plan?from=https://www.mazdausa.com&siteSlug={FREE_SITE_SLUG}`
* Check that you don't see a missing semicolon on `/setup/site-setup/importerWordpress?siteSlug={FREE_SITE_SLUG}&from=https://www.mazdausa.com&option=everything` (See screenshot in [the issue](https://github.com/Automattic/wp-calypso/issues/90715) to compare).
* Try to inject text in the both columns ("Creator" and "Why should you host with us?") through the browser console, and make sure both sides keep the same heights.
* Click on "Show all features" and make sure the right side grows to the same height.
* Simulate a case where the user is not eligible for trial plan or force the variable `isEligibleForTrialPlan` to `false` in `client/blocks/importer/wordpress/upgrade-plan/index.tsx`.
  * And test again with this scenario to make sure it continues working properly.

I would also appreciate it if someone with more knowledge about this code could make sure I didn't miss any other special case.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
