### PR TITLE
Ensure stepper declarative flow components tree-shake properly: try 2

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/package.json
+++ b/client/landing/stepper/declarative-flow/internals/components/package.json
@@ -1,0 +1,6 @@
+{
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	]
+}


### PR DESCRIPTION
Follow-up to #90851, which had to be reverted due to style breakage.

This PR enables tree-shaking for the stepper declarative flow internal components sub-tree, so that only the required components get added to the entry point chunk. Styles should all get included, however.

This appears to result in a massive reduction (160KB gzipped / over 500KB uncompressed) of the stepper entry-point, with the affected components moving instead to more specific chunks such as individual flows.

## Proposed Changes

* Add a `package.json` with `sideEffects` declaration for only the styles to the stepper declarative flow internal components sub-tree

## Why are these changes being made?

* To move unnecessary code away from the entry point chunks, towards the chunks that actually need it

## Testing Instructions

Smoke-test the site setup flow, particularly the `setup/build/launchpad` step, and ensure nothing breaks along the way.
See p1716262266425289-slack-C02FMH4G8 for more details on the breakage caused by #90851.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
