### PR TITLE
E2E: Fix Switch to Draft and add timeout to publish button

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -80,7 +80,7 @@ export class EditorPublishPanelComponent {
 
 		// Check if the button is able to be triggered before proceeding
 		try {
-			await publishButtonLocator.waitFor( { state: 'attached' } );
+			await publishButtonLocator.waitFor( { state: 'attached', timeout: 5 * 1000 } );
 		} catch {
 			return;
 		}

--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -78,7 +78,8 @@ export class EditorPublishPanelComponent {
 		const editorParent = await this.editor.parent();
 		const publishButtonLocator = editorParent.locator( selectors.publishButton );
 
-		// Check if the button is able to be triggered before proceeding
+		// Check if the button is able to be triggered before proceeding.
+		// We limit the timeout to fix local testings.
 		try {
 			await publishButtonLocator.waitFor( { state: 'attached', timeout: 5 * 1000 } );
 		} catch {

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -18,7 +18,7 @@ const selectors = {
 	previewButton: `${ panel } :text("View"):visible, [aria-label="View"]:visible`,
 
 	// Post status
-	postStatusButton: `button.editor-post-status-trigger`,
+	postStatusButton: `.editor-post-status > button`,
 
 	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
 		`button[role="menuitem"] span:text("${ target }")`,

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -766,9 +766,6 @@ export class EditorPage {
 		const editorParent = await this.editor.parent();
 		await this.editorToolbarComponent.switchToDraft();
 
-		// For mobiles, we need to dismiss the settings panel before we can click on publish
-		await this.closeSettings();
-
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
 		// Saves the draft
 		await Promise.race( [ this.editorToolbarComponent.clickPublish(), this.confirmUnpublish() ] );


### PR DESCRIPTION
## Proposed Changes

Update E2E test failing on Gutenberg Edge & Nightlies.

The test broken in this PR (https://github.com/WordPress/gutenberg/pull/61645) because it removes the `editor-post-status-trigger` class from the post status dropdown.

#### TO DO
- [ ] Fix `Schedule the post for next year` on mobile
- [ ] `Switch to Draft` keeps failing on `Gutenberg atomic E2E tests edge` :thinking: 

## Testing Instructions

Run the following E2E tests:
- Simple: `yarn workspace wp-e2e-tests test --  specs/editor/editor__post-advanced-flow.ts`
- Simple + Gutenberg Edge: `GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test --  specs/editor/editor__post-advanced-flow.ts`
- Atomic: `TEST_ON_ATOMIC=true yarn workspace wp-e2e-tests test --  specs/editor/editor__post-advanced-flow.ts`
- Atomic + Gutenberg Edge: `TEST_ON_ATOMIC=true GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test --  specs/editor/editor__post-advanced-flow.ts`
- Atomic + Gutenberg Nightly: `TEST_ON_ATOMIC=true GUTENBERG_NIGHTLY=true yarn workspace wp-e2e-tests test --  specs/editor/editor__post-advanced-flow.ts`
