### PR TITLE
The open site dashboard command is now aware of the admin interface a…

### DIFF
--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -236,7 +236,10 @@ export function useCommands() {
 			openSiteDashboard: {
 				name: 'openSiteDashboard',
 				label: __( 'Open site dashboard', __i18n_text_domain__ ),
-				callback: commandNavigation( '/home/:site' ),
+				callback: ( params ) =>
+					commandNavigation(
+						siteUsesWpAdminInterface( params.site ) ? '/wp-admin' : '/home/:site'
+					)( params ),
 				searchLabel: [
 					_x(
 						'open site dashboard',

--- a/packages/command-palette/test/commands.tsx
+++ b/packages/command-palette/test/commands.tsx
@@ -43,7 +43,7 @@ const expectedCommandsResults = {
 	disableEdgeCache: [ '/hosting-config/:site#edge', siteFilters.adminPublicAtomic ],
 	manageCacheSettings: [ '/hosting-config/:site#cache', siteFilters.adminAtomic ],
 	visitSite: [ 'https://:site' ],
-	openSiteDashboard: [ '/home/:site' ],
+	openSiteDashboard: [ '/wp-admin' ],
 	openHostingConfiguration: [ '/hosting-config/:site', siteFilters.adminP2SelfHosted ],
 	openPHPmyAdmin: [ '/hosting-config/:site#database-access', siteFilters.adminAtomic ],
 	openProfile: [ '/me' ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/wp-calypso/issues/90394

## Proposed Changes

* The open site dashboard command is now aware of the admin interface.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions
* Apply these changes `install-plugin.sh command-palette-wp-admin add/open-site-dashboard-admin-interface-aware`
* Open the command palette with wp-admin interface as default and select the open site dashboard command.
* You should land at `/wp-admin`
* Do the same without wp-admin as default and you should end up in the Calypso version.
* Repeat for Simple and Atomic sites.
* When testing the non wp-admin version make sure to use the Calypso live link in this PR.



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
