### PR TITLE
Fix back redirection from Woo connect switch user flow

### DIFF
--- a/client/layout/masterbar/woo.jsx
+++ b/client/layout/masterbar/woo.jsx
@@ -28,7 +28,7 @@ const WooOauthMasterbar = () => {
 			// Validate the URL and get it back as a string.
 			const homeURL = new URL( nextURL.searchParams.get( 'home_url' ) ).toString();
 			// add the extensions page path.
-			const finalRedirectURL = `${ homeURL }/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions`;
+			const finalRedirectURL = `${ homeURL }wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions`;
 			window.location = finalRedirectURL;
 		} catch {
 			goBack();

--- a/client/layout/masterbar/woo.jsx
+++ b/client/layout/masterbar/woo.jsx
@@ -25,10 +25,8 @@ const WooOauthMasterbar = () => {
 			const siteURL = new URL( redirectURL.searchParams.get( 'redirect_uri' ) );
 			// We just get a path here, so we construct an example URL.
 			const nextURL = new URL( 'http://example.com' + siteURL.searchParams.get( 'next' ) );
-			const homeURL = nextURL.searchParams.get( 'home_url' );
-			if ( ! homeURL ) {
-				return goBack();
-			}
+			// Validate the URL and get it back as a string.
+			const homeURL = new URL( nextURL.searchParams.get( 'home_url' ) ).toString();
 			// add the extensions page path.
 			const finalRedirectURL = `${ homeURL }/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions`;
 			window.location = finalRedirectURL;

--- a/client/layout/masterbar/woo.jsx
+++ b/client/layout/masterbar/woo.jsx
@@ -9,8 +9,32 @@ import './typekit';
 import './woo.scss';
 
 const WooOauthMasterbar = () => {
-	function onClick() {
+	function goBack() {
 		window.history.back();
+	}
+
+	function onClick() {
+		// When the URL that initiates login is the connection page (during a switch user flow),
+		// we need to find the deeply nested home_url parameter to redirect back to the
+		// extensions page. This is because otherwise history back() will just redirect back to
+		// login as we still don't have a user. At any stage if we're not able to find a
+		// parameter, we give up and go back.
+		try {
+			const url = new URL( window.location.href );
+			const redirectURL = new URL( url.searchParams.get( 'redirect_to' ) );
+			const siteURL = new URL( redirectURL.searchParams.get( 'redirect_uri' ) );
+			// We just get a path here, so we construct an example URL.
+			const nextURL = new URL( 'http://example.com' + siteURL.searchParams.get( 'next' ) );
+			const homeURL = nextURL.searchParams.get( 'home_url' );
+			if ( ! homeURL ) {
+				return goBack();
+			}
+			// add the extensions page path.
+			const finalRedirectURL = `${ homeURL }/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions`;
+			window.location = finalRedirectURL;
+		} catch {
+			goBack();
+		}
 	}
 
 	const backNav = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 20362-gh-Automattic/woocommerce.com

## Proposed Changes

Fixes back button redirection from Woo connection switch user flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When redirecting from the Woo connection switch user flow, back button navigation calls `history.back()` which takes you back to the connection flow. At the connection flow however, because a user is not available, the page redirects back to the login flow. You can see this on production here (ensure you are logged into woocommerce.com):

https://github.com/Automattic/wp-calypso/assets/533/670f1ad1-6d2a-4e46-82c8-5073b16d7080

## Testing Instructions

1. Make sure you have a [working Calypso installation](https://github.com/automattic/wp-calypso/?tab=readme-ov-file#getting-started).
2. Switch to this branch.
3. Make sure Calypso is started `yarn start`.
4. Create a test WooCommerce installation ([JN can help](https://jurassic.ninja/))
5. Make sure you are logged in to woocommerce.com and wordpress.com.
6. Connect the site to woocommerce.com by visiting `/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions` and clicking `Connect account`.
7. Now you should ideally see this connect screen:
![CleanShot 2024-05-17 at 11 13 06](https://github.com/Automattic/wp-calypso/assets/533/1295acca-7412-4d71-bb54-849596b34a1d)
8. If you instead see this switch account, then it means you are not logged into woocommerce.com and you should login by clicking on the user account:
![CleanShot 2024-05-17 at 11 13 22](https://github.com/Automattic/wp-calypso/assets/533/2253cc70-4a6b-4f52-9f81-79ef98c7ff08)
9. Once you get back to the connection screen, click `Use a different WooCommerce.com account`
10. Make sure you get to the WP switch account page.
11. First reproduce the behaviour in production by clicking Back, you should see the behavior in the video.
12. Now repeat steps 1-10, and substitute the beginning of the URL `https://wordpress.com/log-in?` with `http://calypso.localhost:3000/log-in?`
13. Click Back
14. Ensure that you are redirected back to the site:


https://github.com/Automattic/wp-calypso/assets/533/a8e0f46e-8203-4ae1-805b-fc2c15389956

15. Ensure that other login flows don't break with this change.
16. Please test around this issue.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
