### PR TITLE
Stats: Remove "month" related copy text for Stats plan usage

### DIFF
--- a/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
@@ -47,7 +47,7 @@ const TierUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const isOverLimit = tierLimit ? currentUsage / tierLimit >= 1 : false;
 
 	const bannerTitle = isOverLimit
-		? translate( 'You have reached your monthly views limit' )
+		? translate( 'You have reached your views limit' )
 		: translate( 'You are nearing your monthly limit' );
 	const bannerBody = isOverLimit
 		? translate(

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -56,7 +56,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 
 	if ( overLimitMonths && overLimitMonths >= 2 ) {
 		overLimitMonthsText = translate(
-			"{{bold}}You've surpassed your limit for two consecutive months already.{{/bold}} ",
+			"{{bold}}You've surpassed your limit for two consecutive periods already.{{/bold}} ",
 			{
 				components: {
 					bold: <b />,
@@ -66,7 +66,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 	}
 
 	const upgradeNote = translate(
-		'Do you want to increase your monthly views limit? {{link}}Upgrade now{{/link}}',
+		'Do you want to increase your views limit? {{link}}Upgrade now{{/link}}',
 		{
 			components: {
 				link: <a href={ upgradeLink } />,
@@ -83,7 +83,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 					style={ { width: `${ progressWidthInPercentage }%` } }
 				></div>
 				<div>
-					{ translate( '%(numberOfUsage)s / %(numberOfLimit)s views this month', {
+					{ translate( '%(numberOfUsage)s / %(numberOfLimit)s views', {
 						args: {
 							numberOfUsage: formattedNumber( usage ),
 							numberOfLimit: formattedNumber( limit ),

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -128,7 +128,7 @@ const StatsBenefitsCommercial = () => {
 			>
 				<div className="stats-purchase__info-popover-content">
 					{ translate(
-						'You will only be prompted to upgrade to higher tiers when you exceed the limit for three consecutive months.' // TODO: We need a 'learn more' link here.
+						'You will only be prompted to upgrade to higher tiers when you exceed the limit for three consecutive periods.' // TODO: We need a 'learn more' link here.
 					) }
 				</div>
 			</Popover>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/1

## Proposed Changes

* Remove `month` related copy text on the Stats plan usage section to avoid confusion.

|Before|After|
|-|-|
|<img width="1268" alt="截圖 2024-05-17 下午4 21 58" src="https://github.com/Automattic/wp-calypso/assets/6869813/553399c2-5dbc-460d-8b22-55314608d410">|<img width="1273" alt="截圖 2024-05-17 下午4 21 45" src="https://github.com/Automattic/wp-calypso/assets/6869813/6e3f1670-12a5-45f3-9d23-25c5673f2550">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Try to avoid confusing users about the billing period of Stats plan usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live link.
* Navigate to Stats > Traffic page.
* Ensure there is no more `month` related copy text on the Stats plan usage section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
