### PR TITLE
A4A: Add the Settings navigation bar

### DIFF
--- a/client/a8c-for-agencies/sections/settings/index.tsx
+++ b/client/a8c-for-agencies/sections/settings/index.tsx
@@ -6,4 +6,12 @@ import { settingsContext } from './controller';
 
 export default function () {
 	page( A4A_SETTINGS_LINK, requireAccessContext, settingsContext, makeLayout, clientRender );
+
+	page(
+		`${ A4A_SETTINGS_LINK }/agency-profile`,
+		requireAccessContext,
+		settingsContext,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/a8c-for-agencies/sections/settings/index.tsx
+++ b/client/a8c-for-agencies/sections/settings/index.tsx
@@ -5,7 +5,10 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import { settingsContext } from './controller';
 
 export default function () {
-	page( A4A_SETTINGS_LINK, requireAccessContext, settingsContext, makeLayout, clientRender );
+	// todo: we have only one tab, this redirect /settings to /settings/agency-profile
+	page( A4A_SETTINGS_LINK, () => {
+		page.redirect( `${ A4A_SETTINGS_LINK }/agency-profile` );
+	} );
 
 	page(
 		`${ A4A_SETTINGS_LINK }/agency-profile`,

--- a/client/a8c-for-agencies/sections/settings/settings.tsx
+++ b/client/a8c-for-agencies/sections/settings/settings.tsx
@@ -4,13 +4,39 @@ import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutNavigation, {
+	LayoutNavigationTabs,
+} from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_SETTINGS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AgencyProfile from './agency-profile';
 
 export default function Settings() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const title = translate( 'Settings' );
+
+	const navItems = [
+		{
+			key: 'agency_profile',
+			label: translate( 'Agency Profile' ),
+		},
+	].map( ( navItem ) => ( {
+		...navItem,
+		selected: true,
+		path: `${ A4A_SETTINGS_LINK }/agency-profile`,
+		onClick: () => {
+			dispatch( recordTracksEvent( 'calypso_a4a_settings_agency_profile_click' ) );
+		},
+	} ) );
+
+	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
+	const selectedItemProps = {
+		selectedText: selectedItem.label,
+	};
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -18,6 +44,9 @@ export default function Settings() {
 				<LayoutHeader>
 					<Title>{ title }</Title>
 				</LayoutHeader>
+				<LayoutNavigation { ...selectedItemProps }>
+					<LayoutNavigationTabs { ...selectedItemProps } items={ navItems } />
+				</LayoutNavigation>
 			</LayoutTop>
 			<LayoutBody>
 				<h1>This is the Settings section with tabs (WIP)</h1>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/485

## Proposed Changes

<img width="712" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/9ff726fa-f2db-4ea6-aa79-08b884c9dc73">

- **/settings** => By default it will show the Agency Profile page
- **/settings/agency-profile** => It will show the Agency Profile page


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Click on the Settings option (menu sidebar)
- You will see the Settings navigation bar with the Agency Profile tab
- Check the URLs manually:
   - /settings => By default, it will show the Agency Profile page (we have only this tab)
   - /settings/agency-profile => It will show the Agency Profile page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
