### PR TITLE
eCommerce Signup Flow: Fix flickering when loading plans on Upgrade Confirmation page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -8,6 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -75,31 +76,38 @@ const TrialUpgradeConfirmation = () => {
 					path="/plans/my-plan/trial-upgraded/:site"
 					title="Plans > Ecommerce Trial Post Upgrade Actions"
 				/>
-				<div className="trial-upgrade-confirmation__header">
-					<h1 className="trial-upgrade-confirmation__title">{ welcomeTitle }</h1>
-					<div className="trial-upgrade-confirmation__subtitle">
-						<span className="trial-upgrade-confirmation__subtitle-line">
-							{ currentPlanName &&
-								translate(
-									"Your purchase is complete and you're now on the {{strong}}%(planName)s plan{{/strong}}. Now it's time to take your store to the next level. What would you like to do next?",
-									{
-										args: { planName: currentPlanName },
-										components: { strong: <strong /> },
-									}
-								) }
-						</span>
+				{ ! isFetchingSitePlan && currentPlanName ? (
+					<>
+						<div className="trial-upgrade-confirmation__header">
+							<h1 className="trial-upgrade-confirmation__title">{ welcomeTitle }</h1>
+							<div className="trial-upgrade-confirmation__subtitle">
+								<span className="trial-upgrade-confirmation__subtitle-line">
+									{ translate(
+										"Your purchase is complete and you're now on the {{strong}}%(planName)s plan{{/strong}}. Now it's time to take your store to the next level. What would you like to do next?",
+										{
+											args: { planName: currentPlanName },
+											components: { strong: <strong /> },
+										}
+									) }
+								</span>
+							</div>
+						</div>
+						<div className="trial-upgrade-confirmation__tasks">
+							{ tasks.map( ( task ) => (
+								<ConfirmationTask
+									key={ task.id }
+									context="wooexpress_trial"
+									{ ...task }
+									taskActionUrlProps={ taskActionUrlProps }
+								/>
+							) ) }
+						</div>
+					</>
+				) : (
+					<div className="trial-upgrade-confirmation__loading">
+						<LoadingEllipsis />
 					</div>
-				</div>
-				<div className="trial-upgrade-confirmation__tasks">
-					{ tasks.map( ( task ) => (
-						<ConfirmationTask
-							key={ task.id }
-							context="wooexpress_trial"
-							{ ...task }
-							taskActionUrlProps={ taskActionUrlProps }
-						/>
-					) ) }
-				</div>
+				) }
 			</Main>
 		</>
 	);

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -69,4 +69,10 @@ body.business-trial-upgraded {
 			grid-template-columns: repeat(1, auto);
 		}
 	}
+
+	.trial-upgrade-confirmation__loading {
+		display: flex;
+		justify-content: center;
+		width: 100%;
+	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/6974

## Proposed Changes

* Add a loading state while fetching the plans on the Upgrade Confirmation page
  * Previous implementation was using a fallback WooExpress message while fetching the plans

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix flickering when loading plans on the Upgrade Confirmation page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local
* Use a full Entrepreneur plan site for testing
* Go to http://calypso.localhost:3000/plans/my-plan/trial-upgraded/<site-slug>?flags=entrepreneur-my-home
* You should see a loading state (ellipsis animation) before rendering the confirmation message
* Perform regression tests on the Upgrade Confirmation page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
