### PR TITLE
Sites List: Fix pagination styles when the list is collapsed

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -519,10 +519,33 @@
 				margin: 0;
 				position: relative;
 				width: 100%;
+			}
+		}
+	}
+}
+
+.wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout.preview-hidden {
+	@media (min-width: $break-xhuge) {
+		div.a4a-layout__viewport {
+			margin: 0 auto;
+			max-width: 1400px;
+			box-sizing: border-box;
+		}
+		.dataviews-wrapper {
+			margin: 0 auto;
+			max-width: 1400px;
+			box-sizing: border-box;
+		}
+	}
+
+	.a4a-layout-column__container {
+		.dataviews-wrapper {
+			.dataviews-pagination {
 				@include break-large {
 					padding-left: 26px;
 					padding-right: 26px;
 				}
+
 				@include break-huge {
 					padding-left: 64px;
 					padding-right: 64px;

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -509,19 +509,6 @@
 			}
 		}
 
-		@media (min-width: $break-xhuge) {
-			div.a4a-layout__viewport {
-				margin: 0 auto;
-				max-width: 1400px;
-				box-sizing: border-box;
-			}
-			.dataviews-wrapper {
-				margin: 0 auto;
-				max-width: 1400px;
-				box-sizing: border-box;
-			}
-		}
-
 		.sites-overview {
 			width: 400px;
 			flex: unset;


### PR DESCRIPTION
## Proposed Changes

This PR fixes some padding issues in collapsed sites list when viewport width >= 1920, introduced by https://github.com/Automattic/wp-calypso/pull/90779.

| Before | After |
| --- | --- |
| ![Screenshot 2024-05-21 at 5 29 33 PM](https://github.com/Automattic/wp-calypso/assets/797888/c33862a6-7193-4955-8497-8b1a6d758604) | ![Screenshot 2024-05-21 at 5 31 18 PM](https://github.com/Automattic/wp-calypso/assets/797888/fc9ae15a-8ad2-41e4-a22a-94c807f099e4) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Regression issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the padding in the collapsed site list is updated as shown above.
* Ensure that the padding in the non-collapsed site list is the same as in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
