### PR TITLE
Automattic for Agencies: Redesign hosting marketplace page

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/style.scss
@@ -5,8 +5,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 64px;
-	margin-block-start: 48px;
-	margin-block-end: 64px;
+	padding-block: 16px 32px;
 }
 
 .hosting-overview__banner {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-hosting-description.tsx
@@ -10,58 +10,77 @@ import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 export default function useHostingDescription( slug: string ): {
 	name: TranslateResult;
 	description: TranslateResult;
+	heading: TranslateResult;
 	features: TranslateResult[];
+	footerText: TranslateResult;
 } {
 	const translate = useTranslate();
 
 	return useMemo( () => {
 		let description = '';
 		let name = '';
+		let heading = '';
 		let features: TranslateResult[] = [];
+		let footerText: TranslateResult = '';
 
 		switch ( slug ) {
 			case 'pressable-hosting':
 				name = translate( 'Pressable' );
-				description = translate(
-					'Best for premier agencies and developers who need significant control and build sites that require scaling.'
-				);
+				heading = translate( 'Premier Agency Hosting w/ WooCommerce' );
+				description = translate( 'Best for large-scale businesses and major eCommerce sites.' );
 				features = [
 					translate( 'Optimized for high-traffic WooCommerce stores {{img/}}', {
 						components: {
 							img: <WooCommerceLogo size={ 32 } />,
 						},
 					} ),
-					translate( '24/7 Expert Support with expanded support options' ),
-					translate( '20GB-1TB Storage' ),
+					translate( '24/7 Expert support w/ expanded options' ),
+					translate( '75GB-1TB Storage' ),
 					translate( '100% uptime SLA' ),
-					translate( 'Custom pricing and packaging are available' ),
+					translate( 'Custom pricing' ),
 					translate( 'Agency tools to manage sites at scale' ),
 				];
+				footerText = translate( 'WP.Cloud powered hosting by' );
 				break;
 			case 'wpcom-hosting':
 				name = translate( 'WordPress.com' );
-				description = translate( 'Best for those who want a hassle-free WordPress experience.' );
+				heading = translate( 'Standard Agency Hosting' );
+				description = translate(
+					'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
+				);
 				features = [
-					translate( 'Great for developers with client-managed sites.' ),
+					translate( 'Great for client-managed sites.' ),
 					translate( '24/7 Expert Support' ),
 					translate( '50 GB Storage' ),
-					translate( 'Unmetered Visits' ),
+					translate( 'Unlimited visitors' ),
 					translate( 'Self-service sales' ),
-					translate( 'Studio (local dev)' ),
+					translate( 'Studio (local development)' ),
 				];
+				footerText = translate( 'WP.Cloud powered hosting by' );
 				break;
 			case 'vip':
 				name = translate( 'VIP' );
+				heading = translate( 'Enterprise CMS' );
 				description = translate(
 					'Deliver unmatched performance with the highest security standards on our enterprise content platform.'
 				);
-				features = [];
+				features = [
+					translate( 'Unmatched flexibility to build a customized web experience' ),
+					translate( 'Tools to increase customer engagement' ),
+					translate(
+						'Scalability to ensure top-notch site performance during campaigns or events'
+					),
+				];
+				footerText = translate( 'Enterprise WordPress hosting by' );
+				break;
 		}
 
 		return {
 			name,
+			heading,
 			description,
 			features,
+			footerText,
 		};
 	}, [ slug, translate ] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -1,20 +1,42 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .is-group-a8c-for-agencies {
 	.hosting-card {
 		border: 1px solid var(--color-neutral-10);
 		border-radius: 4px;
 		user-select: none;
 		padding: 0;
+		position: relative;
+		padding-bottom: 46px;
 
 		.button {
 			width: 100%;
 		}
 
 		.woo-logo {
-			margin: 0;
+			margin: -4px 2px;
 
 			path {
 				fill: var(--color-woocommerce);
 			}
+		}
+
+		@include break-huge {
+			padding-bottom: 32px;
+		}
+	}
+
+	.hosting-card__heading {
+		font-size: rem(24px);
+		font-weight: 600;
+		max-width: 90%;
+
+		@include break-large {
+			height: 95px;
+		}
+		@include break-huge {
+			height: 65px;
 		}
 	}
 
@@ -28,6 +50,10 @@
 		&:last-child:not(:first-child) {
 			border-block-start: 1px solid var(--color-neutral-5);
 		}
+
+		&.hosting-card__feature-section {
+			padding-block-start: 0;
+		}
 	}
 
 	.hosting-card__price {
@@ -35,6 +61,7 @@
 		flex-direction: column;
 		flex-wrap: wrap;
 		gap: 8px;
+		height: 110px;
 	}
 
 	.hosting-card__price-value {
@@ -42,7 +69,7 @@
 		font-size: 1.5rem;
 		font-weight: 600;
 		line-height: 1;
-		margin-bottom: 6px;
+		margin-block-end: 4px;
 	}
 
 	.hosting-card__price-interval {
@@ -59,12 +86,18 @@
 	}
 
 	.hosting-card__description {
-		font-size: 1rem;
+		font-size: rem(16px);
 		line-height: 1.3;
 		font-weight: 400;
-		min-height: 62px;
 		margin: 0;
 		color: var(--studio-gray-80, #2c3338);
+
+		@include break-large {
+			height: 85px;
+		}
+		@include break-huge {
+			height: 65px;
+		}
 	}
 
 	.hosting-card__header {
@@ -119,10 +152,100 @@
 		gap: 16px;
 		max-width: 300px;
 		margin: 0 auto;
+		padding-block: 0;
+		height: 150px;
 
 		svg {
-			flex-basis: 88px;
-			height: 48px;
+			flex-basis: 54px;
+			height: 42px;
+
+			@include break-xlarge {
+				flex-basis: 56px;
+			}
+
+			@include break-wide {
+				flex-basis: 48px;
+				height: 28px;
+			}
+
+			@include break-huge {
+				flex-basis: 60px;
+				height: 28px;
+			}
 		}
+
+		@include break-wide {
+			height: 110px;
+		}
+	}
+}
+
+.hosting-list__vip-card .hosting-card__logo-section {
+	padding-block: 0;
+	margin: auto;
+}
+
+.hosting-card__footer {
+	position: absolute;
+	bottom: 16px;
+	width: 100%;
+	text-align: right;
+
+	@include break-large {
+		bottom: 8px;
+	}
+
+	span {
+		font-size: rem(12px);
+		color: var(--studio-gray-50);
+		margin-inline-end: 6px;
+	}
+
+	img {
+		width: 100px;
+		margin-inline-end: 6px;
+		position: relative;
+		top: 4px;
+		right: 2px;
+
+		@include break-huge {
+			width: 130px;
+			top: 6px;
+		}
+	}
+
+	.wordpress-vip-logo {
+		display: inline-block;
+
+		svg {
+			width: 50px;
+			margin-inline-end: 6px;
+			position: relative;
+			top: 10px;
+		}
+	}
+}
+
+.hosting-card__check-icon {
+	position: absolute;
+	right: 16px;
+	top: 16px;
+	background: var(--color-success);
+	fill: var(--color-text-white);
+	border-radius: 50%;
+	width: 25px;
+	height: 25px;
+	display: none;
+
+	@include break-large {
+		display: block;
+	}
+}
+
+.badge.hosting-card__ownership-badge {
+	display: block;
+
+	@include break-large {
+		display: none;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -4,6 +4,7 @@ import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { APIProductFamily } from 'calypso/state/partner-portal/types';
@@ -109,9 +110,10 @@ export default function HostingList( { selectedSite }: Props ) {
 			<ListingSection
 				title={ translate( 'Hosting' ) }
 				description={ translate(
-					'Choose the hosting that suits your needs from our best-in-class offerings.'
+					'Choose from a variety of world-class managed hosting that will scale with your business.'
 				) }
 				isTwoColumns
+				extraContent={ <MigrationOffer foldable /> }
 			>
 				{ creatorPlan && (
 					<HostingCard
@@ -141,7 +143,7 @@ export default function HostingList( { selectedSite }: Props ) {
 			{ isWPCOMOptionEnabled && (
 				<Card className="hosting-list__features">
 					<h3 className="hosting-list__features-heading">
-						{ translate( 'Included with WordPress.com and Pressable plans' ) }
+						{ translate( 'Included with Standard & Premier hosting' ) }
 					</h3>
 					<SimpleList
 						className="hosting-list__features-list"
@@ -157,7 +159,7 @@ export default function HostingList( { selectedSite }: Props ) {
 							<li>{ translate( 'SFTP/SSH, WP-CLI, Git tools' ) }</li>,
 							<li>{ translate( '10 PHP workers with auto-scaling' ) }</li>,
 							<li>{ translate( 'Resource isolation across every site' ) }</li>,
-							<li>{ translate( 'Real-time cloud backups via Jetpack' ) }</li>,
+							<li>{ translate( 'Jetpack real-time backups' ) }</li>,
 						] }
 					/>
 				</Card>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/style.scss
@@ -3,6 +3,10 @@
 
 .hosting-list {
 	justify-content: flex-start;
+
+	.card.foldable-card.a4a-migration-offer__wrapper {
+		margin-block: 4px 32px;
+	}
 }
 
 .hosting-list__placeholder {
@@ -22,11 +26,6 @@
 	border: 1px solid var(--color-neutral-10);
 	box-shadow: none;
 	border-radius: 4px;
-	margin: 0;
-
-	@include break-wide {
-		width: calc(66.666% - 6px);
-	}
 }
 
 .hosting-list__features-heading {

--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -57,7 +57,7 @@ export function getHostingPageUrl( slug: string ) {
  * @param {string} slug - Hosting provider slug
  * @returns {Element} - Hosting provider logo
  */
-export function getHostingLogo( slug: string ) {
+export function getHostingLogo( slug: string, showText = true ) {
 	switch ( slug ) {
 		case 'pressable-hosting':
 			return <img src={ PressableLogo } alt="" />;
@@ -67,7 +67,7 @@ export function getHostingLogo( slug: string ) {
 			return (
 				<div className="wordpress-vip-logo">
 					<VIPLogo height={ 30 } width={ 67 } />
-					{ translate( '(Enterprise)' ) }
+					{ showText && translate( '(Enterprise)' ) }
 				</div>
 			);
 	}

--- a/client/a8c-for-agencies/sections/marketplace/listing-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/listing-section/index.tsx
@@ -10,6 +10,7 @@ type Props = {
 	description: string;
 	children: ReactNode;
 	isTwoColumns?: boolean;
+	extraContent?: ReactNode;
 };
 
 export default function ListingSection( {
@@ -19,6 +20,7 @@ export default function ListingSection( {
 	description,
 	children,
 	isTwoColumns,
+	extraContent,
 }: Props ) {
 	return (
 		<div
@@ -30,6 +32,8 @@ export default function ListingSection( {
 				<span>{ title }</span>
 			</h2>
 			<p className="listing-section-description">{ description }</p>
+
+			{ extraContent }
 
 			<div className="listing-section-content">{ children }</div>
 		</div>

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -414,3 +414,18 @@ html {
 		}
 	}
 }
+
+.popover.tooltip.gray-tooltip {
+	.popover__arrow {
+		&::before {
+			border-bottom-color: var(--color-accent-60);
+			inset-block-start: 1px;
+		}
+	}
+	.popover__inner {
+		background: var(--color-accent-60);
+		color: var(--color-text-white);
+		padding: 10px 12px;
+		border: none;
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-roadmap/issues/1563

## Proposed Changes

This PR redesigns the hosting marketplace page

## Testing Instructions

1. Open the A4A live link.
2. Visit the Marketplace > Hosting page and verify the UI is redesigned as shown below and matches with the latest design (link on the ticket). Also, verify it works well on the screen sizes. 

![screencapture-agencies-localhost-3000-marketplace-hosting-2024-05-20-17_22_42](https://github.com/Automattic/wp-calypso/assets/10586875/676ff334-1f2f-4eb7-a662-4662c29859e5)

<img width="466" alt="Screenshot 2024-05-20 at 5 25 11 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/db64014c-3447-4988-837d-f21efed26c2f">

Mobile view:

<img width="334" alt="Screenshot 2024-05-21 at 8 55 00 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f3a9db7e-8c64-4fae-b514-5865e7a07316">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
