### PR TITLE
Proxy content via public-api, even when we're on a simple site.

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -15,8 +15,6 @@ import {
 	isImageEditorImageLoaded,
 } from 'calypso/state/editor/image-editor/selectors';
 import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
-import isPrivateSite from 'calypso/state/selectors/is-private-site';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
@@ -101,9 +99,9 @@ export class ImageEditorCanvas extends Component {
 	}
 
 	fetchImageBlob( src ) {
-		const { siteSlug, isJetpack } = this.props;
+		const { siteSlug, isJetpackNonAtomic } = this.props;
 		const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-		const useProxy = ! isJetpack && filePath && isRelativeToSiteRoot;
+		const useProxy = ! isJetpackNonAtomic && !! filePath && isRelativeToSiteRoot;
 
 		if ( useProxy ) {
 			return getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, { query } );
@@ -294,9 +292,7 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSelectedSiteSlug( state );
-		const isPrivateAtomic =
-			isPrivateSite( state, siteId ) && isSiteAutomatedTransfer( state, siteId );
-		const isJetpack = isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } );
+		const isJetpackNonAtomic = isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } );
 
 		const transform = getImageEditorTransform( state );
 		const { src, mimeType } = getImageEditorFileInfo( state );
@@ -306,8 +302,7 @@ export default connect(
 
 		return {
 			siteSlug,
-			isPrivateAtomic,
-			isJetpack,
+			isJetpackNonAtomic,
 			src,
 			mimeType,
 			transform,

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -17,6 +17,7 @@ import {
 import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import ImageEditorCrop from './image-editor-crop';
@@ -100,9 +101,9 @@ export class ImageEditorCanvas extends Component {
 	}
 
 	fetchImageBlob( src ) {
-		const { siteSlug } = this.props;
+		const { siteSlug, isJetpack } = this.props;
 		const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-		const useProxy = filePath && isRelativeToSiteRoot;
+		const useProxy = ! isJetpack && filePath && isRelativeToSiteRoot;
 
 		if ( useProxy ) {
 			return getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, { query } );
@@ -295,6 +296,7 @@ export default connect(
 		const siteSlug = getSelectedSiteSlug( state );
 		const isPrivateAtomic =
 			isPrivateSite( state, siteId ) && isSiteAutomatedTransfer( state, siteId );
+		const isJetpack = isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } );
 
 		const transform = getImageEditorTransform( state );
 		const { src, mimeType } = getImageEditorFileInfo( state );
@@ -305,6 +307,7 @@ export default connect(
 		return {
 			siteSlug,
 			isPrivateAtomic,
+			isJetpack,
 			src,
 			mimeType,
 			transform,

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -100,9 +100,9 @@ export class ImageEditorCanvas extends Component {
 	}
 
 	fetchImageBlob( src ) {
-		const { siteSlug, isPrivateAtomic } = this.props;
+		const { siteSlug } = this.props;
 		const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-		const useProxy = isPrivateAtomic && filePath && isRelativeToSiteRoot;
+		const useProxy = filePath && isRelativeToSiteRoot;
 
 		if ( useProxy ) {
 			return getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, { query } );

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -2,10 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { mediaURLToProxyConfig } from 'calypso/lib/media/utils';
-import isPrivateSite from 'calypso/state/selectors/is-private-site';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { IAppState } from 'calypso/state/types';
-import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import ProxiedImage, { ProxiedImageProps, RenderedComponent } from './proxied-image';
 import type { ReactNode } from 'react';
@@ -53,12 +50,9 @@ const MediaFile: React.FC< MediaFileProps > = function MediaFile( {
 };
 
 export default connect( ( state: IAppState, { src }: Pick< MediaFileProps, 'src' > ) => {
-	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state ) as string;
-	const isAtomic = !! isSiteAutomatedTransfer( state, siteId as number );
-	const isPrivate = !! isPrivateSite( state, siteId ?? 0 );
 	const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-	const useProxy = Boolean( isAtomic && isPrivate && filePath && isRelativeToSiteRoot );
+	const useProxy = Boolean( filePath && isRelativeToSiteRoot );
 
 	return {
 		query,

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { mediaURLToProxyConfig } from 'calypso/lib/media/utils';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { IAppState } from 'calypso/state/types';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import ProxiedImage, { ProxiedImageProps, RenderedComponent } from './proxied-image';
 import type { ReactNode } from 'react';
@@ -50,9 +52,11 @@ const MediaFile: React.FC< MediaFileProps > = function MediaFile( {
 };
 
 export default connect( ( state: IAppState, { src }: Pick< MediaFileProps, 'src' > ) => {
+	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state ) as string;
 	const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-	const useProxy = Boolean( filePath && isRelativeToSiteRoot );
+	const isJetpack = isJetpackSite( state, siteId ?? 0, { treatAtomicAsJetpackSite: false } );
+	const useProxy = Boolean( ! isJetpack && filePath && isRelativeToSiteRoot );
 
 	return {
 		query,

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -55,8 +55,9 @@ export default connect( ( state: IAppState, { src }: Pick< MediaFileProps, 'src'
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state ) as string;
 	const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-	const isJetpack = isJetpackSite( state, siteId ?? 0, { treatAtomicAsJetpackSite: false } );
-	const useProxy = Boolean( ! isJetpack && filePath && isRelativeToSiteRoot );
+	const isJetpackNonAtomic =
+		siteId && isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } );
+	const useProxy = ! isJetpackNonAtomic && !! filePath && isRelativeToSiteRoot;
 
 	return {
 		query,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87642

## Proposed Changes

In order to solve #87642, we need to proxy any images in the media area via the public API.

This solves two main cases:
1) Where the primary redirect is not yet pointed to us via DNS
2) Where a service like Cloudflare is in front of the primary redirect, and blocks "hotlinking" images

These cases both used to work fine, as media was served from *.files.wordpress.com regardless of the actual domain being used.  Once this was been moved to use wp-content/uploads (in order to fix issues when third party cookies are blocked), the two cases above (and probably some others we don't know about) stopped working.

~~This will not work until D149138-code is deployed~~ (this has been deployed)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a media library like http://calypso.localhost:3000/media/meltbeforefailure.net
* Verify images appear
* Inspect an image, verify the src is "blob:http://calypso.localhost" instead of a wp-content/uploads URL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [n/a] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [n/a] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [n/a] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
