### PR TITLE
Site Profiler: Fix menu on mobile views

### DIFF
--- a/client/site-profiler/components/metrics-menu/index.tsx
+++ b/client/site-profiler/components/metrics-menu/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useState } from 'react';
@@ -62,10 +63,14 @@ export const MetricsMenu: React.FC< MetricsMenuProps > = ( props ) => {
 		},
 	];
 
-	const [ selectedTab, setSelectedTab ] = useState< MetricsMenuTabs | undefined >();
 	const basicMetricsVisible = useIsMenuSectionVisible( basicMetricsRef );
 	const performanceMetricsVisible = useIsMenuSectionVisible( performanceMetricsRef );
 	const healthScoresVisible = useIsMenuSectionVisible( healthScoresRef );
+
+	const [ selectedTab, setSelectedTab ] = useState< MetricsMenuTabs | undefined >();
+	const selectedTabText = selectedTab
+		? menuItems.find( ( item ) => item.id === selectedTab )?.label
+		: '';
 
 	useEffect( () => {
 		if ( basicMetricsVisible ) {
@@ -74,8 +79,6 @@ export const MetricsMenu: React.FC< MetricsMenuProps > = ( props ) => {
 			setSelectedTab( MetricsMenuTabs.performance );
 		} else if ( healthScoresVisible ) {
 			setSelectedTab( MetricsMenuTabs.health );
-		} else {
-			setSelectedTab( undefined );
 		}
 	}, [ basicMetricsVisible, performanceMetricsVisible, healthScoresVisible ] );
 
@@ -86,8 +89,8 @@ export const MetricsMenu: React.FC< MetricsMenuProps > = ( props ) => {
 	};
 
 	return (
-		<StickyPanel>
-			<SectionNavbar className="metrics-menu-navbar">
+		<StickyPanel minLimit={ 0 }>
+			<SectionNavbar className="metrics-menu-navbar" selectedText={ selectedTabText }>
 				<NavTabs>
 					{ menuItems.map( ( item ) => (
 						<NavItem
@@ -99,9 +102,12 @@ export const MetricsMenu: React.FC< MetricsMenuProps > = ( props ) => {
 						</NavItem>
 					) ) }
 				</NavTabs>
-				<FullReportButton primary onClick={ onCTAClick }>
-					{ translate( "Get full site report - It's free" ) }
-				</FullReportButton>
+
+				{ ! isMobile() && (
+					<FullReportButton primary onClick={ onCTAClick }>
+						{ translate( "Get full site report - It's free" ) }
+					</FullReportButton>
+				) }
 			</SectionNavbar>
 		</StickyPanel>
 	);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7131

## Proposed Changes

Fix menu visualization in mobile. The CTA is not shown when on mobile view.

PS: This is not the menu proposed in the design, but instead a quick fix on the current version.

## Why are these changes being made?
The menu was broken on the mobile view

## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/example.com`
* Change the to a mobile view
* Check if the menu is fixed.

| Before  | After |
| ------------- | ------------- |
|![image](https://github.com/Automattic/wp-calypso/assets/5039531/ad6777dc-b06d-4a9b-8e88-6c29c4854de5)|![CleanShot 2024-05-16 at 15 37 12@2x](https://github.com/Automattic/wp-calypso/assets/5039531/0826715d-389b-4ba0-9e67-168ed570008a)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?