### PR TITLE
Nav Redesign: Update domain table header font

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -494,6 +494,15 @@
 			padding-right: 24px;
 		}
 	}
+
+	.domains-table-header .list__header-column {
+		font-style: normal;
+		font-weight: 400;
+		font-size: rem(13px);
+		line-height: 20px;
+		color: #757575;
+		text-transform: capitalize;
+	}
 }
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout {

--- a/packages/domains-table/src/domains-table-header/style.scss
+++ b/packages/domains-table/src/domains-table-header/style.scss
@@ -37,6 +37,11 @@
 	}
 
 	.list__header-column {
+		color: var(--studio-gray-80);
+		font-size: rem(11px);
+		font-style: normal;
+		font-weight: 500;
+		line-height: 20px;
 		text-transform: uppercase;
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7169

## Proposed Changes

* Updates the /domain table header font to more closely match the Figma and the style on /sites
  * This also updates the font style on /domains/manage/[site] through CSS inheritance (but I think it looks good)
* Updates the "Active domains" table header font style on the preview pane to more closely match the Figma. (Notably it is NOT all uppercase.)

On /domains/manage
Before | After
--|--
<img width="1303" alt="Screenshot 2024-05-17 at 11 07 15 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/98d68d23-9e26-4406-877a-b8029da5e5a6">  | <img width="1303" alt="Screenshot 2024-05-17 at 11 06 59 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/d7cf8ebe-d5c1-49fb-8f65-0d8be9232034">

On the site preview pane
Before | After
--|--
<img width="937" alt="Screenshot 2024-05-17 at 11 13 54 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/3f31452d-a41b-4ee6-8728-64817a645043"> |  <img width="948" alt="Screenshot 2024-05-17 at 11 13 37 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/3fd87998-3fe5-49f3-bf43-19fc9e10c88e">

On /domains/manage/[site] 
Before | After
--|--
<img width="1240" alt="Screenshot 2024-05-17 at 11 12 04 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/15ecacb5-e2b8-4649-aac0-303eb0cfb072"> | <img width="1240" alt="Screenshot 2024-05-17 at 11 11 48 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/652eefc7-0f84-412a-8ad2-eca81498f5f9">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improved user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* View /domains/manage
* View  /domains/manage/[site]
* View the "Domains active" panel in the preview pane
* Consider any possible regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
