### PR TITLE
Scheduled Updates: Add more details when pre-update health check fails

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-logs.helper.ts
+++ b/client/blocks/plugins-scheduled-updates/schedule-logs.helper.ts
@@ -24,6 +24,17 @@ export const getLogDetails = ( log: ScheduleLog, plugins: CorePlugin[], siteSlug
 			}
 			return translate( 'Plugins update completed' );
 		case 'PLUGIN_UPDATES_FAILURE':
+			if ( log.message === 'pre_update_health_check_failed' && log.context?.path ) {
+				const path = log.context?.path === '/' ? '' : log.context?.path;
+				return translate(
+					'Plugins update failed — pre-update site health check failed on %(path)s',
+					{
+						args: {
+							path: siteSlug + path,
+						},
+					}
+				);
+			}
 			return translate( 'Plugins update failed' );
 
 		case 'PLUGIN_UPDATE_SUCCESS':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89935

## Proposed Changes

* When a user fails on a pre-update health check, we need to show them the path it fails so the user can act on the next steps.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Giving users more information about the failure so they can act on the next steps. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D149225-code first and force record a pre-update health check failure log.
* Navigate to your logs `http://calypso.localhost:3000/plugins/scheduled-updates/logs/<site-slug>/<schedule-id>` and see if you got path information on fail like the screenshot below.

![Screen Shot 2024-05-20 at 6 18 22 PM](https://github.com/Automattic/wp-calypso/assets/4074459/bd076814-a37a-4fcb-9262-d3f108b5fc3f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?