### PR TITLE
GHD: Modified the screen to work better on smaller resolutions

### DIFF
--- a/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
@@ -43,7 +43,7 @@ export const DeploymentStarterMessage = ( { deployment }: DeploymentStarterMessa
 	};
 
 	return (
-		<td colSpan={ 4 }>
+		<td colSpan={ 4 } className="deployment-message">
 			<i css={ { color: 'var(--Gray-Gray-40, #50575E)' } }>
 				{ deployment.is_automated
 					? sprintf(

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -46,18 +46,18 @@ $brand-text: "SF Pro Text", $sans;
 
 	td {
 		vertical-align: middle !important;
-		padding-right: 32px;
+		padding-right: 22px;
 
 		> * {
 			white-space: nowrap;
 		}
 
-		.github-deployments-list__repository-details {
+		.github-deployments-list__repository-details,
+		&.deployment-message i {
 			white-space: normal;
 		}
 
 		&:last-child {
-			padding-left: 32px;
 			padding-right: 0;
 			text-align: right;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1716287043078289-slack-C04H4NY6STW

## Proposed Changes

- We're making sure GHD fits inside the new interface

**Screens of 1420px**

| Before | After |
|--------|--------|
|<img width="1558" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/5302a953-36a3-4cd0-be26-e2bb85c8151c"> | <img width="1561" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/e0b748b8-11b1-448a-994a-c4c21f022145"> |

**Bigger screens**

| Before | After |
|--------|--------|
| <img width="1293" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/aa516f45-30bb-463c-9944-2d6ecb644b94"> | <img width="1296" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/1606bd70-19e8-40f6-87b2-324ac5a47bc0"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?