### PR TITLE
Nav redesign - increase domains table width

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -122,13 +122,27 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				table {
 					overflow-y: auto;
 					max-height: calc( 100vh - 235px );
-					padding-inline: 16px;
 					margin-bottom: 0;
-				}
-				.domains-table-header {
-					position: sticky;
-					top: 0;
-					z-index: 2;
+					padding-inline: 0;
+					margin-inline-start: 0;
+
+					th:last-child,
+					td:last-child {
+						padding: 0 36px 0 0;
+					}
+
+					grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+
+					th:first-child,
+					td:first-child {
+						padding: 0 0 0 24px;
+					}
+
+					thead.domains-table-header {
+						position: sticky;
+						top: 0;
+						z-index: 2;
+					}
 				}
 			}
 
@@ -180,7 +194,12 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						margin-inline: 26px;
 					}
 					table {
-						padding-inline: 26px;
+						grid-template-columns: 75px 2fr 1fr 1fr auto auto auto auto;
+
+						th:first-child,
+						td:first-child {
+							padding: 0 0 0 34px;
+						}
 					}
 				}
 				.is-global-sidebar-visible header.navigation-header {
@@ -196,13 +215,18 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					}
 				}
 				.domains-table {
-					padding: 0 16px;
+					//padding: 0 16px;
+					table {
+						grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+
+						th:first-child,
+						td:first-child {
+							padding: 0 0 0 24px;
+						}
+					}
 				}
 				.domains-table-toolbar {
 					margin-inline: 0 !important;
-				}
-				table {
-					padding-inline: 0 !important;
 				}
 				div.layout.is-global-sidebar-visible {
 					.layout__primary > main {
@@ -233,7 +257,12 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						margin-inline: 16px;
 					}
 					table {
-						padding-inline: 16px;
+						grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+
+						th:first-child,
+						td:first-child {
+							padding: 0 0 0 24px;
+						}
 					}
 				}
 				div.layout.is-global-sidebar-visible {

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -126,12 +126,12 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					padding-inline: 0;
 					margin-inline-start: 0;
 
+					grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+
 					th:last-child,
 					td:last-child {
-						padding: 0 36px 0 0;
+						padding: 0 16px 0 0;
 					}
-
-					grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
 
 					th:first-child,
 					td:first-child {
@@ -196,6 +196,11 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					table {
 						grid-template-columns: 75px 2fr 1fr 1fr auto auto auto auto;
 
+						th:last-child,
+						td:last-child {
+							padding: 0 26px 0 0;
+						}
+
 						th:first-child,
 						td:first-child {
 							padding: 0 0 0 34px;
@@ -215,9 +220,13 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					}
 				}
 				.domains-table {
-					//padding: 0 16px;
 					table {
 						grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+
+						th:last-child,
+						td:last-child {
+							padding: 0 16px 0 0;
+						}
 
 						th:first-child,
 						td:first-child {
@@ -258,6 +267,11 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					}
 					table {
 						grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+
+						th:last-child,
+						td:last-child {
+							padding: 0 16px 0 0;
+						}
 
 						th:first-child,
 						td:first-child {

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -247,7 +247,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			@media only screen and ( max-width: 781px ) {
 				div.layout.is-global-sidebar-visible {
 					.layout__primary {
-						overflow-x: auto;
+						overflow-x: unset;
 					}
 				}
 				.layout__primary > main {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -208,14 +208,23 @@
 
 		table {
 			padding-inline: 0;
+			margin-inline-start: 0;
 
 			&.is-7-column {
 				grid-template-columns: 100px 2fr 1fr 1fr auto auto auto auto;
-			}
 
-			th:first-child,
-			td:first-child {
-				padding: var(--row-gap) 0 0 72px;
+				th:first-child,
+				td:first-child {
+					padding: var(--row-gap) 0 0 72px;
+				}
+			}
+			&.is-5-column {
+				grid-template-columns: 50px 1fr minmax(auto, 1fr) auto auto auto;
+
+				th:first-child,
+				td:first-child {
+					padding: var(--row-gap) 0 0 36px;
+				}
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -229,6 +229,12 @@
 					padding: 0 0 0 36px;
 				}
 			}
+
+			thead {
+				position: sticky;
+				top: 0;
+				z-index: 2;
+			}
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -180,6 +180,17 @@
 			}
 		}
 
+		table {
+			@include break-huge {
+				grid-template-columns: 100px 2fr 1fr 1fr auto auto auto auto;
+
+				th:first-child,
+				td:first-child {
+					padding: 0 0 0 72px;
+				}
+			}
+		}
+
 		.components-base-control {
 			--checkbox-input-size: 16px;
 
@@ -203,37 +214,6 @@
 			.gridicons-ellipsis {
 				height: 18px;
 				width: 18px;
-			}
-		}
-
-		table {
-			padding-inline: 0;
-			margin-inline-start: 0;
-			th:last-child,
-			td:last-child {
-				padding: 0 36px 0 0;
-			}
-			&.is-7-column {
-				grid-template-columns: 100px 2fr 1fr 1fr auto auto auto auto;
-
-				th:first-child,
-				td:first-child {
-					padding: 0 0 0 72px;
-				}
-			}
-			&.is-5-column {
-				grid-template-columns: 50px 1fr minmax(auto, 1fr) auto auto auto;
-
-				th:first-child,
-				td:first-child {
-					padding: 0 0 0 36px;
-				}
-			}
-
-			thead {
-				position: sticky;
-				top: 0;
-				z-index: 2;
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -209,13 +209,16 @@
 		table {
 			padding-inline: 0;
 			margin-inline-start: 0;
-
+			th:last-child,
+			td:last-child {
+				padding: 0 36px 0 0;
+			}
 			&.is-7-column {
 				grid-template-columns: 100px 2fr 1fr 1fr auto auto auto auto;
 
 				th:first-child,
 				td:first-child {
-					padding: var(--row-gap) 0 0 72px;
+					padding: 0 0 0 72px;
 				}
 			}
 			&.is-5-column {
@@ -223,7 +226,7 @@
 
 				th:first-child,
 				td:first-child {
-					padding: var(--row-gap) 0 0 36px;
+					padding: 0 0 0 36px;
 				}
 			}
 		}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -179,11 +179,6 @@
 				margin-inline: 64px;
 			}
 		}
-		> table {
-			@include break-huge {
-				padding-inline: 64px;
-			}
-		}
 
 		.components-base-control {
 			--checkbox-input-size: 16px;
@@ -208,6 +203,19 @@
 			.gridicons-ellipsis {
 				height: 18px;
 				width: 18px;
+			}
+		}
+
+		table {
+			padding-inline: 0;
+
+			&.is-7-column {
+				grid-template-columns: 100px 2fr 1fr 1fr auto auto auto auto;
+			}
+
+			th:first-child,
+			td:first-child {
+				padding: var(--row-gap) 0 0 72px;
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -184,6 +184,11 @@
 			@include break-huge {
 				grid-template-columns: 100px 2fr 1fr 1fr auto auto auto auto;
 
+				th:last-child,
+				td:last-child {
+					padding: 0 64px 0 0;
+				}
+
 				th:first-child,
 				td:first-child {
 					padding: 0 0 0 72px;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -259,6 +259,9 @@
 }
 
 .domains-table-mobile-cards {
+	overflow-y: auto;
+	max-height: calc(100vh - 326px);
+
 	.domains-table-mobile-cards-select-all {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7249

## Proposed Changes

* Overrides the domain table styles to increase width to full width

## Before

https://github.com/Automattic/wp-calypso/assets/5560595/e518fb41-7079-4105-9bed-f331de3836db

## After

https://github.com/Automattic/wp-calypso/assets/5560595/57abf9db-a697-4e61-99a5-5fa50dccd63c

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage` and confirm styles look ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
