### PR TITLE
Site Migrations: Update import flow reference on `/sites` dashboard

### DIFF
--- a/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
@@ -13,6 +13,6 @@ export const useSitesDashboardImportSiteUrl = (
 			source: TRACK_SOURCE_NAME,
 			...additionalParameters,
 		},
-		isHostingFlow ? '/setup/import-hosted-site' : '/start/import'
+		isHostingFlow ? '/setup/import-hosted-site' : '/setup/hosted-site-migration'
 	);
 };

--- a/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites-dashboard/hooks/use-sites-dashboard-import-site-url.ts
@@ -1,18 +1,15 @@
 import { Primitive } from 'utility-types';
-import { useIsCurrentlyHostingFlow } from 'calypso/landing/stepper/utils/hosting-flow';
 import { addQueryArgs } from 'calypso/lib/url';
 import { TRACK_SOURCE_NAME } from '../utils';
 
 export const useSitesDashboardImportSiteUrl = (
 	additionalParameters: Record< string, Primitive >
 ) => {
-	const isHostingFlow = useIsCurrentlyHostingFlow();
-
 	return addQueryArgs(
 		{
 			source: TRACK_SOURCE_NAME,
 			...additionalParameters,
 		},
-		isHostingFlow ? '/setup/import-hosted-site' : '/setup/hosted-site-migration'
+		'/setup/hosted-site-migration'
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90652 and https://github.com/Automattic/dotcom-forge/issues/7237 

## Proposed Changes

* Point `/start/import` to `/setup/hosted-site-migration` when coming from the `/sites` dashboard.

**Tracking**

We can follow the `calypso_sites_dashboard_new_site_action_click_import` event with a `calypso_signup_start` : `flow: site-migration` as a parameter to track incoming hits to this flow from the Site Dashboard.

There's also a `?source=sites-dashboard` and `?ref=topbar` query params carried over in the URL.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of a project to redirect all references of `/start/import` to `/setup/hosted-site-migration` to leverage Migrate Guru for more reliable imports. paYKcK-4BA-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/sites`
* In the top left, click the arrow next to "Add new site"
* Click "Import an existing site"
* You should be brought to the new flow at `/setup/hosted-site-migration`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?