### PR TITLE
Nav Redesign: Remove "Manage all domains" and "Manage all sites" buttons

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,7 +1,5 @@
-import { Button } from '@automattic/components';
 import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
 import { Global, css } from '@emotion/react';
-import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -29,11 +27,6 @@ interface BulkAllDomainsProps {
 	analyticsPath: string;
 	analyticsTitle: string;
 }
-
-const ManageAllSitesButton = styled( Button )`
-	white-space: nowrap;
-	height: 40px;
-`;
 
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	const { domains, isLoading } = useDomainsTable( fetchAllDomains );
@@ -245,7 +238,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	};
 
 	const buttons = [
-		<ManageAllSitesButton href="/sites">{ translate( 'Manage all sites' ) }</ManageAllSitesButton>,
 		<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions allDomainsList />,
 	];
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -54,18 +54,6 @@
 		}
 	}
 
-	.sites-manage-all-domains-button {
-		border-color: var(--color-neutral-10);
-
-		@media (max-width: 959px) {
-			margin-inline-end: 8px !important;
-		}
-	}
-
-	.sites-manage-all-domains-button:hover {
-		border-color: var(--color-neutral-20);
-	}
-
 	height: calc(100vh - var(--masterbar-height));
 
 	@media ( min-width: 782px ) {

--- a/client/sites-dashboard-v2/sites-dashboard-header.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard-header.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button, JetpackLogo } from '@automattic/components';
+import { JetpackLogo } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
@@ -49,18 +49,6 @@ const responsiveButtonStyles = {
 	lineHeight: '14px',
 	padding: '0 12px',
 };
-
-const ManageAllDomainsButton = styled( Button )`
-	border-color: var( --color-neutral-5 );
-	border-radius: 2px;
-	margin-inline-end: 1rem;
-	white-space: nowrap;
-
-	.sites-dashboard__layout:not(.preview-hidden) & {
-		${ responsiveButtonStyles }
-		margin-inline-end: 0.5rem;
-	},
-`;
 
 const AddNewSiteSplitButton = styled( SplitButton )< { isMobile: boolean } >`
 	.split-button__main {
@@ -125,9 +113,6 @@ const SitesDashboardHeader = () => {
 	return (
 		<PageHeader>
 			<HeaderControls>
-				<ManageAllDomainsButton className="sites-manage-all-domains-button" href="/domains/manage">
-					{ __( 'Manage all domains' ) }
-				</ManageAllDomainsButton>
 				<AddNewSiteSplitButton
 					className="sites-add-new-site-split-button"
 					primary


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7241

## Proposed Changes

Removes the "Manage all domains" button from `/sites` and the "Manage all sites" button from `/domains/manage` since they are redundant (they are pointing to the same URLs of the Sites and Domains sidebar menus)

Before | After
--- | ---
<img width="1001" alt="Screenshot 2024-05-17 at 16 42 04" src="https://github.com/Automattic/wp-calypso/assets/1233880/5365249f-25b3-49d4-a9df-522cbed65bdb"> | <img width="1000" alt="Screenshot 2024-05-17 at 16 41 50" src="https://github.com/Automattic/wp-calypso/assets/1233880/d5c52223-b48c-47a7-a31c-180664ed9c40">
<img width="998" alt="Screenshot 2024-05-17 at 16 42 10" src="https://github.com/Automattic/wp-calypso/assets/1233880/2e0a3107-3fbf-465f-aca9-01fc493f567f"> | <img width="1002" alt="Screenshot 2024-05-17 at 16 41 43" src="https://github.com/Automattic/wp-calypso/assets/1233880/4b38079f-4f61-4814-a281-49b2cc1d3d0e">


## Why are these changes being made?

To simplify the overall UI

## Testing Instructions

- Use the Calypso live link below
- Go to `/sites`
- Make sure the "Manage all domains" button is gone
- Go to `/domains/manage`
- Make sure the "Manage all sites" button is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
