### PR TITLE
Nav redesign - update github deployments header style

### DIFF
--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -11,6 +11,7 @@ export default class HeaderCake extends Component {
 		const {
 			backText,
 			backHref,
+			backIcon,
 			actionButton,
 			actionText,
 			actionIcon,
@@ -31,6 +32,7 @@ export default class HeaderCake extends Component {
 					<HeaderCakeBack
 						text={ backText }
 						href={ backHref }
+						icon={ backIcon }
 						onClick={ this.props.onClick }
 						alwaysShowActionText={ alwaysShowBackText }
 					/>
@@ -62,6 +64,7 @@ HeaderCake.propTypes = {
 	onTitleClick: PropTypes.func,
 	backText: PropTypes.string,
 	backHref: PropTypes.string,
+	backIcon: PropTypes.string,
 	actionButton: PropTypes.element,
 	actionText: PropTypes.string,
 	actionHref: PropTypes.string,

--- a/client/my-sites/github-deployments/deployment-creation/index.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/index.tsx
@@ -19,7 +19,11 @@ export const GitHubDeploymentCreation = () => {
 
 	return (
 		<PageShell pageTitle={ __( 'Connect GitHub repository' ) }>
-			<HeaderCake onClick={ data?.length ? goToDeployments : undefined } isCompact>
+			<HeaderCake
+				onClick={ data?.length ? goToDeployments : undefined }
+				isCompact
+				backIcon="chevron-left"
+			>
 				<h1>{ __( 'Connect repository' ) }</h1>
 			</HeaderCake>
 			<ActionPanel>

--- a/client/my-sites/github-deployments/deployment-management/index.tsx
+++ b/client/my-sites/github-deployments/deployment-management/index.tsx
@@ -40,7 +40,7 @@ export const GitHubDeploymentManagement = ( {
 
 	return (
 		<PageShell pageTitle={ __( 'Manage GitHub connection' ) }>
-			<HeaderCake onClick={ goToDeployments } isCompact>
+			<HeaderCake onClick={ goToDeployments } isCompact backIcon="chevron-left">
 				<h1>{ __( 'Manage connection' ) }</h1>
 			</HeaderCake>
 			<ActionPanel>{ renderContent() }</ActionPanel>

--- a/client/my-sites/github-deployments/deployment-run-logs/index.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/index.tsx
@@ -33,7 +33,7 @@ export function DeploymentRunsLogs( { codeDeploymentId }: DeploymentRunsDialogPr
 
 	return (
 		<PageShell pageTitle={ __( 'GitHub Deployments' ) }>
-			<HeaderCake onClick={ goToDeployments } isCompact>
+			<HeaderCake onClick={ goToDeployments } isCompact backIcon="chevron-left">
 				<h1>{ __( 'Deployment runs' ) }</h1>
 			</HeaderCake>
 			<ActionPanel>

--- a/client/my-sites/github-deployments/deployments/index.tsx
+++ b/client/my-sites/github-deployments/deployments/index.tsx
@@ -38,8 +38,8 @@ export function GitHubDeployments() {
 
 		return (
 			<>
-				<HeaderCake isCompact>
-					<h1>{ __( 'Connect repository' ) }</h1>
+				<HeaderCake isCompact onClick={ () => page( '/sites' ) } backIcon="chevron-left">
+					{ __( 'Manage Connection' ) }
 				</HeaderCake>
 				<ActionPanel>
 					<GitHubDeploymentCreationForm onConnected={ refetch } />

--- a/client/my-sites/github-deployments/deployments/index.tsx
+++ b/client/my-sites/github-deployments/deployments/index.tsx
@@ -38,9 +38,7 @@ export function GitHubDeployments() {
 
 		return (
 			<>
-				<HeaderCake isCompact onClick={ () => page( '/sites' ) } backIcon="chevron-left">
-					{ __( 'Manage Connection' ) }
-				</HeaderCake>
+				<HeaderCake isCompact>{ __( 'Manage Connection' ) }</HeaderCake>
 				<ActionPanel>
 					<GitHubDeploymentCreationForm onConnected={ refetch } />
 				</ActionPanel>

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -217,6 +217,8 @@ $brand-text: "SF Pro Text", $sans;
 	.header-cake {
 		gap: 16px;
 		font-family: $brand-text;
+		clip-path: inset(-1px -1px 0 -1px);
+		padding-top: 20px;
 	}
 	.header-cake__title {
 		flex: none;
@@ -228,9 +230,13 @@ $brand-text: "SF Pro Text", $sans;
 	.header-cake__back {
 		color: var(--studio-gray-60);
 		font-size: $font-body-small;
+		padding: 0;
 		svg {
 			fill: var(--studio-gray-10);
 			width: 14px !important;
 		}
+	}
+	.action-panel {
+		clip-path: inset(0 -1px -1px -1px);
 	}
 }

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -215,13 +215,14 @@ $brand-text: "SF Pro Text", $sans;
 
 .github-deployments {
 	.header-cake {
-		gap: 32px;
+		gap: 16px;
 		font-family: $brand-text;
 	}
 	.header-cake__title {
 		flex: none;
 		color: var(--studio-gray-80);
 		font-size: $font-body;
+		font-weight: 500;
 		padding: 0;
 	}
 	.header-cake__back {
@@ -229,7 +230,7 @@ $brand-text: "SF Pro Text", $sans;
 		font-size: $font-body-small;
 		svg {
 			fill: var(--studio-gray-10);
-			height: 8px;
+			width: 14px !important;
 		}
 	}
 }

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -1,3 +1,6 @@
+@import "@automattic/typography/styles/variables";
+$brand-text: "SF Pro Text", $sans;
+
 .github-deployments-list {
 	display: flex;
 	flex-direction: column;
@@ -207,5 +210,26 @@
 .github-deployments-commit-details-popover {
 	.popover__inner {
 		padding: 16px;
+	}
+}
+
+.github-deployments {
+	.header-cake {
+		gap: 32px;
+		font-family: $brand-text;
+	}
+	.header-cake__title {
+		flex: none;
+		color: var(--studio-gray-80);
+		font-size: $font-body;
+		padding: 0;
+	}
+	.header-cake__back {
+		color: var(--studio-gray-60);
+		font-size: $font-body-small;
+		svg {
+			fill: var(--studio-gray-10);
+			height: 8px;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7188

## Proposed Changes

* Updates header-cake component to support using alternative icon (i.e. `chevron-left`) 
* Updates github deployment preview pane header to reflect design changes

## Before

<img width="1166" alt="Screenshot 2024-05-17 at 19 15 45" src="https://github.com/Automattic/wp-calypso/assets/5560595/2fa0c4a4-0158-4b94-9950-909fae2367b7">

## After

<img width="1176" alt="Screenshot 2024-05-17 at 19 15 53" src="https://github.com/Automattic/wp-calypso/assets/5560595/490815ae-4899-4c47-902d-02744fb716ed">

## Not sure about

* The back icon size is 18px - will need to amend the `HeaderCakeBack` component to support alternative sizes. 
* The back link onClick event just redirects to `/sites` - I don't appear to have access to the `closeSitePreviewPane` function which I think would be cleaner here. 

## Testing Instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Github deployments preview pane for a test site and confirm styles are ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
