### PR TITLE
Bulk domains - update ellipsis icon size

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -196,9 +196,13 @@
 			line-height: 14px;
 		}
 
-		.domains-table-row__actions .gridicons-ellipsis {
-			height: 18px;
-			width: 18px;
+		.domains-table-row__actions button {
+			color: var(--color-text-subtle);
+
+			.gridicons-ellipsis {
+				height: 18px;
+				width: 18px;
+			}
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -195,6 +195,11 @@
 		.domains-table-checkbox-th {
 			line-height: 14px;
 		}
+
+		.domains-table-row__actions .gridicons-ellipsis {
+			height: 18px;
+			width: 18px;
+		}
 	}
 
 	.domains-table-mobile-cards {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7273

## Proposed Changes

* Updates the ellipsis icon size on bulk domains page rows to match the size of the ellipsis icon shown in the parallel bulk sites dashboard (18px x 18px)
* The change is nested under `.is-bulk-domains-page`, `.domains-table`, and `.domains-table-row__actions` selectors.

BEFORE


<img width="524" alt="Screenshot 2024-05-20 at 1 29 35 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/673e9d91-d21d-40c8-8ece-1442fc28738b">

AFTER

<img width="530" alt="Screenshot 2024-05-20 at 1 29 14 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/ca9d667a-94b6-4e47-8952-01458b418934">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* design consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso
* Visit the bulk domains page at /domains/manage.
* Verify the ellipsis menu icon matches the size of that shown on the bulk sites dashboard ( /sites)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
