### PR TITLE
Add scheduled update staging check

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -5,14 +5,17 @@ import { PluginsScheduledUpdates } from 'calypso/blocks/plugins-scheduled-update
 import { PluginsScheduledUpdatesMultisite } from 'calypso/blocks/plugins-scheduled-updates-multisite';
 import { redirectLoggedOut } from 'calypso/controller';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { navigate } from 'calypso/lib/navigate';
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
 import { navigation, sites } from 'calypso/my-sites/controller';
 import PluginsSidebar from 'calypso/my-sites/plugins/sidebar';
 import { isUserLoggedIn, getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { getShouldShowCollapsedGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
 import { isSiteOnECommerceTrial, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES } from './categories/use-categories';
 import { UNLISTED_PLUGINS } from './constants';
@@ -340,6 +343,30 @@ export async function redirectTrialSites( context, next ) {
 			page.redirect( `/plans/${ selectedSite.slug }` );
 			return false;
 		}
+	}
+
+	next();
+}
+
+/**
+ * Middleware to redirect staging sites to the admin interface.
+ */
+export function redirectStagingSites( context, next ) {
+	const { store } = context;
+	const state = store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	if ( selectedSite && isSiteWpcomStaging( state, selectedSite.ID ) ) {
+		const adminInterface = getSiteOption( state, selectedSite.ID, 'wpcom_admin_interface' );
+		const siteAdminUrl = getSiteAdminUrl( state, selectedSite.ID );
+
+		if ( selectedSite ) {
+			return navigate(
+				adminInterface === 'wp-admin' ? siteAdminUrl : `/home/${ selectedSite.slug }`
+			);
+		}
+
+		return false;
 	}
 
 	next();

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -24,6 +24,7 @@ import {
 	scrollTopIfNoHash,
 	navigationIfLoggedIn,
 	maybeRedirectLoggedOut,
+	redirectStagingSites,
 } from './controller';
 import { plans, upload } from './controller-logged-in';
 
@@ -166,6 +167,7 @@ export default function ( router ) {
 		redirectLoggedOut,
 		siteSelection,
 		redirectIfCurrentUserCannot( 'update_plugins' ),
+		redirectStagingSites,
 		navigation,
 		scheduledUpdates,
 		makeLayout,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6973

This PR adds Scheduled Updates redirection for staging sites. Users who try to access those pages will be redirected to `/home`.

Important: `redirectIfCurrentUserCannot( 'update_plugins' )` always redirects in staging sites, so it short-circuits the check, but it's left for completeness. See the tests section.

## Proposed Changes

* Add check on staging sites for Scheduled Update pages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install https://github.com/Automattic/jetpack/pull/37449
* Install https://github.com/Automattic/wpcomsh/pull/1880
* Use a user that can't `update_plugin` link an editor and try to visit `http://calypso.localhost:3000/plugins/scheduled-updates/*` pages, you should be redirected.
* Create a staging site and do the same thing (`http://calypso.localhost:3000/plugins/scheduled-updates/staging-XXXX-__NAME__.wpcomstaging.com`). You will be redirected to `/home/__NAME__.wpcomstaging.com` that will redirect you to `stats/day/__NAME__.wpcomstaging.com`
* Comment https://github.com/Automattic/wp-calypso/pull/90925/files#diff-7edd3c450e9fa353a0acd99fdf2b07d0c902ef5c88f419a3f9ddd3df242822f8R169 and ensure you are redirected as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?