### PR TITLE
Allow adding tiered products to cart

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -108,18 +108,20 @@ const ProductLightbox: FC< Props > = ( {
 							siteId={ siteId }
 							onChangeProduct={ onChangeProduct }
 						/>
-						<QuantityDropdown
-							product={ product }
-							siteId={ siteId }
-							onChangeProduct={ onChangeProduct }
-						/>
 						{ ! isOwned && (
-							<PaymentPlan
-								isMultiSiteIncompatible={ isMultiSiteIncompatible }
-								siteId={ siteId }
-								product={ product }
-								quantity={ product.quantity }
-							/>
+							<>
+								<QuantityDropdown
+									product={ product }
+									siteId={ siteId }
+									onChangeProduct={ onChangeProduct }
+								/>
+								<PaymentPlan
+									isMultiSiteIncompatible={ isMultiSiteIncompatible }
+									siteId={ siteId }
+									product={ product }
+									quantity={ product.quantity }
+								/>
+							</>
 						) }
 						<Button
 							primary={ ! isProductInCart }

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
@@ -34,7 +34,7 @@ export const useShoppingCartTracker = () => {
 	const dispatch = useDispatch();
 
 	return useCallback(
-		( eventName: string, { productSlug, addProducts }: EventDataOptions ) => {
+		( eventName: string, { productSlug, addProducts, quantity }: EventDataOptions ) => {
 			// We do need this only for Jetpack cloud
 			// If we want to use it everywhere we could move it as a parameter in event
 			if ( ! isJetpackCloud() ) {
@@ -47,6 +47,10 @@ export const useShoppingCartTracker = () => {
 
 			if ( productSlug ) {
 				eventData[ 'selected_product' ] = productSlug;
+			}
+
+			if ( quantity ) {
+				eventData[ 'quantity' ] = quantity;
 			}
 
 			if ( addProducts ) {

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
@@ -16,6 +16,7 @@ type EventData = {
 type EventDataOptions = {
 	productSlug?: string;
 	addProducts?: boolean;
+	quantity?: number | null;
 };
 
 // Record tracks are not allowing objects inside track events

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -261,12 +261,13 @@ export const useStoreItemInfo = ( {
 
 				shoppingCartTracker( 'calypso_jetpack_shopping_cart_add_product', {
 					productSlug: item.productSlug,
+					quantity: item.quantity,
 				} );
 
 				const addedToCartText = translate( 'added to cart' );
 				const productName = reactNodeToString( item.displayName );
 				dispatch( successNotice( `${ productName } ${ addedToCartText }`, { duration: 5000 } ) );
-				return addProductsToCart( [ { product_slug: item.productSlug } ] );
+				return addProductsToCart( [ { product_slug: item.productSlug, quantity: item.quantity } ] );
 			}
 
 			if ( item.type === 'item-type-plan' ) {


### PR DESCRIPTION
## Proposed Changes

* Add functionality for adding tiered products to the cart for logged in users with a site in context
* Only show tier dropdown if the item is unowned

## Why are these changes being made?

There are a couple bugs with the way this works now
* When the product is owned, the dropdown shows on the `/jetpack/connect/plans/` lightbox above the `manage subscription` button for no reason
* When adding items to the cart, the tiered items are not being added correctly

## Testing Instructions

1. Create a new site with jurassic ninja and go to the pricing page from the `Purchase a product` CTA in My Jetpack. The URL should be something like
`https://cloud.jetpack.com/pricing/{site_id}?site={site_id}&redirect_to=https%3A%2F%2F{site_domain}%2Fwp-admin%2Fadmin.php%3Fpage%3Dmy-jetpack
2. Select AI (or Stats) and add a tier higher than the base tier to the cart
![image](https://github.com/Automattic/wp-calypso/assets/65001528/6759a3c0-31df-4db3-9c31-c157198d3e9d)
3. Make sure the correct tier was added to the cart
![image](https://github.com/Automattic/wp-calypso/assets/65001528/2734157a-5225-4b98-8021-ee26280ca47c)
4. Go to checkout and make sure the correct tier of the product is in checkout
![image](https://github.com/Automattic/wp-calypso/assets/65001528/4cf5b364-f5e6-453c-abc9-49cc6eb94445)
5. Purchase the product
6. Go to `{Calypso blue live link}/jetpack/connect/plans/{site_name}` and select Manage Subscription next to AI. Make sure the dropdown does not show in the lightbox when it opens
![image](https://github.com/Automattic/wp-calypso/assets/65001528/04fe8adc-f534-466a-8508-34f85c84e241)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
