### PR TITLE
CI: Update code style to fail above 0 ESLint errors

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -613,7 +613,6 @@ object CheckCodeStyleBranch : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
-		nonZeroExitCode = false
 		failOnMetricChange {
 			metric = BuildFailureOnMetric.MetricType.INSPECTION_ERROR_COUNT
 			threshold = 0

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -613,6 +613,15 @@ object CheckCodeStyleBranch : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 20
+		nonZeroExitCode = false
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.INSPECTION_ERROR_COUNT
+			units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
+			comparison = BuildFailureOnMetric.MetricComparison.MORE
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
 	}
 
 	features {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -616,11 +616,10 @@ object CheckCodeStyleBranch : BuildType({
 		nonZeroExitCode = false
 		failOnMetricChange {
 			metric = BuildFailureOnMetric.MetricType.INSPECTION_ERROR_COUNT
+			threshold = 0
 			units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
 			comparison = BuildFailureOnMetric.MetricComparison.MORE
-			compareTo = build {
-				buildRule = lastSuccessful()
-			}
+			compareTo = value()
 		}
 	}
 

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -115,7 +115,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 					onDismissClick={ handleDismissNotice }
 					icon="info-outline"
 					status="is-success"
-					isReskinned={ true }
+					isReskinned
 				>
 					{ translate(
 						'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -115,7 +115,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 					onDismissClick={ handleDismissNotice }
 					icon="info-outline"
 					status="is-success"
-					isReskinned
+					isReskinned={ true }
 				>
 					{ translate(
 						'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'


### PR DESCRIPTION
## Proposed Changes

This PR updates the ESLint (code style) check to fail if there are more than 0 ESLint errors (see [docs](https://teamcity.jetbrains.com/app/dsl-documentation/failureConditions/build-failure-on-metric/index.html)). Doable since we got them down to 0 recently in https://github.com/Automattic/wp-calypso/pull/90643. 

## Why are these changes being made?

Necessary because right now the code style check won't fail with new ESLint errors: https://github.com/Automattic/wp-calypso/pull/90705.

## Testing Instructions

Verify check is green.
Observe the prior Code Style run - you'll see it failed correctly when we had an ESLint error.