### PR TITLE
Add missing code to Request Timeout label

### DIFF
--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -337,7 +337,7 @@ const useErrorHttpCodeSeries = () => {
 		{
 			...seriesDefaultProps,
 			statusCode: 408,
-			label: __( 'Request Timeout' ),
+			label: __( '408: Request Timeout' ),
 		},
 		{
 			...seriesDefaultProps,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/90873

## Proposed Changes

I propose to add missing HTTP code for Request Timeout label.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make the Request Timeout label consistent with other errors.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Site Monitoring for a site e.g. https://wordpress.com/site-monitoring/SITE_SLUG
2. Ensure the site has 408 Request Timeout error logged (e.g. modify PHP code and throw such an error)
3. Hover the line chart to see the tooltip that includes 408 Request Timeout error

| **Before** | **After** |
|---|---|
| ![Screenshot 2024-05-20 at 09 23 24](https://github.com/Automattic/wp-calypso/assets/727413/384fa76b-42f2-400e-ab76-157b8540354f) | ![Screenshot 2024-05-20 at 09 42 37](https://github.com/Automattic/wp-calypso/assets/727413/bd051f17-250b-44e5-93ce-26fb22ea21a9) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
