### PR TITLE
Fix layout when there is no host displayed

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -281,6 +281,10 @@ $business-plan-color: #7f54b3;
 				border-bottom-left-radius: 0;
 				border-bottom: 1px solid #e0e0e0;
 				border-left: 0;
+
+				&.import__upgrade-plan-hosting-details-card-container--without-identified-host {
+					margin-bottom: calc(16px + 1rem); /* Height + padding of `.import__upgrade-plan-hosting-details-identified-host` */
+				}
 			}
 
 			.import__upgrade-plan-hosting-details-header {
@@ -404,7 +408,6 @@ $business-plan-color: #7f54b3;
 			text-align: center;
 			padding: 0.5rem 1.5rem;
 			line-height: 16px;
-			min-height: 16px;
 		}
 	}
 

--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -404,6 +404,7 @@ $business-plan-color: #7f54b3;
 			text-align: center;
 			padding: 0.5rem 1.5rem;
 			line-height: 16px;
+			min-height: 16px;
 		}
 	}
 

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
@@ -96,13 +96,12 @@ export const UpgradePlanHostingDetails = () => {
 					</div>
 				) }
 			</div>
-			{ shouldDisplayHostIdentificationMessage && (
-				<div className="import__upgrade-plan-hosting-details-identified-host">
-					{ translate( "We've identified %(hostingProviderName)s as your host.", {
+			<div className="import__upgrade-plan-hosting-details-identified-host">
+				{ shouldDisplayHostIdentificationMessage &&
+					translate( "We've identified %(hostingProviderName)s as your host.", {
 						args: { hostingProviderName },
 					} ) }
-				</div>
-			) }
+			</div>
 		</div>
 	);
 };

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
@@ -3,6 +3,7 @@ import { useState } from '@wordpress/element';
 import { hasTranslation } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { getQueryArg } from '@wordpress/url';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
@@ -42,7 +43,12 @@ export const UpgradePlanHostingDetails = () => {
 
 	return (
 		<div className="import__upgrade-plan-hosting-details">
-			<div className="import__upgrade-plan-hosting-details-card-container">
+			<div
+				className={ classNames( 'import__upgrade-plan-hosting-details-card-container', {
+					'import__upgrade-plan-hosting-details-card-container--without-identified-host':
+						! shouldDisplayHostIdentificationMessage,
+				} ) }
+			>
 				<div className="import__upgrade-plan-hosting-details-header">
 					<p className="import__upgrade-plan-hosting-details-header-main">{ headerMainText }</p>
 					<p className="import__upgrade-plan-hosting-details-header-subtext">
@@ -96,12 +102,13 @@ export const UpgradePlanHostingDetails = () => {
 					</div>
 				) }
 			</div>
-			<div className="import__upgrade-plan-hosting-details-identified-host">
-				{ shouldDisplayHostIdentificationMessage &&
-					translate( "We've identified %(hostingProviderName)s as your host.", {
+			{ shouldDisplayHostIdentificationMessage && (
+				<div className="import__upgrade-plan-hosting-details-identified-host">
+					{ translate( "We've identified %(hostingProviderName)s as your host.", {
 						args: { hostingProviderName },
 					} ) }
-			</div>
+				</div>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/90806

## Proposed Changes

* I noticed that I introduced an issue in the https://github.com/Automattic/wp-calypso/pull/90806 when the host is not populated (the same happened during the loading when the host is being fetched). In this case, the columns were misaligned, so this PR makes sure that space will be filled, not breaking the layout.

#### Before this PR:

<img width="729" alt="Screenshot 2024-05-17 at 15 13 24" src="https://github.com/Automattic/wp-calypso/assets/876340/1c263d1f-1cf8-4b56-8e06-d4da46ff1518">

#### After this PR:

<img width="741" alt="Screenshot 2024-05-17 at 15 16 12" src="https://github.com/Automattic/wp-calypso/assets/876340/4cd9cc4b-4fe3-4a82-9778-af0570bbf587">

It doesn't have exactly the same space on the top and in the bottom of the right column. It has +3px in the bottom. The reason is that it avoids flickering when the host is loaded.

#### With a known host:

<img width="743" alt="Screenshot 2024-05-17 at 15 14 56" src="https://github.com/Automattic/wp-calypso/assets/876340/2ef17f91-5658-4acd-b092-9b3676953048">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix a layout issue introduced in https://github.com/Automattic/wp-calypso/pull/90806.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use the live link.
* Navigate to both links: `/setup/site-setup/importerWordpress?siteSlug={FREE_SITE_SLUG}&from=https://www.unknown.unk&option=everything` and `/setup/site-migration/site-migration-upgrade-plan?from=https://www.unknown.unk&siteSlug={FREE_SITE_SLUG}`
* Check that the columns are not misaligned anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
