### PR TITLE
Site Profiler: Show domain information

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -19,10 +19,11 @@ interface Props {
 	whois: WhoIs;
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
+	hideTitle?: boolean;
 }
 
 export default function DomainInformation( props: Props ) {
-	const { domain, whois, hostingProvider, urlData } = props;
+	const { domain, whois, hostingProvider, urlData, hideTitle = false } = props;
 	const moment = useLocalizedMoment();
 	const momentFormat = 'YYYY-MM-DD HH:mm:ss UTC';
 	const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/g;
@@ -70,7 +71,7 @@ export default function DomainInformation( props: Props ) {
 
 	return (
 		<div className="domain-information">
-			<h3>{ translate( 'Domain information' ) }</h3>
+			{ ! hideTitle && <h3>{ translate( 'Domain information' ) }</h3> }
 
 			<ul className="domain-information-details result-list">
 				{ filteredWhois.domain_name && (

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -16,6 +16,7 @@ import useScrollToTop from '../hooks/use-scroll-to-top';
 import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
 import { getValidUrl } from '../utils/get-valid-url';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
+import DomainInformation from './domain-information';
 import { GetReportForm } from './get-report-form';
 import HostingInformation from './hosting-information';
 import { LandingPageHeader } from './landing-page-header';
@@ -31,6 +32,7 @@ interface Props {
 
 export default function SiteProfilerV2( props: Props ) {
 	const { routerDomain } = props;
+	const hostingRef = useRef( null );
 	const domainRef = useRef( null );
 	const [ isGetReportFormOpen, setIsGetReportFormOpen ] = useState( false );
 
@@ -124,26 +126,49 @@ export default function SiteProfilerV2( props: Props ) {
 			{ showResultScreen && (
 				<LayoutBlock width="medium">
 					{ siteProfilerData && (
-						<MetricsSection
-							name={ translate( 'Hosting' ) }
-							title={ translate(
-								'Struggles with hosting {{alert}}speed and uptime{{/alert}} deter visitors. A switch to WordPress.com could transform the user experience.',
-								{
-									components: {
-										alert: <span className="alert" />,
-									},
-								}
-							) }
-							subtitle={ translate( 'Upgrade your hosting with WordPress.com' ) }
-							ref={ domainRef }
-						>
-							<HostingInformation
-								dns={ siteProfilerData.dns }
-								urlData={ urlData }
-								hostingProvider={ hostingProviderData?.hosting_provider }
-								hideTitle
-							/>
-						</MetricsSection>
+						<>
+							<MetricsSection
+								name={ translate( 'Hosting' ) }
+								title={ translate(
+									'Struggles with hosting {{alert}}speed and uptime{{/alert}} deter visitors. A switch to WordPress.com could transform the user experience.',
+									{
+										components: {
+											alert: <span className="alert" />,
+										},
+									}
+								) }
+								subtitle={ translate( 'Upgrade your hosting with WordPress.com' ) }
+								ref={ hostingRef }
+							>
+								<HostingInformation
+									dns={ siteProfilerData.dns }
+									urlData={ urlData }
+									hostingProvider={ hostingProviderData?.hosting_provider }
+									hideTitle
+								/>
+							</MetricsSection>
+							<MetricsSection
+								name={ translate( 'Domain' ) }
+								title={ translate(
+									'Your domain {{success}}set up is good{{/success}}, but you could boost your site’s visibility and growth.',
+									{
+										components: {
+											success: <span className="success" />,
+										},
+									}
+								) }
+								subtitle={ translate( 'Optimize your domain' ) }
+								ref={ domainRef }
+							>
+								<DomainInformation
+									domain={ domain }
+									whois={ siteProfilerData.whois }
+									hostingProvider={ hostingProviderData?.hosting_provider }
+									urlData={ urlData }
+									hideTitle
+								/>
+							</MetricsSection>
+						</>
 					) }
 				</LayoutBlock>
 			) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7316

## Proposed Changes

Update the DomainInformation component to hide the title as per design
Add a domain section to the results page of the Site Profiler v2.

## Why are these changes being made?

To have the domain information in Site Profiler v2 same way as we have in v1

## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/example.com`
* Check if the domain section matches the [figma layout](https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?node-id=712%3A25795&t=cGUjikUMogRe2gO2-1) and the images below:

| Desktop  | Mobile |
| ------------- | ------------- |
|![CleanShot 2024-05-21 at 11 38 13@2x](https://github.com/Automattic/wp-calypso/assets/5039531/1c1b2f1d-0657-41c0-9b0b-b93bfa4a3d83)|![CleanShot 2024-05-21 at 11 38 48@2x](https://github.com/Automattic/wp-calypso/assets/5039531/d3fb2b4b-9c48-4650-a91b-6b37f0c8b3cd)![CleanShot 2024-05-21 at 11 38 59@2x](https://github.com/Automattic/wp-calypso/assets/5039531/5300d121-eb87-4a9e-84a8-505233da54fc)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?