### PR TITLE
Checkout: Set Gift Subscription to use Site Slug

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -272,8 +272,8 @@ function getDomainToDisplayInCheckoutHeader(
 		return domainUrl;
 	}
 
-	if ( responseCart.gift_details?.receiver_blog_url ) {
-		return responseCart.gift_details.receiver_blog_url;
+	if ( responseCart.gift_details?.receiver_blog_slug ) {
+		return responseCart.gift_details.receiver_blog_slug;
 	}
 
 	if (


### PR DESCRIPTION
Fixes #90480

## Proposed Changes

Use the site slug instead of the site URL in the Checkout for gifted subscriptions. 

## Why are these changes being made?

The logic outlined by @vinnykaur in #90480 is that a user wanting to gift a subscription would have no reason to recognise the actual blog URL - they'd simply know the slug. That seems reasonable to me, not least since it's also used in the gift banner already.

https://github.com/Automattic/wp-calypso/blob/1ff2fbf3ed0c65e4b98b015d51855f67c8e4ccc9/client/my-sites/checkout/src/components/checkout-order-banner/index.tsx#L8

However, it also looks like the blog URL was intentionally set, so I'd appreciate any guidance on if there's something which I'm missing. 

## Testing Instructions

I've just picked a random site which has a Gift subscription enabled - you can test it here: `/checkout/business-bundle/gift/21099146?cancel_to=/home`

| Before | After |
|--------|--------|
| <img width="665" alt="Screenshot 2024-05-19 at 15 19 08" src="https://github.com/Automattic/wp-calypso/assets/43215253/e58ecc07-9060-4179-92bf-89a4017e9dba"> | <img width="669" alt="Screenshot 2024-05-19 at 15 19 12" src="https://github.com/Automattic/wp-calypso/assets/43215253/8358a488-b89a-4a13-8d6c-a660c5ca554e"> | 

cc @sirbrillig 