### PR TITLE
fix clicking table rows on sites page

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -116,18 +116,20 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 						</>
 					) : (
 						<>
-							<a
-								className="sites-dataviews__site-url"
-								href={ siteUrl }
-								title={ siteUrl }
-								target="_blank"
-								rel="noreferrer"
-							>
-								<Truncated>
-									{ displaySiteUrl( siteUrl ) }
-									<Icon icon={ external } size={ 16 } />
-								</Truncated>
-							</a>
+							<div>
+								<a
+									className="sites-dataviews__site-url"
+									href={ siteUrl }
+									title={ siteUrl }
+									target="_blank"
+									rel="noreferrer"
+								>
+									<Truncated>
+										{ displaySiteUrl( siteUrl ) }
+										<Icon icon={ external } size={ 16 } />
+									</Truncated>
+								</a>
+							</div>
 							<a className="sites-dataviews__site-wp-admin-url" href={ adminUrl }>
 								<Truncated>{ adminLabel }</Truncated>
 							</a>

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -33,7 +33,6 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	display: block;
 
 	&:focus {
 		border-radius: 2px;


### PR DESCRIPTION
hopefully micro PR to fix issue raised in slack p1715910138867089-slack-C06DN6QQVAQ

in https://github.com/Automattic/wp-calypso/pull/90726/files I had set display:block on both the site home url and my home link.

This updates the structure to have a div, as it did before  https://github.com/Automattic/wp-calypso/pull/90726/files and reverts the change to the scss file.

### Testing instructions
on /sites:
you should be able to click immediately to the left of the My Home link and it should open the flyout panel 
<img width="535" alt="Screenshot 2024-05-17 at 12 55 47 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/13bd4586-d84d-4342-bfb8-cf70174c66da">
