### PR TITLE
Scheduled Updates: Translate string in case when there are no atomic sites

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -1,3 +1,4 @@
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { __experimentalText as Text, CheckboxControl, SearchControl } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -66,10 +67,14 @@ export const ScheduleFormSites = ( props: Props ) => {
 				{ ! sites.length && (
 					<p className="placeholder-info">
 						{ translate(
-							'You can only select sites with Creator plan.{{br/}}Please upgrade your site to enable this feature.',
+							// Translators: %(planName)s is the plan - Business or Creator
+							'To select a site, please ensure it has a %(planName)s plan or higher.{{br/}}Upgrade your site to proceed.',
 							{
 								components: {
 									br: <br />,
+								},
+								args: {
+									planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
 								},
 							}
 						) }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -55,17 +55,25 @@ export const ScheduleFormSites = ( props: Props ) => {
 						{ error }
 					</Text>
 				) }
-				<SearchControl
-					id="sites"
-					value={ searchTerm }
-					onChange={ ( s ) => setSearchTerm( s.trim() ) }
-					placeholder={ translate( 'Search sites' ) }
-				/>
+				{ !! sites.length && (
+					<SearchControl
+						id="sites"
+						value={ searchTerm }
+						onChange={ ( s ) => setSearchTerm( s.trim() ) }
+						placeholder={ translate( 'Search sites' ) }
+					/>
+				) }
 				{ ! sites.length && (
-					<Text className="info-msg">
-						You can only select sites with Creator plan. Please upgrade your site to enable this
-						feature.
-					</Text>
+					<p className="placeholder-info">
+						{ translate(
+							'You can only select sites with Creator plan.{{br/}}Please upgrade your site to enable this feature.',
+							{
+								components: {
+									br: <br />,
+								},
+							}
+						) }
+					</p>
 				) }
 				<div className="checkbox-options-container checkbox-options-container__sites">
 					{ sites.map( ( site ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes: https://github.com/Automattic/wp-calypso/issues/90354

## Proposed Changes

* Translate the string in the case when there are no atomic sites
* Change the paragraph style to match similar case with other form controls

## Testing Instructions

* Login as a user who doesn't have atomic sites
* Go to `/plugins/scheduled-updates`
* Check for a notification: "You can only select sites with Creator plan. Please upgrade..."

**Before**
<img width="1728" alt="Screenshot 2024-05-21 at 16 06 45" src="https://github.com/Automattic/wp-calypso/assets/1241413/6000b653-0a98-4362-9423-3da6daa3a57a">

**After**
<img width="1728" alt="Screenshot 2024-05-22 at 10 52 44" src="https://github.com/Automattic/wp-calypso/assets/1241413/ef2c2890-4fd7-4d54-bf4a-6a12249902c1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
