### PR TITLE
Dashboard v2 overview - hide domains card for self hosted jetpack sites

### DIFF
--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -7,20 +7,21 @@ import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import { HostingCard, HostingCardHeading } from 'calypso/components/hosting-card';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
+import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const ActiveDomainsCard: FC = () => {
 	const forceMobile = useBreakpoint( '<660px' );
 	const site = useSelector( getSelectedSite );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
+	const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
 	const { data, isLoading } = useSiteDomainsQuery( site?.ID, {
 		queryFn: () => fetchSiteDomains( site?.ID ),
 	} );
 	const translate = useTranslate();
 
-	if ( isJetpack ) {
+	// Do not render for self hosted jetpack sites, since they cannot manage domains with us.
+	if ( isJetpackNotAtomic ) {
 		return null;
 	}
 

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -8,15 +8,21 @@ import { FC } from 'react';
 import { HostingCard, HostingCardHeading } from 'calypso/components/hosting-card';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
 import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const ActiveDomainsCard: FC = () => {
 	const forceMobile = useBreakpoint( '<660px' );
 	const site = useSelector( getSelectedSite );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const { data, isLoading } = useSiteDomainsQuery( site?.ID, {
 		queryFn: () => fetchSiteDomains( site?.ID ),
 	} );
 	const translate = useTranslate();
+
+	if ( isJetpack ) {
+		return null;
+	}
 
 	return (
 		<HostingCard className="hosting-overview__active-domains">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7276

## Proposed Changes

* Prevents rendering the domains overview card for self hosted jetpack sites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* self hosted sites cannot manage domains with us

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Go to the /sites dashboard
* Select a self hosted jetpack site, verify there is no domains card in the overview page.
* Select an atomic site, simple site, etc. Verify the domains card is still there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
