### PR TITLE
Hide dev tools promo when site has certain features

### DIFF
--- a/client/dev-tools-promo/index.tsx
+++ b/client/dev-tools-promo/index.tsx
@@ -12,15 +12,19 @@ const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) =>
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 	const siteId = site?.ID ?? null;
+	const isJetpackSite = !! site?.jetpack;
 	const hasAtomicFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
 	const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 	const isPlanExpired = !! site?.plan?.expired;
 
 	// Check for site features to determine if the promo should be shown in case the site has yet to transfer to Atomic.
 	const shouldShowDevToolsPromo =
-		isPlanExpired || ! hasAtomicFeature || ( ! hasSftpFeature && ! site?.is_wpcom_staging_site );
+		! isJetpackSite &&
+		( isPlanExpired ||
+			! hasAtomicFeature ||
+			( ! hasSftpFeature && ! site?.is_wpcom_staging_site ) );
 
-	if ( ( site && site.jetpack && ! site.plan?.expired ) || ! shouldShowDevToolsPromo ) {
+	if ( ! shouldShowDevToolsPromo ) {
 		return page.redirect( `/overview/${ context.params.site }` );
 	}
 	return next();

--- a/client/dev-tools-promo/index.tsx
+++ b/client/dev-tools-promo/index.tsx
@@ -1,15 +1,26 @@
+import { FEATURE_SFTP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import page, { Context as PageJSContext } from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { siteDashboard } from 'calypso/sites-dashboard-v2/controller';
 import { DOTCOM_DEVELOPER_TOOLS_PROMO } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { devToolsPromo } from './controller';
 
 const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) => {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
-	if ( site && site.jetpack && ! site.plan?.expired ) {
+	const siteId = site?.ID ?? null;
+	const hasAtomicFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
+	const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
+	const isPlanExpired = !! site?.plan?.expired;
+
+	// Check for site features to determine if the promo should be shown in case the site has yet to transfer to Atomic.
+	const shouldShowDevToolsPromo =
+		isPlanExpired || ! hasAtomicFeature || ( ! hasSftpFeature && ! site?.is_wpcom_staging_site );
+
+	if ( ( site && site.jetpack && ! site.plan?.expired ) || ! shouldShowDevToolsPromo ) {
 		return page.redirect( `/overview/${ context.params.site }` );
 	}
 	return next();

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -44,7 +44,7 @@ const DotcomPreviewPane = ( {
 	const { __ } = useI18n();
 
 	const isAtomicSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
-	const isSimpleSite = ! site.jetpack;
+	const isJetpackSite = site.jetpack;
 	const isPlanExpired = !! site.plan?.expired;
 	const siteId = site?.ID ?? null;
 	const { hasAtomicFeature, hasSftpFeature } = useSelector( ( state ) => ( {
@@ -54,7 +54,8 @@ const DotcomPreviewPane = ( {
 
 	// Check for site features to determine if the promo should be shown in case the site has yet to transfer to Atomic.
 	const shouldShowDevToolsPromo =
-		isPlanExpired || ! hasAtomicFeature || ( ! hasSftpFeature && ! site.is_wpcom_staging_site );
+		! isJetpackSite &&
+		( isPlanExpired || ! hasAtomicFeature || ( ! hasSftpFeature && ! site.is_wpcom_staging_site ) );
 
 	const features = useMemo(
 		() => [
@@ -122,7 +123,7 @@ const DotcomPreviewPane = ( {
 			selectedSiteFeature,
 			setSelectedSiteFeature,
 			selectedSiteFeaturePreview,
-			isSimpleSite,
+			isJetpackSite,
 			isPlanExpired,
 			isAtomicSite,
 		]

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_SFTP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useMemo, useEffect } from 'react';
@@ -6,6 +7,8 @@ import ItemPreviewPane, {
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
 import DevToolsIcon from 'calypso/dev-tools-promo/components/dev-tools-icon';
+import { useSelector } from 'calypso/state';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
@@ -43,6 +46,15 @@ const DotcomPreviewPane = ( {
 	const isAtomicSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
 	const isSimpleSite = ! site.jetpack;
 	const isPlanExpired = !! site.plan?.expired;
+	const siteId = site?.ID ?? null;
+	const { hasAtomicFeature, hasSftpFeature } = useSelector( ( state ) => ( {
+		hasAtomicFeature: siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC ),
+		hasSftpFeature: siteHasFeature( state, siteId, FEATURE_SFTP ),
+	} ) );
+
+	// Check for site features to determine if the promo should be shown in case the site has yet to transfer to Atomic.
+	const shouldShowDevToolsPromo =
+		isPlanExpired || ! hasAtomicFeature || ( ! hasSftpFeature && ! site.is_wpcom_staging_site );
 
 	const features = useMemo(
 		() => [
@@ -59,7 +71,7 @@ const DotcomPreviewPane = ( {
 				<span>
 					{ __( 'Dev Tools' ) } <DevToolsIcon />
 				</span>,
-				isSimpleSite || isPlanExpired,
+				shouldShowDevToolsPromo,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7348

## Proposed Changes

* Hide the "Dev Tools" tab on sites that have the Atomic and SFTP feature (effectively Creator and higher plans)
* Redirect traffic to the "Dev Tools Promo" page to Overview on sites that have the Atomic and SFTP feature (effectively Creator and higher plans)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A Creator site can be a Simple site, and we do not want to show an upgrade promo to a site that has already upgraded.
* We check for features instead of plans to determine if we show the promo.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Create a new site with a Creator plan but do NOT take it Atomic
* Go to /sites and view your new site. It should NOT show the "Dev Tools" tab.
* Try going to /dev-tools-promo/[site] on your new Creator non-Atomic site, it should redirect you to /overview.
* Go to /sites and view a Jetpack site. It should NOT show the "Dev Tools" tab.
* Try going to /dev-tools-promo/[site] on your Jetpack site, it should redirect you to /overview.
* Go to /sites and view a Starter or Free site. It should show the "Dev Tools" tab.
* Test other site types and try to break it.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
