### PR TITLE
Fix/update domains table style

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -62,6 +62,12 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				padding-top: 16px !important;
 			}
 
+			.select-dropdown,
+			.select-dropdown__header {
+				height: 40px;
+				border-radius: 4px;
+			}
+
 			header.navigation-header {
 				padding-top: 24px;
 
@@ -112,12 +118,12 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			.domains-table {
 				margin-top: 35px;
 				.domains-table-toolbar {
-					margin-inline: 64px;
+					margin-inline: 16px;
 				}
 				table {
 					overflow-y: auto;
 					max-height: calc( 100vh - 235px );
-					padding-inline: 64px;
+					padding-inline: 16px;
 					margin-bottom: 0;
 				}
 				.domains-table-header {
@@ -128,8 +134,8 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			}
 
 			.search-component.domains-table-filter__search.is-open.has-open-icon {
-				border-radius: 2px;
-				height: 36px;
+				border-radius: 4px;
+				height: 40px;
 				flex-direction: row-reverse;
 				padding-inline: 10px 8px;
 				font-size: 14px;
@@ -141,7 +147,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 
 				input.search-component__input[type='search'] {
 					font-size: 14px;
-					height: 36px;
+					height: 40px;
 
 					&::placeholder {
 						color: var( --studio-gray-40 );
@@ -155,7 +161,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				.is-global-sidebar-visible {
 					header.navigation-header {
 						padding-top: 24px;
-						padding-inline: 64px;
+						padding-inline: 16px;
 						border-block-end: 1px solid var( --studio-gray-0 );
 					}
 					.layout__primary > main {
@@ -169,6 +175,20 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				}
 			}
 
+			@media only screen and ( min-width: 960px ) {
+				.domains-table {
+					.domains-table-toolbar {
+						margin-inline: 26px;
+					}
+					table {
+						padding-inline: 26px;
+					}
+				}
+				.is-global-sidebar-visible header.navigation-header {
+					padding-inline: 26px;
+				}
+			}
+
 			@media only screen and ( max-width: 600px ) {
 				.navigation-header__main {
 					justify-content: space-between;
@@ -177,7 +197,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					}
 				}
 				.domains-table {
-					padding: 0 8px;
+					padding: 0 16px;
 				}
 				.domains-table-toolbar {
 					margin-inline: 0 !important;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -140,10 +140,12 @@
 
 	.main {
 		.navigation-header {
+			@include break-huge {
+				padding-inline: 64px;
+			}
 			@include break-xhuge {
 				margin: 0 auto;
 				max-width: 1400px;
-				padding-inline: 64px;
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -153,6 +153,13 @@
 			box-shadow: none;
 		}
 	}
+	.options-domain-button {
+		padding: 8px 14px;
+		border-radius: 4px;
+	}
+	.domains-table-filter {
+		align-items: flex-start;
+	}
 	.domains-table {
 		@include break-xhuge {
 			max-width: 1400px;
@@ -169,6 +176,15 @@
 				padding-inline: 64px;
 			}
 		}
+		.list__header-column {
+			font-size: rem(11px);
+			font-weight: 500;
+			color: var(--color-text);
+		}
+		.domains-table__row:hover > td {
+			background-color: #f7faff;
+		}
+
 		.components-base-control {
 			--checkbox-input-size: 16px;
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -176,11 +176,6 @@
 				padding-inline: 64px;
 			}
 		}
-		.list__header-column {
-			font-size: rem(11px);
-			font-weight: 500;
-			color: var(--color-text);
-		}
 		.domains-table__row:hover > td {
 			background-color: #f7faff;
 		}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -204,6 +204,9 @@
 	}
 
 	.domains-table-mobile-cards {
+		.domains-table-mobile-card:hover {
+			background-color: #f7faff;
+		}
 		.components-base-control {
 			display: flex;
 			align-items: center;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -178,9 +178,6 @@
 				padding-inline: 64px;
 			}
 		}
-		.domains-table__row:hover > td {
-			background-color: #f7faff;
-		}
 
 		.components-base-control {
 			--checkbox-input-size: 16px;

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1018,7 +1018,7 @@ $font-size: rem(14px);
 	// client/layout/sidebar/style.scss
 	.theme-default {
 		.focus-content .layout__content {
-			padding: 71px 24px 24px;
+			padding: 70px 24px 24px;
 			transition: padding 0.15s ease-in-out;
 		}
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -196,13 +196,13 @@
 
 	.components-search-control .components-input-control__container {
 		width: 100%;
-		height: 36px;
+		height: 40px;
 		flex: 1 1 auto;
 		flex-direction: row;
 		align-items: center;
 		// Places search above filters
 		z-index: 1;
-		border-radius: 2px;
+		border-radius: 4px;
 		border: 1px solid var(--studio-gray-10);
 		background-color: var(--color-surface, $white);
 

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -189,7 +189,6 @@
 
 			.components-flex.components-h-stack {
 				flex: 6;
-				padding-left: 8px;
 			}
 
 		}
@@ -585,11 +584,11 @@
 
 					.dataviews-filters__view-actions {
 						& > :first-child {
-							margin-inline-start: 30px;
+							margin-inline-start: 26px;
 						}
 
 						& > :last-child {
-							margin-inline-end: 30px;
+							margin-inline-end: 26px;
 						}
 					}
 				}
@@ -1145,6 +1144,6 @@
 
 .layout__content {
 	@include breakpoint-deprecated( "<960px" ) {
-		padding: 71px 24px 24px calc(var(--sidebar-width-min) + 1px);
+		padding: 70px 24px 24px calc(var(--sidebar-width-min) + 1px);
 	}
 }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -37,22 +37,22 @@
 		// Note: The checkbox does not count for column counting purposes
 
 		&.is-7-column {
-			grid-template-columns: 20px 2fr 1fr 1fr auto auto auto auto;
+			grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
 		}
 		&.is-7-column:not(.has-checkbox) {
-			grid-template-columns: 2fr 1fr 1fr auto auto auto auto;
+			grid-template-columns: 2fr 1fr 1fr auto auto auto 36px;
 		}
 		&.is-6-column {
-			grid-template-columns: 20px 2fr 1fr minmax(auto, 1fr) auto auto auto;
+			grid-template-columns: 20px 2fr 1fr minmax(auto, 1fr) auto auto 36px;
 		}
 		&.is-6-column:not(.has-checkbox) {
-			grid-template-columns: 2fr 1fr minmax(auto, 1fr) auto auto auto;
+			grid-template-columns: 2fr 1fr minmax(auto, 1fr) auto auto 36px;
 		}
 		&.is-5-column {
-			grid-template-columns: 20px 1fr minmax(auto, 1fr) auto auto auto;
+			grid-template-columns: 20px 1fr minmax(auto, 1fr) auto auto 36px;
 		}
 		&.is-5-column:not(.has-checkbox) {
-			grid-template-columns: 1fr minmax(auto, 1fr) auto auto auto;
+			grid-template-columns: 1fr minmax(auto, 1fr) auto auto 36px;
 		}
 
 		tr::after {
@@ -104,10 +104,6 @@
 	.domains-table__row {
 		&:has(a.domains-table__domain-name) {
 			cursor: pointer;
-
-			&:hover td {
-				background-color: #f7faff;
-			}
 		}
 	}
 
@@ -152,12 +148,6 @@
 
 	.domains-table-row__actions {
 		text-align: right;
-		justify-content: flex-end;
-
-		button {
-			min-width: unset;
-			padding: 0;
-		}
 	}
 }
 

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -37,22 +37,22 @@
 		// Note: The checkbox does not count for column counting purposes
 
 		&.is-7-column {
-			grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
+			grid-template-columns: 20px 2fr 1fr 1fr auto auto auto auto;
 		}
 		&.is-7-column:not(.has-checkbox) {
-			grid-template-columns: 2fr 1fr 1fr auto auto auto 36px;
+			grid-template-columns: 2fr 1fr 1fr auto auto auto auto;
 		}
 		&.is-6-column {
-			grid-template-columns: 20px 2fr 1fr minmax(auto, 1fr) auto auto 36px;
+			grid-template-columns: 20px 2fr 1fr minmax(auto, 1fr) auto auto auto;
 		}
 		&.is-6-column:not(.has-checkbox) {
-			grid-template-columns: 2fr 1fr minmax(auto, 1fr) auto auto 36px;
+			grid-template-columns: 2fr 1fr minmax(auto, 1fr) auto auto auto;
 		}
 		&.is-5-column {
-			grid-template-columns: 20px 1fr minmax(auto, 1fr) auto auto 36px;
+			grid-template-columns: 20px 1fr minmax(auto, 1fr) auto auto auto;
 		}
 		&.is-5-column:not(.has-checkbox) {
-			grid-template-columns: 1fr minmax(auto, 1fr) auto auto 36px;
+			grid-template-columns: 1fr minmax(auto, 1fr) auto auto auto;
 		}
 
 		tr::after {
@@ -104,6 +104,10 @@
 	.domains-table__row {
 		&:has(a.domains-table__domain-name) {
 			cursor: pointer;
+
+			&:hover td {
+				background-color: #f7faff;
+			}
 		}
 	}
 
@@ -148,6 +152,12 @@
 
 	.domains-table-row__actions {
 		text-align: right;
+		justify-content: flex-end;
+
+		button {
+			min-width: unset;
+			padding: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes most of 7169-gh-Automattic/dotcom-forge

>We can make these two tables more consistent:
> Add hover state to the domains table.
> 
> Table headers are the same for both tables (Font sizes, color, etc).

This PR tidies up padding, alignment and heights so that the domains table matches the sites table on all resolutions. I also tidied up alignment of the sites table header.

before:
<img width="470" alt="Screenshot 2024-05-20 at 8 58 18 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/286e1911-4531-4e4f-9b74-29872d55b9ff">


after:
<img width="474" alt="Screenshot 2024-05-20 at 8 58 09 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/d90efa8f-f412-420c-bed4-eb8650f5f6dc">

#### Sites table header:
before:
<img width="772" alt="Screenshot 2024-05-20 at 8 49 17 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/bc33e017-ef31-4a00-a25b-977175dc6307">

after:

<img width="771" alt="Screenshot 2024-05-20 at 8 49 23 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/dba41c91-075f-4662-ba2d-86d6bbdd6797">


Note: I haven't dealt with table widths on the domains table, because it has quite a complex display method that is different from the sites table, we can work on that in another PR

### Testing instructions

Ensure that /domains/manage and /sites table headers are similar at all resolutions.
