### PR TITLE
useSiteAdminInterfaceData hook - fix jetpack check

### DIFF
--- a/client/state/sites/hooks/use-site-admin-interface-data.ts
+++ b/client/state/sites/hooks/use-site-admin-interface-data.ts
@@ -14,7 +14,9 @@ const useSiteAdminInterfaceData = ( siteId: number = 0 ) => {
 	const wpcomAdminInterface = useSelector( ( state: AppState ) =>
 		getSiteOption( state, siteId, 'wpcom_admin_interface' )
 	);
-	const isJetpack = useSelector( ( state: AppState ) => isJetpackSite( state, siteId ) );
+	const isJetpack = useSelector( ( state: AppState ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
 	const isWPAdmin = wpcomAdminInterface === 'wp-admin' || isJetpack;
 	const adminLabel = isWPAdmin ? translate( 'WP Admin' ) : translate( 'My Home' );
 	const adminUrl =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7310

## Proposed Changes

* Updates the `isJetpackSite` check in the `useSiteAdminInterfaceData` hook to include the options for not counting atomic sites as jetpack.
* This fixes the logic used with the data to behave as expected. Previously, all atomic sites regardless of their interface setting were having `isWpAdmin` as `true` since the `isJetpack` fallback was always true for them.


BEFORE (all atomic regardless of interface setting)
<img width="1090" alt="Screenshot 2024-05-20 at 3 04 30 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/2696ee9c-45e2-4188-aa7c-2f904cb06669">

AFTER (atomic with default setting)
<img width="1007" alt="Screenshot 2024-05-20 at 2 49 37 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a7d50af4-4969-40ba-8445-dfdbe5f48c63">


NOTE this also affects other places this hook is used, such as the links in the site rows and countless other places we are syncing determing wp-admin vs. my-home with this hook:
<img width="414" alt="Screenshot 2024-05-20 at 3 06 08 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d138cfd5-2733-47be-bf55-ef9a56cf0c7a">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* noted in issue...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Look at admin links for atomic site in the /sites dashboard.
* Atomic sites with 'classic' setting should continue to show "WP Admin" labels and links, atomic sites with 'default' setting should now show "My Home" as expected.
* Test simple and self hosted sites and verify they continue to work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
