### PR TITLE
Bypass "Site overview" screen for non-admins

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -19,6 +19,7 @@ import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { loadExperimentAssignment, useExperiment } from 'calypso/lib/explat';
+import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl, login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -28,6 +29,7 @@ import {
 	getImmediateLoginLocale,
 } from 'calypso/state/immediate-login/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { makeLayoutMiddleware } from './shared.js';
 import { hydrate, render } from './web-util.js';
@@ -212,9 +214,11 @@ export function redirectIfCurrentUserCannot( capability ) {
 		const state = context.store.getState();
 		const site = getSelectedSite( state );
 		const currentUserCan = canCurrentUser( state, site?.ID, capability );
+		const adminInterface = getSiteOption( state, site?.ID, 'wpcom_admin_interface' );
+		const siteAdminUrl = getSiteAdminUrl( state, site?.ID );
 
 		if ( site && ! currentUserCan ) {
-			return page.redirect( `/home/${ site.slug }` );
+			return navigate( adminInterface === 'wp-admin' ? siteAdminUrl : `/home/${ site.slug }` );
 		}
 
 		next();

--- a/client/hosting-overview/index.tsx
+++ b/client/hosting-overview/index.tsx
@@ -18,6 +18,9 @@ export default function () {
 	page(
 		'/overview/:site',
 		siteSelection,
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		redirectIfCurrentUserCannot( 'manage_options' ),
 		navigation,
 		hostingOverview,
 		siteDashboard( DOTCOM_OVERVIEW ),

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -37,6 +37,7 @@ import {
 	isRequesting as isRequestingInstalledPlugins,
 } from 'calypso/state/plugins/installed/selectors';
 import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getRequest from 'calypso/state/selectors/get-request';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
@@ -80,6 +81,7 @@ const Home = ( {
 	ssoModuleActive,
 	fetchingJetpackModules,
 	handleVerifyIcannEmail,
+	isAdmin,
 } ) => {
 	const [ celebrateLaunchModalIsOpen, setCelebrateLaunchModalIsOpen ] = useState( false );
 	const [ launchedSiteId, setLaunchedSiteId ] = useState( null );
@@ -172,7 +174,7 @@ const Home = ( {
 			<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
 				{ isGlobalSiteViewEnabled ? translate( 'View site' ) : translate( 'Visit site' ) }
 			</Button>
-			{ config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && (
+			{ config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && isAdmin && (
 				<Button primary href={ `/overview/${ site.slug }` }>
 					{ translate( 'Hosting Overview' ) }
 				</Button>
@@ -338,6 +340,7 @@ const mapStateToProps = ( state ) => {
 		ssoModuleActive: !! isJetpackModuleActive( state, siteId, 'sso' ),
 		fetchingJetpackModules: !! isFetchingJetpackModules( state, siteId ),
 		isSiteLaunching: getRequest( state, launchSite( siteId ) )?.isLoading ?? false,
+		isAdmin: canCurrentUser( state, siteId, 'manage_options' ),
 	};
 };
 

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import * as React from 'react';
 //import { useInView } from 'react-intersection-observer';
 import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
+import { navigate } from 'calypso/lib/navigate';
 import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import SitesP2Badge from 'calypso/sites-dashboard/components/sites-p2-badge';
 import { SiteName } from 'calypso/sites-dashboard/components/sites-site-name';
@@ -15,6 +16,7 @@ import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-
 import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link';
 import { displaySiteUrl, isStagingSite, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
 import type { SiteExcerptData } from '@automattic/sites';
@@ -70,8 +72,14 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const isWpcomStagingSite = isStagingSite( site );
 	const isTrialSitePlan = useSelector( ( state ) => isTrialSite( state, site.ID ) );
 
+	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
+
 	const onSiteClick = ( event: React.MouseEvent ) => {
-		openSitePreviewPane && openSitePreviewPane( site );
+		if ( isAdmin ) {
+			openSitePreviewPane && openSitePreviewPane( site );
+		} else {
+			navigate( adminUrl );
+		}
 		event.preventDefault();
 	};
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7283

## Proposed Changes

This PR ensures that the "Site overview" screen (`/overview/:site`) is bypassed by non-admins, so when a site is selected in the "Sites list" screen (`/sites`) we redirect them to either WP Admin or My Home depending on the site admin interface.

**Before**

https://github.com/Automattic/wp-calypso/assets/1233880/d321e22f-7a60-4ec8-9460-b4ff58c83105

**After**

https://github.com/Automattic/wp-calypso/assets/1233880/bc29e4d1-fc6a-4394-b641-6d2f0ca60fd3

This PR also removes the "Hosting Overview" button from My Home for non-admins.

Before | After
--- | ---
<img width="977" alt="Screenshot 2024-05-20 at 13 12 33" src="https://github.com/Automattic/wp-calypso/assets/1233880/2fa7a99d-0ea4-449f-b3b6-ae9b0b55cbf3"> | <img width="983" alt="Screenshot 2024-05-20 at 13 12 37" src="https://github.com/Automattic/wp-calypso/assets/1233880/8fcbd399-624d-4ade-813a-6f850749e56d">


## Why are these changes being made?

Because the "Site overview" screen is not usable by non-admins.

## Testing Instructions

- Use the Calypso live link below
- Go to `/sites`
- Select a site of which you are an admin
- Make sure you land in `/overview/:site` as before
- Go back to `/sites`
- Now, select a site of which you are not an admin (e.g. an editor)
- Make sure you land in either My Home or WP Admin according to the site admin interface
- Try going directly to `/overview/:site` as non-admin
- Make sure it redirects to WP Admin or My Home according to the site admin interface

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
