### PR TITLE
A4A: Update the 'Add new site' split button to show the A4A plugin download link.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -1,12 +1,11 @@
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import JetpackLogo from 'calypso/components/jetpack-logo';
+import { A4A_DOWNLOAD_LINK_ON_GITHUB } from 'calypso/a8c-for-agencies/constants';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
+import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from '../a4a-logo';
 import { A4A_SITES_CONNECT_URL_LINK } from '../sidebar-menu/lib/constants';
 import type { MutableRefObject } from 'react';
-
-const JETPACK_CONNECT_URL = 'https://wordpress.com/jetpack/connect?source=a8c-for-agencies';
 
 type Props = {
 	showMainButtonLabel?: boolean;
@@ -14,7 +13,7 @@ type Props = {
 	popoverContext?: MutableRefObject< HTMLElement | null >;
 	onToggleMenu?: ( isOpen: boolean ) => void;
 	onClickAddNewSite?: () => void;
-	onClickJetpackMenuItem?: () => void;
+	onClickA4APluginMenuItem?: () => void;
 	onClickUrlMenuItem?: () => void;
 };
 
@@ -24,7 +23,7 @@ const AddNewSiteButton = ( {
 	popoverContext,
 	onToggleMenu,
 	onClickAddNewSite,
-	onClickJetpackMenuItem,
+	onClickA4APluginMenuItem,
 	onClickUrlMenuItem,
 }: Props ): JSX.Element => {
 	const translate = useTranslate();
@@ -40,12 +39,15 @@ const AddNewSiteButton = ( {
 			toggleIcon={ showMainButtonLabel ? undefined : 'plus' }
 			onToggle={ onToggleMenu }
 			onClick={ onClickAddNewSite }
-			href={ JETPACK_CONNECT_URL }
+			href={ A4A_DOWNLOAD_LINK_ON_GITHUB }
 		>
-			{ /** @todo Add support for the "a8c-for-agencies" source parameter in JETPACK_CONNECT_URL. */ }
-			<PopoverMenuItem onClick={ onClickJetpackMenuItem } href={ JETPACK_CONNECT_URL }>
-				<JetpackLogo className="gridicon" size={ 18 } />
-				<span>{ translate( 'Connect a site to Jetpack' ) }</span>
+			<PopoverMenuItem onClick={ onClickA4APluginMenuItem } href={ A4A_DOWNLOAD_LINK_ON_GITHUB }>
+				<A4ALogo
+					className="gridicon"
+					size={ 18 }
+					colors={ { secondary: LOGO_COLOR_SECONDARY_ALT } }
+				/>
+				<span>{ translate( 'Download A4A Plugin' ) }</span>
 			</PopoverMenuItem>
 
 			{ showAddSitesByURLButton && (

--- a/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
@@ -20,8 +20,8 @@ export default function OverviewHeaderActions() {
 				onClickAddNewSite={ () =>
 					dispatch( recordTracksEvent( 'calypso_a4a_overview_add_new_site_click' ) )
 				}
-				onClickJetpackMenuItem={ () =>
-					dispatch( recordTracksEvent( 'calypso_a4a_overview_connect_jetpack_site_click' ) )
+				onClickA4APluginMenuItem={ () =>
+					dispatch( recordTracksEvent( 'calypso_a4a_overview_download_a4a_plugin_click' ) )
 				}
 				onClickUrlMenuItem={ () =>
 					dispatch( recordTracksEvent( 'calypso_a4a_overview_connect_url_site_click' ) )

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -25,8 +25,8 @@ export default function SitesHeaderActions() {
 					onClickAddNewSite={ () =>
 						dispatch( recordTracksEvent( 'calypso_a4a_sites_add_new_site_click' ) )
 					}
-					onClickJetpackMenuItem={ () =>
-						dispatch( recordTracksEvent( 'calypso_a4a_sites_connect_jetpack_site_click' ) )
+					onClickA4APluginMenuItem={ () =>
+						dispatch( recordTracksEvent( 'calypso_a4a_sites_download_a4a_plugin_click' ) )
 					}
 					onClickUrlMenuItem={ () =>
 						dispatch( recordTracksEvent( 'calypso_a4a_sites_connect_url_site_click' ) )


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="271" alt="Screenshot 2024-05-20 at 7 43 58 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/85555335-c101-43e4-b265-9393927794a3"> | <img width="270" alt="Screenshot 2024-05-20 at 7 43 51 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9ef5c13f-d3f0-4e37-8c1f-508731d732cb"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/458

## Proposed Changes

* Update the 'Add site' split button to show the A4A plugin download link instead of the Jetpack connection URL.

## Why are these changes being made?
We should recommend using the A4A plugin instead of Jetpack when connecting a site to improve branding around A4A.

## Testing Instructions

* Use the A4A live link below and go to the overview page. (`/overview`)
* Click the 'Add site' split button and confirm the button now shows the A4A plugin download link.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?