### PR TITLE
Fix reader notification badge position

### DIFF
--- a/client/reader/update-notice/style.scss
+++ b/client/reader/update-notice/style.scss
@@ -2,8 +2,7 @@
 // Slides in when there are new posts available
 .reader-update-notice {
 	position: fixed;
-	top: ( 47px + 8px );
-	right: 16px;
+	right: 32px;
 	background: rgba(var(--color-accent-rgb), 0.96);
 	padding: 8px 18px 8px 34px;
 	border-radius: 24px; /* stylelint-disable-line scales/radii */

--- a/client/reader/update-notice/style.scss
+++ b/client/reader/update-notice/style.scss
@@ -2,7 +2,8 @@
 // Slides in when there are new posts available
 .reader-update-notice {
 	position: fixed;
-	right: 32px;
+	right: 16px;
+	top: calc(var(--masterbar-height) + 16px);
 	background: rgba(var(--color-accent-rgb), 0.96);
 	padding: 8px 18px 8px 34px;
 	border-radius: 24px; /* stylelint-disable-line scales/radii */
@@ -15,6 +16,16 @@
 	pointer-events: none;
 	transition: background 0.15s ease-in-out, transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	font-size: $font-body;
+
+	@media ( min-width: 600px ) {
+		top: calc(var(--masterbar-height) + (24px * 2));
+		right: calc(24px* 2);
+	}
+
+	@media ( min-width: 782px ) {
+		top: 32px;
+		right: 32px;
+	}
 
 	&:hover {
 		background: var(--color-primary);


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7233

## Proposed Changes

Fix reader notification badge position.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/091b51cb-f863-48ef-a83c-99b3bc2d697a) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/fe0653fa-6498-4cd0-bd0d-29d2dba77ecf) |


## Why are these changes being made?

* Because of the nav-redesign, the badge shows misaligned (look the Before screenshot)

## Testing Instructions

* Go to `/read`
* Wait to the badge show
* Or follow one of your sites and publish a new post :wink: 
