### PR TITLE
Close Command Palette after selecting a command

### DIFF
--- a/client/layout/command-palette.tsx
+++ b/client/layout/command-palette.tsx
@@ -2,7 +2,7 @@ import CommandPalette from '@automattic/command-palette';
 import { useSiteExcerptsSorted } from 'calypso/data/sites/use-site-excerpts-sorted';
 import { navigate } from 'calypso/lib/navigate';
 import { useCommandsCalypso } from 'calypso/sites-dashboard/components/wpcom-smp-commands';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { closeCommandPalette } from 'calypso/state/command-palette/actions';
 import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
 import { getCurrentRoutePattern } from 'calypso/state/selectors/get-current-route-pattern';
@@ -22,17 +22,19 @@ const getCurrentUserCapabilities = ( state: CurrentUserCapabilitiesState ) =>
 	state.currentUser.capabilities;
 
 const CalypsoCommandPalette = () => {
+	const dispatch = useDispatch();
 	const isCommandPaletteOpen = useSelector( getIsCommandPaletteOpen );
 	const currentRoutePattern = useSelector( getCurrentRoutePattern ) ?? '';
 	const currentSiteId = useSelector( getSelectedSiteId );
 	const userCapabilities = useSelector( getCurrentUserCapabilities );
+	const onClose = () => dispatch( closeCommandPalette() );
 
 	return (
 		<CommandPalette
 			currentRoute={ currentRoutePattern }
 			currentSiteId={ currentSiteId }
 			isOpenGlobal={ isCommandPaletteOpen }
-			onClose={ closeCommandPalette }
+			onClose={ onClose }
 			navigate={ navigate }
 			useCommands={ useCommandsCalypso }
 			useSites={ useSiteExcerptsSorted }


### PR DESCRIPTION
## Proposed Changes

Fixes a regression introduced in #90887 that was preventing the command palette from being closed when invoked from the new sidebar.

**Before**

https://github.com/Automattic/wp-calypso/assets/1233880/5b16e628-2757-41e9-9197-f75aced6a8e8

**After**


https://github.com/Automattic/wp-calypso/assets/1233880/c4c500e4-51fa-42dc-a231-72cdc3aea30c




## Why are these changes being made?

To fix a command palette bug.

## Testing Instructions

- Use the Calypso live link below
- Go to `/sites`
- Open the command palette using the search icon
- Select a command (and a site if needed)
- Make sure the command palette is automatically closed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
