### PR TITLE
Jetpack Backup: Redirect back to main backup page when clicking on `Back up now` button

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/README.md
+++ b/client/components/jetpack/backup-actions-toolbar/README.md
@@ -3,15 +3,14 @@
 ```jsx
 import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
 import { useSelector } from 'react-redux';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 function render() {
     const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	return (
 		<div>
-			<BackupActionsToolbar siteId={ siteId } siteSlug={ siteSlug } />
+			<BackupActionsToolbar siteId={ siteId } />
 		</div>
 	);
 }

--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -12,9 +12,14 @@ import './style.scss';
 interface Props {
 	siteId: number;
 	siteSlug: string;
+	onBackupNowClick?: ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => void;
 }
 
-const BackupActionsToolbar: FunctionComponent< Props > = ( { siteId, siteSlug } ) => {
+const BackupActionsToolbar: FunctionComponent< Props > = ( {
+	siteId,
+	siteSlug,
+	onBackupNowClick,
+} ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -41,6 +46,7 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( { siteId, siteSlug } 
 			siteId={ siteId }
 			variant="primary"
 			trackEventName="calypso_jetpack_backup_now"
+			onClick={ onBackupNowClick }
 		>
 			{ translate( 'Back up now' ) }
 		</BackupNowButton>

--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -1,29 +1,30 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { backupClonePath } from 'calypso/my-sites/backup/paths';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { backupClonePath, backupMainPath } from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import siteHasBackups from 'calypso/state/rewind/selectors/site-has-backups';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import BackupNowButton from '../backup-now-button';
 import './style.scss';
 
 interface Props {
 	siteId: number;
-	siteSlug: string;
-	onBackupNowClick?: ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => void;
 }
 
-const BackupActionsToolbar: FunctionComponent< Props > = ( {
-	siteId,
-	siteSlug,
-	onBackupNowClick,
-} ) => {
+const BackupActionsToolbar: FunctionComponent< Props > = ( { siteId } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-
+	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 	const hasBackups = useSelector( ( state ) => siteHasBackups( state, siteId ) );
+
+	// Show the "Copy site" button if accessing on Jetpack Cloud or A4A
+	const showCopySiteButton = isJetpackCloud() || isA8CForAgencies();
 
 	const copySite = (
 		<Tooltip
@@ -41,6 +42,11 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( {
 		</Tooltip>
 	);
 
+	const onBackupNowClick = () => {
+		// Redirect back to the main backup page when queueing a new backup
+		page( backupMainPath( siteSlug ) );
+	};
+
 	const backupNow = (
 		<BackupNowButton
 			siteId={ siteId }
@@ -54,7 +60,7 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( {
 
 	return (
 		<div className="jetpack-backup__actions-toolbar">
-			{ hasBackups && copySite }
+			{ showCopySiteButton && hasBackups && copySite }
 			{ backupNow }
 		</div>
 	);

--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -27,7 +27,7 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 	tooltipText,
 	trackEventName,
 	variant,
-	onClick = () => {},
+	onClick,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();

--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -11,7 +11,6 @@ import { rewindBackupSite } from 'calypso/state/activity-log/actions';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
 import getBackupStoppedFlag from 'calypso/state/rewind/selectors/get-backup-stopped-flag';
-import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 
 interface Props {
 	children?: React.ReactNode;
@@ -37,7 +36,6 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 	const [ buttonContent, setButtonContent ] = useState( children );
 	const [ currentTooltip, setCurrentTooltip ] = useState( tooltipText );
 	const [ enqueued, setEnqueued ] = useState( false );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const requestBackupSite = useCallback(
 		() => dispatch( rewindBackupSite( siteId ) ),
 		[ dispatch, siteId ]
@@ -89,15 +87,7 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 			setCurrentTooltip( tooltipText );
 			setDisabled( false );
 		}
-	}, [
-		areBackupsStopped,
-		backupCurrentlyInProgress,
-		tooltipText,
-		translate,
-		enqueued,
-		children,
-		siteSlug,
-	] );
+	}, [ areBackupsStopped, backupCurrentlyInProgress, tooltipText, translate, enqueued, children ] );
 
 	const button = (
 		<div>

--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Tooltip } from '@wordpress/components';
 import { useCallback, useState, useEffect } from '@wordpress/element';
@@ -6,11 +7,13 @@ import { FunctionComponent } from 'react';
 import { recordLogRocketEvent } from 'calypso/lib/analytics/logrocket';
 import { EVERY_SECOND, Interval } from 'calypso/lib/interval';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { backupMainPath } from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { rewindBackupSite } from 'calypso/state/activity-log/actions';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
 import getBackupStoppedFlag from 'calypso/state/rewind/selectors/get-backup-stopped-flag';
+import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 
 interface Props {
 	children?: React.ReactNode;
@@ -34,6 +37,7 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 	const [ buttonContent, setButtonContent ] = useState( children );
 	const [ currentTooltip, setCurrentTooltip ] = useState( tooltipText );
 	const [ enqueued, setEnqueued ] = useState( false );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 	const requestBackupSite = useCallback(
 		() => dispatch( rewindBackupSite( siteId ) ),
 		[ dispatch, siteId ]
@@ -72,6 +76,7 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 			setButtonContent( statusLabels.IN_PROGRESS );
 			setEnqueued( false );
 		} else if ( enqueued ) {
+			page( backupMainPath( siteSlug ) );
 			setButtonContent( statusLabels.QUEUED );
 			setCurrentTooltip( statusTooltipTexts.QUEUED );
 		} else {
@@ -79,9 +84,15 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 			setCurrentTooltip( tooltipText );
 			setDisabled( false );
 		}
-	}, [ areBackupsStopped, backupCurrentlyInProgress, tooltipText, translate, enqueued, children ] );
-
-	// TODO: If we want to re-enable the backup button we can set enqueue to false once we detect a backup in progress
+	}, [
+		areBackupsStopped,
+		backupCurrentlyInProgress,
+		tooltipText,
+		translate,
+		enqueued,
+		children,
+		siteSlug,
+	] );
 
 	const button = (
 		<div>

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -202,6 +202,11 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 		return <BackupPlaceholder showDatePicker={ true } />;
 	}
 
+	const onBackupNowClick = () => {
+		// Redirect back to the main backup page when queueing a new backup
+		page( backupMainPath( siteSlug ) );
+	};
+
 	return (
 		<div className="backup__main-wrap">
 			<div className="backup__last-backup-status">
@@ -216,7 +221,11 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 						<div className="backup__header-right">
 							{ siteSlug && (
 								<>
-									<BackupActionsToolbar siteId={ siteId } siteSlug={ siteSlug } />
+									<BackupActionsToolbar
+										siteId={ siteId }
+										siteSlug={ siteSlug }
+										onBackupNowClick={ onBackupNowClick }
+									/>
 								</>
 							) }
 						</div>

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -18,7 +18,6 @@ import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
-import BackupNowButton from 'calypso/components/jetpack/backup-now-button';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -106,13 +105,7 @@ const BackupPage = ( { queryDate } ) => {
 							}
 						) }
 					>
-						<BackupNowButton
-							siteId={ siteId }
-							variant="primary"
-							trackEventName="calypso_jetpack_backup_now"
-						>
-							{ translate( 'Back up now' ) }
-						</BackupNowButton>
+						<BackupActionsToolbar siteId={ siteId } />
 					</NavigationHeader>
 				) }
 
@@ -189,7 +182,6 @@ function AdminContent( { selectedDate } ) {
 function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
 	const translate = useTranslate();
 
@@ -201,11 +193,6 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 	if ( isFetchingSiteFeatures || ! isPoliciesInitialized ) {
 		return <BackupPlaceholder showDatePicker={ true } />;
 	}
-
-	const onBackupNowClick = () => {
-		// Redirect back to the main backup page when queueing a new backup
-		page( backupMainPath( siteSlug ) );
-	};
 
 	return (
 		<div className="backup__main-wrap">
@@ -219,15 +206,7 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 							</div>
 						</div>
 						<div className="backup__header-right">
-							{ siteSlug && (
-								<>
-									<BackupActionsToolbar
-										siteId={ siteId }
-										siteSlug={ siteSlug }
-										onBackupNowClick={ onBackupNowClick }
-									/>
-								</>
-							) }
+							<BackupActionsToolbar siteId={ siteId } />
 						</div>
 					</div>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/482

## Proposed Changes
* Add a custom `onClick` handler on `BackupNowButton`, that will give us more flexibility on adding custom logic when clicking that button. 
* Redirect to the main backup page when clicking on `Back up now` button, so the user can monitor the progress of the backup being created

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, if the user clicks on Back up now, it indicates their interest in securing their latest changes. Therefore, we want to ensure they can monitor the progress of the backup being created.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a **Calypso Blue** or **Jetpack Cloud** live branch
* Pick a site with Jetpack VaultPress Backup plan with more than 1 backup
* Navigate to the backup page
* Pick a date on the calendar rather than Today
* Click on `Back up now`
* You should be redirected back to `Today` and you should see the progress of the backup being created.

To validate how it was working before, you can try the same steps in production.



## Demo

https://github.com/Automattic/wp-calypso/assets/1488641/4165f1d3-7d9d-4624-a0ed-29bc3848d058

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
