### PR TITLE
Editor iframe: remove site editor Dashboard link handler

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1020,39 +1020,6 @@ function handleCheckoutModal( calypsoPort ) {
 }
 
 /**
- * Handles the back to Dashboard link after the removal of the previously-used Portal in Gutenberg 14.5
- * @param {MessagePort} calypsoPort Port used for communication with parent frame.
- */
-function handleSiteEditorBackButton( calypsoPort ) {
-	// We use the traversal helper because the target element may be the SVG or an SVG element inside.
-	function traverseToFindLink( element, link, depth = 2 ) {
-		let foundLink = false;
-		while ( depth >= 0 ) {
-			if ( element.tagName.toLowerCase() === 'a' && element?.href === link ) {
-				foundLink = true;
-				break;
-			}
-			element = element.parentElement;
-			depth--;
-		}
-		return foundLink;
-	}
-
-	// have to do this event delegation style because the Editor isn't fully initialized yet.
-	document.getElementById( 'wpwrap' ).addEventListener( 'click', ( event ) => {
-		const dashboardLink = select( 'core/edit-site' )?.getSettings?.().__experimentalDashboardLink;
-		// The link has changed. Pray it doesn't change any further.
-		// This is how to find it in Gutenberg 15.2.
-		const isDashboardLink = traverseToFindLink( event.target, dashboardLink );
-
-		if ( isDashboardLink ) {
-			event.preventDefault();
-			calypsoPort.postMessage( { action: 'navigateToHome' } );
-		}
-	} );
-}
-
-/**
  * If WelcomeTour is set to show, check if the App Banner is visible.
  * If App Banner is visible, we set the Welcome Tour to not show.
  * When the App Banner gets dismissed, we set the Welcome Tour to show.
@@ -1184,8 +1151,6 @@ function initPort( message ) {
 		handleCheckoutModal( calypsoPort );
 
 		handleAppBannerShowing( calypsoPort );
-
-		handleSiteEditorBackButton( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );


### PR DESCRIPTION
Fixes #90791. There is a `handleSiteEditorBackButton` click handler that detects clicks on the Site Editor Dashboard link and does a custom handling on these clicks. The handler is buggy and can sometimes cause crashes (doesn't check if `element` is `null`). And nowadays the handler no longer has any function, because we never iframe the Site Editor. See for example #76371 which was a part of the iframe deprecation effort a year ago.

This PR simply removes the `handleSiteEditorBackButton` handler.