### PR TITLE
Check the plan on launch site to show domain message or not

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -1029,3 +1029,7 @@ export const getDIFMTieredPurchaseDetails = (
 
 	return { extraPageCount, numberOfIncludedPages, formattedCostOfExtraPages, formattedOneTimeFee };
 };
+
+export function isA4APurchase( purchase?: Purchase ) {
+	return 'a4a_agency' === purchase?.partnerType;
+}

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -18,29 +18,14 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 	const translate = useTranslate();
 	const isPaidPlan = ! site?.plan?.is_free;
 	const isBilledMonthly = site?.plan?.product_slug?.includes( 'monthly' );
-
 	const transformedDomains = allDomains.map( createSiteDomainObject );
-
 	const [ isInitiallyLoaded, setIsInitiallyLoaded ] = useState( false );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardButtonEl = useRef( null );
 	const hasCustomDomain = Boolean(
 		transformedDomains.find( ( domain ) => ! domain.isWPCOMDomain )
 	);
-
-	useEffect( () => {
-		dispatch( fetchSitePurchases( site?.ID ) );
-	}, [ dispatch, site?.ID ] );
-
-	const isLoading = useSelector( isFetchingSitePurchases );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site?.ID ) );
-
-	useEffect( () => {
-		if ( ! isLoading && ( ! isPaidPlan || purchases.length > 0 ) && ! isInitiallyLoaded ) {
-			setIsInitiallyLoaded( true );
-		}
-	}, [ isLoading, purchases, isInitiallyLoaded ] );
-
 	const actualPlanPurchase =
 		purchases
 			.filter(
@@ -48,8 +33,21 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 			)
 			.sort( ( a, b ) => new Date( a.expiryDate ) - new Date( b.expiryDate ) )[ 0 ] || null;
 	const isA4ASite = actualPlanPurchase?.partnerType === 'a4a_agency';
+	const isLoading = useSelector( isFetchingSitePurchases );
 
 	useEffect( () => {
+		dispatch( fetchSitePurchases( site?.ID ) );
+	}, [ dispatch, site?.ID ] );
+
+	useEffect( () => {
+		if ( ! isLoading && ( ! isPaidPlan || purchases.length > 0 ) && ! isInitiallyLoaded ) {
+			setIsInitiallyLoaded( true );
+		}
+	}, [ isLoading, purchases, isPaidPlan, isInitiallyLoaded ] );
+
+	useEffect( () => {
+		// Remove the celebrateLaunch URL param without reloading the page as soon as the modal loads
+		// Make sure the modal is shown only once
 		window.history.replaceState(
 			null,
 			'',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7164

## Proposed Changes

We need to check the site's current plan when it launches. If the site doesn't include a plan, like when the site was created by A4A, it shouldn't show the "claim your domain" message. This PR makes this change.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We don't offer a free domain as part of a Creator plan made by A4A. More context: https://github.com/Automattic/automattic-for-agencies-dev/issues/482

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Instructions to test not A4A sites**
- Go to `http://calypso.localhost:3000/sites` and create a site normally. It would be awesome to test different plans, including Free.
- In My Home, click on "Launch your site" (note: there are different launchpads, so the link to launch your site could be in a different order):
<img width="690" alt="Screenshot 2024-05-18 at 13 47 39" src="https://github.com/Automattic/wp-calypso/assets/3832570/f67e4130-bdd8-4d48-901a-901ded04074e">

You should see different popups depending on the circumstances of the blog:
- a free blog (no domain included):
<img width="1650" alt="Screenshot 2024-05-17 at 19 57 17" src="https://github.com/Automattic/wp-calypso/assets/3832570/596d29b0-47b8-4629-82e8-69684c59d5c7">

- a paid plan, including a domain:
<img width="1654" alt="Screenshot 2024-05-17 at 20 14 45" src="https://github.com/Automattic/wp-calypso/assets/3832570/10bba4ab-8c45-47c3-965f-6c1f59283238">

**Instructions to test A4A sites**
- Log into our A4A testing account (details here: pfunGA-1mD-p2).
- Create a new site (or use one of the existing sites that hasn't launched yet).
- Create a new admin user on that site. You will require the credentials of such user in your local calypso. Accept the invitation in the new admin user email.
- Login to the site using your local Calypso instance and this newly created account.
- In My Home, click on "Launch your site":
- This site has a paid plan, created with A4A (no domain included), so the popup should look like this:
<img width="1221" alt="Screenshot 2024-05-17 at 19 48 16" src="https://github.com/Automattic/wp-calypso/assets/3832570/4d041b3e-d723-4277-b2ae-17fbf5c63df8">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?