### PR TITLE
Add currency in the sub-description of the plan selection component.

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
@@ -94,7 +94,7 @@ const useEntrepreneurPlanPrices = () => {
 					args: {
 						rawPrice: formatCurrency( plan.price, currencyCode, {
 							stripZeros: true,
-							isSmallestUnit: true,
+							isSmallestUnit: false,
 						} ),
 					},
 					comment: 'Excl. Taxes is short for excluding taxes',
@@ -105,7 +105,7 @@ const useEntrepreneurPlanPrices = () => {
 					args: {
 						rawPrice: formatCurrency( plan.price, currencyCode, {
 							stripZeros: true,
-							isSmallestUnit: true,
+							isSmallestUnit: false,
 						} ),
 					},
 					comment: 'Excl. Taxes is short for excluding taxes',
@@ -116,7 +116,7 @@ const useEntrepreneurPlanPrices = () => {
 					args: {
 						rawPrice: formatCurrency( plan.price, currencyCode, {
 							stripZeros: true,
-							isSmallestUnit: true,
+							isSmallestUnit: false,
 						} ),
 					},
 					comment: 'Excl. Taxes is short for excluding taxes',

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
@@ -8,6 +8,7 @@ import {
 import page from '@automattic/calypso-router';
 import { PlanPrice } from '@automattic/components';
 import Card from '@automattic/components/src/card';
+import { formatCurrency } from '@automattic/format-currency';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { CustomSelectControl } from '@wordpress/components';
 import { hasTranslation } from '@wordpress/i18n';
@@ -43,6 +44,7 @@ type PlanKeys =
 
 const useEntrepreneurPlanPrices = () => {
 	const translate = useTranslate();
+	const currencyCode = useSelector( getCurrentUserCurrencyCode ) || '';
 	const state = useSelector( ( stateValue ) => stateValue );
 	const rawPlans = getPlans();
 
@@ -89,19 +91,34 @@ const useEntrepreneurPlanPrices = () => {
 		switch ( key ) {
 			case 'PLAN_ECOMMERCE':
 				plan.subText = translate( 'per month, %(rawPrice)s billed annually, excl. taxes', {
-					args: { rawPrice: plan.price },
+					args: {
+						rawPrice: formatCurrency( plan.price, currencyCode, {
+							stripZeros: true,
+							isSmallestUnit: true,
+						} ),
+					},
 					comment: 'Excl. Taxes is short for excluding taxes',
 				} );
 				break;
 			case 'PLAN_ECOMMERCE_2_YEARS':
 				plan.subText = translate( 'per month, %(rawPrice)s billed every two years, excl. taxes', {
-					args: { rawPrice: plan.price },
+					args: {
+						rawPrice: formatCurrency( plan.price, currencyCode, {
+							stripZeros: true,
+							isSmallestUnit: true,
+						} ),
+					},
 					comment: 'Excl. Taxes is short for excluding taxes',
 				} );
 				break;
 			case 'PLAN_ECOMMERCE_3_YEARS':
 				plan.subText = translate( 'per month, %(rawPrice)s billed every three years, excl. taxes', {
-					args: { rawPrice: plan.price },
+					args: {
+						rawPrice: formatCurrency( plan.price, currencyCode, {
+							stripZeros: true,
+							isSmallestUnit: true,
+						} ),
+					},
 					comment: 'Excl. Taxes is short for excluding taxes',
 				} );
 				break;


### PR DESCRIPTION
## Proposed Changes
![image](https://github.com/Automattic/wp-calypso/assets/33497086/cd486d89-71e2-4966-a7aa-53472cfae5d2)
![image](https://github.com/Automattic/wp-calypso/assets/33497086/583530cf-157f-4b6f-abc2-a22f7898e148)

Plans page: Add currency in the sub-description of the plan selection component.

## Testing Instructions
- With an Entrepreneur trial site, open the plans page.
- Check that the currency code was added to the sub-description of the price.
- Check it for different payment periods, `Pay annually` , `Pay every 2 years`, `Pay every 3 years`.
- There is no currency code on the the `Pay monthly` period.
- Try different idioms. The translation should still work, because translated text is still the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
