### PR TITLE
Stats: Allow VideoPress subscribers to use Jetpack Stats commercial

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -34,7 +34,7 @@ const filterPurchasesByProducts = ( ownedPurchases: Purchase[], productSlugs: st
 const isProductOwned = ( ownedPurchases: Purchase[], searchedProduct: string ) => {
 	return filterPurchasesByProducts( ownedPurchases, [ searchedProduct ] ).length > 0;
 };
-const isProductsOwned = ( ownedPurchases: Purchase[], searchedProducts: string[] ) => {
+const areProductsOwned = ( ownedPurchases: Purchase[], searchedProducts: string[] ) => {
 	return filterPurchasesByProducts( ownedPurchases, searchedProducts ).length > 0;
 };
 

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -55,7 +55,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 	}, [ sitePurchases ] );
 
 	const isCommercialOwned = useMemo( () => {
-		return isProductsOwned( sitePurchases, [
+		return areProductsOwned( sitePurchases, [
 			...JETPACK_VIDEOPRESS_PRODUCTS,
 			PRODUCT_JETPACK_STATS_MONTHLY,
 			PRODUCT_JETPACK_STATS_YEARLY,

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -1,5 +1,6 @@
 import {
 	JETPACK_COMPLETE_PLANS,
+	JETPACK_VIDEOPRESS_PRODUCTS,
 	PRODUCT_JETPACK_STATS_BI_YEARLY,
 	PRODUCT_JETPACK_STATS_FREE,
 	PRODUCT_JETPACK_STATS_MONTHLY,
@@ -33,6 +34,9 @@ const filterPurchasesByProducts = ( ownedPurchases: Purchase[], productSlugs: st
 const isProductOwned = ( ownedPurchases: Purchase[], searchedProduct: string ) => {
 	return filterPurchasesByProducts( ownedPurchases, [ searchedProduct ] ).length > 0;
 };
+const isProductsOwned = ( ownedPurchases: Purchase[], searchedProducts: string[] ) => {
+	return filterPurchasesByProducts( ownedPurchases, searchedProducts ).length > 0;
+};
 
 const getPurchasesBySiteId = createSelector(
 	( state, siteId ) => getSitePurchases( state, siteId ),
@@ -51,11 +55,12 @@ export default function useStatsPurchases( siteId: number | null ) {
 	}, [ sitePurchases ] );
 
 	const isCommercialOwned = useMemo( () => {
-		return (
-			isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_MONTHLY ) ||
-			isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_YEARLY ) ||
-			isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_BI_YEARLY )
-		);
+		return isProductsOwned( sitePurchases, [
+			...JETPACK_VIDEOPRESS_PRODUCTS,
+			PRODUCT_JETPACK_STATS_MONTHLY,
+			PRODUCT_JETPACK_STATS_YEARLY,
+			PRODUCT_JETPACK_STATS_BI_YEARLY,
+		] );
 	}, [ sitePurchases ] );
 
 	const isPWYWOwned = useMemo( () => {


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/30

## Proposed Changes

Treat VideoPress subscriptions just like Jetpack Stats commercial. We'll remove the logic when we figure out a way to allow VideoPress users to look at video stats, which is likely to be another tab(?)

## Testing Instructions

* Enable VideoPress + Jetpack on your local
* Build Odyssey Stats for `fix/allow-paid-vp-use-stats`
* Remove any Jetpack Stats products from the site
* Purchase a VideoPress product
* Ensure users are able to view Jetapck Stats like they are commercial plan subscribers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?