### PR TITLE
Site Monitoring: Add 429 Errors to Filter

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -1,7 +1,7 @@
 import { SelectDropdown, Gridicon, Badge } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
@@ -103,15 +103,15 @@ export const SiteLogsToolbar = ( {
 
 	const requestStatuses = [
 		{ value: '', label: translate( 'All' ) },
-		{ value: '200', label: '200' },
-		{ value: '301', label: '301' },
-		{ value: '302', label: '302' },
-		{ value: '400', label: '400' },
-		{ value: '401', label: '401' },
-		{ value: '403', label: '403' },
-		{ value: '404', label: '404' },
-		{ value: '429', label: '429' },
-		{ value: '500', label: '500' },
+		{ value: '200', label: numberFormat( 200, 0 ) },
+		{ value: '301', label: numberFormat( 301, 0 ) },
+		{ value: '302', label: numberFormat( 302, 0 ) },
+		{ value: '400', label: numberFormat( 400, 0 ) },
+		{ value: '401', label: numberFormat( 401, 0 ) },
+		{ value: '403', label: numberFormat( 403, 0 ) },
+		{ value: '404', label: numberFormat( 404, 0 ) },
+		{ value: '429', label: numberFormat( 429, 0 ) },
+		{ value: '500', label: numberFormat( 500, 0 ) },
 	];
 
 	const selectedSeverity =

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -103,14 +103,15 @@ export const SiteLogsToolbar = ( {
 
 	const requestStatuses = [
 		{ value: '', label: translate( 'All' ) },
-		{ value: '200', label: translate( '200' ) },
-		{ value: '301', label: translate( '301' ) },
-		{ value: '302', label: translate( '302' ) },
-		{ value: '400', label: translate( '400' ) },
-		{ value: '401', label: translate( '401' ) },
-		{ value: '403', label: translate( '403' ) },
-		{ value: '404', label: translate( '404' ) },
-		{ value: '500', label: translate( '500' ) },
+		{ value: '200', label: '200' },
+		{ value: '301', label: '301' },
+		{ value: '302', label: '302' },
+		{ value: '400', label: '400' },
+		{ value: '401', label: '401' },
+		{ value: '403', label: '403' },
+		{ value: '404', label: '404' },
+		{ value: '429', label: '429' },
+		{ value: '500', label: '500' },
 	];
 
 	const selectedSeverity =

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -1,7 +1,7 @@
 import { SelectDropdown, Gridicon, Badge } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
-import { numberFormat, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
@@ -103,15 +103,15 @@ export const SiteLogsToolbar = ( {
 
 	const requestStatuses = [
 		{ value: '', label: translate( 'All' ) },
-		{ value: '200', label: numberFormat( 200, 0 ) },
-		{ value: '301', label: numberFormat( 301, 0 ) },
-		{ value: '302', label: numberFormat( 302, 0 ) },
-		{ value: '400', label: numberFormat( 400, 0 ) },
-		{ value: '401', label: numberFormat( 401, 0 ) },
-		{ value: '403', label: numberFormat( 403, 0 ) },
-		{ value: '404', label: numberFormat( 404, 0 ) },
-		{ value: '429', label: numberFormat( 429, 0 ) },
-		{ value: '500', label: numberFormat( 500, 0 ) },
+		{ value: '200', label: translate( '200' ) },
+		{ value: '301', label: translate( '301' ) },
+		{ value: '302', label: translate( '302' ) },
+		{ value: '400', label: translate( '400' ) },
+		{ value: '401', label: translate( '401' ) },
+		{ value: '403', label: translate( '403' ) },
+		{ value: '404', label: translate( '404' ) },
+		{ value: '429', label: translate( '429' ) },
+		{ value: '500', label: translate( '500' ) },
 	];
 
 	const selectedSeverity =


### PR DESCRIPTION
Fixes #90868

## Proposed Changes

* Adds the 429 HTTP error to the Status dropdown under Site Monitoring. Incidentally, everything is already set up to filter those requests, including the API request - I assume it was simply just an oversight not to include it in the filter? 

<img width="1094" alt="Screenshot 2024-05-19 at 14 31 45" src="https://github.com/Automattic/wp-calypso/assets/43215253/9fa1a1df-746b-43a9-9c64-dea7cca3cac0">

## Why are these changes being made?

See #90868. I also think this handles some of my concerns in #90306 by making those errors more accessible - at least I see where issues have arisen now! 

## Testing Instructions

Visit `/site-monitoring/SITE/web`, and confirm that "429" appears in the dropdown and works appropriately.

cc @sejas  