### PR TITLE
Untangling: Point the admin interface style notice to wp-admin when appropriate

### DIFF
--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -21,7 +21,7 @@ import {
 	removeNotice,
 	successNotice,
 } from 'calypso/state/notices/actions';
-import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSiteOption, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { useSiteInterfaceMutation } from './use-select-interface-mutation';
 import './style.scss';
 const changeLoadingNoticeId = 'admin-interface-change-loading';
@@ -48,6 +48,7 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 	const adminInterface = useSelector(
 		( state ) => getSiteOption( state, siteId, 'wpcom_admin_interface' ) || 'calypso'
 	);
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
 	const { setSiteInterface, isLoading: isUpdating } = useSiteInterfaceMutation( siteId, {
 		onMutate: () => {
@@ -172,7 +173,11 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 							components: {
 								a: (
 									<a
-										href={ `/settings/general/${ siteSlug }#admin-interface-style` }
+										href={
+											adminInterface === 'wp-admin'
+												? `${ siteAdminUrl }options-general.php`
+												: `/settings/general/${ siteSlug }#admin-interface-style`
+										}
 										rel="noreferrer"
 									/>
 								),


### PR DESCRIPTION
Related to: pdtkmj-2Bi-p2#comment-5066

> Aside from that, does it perhaps make more sense to let the ‘this setting has now moved to Settings → General’ link point to the wp-admin settings page if the site has classic style enabled?

## Proposed Changes

This PR updates the notice on the Hosting Config -> Admin Interface Style setting so that it points to `/wp-admin/options-general.php` when the site is already in Classic style (and nav redesign v2 is enabled).

## Why are these changes being made?

This is because the current link does not exist in Classic style and could be confusing.

## Testing Instructions

1. Prepare an Atomic site with Classic style.
1. Go to `/hosting-config/:site`.
2. Verify that the link points to `/wp-admin/options-general.php` and you can actually see the config at the end of the page.

<img width="521" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/0e84f8d2-32c9-4f13-af21-0d0afbcdd581">

4. Repeat the above with an Atomic site with Default style.
5. Verify that the link still points to `/settings/general/:site`.
   - IMPORTANT: Your site might already have the preferred view for Settings -> General page set to Classic (via the switcher at the top-right corner). In this case, the link points to a Calypso page, but it has no place in the sidebar, which could be confusing. I think this is an edge case and does happen that often. I don't have workaround since we cannot check for preferred view in Calypso :(

<img width="966" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/5bc3cde3-a57d-4b77-adf5-01738b4a114e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?