### PR TITLE
Untangling: Replace Hosting -> Connections with Marketing

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -21,6 +21,7 @@ import {
 	getSiteSlug,
 	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
 	isJetpackSite,
+	getSiteAdminUrl,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
@@ -40,6 +41,13 @@ export const Sharing = ( {
 	translate,
 	premiumPlanName,
 } ) => {
+	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
+		getIsGlobalSiteViewEnabled( state, siteId )
+	);
+	const isJetpackClassic = isJetpack && isGlobalSiteViewEnabled;
+
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+
 	const pathSuffix = siteSlug ? '/' + siteSlug : '';
 	let filters = [];
 
@@ -49,23 +57,13 @@ export const Sharing = ( {
 		title: translate( 'Marketing Tools' ),
 	} );
 
-	// Include SEO link if a site is selected and the
-	// required Jetpack module is active
-	if ( showTraffic ) {
+	// Include Business Tools link if a site is selected and the
+	// site is not VIP
+	if ( ! isVip && showBusinessTools ) {
 		filters.push( {
-			id: 'traffic',
-			route: '/marketing/traffic' + pathSuffix,
-			title: translate( 'Traffic' ),
-			description: translate(
-				'Manage settings and tools related to the traffic your website receives. {{learnMoreLink/}}',
-				{
-					components: {
-						learnMoreLink: (
-							<InlineSupportLink key="traffic" supportContext="traffic" showIcon={ false } />
-						),
-					},
-				}
-			),
+			id: 'business-buttons',
+			route: '/marketing/business-tools' + pathSuffix,
+			title: translate( 'Business Tools' ),
 		} );
 	}
 
@@ -90,12 +88,38 @@ export const Sharing = ( {
 		filters.push( connectionsFilter );
 	}
 
+	// Include SEO link if a site is selected and the
+	// required Jetpack module is active
+	if ( showTraffic ) {
+		filters.push( {
+			id: 'traffic',
+			route: isJetpackClassic
+				? siteAdminUrl + 'admin.php?page=jetpack#/traffic'
+				: '/marketing/traffic' + pathSuffix,
+			isExternalLink: isJetpackClassic,
+			title: translate( 'Traffic' ),
+			description: translate(
+				'Manage settings and tools related to the traffic your website receives. {{learnMoreLink/}}',
+				{
+					components: {
+						learnMoreLink: (
+							<InlineSupportLink key="traffic" supportContext="traffic" showIcon={ false } />
+						),
+					},
+				}
+			),
+		} );
+	}
+
 	// Include Sharing Buttons link if a site is selected and the
 	// required Jetpack module is active
 	if ( showButtons ) {
 		filters.push( {
 			id: 'sharing-buttons',
-			route: '/marketing/sharing-buttons' + pathSuffix,
+			route: isJetpackClassic
+				? siteAdminUrl + 'admin.php?page=jetpack#/sharing'
+				: '/marketing/sharing-buttons' + pathSuffix,
+			isExternalLink: isJetpackClassic,
 			title: translate( 'Sharing Buttons' ),
 			description: translate(
 				'Make it easy for your readers to share your content online. {{learnMoreLink/}}',
@@ -110,25 +134,10 @@ export const Sharing = ( {
 		} );
 	}
 
-	// Include Business Tools link if a site is selected and the
-	// site is not VIP
-	if ( ! isVip && showBusinessTools ) {
-		filters.push( {
-			id: 'business-buttons',
-			route: '/marketing/business-tools' + pathSuffix,
-			title: translate( 'Business Tools' ),
-		} );
-	}
-
 	let titleHeader = translate( 'Marketing and Integrations' );
 
-	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
-		getIsGlobalSiteViewEnabled( state, siteId )
-	);
-
 	if ( isGlobalSiteViewEnabled ) {
-		filters = [];
-		titleHeader = translate( 'Connections' );
+		titleHeader = translate( 'Marketing' );
 	}
 
 	if ( isP2Hub ) {
@@ -156,8 +165,13 @@ export const Sharing = ( {
 			{ filters.length > 0 && (
 				<SectionNav selectedText={ selected?.title ?? '' }>
 					<NavTabs>
-						{ filters.map( ( { id, route, title } ) => (
-							<NavItem key={ id } path={ route } selected={ pathname === route }>
+						{ filters.map( ( { id, route, isExternalLink, title } ) => (
+							<NavItem
+								key={ id }
+								path={ route }
+								isExternalLink={ isExternalLink }
+								selected={ pathname === route }
+							>
 								{ title }
 							</NavItem>
 						) ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/7168
- https://github.com/Automattic/dotcom-forge/issues/6231

## Proposed Changes

This PR restores Calypso's Tools -> Marketing page under Hosting.

For Atomic (including Jetpack) using Early Classic style, I improvised a bit and replace the link with an external link pointing to the respective tabs in Jetpack -> Settings.

This PR also reorders the tab order a bit so that all possible external links come last.

**Before**

|Default|Classic
|-|-|
|<img width="1023" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/df55f830-3cf9-4f41-ad85-0a72fd8c044a">|<img width="799" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/42def15c-781d-475c-b2b7-c3461ab7e327">|

**After**

| Default|
|-|
|<img width="400" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/3a24afd5-c370-4a07-a3ea-79860d0e701c">|

|Simple Classic|Atomic/Jetpack Classic|
|-|-|
|<img width="1036" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/2c305961-f678-42a6-9b96-8549c167f1b3">|<img width="976" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/edab6c55-7155-437a-baff-d09d77896b6f">|


## Why are these changes being made?

We don't want to lose possible revenue coming from this page.

## Testing Instructions

1. Apply this Jetpack patch https://github.com/Automattic/jetpack/pull/37431 to your Atomic site / sandbox.
2. Verify the contents of the Marketing page as per screenshots above.
3. Verify that the external links point to the correct tab in Jetpack -> Settings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
