### PR TITLE
Woo Core Profiler: lazily load

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -26,7 +26,6 @@ import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
 import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
-import WooCoreProfilerMasterbar from 'calypso/layout/masterbar/woo-core-profiler';
 import OfflineStatus from 'calypso/layout/offline-status';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -306,7 +305,9 @@ class Layout extends Component {
 			return <EmptyMasterbar />;
 		}
 		if ( this.props.isWooCoreProfilerFlow ) {
-			return <WooCoreProfilerMasterbar />;
+			return (
+				<AsyncLoad require="calypso/layout/masterbar/woo-core-profiler" placeholder={ null } />
+			);
 		}
 
 		const MasterbarComponent = config.isEnabled( 'jetpack-cloud' )

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -15,7 +15,6 @@ import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import MasterbarLogin from 'calypso/layout/masterbar/login';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
-import WooCoreProfilerMasterbar from 'calypso/layout/masterbar/woo-core-profiler';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
@@ -209,7 +208,9 @@ const LayoutLoggedOut = ( {
 	} else if ( isWooCoreProfilerFlow ) {
 		classes.woo = true;
 		classes[ 'has-no-masterbar' ] = false;
-		masterbar = <WooCoreProfilerMasterbar />;
+		masterbar = (
+			<AsyncLoad require="calypso/layout/masterbar/woo-core-profiler" placeholder={ null } />
+		);
 	} else {
 		masterbar = ! masterbarIsHidden && (
 			<MasterbarLoggedOut


### PR DESCRIPTION
The Woo Core Profiler masterbar was already correctly conditionally rendered. However, we can go a step further and conditionally load it as well.

This PR lazily loads the Woo Core Profiler masterbar, instead of statically loading it in Layout.

## Proposed Changes

* Use `AsyncLoad` to load the Woo Core Profiler masterbar

## Why are these changes being made?

* To avoid loading the widget code unless it's being displayed. This should save a bit of time during application boot.

## Testing Instructions

I'm not familiar with this flow, and wasn't able to reproduce it, so I am not sure what the exact steps should be. In general, please smoke-test this flow and ensure that it continues to work correctly.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- N/A Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
