### PR TITLE
Dashboard v2 overview - P2s - hide devTools and plan details.

### DIFF
--- a/client/dev-tools-promo/index.tsx
+++ b/client/dev-tools-promo/index.tsx
@@ -6,12 +6,15 @@ import { DOTCOM_DEVELOPER_TOOLS_PROMO } from 'calypso/sites-dashboard-v2/site-pr
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { devToolsPromo } from './controller';
 
-const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) => {
+const redirectForNonSimpleSiteOrP2 = ( context: PageJSContext, next: () => void ) => {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
-	if ( site && site.jetpack && ! site.plan?.expired ) {
+	const isP2 = site && site.options?.is_wpforteams_site;
+	const isNonSimpleSite = site && site.jetpack && ! site.plan?.expired;
+	if ( isNonSimpleSite || isP2 ) {
 		return page.redirect( `/overview/${ context.params.site }` );
 	}
+
 	return next();
 };
 
@@ -21,7 +24,7 @@ export default function () {
 		'/dev-tools-promo/:site',
 		siteSelection,
 		navigation,
-		redirectForNonSimpleSite,
+		redirectForNonSimpleSiteOrP2,
 		devToolsPromo,
 		siteDashboard( DOTCOM_DEVELOPER_TOOLS_PROMO ),
 		makeLayout,

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -198,14 +198,22 @@ const PlanCard: FC = () => {
 		}
 	};
 
+	const getPlanName = () => {
+		if ( isStaging ) {
+			return translate( 'Staging site' );
+		}
+		if ( isP2 ) {
+			return translate( 'P2+' );
+		}
+		return planName;
+	};
+
 	return (
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
 			<HostingCard className="hosting-overview__plan">
 				<div className="hosting-overview__plan-card-header">
-					<h3 className="hosting-overview__plan-card-title">
-						{ isStaging ? translate( 'Staging site' ) : planName }
-					</h3>
+					<h3 className="hosting-overview__plan-card-title">{ getPlanName() }</h3>
 					{ renderManageButton() }
 				</div>
 				{ ! isStaging && ! isP2 && (

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -14,7 +14,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
-import { isStagingSite } from 'calypso/sites-dashboard/utils';
+import { isP2Site, isStagingSite } from 'calypso/sites-dashboard/utils';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -152,6 +152,7 @@ const PlanCard: FC = () => {
 	const isJetpack = useSelector( ( state ) =>
 		isJetpackSite( state, site?.ID, { treatAtomicAsJetpackSite: false } )
 	);
+	const isP2 = site && isP2Site( site );
 	const isStaging = isStagingSite( site ?? undefined );
 	const isOwner = planDetails?.user_is_owner;
 	const planPurchaseId = useSelector( ( state: IAppState ) =>
@@ -164,7 +165,7 @@ const PlanCard: FC = () => {
 		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE && ! addOn?.exceedsSiteStorageLimits
 	);
 	const renderManageButton = () => {
-		if ( isJetpack || ! site || isStaging ) {
+		if ( isJetpack || ! site || isStaging || isP2 ) {
 			return false;
 		}
 		if ( isFreePlan ) {
@@ -207,7 +208,7 @@ const PlanCard: FC = () => {
 					</h3>
 					{ renderManageButton() }
 				</div>
-				{ ! isStaging && (
+				{ ! isStaging && ! isP2 && (
 					<>
 						<PricingSection />
 						<PlanStorage

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -6,6 +6,7 @@ import ItemPreviewPane, {
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
 import DevToolsIcon from 'calypso/dev-tools-promo/components/dev-tools-icon';
+import { isP2Site } from 'calypso/sites-dashboard/utils';
 import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
@@ -43,6 +44,7 @@ const DotcomPreviewPane = ( {
 	const isAtomicSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
 	const isSimpleSite = ! site.jetpack;
 	const isPlanExpired = !! site.plan?.expired;
+	const isP2 = isP2Site( site );
 
 	const features = useMemo(
 		() => [
@@ -59,7 +61,7 @@ const DotcomPreviewPane = ( {
 				<span>
 					{ __( 'Dev Tools' ) } <DevToolsIcon />
 				</span>,
-				isSimpleSite || isPlanExpired,
+				! isP2 && ( isSimpleSite || isPlanExpired ),
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7278

## Proposed Changes

* Removes the DevTools tab and plan details for P2 sites.
* The plan card definitely looks very empty in this case. I wonder if there is something quirky or useful to put in the empty space here 🤷‍♀️  🤔 



BEFORE for p2 sites
<img width="271" alt="Screenshot 2024-05-21 at 12 50 31 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/4c7d67a7-46ba-491f-9b4d-b1f3ae6f2056">


AFTER for p2 sites
<img width="584" alt="Screenshot 2024-05-21 at 12 50 43 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/67f6098d-4d5a-4246-a190-a57536bf673f">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* see linked related issue for more context



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* visit the sites dashboard.
* Verify that p2 sites no longer have a "DevTools" tab in the flyout pane when selected. Verify they also do not show plan details and only show the plan title in the plan card in the Overview pane.
* Test a variety of non-p2 sites and verify there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
