### PR TITLE
Nav Redesign: Remove duplicate All Sites link

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -97,7 +97,9 @@ class CurrentSite extends Component {
 							<Site site={ selectedSite } homeLink />
 						</div>
 					) : (
-						<AllSites href="/sites" onSelect={ this.onAllSitesClick } />
+						! isEnabled( 'layout/dotcom-nav-redesign-v2' ) && (
+							<AllSites href="/sites" onSelect={ this.onAllSitesClick } />
+						)
 					) }
 					{ selectedSite && isEnabled( 'current-site/domain-warning' ) && (
 						<AsyncLoad

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -5,7 +5,6 @@ import { localize, withRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import AllSites from 'calypso/blocks/all-sites';
 import Site from 'calypso/blocks/site';
 import AsyncLoad from 'calypso/components/async-load';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -92,14 +91,10 @@ class CurrentSite extends Component {
 				<div role="button" tabIndex="0" aria-hidden="true" onClick={ this.expandUnifiedNavSidebar }>
 					{ this.renderSiteSwitcher() }
 
-					{ selectedSite ? (
+					{ selectedSite && (
 						<div>
 							<Site site={ selectedSite } homeLink />
 						</div>
-					) : (
-						! isEnabled( 'layout/dotcom-nav-redesign-v2' ) && (
-							<AllSites href="/sites" onSelect={ this.onAllSitesClick } />
-						)
 					) }
 					{ selectedSite && isEnabled( 'current-site/domain-warning' ) && (
 						<AsyncLoad


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7350

## Proposed Changes

* Remove the duplicated "All Sites" link when on domain details page.

Before | After
--|--
<img width="1067" alt="Screenshot 2024-05-21 at 5 59 33 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/da1f54be-d5b3-4078-8b57-f51174f04447"> |  <img width="1067" alt="Screenshot 2024-05-21 at 6 00 47 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/3d70d57d-7442-4367-b389-7a5b5fec7d0f">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improved user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains/manage
* Select a domain you own. It'll take you to /domains/manage/all/[domain]/edit/[site]
* View that the 2nd "All Sites" link is gone.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
