### PR TITLE
Guides: Update triggerGuidesForStep function

### DIFF
--- a/client/lib/guides/trigger-guides-for-step.ts
+++ b/client/lib/guides/trigger-guides-for-step.ts
@@ -7,7 +7,6 @@ import wpcom from 'calypso/lib/wp';
 const previousRequests = new Set< string >();
 
 // trigger guides on step movement, we don't care about failures or response
-// modify the function to include siteSlug and siteId as optional
 export function triggerGuidesForStep(
 	flowName: string,
 	stepName?: string,

--- a/client/lib/guides/trigger-guides-for-step.ts
+++ b/client/lib/guides/trigger-guides-for-step.ts
@@ -7,8 +7,21 @@ import wpcom from 'calypso/lib/wp';
 const previousRequests = new Set< string >();
 
 // trigger guides on step movement, we don't care about failures or response
-export function triggerGuidesForStep( flowName: string, stepName?: string ) {
-	const key = flowName + ':' + ( stepName || '' );
+// modify the function to include siteSlug and siteId as optional
+export function triggerGuidesForStep(
+	flowName: string,
+	stepName?: string,
+	siteSlug?: string,
+	siteId?: number
+) {
+	const key =
+		flowName +
+		':' +
+		( stepName || '' ) +
+		':' +
+		( siteSlug || 'no-site' ) +
+		':' +
+		( siteId || 'no-id' );
 	if ( previousRequests.has( key ) ) {
 		return;
 	}
@@ -22,6 +35,8 @@ export function triggerGuidesForStep( flowName: string, stepName?: string ) {
 			{
 				flow: flowName,
 				step: stepName,
+				siteSlug: siteSlug,
+				siteId: siteId,
 			}
 		)
 		.then()


### PR DESCRIPTION
## Proposed Changes

Added optional siteSlug and siteId in triggerGuidesForStep function to support Migration flow and steps. A separate PR will update the Migration flow.

## Testing Instructions

There should be no functional change. 

Go through the Stepper flows (/setup/newsletter, /setup/link-in-bio) and confirm that the network request is sent on step change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
