### PR TITLE
Nav Redesign: Fix domains header responsiveness

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -89,11 +89,34 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					line-height: 1.2;
 				}
 				.domain-header__buttons .button {
-					border-radius: 4px;
+					line-height: 22px;
+					border-radius: 2px;
 					white-space: nowrap;
 					margin-left: 0;
-					&:not( .is-primary ) {
-						margin-inline-end: 1rem;
+				}
+				.domain-header__buttons-mobile {
+					white-space: nowrap;
+				}
+				.options-domain-button__add {
+					display: none;
+				}
+				@media only screen and ( max-width: 479px ) {
+					.domain-header__buttons-mobile {
+						.options-domain-button__add {
+							display: inline;
+							height: 24px;
+							width: 24px;
+							margin: auto;
+							transition: transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+						}
+
+						.is-menu-visible .options-domain-button__add {
+							transform: rotate( 180deg );
+						}
+
+						.options-domain-button {
+							width: 48px;
+						}
 					}
 				}
 			}
@@ -160,7 +183,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 
 			@media only screen and ( max-width: 600px ) {
 				.navigation-header__main {
-					justify-content: normal;
+					justify-content: space-between;
 					.formatted-header {
 						flex: none;
 					}

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -97,16 +97,11 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				.domain-header__buttons-mobile {
 					white-space: nowrap;
 				}
-				.options-domain-button__add {
-					display: none;
-				}
 				@media only screen and ( max-width: 479px ) {
 					.domain-header__buttons-mobile {
 						.options-domain-button__add {
-							display: inline;
 							height: 24px;
 							width: 24px;
-							margin: auto;
 							transition: transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 						}
 

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -3,7 +3,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { isMobile } from '@automattic/viewport';
 import { Icon, plus, search } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -124,10 +123,8 @@ class AddDomainButton extends Component {
 
 		return (
 			<>
-				{ isMobile() && (
-					<Icon icon={ plus } className="options-domain-button__add gridicon" viewBox="2 2 20 20" />
-				) }
-				{ ! isMobile() && <span className="options-domain-button__desktop">{ label }</span> }
+				<Icon icon={ plus } className="options-domain-button__add gridicon" viewBox="2 2 20 20" />
+				<span className="options-domain-button__desktop">{ label }</span>
 			</>
 		);
 	}
@@ -135,6 +132,9 @@ class AddDomainButton extends Component {
 	render() {
 		const { specificSiteActions, ellipsisButton, borderless } = this.props;
 		const classes = classNames( 'options-domain-button', ellipsisButton && 'ellipsis' );
+		const spanClasses = classNames( {
+			'is-menu-visible': this.state.isAddMenuVisible,
+		} );
 
 		if ( ellipsisButton ) {
 			return (
@@ -145,7 +145,7 @@ class AddDomainButton extends Component {
 		}
 
 		return (
-			<Fragment>
+			<span className={ spanClasses }>
 				<Button
 					primary={ specificSiteActions }
 					className={ classes }
@@ -164,7 +164,7 @@ class AddDomainButton extends Component {
 				>
 					{ this.renderOptions() }
 				</PopoverMenu>
-			</Fragment>
+			</span>
 		);
 	}
 }

--- a/client/my-sites/domains/domain-management/list/options-domain-button.scss
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.scss
@@ -30,6 +30,14 @@ button {
 		}
 	}
 
+	.options-domain-button__add {
+		display: inline;
+
+		@include break-mobile {
+			display: none;
+		}
+	}
+
 	.options-domain-button.ellipsis {
 		border: none;
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -185,4 +185,8 @@
 			}
 		}
 	}
+
+	.options-domain-button__add.gridicon:not(:last-child) {
+		margin: auto;
+	}
 }

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -52,7 +52,7 @@ const responsiveButtonStyles = {
 
 const ManageAllDomainsButton = styled( Button )`
 	border-color: var( --color-neutral-5 );
-	border-radius: 4px;
+	border-radius: 2px;
 	margin-inline-end: 1rem;
 	white-space: nowrap;
 
@@ -64,19 +64,19 @@ const ManageAllDomainsButton = styled( Button )`
 
 const AddNewSiteSplitButton = styled( SplitButton )< { isMobile: boolean } >`
 	.split-button__main {
-		border-radius: 4px 0 0 4px;
+		border-radius: 2px 0 0 2px;
 		-webkit-font-smoothing: antialiased;
 
 		.rtl & {
-			border-radius: 0 4px 4px 0;
+			border-radius: 0 2px 2px 0;
 		}
 	}
 
 	.split-button__toggle {
-		border-radius: ${ ( { isMobile } ) => ( isMobile ? '4px' : '0 4px 4px 0' ) };
+		border-radius: ${ ( { isMobile } ) => ( isMobile ? '2px' : '0 2px 2px 0' ) };
 
 		.rtl & {
-			border-radius: ${ ( { isMobile } ) => ( isMobile ? '4px' : '4px 0 0 4px' ) };
+			border-radius: ${ ( { isMobile } ) => ( isMobile ? '2px' : '2px 0 0 2px' ) };
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7226

## Proposed Changes

* The border-radius has been changed from 4px to 2px to better match the Figma on both /sites and /domains.
* The CSS transition rotation animation has been added to the + button on /domain to match the behavior of /sites.
* `no-wrap` was applied to the /domain buttons to prevent wrapping at certain widths.
* The action buttons have been pulled to the right on all widths.
* The method for switching the button label from "Add a Domain" to "+" was implemented using CSS to prevent an empty button label when dynamically changing the browser width.

> [!NOTE]  
> I did not alter the /domains search bar on mobile widths. I initially thought it was misaligned due to padding, but I discovered it has been set to align center. I recommend following up on it in a new PR if it needs any adjustments.

Before | After
--|--
<img width="599" alt="Screenshot 2024-05-16 at 10 57 00 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/2b1706a6-99d5-4468-8703-0da9277c2ab5">  | <img width="526" alt="Screenshot 2024-05-16 at 5 41 56 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/53ac6905-c10d-425a-8674-c6bea30a70b3">

Before | After
--|--
<img width="466" alt="Screenshot 2024-05-16 at 10 56 11 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/9405e6cf-e18b-4c30-b5fa-976e76aed0b4"> |   <img width="447" alt="Screenshot 2024-05-16 at 5 42 13 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/9c293712-46eb-45b0-b7eb-3877e506dbcd">
 
Before | After
--|--
<img width="778" alt="Screenshot 2024-05-16 at 10 53 08 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/fba2a09b-de61-45eb-be6b-406404327188"> |  <img width="775" alt="Screenshot 2024-05-16 at 5 42 55 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/38d5761a-8710-479d-a233-9be76f261007">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improving user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live
* Go to /domains/manage
* See how it compare to /sites
* Try changing the browser width
* Check /domains/manage/[site] for any regressions
* Try and break it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
