### PR TITLE
POC: Show progress and celebration step after complete the site migration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/use-celebration-data.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/use-celebration-data.tsx
@@ -1,4 +1,8 @@
-import { isStartWritingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
+import {
+	isStartWritingFlow,
+	isSiteAssemblerFlow,
+	isNewSiteMigrationFlow,
+} from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 
 interface Props {
@@ -16,11 +20,27 @@ const useCelebrationData = ( {
 }: Props ) => {
 	const translate = useTranslate();
 	const isStartWritingFlowOrFirstPostPublished = isStartWritingFlow( flow ) || isFirstPostPublished;
+
+	const isMigrationFlowValue = isNewSiteMigrationFlow( flow );
+
 	const defaultCelebrationData = {
 		dashboardCtaName: 'Go to dashboard',
 		dashboardCtaText: translate( 'Go to dashboard' ),
 		dashboardCtaLink: `/home/${ siteSlug }`,
 	};
+
+	if ( isMigrationFlowValue ) {
+		return {
+			...defaultCelebrationData,
+			title: translate( 'Your site’s ready!' ),
+			primaryCtaName: 'Edit your content',
+			primaryCtaText: translate( 'Edit your content' ),
+			primaryCtaLink: `#########`,
+			secondaryCtaName: 'Migrate your domain',
+			secondaryCtaText: translate( 'Visit your site' ),
+			secondaryCtaLink: `https://${ siteSlug }`,
+		};
+	}
 
 	if ( isSiteAssemblerFlow( flow ) ) {
 		const siteEditorParams = new URLSearchParams( {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -32,6 +32,7 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_INSTRUCTIONS_I2,
 			STEPS.ERROR,
 			STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+			STEPS.CELEBRATION,
 		];
 	},
 	useAssertConditions(): AssertConditionResult {
@@ -204,6 +205,10 @@ const siteMigration: Flow = {
 						} );
 						return;
 					}
+				}
+
+				case STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug: {
+					return navigate( STEPS.CELEBRATION.slug, { siteId, siteSlug } );
 				}
 			}
 		}

--- a/client/my-sites/migrate/components/migration-in-progress/index.tsx
+++ b/client/my-sites/migrate/components/migration-in-progress/index.tsx
@@ -30,7 +30,7 @@ export const MigrationInProgress: FC< Props > = ( props ) => {
 	} );
 
 	useEffect( () => {
-		if ( status === MigrationStatus.DONE || status === MigrationStatus.INACTIVE ) {
+		if ( status === MigrationStatus.DONE ) {
 			onComplete();
 		}
 	}, [ onComplete, status ] );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -549,6 +549,7 @@ export enum MigrationStatus {
 	DONE = 'done',
 	DONE_USER = 'done-user',
 	ERROR = 'error',
+	IN_PROGRESS = 'in-progress',
 }
 
 export enum MigrationStatusError {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
