### PR TITLE
Improve plans page pontuation.

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
@@ -8,7 +8,9 @@ import {
 import page from '@automattic/calypso-router';
 import { PlanPrice } from '@automattic/components';
 import Card from '@automattic/components/src/card';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { CustomSelectControl } from '@wordpress/components';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useState } from 'react';
 import './style.scss';
@@ -115,6 +117,7 @@ export function EntrepreneurPlan( props: EntrepreneurPlanProps ) {
 	const selectedSite = useSelector( getSelectedSite );
 	const plans = useEntrepreneurPlanPrices();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const isEnglish = useIsEnglishLocale();
 	const [ selectedInterval, setSelectedInterval ] = useState< PlanKeys >( 'PLAN_ECOMMERCE' );
 	const selectedPlan = plans[ selectedInterval ];
 
@@ -146,13 +149,17 @@ export function EntrepreneurPlan( props: EntrepreneurPlanProps ) {
 		setSelectedInterval( key );
 	};
 
+	const hasNewTitleTranslation = hasTranslation( "What's included in your free trial:" );
+	const titleTranslation =
+		isEnglish || hasNewTitleTranslation
+			? translate( "What's included in your free trial:" )
+			: translate( "What's included in your free trial" );
+
 	return (
 		<>
 			{ ! hideTrialIncluded && (
 				<>
-					<h2 className="entrepreneur-trial-plan__section-title">
-						{ translate( "What's included in your free trial" ) }
-					</h2>
+					<h2 className="entrepreneur-trial-plan__section-title">{ titleTranslation }</h2>
 					<div className="entrepreneur-trial-plan__included-wrapper">
 						<EcommerceTrialIncluded displayAll />
 					</div>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -15,8 +15,10 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { WpcomPlansUI } from '@automattic/data-stores';
+import { englishLocales } from '@automattic/i18n-utils';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
+import { hasTranslation } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -40,6 +42,7 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
@@ -396,9 +399,17 @@ class Plans extends Component {
 		const wooExpressSubHeaderText = translate(
 			"Discover what's available in your Woo Express plan."
 		);
-		const entrepreneurTrialSubHeaderText = translate(
-			"Discover what's available in your Entrepreneur plan"
+
+		const hasEntrepreneurTrialSubHeaderTextTranslation = hasTranslation(
+			"Discover what's available in your Entrepreneur plan."
 		);
+
+		const isEnglishLocale = englishLocales.includes( this.props.locale );
+
+		const entrepreneurTrialSubHeaderText =
+			isEnglishLocale || hasEntrepreneurTrialSubHeaderTextTranslation
+				? translate( "Discover what's available in your Entrepreneur plan." )
+				: translate( "Discover what's available in your Entrepreneur plan" );
 
 		const isWooExpressTrial = purchase?.isWooExpressTrial;
 
@@ -521,6 +532,7 @@ const ConnectedPlans = connect(
 			isFreePlan: isFreePlanProduct( currentPlan ),
 			domainFromHomeUpsellFlow: getDomainFromHomeUpsellInQuery( state ),
 			siteHasLegacyStorage: siteHasFeature( state, selectedSiteId, FEATURE_LEGACY_STORAGE_200GB ),
+			locale: getCurrentLocaleSlug( state ),
 		};
 	},
 	( dispatch ) => ( {


### PR DESCRIPTION
Fixes: [7121](https://github.com/Automattic/dotcom-forge/issues/7121) and [7119]( https://github.com/Automattic/dotcom-forge/issues/7119)
## Proposed Changes
![image](https://github.com/Automattic/wp-calypso/assets/33497086/523d5963-aa57-497b-a2e6-7b6f38a01cc7)
We are improving plans page ponctuation by adding dot at the end of
`Discover what's available in your Entrepreneur plan.`
and adding coma at the end of
`What's included in your free trial:`


## Testing Instructions
- With an Entrepreneur trial, open the plans page.
- Check that the new dot and coma are displayed.
- Change the idiom to another language.
- You should not see the new pontuation on new idioms, because translations are not expected to be ready on other idioms.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
