### PR TITLE
Segmentation Survey: Fix error when clicking Continue after previously selected options are unselected

### DIFF
--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -10,6 +10,8 @@ import {
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useSegmentationSurveyNavigation from './hooks/use-segmentation-survey-navigation';
 
+const SKIP_ANSWER_KEY = 'skip';
+
 type SegmentationSurveyProps = {
 	surveyKey: string;
 	onBack?: () => void;
@@ -68,14 +70,19 @@ const SegmentationSurvey = ( { surveyKey, onBack, onNext }: SegmentationSurveyPr
 
 	const onContinue = useCallback(
 		async ( currentQuestion: Question ) => {
-			await handleSave( currentQuestion, answers[ currentQuestion.key ] || [] );
+			const currentAnswers = answers[ currentQuestion.key ] || [];
+
+			await handleSave(
+				currentQuestion,
+				currentAnswers.length ? currentAnswers : [ SKIP_ANSWER_KEY ]
+			);
 		},
 		[ answers, handleSave ]
 	);
 
 	const onSkip = useCallback(
 		async ( currentQuestion: Question ) => {
-			await handleSave( currentQuestion, [ 'skip' ] );
+			await handleSave( currentQuestion, [ SKIP_ANSWER_KEY ] );
 		},
 		[ handleSave ]
 	);


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/7287

## Proposed Changes

* Fix error when clicking Continue after previously selected options are unselected

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In the segmentation survey, the "Continue" button becomes non-functional after previously selected options are unselected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur
* Open the Network tab
* Go to the second question, select and unselect some answers
* Click Continue (without selected options)
* Check if the save request succeeds and has a `skip` answer
* Perform regression tests on the Continue button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
