### PR TITLE
Update how list items in lightbox are highlighted

### DIFF
--- a/client/components/jetpack/jetpack-product-info/regular-list.tsx
+++ b/client/components/jetpack/jetpack-product-info/regular-list.tsx
@@ -1,10 +1,11 @@
-import { useRef, useEffect, type FC, type ReactNode } from 'react';
+import { useRef, useEffect } from 'react';
+import type { TranslateResult } from 'i18n-calypso';
 
 type Props = {
-	items: ReactNode[];
+	items: TranslateResult[];
 };
 
-const JetpackProductInfoRegularList: FC< Props > = ( { items } ) => {
+const JetpackProductInfoRegularList = ( { items }: Props ) => {
 	const listRef = useRef< HTMLUListElement | null >( null );
 
 	const highlightListItem = ( target: HTMLElement ) => {
@@ -25,10 +26,6 @@ const JetpackProductInfoRegularList: FC< Props > = ( { items } ) => {
 
 		const observer = new MutationObserver( ( record ) => {
 			for ( const mutation of record ) {
-				if ( mutation.type !== 'characterData' ) {
-					continue;
-				}
-
 				const targetParent = mutation.target.parentNode as HTMLElement | null;
 				if ( targetParent?.className === 'jetpack-product-info__regular-list-item' ) {
 					highlightListItem( targetParent );

--- a/client/components/jetpack/jetpack-product-info/regular-list.tsx
+++ b/client/components/jetpack/jetpack-product-info/regular-list.tsx
@@ -42,7 +42,12 @@ const JetpackProductInfoRegularList = ( { items }: Props ) => {
 	}, [] );
 
 	return (
-		<ul className="jetpack-product-info__regular-list" ref={ listRef }>
+		<ul
+			className="jetpack-product-info__regular-list"
+			ref={ listRef }
+			aria-live="polite"
+			aria-relevant="text"
+		>
 			{ items.map( ( item, index ) => (
 				<li className="jetpack-product-info__regular-list-item" key={ index }>
 					{ item }

--- a/client/components/jetpack/jetpack-product-info/regular-list.tsx
+++ b/client/components/jetpack/jetpack-product-info/regular-list.tsx
@@ -1,14 +1,55 @@
-import { FunctionComponent, ReactNode } from 'react';
+import { useRef, useEffect, type FC, type ReactNode } from 'react';
 
 type Props = {
 	items: ReactNode[];
 };
 
-const JetpackProductInfoRegularList: FunctionComponent< Props > = ( { items } ) => {
+const JetpackProductInfoRegularList: FC< Props > = ( { items } ) => {
+	const listRef = useRef< HTMLUListElement | null >( null );
+
+	const highlightListItem = ( target: HTMLElement ) => {
+		target.animate(
+			[ { backgroundColor: 'var(--studio-yellow-5)' }, { backgroundColor: 'initial' } ],
+			{
+				duration: 500,
+				easing: 'ease-out',
+			}
+		);
+	};
+
+	// Highlight list item when its content changes
+	useEffect( () => {
+		if ( ! listRef.current ) {
+			return;
+		}
+
+		const observer = new MutationObserver( ( record ) => {
+			for ( const mutation of record ) {
+				if ( mutation.type !== 'characterData' ) {
+					continue;
+				}
+
+				const targetParent = mutation.target.parentNode as HTMLElement | null;
+				if ( targetParent?.className === 'jetpack-product-info__regular-list-item' ) {
+					highlightListItem( targetParent );
+				}
+			}
+		} );
+
+		observer.observe( listRef.current as Node, {
+			characterData: true,
+			subtree: true,
+		} );
+
+		return () => observer.disconnect();
+	}, [] );
+
 	return (
-		<ul className="jetpack-product-info__regular-list">
+		<ul className="jetpack-product-info__regular-list" ref={ listRef }>
 			{ items.map( ( item, index ) => (
-				<li key={ index }>{ item }</li>
+				<li className="jetpack-product-info__regular-list-item" key={ index }>
+					{ item }
+				</li>
 			) ) }
 		</ul>
 	);

--- a/client/components/jetpack/jetpack-product-info/regular-list.tsx
+++ b/client/components/jetpack/jetpack-product-info/regular-list.tsx
@@ -9,13 +9,13 @@ const JetpackProductInfoRegularList = ( { items }: Props ) => {
 	const listRef = useRef< HTMLUListElement | null >( null );
 
 	const highlightListItem = ( target: HTMLElement ) => {
-		target.animate(
-			[ { backgroundColor: 'var(--studio-yellow-5)' }, { backgroundColor: 'initial' } ],
-			{
-				duration: 500,
-				easing: 'ease-out',
-			}
-		);
+		target.classList.add( 'trigger-highlight' );
+	};
+
+	const removeHighlight = ( event: AnimationEvent ) => {
+		if ( event.animationName === 'trigger-highlight' ) {
+			( event.target as HTMLLIElement )?.classList.remove( 'trigger-highlight' );
+		}
 	};
 
 	// Highlight list item when its content changes
@@ -38,7 +38,12 @@ const JetpackProductInfoRegularList = ( { items }: Props ) => {
 			subtree: true,
 		} );
 
-		return () => observer.disconnect();
+		window.addEventListener( 'animationend', ( event ) => removeHighlight( event ) );
+
+		return () => {
+			observer.disconnect();
+			window.removeEventListener( 'animationend', ( event ) => removeHighlight( event ) );
+		};
 	}, [] );
 
 	return (

--- a/client/components/jetpack/jetpack-product-info/regular-list.tsx
+++ b/client/components/jetpack/jetpack-product-info/regular-list.tsx
@@ -38,11 +38,11 @@ const JetpackProductInfoRegularList = ( { items }: Props ) => {
 			subtree: true,
 		} );
 
-		window.addEventListener( 'animationend', ( event ) => removeHighlight( event ) );
+		window.addEventListener( 'animationend', removeHighlight );
 
 		return () => {
 			observer.disconnect();
-			window.removeEventListener( 'animationend', ( event ) => removeHighlight( event ) );
+			window.removeEventListener( 'animationend', removeHighlight );
 		};
 	}, [] );
 

--- a/client/components/jetpack/jetpack-product-info/style.scss
+++ b/client/components/jetpack/jetpack-product-info/style.scss
@@ -150,11 +150,24 @@
 		color: var(--studio-gray-70);
 	}
 
+	li.trigger-highlight {
+		animation: trigger-highlight 500ms ease-out;
+	}
+
 	&:not(.jetpack-product-info__faq-list) li {
 		background: url(../../../assets/images/jetpack/jetpack-green-checkmark.svg) no-repeat 0 2px;
 		padding-left: 20px;
 		background-size: 14px;
 		background-position-y: 5px;
+	}
+}
+
+@keyframes trigger-highlight {
+	0% {
+		background-color: var(--studio-yellow-5);
+	}
+	100% {
+		background-color: initial;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/quantity-dropdown.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/quantity-dropdown.tsx
@@ -50,27 +50,8 @@ const QuantityDropdown: FC< QuantityDropdownProps > = ( { product, siteId, onCha
 		} );
 	}, [ listPrices.priceTierList, product.productSlug ] );
 
-	const triggerHighlightedIncludes = useCallback( () => {
-		const highlightedIncludes = document.getElementsByClassName( 'highlight-on-render' );
-
-		if ( highlightedIncludes.length > 0 ) {
-			for ( const element of highlightedIncludes ) {
-				element.classList.add( 'trigger-highlight' );
-			}
-		}
-
-		setTimeout( () => {
-			if ( highlightedIncludes.length > 0 ) {
-				for ( const element of highlightedIncludes ) {
-					element.classList.remove( 'trigger-highlight' );
-				}
-			}
-		}, 500 );
-	}, [] );
-
 	const onDropdownTierSelect = useCallback(
 		( { value: slug }: { value: string } ) => {
-			triggerHighlightedIncludes();
 			onChangeProduct( slugToSelectorProduct( slug ) );
 			const { slug: productSlug, quantity } = getProductPartsFromAlias( slug );
 
@@ -82,7 +63,7 @@ const QuantityDropdown: FC< QuantityDropdownProps > = ( { product, siteId, onCha
 				} )
 			);
 		},
-		[ onChangeProduct, dispatch, siteId, triggerHighlightedIncludes ]
+		[ onChangeProduct, dispatch, siteId ]
 	);
 
 	if ( ! isJetpackTieredProduct( product.productSlug ) || tierOptions.length < 1 ) {

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -263,21 +263,3 @@
 .popover.product-lightbox__variants-dropdown--popover {
 	z-index: 100200;
 }
-
-.highlight-on-render {
-	display: inline-block;
-	height: 100%;
-
-	&.trigger-highlight {
-		animation: trigger-highlight 500ms ease-out;
-	}
-}
-
-@keyframes trigger-highlight {
-	0% {
-		background-color: var(--studio-yellow-5);
-	}
-	100% {
-		background-color: initial;
-	}
-}

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1361,7 +1361,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedIncludesInfo,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedIncludesInfo,
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: [
-			highlightable( translate( '10K site views (upgradeable)' ) ),
+			translate( '10K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_10K ]: [

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -118,10 +118,6 @@ import {
 import type { FAQ, SelectorProductFeaturesItem } from './types';
 import type { TranslateResult } from 'i18n-calypso';
 
-const highlightable = ( inner: TranslateResult ): TranslateResult => {
-	return <span className="highlight-on-render">{ inner }</span>;
-};
-
 export const getJetpackProductsShortNames = (): Record< string, React.ReactElement | string > => {
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: (
@@ -1252,75 +1248,75 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 
 	return {
 		[ PRODUCT_JETPACK_AI_MONTHLY ]: [
-			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
+			translate( '100 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_100 ]: [
-			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
+			translate( '100 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_200 ]: [
-			highlightable( translate( '200 monthly requests (upgradeable)' ) ),
+			translate( '200 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_500 ]: [
-			highlightable( translate( '500 monthly requests (upgradeable)' ) ),
+			translate( '500 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_750 ]: [
-			highlightable( translate( '750 monthly requests (upgradeable)' ) ),
+			translate( '750 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_MONTHLY_1000 ]: [
-			highlightable( translate( '1000 monthly requests (upgradeable)' ) ),
+			translate( '1000 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY ]: [
-			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
+			translate( '100 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_100 ]: [
-			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
+			translate( '100 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_200 ]: [
-			highlightable( translate( '200 monthly requests (upgradeable)' ) ),
+			translate( '200 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_500 ]: [
-			highlightable( translate( '500 monthly requests (upgradeable)' ) ),
+			translate( '500 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_750 ]: [
-			highlightable( translate( '750 monthly requests (upgradeable)' ) ),
+			translate( '750 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_YEARLY_1000 ]: [
-			highlightable( translate( '1000 monthly requests (upgradeable)' ) ),
+			translate( '1000 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY ]: [
-			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
+			translate( '100 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_100 ]: [
-			highlightable( translate( '100 monthly requests (upgradeable)' ) ),
+			translate( '100 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_200 ]: [
-			highlightable( translate( '200 monthly requests (upgradeable)' ) ),
+			translate( '200 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_500 ]: [
-			highlightable( translate( '500 monthly requests (upgradeable)' ) ),
+			translate( '500 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_750 ]: [
-			highlightable( translate( '750 monthly requests (upgradeable)' ) ),
+			translate( '750 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_AI_BI_YEARLY_1000 ]: [
-			highlightable( translate( '1000 monthly requests (upgradeable)' ) ),
+			translate( '1000 monthly requests (upgradeable)' ),
 			...aiAssistantIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_BACKUP_T0_YEARLY ]: backupIncludesInfoT0,
@@ -1365,71 +1361,71 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_10K ]: [
-			highlightable( translate( '10K site views (upgradeable)' ) ),
+			translate( '10K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_100K ]: [
-			highlightable( translate( '100K site views (upgradeable)' ) ),
+			translate( '100K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_250K ]: [
-			highlightable( translate( '250K site views (upgradeable)' ) ),
+			translate( '250K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_500K ]: [
-			highlightable( translate( '500K site views (upgradeable)' ) ),
+			translate( '500K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY_1M ]: [
-			highlightable( translate( '1M site views (upgradeable)' ) ),
+			translate( '1M site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY ]: [
-			highlightable( translate( '10K site views (upgradeable)' ) ),
+			translate( '10K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_10K ]: [
-			highlightable( translate( '10K site views (upgradeable)' ) ),
+			translate( '10K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_100K ]: [
-			highlightable( translate( '100K site views (upgradeable)' ) ),
+			translate( '100K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_250K ]: [
-			highlightable( translate( '250K site views (upgradeable)' ) ),
+			translate( '250K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_500K ]: [
-			highlightable( translate( '500K site views (upgradeable)' ) ),
+			translate( '500K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_YEARLY_1M ]: [
-			highlightable( translate( '1M site views (upgradeable)' ) ),
+			translate( '1M site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY ]: [
-			highlightable( translate( '10K site views (upgradeable)' ) ),
+			translate( '10K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_10K ]: [
-			highlightable( translate( '10K site views (upgradeable)' ) ),
+			translate( '10K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_100K ]: [
-			highlightable( translate( '100K site views (upgradeable)' ) ),
+			translate( '100K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_250K ]: [
-			highlightable( translate( '250K site views (upgradeable)' ) ),
+			translate( '250K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_500K ]: [
-			highlightable( translate( '500K site views (upgradeable)' ) ),
+			translate( '500K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_STATS_MONTHLY_1M ]: [
-			highlightable( translate( '1M site views (upgradeable)' ) ),
+			translate( '1M site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
 		],
 		[ PRODUCT_JETPACK_MONITOR_YEARLY ]: monitorIncludesInfo,


### PR DESCRIPTION
## Proposed Changes

* Move logic that highlights list items upon change to the element that renders the list items using a MutationObserver

## Why are these changes being made?

@tyxla had some good points about how this was [previously implemented here](https://github.com/Automattic/wp-calypso/pull/90528), this moves all the logic to a single file where the elements are rendered and doesn't need to be aware of what changes the list, only that the list was changed.

## Testing Instructions

1. Using the Calypso Green live link, go to `/pricing`
2. On the AI or Stats lightbox, switch between tiers and make sure the highlight animation looks good

https://github.com/Automattic/wp-calypso/assets/65001528/de723612-3044-4761-aa3d-c8654bf5ce9a

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
