### PR TITLE
Sidebar: Remove Creator trial notice

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -166,7 +166,6 @@ export class SiteNotice extends Component {
 
 		const discountOrFreeToPaid = this.activeDiscountNotice();
 		const siteRedirectNotice = this.getSiteRedirectNotice( site );
-		const siteTrialUpgrade = this.trialUpgradeNotice();
 
 		const showJitms =
 			! this.props.isSiteWPForTeams &&
@@ -177,7 +176,6 @@ export class SiteNotice extends Component {
 			<div className="current-site__notices">
 				<QueryActivePromotions />
 				{ siteRedirectNotice }
-				{ siteTrialUpgrade }
 				{ showJitms && (
 					<AsyncLoad
 						require="calypso/blocks/jitm"

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
-import { createInterpolateElement } from '@wordpress/element';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
@@ -90,63 +89,6 @@ export class SiteNotice extends Component {
 				href={ `/plans/${ site.slug }?discount=${ name }` }
 				title={ bannerText }
 			/>
-		);
-	}
-
-	trialUpgradeNotice() {
-		const { translate, site, isTrialSite, currentPlan } = this.props;
-		const { expiry } = currentPlan || {};
-
-		if ( ! isTrialSite || ! expiry ) {
-			return null;
-		}
-
-		let bannerText;
-		const eventProperties = { cta_name: 'migration-trial-upgrade-sidebar' };
-		const daysRemaining = this.daysRemaining( { endsAt: currentPlan.expiry } );
-
-		if ( daysRemaining < 0 ) {
-			bannerText = translate( 'Your trial has expired' );
-		} else if ( daysRemaining === 0 ) {
-			bannerText = createInterpolateElement(
-				translate( 'Your trial ends <strong>today</strong>' ),
-				{
-					strong: <strong />,
-				}
-			);
-		} else {
-			bannerText = createInterpolateElement(
-				translate(
-					'<strong>%(daysRemaining)d day</strong> left in your trial',
-					'<strong>%(daysRemaining)d days</strong> left in your trial',
-					{
-						count: daysRemaining,
-						args: {
-							daysRemaining,
-						},
-						comment: '%(daysRemaining) is the no of days, e.g. "1 day"',
-					}
-				),
-				{ strong: <strong /> }
-			);
-		}
-
-		return (
-			<>
-				<QuerySitePlans siteId={ site.ID } />
-				<UpsellNudge
-					compact
-					forceDisplay
-					event="calypso_upgrade_nudge_impression"
-					tracksClickName="calypso_upgrade_nudge_cta_click"
-					tracksClickProperties={ eventProperties }
-					tracksImpressionName="calypso_upgrade_nudge_impression"
-					tracksImpressionProperties={ eventProperties }
-					callToAction={ translate( 'Upgrade' ) }
-					href={ `/checkout/${ site.slug }/business` }
-					title={ bannerText }
-				/>
-			</>
 		);
 	}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -576,6 +576,7 @@ $font-size: rem(14px);
 				padding: 0;
 				flex-direction: column;
 				gap: 6px;
+				width: 100%;
 			}
 
 			.banner__info {


### PR DESCRIPTION
## Proposed Changes

Removes the Calypso-specific sidebar notice for Creator trial notices since we're adding it as a new JITM in D149397-code so it can be displayed in WP Admin too. However, JITMs are also visible in Calypso, so the notice would be duplicated if we don't remove the Calypso-specific notice.

Before | After
--- | ---
<img width="435" alt="Screenshot 2024-05-21 at 15 57 11" src="https://github.com/Automattic/wp-calypso/assets/1233880/a6340c1e-ff2b-4b38-8ab5-968f87896440"> | <img width="340" alt="Screenshot 2024-05-21 at 16 41 33" src="https://github.com/Automattic/wp-calypso/assets/1233880/336db62f-2688-4c91-b63d-9aa2dcd46e38">



## Why are these changes being made?

To prevent a duplicated trial notice in the sidebar after D149397-code lands.

## Testing Instructions

- Follow instructions from D149397-code
- Use the Calypso live link below
- Navigate to `/home`
- Select the WoA dev site you created in D149397-code
- Make sure the trial notice is no longer duplicated in the sidebar