### PR TITLE
Site Migration: remove back button on variant flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer, Title, SubTitle } from '@automattic/onboarding';
+import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
@@ -79,7 +79,7 @@ const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unk
 	);
 };
 
-const SiteMigrationIdentify: Step = function ( { navigation } ) {
+const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 	const siteSlug = useSiteSlug();
 
 	const handleSubmit = useCallback(
@@ -96,7 +96,10 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 	);
 
 	const urlQueryParams = useQuery();
-	const isEntrepreneurSignup = urlQueryParams.get( 'ref' ) === 'entrepreneur-signup';
+	const shouldHideBack = () => {
+		const isEntrepreneurSignup = urlQueryParams.get( 'ref' ) === 'entrepreneur-signup';
+		return variantSlug === HOSTED_SITE_MIGRATION_FLOW || isEntrepreneurSignup;
+	};
 
 	return (
 		<>
@@ -105,7 +108,7 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 				stepName="site-migration-identify"
 				flowName="site-migration"
 				className="import__onboarding-page"
-				hideBack={ isEntrepreneurSignup }
+				hideBack={ shouldHideBack() }
 				hideSkip
 				hideFormattedHeader
 				goBack={ navigation.goBack }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes to https://github.com/Automattic/wp-calypso/issues/90656

## Proposed Changes

Since the new variant flow is standalone, in the sense that it can be accessed directly via URL, I've added this change to hide the `< Back` button when the Identify step is rendered within the hosted-site-migration flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In order to prevent the Back button appearing in places where it doesn't make sense.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or go to the calypso.live link
* Navigate to `/setup/hosted-site-migration`
* Verify you don't see the `< Back` button on top-left
* Navigate to `/start` and go through the flow until you get to `/setup/site-migration`
* Verify you see the `< Back` button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
