### PR TITLE
Fix flaky E2E test

### DIFF
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -84,7 +84,16 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 		it( 'See secure payment', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` );
+			try {
+				await Promise.any( [
+					cartCheckoutPage.validateCartItem( 'WordPress.com Beginner' ),
+					cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` ),
+				] );
+			} catch ( error ) {
+				// If both promises are rejected, handle the error (optional)
+				console.log( `Neither "Beginner" or "Starter" were found on the page.` );
+				throw error; // Re-throw the error to fail the test
+			}
 		} );
 
 		it( 'Prices are shown in GBP', async function () {
@@ -231,11 +240,22 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		it( 'View details of purchased plan', async function () {
 			purchasesPage = new PurchasesPage( page );
 
-			await purchasesPage.clickOnPurchase(
-				`WordPress.com ${ newPlanName }`,
-				newSiteDetails.blog_details.site_slug
-			);
-			await purchasesPage.purchaseAction( 'Cancel plan' );
+			try {
+				await Promise.any( [
+					purchasesPage.clickOnPurchase(
+						'WordPress.com Beginner',
+						newSiteDetails.blog_details.site_slug
+					),
+					purchasesPage.clickOnPurchase(
+						`WordPress.com ${ newPlanName }`,
+						newSiteDetails.blog_details.site_slug
+					),
+				] );
+				await purchasesPage.purchaseAction( 'Cancel plan' );
+			} catch ( error ) {
+				console.log( `Neither "Beginner" nor "Starter" plan was found.` );
+				throw error;
+			}
 		} );
 
 		it( 'Cancel plan renewal', async function () {

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -85,14 +85,14 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		it( 'See secure payment', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
 			try {
+				// Check for either the "Beginner" or "Starter" plan while the name change experiment is in progress.
 				await Promise.any( [
 					cartCheckoutPage.validateCartItem( 'WordPress.com Beginner' ),
 					cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` ),
 				] );
 			} catch ( error ) {
-				// If both promises are rejected, handle the error (optional)
 				console.log( `Neither "Beginner" or "Starter" were found on the page.` );
-				throw error; // Re-throw the error to fail the test
+				throw error;
 			}
 		} );
 
@@ -241,6 +241,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			purchasesPage = new PurchasesPage( page );
 
 			try {
+				// Check for either the "Beginner" or "Starter" plan while the name change experiment is in progress.
 				await Promise.any( [
 					purchasesPage.clickOnPurchase(
 						'WordPress.com Beginner',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [failed test.](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/12548079?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&logFilter=debug&logView=flowAware)

Slack thread: p1715984606123039-slack-C7HH3V5AS

## Proposed Changes

* The flaky e2e test is failing due to the Beginner | Starter name change experiment pbxNRc-3E6-p2. Sometimes the e2e test user is placed in the treatment group, and sometimes it is not. This PR checks for either the Beginner or Starter plan names so the test will pass if either is present.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix failing Calypso e2e test.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions [here](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md) to setup e2e tests locally.
* Run: yarn workspace wp-e2e-tests test test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?