### PR TITLE
Site Profiler: Show hosting information

### DIFF
--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -9,16 +9,17 @@ interface Props {
 	dns: DNS[];
 	urlData?: UrlData;
 	hostingProvider?: HostingProvider;
+	displayTitle?: boolean;
 }
 
 export default function HostingInformation( props: Props ) {
-	const { dns = [], urlData, hostingProvider } = props;
+	const { dns = [], urlData, hostingProvider, displayTitle = true } = props;
 	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
 	const supportUrl = useHostingProviderURL( 'support', hostingProvider, urlData );
 
 	return (
 		<div className="hosting-information">
-			<h3>{ translate( 'Hosting information' ) }</h3>
+			{ displayTitle && <h3>{ translate( 'Hosting information' ) }</h3> }
 			<ul className="hosting-information-details result-list">
 				<li>
 					<div className="name">{ translate( 'Provider' ) }</div>

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -9,17 +9,17 @@ interface Props {
 	dns: DNS[];
 	urlData?: UrlData;
 	hostingProvider?: HostingProvider;
-	displayTitle?: boolean;
+	hideTitle?: boolean;
 }
 
 export default function HostingInformation( props: Props ) {
-	const { dns = [], urlData, hostingProvider, displayTitle = true } = props;
+	const { dns = [], urlData, hostingProvider, hideTitle = false } = props;
 	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
 	const supportUrl = useHostingProviderURL( 'support', hostingProvider, urlData );
 
 	return (
 		<div className="hosting-information">
-			{ displayTitle && <h3>{ translate( 'Hosting information' ) }</h3> }
+			{ ! hideTitle && <h3>{ translate( 'Hosting information' ) }</h3> }
 			<ul className="hosting-information-details result-list">
 				<li>
 					<div className="name">{ translate( 'Provider' ) }</div>

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -31,7 +31,6 @@ interface Props {
 export default function SiteProfilerV2( props: Props ) {
 	const { routerDomain } = props;
 	const domainRef = useRef( null );
-
 	const [ isGetReportFormOpen, setIsGetReportFormOpen ] = useState( false );
 
 	const {

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -17,6 +17,7 @@ import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-an
 import { getValidUrl } from '../utils/get-valid-url';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
 import { GetReportForm } from './get-report-form';
+import HostingInformation from './hosting-information';
 import { LandingPageHeader } from './landing-page-header';
 import { MetricsSection } from './metrics-section';
 import './styles-v2.scss';
@@ -124,18 +125,25 @@ export default function SiteProfilerV2( props: Props ) {
 				<LayoutBlock width="medium">
 					{ siteProfilerData && (
 						<MetricsSection
-							name={ translate( 'Domain' ) }
+							name={ translate( 'Hosting' ) }
 							title={ translate(
-								"Your domain {{success}}set up is good,{{/success}} but you could boost your site's visibility and growth.",
+								'Struggles with hosting {{alert}}speed and uptime{{/alert}} deter visitors. A switch to WordPress.com could transform the user experience.',
 								{
 									components: {
-										success: <span className="success" />,
+										alert: <span className="alert" />,
 									},
 								}
 							) }
-							subtitle={ translate( 'Optimize your domain' ) }
+							subtitle={ translate( 'Upgrade your hosting with WordPress.com' ) }
 							ref={ domainRef }
-						></MetricsSection>
+						>
+							<HostingInformation
+								dns={ siteProfilerData.dns }
+								urlData={ urlData }
+								hostingProvider={ hostingProviderData?.hosting_provider }
+								displayTitle={ false }
+							/>
+						</MetricsSection>
 					) }
 				</LayoutBlock>
 			) }

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -141,7 +141,7 @@ export default function SiteProfilerV2( props: Props ) {
 								dns={ siteProfilerData.dns }
 								urlData={ urlData }
 								hostingProvider={ hostingProviderData?.hosting_provider }
-								displayTitle={ false }
+								hideTitle
 							/>
 						</MetricsSection>
 					) }

--- a/client/site-profiler/components/styles-v2.scss
+++ b/client/site-profiler/components/styles-v2.scss
@@ -57,12 +57,12 @@
 
 	a,
 	button.is-link {
-		color: var(--wp-admin-theme-color);
+		color: var(--studio-gray-20);
 		text-decoration: underline;
 		font-size: 1rem;
 
 		&:hover {
-			color: var(--wp-admin-theme-color-darker-20);
+			color: var(--studio-gray-40);
 		}
 	}
 
@@ -88,6 +88,7 @@
 	.result-list {
 		margin: 0;
 		list-style: none;
+		line-height: normal;
 
 		ul {
 			margin: 0;
@@ -96,13 +97,13 @@
 
 		& > li {
 			display: flex;
-			padding: 1rem 0;
-			border-top: solid 1px var(--studio-gray-5);
+			padding: 1.5rem 0;
+			border-top: solid 1px var(--studio-gray-100);
 			gap: 2rem;
 			overflow-x: scroll;
 
-			&:first-child {
-				border: none;
+			&:last-child {
+				border-bottom: solid 1px var(--studio-gray-100);
 			}
 
 			&.redacted {
@@ -114,7 +115,7 @@
 
 			.name {
 				min-width: 200px;
-				text-transform: uppercase;
+				text-transform: none;
 			}
 
 			@media (max-width: $break-small) {
@@ -151,6 +152,11 @@
 
 		.col {
 			max-width: 300px;
+			line-height: 20px;
+		}
+
+		div:not(:first-child) {
+			color: var(--studio-gray-20);
 		}
 	}
 


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/90901
Fixes https://github.com/Automattic/dotcom-forge/issues/7314

## Proposed Changes

Update the hosting information component to better suit on the Site profiler V2.
Update the styles for Site Profiler V2.
Show hosting information on Site Profiler V2.
Remove Domain headers and add Hosting headers and information.

## Why are these changes being made?

To be displayed on the Site Profiler V2.

## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/example.com`
* Check if the hosting section matches the [figma layout](https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?node-id=712%3A25795&t=cGUjikUMogRe2gO2-1) and the images below:

| Desktop  | Mobile |
| ------------- | ------------- |
|![CleanShot 2024-05-20 at 17 51 08@2x](https://github.com/Automattic/wp-calypso/assets/5039531/57ce03ef-9920-45af-ae7c-2b57da9476dd)|![CleanShot 2024-05-20 at 17 49 54@2x](https://github.com/Automattic/wp-calypso/assets/5039531/dd8f6cbd-2493-47dc-8c40-3bb58e197c13)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?