### PR TITLE
Update navbar styles on the site-profiler page

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { useLocalizeUrl, removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
 import { UniversalNavbarHeader, UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
@@ -199,7 +199,10 @@ const LayoutLoggedOut = ( {
 			<UniversalNavbarHeader
 				isLoggedIn={ isLoggedIn }
 				sectionName={ sectionName }
-				{ ...( sectionName === 'site-profiler' && { logoColor: 'white' } ) }
+				{ ...( isEnabled( 'site-profiler/metrics' ) && {
+					logoColor: 'white',
+					className: 'is-style-monochrome',
+				} ) }
 				{ ...( sectionName === 'subscriptions' && { variant: 'minimal' } ) }
 				{ ...( sectionName === 'patterns' && {
 					startUrl: getPatternLibraryOnboardingUrl( locale, isLoggedIn ),

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -199,6 +199,7 @@ const LayoutLoggedOut = ( {
 			<UniversalNavbarHeader
 				isLoggedIn={ isLoggedIn }
 				sectionName={ sectionName }
+				{ ...( sectionName === 'site-profiler' && { logoColor: 'white' } ) }
 				{ ...( sectionName === 'subscriptions' && { variant: 'minimal' } ) }
 				{ ...( sectionName === 'patterns' && {
 					startUrl: getPatternLibraryOnboardingUrl( locale, isLoggedIn ),

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -31,7 +31,6 @@ $studio-blue-30: #0675c4;
 
 .is-section-patterns,
 .is-section-reader,
-.is-section-site-profiler,
 .is-section-theme,
 .is-section-themes {
 	&.has-no-sidebar {
@@ -854,3 +853,38 @@ $x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
 }
 
 /* End subscriptions section overrides */
+
+/* Start site profiler section overrides */
+.is-section-site-profiler {
+	&.has-no-sidebar {
+		.masterbar-menu {
+			.masterbar {
+				border-bottom: none;
+				background: #000;
+				height: 56px;
+				position: relative;
+				.x-nav {
+					height: 56px;
+				}
+			}
+		}
+
+		.x-nav-item {
+			color: #fff;
+
+			.cta-btn-nav {
+				border-radius: 4px;
+				background: inherit !important;
+				border: 1px solid #fff;
+			}
+
+			.x-nav-link__chevron::after,
+			.x-nav-link-chevron::before {
+				content: $lp-chevron-content-down;
+				color: #fff;
+			}
+		}
+	}
+}
+
+/* End site profiler section overrides */

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -31,6 +31,7 @@ $studio-blue-30: #0675c4;
 
 .is-section-patterns,
 .is-section-reader,
+.is-section-site-profiler,
 .is-section-theme,
 .is-section-themes {
 	&.has-no-sidebar {
@@ -855,8 +856,8 @@ $x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
 /* End subscriptions section overrides */
 
 /* Start site profiler section overrides */
-.is-section-site-profiler {
-	&.has-no-sidebar {
+.is-style-monochrome {
+	.x-root {
 		.masterbar-menu {
 			.masterbar {
 				border-bottom: none;
@@ -868,21 +869,21 @@ $x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
 				}
 			}
 		}
+	}
 
-		.x-nav-item {
+	.x-nav-item {
+		color: #fff;
+
+		.cta-btn-nav {
+			border-radius: 4px;
+			background: inherit !important;
+			border: 1px solid #fff;
+		}
+
+		.x-nav-link__chevron::after,
+		.x-nav-link-chevron::before {
+			content: $lp-chevron-content-down;
 			color: #fff;
-
-			.cta-btn-nav {
-				border-radius: 4px;
-				background: inherit !important;
-				border: 1px solid #fff;
-			}
-
-			.x-nav-link__chevron::after,
-			.x-nav-link-chevron::before {
-				content: $lp-chevron-content-down;
-				color: #fff;
-			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7297

## Proposed Changes

* Update the styles of the navbar on the `site-profiler` page to match the new figma designs

## Testing Instructions

- In a logged-out session, navigate to the `/site-profiler` page
- Check that the navbar looks like on the figma designs [here](https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?node-id=787-51546)
- Go to `/site-profiler?flags=-site-profiler/metrics` and check for regressions

| Mode | Before | After |
|--------|--------|--------|
| Desktop | <img width="1277" alt="image" src="https://github.com/Automattic/wp-calypso/assets/11555574/2c618103-be13-4c87-b16f-caf420df4d64"> | <img width="1085" alt="image" src="https://github.com/Automattic/wp-calypso/assets/11555574/395f03d1-b24e-400a-a86e-c1670bfce46c"> |
| Mobile | <img width="574" alt="image" src="https://github.com/Automattic/wp-calypso/assets/11555574/3f000597-842b-40d8-acc1-6e0ea235ec20"> | <img width="576" alt="image" src="https://github.com/Automattic/wp-calypso/assets/11555574/466b6c52-8680-49e7-8983-8dbdc46af985"> | 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
