### PR TITLE
Sites: Update actions for the Jetpack sites

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -42,6 +42,7 @@ import {
 	isP2Site,
 } from '../utils';
 import type { SiteExcerptData } from '@automattic/sites';
+import type { AppState } from 'calypso/types';
 
 interface SitesMenuItemProps {
 	site: SiteExcerptData;
@@ -119,8 +120,9 @@ const ManagePluginsItem = ( {
 }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
 	const hasManagePluginsFeature =
-		useSelector( ( state ) => siteHasFeature( state, site.ID, WPCOM_FEATURES_MANAGE_PLUGINS ) ) ||
-		isNotAtomicJetpack( site );
+		useSelector( ( state: AppState ) =>
+			siteHasFeature( state, site.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
+		) || isNotAtomicJetpack( site );
 	// If the site can't manage plugins then go to the main plugins page instead
 	// because it shows an upsell message.
 	const [ href, label ] = hasManagePluginsFeature
@@ -174,7 +176,7 @@ function useSafeSiteHasFeature( siteId: number, feature: string ) {
 		dispatch( fetchSiteFeatures( siteId ) );
 	}, [ dispatch, siteId ] );
 
-	return useSelector( ( state ) => {
+	return useSelector( ( state: AppState ) => {
 		return siteHasFeature( state, siteId, feature );
 	} );
 }
@@ -418,6 +420,43 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 	);
 }
 
+function JetpackSiteItems( { site, recordTracks }: SitesMenuItemProps ) {
+	const { __ } = useI18n();
+	const siteSlug = site.slug;
+	const items = [
+		{
+			label: __( 'Jetpack Cloud' ),
+			href: `https://cloud.jetpack.com/landing/${ siteSlug }`,
+			onClick: () => recordTracks( 'calypso_sites_dashboard_site_action_jetpack_cloud_click' ),
+		},
+		{
+			label: __( 'Billing' ),
+			href: `https://cloud.jetpack.com/purchase/${ siteSlug }`,
+			onClick: () => recordTracks( 'calypso_sites_dashboard_site_action_jetpack_billing_click' ),
+		},
+		{
+			label: __( 'Support' ),
+			href: 'https://jetpack.com/support/',
+			onClick: () => recordTracks( 'calypso_sites_dashboard_site_action_jetpack_support_click' ),
+		},
+		{
+			label: __( 'Migrate to WordPress.com' ),
+			href: 'https://wordpress.com/move/',
+			onClick: () => recordTracks( 'calypso_sites_dashboard_site_action_migrate_to_wpcom_click' ),
+		},
+	];
+
+	return (
+		<>
+			{ items.map( ( { label, href, onClick } ) => (
+				<MenuItemLink key={ label } href={ href } onClick={ onClick }>
+					{ label }
+				</MenuItemLink>
+			) ) }
+		</>
+	);
+}
+
 export const SitesEllipsisMenu = ( {
 	className,
 	site,
@@ -431,8 +470,8 @@ export const SitesEllipsisMenu = ( {
 		dispatch( recordTracksEvent( eventName, extraProps ) );
 	}
 
-	const wpAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site.ID ) ?? '' );
-	const adminInterface = useSelector( ( state ) =>
+	const wpAdminUrl = useSelector( ( state: AppState ) => getSiteAdminUrl( state, site.ID ) ?? '' );
+	const adminInterface = useSelector( ( state: AppState ) =>
 		getSiteOption( state, site.ID, 'wpcom_admin_interface' )
 	);
 
@@ -445,12 +484,74 @@ export const SitesEllipsisMenu = ( {
 		recordTracks,
 	};
 
-	const hasHostingFeatures = ! isNotAtomicJetpack( site ) && ! isP2Site( site );
+	const isSiteJetpackNotAtomic = isNotAtomicJetpack( site );
+	const hasHostingFeatures = ! isSiteJetpackNotAtomic && ! isP2Site( site );
 	const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( site );
 	const hasCustomDomain = isCustomDomain( site.slug );
 	const isLaunched = site.launch_status !== 'unlaunched';
 	const isClassicSimple = isWpAdminInterface && isSimpleSite( site );
-	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, site.ID ) );
+	const isWpcomStagingSite = useSelector( ( state: AppState ) =>
+		isSiteWpcomStaging( state, site.ID )
+	);
+	const renderDropdownMenu = () => {
+		if ( isSiteJetpackNotAtomic ) {
+			return (
+				<SiteMenuGroup>
+					<WpAdminItem { ...props } />
+					<JetpackSiteItems { ...props } />
+				</SiteMenuGroup>
+			);
+		}
+
+		return (
+			<SiteMenuGroup>
+				{ ! isWpcomStagingSite && ! isLaunched && <LaunchItem { ...props } /> }
+				<SettingsItem { ...props } />
+				{ hasHostingFeatures && <HostingConfigurationSubmenu { ...props } /> }
+				{ site.is_wpcom_atomic && <SiteMonitoringItem { ...props } /> }
+				{ ! isP2Site( site ) && <ManagePluginsItem { ...props } /> }
+				{ site.is_coming_soon && <PreviewSiteModalItem { ...props } /> }
+				{ ! isWpcomStagingSite && shouldShowSiteCopyItem && (
+					<CopySiteItem { ...props } onClick={ startSiteCopy } />
+				) }
+				{ ! isClassicSimple && (
+					<MenuItemLink
+						href={
+							isWpAdminInterface
+								? `${ wpAdminUrl }options-general.php?page=page-optimize`
+								: `/settings/performance/${ site.slug }`
+						}
+						onClick={ () =>
+							recordTracks( 'calypso_sites_dashboard_site_action_performance_settings_click' )
+						}
+					>
+						{ __( 'Performance settings' ) }
+					</MenuItemLink>
+				) }
+				{ isLaunched && (
+					<MenuItemLink
+						href={ `/settings/general/${ site.slug }#site-privacy-settings` }
+						onClick={ () =>
+							recordTracks( 'calypso_sites_dashboard_site_action_privacy_settings_click' )
+						}
+					>
+						{ __( 'Privacy settings' ) }
+					</MenuItemLink>
+				) }
+				{ hasCustomDomain && ! isSiteJetpackNotAtomic && (
+					<MenuItemLink
+						href={ `/domains/manage/${ site.slug }/dns/${ site.slug }` }
+						onClick={ () =>
+							recordTracks( 'calypso_sites_dashboard_site_action_dns_records_click' )
+						}
+					>
+						{ __( 'Domains and DNS' ) }
+					</MenuItemLink>
+				) }
+				<WpAdminItem { ...props } />
+			</SiteMenuGroup>
+		);
+	};
 
 	return (
 		<SiteDropdownMenu
@@ -459,54 +560,7 @@ export const SitesEllipsisMenu = ( {
 			popoverProps={ { className: siteDropdownMenuPopoverClassName } }
 			label={ __( 'Site Actions' ) }
 		>
-			{ () => (
-				<SiteMenuGroup>
-					{ ! isWpcomStagingSite && ! isLaunched && <LaunchItem { ...props } /> }
-					<SettingsItem { ...props } />
-					{ hasHostingFeatures && <HostingConfigurationSubmenu { ...props } /> }
-					{ site.is_wpcom_atomic && <SiteMonitoringItem { ...props } /> }
-					{ ! isP2Site( site ) && <ManagePluginsItem { ...props } /> }
-					{ site.is_coming_soon && <PreviewSiteModalItem { ...props } /> }
-					{ ! isWpcomStagingSite && shouldShowSiteCopyItem && (
-						<CopySiteItem { ...props } onClick={ startSiteCopy } />
-					) }
-					{ ! isClassicSimple && (
-						<MenuItemLink
-							href={
-								isWpAdminInterface
-									? `${ wpAdminUrl }options-general.php?page=page-optimize`
-									: `/settings/performance/${ site.slug }`
-							}
-							onClick={ () =>
-								recordTracks( 'calypso_sites_dashboard_site_action_performance_settings_click' )
-							}
-						>
-							{ __( 'Performance settings' ) }
-						</MenuItemLink>
-					) }
-					{ isLaunched && (
-						<MenuItemLink
-							href={ `/settings/general/${ site.slug }#site-privacy-settings` }
-							onClick={ () =>
-								recordTracks( 'calypso_sites_dashboard_site_action_privacy_settings_click' )
-							}
-						>
-							{ __( 'Privacy settings' ) }
-						</MenuItemLink>
-					) }
-					{ hasCustomDomain && ! isNotAtomicJetpack( site ) && (
-						<MenuItemLink
-							href={ `/domains/manage/${ site.slug }/dns/${ site.slug }` }
-							onClick={ () =>
-								recordTracks( 'calypso_sites_dashboard_site_action_dns_records_click' )
-							}
-						>
-							{ __( 'Domains and DNS' ) }
-						</MenuItemLink>
-					) }
-					<WpAdminItem { ...props } />
-				</SiteMenuGroup>
-			) }
+			{ renderDropdownMenu }
 		</SiteDropdownMenu>
 	);
 };

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -17,6 +17,7 @@ import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { DropdownMenu, MenuGroup, MenuItem as CoreMenuItem, Modal } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentType, useEffect, useMemo, useState } from 'react';
@@ -55,6 +56,7 @@ interface SitesMenuItemProps {
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof CoreMenuItem >, 'href' > {
 	href?: string;
+	target?: string;
 }
 
 // Work around changes to core button styles done in _wp-components-overrides.scss
@@ -449,7 +451,14 @@ function JetpackSiteItems( { site, recordTracks }: SitesMenuItemProps ) {
 	return (
 		<>
 			{ items.map( ( { label, href, onClick } ) => (
-				<MenuItemLink key={ label } href={ href } onClick={ onClick }>
+				<MenuItemLink
+					key={ label }
+					href={ href }
+					target="_blank"
+					icon={ external }
+					iconPosition="right"
+					onClick={ onClick }
+				>
 					{ label }
 				</MenuItemLink>
 			) ) }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -433,7 +433,7 @@ function JetpackSiteItems( { site, recordTracks }: SitesMenuItemProps ) {
 		},
 		{
 			label: __( 'Billing' ),
-			href: `https://cloud.jetpack.com/purchase/${ siteSlug }`,
+			href: `https://cloud.jetpack.com/purchases/${ siteSlug }`,
 			onClick: () => recordTracks( 'calypso_sites_dashboard_site_action_jetpack_billing_click' ),
 		},
 		{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7284

## Proposed Changes

* Update actions for the Jetpack sites

| Before | After | With the external icon |
| - | - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/0559c1ab-05dc-41af-894a-c608a337366c) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a9ffd195-2a9c-493c-810f-ab42b8b1f760) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/f3f8041c-bdf1-4709-b9e7-555b70c4ac7f) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Open the actions on your jetpack site
* Make sure the actions display as the screenshot above
* Try actions
* Make sure they work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
