### PR TITLE
Revert "Entrepreneur Plan: Use Calypso My Home based

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -36,7 +36,6 @@ import {
 	getPluginOnSite,
 	isRequesting as isRequestingInstalledPlugins,
 } from 'calypso/state/plugins/installed/selectors';
-import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getRequest from 'calypso/state/selectors/get-request';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
@@ -45,11 +44,7 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { launchSite } from 'calypso/state/sites/launch/actions';
-import {
-	isSiteOnWooExpressEcommerceTrial,
-	isSiteOnWooExpress,
-	isRequestingSitePlans as isFetchingSitePlans,
-} from 'calypso/state/sites/plans/selectors';
+import { isSiteOnWooExpressEcommerceTrial } from 'calypso/state/sites/plans/selectors';
 import {
 	canCurrentUserUseCustomerHome,
 	getSitePlan,
@@ -57,11 +52,7 @@ import {
 	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
 } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedPurchase,
-} from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CelebrateLaunchModal from './components/celebrate-launch-modal';
 
 import './style.scss';
@@ -76,7 +67,6 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
-	isSiteWooExpress,
 	isSiteWooExpressEcommerceTrial,
 	ssoModuleActive,
 	fetchingJetpackModules,
@@ -114,10 +104,6 @@ const Home = ( {
 	const emailDnsDiagnostics = domainDiagnosticData?.email_dns_records;
 	const [ dismissedEmailDnsDiagnostics, setDismissedEmailDnsDiagnostics ] = useState( false );
 
-	const isRequestingSitePlans = useSelector( isFetchingSitePlans );
-	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );
-	const purchase = useSelector( getSelectedPurchase );
-
 	useEffect( () => {
 		if ( getQueryArgs().celebrateLaunch === 'true' && isSuccess ) {
 			setCelebrateLaunchModalIsOpen( true );
@@ -153,18 +139,12 @@ const Home = ( {
 		);
 	}
 
-	// While fetching all the data, show placeholder.
-	// After fetching all the data:
-	//  - For eCommerce & eCommerce trial, don't show placeholder.
-	//  - For Woo Express Trial, Essential & Performance, show placeholder while redirecting to WooCommerce Home (search for `wc-admin` under customer-home/controller.jsx).
+	// Ecommerce Plan's Home redirects to WooCommerce Home, so we show a placeholder
+	// while doing the redirection.
 	if (
 		isSiteWooExpressEcommerceTrial &&
 		( isRequestingSitePlugins || hasWooCommerceInstalled ) &&
-		( fetchingJetpackModules || ssoModuleActive ) &&
-		( isRequestingSitePlans ||
-			isRequestingSitePurchases ||
-			isSiteWooExpress ||
-			purchase?.isWooExpressTrial )
+		( fetchingJetpackModules || ssoModuleActive )
 	) {
 		return <WooCommerceHomePlaceholder />;
 	}
@@ -335,7 +315,6 @@ const mapStateToProps = ( state ) => {
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 		hasWooCommerceInstalled: !! ( installedWooCommercePlugin && installedWooCommercePlugin.active ),
 		isRequestingSitePlugins: isRequestingInstalledPlugins( state, siteId ),
-		isSiteWooExpress: isSiteOnWooExpress( state, siteId ),
 		isSiteWooExpressEcommerceTrial: isSiteOnWooExpressEcommerceTrial( state, siteId ),
 		ssoModuleActive: !! isJetpackModuleActive( state, siteId, 'sso' ),
 		fetchingJetpackModules: !! isFetchingJetpackModules( state, siteId ),


### PR DESCRIPTION
## Proposed Changes

This PR reverts [90047](https://github.com/Automattic/wp-calypso/pull/90047).
Ensures that  sites on Entrepreneur Plan and Woo Express plans (trial and non trial) lands on wp-admin instead Calypso `My home`.

## Testing Instructions

Go to `http://calypso.localhost:3000/home/yoursitehere.wpcomstaging.com?flags=entrepreneur-my-home`.
You should land on wp-admin and **not** on Calypso `My home`.

The `entrepreneur-my-home` feature flag is not relevant anymore, but adding it does not hurt.

Test it for Entrepreneur and trial plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
