### PR TITLE
Sites list: Fix table margins

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -2,7 +2,6 @@ import { DESKTOP_BREAKPOINT, WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import classnames from 'classnames';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -254,7 +253,7 @@ const DotcomSitesDataViews = ( {
 		<ItemsDataViews
 			data={ itemsData }
 			isLoading={ isLoading }
-			className={ classnames( 'sites-overview__content', 'is-hiding-navigation' ) }
+			className="sites-overview__content"
 		/>
 	);
 };

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -280,11 +280,6 @@
 				min-height: calc(100vh - 277px); /* Set min-height to prevent the table from shrinking when there are few rows. */
 				max-height: calc(100vh - 255px); /* 255px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
 			}
-
-			.is-hiding-navigation .dataviews-view-table-wrapper {
-				overflow-y: auto;
-				max-height: calc(100vh - 277px); /* 277px is the size of all content above the dataview in table style, which includes our CTA elements, the pagination bottom bar, and an additional 10px margin. */
-			}
 		}
 
 		&.sites-dashboard__layout:not(.preview-hidden) {
@@ -533,10 +528,6 @@
 
 			.sites-overview__content {
 				margin-top: 24px;
-
-				&.is-hiding-navigation {
-					margin-top: 48px; // If there is no navigation bar we need to add a bigger margin.
-				}
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7179

## Proposed Changes

Removes the `is-hiding-navigation` class from the sites list table since apparently was copied from the A4A classes but seems unnecessary for WP.com.

By removing this class, we're effectively fixing an incorrect margin that was applied to the sites list table.

Before | After
--- | ---
<img width="348" alt="Screenshot 2024-05-17 at 15 53 55" src="https://github.com/Automattic/wp-calypso/assets/1233880/1546051f-1ff5-497c-931a-557762060e7d"> | <img width="355" alt="Screenshot 2024-05-17 at 15 54 12" src="https://github.com/Automattic/wp-calypso/assets/1233880/12825e86-65b0-479d-b299-ebc047657d63">
<img width="313" alt="Screenshot 2024-05-17 at 15 54 36" src="https://github.com/Automattic/wp-calypso/assets/1233880/8f83c101-e99f-4f22-8703-209e3e5a1913"> | <img width="331" alt="Screenshot 2024-05-17 at 15 54 43" src="https://github.com/Automattic/wp-calypso/assets/1233880/346787fa-9c6e-4228-9bf7-820760777854">






## Why are these changes being made?

To have a consistent spacing in the sites list table

## Testing Instructions

- Use the Calypso live link below
- Go to `/domains` first and then click on Sites (if you go directly to `/sites` the issue described in https://github.com/Automattic/dotcom-forge/issues/7179 is not reproducible)
- Make sure there is the same space above the search box in both Sites and Domains
- Make sure the footer of the table no longer has an extra padding

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
