### PR TITLE
Scheduled Updates: Improve error message when the status is 500

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/error-utils.tsx
+++ b/client/blocks/plugin-scheduled-updates-common/error-utils.tsx
@@ -3,25 +3,26 @@ import { translate } from 'i18n-calypso';
 import type { APIError } from '@automattic/data-stores';
 
 export const handleErrorMessage = ( error: APIError ): string => {
-	let errorMsg = error.message;
-	if ( error.status === 500 ) {
-		// If error code is 500, we want to output a more useful error message and point them to support doc
-		errorMsg = translate(
-			'Your website is experiencing technical issues. Please refer to our {{a}}support documentation{{/a}} for assistance in resolving this error.',
-			{
-				components: {
-					a: (
-						<a
-							href={ localizeUrl(
-								'https://wordpress.com/support/resolve-jetpack-errors/#critical-error-on-the-site'
-							) }
-							target="_blank"
-							rel="noreferrer"
-						/>
-					 ) as JSX.Element,
-				},
-			}
-		) as string;
+	switch ( error.status ) {
+		case 500:
+			return translate(
+				'Your website is experiencing technical issues. Please refer to our {{a}}support documentation{{/a}} for assistance in resolving this error.',
+				{
+					components: {
+						a: (
+							<a
+								href={ localizeUrl(
+									'https://wordpress.com/support/resolve-jetpack-errors/#critical-error-on-the-site'
+								) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						 ) as JSX.Element,
+					},
+				}
+			) as string;
+		default:
+			// Return the default error message for other error codes
+			return error.message;
 	}
-	return errorMsg;
 };

--- a/client/blocks/plugin-scheduled-updates-common/error-utils.tsx
+++ b/client/blocks/plugin-scheduled-updates-common/error-utils.tsx
@@ -6,7 +6,6 @@ export const handleErrorMessage = ( error: APIError ): string => {
 	let errorMsg = error.message;
 	if ( error.status === 500 ) {
 		// If error code is 500, we want to output a more useful error message and point them to support doc
-		// eslint-disable-next-line
 		errorMsg = translate(
 			'Your website is experiencing technical issues. Please refer to our {{a}}support documentation{{/a}} for assistance in resolving this error.',
 			{

--- a/client/blocks/plugin-scheduled-updates-common/error-utils.tsx
+++ b/client/blocks/plugin-scheduled-updates-common/error-utils.tsx
@@ -1,0 +1,28 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
+import type { APIError } from '@automattic/data-stores';
+
+export const handleErrorMessage = ( error: APIError ): string => {
+	let errorMsg = error.message;
+	if ( error.status === 500 ) {
+		// If error code is 500, we want to output a more useful error message and point them to support doc
+		// eslint-disable-next-line
+		errorMsg = translate(
+			'Your website is experiencing technical issues. Please refer to our {{a}}support documentation{{/a}} for assistance in resolving this error.',
+			{
+				components: {
+					a: (
+						<a
+							href={ localizeUrl(
+								'https://wordpress.com/support/resolve-jetpack-errors/#critical-error-on-the-site'
+							) }
+							target="_blank"
+							rel="noreferrer"
+						/>
+					 ) as JSX.Element,
+				},
+			}
+		) as string;
+	}
+	return errorMsg;
+};

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -1,7 +1,9 @@
+import { APIError } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { handleErrorMessage } from 'calypso/blocks/plugin-scheduled-updates-common/error-utils';
 import { useCreateMonitors } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-create-monitor';
 import { useCoreSitesPluginsQuery } from 'calypso/data/plugins/use-core-sites-plugins-query';
 import {
@@ -177,7 +179,7 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit, onRecordSuccessEvent
 		createResults
 			.filter( ( result ) => result.error )
 			.forEach( ( result ) =>
-				addError( result.siteSlug, 'create', ( result.error as Error ).message )
+				addError( result.siteSlug, 'create', handleErrorMessage( result.error as APIError ) )
 			);
 
 		// Update existing schedules
@@ -197,7 +199,7 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit, onRecordSuccessEvent
 			updateResults
 				.filter( ( result ) => result.error )
 				.forEach( ( result ) =>
-					addError( result.siteSlug, 'update', ( result.error as Error ).message )
+					addError( result.siteSlug, 'update', handleErrorMessage( result.error as APIError ) )
 				);
 
 			// Delete schedules no longer needed
@@ -208,7 +210,7 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit, onRecordSuccessEvent
 			deleteResults
 				.filter( ( result ) => result.error )
 				.forEach( ( result ) =>
-					addError( result.siteSlug, 'delete', ( result.error as Error ).message )
+					addError( result.siteSlug, 'delete', handleErrorMessage( result.error as APIError ) )
 				);
 		}
 

--- a/client/blocks/plugins-scheduled-updates/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.tsx
@@ -1,7 +1,9 @@
+import { APIError } from '@automattic/data-stores';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { __experimentalText as Text } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import { handleErrorMessage } from 'calypso/blocks/plugin-scheduled-updates-common/error-utils';
 import { useCorePluginsQuery } from 'calypso/data/plugins/use-core-plugins-query';
 import {
 	useCreateUpdateScheduleMutation,
@@ -73,7 +75,7 @@ export const ScheduleForm = ( props: Props ) => {
 				weekday: frequency === 'weekly' ? date.getDay() : undefined,
 			} );
 		},
-		onError: ( e: Error ) => onSyncError && onSyncError( e.message ),
+		onError: ( e: APIError ) => onSyncError && onSyncError( handleErrorMessage( e ) ),
 	};
 	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, serverSyncCallbacks );
 	const { editUpdateSchedule } = useEditUpdateScheduleMutation( siteSlug, serverSyncCallbacks );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90547

## Proposed Changes

* When site status is 500, we'd like to point users to the support doc so they know how to fix it instead of showing default message`<p>There has been a critical error on this website.<\/p><p><a href=\"https:\/\/wordpress.org\/documentation\/article\/faq-troubleshooting\/\">Learn more about troubleshooting WordPress.<\/a><\/p>`


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Provides a better user experience when facing errors.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare a broken WoA developer site, you can do it by adding any code that causes a fatal error when creating a schedule.
* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/create/` and try to create a schedule. When it fails, it should show the error message like the screenshot below:

![Screen Shot 2024-05-20 at 9 35 31 PM](https://github.com/Automattic/wp-calypso/assets/4074459/ef6e50bf-e595-47d7-a9b9-bf6f9050b6bf)

* Navigate to a specific-site level (http://calypso.localhost:3000/plugins/scheduled-updates/create/<site-slug>) and try to create a schedule. When it fails, it should show the error message like the screenshot below:
![Screen Shot 2024-05-20 at 9 40 50 PM](https://github.com/Automattic/wp-calypso/assets/4074459/39cc28d6-b78e-4560-ad79-35a6529bb921)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
