### PR TITLE
Automattic for Agencies: Enable Downtime Monitoring for Atomic sites from the Sites dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -147,8 +147,8 @@ export default function ToggleActivateMonitoring( {
 		<ToggleControl
 			onChange={ handleToggleActivateMonitoring }
 			checked={ isChecked }
-			disabled={ site.is_atomic || isLoading || siteError }
-			label={ ! site.is_atomic && isChecked && currentSettings() }
+			disabled={ isLoading || siteError }
+			label={ isChecked && currentSettings() }
 		/>
 	);
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -99,19 +99,18 @@ export default function MonitorActivity( { hasMonitor, site, trackEvent, hasErro
 		<ExpandedCard
 			header={ translate( 'Monitor activity' ) }
 			isEnabled={ hasMonitor }
-			emptyContent={
-				site.is_atomic
-					? translate( 'Monitoring is managed by WordPress.com' )
-					: translate( 'Activate {{strong}}Monitor{{/strong}} to see your uptime records', {
-							components: {
-								strong: <strong></strong>,
-							},
-					  } )
-			}
+			emptyContent={ translate(
+				'Activate {{strong}}Monitor{{/strong}} to see your uptime records',
+				{
+					components: {
+						strong: <strong></strong>,
+					},
+				}
+			) }
 			isLoading={ isLoading }
 			hasError={ hasError }
 			// Allow to click on the card only if the monitor is not active & the site is not atomic
-			onClick={ ! hasMonitor && ! site.is_atomic ? handleOnClick : undefined }
+			onClick={ ! hasMonitor ? handleOnClick : undefined }
 		>
 			{ hasMonitor && <MonitorDataContent siteId={ site.blog_id } /> }
 		</ExpandedCard>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-tooltip.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-tooltip.ts
@@ -54,8 +54,6 @@ const useTooltip = ( type: AllowedRowType, rows: SiteData ): TranslateResult | u
 	// Backup and the site does not have a backup subscription https://href.li/?https://wp.me/pbuNQi-1jg
 	const isMultisiteSupported = useIsMultisiteSupported( rows?.site?.value, type );
 
-	const isAtomicSite = rows?.site?.value?.is_atomic;
-
 	const translate = useTranslate();
 
 	return useMemo( () => {
@@ -64,12 +62,8 @@ const useTooltip = ( type: AllowedRowType, rows: SiteData ): TranslateResult | u
 			return translate( 'Not supported on multisite' );
 		}
 
-		if ( isAtomicSite && ( type === 'site' || type === 'monitor' ) ) {
-			return translate( 'Monitoring is managed by WordPress.com' );
-		}
-
 		return ALL_TOOLTIPS[ type ]?.[ row?.status ]?.( translate );
-	}, [ isAtomicSite, isMultisiteSupported, rows, translate, type ] );
+	}, [ isMultisiteSupported, rows, translate, type ] );
 };
 
 export default useTooltip;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/500

## Proposed Changes

We initially disabled downtime monitoring for atomic sites from A4A (then Jetpack Manage). Now, we are enabling it because it works as expected. 

More details: pdKhl6-3EA-p2#comment-6549

This PR enables Downtime Monitoring for Atomic sites from the Sites dashboard

## Testing Instructions

1. Open the A4A live link.
2. Go to the Sites dashboard > Verify that the monitor toggle is not disabled for an Atomic site, and you can enable/disable it and change the notification settings. Verify the status gets updated on WordPress.com (https://wordpress.com/settings/security/site-url) when you update from A4A and vice-versa

<img width="321" alt="Screenshot 2024-05-17 at 4 08 57 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/34eecf82-9259-4465-9f4a-cbb374f30126">

4. Open any site details on a preview panel > Open the Monitor tab > Verify that the monitoring data is shown. Also, verify that you can enable monitor from the monitor tab when it is not enabled. 

<img width="986" alt="Screenshot 2024-05-17 at 4 09 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/42628afc-ee63-4961-8e0a-5653bd454020">

<img width="966" alt="Screenshot 2024-05-17 at 4 14 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/946258bf-589f-4b01-804f-24e921336f5f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?