### PR TITLE
TeamCity: Fix grep query for # of files changed

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -577,7 +577,7 @@ object CheckCodeStyleBranch : BuildType({
 				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -cE '\.[jt]sx? || true')
 
 				# Avoid running more than 16 parallel eslint tasks as it could OOM
-				if [ "%run_full_eslint%" = "true" ] || [ "${'$'}TOTAL_FILES_TO_LINT" -gt 16 ]; then
+				if [ "%run_full_eslint%" = "true" ] || [ "${'$'}TOTAL_FILES_TO_LINT" -gt 16 ] || [ "${'$'}TOTAL_FILES_TO_LINT" == "0" ]; then
 					echo "Linting all files"
 					yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" .
 				else

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -574,7 +574,7 @@ object CheckCodeStyleBranch : BuildType({
 				export NODE_ENV="test"
 
 				# Find files to lint
-				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -cE '\.[jt]sx? || true')
+				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -cE '\.[jt]sx?' || true)
 
 				# Avoid running more than 16 parallel eslint tasks as it could OOM
 				if [ "%run_full_eslint%" = "true" ] || [ "${'$'}TOTAL_FILES_TO_LINT" -gt 16 ] || [ "${'$'}TOTAL_FILES_TO_LINT" == "0" ]; then

--- a/client/landing/stepper/declarative-flow/internals/components/package.json
+++ b/client/landing/stepper/declarative-flow/internals/components/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/client/landing/stepper/declarative-flow/internals/components/package.json
+++ b/client/landing/stepper/declarative-flow/internals/components/package.json
@@ -1,3 +1,0 @@
-{
-	"sideEffects": false
-}


### PR DESCRIPTION
Had a typo, so 0 matches grep would just `exit 1`. Silly, it was a regexp, so it worked...