### PR TITLE
Advertising A4A: Add touchpoint to sites dashboard

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -84,6 +84,23 @@
 	.sites-a8c-for-agencies-banner {
 		margin-inline: 16px;
 
+		.banner__content {
+			max-width: 90%;
+		}
+
+		.banner__action {
+			margin-top: 0;
+
+			a {
+				display: flex;
+				white-space: nowrap;
+			}
+		}
+
+		.dismissible-card__close-button {
+			top: 28px;
+		}
+
 		@include break-large {
 			margin-inline: 26px;
 		}

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -81,6 +81,11 @@
 		}
 	}
 
+	.sites-a8c-for-agencies-banner-container {
+		display: flex;
+		justify-content: center;
+	}
+
 	.sites-a8c-for-agencies-banner {
 		margin-inline: 16px;
 
@@ -97,6 +102,8 @@
 
 		@include break-huge {
 			margin-inline: 64px;
+			width: 100%;
+			max-width: 1400px;
 		}
 	}
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -81,6 +81,18 @@
 		}
 	}
 
+	.sites-a8c-for-agencies-banner {
+		margin-inline: 16px;
+
+		@include break-large {
+			margin-inline: 26px;
+		}
+
+		@include break-huge {
+			margin-inline: 64px;
+		}
+	}
+
 	.dataviews-filters__view-actions {
 		border-bottom: 0;
 		align-items: center;

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -84,21 +84,11 @@
 	.sites-a8c-for-agencies-banner {
 		margin-inline: 16px;
 
-		.banner__content {
-			max-width: 90%;
-		}
-
 		.banner__action {
-			margin-top: 0;
-
 			a {
 				display: flex;
 				white-space: nowrap;
 			}
-		}
-
-		.dismissible-card__close-button {
-			top: 28px;
 		}
 
 		@include break-large {

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import {
 	SitesSortKey,
 	useSitesListFiltering,
@@ -267,7 +268,11 @@ const SitesDashboardV2 = ( {
 					<DocumentHead title={ __( 'Sites' ) } />
 					{ showA8CForAgenciesBanner && (
 						<Banner
-							callToAction={ translate( 'Learn more' ) }
+							callToAction={ translate( 'Learn more {{icon/}}', {
+								components: {
+									icon: <Gridicon icon="external" />,
+								},
+							} ) }
 							className="sites-a8c-for-agencies-banner"
 							description={ translate(
 								'As you’re managing multiple sites, Automattic for Agencies offers you efficient multisite management, volume discounts on hosting products, and up to 50% revenue share for migrating sites and referring products.'

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -278,7 +278,6 @@ const SitesDashboardV2 = ( {
 								'As you’re managing multiple sites, Automattic for Agencies offers you efficient multisite management, volume discounts on hosting products, and up to 50% revenue share for migrating sites and referring products.'
 							) }
 							dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
-							dismissTemporary
 							horizontal
 							href="https://agencies.automattic.com"
 							title={ translate( 'Streamlined multisite agency hosting' ) }

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -24,6 +24,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import { GuidedTourContextProvider } from 'calypso/a8c-for-agencies/data/guided-tours/guided-tour-context';
+import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import {
@@ -237,6 +238,8 @@ const SitesDashboardV2 = ( {
 	const hideListing = false;
 	const isNarrowView = false;
 
+	const showA8CForAgenciesBanner = paginatedSites.length >= 5;
+
 	return (
 		<Layout
 			className={ clsx(
@@ -262,12 +265,26 @@ const SitesDashboardV2 = ( {
 					</LayoutTop>
 
 					<DocumentHead title={ __( 'Sites' ) } />
+					{ showA8CForAgenciesBanner && (
+						<Banner
+							callToAction={ translate( 'Learn more' ) }
+							className="sites-a8c-for-agencies-banner"
+							description={ translate(
+								'As you’re managing multiple sites, Automattic for Agencies offers you efficient multisite management, volume discounts on hosting products, and up to 50% revenue share for migrating sites and referring products.'
+							) }
+							dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
+							dismissTemporary
+							href="https://agencies.automattic.com"
+							title={ translate( 'Streamlined multisite agency hosting' ) }
+						/>
+					) }
 					<DotcomSitesDataViews
 						sites={ paginatedSites }
 						isLoading={ isLoading }
 						paginationInfo={ getSitesPagination( filteredSites, perPage ) }
 						dataViewsState={ dataViewsState }
 						setDataViewsState={ setDataViewsState }
+						showBanner={ showA8CForAgenciesBanner }
 					/>
 				</LayoutColumn>
 			) }

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -267,21 +267,23 @@ const SitesDashboardV2 = ( {
 
 					<DocumentHead title={ __( 'Sites' ) } />
 					{ showA8CForAgenciesBanner && (
-						<Banner
-							callToAction={ translate( 'Learn more {{icon/}}', {
-								components: {
-									icon: <Gridicon icon="external" />,
-								},
-							} ) }
-							className="sites-a8c-for-agencies-banner"
-							description={ translate(
-								'As you’re managing multiple sites, Automattic for Agencies offers you efficient multisite management, volume discounts on hosting products, and up to 50% revenue share for migrating sites and referring products.'
-							) }
-							dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
-							horizontal
-							href="https://agencies.automattic.com"
-							title={ translate( 'Streamlined multisite agency hosting' ) }
-						/>
+						<div className="sites-a8c-for-agencies-banner-container">
+							<Banner
+								callToAction={ translate( 'Learn more {{icon/}}', {
+									components: {
+										icon: <Gridicon icon="external" />,
+									},
+								} ) }
+								className="sites-a8c-for-agencies-banner"
+								description={ translate(
+									'As you’re managing multiple sites, Automattic for Agencies offers you efficient multisite management, volume discounts on hosting products, and up to 50% revenue share for migrating sites and referring products.'
+								) }
+								dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
+								horizontal
+								href="https://agencies.automattic.com"
+								title={ translate( 'Streamlined multisite agency hosting' ) }
+							/>
+						</div>
 					) }
 					<DotcomSitesDataViews
 						sites={ paginatedSites }

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -280,7 +280,7 @@ const SitesDashboardV2 = ( {
 								) }
 								dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
 								horizontal
-								href="https://agencies.automattic.com"
+								href="https://wordpress.com/for-agencies/"
 								title={ translate( 'Streamlined multisite agency hosting' ) }
 							/>
 						</div>

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -290,7 +290,6 @@ const SitesDashboardV2 = ( {
 						paginationInfo={ getSitesPagination( filteredSites, perPage ) }
 						dataViewsState={ dataViewsState }
 						setDataViewsState={ setDataViewsState }
-						showBanner={ showA8CForAgenciesBanner }
 					/>
 				</LayoutColumn>
 			) }

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -279,6 +279,7 @@ const SitesDashboardV2 = ( {
 							) }
 							dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
 							dismissTemporary
+							horizontal
 							href="https://agencies.automattic.com"
 							title={ translate( 'Streamlined multisite agency hosting' ) }
 						/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3002

## Proposed Changes

* Add a dismissable a4a banner to the sites dashboard if a user has 5 or more sites
<img width="1688" alt="Screenshot 2024-05-21 at 11 40 16 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/d4bfce77-b7ed-4993-ae7d-d697ea9ca861">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As part of the release of the Automattic for Agencies initiative ( A4A ), the A4A team is implementing the ability for users to purchase plans in bulk for a discount pfunGA-1a8-p2. A4A, however, is a relatively new platform, meaning that folks will be otherwise unaware of its existence, let alone the bulk plans purchasing feature A4A offers.

Because of this, we’d like to promote the bulk purchasing feature and drive traffic to the site through different logged-out and logged-in touchpoints on [WordPress.com](http://wordpress.com/).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Navigate to `/sites` as a user with 5 or more sites
* Verify that the banner is rendered
* Verify that the banner can be dismissed permanently

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?