### PR TITLE
E2E: Fix Form Patterns test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -8,7 +8,6 @@ import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 interface ConfigurationData {
 	labelPrefix: string;
-	patternName: string;
 }
 
 interface ValidationData {
@@ -48,6 +47,7 @@ export class FormPatternsFlow implements BlockFlow {
 		// So we have to grab a new parent locator ourselves instead of relying on the old on in the context.
 		const editorCanvas = await context.editorPage.getEditorCanvas();
 		const newParentBlockId = await editorCanvas
+			// Handle old and new block patterns.
 			.locator(
 				'[aria-label="Block: Form"].is-selected, [aria-label="Block: Group"].is-selected [aria-label="Block: Form"]'
 			)
@@ -99,7 +99,8 @@ export class FormPatternsFlow implements BlockFlow {
 		const editorParent = await context.editorPage.getEditorParent();
 		await editorParent
 			.getByRole( 'dialog', { name: 'Choose a pattern' } )
-			.getByRole( 'option', { name: this.configurationData.patternName } )
+			.getByRole( 'option' )
+			.first()
 			// These patterns can load in quite slowly, messing with animation wait checks, so let's give extra time.
 			.click( { timeout: 30 * 1000 } );
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -48,7 +48,9 @@ export class FormPatternsFlow implements BlockFlow {
 		// So we have to grab a new parent locator ourselves instead of relying on the old on in the context.
 		const editorCanvas = await context.editorPage.getEditorCanvas();
 		const newParentBlockId = await editorCanvas
-			.locator( '[aria-label="Block: Form"].is-selected' )
+			.locator(
+				'[aria-label="Block: Form"].is-selected, [aria-label="Block: Group"].is-selected [aria-label="Block: Form"]'
+			)
 			.getAttribute( 'id' );
 		const newParentBlockLocator = editorCanvas.locator( `#${ newParentBlockId }` );
 

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -21,13 +21,13 @@ const blockFlows: BlockFlow[] = [
 	new FormPatternsFlow(
 		{
 			labelPrefix: 'Form Patterns',
-			patternName: 'Lead Capture Form',
+			patternName: 'Contact left, form right',
 		},
 		{
 			otherExpectedFields: [
 				{ type: 'textbox', accessibleName: 'Name' },
 				{ type: 'textbox', accessibleName: 'Email' },
-				{ type: 'button', accessibleName: 'Subscribe' },
+				{ type: 'button', accessibleName: 'Submit' },
 			],
 		}
 	),

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -21,13 +21,11 @@ const blockFlows: BlockFlow[] = [
 	new FormPatternsFlow(
 		{
 			labelPrefix: 'Form Patterns',
-			patternName: 'Contact left, form right',
 		},
 		{
 			otherExpectedFields: [
 				{ type: 'textbox', accessibleName: 'Name' },
 				{ type: 'textbox', accessibleName: 'Email' },
-				{ type: 'button', accessibleName: 'Submit' },
 			],
 		}
 	),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The Form Patterns modal in Jetpack Forms has been loaded with a new set of forms depending on the environment, which was resulting in failing tests. This PR just grabs the first pattern available and inserts that, allowing compatibility for old- and new-style patterns.

The old patterns came from here:
https://github.com/Automattic/jetpack/blob/78d40351ea956cf913ab079e80b460798dc331d4/projects/packages/forms/src/contact-form/class-util.php#L44

The new patterns appear to come from Big Sky.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
I'm not sure how to trigger a test on an older variant (e.g. the one that shows up in Jurassic Ninja/non-Calypso), but this should be backward-compatible and will pass when the `fix/e2e/form_patterns` branch is checked out.

```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=default TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/blocks/blocks__jetpack-forms.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?