### PR TITLE
Add Ons: Track primary action clicks

### DIFF
--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -9,6 +9,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -108,6 +109,10 @@ const AddOnsMain = () => {
 	}
 
 	const handleActionPrimary = ( addOnSlug: string, quantity?: number ) => {
+		recordTracksEvent( 'calypso_add_ons_action_primary_click', {
+			add_on_slug: addOnSlug,
+			quantity,
+		} );
 		page.redirect( `${ checkoutLink( selectedSite?.ID ?? null, addOnSlug, quantity ) }` );
 	};
 

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -110,9 +110,11 @@ const AddOnsMain = () => {
 
 	const handleActionPrimary = ( addOnSlug: string, quantity?: number ) => {
 		recordTracksEvent( 'calypso_add_ons_action_primary_click', {
+			add_on_slug_with_quantity: `${ addOnSlug }${ quantity ? `:${ quantity }` : '' }`,
 			add_on_slug: addOnSlug,
 			quantity,
 		} );
+
 		page.redirect( `${ checkoutLink( selectedSite?.ID ?? null, addOnSlug, quantity ) }` );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7231

## Proposed Changes

This PR adds the Tracks event `calypso_add_ons_action_primary_click` to every primary action available in the Add-ons page.

| Add-on | add_on_slug_with_quantity | add_on_slug | quantity |
| --- | --- | --- |  --- | 
| Jetpack AI Assistant | jetpack_ai_monthly | jetpack_ai_monthly | undefined |
| Premium Themes | unlimited_themes | unlimited_themes | undefined |
| Custom CSS | custom-design | custom-design | undefined |
| 50 GB Storage | wordpress_com_1gb_space_addon_yearly:50 | wordpress_com_1gb_space_addon_yearly | 50 |
| 100 GB Storage | wordpress_com_1gb_space_addon_yearly:100 | wordpress_com_1gb_space_addon_yearly | 100 |

Note that the slug `custom-design` is indeed a dash and not an underscore. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/add-ons/:site` with a Simple site.
* Ensure that primary action clicks trigger events as detailed above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
