### PR TITLE
Onboarding: Fix the browser back button redirects people to the plan step

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -225,13 +225,6 @@ export default {
 			return;
 		}
 
-		if ( context.pathname !== getValidPath( context.params, userLoggedIn ) ) {
-			return page.redirect(
-				getValidPath( context.params, userLoggedIn ) +
-					( context.querystring ? '?' + context.querystring : '' )
-			);
-		}
-
 		store.set( 'signup-locale', localeFromParams );
 
 		/**
@@ -259,6 +252,22 @@ export default {
 			// Force display of the new user survey for the onboarding flow
 			initialContext.isSignupSurveyActive = true;
 		}
+
+		// We have to filter out the new user survey at the beginning.
+		// Otherwise, calypso will redirect the user to the next step
+		// when they come back from the browser back button.
+		// See https://github.com/Automattic/dotcom-forge/issues/7232.
+		if ( ! initialContext.isSignupSurveyActive ) {
+			flows.excludeStep( 'new-user-survey' );
+		}
+
+		if ( context.pathname !== getValidPath( context.params, userLoggedIn ) ) {
+			return page.redirect(
+				getValidPath( context.params, userLoggedIn ) +
+					( context.querystring ? '?' + context.querystring : '' )
+			);
+		}
+
 		next();
 	},
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7232

## Proposed Changes

* The issue is the new user survey step was dynamically excluded by the [excludeSurveyStepIfInactive](https://github.com/Automattic/wp-calypso/blob/5aa32b5f462e91b3c844033877b2b3548cf06f67/client/lib/signup/step-actions/index.js#L1219) when the `fulfilledStepCallback` was triggered. However, we [redirected people to the first step](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/controller.js#L229) when they entered the flow, so the URL was recorded by the browser. Next, people got back to the new user survey step when they clicked the browser back button. The step was excluded so calypso [redirected the user to the next step](https://github.com/Automattic/wp-calypso/blob/ac2dafe65bc0aebde0e9b74361d06b39dbd212f8/client/signup/main.jsx#L484), that was the "Plan" step 💥  
* As a result, this PR made a change to check whether the new user survey step is available, and then do the first redirection to resolve this issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /sites
2. Click Add new site
3. Click anywhere on that page
4. Go back using the browser back button
5. Make sure it redirects you back to the /sites page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
