### PR TITLE
Add upload command to VBE

### DIFF
--- a/packages/verbum-block-editor/README.md
+++ b/packages/verbum-block-editor/README.md
@@ -33,7 +33,7 @@ This package can be utilized in two primary ways:
 
 To deploy modifications to the package:
 1. Ensure your sandbox is in a clean git state.
-2. Run `yarn build --sync`.
+2. Run `yarn upload`. This will upload the production-built files to your sandbox.
 3. Create a patch.
 4. Deploy the patch.
 

--- a/packages/verbum-block-editor/package.json
+++ b/packages/verbum-block-editor/package.json
@@ -25,6 +25,7 @@
 	"scripts": {
 		"clean": "",
 		"build": "NODE_ENV=production yarn dev && yarn translate",
+		"upload": "yarn build && rsync -ahz --exclude='.*' dist/ wpcom-sandbox:/home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
 		"build:app": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
 		"watch": "tsc --build ./tsconfig.json --watch",


### PR DESCRIPTION
This adds an upload command to VBE so it can upload built files and translation files as well. Using classic `yarn build --sync` does not upload translation files. And using `yarn dev --sync` does upload translation files but it doesn't minify.