### PR TITLE
Multisite Scheduled Updates: Show an empty state when the search criteria returns empty result

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -67,6 +67,14 @@ $brand-display: "SF Pro Display", sans-serif;
 		}
 	}
 
+	.empty-state__center {
+		margin: auto;
+
+		p {
+			text-align: center;
+		}
+	}
+
 	&-table {
 		th,
 		td {

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
@@ -35,7 +35,7 @@ export const ScheduleListCards = ( props: Props ) => {
 				<div className="empty-state empty-state__center">
 					<p>
 						{ translate(
-							"Oops! We couldn't find any scheduled updates based on your search criteria. You might want to check your input and try again"
+							'Oops! We couldn&#8217;t find any schedules based on your search criteria. You might want to check your search terms and try again.'
 						) }
 					</p>
 				</div>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
@@ -1,4 +1,5 @@
 import clsx from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { SiteSlug } from 'calypso/types';
 import { ScheduleListCard } from './schedule-list-card';
 import type { MultisiteSchedulesUpdates } from 'calypso/data/plugins/use-update-schedules-query';
@@ -14,6 +15,7 @@ type Props = {
 };
 
 export const ScheduleListCards = ( props: Props ) => {
+	const translate = useTranslate();
 	const { compact, schedules, selectedScheduleId, onEditClick, onLogsClick, onRemoveClick } = props;
 
 	return (
@@ -29,6 +31,15 @@ export const ScheduleListCards = ( props: Props ) => {
 					key={ schedule.id }
 				/>
 			) ) }
+			{ schedules.length === 0 && (
+				<div className="empty-state empty-state__center">
+					<p>
+						{ translate(
+							"Oops! We couldn't find any scheduled updates based on your search criteria. You might want to check your input and try again"
+						) }
+					</p>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-cards.tsx
@@ -35,7 +35,7 @@ export const ScheduleListCards = ( props: Props ) => {
 				<div className="empty-state empty-state__center">
 					<p>
 						{ translate(
-							'Oops! We couldn&#8217;t find any schedules based on your search criteria. You might want to check your search terms and try again.'
+							"Oops! We couldn't find any schedules based on your search criteria. You might want to check your search terms and try again."
 						) }
 					</p>
 				</div>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
@@ -47,7 +47,7 @@ export const ScheduleListTable = ( props: Props ) => {
 							<div className="empty-state empty-state__center">
 								<p>
 									{ translate(
-										'Oops! We couldn&#8217;t find any schedules based on your search criteria. You might want to check your search terms and try again.'
+										"Oops! We couldn't find any schedules based on your search criteria. You might want to check your search terms and try again."
 									) }
 								</p>
 							</div>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
@@ -40,6 +40,20 @@ export const ScheduleListTable = ( props: Props ) => {
 						key={ schedule.id }
 					/>
 				) ) }
+
+				{ schedules.length === 0 && (
+					<tr>
+						<td colSpan={ 9 }>
+							<div className="empty-state empty-state__center">
+								<p>
+									{ translate(
+										"Oops! We couldn't find any scheduled updates based on your search criteria. You might want to check your input and try again"
+									) }
+								</p>
+							</div>
+						</td>
+					</tr>
+				) }
 			</tbody>
 		</table>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
@@ -47,7 +47,7 @@ export const ScheduleListTable = ( props: Props ) => {
 							<div className="empty-state empty-state__center">
 								<p>
 									{ translate(
-										"Oops! We couldn't find any scheduled updates based on your search criteria. You might want to check your input and try again"
+										'Oops! We couldn&#8217;t find any schedules based on your search criteria. You might want to check your search terms and try again.'
 									) }
 								</p>
 							</div>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -98,8 +98,8 @@ export const ScheduleList = ( props: Props ) => {
 			}
 			const filteredSites = schedule.sites.filter(
 				( site ) =>
-					site.title.toLowerCase().includes( lowercasedSearchTerm ) ||
-					site.URL.toLowerCase().includes( lowercasedSearchTerm )
+					site.title?.toLowerCase().includes( lowercasedSearchTerm ) ||
+					site.URL?.toLowerCase().includes( lowercasedSearchTerm )
 			);
 
 			return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90553

## Proposed Changes

* Show an empty state when the search criteria returns empty result
* Fix a bug accessing undefined value

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates`
* Enter random string in the search input
* Check if there is an empty state

<img width="1443" alt="Screenshot 2024-05-16 at 19 02 23" src="https://github.com/Automattic/wp-calypso/assets/1241413/09bf7ee8-28fe-4ae1-99eb-c3dd8e4ed2f4">
<img width="460" alt="Screenshot 2024-05-16 at 19 15 29" src="https://github.com/Automattic/wp-calypso/assets/1241413/cb27950b-bf0f-40ea-8487-120bac57088f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
