### PR TITLE
Add check that feed_URL exists before URL check

### DIFF
--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -62,7 +62,7 @@ class SearchFollowButton extends Component {
 		// If we find a feed then set the feed object
 		let feed;
 		if ( resemblesUrl( query ) ) {
-			feed = feeds?.find( ( f ) => f.feed_URL.includes( urlToDomainAndPath( query ) ) );
+			feed = feeds?.find( ( f ) => f?.feed_URL.includes( urlToDomainAndPath( query ) ) );
 		}
 
 		// If no feed found, then don't show the follow button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7338

## Proposed Changes

* Add an optional chaining operator to guard against the feed_URL being null or undefined, in which case we don't want to check if it in includes a URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check if reader search still works and tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
