### PR TITLE
Dataviews: Update the layout styles to get rid of the fixed height

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -21,10 +21,8 @@
 	font-size: 0.875rem;
 	font-weight: 400;
 	justify-content: space-between !important;
-	margin-bottom: 1rem;
 	padding: 12px 16px 12px 16px;
-	position: fixed;
-	width: calc(100% - 64px);
+	margin-top: auto;
 
 	.components-input-control__backdrop {
 		border-color: var(--Gray-Gray-5, #dcdcde);
@@ -32,10 +30,6 @@
 
 	.components-input-control__container {
 		padding: 0 5px;
-	}
-
-	@include breakpoint-deprecated( ">660px" ) {
-		width: calc(100% - ( var(--sidebar-width-max) + 48px));
 	}
 
 	@include breakpoint-deprecated( ">1400px" ) {

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -2,6 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .dataviews-filters__view-actions {
+	flex-shrink: 0;
 	margin-bottom: 8px;
 
 	.components-button.is-compact.is-tertiary:not(.dataviews-filters-button)[aria-disabled="true"] {
@@ -10,6 +11,7 @@
 }
 
 .dataviews-pagination {
+	flex-shrink: 0;
 	background: #fff;
 	border-top: 1px solid #f1f1f1;
 	border-bottom-left-radius: 4px;

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -42,6 +42,8 @@ html,
 	flex-direction: row;
 	flex-wrap: nowrap;
 	gap: 16px;
+	height: 100%;
+	overflow: hidden;
 }
 
 .a4a-layout-column {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -71,10 +71,6 @@
 	}
 }
 
-.sites-overview__content:has(.dataviews-pagination) {
-	padding-bottom: 32px !important;
-}
-
 .main.sites-dashboard.sites-dashboard__layout:has(.dataviews-pagination) {
 	height: calc(100vh - 70px);
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -70,7 +70,3 @@
 		}
 	}
 }
-
-.main.sites-dashboard.sites-dashboard__layout:has(.dataviews-pagination) {
-	height: calc(100vh - 70px);
-}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -85,8 +85,6 @@
 	}
 
 	@media (max-width: $break-large) {
-		height: calc(100vh - 120px); /* Matches the offset defined in PR #65520 */
-
 		.section-nav__mobile-header {
 			padding: 13px;
 		}

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -542,8 +542,14 @@
 
 		.dataviews-wrapper {
 			display: flex;
+			flex-direction: column;
 			height: 100%;
 			overflow: hidden;
+
+			> div[data-wp-component="VStack"] {
+				align-items: stretch;
+				overflow: hidden;
+			}
 
 			.components-button:focus:not(:disabled) {
 				box-shadow: 0 0 0 2px var(--color-primary-light);

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -544,6 +544,7 @@
 			display: flex;
 			flex-direction: column;
 			height: 100%;
+			width: 100%;
 			overflow: hidden;
 
 			> div[data-wp-component="VStack"] {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -328,7 +328,6 @@
 				margin: 0;
 				padding: 0;
 				overflow-y: auto;
-				max-height: calc(100vh - 300px); /* 300px is the size of all content above the dataview in list style, which includes our CTA elements, the pagination bottom bar, and an additional 20px margin. */
 
 				li {
 					padding: 8px 24px;
@@ -576,11 +575,6 @@
 				flex: 1;
 				height: 100%;
 				overflow: hidden;
-				margin-top: 24px;
-
-				&.is-hiding-navigation {
-					margin-top: 48px; // If there is no navigation bar we need to add a bigger margin.
-				}
 			}
 		}
 
@@ -627,6 +621,14 @@
 			@media only screen and (min-width: $break-large) {
 				.sites-overview {
 					padding: 0;
+
+					.sites-overview__content {
+						margin-top: 24px;
+
+						&.is-hiding-navigation {
+							margin-top: 48px; // If there is no navigation bar we need to add a bigger margin.
+						}
+					}
 
 					.dataviews-filters__view-actions {
 						& > :first-child {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -14,6 +14,12 @@
 	}
 
 	.a4a-layout-column {
+		.a4a-layout-column__container {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+		}
+
 		@include breakpoint-deprecated( "<660px" ) {
 			border-radius: 0;
 		}
@@ -203,8 +209,8 @@
 		}
 
 		.dataviews-view-table-wrapper {
+			flex: 1;
 			overflow-y: auto;
-			max-height: calc(100vh - 326px); /* 326px is the size of all the height above and below the dataview, from the edges of the screen, plus 10px offset from the padding. Currently below 9px + 309 above */
 
 			table {
 				width: 100%;
@@ -248,12 +254,6 @@
 		&.sites-dashboard__layout {
 			.dataviews-view-table-wrapper {
 				overflow-y: auto;
-				max-height: calc(100vh - 255px); /* 255px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
-			}
-
-			.is-hiding-navigation .dataviews-view-table-wrapper {
-				overflow-y: auto;
-				max-height: calc(100vh - 260px); /* 260px is the size of all content above the dataview in table style, which includes our CTA elements, the pagination bottom bar, and an additional 10px margin. */
 			}
 		}
 
@@ -541,6 +541,10 @@
 		}
 
 		.dataviews-wrapper {
+			display: flex;
+			height: 100%;
+			overflow: hidden;
+
 			.components-button:focus:not(:disabled) {
 				box-shadow: 0 0 0 2px var(--color-primary-light);
 			}
@@ -556,12 +560,17 @@
 		}
 
 		.sites-overview {
+			height: 100%;
 			width: 400px;
 			flex: unset;
 			transition: all 0.2s;
 			background: var(--color-light-backdrop);
 
 			.sites-overview__content {
+				display: flex;
+				flex: 1;
+				height: 100%;
+				overflow: hidden;
 				margin-top: 24px;
 
 				&.is-hiding-navigation {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -176,10 +176,6 @@
 	}
 }
 
-.sites-overview__content:has(.dataviews-pagination) {
-	padding-bottom: 32px !important;
-}
-
 .main.a4a-layout.sites-dashboard:has(.dataviews-pagination) {
 	height: calc(100vh - 70px) !important;
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -176,11 +176,6 @@
 	}
 }
 
-.main.a4a-layout.sites-dashboard:has(.dataviews-pagination) {
-	height: calc(100vh - 70px) !important;
-}
-
-
 .dataviews-pagination {
 	background: #fff;
 	border-top: 1px solid #f1f1f1;

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -242,7 +242,9 @@
 
 // New navigation will not include a masterbar
 .theme-a8c-for-agencies .layout.has-no-masterbar {
-	--masterbar-height: 0;
+	/* We are ignoring these lines because without the px value the calc function does not work as expected */
+	/* stylelint-disable-next-line length-zero-no-unit */
+	--masterbar-height: 0px;
 
 	.layout__content {
 		padding: 16px;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -183,10 +183,6 @@
 	}
 }
 
-.sites-overview__content:has(.dataviews-pagination) {
-	padding-bottom: 32px !important;
-}
-
 .main.a4a-layout.sites-dashboard:has(.dataviews-pagination) {
 	height: calc(100vh - 70px) !important;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -183,11 +183,6 @@
 	}
 }
 
-.main.a4a-layout.sites-dashboard:has(.dataviews-pagination) {
-	height: calc(100vh - 70px) !important;
-}
-
-
 .dataviews-pagination {
 	background: #fff;
 	border-top: 1px solid #f1f1f1;

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -25,7 +25,9 @@
 
 // New navigation will not include a masterbar
 .theme-jetpack-cloud .layout.has-no-masterbar {
-	--masterbar-height: 0;
+	/* We are ignoring these lines because without the px value the calc function does not work as expected */
+	/* stylelint-disable-next-line length-zero-no-unit */
+	--masterbar-height: 0px;
 
 	// By default, there's 32px of top padding on the layout component.
 	// On mobile views this accommodates the masterbar, but we don't have one;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -383,7 +383,9 @@ body.is-mobile-app-view {
 .layout.has-no-masterbar.is-group-me,
 .layout.has-no-masterbar.is-group-sites,
 .layout.has-no-masterbar.is-section-reader {
-	--masterbar-height: 0;
+	/* We are ignoring these lines because without the px value the calc function does not work as expected */
+	/* stylelint-disable-next-line length-zero-no-unit */
+	--masterbar-height: 0px;
 
 	.layout__content {
 		padding-top: 32px;

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -176,7 +176,7 @@
 	}
 
 	.sites-overview__content {
-		margin-top: 35px;
+		margin-top: 11px;
 	}
 
 	@media (max-width: $break-wide) {
@@ -512,7 +512,14 @@
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout {
 	.a4a-layout-column__container {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+
 		.dataviews-wrapper {
+			display: flex;
+			height: 100%;
+			overflow: hidden;
 			position: relative;
 
 			.dataviews-pagination {
@@ -627,15 +634,5 @@
 	// Prevent the content pushed out via translateX(100%) creating a scrollbar
 	&.focus-sidebar .layout__content .layout__primary {
 		overflow-x: hidden;
-	}
-}
-
-.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper,
-.wpcom-site div.is-section-plugins:not(.has-no-masterbar) .main.a4a-layout.sites-dashboard .dataviews-view-table-wrapper {
-	max-height: calc(100vh - 276px); /* 276px is the size of all the height above and below the dataviews-view-table-wrapper */
-
-	// With 48px padding.
-	@media ( min-width: 601px ) {
-		max-height: calc(100vh - 324px); /* 324px is the size of all the height above and below the dataviews-view-table-wrapper */
 	}
 }

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -594,8 +594,7 @@
 		}
 
 		.dataviews-wrapper {
-			display: flex;
-			height: 100%;
+			width: 100%;
 
 			> * {
 				flex-grow: 1;

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -89,10 +89,6 @@
 	}
 }
 
-.sites-overview__content:has(.dataviews-pagination) {
-	padding-bottom: 32px !important;
-}
-
 .main.sites-dashboard.sites-dashboard__layout:has(.dataviews-pagination) {
 	.dataviews-view-table {
 		margin: 0;

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -105,8 +105,6 @@
 	}
 
 	@media (max-width: $break-large) {
-		height: calc(100vh - 120px); /* Matches the offset defined in PR #65520 */
-
 		.section-nav__mobile-header {
 			padding: 13px;
 		}

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -534,7 +534,7 @@
 			width: auto;
 			transition: flex-grow 0.2s;
 			background: var(--color-light-backdrop);
-			max-height: calc(100vh - 32px);
+			max-height: calc(100vh - 32px - var(--masterbar-height));
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
 			.preview-pane__navigation {
 				box-shadow: 0 0 0 1px var(--color-border-subtle), 0 1px 2px var(--color-border-subtle);

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -54,6 +54,10 @@
 		text-align: end;
 	}
 
+	.dataviews-view-table-wrapper {
+		overflow: auto;
+	}
+
 	@media (min-width: $break-large) {
 		background: inherit;
 
@@ -225,9 +229,8 @@
 		}
 
 		.dataviews-view-table-wrapper {
+			flex: 1;
 			overflow-y: auto;
-			// Without masterbar
-			max-height: calc(100vh - 285px); /* 285px is the size of all the height above and below the dataviews-view-table-wrapper */
 
 			table {
 				width: 100%;
@@ -241,12 +244,6 @@
 				display: none;
 			}
 
-		}
-	}
-
-	@media (max-width: 600px) {
-		.dataviews-view-table-wrapper {
-			max-height: calc(100vh - 323px); /* 323px is the size of all the height above and below the dataviews-view-table-wrapper */
 		}
 	}
 
@@ -272,14 +269,6 @@
 	}
 
 	@media (min-width: $break-large) {
-		&.sites-dashboard__layout {
-			.dataviews-view-table-wrapper {
-				overflow-y: auto;
-				min-height: calc(100vh - 277px); /* Set min-height to prevent the table from shrinking when there are few rows. */
-				max-height: calc(100vh - 255px); /* 255px is the size of all the content above the dataview when in table style, which includes our CTA elements, plus a 10px margin. */
-			}
-		}
-
 		&.sites-dashboard__layout:not(.preview-hidden) {
 			.sites-overview {
 				padding: 0;
@@ -510,12 +499,17 @@
 		}
 
 		.sites-overview {
+			height: 100%;
 			width: 400px;
 			flex: unset;
 			transition: all 0.2s;
 			background: var(--color-light-backdrop);
 
 			.sites-overview__content {
+				display: flex;
+				flex: 1;
+				height: 100%;
+				overflow: hidden;
 				margin-top: 24px;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Try to fix the pagination footer by getting rid of the fixed height from the `.dataviews-view-table-wrapper` element

| Before | After |
| - | - |
| ![Screenshot 2024-05-20 at 6 04 48 PM](https://github.com/Automattic/wp-calypso/assets/13596067/75c3f67c-7d8f-464f-a178-63f8a6d71612) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/b17dc62a-ef7e-4785-b20c-9cc9eeb4cb69) |
| ![Screenshot 2024-05-20 at 6 05 00 PM](https://github.com/Automattic/wp-calypso/assets/13596067/d222db3d-a026-4023-91f0-9f6cd1daad6f) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/f6e81147-907f-41ec-827c-d13795d2ff0b) |
| ![Screenshot 2024-05-20 at 6 05 56 PM](https://github.com/Automattic/wp-calypso/assets/13596067/7f6ca5d8-a143-4e92-a6e5-e3586977fe1d) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6bce8f35-6819-48f6-8969-8fbb7c8121ec) |

* Fix the padding of the pagination when the GSV opened
* Fix the content of the GSV wasn't scrollable when the masterbar was shown

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's not easy to maintain, and the height may be incorrect 😓

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Calypso

* Go to /sites
* Resize the window or open the preview
* Make sure the table looks good

## A4A

* Go to /sites
* Resize the window or open the preview
* Make sure the table looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
