### PR TITLE
Checkout: Try switching CartFreeUserPlanUpsell to usePricingMetaForGridPlans and original prices

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -46,9 +46,10 @@ function UpgradeText( {
 	firstDomain: ResponseCartProduct;
 } ) {
 	const translate = useTranslate();
-	// Use the subtotal with discounts for the current cart price, but use the
-	// subtotal without discounts to calculate the price after the upsell
-	// because some discounts may be removed by the upsell.
+	// Use the subtotal with discounts for the current cart item price if the
+	// item's discounts are only for the first year, but use the subtotal
+	// without discounts to calculate the price after the upsell because the
+	// upsell will remove other first year discounts.
 	//
 	// For example, if the domain has a sale coupon then it will be removed by
 	// the "first year free" bundle discount when a plan is added to the cart
@@ -57,10 +58,15 @@ function UpgradeText( {
 	// predicted cart price with the plan, we must consider the current cart
 	// with the sale and the predicted cart without the sale.
 	//
-	// This may not be accurate for all types of discounts (in the previous
-	// example it only happens because they are both first-year percentage
-	// discounts) but it should be accurate most of the time.
-	const domainInCartPrice = firstDomain.item_subtotal_integer;
+	// This will not be accurate for all types of discounts and predicting what
+	// discounts will be applied is difficult, but this makes an attempt based
+	// on what discounts are currently applied.
+	const isDomainDiscountFromFirstYearOverride = firstDomain.cost_overrides.every(
+		( override ) => override.first_unit_only
+	);
+	const domainInCartPrice = isDomainDiscountFromFirstYearOverride
+		? firstDomain.item_subtotal_integer
+		: firstDomain.item_original_subtotal_integer;
 	const domainInCartPricePerYear = firstDomain.item_original_subtotal_integer / firstDomain.volume;
 	const cartPriceWithDomainAndPlan =
 		domainInCartPricePerYear * ( firstDomain.volume - 1 ) + planPrice;

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -58,5 +58,6 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		product_type: 'test',
 		included_domain_purchase_amount: 0,
 		product_variants: [],
+		cost_overrides: [],
 	};
 }

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -418,7 +418,7 @@ export interface ResponseCartProduct {
 	 * The override_code is a string that identifies the reason for the override.
 	 * When displaying the reason to the customer, use the human_readable_reason.
 	 */
-	cost_overrides?: ResponseCartCostOverride[];
+	cost_overrides: ResponseCartCostOverride[];
 
 	/**
 	 * If set, is used to transform the usage/quantity of units used to derive the number of units
@@ -525,6 +525,8 @@ export interface ResponseCartCostOverride {
 	old_subtotal_integer: number;
 	override_code: string;
 	does_override_original_cost: boolean;
+	percentage: number;
+	first_unit_only: boolean;
 }
 
 export type IntroductoryOfferUnit = 'day' | 'week' | 'month' | 'year' | 'indefinite';


### PR DESCRIPTION
## Proposed Changes

This is an experiment to try the suggestions made in https://github.com/Automattic/wp-calypso/pull/89472#issuecomment-2122923862

This PR refactors `CartFreeUserPlanUpsell` to make two changes:

1. Using `usePricingMetaForGridPlans()` to get the price of the plan instead of `useProducts()`.
2. Using `item_original_cost_integer` in place of `item_subtotal_integer` to get the price of the current domain when computing the extra amount that will be paid by adding a plan.

## Testing Instructions

1. Using a site that has no plan, add a domain registration to your cart and visit checkout.
5. Record the current cart total.
6. Notice the "Upgrade and save" upsell in the sidebar and record the price difference written there ("Save X" or "Pay an extra X").
7. Click "Add to Cart" in the upsell.
8. Compare the actual price difference between the old cart total and the new cart total with the price difference that was in the upsell. Make sure that the math is correct.
9. Remove the plan from your cart to make the upsell appear again.
10. Change the volume of the domain from "One year" to a longer billing term.
11. Repeat steps 2 - 5 and verify that the math is still correct.

It's a good idea to test this for a domain with a sale coupon and a domain without a sale coupon. It's also a good idea to try adding a coupon code to make sure the prices are still accurate.