### PR TITLE
Update import-hosted-site reference from /start/hosting to new flow

### DIFF
--- a/client/signup/steps/hosting-decider/hosting-flow-forking-page.tsx
+++ b/client/signup/steps/hosting-decider/hosting-flow-forking-page.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { IMPORT_HOSTED_SITE_FLOW, NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
+import { HOSTED_SITE_MIGRATION_FLOW, NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { MEDIA_QUERIES } from '../../../sites-dashboard/utils';
 import { StepProps } from '.';
@@ -50,7 +50,7 @@ export const HostingFlowCTA = ( { description, label, onClick }: HostingFlowCTAP
 export const HostingFlowForkingPage = ( props: StepProps ) => {
 	const translate = useTranslate();
 	const onClick = (
-		stepperHostingFlow: typeof NEW_HOSTED_SITE_FLOW | typeof IMPORT_HOSTED_SITE_FLOW
+		stepperHostingFlow: typeof NEW_HOSTED_SITE_FLOW | typeof HOSTED_SITE_MIGRATION_FLOW
 	) => {
 		props.submitSignupStep(
 			{
@@ -104,7 +104,7 @@ export const HostingFlowForkingPage = ( props: StepProps ) => {
 				<HostingFlowCTA
 					description={ translate( 'Bring a site to WordPress.com' ) }
 					label={ translate( 'Migrate a site' ) }
-					onClick={ () => onClick( IMPORT_HOSTED_SITE_FLOW ) }
+					onClick={ () => onClick( HOSTED_SITE_MIGRATION_FLOW ) }
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/90648

## Proposed Changes

While this shouldn't be merged because of missing pieces in the flow (mainly https://github.com/Automattic/wp-calypso/pull/90710) I was exploring some code and made this changes to test.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To point /start/hosting to a Migrate Guru flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch or follow the calypso.live link
* Go to `/start/hosting`
* Select `Migrate Site`
* Verify you get redirected to `/setup/hosted-site-migration/site-migration-identify`

### Tracking
To track the performance of this link, the `calypso_signup_actions_submit_step` track event with these props:
* `step: hosting-decider`
* `stepper_hosting_flow: hosted-site-migration`

can be used as a starting point for the funnels.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
