### PR TITLE
What's New: lazily load

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -3,7 +3,7 @@ import { HelpCenter } from '@automattic/data-stores';
 import { shouldLoadInlineHelp } from '@automattic/help-center';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import WhatsNewGuide, { useShouldShowCriticalAnnouncementsQuery } from '@automattic/whats-new';
+import { useShouldShowCriticalAnnouncementsQuery } from '@automattic/whats-new';
 import { useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
@@ -123,7 +123,16 @@ function WhatsNewLoader( { loadWhatsNew, siteId } ) {
 		return null;
 	}
 
-	return showWhatsNew && <WhatsNewGuide onClose={ handleClose } siteId={ siteId } />;
+	return (
+		showWhatsNew && (
+			<AsyncLoad
+				require="@automattic/whats-new"
+				placeholder={ null }
+				onClose={ handleClose }
+				siteId={ siteId }
+			/>
+		)
+	);
 }
 
 function HelpCenterLoader( { sectionName, loadHelpCenter, currentRoute } ) {

--- a/packages/whats-new/src/guide.tsx
+++ b/packages/whats-new/src/guide.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable no-restricted-imports */
+import { useEffect } from 'react';
+import Guide from './components/guide';
+import { useSeenWhatsNewAnnouncementsMutation } from './hooks/use-seen-whats-new-announcements-mutation';
+import { useWhatsNewAnnouncementsQuery } from './hooks/use-whats-new-announcements-query';
+import WhatsNewPage from './whats-new-page';
+import './style.scss';
+
+interface Props {
+	onClose: () => void;
+	siteId: string;
+}
+
+const WhatsNewGuide: React.FC< Props > = ( { onClose, siteId } ) => {
+	const { data, isLoading } = useWhatsNewAnnouncementsQuery( siteId );
+	const { mutate } = useSeenWhatsNewAnnouncementsMutation();
+
+	useEffect( () => {
+		// check for whether the announcement has been seen already.
+		if ( data && data.length ) {
+			const announcementIds = data.map( ( item ) => item.announcementId );
+			mutate( announcementIds );
+		}
+	}, [ data, mutate ] );
+
+	if ( ! data || isLoading ) {
+		return null;
+	}
+
+	return (
+		<Guide
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			className="whats-new-guide__main"
+			onFinish={ onClose }
+		>
+			{ data.map( ( page, index ) => (
+				<WhatsNewPage
+					key={ page.announcementId }
+					pageNumber={ index + 1 }
+					isLastPage={ index === data.length - 1 }
+					description={ page.description }
+					heading={ page.heading }
+					imageSrc={ page.imageSrc }
+					link={ page.link }
+				/>
+			) ) }
+		</Guide>
+	);
+};
+
+export default WhatsNewGuide;

--- a/packages/whats-new/src/index.tsx
+++ b/packages/whats-new/src/index.tsx
@@ -1,10 +1,4 @@
-/* eslint-disable no-restricted-imports */
 import { HelpCenter } from '@automattic/data-stores';
-import { useEffect } from 'react';
-import Guide from './components/guide';
-import { useSeenWhatsNewAnnouncementsMutation } from './hooks/use-seen-whats-new-announcements-mutation';
-import { useWhatsNewAnnouncementsQuery } from './hooks/use-whats-new-announcements-query';
-import WhatsNewPage from './whats-new-page';
 import './style.scss';
 
 export const HELP_CENTER_STORE = HelpCenter.register();
@@ -13,47 +7,4 @@ export {
 	type WhatsNewAnnouncement,
 } from './hooks/use-whats-new-announcements-query';
 export { useShouldShowCriticalAnnouncementsQuery } from './hooks/use-should-show-critical-announcements-query';
-
-interface Props {
-	onClose: () => void;
-	siteId: string;
-}
-
-const WhatsNewGuide: React.FC< Props > = ( { onClose, siteId } ) => {
-	const { data, isLoading } = useWhatsNewAnnouncementsQuery( siteId );
-	const { mutate } = useSeenWhatsNewAnnouncementsMutation();
-
-	useEffect( () => {
-		// check for whether the announcement has been seen already.
-		if ( data && data.length ) {
-			const announcementIds = data.map( ( item ) => item.announcementId );
-			mutate( announcementIds );
-		}
-	}, [ data, mutate ] );
-
-	if ( ! data || isLoading ) {
-		return null;
-	}
-
-	return (
-		<Guide
-			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-			className="whats-new-guide__main"
-			onFinish={ onClose }
-		>
-			{ data.map( ( page, index ) => (
-				<WhatsNewPage
-					key={ page.announcementId }
-					pageNumber={ index + 1 }
-					isLastPage={ index === data.length - 1 }
-					description={ page.description }
-					heading={ page.heading }
-					imageSrc={ page.imageSrc }
-					link={ page.link }
-				/>
-			) ) }
-		</Guide>
-	);
-};
-
-export default WhatsNewGuide;
+export { default } from './guide';


### PR DESCRIPTION
The What's New widget was already correctly conditionally rendered. However, we can go a step further and conditionally load it as well.

This PR lazily loads the What's New widget, instead of statically loading it in `Layout`.

## Proposed Changes

* Use `AsyncLoad` to load the What's New widget
* Reorganize code in the `@automattic/whats-new` package so that the `WhatsNewGuide` component is not in the main index file. This improves tree-shaking when combined with the above.

## Why are these changes being made?

* To avoid loading the `WhatsNew` widget code unless it's being displayed. This should save a bit of time during application boot.

## Testing Instructions

* Run `wp user meta delete <YOUR_USER_ID> seen_whats_new_announcement_ids` in your sandbox, to clear What's New seen status.
* Load Home and ensure that the What's New widget displays correctly.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- N/A Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
