### PR TITLE
Move bulk domains CSS to affect only the global domains table

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -266,7 +266,9 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
 			<Main>
 				<DocumentHead title={ translate( 'Domains' ) } />
-				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
+				<BodySectionCssClass
+					bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page', 'is-bulk-all-domains-page' ] }
+				/>
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				{ ! isLoading && <GoogleDomainOwnerBanner /> }
 				<DomainsTable

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -124,9 +124,11 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	return (
 		<>
 			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
-			<Main>
+			<Main wideLayout>
 				<DocumentHead title={ translate( 'Domains' ) } />
-				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
+				<BodySectionCssClass
+					bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page', 'is-bulk-site-domains-page' ] }
+				/>
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				{ ! isLoading && <GoogleDomainOwnerBanner /> }
 				<PrimaryDomainSelector

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -135,14 +135,15 @@
 	}
 }
 
-// this affects the /domains/manage/:site page as well.
-.is-bulk-domains-page .layout__content {
+// The /domains/manage/:site page
+.is-bulk-site-domains-page .layout__content {
 	overflow: auto;
 }
 
-// Custom layout for the global `/domains/manage` page only
+// The `/domains/manage` page
 // Generic domains table styles should go in `packages/domains-table/src/domains-table/style.scss`
-.is-bulk-domains-page.is-group-sites .layout__content {
+.is-bulk-all-domains-page .layout__content {
+	overflow: auto;
 	.main {
 		.navigation-header {
 			@include break-huge {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -134,10 +134,15 @@
 		}
 	}
 }
-// Custom layout width for the bulk domains pages
+
+// this affects the /domains/manage/:site page as well.
 .is-bulk-domains-page .layout__content {
 	overflow: auto;
+}
 
+// Custom layout for the global `/domains/manage` page only
+// Generic domains table styles should go in `packages/domains-table/src/domains-table/style.scss`
+.is-bulk-domains-page.is-group-sites .layout__content {
 	.main {
 		.navigation-header {
 			@include break-huge {
@@ -198,9 +203,6 @@
 	}
 
 	.domains-table-mobile-cards {
-		.domains-table-mobile-card:hover {
-			background-color: #f7faff;
-		}
 		.components-base-control {
 			display: flex;
 			align-items: center;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -296,7 +296,9 @@
 	position: relative;
 	padding: 16px 0;
 	border-bottom: 1px solid var(--color-border-secondary);
-
+	&:hover {
+		background-color: #f7faff;
+	}
 	&-header {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
I personally didn't realise that the CSS code I was writing for `/domains/manage` was also affecting `/domains/manage/:site`. The issue is that we want `/domains/manage` to match the new global nav style, wheras `/domains/manage/:site` lives within the older unified nav style.

This change limits CSS changes in `client/my-sites/domains/domain-management/list/style.scss` to only affect the global domains page. It fixes an immediate bug discussed here p1716197535301749-slack-C06DN6QQVAQ and sets up more organised locations for our CSS.

I also fixed an existing issue by adding `wideLayout` to the site domains page

This is how the /domains/manage/:site page is affected by having the shared CSS removed. (in addition to alignment issue on wide screens)

Before: 
<img width="928" alt="Screenshot 2024-05-21 at 10 43 47 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/0d60a9f7-848c-41bb-81db-9d73f42ae09e">

After: 
<img width="927" alt="Screenshot 2024-05-21 at 11 02 20 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/450ea5ae-7cc0-4fbf-91dd-290af0a22e8b">

### Test instructions 

`/domains/manage` should match /sites on all resolutions
 `/domains/manage/:site` should match other calypso pages.
