### PR TITLE
Update nav redesign overview plan card

### DIFF
--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -1,5 +1,8 @@
 .plan-storage {
 	display: flex;
+	&:visited {
+		color: var(--studio-gray-80);
+	}
 }
 
 .plan-storage__bar {

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -1,4 +1,4 @@
-import { PlanSlug, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import { isJetpackProductSlug, PlanSlug, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
@@ -158,18 +158,20 @@ const PlanCard: FC = () => {
 				<div className="hosting-overview__plan-card-header">
 					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
 
-					<Button
-						className={ classNames(
-							'hosting-overview__link-button',
-							'hosting-overview__mobile-hidden-link-button'
-						) }
-						plain
-						href={
-							isFreePlan ? `/add-ons/${ site?.slug }` : `/purchases/subscriptions/${ site?.slug }`
-						}
-					>
-						{ isFreePlan ? translate( 'Manage add-ons' ) : translate( 'Manage plan' ) }
-					</Button>
+					{ isJetpackProductSlug( planDetails?.product_slug ?? '' ) && (
+						<Button
+							className={ classNames(
+								'hosting-overview__link-button',
+								'hosting-overview__mobile-hidden-link-button'
+							) }
+							plain
+							href={
+								isFreePlan ? `/add-ons/${ site?.slug }` : `/purchases/subscriptions/${ site?.slug }`
+							}
+						>
+							{ isFreePlan ? translate( 'Manage add-ons' ) : translate( 'Manage plan' ) }
+						</Button>
+					) }
 				</div>
 				<PricingSection />
 				<PlanStorage

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -3,7 +3,6 @@ import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { formatCurrency } from '@automattic/format-currency';
-import { SiteExcerptNetworkData } from '@automattic/sites';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -14,7 +13,6 @@ import { HostingCard } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
-import { isP2Site } from 'calypso/sites-dashboard/utils';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -146,7 +144,6 @@ const PlanCard: FC = () => {
 	const planDetails = site?.plan;
 	const planName = planDetails?.product_name_short ?? '';
 	const isFreePlan = planDetails?.is_free;
-	const isP2Plan = isP2Site( site as SiteExcerptNetworkData );
 
 	// Check for storage addons available for purchase.
 	const addOns = AddOns.useAddOns( { selectedSiteId: site?.ID } );
@@ -159,7 +156,7 @@ const PlanCard: FC = () => {
 			<QuerySitePlans siteId={ site?.ID } />
 			<HostingCard className="hosting-overview__plan">
 				<div className="hosting-overview__plan-card-header">
-					<h3 className="hosting-overview__plan-card-title">{ isP2Plan ? 'P2' : planName }</h3>
+					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
 
 					{ isJetpackProductSlug( planDetails?.product_slug ?? '' ) && (
 						<Button

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -162,26 +162,37 @@ const PlanCard: FC = () => {
 		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE && ! addOn?.exceedsSiteStorageLimits
 	);
 	const renderManageButton = () => {
-		if ( ! isOwner || isJetpack || ! site || ! planPurchaseId ) {
+		if ( isJetpack || ! site ) {
 			return false;
 		}
-		return (
-			<Button
-				className={ classNames(
-					'hosting-overview__link-button',
-					'hosting-overview__mobile-hidden-link-button'
-				) }
-				plain
-				disabled
-				href={
-					isFreePlan
-						? `/add-ons/${ site?.slug }`
-						: getManagePurchaseUrlFor( site?.slug, planPurchaseId )
-				}
-			>
-				{ isFreePlan ? translate( 'Manage add-ons' ) : translate( 'Manage plan' ) }
-			</Button>
-		);
+		if ( isFreePlan ) {
+			return (
+				<Button
+					className={ classNames(
+						'hosting-overview__link-button',
+						'hosting-overview__mobile-hidden-link-button'
+					) }
+					plain
+					href={ `/add-ons/${ site?.slug }` }
+				>
+					{ translate( 'Manage add-ons' ) }
+				</Button>
+			);
+		}
+		if ( isOwner ) {
+			return (
+				<Button
+					className={ classNames(
+						'hosting-overview__link-button',
+						'hosting-overview__mobile-hidden-link-button'
+					) }
+					plain
+					href={ getManagePurchaseUrlFor( site?.slug, planPurchaseId ?? 0 ) }
+				>
+					{ translate( 'Manage plan' ) }
+				</Button>
+			);
+		}
 	};
 
 	return (

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -14,6 +14,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
+import { isStagingSite } from 'calypso/sites-dashboard/utils';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -151,6 +152,7 @@ const PlanCard: FC = () => {
 	const isJetpack = useSelector( ( state ) =>
 		isJetpackSite( state, site?.ID, { treatAtomicAsJetpackSite: false } )
 	);
+	const isStaging = isStagingSite( site ?? undefined );
 	const isOwner = planDetails?.user_is_owner;
 	const planPurchaseId = useSelector( ( state: IAppState ) =>
 		getCurrentPlanPurchaseId( state, site?.ID ?? 0 )
@@ -162,7 +164,7 @@ const PlanCard: FC = () => {
 		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE && ! addOn?.exceedsSiteStorageLimits
 	);
 	const renderManageButton = () => {
-		if ( isJetpack || ! site ) {
+		if ( isJetpack || ! site || isStaging ) {
 			return false;
 		}
 		if ( isFreePlan ) {
@@ -200,28 +202,34 @@ const PlanCard: FC = () => {
 			<QuerySitePlans siteId={ site?.ID } />
 			<HostingCard className="hosting-overview__plan">
 				<div className="hosting-overview__plan-card-header">
-					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
+					<h3 className="hosting-overview__plan-card-title">
+						{ isStaging ? translate( 'Staging site' ) : planName }
+					</h3>
 					{ renderManageButton() }
 				</div>
-				<PricingSection />
-				<PlanStorage
-					className="hosting-overview__plan-storage"
-					hideWhenNoStorage
-					siteId={ site?.ID }
-					StorageBarComponent={ PlanStorageBar }
-				>
-					{ storageAddons.length > 0 && (
-						<div className="hosting-overview__plan-storage-footer">
-							<Button
-								className="hosting-overview__link-button"
-								plain
-								href={ `/add-ons/${ site?.slug }` }
-							>
-								{ translate( 'Need more storage?' ) }
-							</Button>
-						</div>
-					) }
-				</PlanStorage>
+				{ ! isStaging && (
+					<>
+						<PricingSection />
+						<PlanStorage
+							className="hosting-overview__plan-storage"
+							hideWhenNoStorage
+							siteId={ site?.ID }
+							StorageBarComponent={ PlanStorageBar }
+						>
+							{ storageAddons.length > 0 && (
+								<div className="hosting-overview__plan-storage-footer">
+									<Button
+										className="hosting-overview__link-button"
+										plain
+										href={ `/add-ons/${ site?.slug }` }
+									>
+										{ translate( 'Need more storage?' ) }
+									</Button>
+								</div>
+							) }
+						</PlanStorage>
+					</>
+				) }
 			</HostingCard>
 		</>
 	);

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -3,6 +3,7 @@ import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { formatCurrency } from '@automattic/format-currency';
+import { SiteExcerptNetworkData } from '@automattic/sites';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -13,6 +14,7 @@ import { HostingCard } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
+import { isP2Site } from 'calypso/sites-dashboard/utils';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -144,6 +146,7 @@ const PlanCard: FC = () => {
 	const planDetails = site?.plan;
 	const planName = planDetails?.product_name_short ?? '';
 	const isFreePlan = planDetails?.is_free;
+	const isP2Plan = isP2Site( site as SiteExcerptNetworkData );
 
 	// Check for storage addons available for purchase.
 	const addOns = AddOns.useAddOns( { selectedSiteId: site?.ID } );
@@ -156,7 +159,7 @@ const PlanCard: FC = () => {
 			<QuerySitePlans siteId={ site?.ID } />
 			<HostingCard className="hosting-overview__plan">
 				<div className="hosting-overview__plan-card-header">
-					<h3 className="hosting-overview__plan-card-title">{ planName }</h3>
+					<h3 className="hosting-overview__plan-card-title">{ isP2Plan ? 'P2' : planName }</h3>
 
 					{ isJetpackProductSlug( planDetails?.product_slug ?? '' ) && (
 						<Button

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -16,15 +16,14 @@ import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const PlanCard: FC = () => {
+const PricingSection: FC = () => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
-	const planName = planDetails?.product_name_short ?? '';
 	const planSlug = ( planDetails?.product_slug || '' ) as PlanSlug;
-	const isPaidPlan = ! planDetails?.is_free;
 	const planData = useSelector( ( state ) => getCurrentPlan( state, site?.ID ) );
+	const isFreePlan = planDetails?.is_free;
 	const pricing = usePricingMetaForGridPlans( {
 		coupon: undefined,
 		planSlugs: [ planSlug ],
@@ -32,14 +31,125 @@ const PlanCard: FC = () => {
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );
+	const isLoading = ! pricing || ! planData;
+
+	const getBillingDetails = () => {
+		if ( isFreePlan ) {
+			return null;
+		}
+		return translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
+			args: {
+				rawPrice: formatCurrency(
+					pricing?.[ planSlug ].originalPrice.full ?? 0,
+					planData?.currencyCode ?? '',
+					{
+						stripZeros: true,
+						isSmallestUnit: true,
+					}
+				),
+			},
+			components: {
+				span: <span />,
+			},
+		} );
+	};
+
+	const getExpireDetails = () => {
+		if ( isFreePlan ) {
+			return translate( 'No expiration date.' );
+		}
+		return site?.plan?.expired
+			? translate( 'Your plan has expired.' )
+			: translate( 'Expires on %s.', {
+					args: moment( planData?.expiryDate ).format( 'LL' ),
+			  } );
+	};
+
+	return (
+		<>
+			{ isLoading ? (
+				<LoadingPlaceholder
+					className="hosting-overview__plan-price-loading-placeholder"
+					width="100px"
+					height="32px"
+				/>
+			) : (
+				<div className="hosting-overview__plan-price-wrapper">
+					<PlanPrice
+						className="hosting-overview__plan-price"
+						currencyCode={ planData?.currencyCode }
+						isSmallestUnit
+						rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
+					/>
+					<span className="hosting-overview__plan-price-term">
+						{ translate( '/mo', {
+							comment: '/mo is short for per month, referring to the monthly price of a site plan',
+						} ) }
+					</span>
+				</div>
+			) }
+			{ isLoading ? (
+				<LoadingPlaceholder
+					className="hosting-overview__plan-info-loading-placeholder"
+					width="200px"
+					height="16px"
+				/>
+			) : (
+				<div className="hosting-overview__plan-info">{ getBillingDetails() }</div>
+			) }
+			{ isLoading ? (
+				<LoadingPlaceholder
+					className="hosting-overview__plan-info-loading-placeholder"
+					width="200px"
+					height="16px"
+				/>
+			) : (
+				<div
+					className={ classNames( 'hosting-overview__plan-info', {
+						'is-expired': site?.plan?.expired,
+					} ) }
+				>
+					{ getExpireDetails() }
+					<div className="hosting-overview__plan-cta">
+						{ isFreePlan && (
+							<Button primary compact href={ `/plans/${ site?.slug }` }>
+								{ translate( 'Upgrade your plan' ) }
+							</Button>
+						) }
+						{ site?.plan?.expired && (
+							<>
+								<Button compact href={ `/plans/${ site?.slug }` }>
+									{ translate( 'See all plans' ) }
+								</Button>
+								<Button
+									style={ { marginLeft: '8px' } }
+									primary
+									compact
+									href={ `/checkout/${ site?.slug }/${ planData.productSlug }` }
+								>
+									{ translate( 'Renew plan' ) }
+								</Button>
+							</>
+						) }
+					</div>
+				</div>
+			) }
+		</>
+	);
+};
+
+const PlanCard: FC = () => {
+	const translate = useTranslate();
+	const site = useSelector( getSelectedSite );
+	const planDetails = site?.plan;
+	const planName = planDetails?.product_name_short ?? '';
+	const isFreePlan = planDetails?.is_free;
 
 	// Check for storage addons available for purchase.
 	const addOns = AddOns.useAddOns( { selectedSiteId: site?.ID } );
 	const storageAddons = addOns.filter(
 		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE && ! addOn?.exceedsSiteStorageLimits
 	);
-
-	const isLoading = ! pricing || ! planData;
 
 	return (
 		<>
@@ -54,81 +164,14 @@ const PlanCard: FC = () => {
 							'hosting-overview__mobile-hidden-link-button'
 						) }
 						plain
-						href={ `/plans/${ site?.slug }` }
+						href={
+							isFreePlan ? `/add-ons/${ site?.slug }` : `/purchases/subscriptions/${ site?.slug }`
+						}
 					>
-						{ translate( 'Manage plan' ) }
+						{ isFreePlan ? translate( 'Manage add-ons' ) : translate( 'Manage plan' ) }
 					</Button>
 				</div>
-				{ isPaidPlan && (
-					<>
-						{ isLoading ? (
-							<LoadingPlaceholder
-								className="hosting-overview__plan-price-loading-placeholder"
-								width="100px"
-								height="32px"
-							/>
-						) : (
-							<div className="hosting-overview__plan-price-wrapper">
-								<PlanPrice
-									className="hosting-overview__plan-price"
-									currencyCode={ planData?.currencyCode }
-									isSmallestUnit
-									rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
-								/>
-								<span className="hosting-overview__plan-price-term">
-									{ translate( '/mo', {
-										comment:
-											'/mo is short for per month, referring to the monthly price of a site plan',
-									} ) }
-								</span>
-							</div>
-						) }
-						{ isLoading ? (
-							<LoadingPlaceholder
-								className="hosting-overview__plan-info-loading-placeholder"
-								width="200px"
-								height="16px"
-							/>
-						) : (
-							<div className="hosting-overview__plan-info">
-								{ translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
-									args: {
-										rawPrice: formatCurrency(
-											pricing?.[ planSlug ].originalPrice.full ?? 0,
-											planData?.currencyCode ?? '',
-											{
-												stripZeros: true,
-												isSmallestUnit: true,
-											}
-										),
-									},
-									components: {
-										span: <span />,
-									},
-								} ) }
-							</div>
-						) }
-						{ isLoading ? (
-							<LoadingPlaceholder
-								className="hosting-overview__plan-info-loading-placeholder"
-								width="200px"
-								height="16px"
-							/>
-						) : (
-							<div
-								className={ classNames( 'hosting-overview__plan-info', {
-									'is-expired': site?.plan?.expired,
-								} ) }
-							>
-								{ site?.plan?.expired
-									? translate( 'Expired' )
-									: translate( 'Expires on %s.', {
-											args: moment( planData?.expiryDate ).format( 'LL' ),
-									  } ) }
-							</div>
-						) }
-					</>
-				) }
+				<PricingSection />
 				<PlanStorage
 					className="hosting-overview__plan-storage"
 					hideWhenNoStorage
@@ -142,7 +185,7 @@ const PlanCard: FC = () => {
 								plain
 								href={ `/add-ons/${ site?.slug }` }
 							>
-								{ translate( 'Need more storage?' ) }
+								{ translate( 'Need more space?' ) }
 							</Button>
 						</div>
 					) }

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -157,6 +157,10 @@ a.hosting-overview__link-button {
 	margin-bottom: 4px;
 }
 
+.hosting-overview__plan-cta {
+	margin-top: 8px;
+}
+
 .hosting-overview__plan-storage {
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-0);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7205

## Proposed Changes

### Free plan
* Add "Upgrade your plan" CTA button
* Add 0 dollars for currency
* Add "No expiration date"
* Change "Mange plan" to "Manage add-ons"


### Expired plan
* Add "See all plans" and "Renew now" CTA buttons


### Where each link/button goes

- "Renew plan" goes to the checkout page directly.
- "See all plans" goes to the /plans/:site page.
- "Manage plan" goes to /purchases/subscription/:site
- "Manage add-ons" goes to /add-ons/:site

### Other changes
- "Need more storage?" -> "Need more space?"

#### Jetpack site ("Upgrade your plan" CTA will list Jetpack upgrades)
![jetpack](https://github.com/Automattic/wp-calypso/assets/6586048/9b9f5a21-decb-4333-b746-219c6538cb2d)

#### Legacy Creator/Business plan (no storage upsell)
![old creator](https://github.com/Automattic/wp-calypso/assets/6586048/c2bd2af6-e8a8-4c88-b536-fe4f47be9d21)

#### Creator plan
![new creator](https://github.com/Automattic/wp-calypso/assets/6586048/38d7a9b2-3c45-4a87-bad3-78fcdfd63dec)

#### Free plan
![Free](https://github.com/Automattic/wp-calypso/assets/6586048/c53c13b5-e7e1-4a1b-b82b-9234d0d2bffe)

#### Expired legacy Creator/Business plan
![expired](https://github.com/Automattic/wp-calypso/assets/6586048/550bf01f-3ce4-4ad0-9bd7-f9abd9493a41)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To be more consistent and still have upsells available when needed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites, and check out each type of plan type to see if the purposed changes are correct


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
