### PR TITLE
Scheduled Updates: Fix styling issue

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -166,5 +166,9 @@ $brand-display: "SF Pro Display", sans-serif;
 		.components-base-control__field {
 			display: block !important;
 		}
+
+		.components-input-control__suffix svg {
+			fill: var(--studio-gray-30);
+		}
 	}
 }

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -153,4 +153,18 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 		}
 	}
+
+	.components-search-control {
+		max-width: 300px;
+		margin-bottom: 1.5rem;
+
+		.components-input-control__container {
+			border: solid 1px var(--studio-gray-10);
+			background-color: var(--studio-white);
+		}
+
+		.components-base-control__field {
+			display: block !important;
+		}
+	}
 }

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -84,7 +84,10 @@ $brand-display: "SF Pro Display", sans-serif;
 		}
 
 		th {
+			font-size: rem(11px);
 			font-weight: 500;
+			text-transform: uppercase;
+			color: var(--studio-gray-80);
 
 			&.expand {
 				width: 4rem;

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -39,7 +39,6 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		button {
 			font-size: rem(14px);
-			border-radius: 4px;
 		}
 
 		.buttons {

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-filter.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-filter.tsx
@@ -1,52 +1,18 @@
-import SearchInput from '@automattic/search';
-import { Icon } from '@wordpress/icons';
+import { SearchControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import { MultisitePluginUpdateManagerContext } from './context';
 
-const SearchSVG = (
-	<svg
-		className="plugins-update-manager-multisite-filter__search-icon"
-		width="20"
-		height="20"
-		viewBox="0 0 20 20"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
-		<path
-			d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z"
-			stroke="#8C8F94"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-		<path
-			d="M17.5 17.5L13.875 13.875"
-			stroke="#8C8F94"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-	</svg>
-);
-interface Props {
-	compact?: boolean;
-}
-
-export const ScheduleListFilter = ( props: Props ) => {
+export const ScheduleListFilter = () => {
 	const translate = useTranslate();
-	const { compact } = props;
 	const { searchTerm, handleSearch } = useContext( MultisitePluginUpdateManagerContext );
 
 	return (
 		<div className="plugins-update-manager-multisite-filter">
-			<SearchInput
-				compact={ compact }
+			<SearchControl
+				value={ searchTerm }
 				placeholder={ translate( 'Search by site' ) }
-				searchIcon={ <Icon icon={ SearchSVG } size={ 18 } /> }
-				onSearch={ handleSearch }
-				onSearchClose={ () => handleSearch( '' ) }
-				defaultValue={ searchTerm }
+				onChange={ handleSearch }
 			/>
 		</div>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -145,7 +145,7 @@ export const ScheduleList = ( props: Props ) => {
 			{ isScheduleEmpty && compact && <ScheduleListCardNew className="is-selected" /> }
 			{ ! isScheduleEmpty && ScheduleListComponent ? (
 				<>
-					<ScheduleListFilter compact={ compact } />
+					<ScheduleListFilter />
 					<ScheduleListComponent
 						compact={ compact }
 						schedules={ filteredSchedules }

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -22,46 +22,9 @@ $brand-display: "SF Pro Display", sans-serif;
 	.plugins-update-manager-multisite-filter {
 		margin-top: 1.25rem;
 		margin-bottom: 1.25rem;
-		display: flex;
-		justify-content: flex-start;
-		align-items: center;
-		gap: 1rem;
-		flex-wrap: wrap;
 
-		.search-component {
-			min-width: min(25rem, 100%);
-			height: 44px;
-			flex: 1;
-
-			max-width: 30rem;
-			box-sizing: border-box;
-
-			border: 1px solid $studio-gray-10;
-			border-radius: 2px;
-
-			&.is-compact {
-				.plugins-update-manager-multisite-filter__search-icon {
-					width: 0.875rem;
-					margin: 0 0.5rem;
-				}
-
-				input {
-					font-size: 0.875rem;
-				}
-			}
-
-			.plugins-update-manager-multisite-filter__search-icon {
-				margin-left: 1rem;
-				margin-right: 0.875rem;
-			}
-
-			input.search-component__input[type="search"]::placeholder {
-				color: $studio-gray-50;
-			}
-
-			.components-spinner {
-				display: none;
-			}
+		.components-search-control {
+			margin-bottom: 0;
 		}
 	}
 

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -30,6 +30,7 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		.search-component {
 			min-width: min(25rem, 100%);
+			height: 44px;
 			flex: 1;
 
 			max-width: 30rem;

--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -58,15 +58,6 @@
 	.components-search-control {
 		max-width: 300px;
 		margin-bottom: 1.5rem;
-
-		.components-input-control__container {
-			border: solid 1px var(--studio-gray-10);
-			background-color: var(--studio-white);
-		}
-
-		.components-base-control__field {
-			display: block !important;
-		}
 	}
 
 	.checkbox-options-container {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -96,6 +96,10 @@ body.is-section-plugins {
 		.plugins-update-manager-multisite-filter {
 			margin: 0;
 			padding: 1rem 1.5rem;
+
+			.components-search-control {
+				max-width: 100%;
+			}
 		}
 
 		.plugins-update-manager-multisite-card {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Revert button radius
* Match table heading style
* Replace search input component with one from the `@wordpress/components` package library 

## Testing Instructions

* Go to `/plugins/scheduled-updates`
* Check button, table heading and search input styles

| Before | After |
|--------|--------|
| <img width="163" alt="Screenshot 2024-05-20 at 12 53 56" src="https://github.com/Automattic/wp-calypso/assets/1241413/89c35452-0d37-4df1-9570-a67f063a95e3"> | <img width="152" alt="Screenshot 2024-05-20 at 12 54 00" src="https://github.com/Automattic/wp-calypso/assets/1241413/e432928f-e0c4-4bc5-b4bf-de022d3b8b52"> |
| <img width="590" alt="Screenshot 2024-05-20 at 12 54 45" src="https://github.com/Automattic/wp-calypso/assets/1241413/38f2c7e5-eb21-4656-ac9c-fb2442b46725"> | <img width="434" alt="Screenshot 2024-05-20 at 18 13 51" src="https://github.com/Automattic/wp-calypso/assets/1241413/718bb5af-2d5d-469b-ab0d-52f346ee0db6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
