### PR TITLE
Add site context to command palette footer

### DIFF
--- a/apps/command-palette-wp-admin/src/use-sites.ts
+++ b/apps/command-palette-wp-admin/src/use-sites.ts
@@ -9,6 +9,7 @@ export const useSites = (): SiteExcerptData[] => {
 		isComingSoon,
 		isP2,
 		siteHostname,
+		siteName,
 		shouldUseWpAdmin,
 		isWpcomStore,
 	} = window.commandPaletteConfig;
@@ -18,6 +19,7 @@ export const useSites = (): SiteExcerptData[] => {
 		{
 			ID: siteId,
 			slug: siteHostname,
+			name: siteName,
 			jetpack: isAtomic,
 			is_wpcom_atomic: isAtomic,
 			is_coming_soon: isComingSoon,

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -19,7 +19,7 @@ export interface CommandPaletteContext
 	search: string;
 	selectedCommandName: string;
 	setEmptyListNotice: ( message: string ) => void;
-	setFooterMessage: ( message: string ) => void;
+	setFooterMessage: ( message: string | JSX.Element ) => void;
 	setSelectedCommandName: ( name: string ) => void;
 }
 

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -91,12 +91,32 @@ export function CommandMenuGroup() {
 		setEmptyListNotice,
 		navigate,
 		currentRoute,
+		currentSiteId,
+		useSites,
 	} = useCommandPaletteContext();
 	const { commands, filterNotice, emptyListNotice } = useCommandPalette();
 
+	const sites = useSites();
+	const currentSite = sites.find( ( site: { ID: unknown } ) => site.ID === currentSiteId );
+
 	useEffect( () => {
+		if ( ! filterNotice && currentSiteId ) {
+			const sitesPath = currentRoute.startsWith( '/wp-admin' )
+				? 'https://wordpress.com/sites'
+				: '/sites/';
+			const message = (
+				<>
+					<a href={ sitesPath }>All sites</a> { ' / ' }
+					{ currentSite?.options && (
+						<a href={ currentSite.options.admin_url }>{ currentSite.name }</a>
+					) }
+				</>
+			);
+			setFooterMessage( message );
+			return;
+		}
 		setFooterMessage( filterNotice ?? '' );
-	}, [ setFooterMessage, filterNotice ] );
+	}, [ setFooterMessage, filterNotice, currentSiteId, currentRoute, currentSite ] );
 
 	useEffect( () => {
 		setEmptyListNotice( emptyListNotice ?? '' );

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -82,6 +82,7 @@ const StyledCommandsFooter = styled.div( {
 	color: 'var(--studio-gray-50)',
 	a: {
 		color: 'var(--studio-gray-50)',
+		'text-decoration': 'none',
 	},
 	'a.command-palette__footer-current-site, a:hover': {
 		color: 'var(--studio-gray-100)',

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -102,6 +102,7 @@ export function CommandMenuGroup() {
 		useSites,
 	} = useCommandPaletteContext();
 	const { commands, filterNotice, emptyListNotice, singleSiteMode } = useCommandPalette();
+	const { __ } = useI18n();
 
 	const sites = useSites();
 	const currentSite = sites.find( ( site: { ID: unknown } ) => site.ID === currentSiteId );
@@ -121,7 +122,7 @@ export function CommandMenuGroup() {
 			const message = (
 				<>
 					<a className="command-palette__footer-all-sites" href={ sitesPath }>
-						All sites
+						{ __( 'All sites', __i18n_text_domain__ ) }
 					</a>
 					{ ' / ' }
 					{ adminUrl && (

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -105,6 +105,13 @@ export function CommandMenuGroup() {
 
 	const sites = useSites();
 	const currentSite = sites.find( ( site: { ID: unknown } ) => site.ID === currentSiteId );
+	const adminUrl =
+		currentSite?.options?.wpcom_admin_interface === 'wp-admin'
+			? 'https://' + currentSite.slug + '/wp-admin'
+			: 'https://wordpress.com/home/' + currentSite?.slug;
+
+	// Should just use the name but need Jetpack change for this to work in wp-admin
+	const siteName = currentSite?.name ?? currentSite?.slug;
 
 	useEffect( () => {
 		if ( ! filterNotice && singleSiteMode ) {
@@ -115,14 +122,11 @@ export function CommandMenuGroup() {
 				<>
 					<a className="command-palette__footer-all-sites" href={ sitesPath }>
 						All sites
-					</a>{ ' ' }
+					</a>
 					{ ' / ' }
-					{ currentSite?.options && (
-						<a
-							className="command-palette__footer-current-site"
-							href={ currentSite.options.admin_url }
-						>
-							{ currentSite.name }
+					{ adminUrl && (
+						<a className="command-palette__footer-current-site" href={ adminUrl }>
+							{ siteName }
 						</a>
 					) }
 				</>
@@ -130,8 +134,7 @@ export function CommandMenuGroup() {
 			setFooterMessage( message );
 			return;
 		}
-		setFooterMessage( filterNotice ?? '' );
-	}, [ setFooterMessage, filterNotice, singleSiteMode, currentRoute, currentSite ] );
+	}, [ setFooterMessage, filterNotice, singleSiteMode, currentRoute, adminUrl, siteName ] );
 
 	useEffect( () => {
 		setEmptyListNotice( emptyListNotice ?? '' );

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -79,6 +79,13 @@ const StyledCommandsFooter = styled.div( {
 	paddingBottom: '12px',
 	borderTop: '1px solid var(--studio-gray-5)',
 	color: 'var(--studio-gray-50)',
+	a: {
+		color: 'var(--studio-gray-50)',
+	},
+	'a.command-palette__footer-current-site': {
+		color: 'var(--studio-gray-100)',
+	},
+	'a:hover': { 'text-decoration': 'underline' },
 } );
 
 export function CommandMenuGroup() {
@@ -106,9 +113,17 @@ export function CommandMenuGroup() {
 				: '/sites/';
 			const message = (
 				<>
-					<a href={ sitesPath }>All sites</a> { ' / ' }
+					<a className="command-palette__footer-all-sites" href={ sitesPath }>
+						All sites
+					</a>{ ' ' }
+					{ ' / ' }
 					{ currentSite?.options && (
-						<a href={ currentSite.options.admin_url }>{ currentSite.name }</a>
+						<a
+							className="command-palette__footer-current-site"
+							href={ currentSite.options.admin_url }
+						>
+							{ currentSite.name }
+						</a>
 					) }
 				</>
 			);

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -82,7 +82,7 @@ const StyledCommandsFooter = styled.div( {
 	a: {
 		color: 'var(--studio-gray-50)',
 	},
-	'a.command-palette__footer-current-site': {
+	'a.command-palette__footer-current-site, a:hover': {
 		color: 'var(--studio-gray-100)',
 	},
 	'a:hover': { 'text-decoration': 'underline' },

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -101,13 +101,13 @@ export function CommandMenuGroup() {
 		currentSiteId,
 		useSites,
 	} = useCommandPaletteContext();
-	const { commands, filterNotice, emptyListNotice } = useCommandPalette();
+	const { commands, filterNotice, emptyListNotice, singleSiteMode } = useCommandPalette();
 
 	const sites = useSites();
 	const currentSite = sites.find( ( site: { ID: unknown } ) => site.ID === currentSiteId );
 
 	useEffect( () => {
-		if ( ! filterNotice && currentSiteId ) {
+		if ( ! filterNotice && singleSiteMode ) {
 			const sitesPath = currentRoute.startsWith( '/wp-admin' )
 				? 'https://wordpress.com/sites'
 				: '/sites/';
@@ -131,7 +131,7 @@ export function CommandMenuGroup() {
 			return;
 		}
 		setFooterMessage( filterNotice ?? '' );
-	}, [ setFooterMessage, filterNotice, currentSiteId, currentRoute, currentSite ] );
+	}, [ setFooterMessage, filterNotice, singleSiteMode, currentRoute, currentSite ] );
 
 	useEffect( () => {
 		setEmptyListNotice( emptyListNotice ?? '' );

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -283,7 +283,7 @@ const CommandPalette = ( {
 	const [ selectedCommandName, setSelectedCommandName ] = useState( '' );
 	const [ isOpenLocal, setIsOpenLocal ] = useState( false );
 	const isOpen = isOpenLocal || isOpenGlobal;
-	const [ footerMessage, setFooterMessage ] = useState( '' );
+	const [ footerMessage, setFooterMessage ] = useState< string | JSX.Element >( '' );
 	const [ emptyListNotice, setEmptyListNotice ] = useState( '' );
 	const open = useCallback( () => {
 		toggleModalOpenClassnameOnDocumentHtmlElement( true );

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -102,7 +102,7 @@ export function CommandMenuGroup() {
 		currentSiteId,
 		useSites,
 	} = useCommandPaletteContext();
-	const { commands, filterNotice, emptyListNotice, singleSiteMode } = useCommandPalette();
+	const { commands, filterNotice, emptyListNotice, inSiteContext } = useCommandPalette();
 	const { __ } = useI18n();
 
 	const sites = useSites();
@@ -116,7 +116,7 @@ export function CommandMenuGroup() {
 	const siteName = currentSite?.name ?? currentSite?.slug;
 
 	useEffect( () => {
-		if ( ! filterNotice && singleSiteMode ) {
+		if ( ! filterNotice && inSiteContext ) {
 			const sitesPath = currentRoute.startsWith( '/wp-admin' )
 				? 'https://wordpress.com/sites'
 				: '/sites/';
@@ -136,7 +136,7 @@ export function CommandMenuGroup() {
 			setFooterMessage( message );
 			return;
 		}
-	}, [ setFooterMessage, filterNotice, singleSiteMode, currentRoute, adminUrl, siteName ] );
+	}, [ setFooterMessage, filterNotice, inSiteContext, currentRoute, adminUrl, siteName, __ ] );
 
 	useEffect( () => {
 		setEmptyListNotice( emptyListNotice ?? '' );

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -15,6 +15,7 @@ import {
 } from './context';
 import { COMMAND_SEPARATOR, useCommandFilter } from './use-command-filter';
 import { useCommandPalette } from './use-command-palette';
+import { siteUsesWpAdminInterface } from './utils';
 import type { Command as PaletteCommand } from './commands';
 import type { SiteExcerptData } from '@automattic/sites';
 import './style.scss';
@@ -107,7 +108,7 @@ export function CommandMenuGroup() {
 	const sites = useSites();
 	const currentSite = sites.find( ( site: { ID: unknown } ) => site.ID === currentSiteId );
 	const adminUrl =
-		currentSite?.options?.wpcom_admin_interface === 'wp-admin'
+		currentSite && siteUsesWpAdminInterface( currentSite )
 			? 'https://' + currentSite.slug + '/wp-admin'
 			: 'https://wordpress.com/home/' + currentSite?.slug;
 

--- a/packages/command-palette/src/use-command-palette.tsx
+++ b/packages/command-palette/src/use-command-palette.tsx
@@ -137,6 +137,7 @@ export const useCommandPalette = (): {
 	commands: Command[];
 	filterNotice: string | undefined;
 	emptyListNotice: string | undefined;
+	singleSiteMode: boolean | undefined;
 } => {
 	const {
 		currentSiteId,
@@ -168,6 +169,10 @@ export const useCommandPalette = (): {
 			search_text: search,
 		} );
 	};
+
+	const currentSite = sites.find( ( site ) => site.ID === currentSiteId );
+	const singleSiteMode =
+		currentSite && ( currentRoute.includes( ':site' ) || currentRoute.startsWith( '/wp-admin' ) );
 
 	// Logic for selected command (sites)
 	if ( selectedCommandName ) {
@@ -220,7 +225,7 @@ export const useCommandPalette = (): {
 			);
 		}
 
-		return { commands: sitesToPick ?? [], filterNotice, emptyListNotice };
+		return { commands: sitesToPick ?? [], filterNotice, emptyListNotice, singleSiteMode };
 	}
 
 	// Logic for root commands
@@ -253,13 +258,8 @@ export const useCommandPalette = (): {
 		return 0; // no change in order
 	} );
 
-	const currentSite = sites.find( ( site ) => site.ID === currentSiteId );
-
 	// If we are on a current site context, filter and map the commands for single site use.
-	if (
-		currentSite &&
-		( currentRoute.includes( ':site' ) || currentRoute.startsWith( '/wp-admin' ) )
-	) {
+	if ( singleSiteMode ) {
 		sortedCommands = sortedCommands.filter( ( command ) =>
 			isCommandAvailableOnSite( command, currentSite, userCapabilities )
 		);
@@ -312,5 +312,10 @@ export const useCommandPalette = (): {
 		}
 	}
 
-	return { commands: finalSortedCommands, filterNotice: undefined, emptyListNotice: undefined };
+	return {
+		commands: finalSortedCommands,
+		filterNotice: undefined,
+		emptyListNotice: undefined,
+		singleSiteMode,
+	};
 };

--- a/packages/command-palette/src/use-command-palette.tsx
+++ b/packages/command-palette/src/use-command-palette.tsx
@@ -137,7 +137,7 @@ export const useCommandPalette = (): {
 	commands: Command[];
 	filterNotice: string | undefined;
 	emptyListNotice: string | undefined;
-	singleSiteMode: boolean | undefined;
+	inSiteContext: boolean | undefined;
 } => {
 	const {
 		currentSiteId,
@@ -171,7 +171,7 @@ export const useCommandPalette = (): {
 	};
 
 	const currentSite = sites.find( ( site ) => site.ID === currentSiteId );
-	const singleSiteMode =
+	const inSiteContext =
 		currentSite && ( currentRoute.includes( ':site' ) || currentRoute.startsWith( '/wp-admin' ) );
 
 	// Logic for selected command (sites)
@@ -225,7 +225,7 @@ export const useCommandPalette = (): {
 			);
 		}
 
-		return { commands: sitesToPick ?? [], filterNotice, emptyListNotice, singleSiteMode };
+		return { commands: sitesToPick ?? [], filterNotice, emptyListNotice, inSiteContext };
 	}
 
 	// Logic for root commands
@@ -259,7 +259,7 @@ export const useCommandPalette = (): {
 	} );
 
 	// If we are on a current site context, filter and map the commands for single site use.
-	if ( singleSiteMode ) {
+	if ( inSiteContext ) {
 		sortedCommands = sortedCommands.filter( ( command ) =>
 			isCommandAvailableOnSite( command, currentSite, userCapabilities )
 		);
@@ -316,6 +316,6 @@ export const useCommandPalette = (): {
 		commands: finalSortedCommands,
 		filterNotice: undefined,
 		emptyListNotice: undefined,
-		singleSiteMode,
+		inSiteContext,
 	};
 };

--- a/packages/command-palette/test/index.tsx
+++ b/packages/command-palette/test/index.tsx
@@ -54,6 +54,7 @@ describe( 'CommandPalette', () => {
 			commands: commands,
 			filterNotice: 'Mock Filter Notice',
 			emptyListNotice: 'No results found',
+			currentSiteId: null,
 		} );
 
 		render(
@@ -63,6 +64,7 @@ describe( 'CommandPalette', () => {
 					currentSiteId={ null }
 					navigate={ () => {} }
 					useCommands={ () => commands }
+					useSites={ () => [] }
 				/>
 			</QueryClientProvider>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90399

## Proposed Changes

The command palette footer will now show the current site, including links to the site admin and to the /sites page, when working in a site context.

### TODO

- [x] Look more like the design
- [x] Make the hover state work as in the design
- [x] Fix the unit tests
- [x] Go to the correct site admin UI (calypso or wp-admin) for this site rather than assuming wp-admin
- [x] This might need refactoring, see also #90394

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make it clearer when the command palette is working in a site-specific context

## Testing Instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Calypso

1. Use Calypso live link
2. Go to a site-specific context like /home/:siteSlug
3. Invoke the command palette with ⌘k or CTRL k
4. Notice it has a footer that says All sites / your current site name
5. All sites should link to /sites
6. Your current site name should link to either /wp-admin or wordpress.com/home depending upon the preference for that site
7. Go to /read or /sites where there is no site selected
8. Invoke the command palette with ⌘k or CTRL k
9. Note it doesn't display the footer

### wp-admin

1. Use the generated command to apply patch to sandbox
2. Sandbox the site and widgets.wp.com
3. Go to yoursite's wp-admin page
4. Invoke the command palette with ⌘k or CTRL k
5. Notice it has a footer that says All sites / your current site's url 
6. All sites should link to /sites
7. Your current site name should link to either /wp-admin or wordpress.com/home depending upon the preference for that site
8. Apply https://github.com/Automattic/jetpack/pull/37475  if it's not been released yet
9. Go to your sites wp-admin
10. Invoke the command palette with ⌘k or CTRL k
11. Notice the footer now says All sites / your current site's name

Env | Before | After
----|---|------
wp-admin | <img width="1460" alt="Screenshot 2024-05-21 at 20 29 18" src="https://github.com/Automattic/wp-calypso/assets/93301/cdd845ab-fde2-4c68-a6d1-24f578f17016"> | <img width="1460" alt="Screenshot 2024-05-21 at 20 27 21" src="https://github.com/Automattic/wp-calypso/assets/93301/890efe2a-7d29-44d6-ba9e-d6c33a8149bd">
calypso | <img width="1460" alt="Screenshot 2024-05-21 at 20 30 25" src="https://github.com/Automattic/wp-calypso/assets/93301/3ebfbd43-b2c4-4c0b-be62-e20f77c15264"> | <img width="1460" alt="Screenshot 2024-05-21 at 20 42 43" src="https://github.com/Automattic/wp-calypso/assets/93301/070eed4f-69d4-40c0-93dd-548632b60769">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
