### PR TITLE
A4A: Improve Marketplace navigation and header.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/marketplace.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/marketplace.tsx
@@ -17,6 +17,9 @@ export default function ( { path }: Props ) {
 		<Sidebar
 			path={ A4A_PURCHASES_LINK }
 			title={ translate( 'Marketplace' ) }
+			description={ translate(
+				'Choose from a variety of hosting, or à la carte products for your sites.'
+			) }
 			backButtonProps={ {
 				label: translate( 'Back to overview' ),
 				icon: chevronLeft,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -4,12 +4,15 @@ import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
-	LayoutHeaderTitle as Title,
 	LayoutHeaderActions as Actions,
+	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_CHECKOUT_LINK,
+	A4A_MARKETPLACE_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import HostingList from './hosting-list';
@@ -26,10 +29,21 @@ export default function Hosting() {
 			title={ translate( 'Hosting Marketplace' ) }
 			wide
 			withBorder
+			compact
 		>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>{ translate( 'Marketplace' ) }</Title>
+					<Breadcrumb
+						items={ [
+							{
+								label: translate( 'Marketplace' ),
+								href: A4A_MARKETPLACE_LINK,
+							},
+							{
+								label: translate( 'Hosting' ),
+							},
+						] }
+					/>
 
 					<Actions>
 						<MobileSidebarNavigation />

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -7,11 +7,14 @@ import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
-	LayoutHeaderTitle as Title,
+	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_CHECKOUT_LINK,
+	A4A_MARKETPLACE_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { useSelector } from 'calypso/state';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -71,10 +74,21 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 			title={ translate( 'Product Marketplace' ) }
 			wide
 			withBorder
+			compact
 		>
 			<LayoutTop>
 				<LayoutHeader showStickyContent={ showStickyContent }>
-					<Title>{ translate( 'Marketplace' ) } </Title>
+					<Breadcrumb
+						items={ [
+							{
+								label: translate( 'Marketplace' ),
+								href: A4A_MARKETPLACE_LINK,
+							},
+							{
+								label: translate( 'Products' ),
+							},
+						] }
+					/>
 
 					<Actions className="a4a-marketplace__header-actions">
 						<MobileSidebarNavigation />


### PR DESCRIPTION
This PR updates the Marketplace section headers and navigation to improve the scalability and navigation of the product marketplace.

| Before | After |
|--------|--------|
| <img width="865" alt="Screenshot 2024-05-21 at 11 35 59 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ad2b56dd-9f80-480d-98f9-5ccb27fcd90f"> | <img width="1727" alt="Screenshot 2024-05-21 at 11 29 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/530fcc9d-51ea-4285-bb15-33ab28a43b3a"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/521
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/523


## Proposed Changes

* Add Marketplace sidebar description.
* Update both the Hosting and Products overview pages to use breadcrumb instead of static title.

## Why are these changes being made?

* The breadcrumb creates a scalable pattern for when we have fully detailed pages for products.

## Testing Instructions

* Use the A4A live link and go to `/marketplace`.
* Confirm that you can see a description of the Marketplace section in the sidebar.
* Confirm that the Hosting and Products page now uses Breadcrumb in the header.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
