### PR TITLE
Automattic for Agencies: Redesign hosting marketplace page

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/style.scss
@@ -5,8 +5,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 64px;
-	margin-block-start: 48px;
-	margin-block-end: 64px;
+	padding-block: 16px 32px;
 }
 
 .hosting-overview__banner {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
@@ -10,20 +10,25 @@ import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 export default function useHostingDescription( slug: string ): {
 	name: TranslateResult;
 	description: TranslateResult;
+	heading: TranslateResult;
 	features: TranslateResult[];
+	footerText: TranslateResult;
 } {
 	const translate = useTranslate();
 
 	return useMemo( () => {
 		let description = '';
 		let name = '';
+		let heading = '';
 		let features: TranslateResult[] = [];
+		let footerText: TranslateResult = '';
 
 		switch ( slug ) {
 			case 'pressable-hosting':
 				name = translate( 'Pressable' );
+				heading = translate( 'Premier Agency Hosting w/ WooCommerce' );
 				description = translate(
-					'Best for premier agencies and developers who need significant control and build sites that require scaling.'
+					'Premier agency hosting for large-scale businesses and major eCommerce.'
 				);
 				features = [
 					translate( 'Optimized for high-traffic WooCommerce stores {{img/}}', {
@@ -37,10 +42,14 @@ export default function useHostingDescription( slug: string ): {
 					translate( 'Custom pricing and packaging are available' ),
 					translate( 'Agency tools to manage sites at scale' ),
 				];
+				footerText = translate( 'WP.Cloud powered hosting by' );
 				break;
 			case 'wpcom-hosting':
 				name = translate( 'WordPress.com' );
-				description = translate( 'Best for those who want a hassle-free WordPress experience.' );
+				heading = translate( 'Standard Agency Hosting' );
+				description = translate(
+					'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
+				);
 				features = [
 					translate( 'Great for developers with client-managed sites.' ),
 					translate( '24/7 Expert Support' ),
@@ -49,19 +58,31 @@ export default function useHostingDescription( slug: string ): {
 					translate( 'Self-service sales' ),
 					translate( 'Studio (local dev)' ),
 				];
+				footerText = translate( 'WP.Cloud powered hosting by' );
 				break;
 			case 'vip':
 				name = translate( 'VIP' );
+				heading = translate( 'Enterprise CMS' );
 				description = translate(
 					'Deliver unmatched performance with the highest security standards on our enterprise content platform.'
 				);
-				features = [];
+				features = [
+					translate( 'Unmatched flexibility to build a customized web experience' ),
+					translate( 'Tools to increase customer engagement' ),
+					translate(
+						'Scalability to ensure top-notch site performance during campaigns or events'
+					),
+				];
+				footerText = translate( 'Enterprise WordPress hosting by' );
+				break;
 		}
 
 		return {
 			name,
+			heading,
 			description,
 			features,
+			footerText,
 		};
 	}, [ slug, translate ] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
@@ -27,19 +27,17 @@ export default function useHostingDescription( slug: string ): {
 			case 'pressable-hosting':
 				name = translate( 'Pressable' );
 				heading = translate( 'Premier Agency Hosting w/ WooCommerce' );
-				description = translate(
-					'Premier agency hosting for large-scale businesses and major eCommerce.'
-				);
+				description = translate( 'Best for large-scale businesses and major eCommerce sites.' );
 				features = [
 					translate( 'Optimized for high-traffic WooCommerce stores {{img/}}', {
 						components: {
 							img: <WooCommerceLogo size={ 32 } />,
 						},
 					} ),
-					translate( '24/7 Expert Support with expanded support options' ),
-					translate( '20GB-1TB Storage' ),
+					translate( '24/7 Expert support w/ expanded options' ),
+					translate( '75GB-1TB Storage' ),
 					translate( '100% uptime SLA' ),
-					translate( 'Custom pricing and packaging are available' ),
+					translate( 'Custom pricing' ),
 					translate( 'Agency tools to manage sites at scale' ),
 				];
 				footerText = translate( 'WP.Cloud powered hosting by' );
@@ -51,12 +49,12 @@ export default function useHostingDescription( slug: string ): {
 					'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
 				);
 				features = [
-					translate( 'Great for developers with client-managed sites.' ),
+					translate( 'Great for client-managed sites.' ),
 					translate( '24/7 Expert Support' ),
 					translate( '50 GB Storage' ),
-					translate( 'Unmetered Visits' ),
+					translate( 'Unlimited visitors' ),
 					translate( 'Self-service sales' ),
-					translate( 'Studio (local dev)' ),
+					translate( 'Studio (local development)' ),
 				];
 				footerText = translate( 'WP.Cloud powered hosting by' );
 				break;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -1,6 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
-	Badge,
 	BloombergLogo,
 	Button,
 	CNNLogo,
@@ -11,13 +10,14 @@ import {
 	SalesforceLogo,
 	SlackLogo,
 	TimeLogo,
+	Tooltip,
 } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { debounce } from '@wordpress/compose';
-import { Icon, external } from '@wordpress/icons';
+import { Icon, external, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -48,13 +48,19 @@ export default function HostingCard( {
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const [ showTooltip, setShowTooltip ] = useState( false );
+
 	//FIXME: We want to unify and refactor this logic, once we decide
 	//on how the UX should look in the end
 	const pressableUrl = 'https://my.pressable.com/agency/auth';
 
-	const { name, description, features } = useHostingDescription( plan.family_slug );
+	const { name, heading, description, features, footerText } = useHostingDescription(
+		plan.family_slug
+	);
 
 	const priceRef = useRef< HTMLDivElement >( null );
+	const tooltip = useRef< HTMLDivElement >( null );
 
 	const onExploreClick = useCallback( () => {
 		dispatch(
@@ -159,34 +165,72 @@ export default function HostingCard( {
 	return (
 		<div className={ classNames( 'hosting-card', className ) }>
 			<div className="hosting-card__section">
-				<div className="hosting-card__header">
-					{ getHostingLogo( plan.family_slug ) }
-					{ pressableOwnership && <Badge type="success">{ translate( 'You own this' ) }</Badge> }
-				</div>
+				<div className="hosting-card__heading">{ heading }</div>
 
-				<div
-					className="hosting-card__price"
-					ref={ priceRef }
-					style={ { minHeight: `${ minPriceHeight }px` } }
-				>
-					<div>
-						<div className="hosting-card__price-value">
-							{ translate( 'Starting at %(priceStartingAt)s', {
-								args: { priceStartingAt },
-							} ) }
-						</div>
-						<div className="hosting-card__price-interval">{ priceIntervalDescription }</div>
-					</div>
-					{ highestDiscountPercentage ? (
-						<div className="hosting-card__price-discount">
-							{ translate( 'Volume savings up to %(highestDiscountPercentage)s%', {
-								args: { highestDiscountPercentage: Math.trunc( highestDiscountPercentage ) },
-							} ) }
-						</div>
-					) : null }
-				</div>
+				{ pressableOwnership && (
+					<>
+						<Icon
+							onMouseEnter={ () => setShowTooltip( true ) }
+							onMouseLeave={ () => setShowTooltip( false ) }
+							onMouseDown={ () => setShowTooltip( false ) }
+							onTouchStart={ () => setShowTooltip( ! showTooltip ) }
+							role="button"
+							tabIndex={ 0 }
+							ref={ tooltip }
+							className="hosting-card__check-icon"
+							icon={ check }
+							size={ 18 }
+						/>
+						<Tooltip
+							className="gray-tooltip"
+							context={ tooltip.current }
+							isVisible={ showTooltip }
+							position="bottom"
+							showOnMobile
+						>
+							{ translate( 'You own this' ) }
+						</Tooltip>
+					</>
+				) }
 
 				<p className="hosting-card__description">{ description }</p>
+
+				{ plan.family_slug === 'vip' ? (
+					<div className="hosting-card__section hosting-card__logo-section">
+						<div className="hosting-card__logos">
+							<TimeLogo />
+							<SlackLogo />
+							<DisneyLogo />
+							<CondenastLogo />
+							<BloombergLogo />
+							<CNNLogo />
+							<SalesforceLogo />
+							<FacebookLogo />
+						</div>
+					</div>
+				) : (
+					<div
+						className="hosting-card__price"
+						ref={ priceRef }
+						style={ { minHeight: `${ minPriceHeight }px` } }
+					>
+						<div>
+							<div className="hosting-card__price-value">
+								{ translate( 'Starting at %(priceStartingAt)s', {
+									args: { priceStartingAt },
+								} ) }
+							</div>
+							<div className="hosting-card__price-interval">{ priceIntervalDescription }</div>
+						</div>
+						{ highestDiscountPercentage ? (
+							<div className="hosting-card__price-discount">
+								{ translate( 'Volume savings up to %(highestDiscountPercentage)s%', {
+									args: { highestDiscountPercentage: Math.trunc( highestDiscountPercentage ) },
+								} ) }
+							</div>
+						) : null }
+					</div>
+				) }
 
 				{ exploreButton }
 			</div>
@@ -198,22 +242,13 @@ export default function HostingCard( {
 							<SimpleList items={ features } />
 						</div>
 					) }
-					{ plan.family_slug === 'vip' && (
-						<div className="hosting-card__section">
-							<div className="hosting-card__logos">
-								<TimeLogo />
-								<SlackLogo />
-								<DisneyLogo />
-								<CNNLogo />
-								<SalesforceLogo />
-								<FacebookLogo />
-								<CondenastLogo />
-								<BloombergLogo />
-							</div>
-						</div>
-					) }
 				</>
 			) }
+
+			<div className="hosting-card__footer">
+				<span>{ footerText }</span>
+				{ getHostingLogo( plan.family_slug, false ) }
+			</div>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -1,20 +1,42 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .is-group-a8c-for-agencies {
 	.hosting-card {
 		border: 1px solid var(--color-neutral-10);
 		border-radius: 4px;
 		user-select: none;
 		padding: 0;
+		position: relative;
+		padding-bottom: 46px;
 
 		.button {
 			width: 100%;
 		}
 
 		.woo-logo {
-			margin: 0;
+			margin: -4px 2px;
 
 			path {
 				fill: var(--color-woocommerce);
 			}
+		}
+
+		@include break-huge {
+			padding-bottom: 32px;
+		}
+	}
+
+	.hosting-card__heading {
+		font-size: rem(24px);
+		font-weight: 600;
+		max-width: 90%;
+
+		@include break-large {
+			height: 95px;
+		}
+		@include break-huge {
+			height: 65px;
 		}
 	}
 
@@ -35,6 +57,7 @@
 		flex-direction: column;
 		flex-wrap: wrap;
 		gap: 8px;
+		height: 110px;
 	}
 
 	.hosting-card__price-value {
@@ -59,12 +82,18 @@
 	}
 
 	.hosting-card__description {
-		font-size: 1rem;
+		font-size: rem(16px);
 		line-height: 1.3;
 		font-weight: 400;
-		min-height: 62px;
 		margin: 0;
 		color: var(--studio-gray-80, #2c3338);
+
+		@include break-large {
+			height: 85px;
+		}
+		@include break-huge {
+			height: 65px;
+		}
 	}
 
 	.hosting-card__header {
@@ -119,10 +148,84 @@
 		gap: 16px;
 		max-width: 300px;
 		margin: 0 auto;
+		padding-block: 0;
+		height: 150px;
 
 		svg {
-			flex-basis: 88px;
-			height: 48px;
+			flex-basis: 54px;
+			height: 42px;
+
+			@include break-xlarge {
+				flex-basis: 56px;
+			}
+
+			@include break-wide {
+				flex-basis: 48px;
+				height: 28px;
+			}
+
+			@include break-huge {
+				flex-basis: 60px;
+				height: 28px;
+			}
+		}
+
+		@include break-wide {
+			height: 110px;
 		}
 	}
 }
+
+.hosting-list__vip-card .hosting-card__logo-section {
+	padding-block: 0;
+	margin: auto;
+}
+
+.hosting-card__footer {
+	position: absolute;
+	bottom: 8px;
+	width: 100%;
+	text-align: right;
+
+	span {
+		font-size: rem(12px);
+		color: var(--studio-gray-50);
+		margin-inline-end: 6px;
+	}
+
+	img {
+		width: 100px;
+		margin-inline-end: 6px;
+		position: relative;
+		top: 4px;
+		right: 2px;
+
+		@include break-huge {
+			width: 130px;
+			top: 6px;
+		}
+	}
+
+	.wordpress-vip-logo {
+		display: inline-block;
+
+		svg {
+			width: 50px;
+			margin-inline-end: 6px;
+			position: relative;
+			top: 10px;
+		}
+	}
+}
+
+.hosting-card__check-icon {
+	position: absolute;
+	right: 16px;
+	top: 16px;
+	background: var(--color-success);
+	fill: var(--color-text-white);
+	border-radius: 50%;
+	width: 25px;
+	height: 25px;
+}
+

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -4,6 +4,7 @@ import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { APIProductFamily } from 'calypso/state/partner-portal/types';
@@ -109,9 +110,10 @@ export default function HostingList( { selectedSite }: Props ) {
 			<ListingSection
 				title={ translate( 'Hosting' ) }
 				description={ translate(
-					'Choose the hosting that suits your needs from our best-in-class offerings.'
+					'Choose from a variety of world-class managed hosting that will scale with your business.'
 				) }
 				isTwoColumns
+				extraContent={ <MigrationOffer foldable /> }
 			>
 				{ creatorPlan && (
 					<HostingCard

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -143,7 +143,7 @@ export default function HostingList( { selectedSite }: Props ) {
 			{ isWPCOMOptionEnabled && (
 				<Card className="hosting-list__features">
 					<h3 className="hosting-list__features-heading">
-						{ translate( 'Included with WordPress.com and Pressable plans' ) }
+						{ translate( 'Included with Standard & Premier hosting' ) }
 					</h3>
 					<SimpleList
 						className="hosting-list__features-list"
@@ -159,7 +159,7 @@ export default function HostingList( { selectedSite }: Props ) {
 							<li>{ translate( 'SFTP/SSH, WP-CLI, Git tools' ) }</li>,
 							<li>{ translate( '10 PHP workers with auto-scaling' ) }</li>,
 							<li>{ translate( 'Resource isolation across every site' ) }</li>,
-							<li>{ translate( 'Real-time cloud backups via Jetpack' ) }</li>,
+							<li>{ translate( 'Jetpack real-time backups' ) }</li>,
 						] }
 					/>
 				</Card>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
@@ -26,11 +26,6 @@
 	border: 1px solid var(--color-neutral-10);
 	box-shadow: none;
 	border-radius: 4px;
-	margin: auto;
-
-	@include break-wide {
-		width: calc(66.666% - 6px);
-	}
 }
 
 .hosting-list__features-heading {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
@@ -22,7 +22,7 @@
 	border: 1px solid var(--color-neutral-10);
 	box-shadow: none;
 	border-radius: 4px;
-	margin: 0;
+	margin: auto;
 
 	@include break-wide {
 		width: calc(66.666% - 6px);

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
@@ -3,6 +3,10 @@
 
 .hosting-list {
 	justify-content: flex-start;
+
+	.card.foldable-card.a4a-migration-offer__wrapper {
+		margin-block: 4px 32px;
+	}
 }
 
 .hosting-list__placeholder {

--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -57,7 +57,7 @@ export function getHostingPageUrl( slug: string ) {
  * @param {string} slug - Hosting provider slug
  * @returns {Element} - Hosting provider logo
  */
-export function getHostingLogo( slug: string ) {
+export function getHostingLogo( slug: string, showText = true ) {
 	switch ( slug ) {
 		case 'pressable-hosting':
 			return <img src={ PressableLogo } alt="" />;
@@ -67,7 +67,7 @@ export function getHostingLogo( slug: string ) {
 			return (
 				<div className="wordpress-vip-logo">
 					<VIPLogo height={ 30 } width={ 67 } />
-					{ translate( '(Enterprise)' ) }
+					{ showText && translate( '(Enterprise)' ) }
 				</div>
 			);
 	}

--- a/client/a8c-for-agencies/sections/marketplace/listing-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/listing-section/index.tsx
@@ -10,6 +10,7 @@ type Props = {
 	description: string;
 	children: ReactNode;
 	isTwoColumns?: boolean;
+	extraContent?: ReactNode;
 };
 
 export default function ListingSection( {
@@ -19,6 +20,7 @@ export default function ListingSection( {
 	description,
 	children,
 	isTwoColumns,
+	extraContent,
 }: Props ) {
 	return (
 		<div
@@ -30,6 +32,8 @@ export default function ListingSection( {
 				<span>{ title }</span>
 			</h2>
 			<p className="listing-section-description">{ description }</p>
+
+			{ extraContent }
 
 			<div className="listing-section-content">{ children }</div>
 		</div>

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -415,16 +415,16 @@ html {
 	}
 }
 
-.gray-tooltip {
+.popover.tooltip.gray-tooltip {
 	.popover__arrow {
 		&::before {
-			border-bottom-color: var(--studio-gray-60) !important;
-			inset-block-start: 1px !important;
+			border-bottom-color: var(--color-accent-60);
+			inset-block-start: 1px;
 		}
 	}
 	.popover__inner {
-		background: var(--studio-gray-60);
-		color: var(--studio-white);
+		background: var(--color-accent-60);
+		color: var(--color-text-white);
 		padding: 10px 12px;
 		border: none;
 	}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -414,3 +414,18 @@ html {
 		}
 	}
 }
+
+.gray-tooltip {
+	.popover__arrow {
+		&::before {
+			border-bottom-color: var(--studio-gray-60) !important;
+			inset-block-start: 1px !important;
+		}
+	}
+	.popover__inner {
+		background: var(--studio-gray-60);
+		color: var(--studio-white);
+		padding: 10px 12px;
+		border: none;
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-roadmap/issues/1563

## Proposed Changes

This PR redesigns the hosting marketplace page

## Testing Instructions

1. Open the A4A live link.
2. Visit the Marketplace > Hosting page and verify the UI is redesigned as shown below and matches with the latest design (link on the ticket). Also, verify it works well on the screen sizes. 

![screencapture-agencies-localhost-3000-marketplace-hosting-2024-05-20-17_22_42](https://github.com/Automattic/wp-calypso/assets/10586875/676ff334-1f2f-4eb7-a662-4662c29859e5)

<img width="466" alt="Screenshot 2024-05-20 at 5 25 11 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/db64014c-3447-4988-837d-f21efed26c2f">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
