### PR TITLE
Command Palette: lazily load Calypso dependencies

### DIFF
--- a/client/layout/command-palette.tsx
+++ b/client/layout/command-palette.tsx
@@ -16,6 +16,8 @@ interface CurrentUserCapabilitiesState {
 	};
 }
 
+// This selector is a bit too broad, but is needed to match the interface on CommandPalette.
+// We're therefore keeping it private here, instead of making it available across Calypso.
 const getCurrentUserCapabilities = ( state: CurrentUserCapabilitiesState ) =>
 	state.currentUser.capabilities;
 

--- a/client/layout/command-palette.tsx
+++ b/client/layout/command-palette.tsx
@@ -7,7 +7,6 @@ import { closeCommandPalette } from 'calypso/state/command-palette/actions';
 import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
 import { getCurrentRoutePattern } from 'calypso/state/selectors/get-current-route-pattern';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { CommandPaletteProps } from '@automattic/command-palette';
 
 interface CurrentUserCapabilitiesState {
 	currentUser: {
@@ -22,19 +21,7 @@ interface CurrentUserCapabilitiesState {
 const getCurrentUserCapabilities = ( state: CurrentUserCapabilitiesState ) =>
 	state.currentUser.capabilities;
 
-const CalypsoCommandPalette = (
-	props: Omit<
-		CommandPaletteProps,
-		| 'currentRoute'
-		| 'currentSiteId'
-		| 'isOpenGlobal'
-		| 'onClose'
-		| 'navigate'
-		| 'useCommands'
-		| 'useSites'
-		| 'userCapabilities'
-	>
-) => {
+const CalypsoCommandPalette = () => {
 	const isCommandPaletteOpen = useSelector( getIsCommandPaletteOpen );
 	const currentRoutePattern = useSelector( getCurrentRoutePattern ) ?? '';
 	const currentSiteId = useSelector( getSelectedSiteId );
@@ -50,7 +37,6 @@ const CalypsoCommandPalette = (
 			useCommands={ useCommandsCalypso }
 			useSites={ useSiteExcerptsSorted }
 			userCapabilities={ userCapabilities }
-			{ ...props }
 		/>
 	);
 };

--- a/client/layout/command-palette.tsx
+++ b/client/layout/command-palette.tsx
@@ -1,0 +1,34 @@
+import CommandPalette from '@automattic/command-palette';
+import { useSiteExcerptsSorted } from 'calypso/data/sites/use-site-excerpts-sorted';
+import { useCommandsCalypso } from 'calypso/sites-dashboard/components/wpcom-smp-commands';
+import type { CommandPaletteProps } from '@automattic/command-palette';
+
+const CalypsoCommandPalette = ( {
+	currentRoute,
+	currentSiteId,
+	isOpenGlobal,
+	navigate,
+	onClose = () => {},
+	userCapabilities,
+	selectedCommand,
+	onBack,
+	shouldCloseOnClickOutside,
+}: Omit< CommandPaletteProps, 'useCommands' | 'useSites' > ) => {
+	return (
+		<CommandPalette
+			currentRoute={ currentRoute }
+			currentSiteId={ currentSiteId }
+			isOpenGlobal={ isOpenGlobal }
+			navigate={ navigate }
+			onClose={ onClose }
+			userCapabilities={ userCapabilities }
+			selectedCommand={ selectedCommand }
+			onBack={ onBack }
+			shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
+			useCommands={ useCommandsCalypso }
+			useSites={ useSiteExcerptsSorted }
+		/>
+	);
+};
+
+export default CalypsoCommandPalette;

--- a/client/layout/command-palette.tsx
+++ b/client/layout/command-palette.tsx
@@ -6,6 +6,7 @@ import { useSelector } from 'calypso/state';
 import { closeCommandPalette } from 'calypso/state/command-palette/actions';
 import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
 import { getCurrentRoutePattern } from 'calypso/state/selectors/get-current-route-pattern';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { CommandPaletteProps } from '@automattic/command-palette';
 
 interface CurrentUserCapabilitiesState {
@@ -25,6 +26,7 @@ const CalypsoCommandPalette = (
 	props: Omit<
 		CommandPaletteProps,
 		| 'currentRoute'
+		| 'currentSiteId'
 		| 'isOpenGlobal'
 		| 'onClose'
 		| 'navigate'
@@ -35,11 +37,13 @@ const CalypsoCommandPalette = (
 ) => {
 	const isCommandPaletteOpen = useSelector( getIsCommandPaletteOpen );
 	const currentRoutePattern = useSelector( getCurrentRoutePattern ) ?? '';
+	const currentSiteId = useSelector( getSelectedSiteId );
 	const userCapabilities = useSelector( getCurrentUserCapabilities );
 
 	return (
 		<CommandPalette
 			currentRoute={ currentRoutePattern }
+			currentSiteId={ currentSiteId }
 			isOpenGlobal={ isCommandPaletteOpen }
 			onClose={ closeCommandPalette }
 			navigate={ navigate }

--- a/client/layout/command-palette.tsx
+++ b/client/layout/command-palette.tsx
@@ -1,32 +1,50 @@
 import CommandPalette from '@automattic/command-palette';
 import { useSiteExcerptsSorted } from 'calypso/data/sites/use-site-excerpts-sorted';
+import { navigate } from 'calypso/lib/navigate';
 import { useCommandsCalypso } from 'calypso/sites-dashboard/components/wpcom-smp-commands';
+import { useSelector } from 'calypso/state';
+import { closeCommandPalette } from 'calypso/state/command-palette/actions';
+import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
+import { getCurrentRoutePattern } from 'calypso/state/selectors/get-current-route-pattern';
 import type { CommandPaletteProps } from '@automattic/command-palette';
 
-const CalypsoCommandPalette = ( {
-	currentRoute,
-	currentSiteId,
-	isOpenGlobal,
-	navigate,
-	onClose = () => {},
-	userCapabilities,
-	selectedCommand,
-	onBack,
-	shouldCloseOnClickOutside,
-}: Omit< CommandPaletteProps, 'useCommands' | 'useSites' > ) => {
+interface CurrentUserCapabilitiesState {
+	currentUser: {
+		capabilities: {
+			[ key: number ]: { [ key: string ]: boolean };
+		};
+	};
+}
+
+const getCurrentUserCapabilities = ( state: CurrentUserCapabilitiesState ) =>
+	state.currentUser.capabilities;
+
+const CalypsoCommandPalette = (
+	props: Omit<
+		CommandPaletteProps,
+		| 'currentRoute'
+		| 'isOpenGlobal'
+		| 'onClose'
+		| 'navigate'
+		| 'useCommands'
+		| 'useSites'
+		| 'userCapabilities'
+	>
+) => {
+	const isCommandPaletteOpen = useSelector( getIsCommandPaletteOpen );
+	const currentRoutePattern = useSelector( getCurrentRoutePattern ) ?? '';
+	const userCapabilities = useSelector( getCurrentUserCapabilities );
+
 	return (
 		<CommandPalette
-			currentRoute={ currentRoute }
-			currentSiteId={ currentSiteId }
-			isOpenGlobal={ isOpenGlobal }
+			currentRoute={ currentRoutePattern }
+			isOpenGlobal={ isCommandPaletteOpen }
+			onClose={ closeCommandPalette }
 			navigate={ navigate }
-			onClose={ onClose }
-			userCapabilities={ userCapabilities }
-			selectedCommand={ selectedCommand }
-			onBack={ onBack }
-			shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
 			useCommands={ useCommandsCalypso }
 			useSites={ useSiteExcerptsSorted }
+			userCapabilities={ userCapabilities }
+			{ ...props }
 		/>
 	);
 };

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -30,14 +30,11 @@ import OfflineStatus from 'calypso/layout/offline-status';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
-import { navigate } from 'calypso/lib/navigate';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { getAdminColor } from 'calypso/state/admin-color/selectors';
 import { isOffline } from 'calypso/state/application/selectors';
-import { closeCommandPalette } from 'calypso/state/command-palette/actions';
-import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getShouldShowCollapsedGlobalSidebar,
@@ -48,7 +45,6 @@ import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tour
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import { getCurrentRoutePattern } from 'calypso/state/selectors/get-current-route-pattern';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -466,12 +462,7 @@ class Layout extends Component {
 					<AsyncLoad
 						require="calypso/layout/command-palette"
 						placeholder={ null }
-						isOpenGlobal={ this.props.isCommandPaletteOpen }
-						onClose={ this.props.closeCommandPalette }
 						currentSiteId={ this.props.siteId }
-						navigate={ navigate }
-						currentRoute={ this.props.currentRoutePattern }
-						userCapabilities={ this.props.userCapabilities }
 					/>
 				) }
 			</div>
@@ -480,124 +471,115 @@ class Layout extends Component {
 }
 
 export default withCurrentRoute(
-	connect(
-		( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
-			const sectionGroup = currentSection?.group ?? null;
-			const sectionName = currentSection?.name ?? null;
-			const siteId = getSelectedSiteId( state );
-			const sectionJitmPath = getMessagePathForJITM( currentRoute );
-			const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
-			const isDomainAndPlanPackageFlow = !! getCurrentQueryArguments( state )?.domainAndPlanPackage;
-			const isJetpack =
-				( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
-				currentRoute.startsWith( '/checkout/jetpack' );
-			const isWooCoreProfilerFlow =
-				[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
-				isWooCommerceCoreProfilerFlow( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
-			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
-			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
-			const noMasterbarForRoute =
-				isJetpackLogin ||
-				currentRoute === '/me/account/closed' ||
-				isDomainAndPlanPackageFlow ||
-				isReaderTagEmbedPage( window?.location );
-			const noMasterbarForSection =
-				// hide the masterBar until the section is loaded. To flicker the masterBar in, is better than to flicker it out.
-				! sectionName ||
-				( ! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName ) );
-			const isFromAutomatticForAgenciesPlugin =
-				'automattic-for-agencies-client' === currentQuery?.from;
-			const masterbarIsHidden =
-				! masterbarIsVisible( state ) ||
-				noMasterbarForSection ||
-				noMasterbarForRoute ||
-				isWpMobileApp() ||
-				isWcMobileApp() ||
-				isJetpackCloud() ||
-				isA8CForAgencies();
-			const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
-			const isJetpackWooCommerceFlow =
-				[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
-				'woocommerce-onboarding' === currentQuery?.from;
-			const isJetpackWooDnaFlow =
-				[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
-				wooDnaConfig( currentQuery ).isWooDnaFlow();
-			const oauth2Client = getCurrentOAuth2Client( state );
-			const wccomFrom = currentQuery?.[ 'wccom-from' ];
-			const isEligibleForJITM = [
-				'home',
-				'stats',
-				'plans',
-				'themes',
-				'plugins',
-				'comments',
-			].includes( sectionName );
-			const sidebarIsHidden = ! secondary || isWcMobileApp() || isDomainAndPlanPackageFlow;
-			const userAllowedToHelpCenter = config.isEnabled( 'calypso/help-center' );
-			const isCommandPaletteOpen = getIsCommandPaletteOpen( state );
+	connect( ( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
+		const sectionGroup = currentSection?.group ?? null;
+		const sectionName = currentSection?.name ?? null;
+		const siteId = getSelectedSiteId( state );
+		const sectionJitmPath = getMessagePathForJITM( currentRoute );
+		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
+		const isDomainAndPlanPackageFlow = !! getCurrentQueryArguments( state )?.domainAndPlanPackage;
+		const isJetpack =
+			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
+			currentRoute.startsWith( '/checkout/jetpack' );
+		const isWooCoreProfilerFlow =
+			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
+			isWooCommerceCoreProfilerFlow( state );
+		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+			state,
+			siteId,
+			sectionGroup,
+			sectionName
+		);
+		const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
+			state,
+			siteId,
+			sectionGroup,
+			sectionName
+		);
+		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
+			state,
+			siteId,
+			sectionGroup,
+			sectionName
+		);
+		const noMasterbarForRoute =
+			isJetpackLogin ||
+			currentRoute === '/me/account/closed' ||
+			isDomainAndPlanPackageFlow ||
+			isReaderTagEmbedPage( window?.location );
+		const noMasterbarForSection =
+			// hide the masterBar until the section is loaded. To flicker the masterBar in, is better than to flicker it out.
+			! sectionName ||
+			( ! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName ) );
+		const isFromAutomatticForAgenciesPlugin =
+			'automattic-for-agencies-client' === currentQuery?.from;
+		const masterbarIsHidden =
+			! masterbarIsVisible( state ) ||
+			noMasterbarForSection ||
+			noMasterbarForRoute ||
+			isWpMobileApp() ||
+			isWcMobileApp() ||
+			isJetpackCloud() ||
+			isA8CForAgencies();
+		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
+		const isJetpackWooCommerceFlow =
+			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
+			'woocommerce-onboarding' === currentQuery?.from;
+		const isJetpackWooDnaFlow =
+			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
+			wooDnaConfig( currentQuery ).isWooDnaFlow();
+		const oauth2Client = getCurrentOAuth2Client( state );
+		const wccomFrom = currentQuery?.[ 'wccom-from' ];
+		const isEligibleForJITM = [
+			'home',
+			'stats',
+			'plans',
+			'themes',
+			'plugins',
+			'comments',
+		].includes( sectionName );
+		const sidebarIsHidden = ! secondary || isWcMobileApp() || isDomainAndPlanPackageFlow;
+		const userAllowedToHelpCenter = config.isEnabled( 'calypso/help-center' );
 
-			const calypsoColorScheme = getPreference( state, 'colorScheme' );
-			const siteColorScheme = getAdminColor( state, siteId ) ?? calypsoColorScheme;
-			const colorScheme = shouldShowUnifiedSiteSidebar ? siteColorScheme : calypsoColorScheme;
+		const calypsoColorScheme = getPreference( state, 'colorScheme' );
+		const siteColorScheme = getAdminColor( state, siteId ) ?? calypsoColorScheme;
+		const colorScheme = shouldShowUnifiedSiteSidebar ? siteColorScheme : calypsoColorScheme;
 
-			return {
-				masterbarIsHidden,
-				sidebarIsHidden,
-				isCommandPaletteOpen,
-				isJetpack,
-				isJetpackLogin,
-				isJetpackWooCommerceFlow,
-				isJetpackWooDnaFlow,
-				isJetpackMobileFlow,
-				isWooCoreProfilerFlow,
-				isFromAutomatticForAgenciesPlugin,
-				isEligibleForJITM,
-				oauth2Client,
-				wccomFrom,
-				isLoggedIn: isUserLoggedIn( state ),
-				isSupportSession: isSupportSession( state ),
-				sectionGroup,
-				sectionName,
-				sectionJitmPath,
-				isOffline: isOffline( state ),
-				currentLayoutFocus: getCurrentLayoutFocus( state ),
-				colorScheme,
-				siteId,
-				// We avoid requesting sites in the Jetpack Connect authorization step, because this would
-				// request all sites before authorization has finished. That would cause the "all sites"
-				// request to lack the newly authorized site, and when the request finishes after
-				// authorization, it would remove the newly connected site that has been fetched separately.
-				// See https://github.com/Automattic/wp-calypso/pull/31277 for more details.
-				shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
-				sidebarIsCollapsed: sectionName !== 'reader' && getSidebarIsCollapsed( state ),
-				userAllowedToHelpCenter,
-				currentRoute,
-				isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
-				isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
-				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
-				currentRoutePattern: getCurrentRoutePattern( state ) ?? '',
-				userCapabilities: state.currentUser.capabilities,
-				isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS )( state ),
-			};
-		},
-		{
-			closeCommandPalette,
-		}
-	)( Layout )
+		return {
+			masterbarIsHidden,
+			sidebarIsHidden,
+			isJetpack,
+			isJetpackLogin,
+			isJetpackWooCommerceFlow,
+			isJetpackWooDnaFlow,
+			isJetpackMobileFlow,
+			isWooCoreProfilerFlow,
+			isFromAutomatticForAgenciesPlugin,
+			isEligibleForJITM,
+			oauth2Client,
+			wccomFrom,
+			isLoggedIn: isUserLoggedIn( state ),
+			isSupportSession: isSupportSession( state ),
+			sectionGroup,
+			sectionName,
+			sectionJitmPath,
+			isOffline: isOffline( state ),
+			currentLayoutFocus: getCurrentLayoutFocus( state ),
+			colorScheme,
+			siteId,
+			// We avoid requesting sites in the Jetpack Connect authorization step, because this would
+			// request all sites before authorization has finished. That would cause the "all sites"
+			// request to lack the newly authorized site, and when the request finishes after
+			// authorization, it would remove the newly connected site that has been fetched separately.
+			// See https://github.com/Automattic/wp-calypso/pull/31277 for more details.
+			shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
+			sidebarIsCollapsed: sectionName !== 'reader' && getSidebarIsCollapsed( state ),
+			userAllowedToHelpCenter,
+			currentRoute,
+			isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
+			isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
+			isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
+			isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS )( state ),
+		};
+	} )( Layout )
 );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -459,11 +459,7 @@ class Layout extends Component {
 				) }
 				<GlobalNotifications />
 				{ shouldEnableCommandPalette && (
-					<AsyncLoad
-						require="calypso/layout/command-palette"
-						placeholder={ null }
-						currentSiteId={ this.props.siteId }
-					/>
+					<AsyncLoad require="calypso/layout/command-palette" placeholder={ null } />
 				) }
 			</div>
 		);

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -20,7 +20,6 @@ import QuerySites from 'calypso/components/data/query-sites';
 import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
-import { useSiteExcerptsSorted } from 'calypso/data/sites/use-site-excerpts-sorted';
 import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
@@ -35,7 +34,6 @@ import { navigate } from 'calypso/lib/navigate';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
-import { useCommandsCalypso } from 'calypso/sites-dashboard/components/wpcom-smp-commands';
 import { getAdminColor } from 'calypso/state/admin-color/selectors';
 import { isOffline } from 'calypso/state/application/selectors';
 import { closeCommandPalette } from 'calypso/state/command-palette/actions';
@@ -466,15 +464,13 @@ class Layout extends Component {
 				<GlobalNotifications />
 				{ shouldEnableCommandPalette && (
 					<AsyncLoad
-						require="@automattic/command-palette"
+						require="calypso/layout/command-palette"
 						placeholder={ null }
 						isOpenGlobal={ this.props.isCommandPaletteOpen }
 						onClose={ this.props.closeCommandPalette }
 						currentSiteId={ this.props.siteId }
 						navigate={ navigate }
-						useCommands={ useCommandsCalypso }
 						currentRoute={ this.props.currentRoutePattern }
-						useSites={ useSiteExcerptsSorted }
 						userCapabilities={ this.props.userCapabilities }
 					/>
 				) }


### PR DESCRIPTION
The command palette is already correctly lazily loaded, which reduces initialisation time, and saves bytes on the initial bundle.

However, the Calypso command palette specifically has some non-trivial dependencies (such as `wpcom-smp-commands`) that are currently statically imported, and thus not lazily loaded.

This PR changes that, by creating a wrapping `CalypsoCommandPalette` and lazily loading that instead.

## Proposed Changes

* Creating a wrapping `CalypsoCommandPalette`
* Move Calypso-specific imports to `CalypsoCommandPalette`
* Lazily load `CalypsoCommandPalette` instead of `CommandPalette` in `Layout`

## Why are these changes being made?

* To avoid loading dependencies such as `wpcom-smp-commands` until they're needed

## Testing Instructions

* Open e.g. Home
* Open the command palette with Cmd+K
* Ensure that the command palette works correctly

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- N/A Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
