### PR TITLE
Checkout: Change plan upsell calculation to take volume and discounts into account

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -46,9 +46,10 @@ function UpgradeText( {
 	firstDomain: ResponseCartProduct;
 } ) {
 	const translate = useTranslate();
-	// Use the subtotal with discounts for the current cart price, but use the
-	// subtotal without discounts to calculate the price after the upsell
-	// because some discounts may be removed by the upsell.
+	// Use the subtotal with discounts for the current cart item price if the
+	// item's discounts are only for the first year, but use the subtotal
+	// without discounts to calculate the price after the upsell because the
+	// upsell will remove other first year discounts.
 	//
 	// For example, if the domain has a sale coupon then it will be removed by
 	// the "first year free" bundle discount when a plan is added to the cart
@@ -57,10 +58,15 @@ function UpgradeText( {
 	// predicted cart price with the plan, we must consider the current cart
 	// with the sale and the predicted cart without the sale.
 	//
-	// This may not be accurate for all types of discounts (in the previous
-	// example it only happens because they are both first-year percentage
-	// discounts) but it should be accurate most of the time.
-	const domainInCartPrice = firstDomain.item_subtotal_integer;
+	// This will not be accurate for all types of discounts and predicting what
+	// discounts will be applied is difficult, but this makes an attempt based
+	// on what discounts are currently applied.
+	const isDomainDiscountFromFirstYearOverride = firstDomain.cost_overrides.every(
+		( override ) => override.first_unit_only
+	);
+	const domainInCartPrice = isDomainDiscountFromFirstYearOverride
+		? firstDomain.item_subtotal_integer
+		: firstDomain.item_original_subtotal_integer;
 	const domainInCartPricePerYear = firstDomain.item_original_subtotal_integer / firstDomain.volume;
 	const cartPriceWithDomainAndPlan =
 		domainInCartPricePerYear * ( firstDomain.volume - 1 ) + planPrice;

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -58,5 +58,6 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		product_type: 'test',
 		included_domain_purchase_amount: 0,
 		product_variants: [],
+		cost_overrides: [],
 	};
 }

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -418,7 +418,7 @@ export interface ResponseCartProduct {
 	 * The override_code is a string that identifies the reason for the override.
 	 * When displaying the reason to the customer, use the human_readable_reason.
 	 */
-	cost_overrides?: ResponseCartCostOverride[];
+	cost_overrides: ResponseCartCostOverride[];
 
 	/**
 	 * If set, is used to transform the usage/quantity of units used to derive the number of units
@@ -525,6 +525,8 @@ export interface ResponseCartCostOverride {
 	old_subtotal_integer: number;
 	override_code: string;
 	does_override_original_cost: boolean;
+	percentage: number;
+	first_unit_only: boolean;
 }
 
 export type IntroductoryOfferUnit = 'day' | 'week' | 'month' | 'year' | 'indefinite';


### PR DESCRIPTION
## Proposed Changes

When you have a domain in your cart and no plan (pre-owned or in the cart), checkout displays an upsell that suggests adding a plan. It includes text that reads either "save X" or "pay an extra X" to inform the user what the price difference would be for their cart with the plan. However, the calculation currently is not accurate if the domain item is for multiple years. 

The calculation is inaccurate because of the following reasons:

1. Currently we subtract the _discounted_ price of the domain from the price of the plan to figure out the extra amount that must be paid to have the plan because the plan will give you the first year free. However, for a multi-year plan, this subtracts too much since only one year of the plan is free and the price of the domain includes all the years.
2. We cannot use the _undiscounted_ price of the domain for one year in the above calculation because the price of the plan minus the undiscounted price of the domain will be too small when you consider that the domain currently has a discount. 
3. We also cannot use the _discounted_ price of the domain for one year in the above calculation because the discount (if it comes from a first year sale) won't exist when the plan is added to the cart since a 30% first-year discount on top of a 100% first-year discount is 0.
4. If there is another kind of percentage discount which is applied to the total and not only the first year, like a coupon code, then that discount will be applied to the domain currently in the cart, any number of the years of the domain that will remain in the cart when the plan is added, and the plan itself. Therefore, the calculation must take this into account.

In this PR we refactor the calculation to cover each of the above cases to better predict the savings or extra cost that will occur when adding a plan to the cart.

It's possible for this calculation to still be incorrect for discount types not covered above (introductory offers, maybe?), but since sale coupons and coupon code are probably the most common discounts applied to domains and wpcom plans, this should cover most scenarios.

Fixes the bug reported here: https://github.com/Automattic/wp-calypso/pull/89472#pullrequestreview-2007875781. That PR was never merged because I accidentally made a very similar refactor around the same time (https://github.com/Automattic/wp-calypso/pull/89874) for a different purpose which ended up causing the same bug reported in the original PR. Huge apologies to @chriskmnds and @aneeshd16 for that oversight! 🙇 

## Screenshots

Here is an example with a sale coupon on the domain. Note the referenced price difference in the **"Upgrade and save"** box on the right side. Prior to this change, it reads "Save $11.40" and after this change it reads "Pay an extra $32.60". The actual difference in the cart total will be an increase from $59.40 to $92.00, an increase of $32.60.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1052" alt="before-upsell-fix" src="https://github.com/Automattic/wp-calypso/assets/2036909/560056e3-a37a-4b4e-812d-6fa8f6d6bbca"> | <img width="1054" alt="after-upsell-fix" src="https://github.com/Automattic/wp-calypso/assets/2036909/0fd7d816-2c34-462d-9c4a-fdc71c282083">

For reference, here's what my cart looks like after I accept the upsell:

<img width="1073" alt="cart-with-plan-and-domain" src="https://github.com/Automattic/wp-calypso/assets/2036909/9da8a3db-028c-4f06-967c-baa2e02f0e76">

Here is another example with a coupon code instead of a sale coupon (a cart cannot have both at the same time). Note that the "Pay an extra X" now includes the 50% savings from the coupon. Prior to this change it read "Pay an extra $42" and after this change it reads "Pay an extra $18". The actual difference in the cart total will be an increase from $6 to $24, a difference of $18.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1055" alt="incorrect-upsell-with-coupon" src="https://github.com/Automattic/wp-calypso/assets/2036909/8e825ac0-efd6-473e-a83a-c7d7202d495e"> | <img width="1040" alt="correct-upsell-with-coupon" src="https://github.com/Automattic/wp-calypso/assets/2036909/16b673db-c291-4752-bc80-76a053fd83c2">

Here's what the cart looks like after the upsell:

<img width="1056" alt="cart-after-upsell-with-coupon" src="https://github.com/Automattic/wp-calypso/assets/2036909/b0df519d-aa6b-4bda-9eec-2e8620ee3b72">

## Testing Instructions

1. Using a site that has no plan, add a domain registration to your cart and visit checkout.
5. Record the current cart total.
6. Notice the "Upgrade and save" upsell in the sidebar and record the price difference written there ("Save X" or "Pay an extra X").
7. Click "Add to Cart" in the upsell.
8. Compare the actual price difference between the old cart total and the new cart total with the price difference that was in the upsell. Make sure that the math is correct.
9. Remove the plan from your cart to make the upsell appear again.
10. Change the volume of the domain from "One year" to a longer billing term.
11. Repeat steps 2 - 5 and verify that the math is still correct.

It's a good idea to test this for a domain with a sale coupon and a domain without a sale coupon. It's also a good idea to try adding a coupon code to make sure the prices are still accurate.