### PR TITLE
LogRocket: load script across all sections of Jetpack Cloud

### DIFF
--- a/client/components/advanced-credentials/index.tsx
+++ b/client/components/advanced-credentials/index.tsx
@@ -8,7 +8,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { useSelector, useDispatch } from 'calypso/state';
 import { JETPACK_CREDENTIALS_UPDATE_RESET } from 'calypso/state/action-types';
-import { loadTrackingTool, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	deleteCredentials,
 	updateCredentials,
@@ -411,10 +411,6 @@ const AdvancedCredentials: FunctionComponent< Props > = ( {
 				return renderCredentialsForm( true );
 		}
 	};
-
-	useEffect( () => {
-		dispatch( loadTrackingTool( 'LogRocket' ) );
-	}, [ dispatch ] );
 
 	return (
 		<div className={ `advanced-credentials ${ isAlternate ? 'alternate' : '' }` }>

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,7 +1,7 @@
 import { Icon, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,
@@ -11,7 +11,7 @@ import Sidebar, {
 	SidebarNavigatorMenuItem,
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch, useSelector } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { getJetpackAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -81,6 +81,10 @@ const JetpackCloudSidebar = ( {
 		history.pushState( null, '', window.location.pathname + window.location.search );
 		setShowUserFeedbackForm( false );
 	}, [] );
+
+	useEffect( () => {
+		dispatch( loadTrackingTool( 'LogRocket' ) );
+	}, [ dispatch ] );
 
 	return (
 		<Sidebar className={ classNames( 'jetpack-cloud-sidebar', className ) }>

--- a/client/lib/analytics/logrocket.js
+++ b/client/lib/analytics/logrocket.js
@@ -1,6 +1,7 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import debug from 'debug';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { TRACKING_IDS } from './ad-tracking/constants';
 import { mayWeTrackByTracker } from './tracker-buckets';
 
@@ -20,6 +21,11 @@ export function maybeAddLogRocketScript() {
 
 	if ( ! mayWeLoadLogRocketScript() ) {
 		logRocketDebug( 'Not loading LogRocket script' );
+		return;
+	}
+
+	if ( ! isJetpackCloud() ) {
+		logRocketDebug( 'Not loading LogRocket script: not Jetpack Cloud' );
 		return;
 	}
 

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -3,7 +3,6 @@ import { Button } from '@automattic/components';
 import { Tooltip } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import ActivityCardList from 'calypso/components/activity-card-list';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -21,7 +20,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { backupClonePath } from 'calypso/my-sites/backup/paths';
 import { useSelector, useDispatch } from 'calypso/state';
-import { loadTrackingTool, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
@@ -110,10 +109,6 @@ const ActivityLogV2: FunctionComponent = () => {
 			openButtonLinkOnNewTab={ false }
 		/>
 	);
-
-	useEffect( () => {
-		dispatch( loadTrackingTool( 'LogRocket' ) );
-	}, [ dispatch ] );
 
 	return (
 		<Main

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -3,8 +3,8 @@ import page from '@automattic/calypso-router';
 import { ExternalLink } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import BackupStorageSpace from 'calypso/components/backup-storage-space';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -28,7 +28,6 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { loadTrackingTool } from 'calypso/state/analytics/actions';
 import isRewindPoliciesInitialized from 'calypso/state/rewind/selectors/is-rewind-policies-initialized';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -72,12 +71,6 @@ const BackupPage = ( { queryDate } ) => {
 	) : (
 		<ExternalLink href="https://jetpack.com/support/backup/">Learn more</ExternalLink>
 	);
-
-	const dispatch = useDispatch();
-
-	useEffect( () => {
-		dispatch( loadTrackingTool( 'LogRocket' ) );
-	}, [ dispatch ] );
 
 	return (
 		<div


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/498

> [!IMPORTANT]
> LogRocket is currently disabled in production. The purpose of this PR is to be ready for when we decide to enable it.

## Proposed Changes

* Enable LogRocket across Jetpack Cloud
  * Enforce the LogRocket's script to load only on Jetpack Cloud
  * Load the LogRocket's script on Jetpack Cloud's sidebar, so we could avoid duplicated code.
  * Remove the explicit loading on Activity Log, Backup, and Settings page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, the LogRocket's script is being loaded when users access specific pages in Jetpack Cloud:
* Activity Log
* Backup
* Settings

The idea is to load it across all sections in Jetpack Cloud, so we could get more data that we could use to explore the tool properly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud Live branch and append `?flags=ad-tracking,logrocket` to the URL to enable the feature flags.
* Enable debug logs using the developer console:
  `localStorage.setItem( 'debug', 'calypso:*' );`
* Filter console and network tabs by `logrocket`
* Navigate to any Jetpack Cloud page and ensure you see these debug records:
   ![CleanShot 2024-04-08 at 00 04 11@2x](https://github.com/Automattic/wp-calypso/assets/1488641/45cb2bfc-64a6-4029-8a13-83fdab7f88e9)
* Now try the same, navigating to any Jetpack page (for example: Jetpack > Backup) and ensure there is no log record related to LogRocket (because we are loading it only on the Jetpack Cloud sidebar).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
