### PR TITLE
Me: Fix the back link after the settings are changed

### DIFF
--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Spinner, Gridicon } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { GlobalSidebarHeader } from 'calypso/layout/global-sidebar/header';
 import useSiteMenuItems from 'calypso/my-sites/sidebar/use-site-menu-items';
@@ -31,8 +31,7 @@ const GlobalSidebar = ( {
 	const isDesktop = useBreakpoint( '>=782px' );
 	const previousRoute = useSelector( getPreviousRoute );
 	const section = useSelector( getSection );
-	const previousLink = useRef( previousRoute );
-
+	const [ previousLink, setPreviousLink ] = useState( '' );
 	const handleWheel = useCallback( ( event ) => {
 		const bodyEl = bodyRef.current;
 		if ( bodyEl && bodyEl.contains( event.target ) && bodyEl.scrollHeight > bodyEl.clientHeight ) {
@@ -55,7 +54,7 @@ const GlobalSidebar = ( {
 	useEffect( () => {
 		// Update the previous link only when the group is changed.
 		if ( previousRoute && ! previousRoute.startsWith( `/${ section.group }` ) ) {
-			previousLink.current = previousRoute;
+			setPreviousLink( previousRoute );
 		}
 	}, [ previousRoute, section.group ] );
 
@@ -70,7 +69,7 @@ const GlobalSidebar = ( {
 	}
 
 	const { requireBackLink, siteTitle, backLinkHref, ...sidebarProps } = props;
-	const sidebarBackLinkHref = backLinkHref || previousLink.current || '/sites';
+	const sidebarBackLinkHref = backLinkHref || previousLink || '/sites';
 
 	return (
 		<div className="global-sidebar" ref={ wrapperRef }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/90792

## Proposed Changes

* Fix the incorrect back link after you navigated to the `/me/account` page and updated your language interface.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
 1. Go to /me/account
 2. Click on Interface Language, select a new language and then press Apply Changes
 3. It redirects you to /me/account?updated=success
 4. Which then redirects you to /me/account
 5. Pressing back
 6. Make sure it redirects you to /sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
