### PR TITLE
Site Monitoring: Avoid Translating Response Codes

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -101,17 +101,18 @@ export const SiteLogsToolbar = ( {
 		{ value: 'DELETE', label: translate( 'DELETE' ) },
 	];
 
+	// Numbers don't need to be translated.
 	const requestStatuses = [
 		{ value: '', label: translate( 'All' ) },
-		{ value: '200', label: translate( '200' ) },
-		{ value: '301', label: translate( '301' ) },
-		{ value: '302', label: translate( '302' ) },
-		{ value: '400', label: translate( '400' ) },
-		{ value: '401', label: translate( '401' ) },
-		{ value: '403', label: translate( '403' ) },
-		{ value: '404', label: translate( '404' ) },
-		{ value: '429', label: translate( '429' ) },
-		{ value: '500', label: translate( '500' ) },
+		{ value: '200', label: '200' },
+		{ value: '301', label: '301' },
+		{ value: '302', label: '302' },
+		{ value: '400', label: '400' },
+		{ value: '401', label: '401' },
+		{ value: '403', label: '403' },
+		{ value: '404', label: '404' },
+		{ value: '429', label: '429' },
+		{ value: '500', label: '500' },
 	];
 
 	const selectedSeverity =


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/90869#discussion_r1607695048

## Proposed Changes

* Removes translation calls for the numbers that form the HTTP Response codes.  

## Why are these changes being made?

They're unnecessary; but despite this, as long as they're wrapped in a translate code, translators for each language need to handle nine of these when it doesn't change anything. 

## Testing Instructions

Visit /site-monitoring/SITE/web, and confirm that the numbers still appear in the dropdown. 

cc @wojtekn 
