### PR TITLE
Dashboard v2 overview - Change overview subtitle for self hosted sites.

### DIFF
--- a/client/hosting-overview/components/hosting-overview.tsx
+++ b/client/hosting-overview/components/hosting-overview.tsx
@@ -4,16 +4,26 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import ActiveDomainsCard from 'calypso/hosting-overview/components/active-domains-card';
 import PlanCard from 'calypso/hosting-overview/components/plan-card';
 import QuickActionsCard from 'calypso/hosting-overview/components/quick-actions-card';
+import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 const HostingOverview: FC = () => {
+	const site = useSelector( getSelectedSite );
+	const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
+
+	const subtitle = isJetpackNotAtomic
+		? translate( 'Get a quick glance at your plans and upgrades.' )
+		: translate( 'Get a quick glance at your plans, storage, and domains.' );
+
 	return (
 		<div className="hosting-overview">
 			<NavigationHeader
 				className="hosting-overview__navigation-header"
 				title={ translate( 'Overview' ) }
-				subtitle={ translate( 'Get a quick glance at your plans, storage, and domains.' ) }
+				subtitle={ subtitle }
 			/>
 			<PlanCard />
 			<QuickActionsCard />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7275

## Proposed Changes

* Updates the copy used for the subtitle on the overview page for self hosted sites.

BEOFRE (all)
<img width="398" alt="Screenshot 2024-05-20 at 2 29 52 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/2b92519b-3732-4e29-83dc-f7fb9fc0daec">


AFTER (self hosted)
<img width="398" alt="Screenshot 2024-05-20 at 2 29 41 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/9634440b-ff85-4573-be6b-d83fd813fc1d">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To be more accurate in the context of self hosted sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit the sites dashboard.
* Select a self hosted site, verify the overview subtitle is updated as above.
* Select a simple or atomic site, verify the copy has not changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
