### PR TITLE
Jetpack Visibility i1: Update Malware protection copy.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts
@@ -27,7 +27,7 @@ export default function useWPCOMPlanDescription( slug: string ) {
 			translate( 'DDOS mitigation' ),
 			translate( 'Free staging environment' ),
 			translate( 'Isolated site infrastructure' ),
-			translate( 'Managed malware protection' ),
+			translate( 'Malware detection & removal' ),
 			translate( 'SFTP/SSH, WP-CLI, Git tools' ),
 			translate( 'Extremely fast DNS with SSL' ),
 			translate( 'Centralized site management' ),

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -2126,8 +2126,9 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_SECURITY_MALWARE ]: {
 		getSlug: () => FEATURE_SECURITY_MALWARE,
-		getTitle: () => i18n.translate( 'Managed malware protection' ),
-		getDescription: () => i18n.translate( 'Stay safe with automated malware scanning.' ),
+		getTitle: () => i18n.translate( 'Malware detection & removal' ),
+		getDescription: () =>
+			i18n.translate( 'Stay safe with automated malware scanning and removal.' ),
 	},
 	[ FEATURE_REAL_TIME_SECURITY_SCANS ]: {
 		getSlug: () => FEATURE_REAL_TIME_SECURITY_SCANS,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7265

## Proposed Changes

* Change pricing grid feature to `Malware detection & removal`
* Change is also made in the agency dashboard for wpcom hosting  

![image](https://github.com/Automattic/wp-calypso/assets/47489215/e12a0706-0098-4cde-a3c1-0d36c1b2a942)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the project to make jetpack scan more visible thus using a more explicit language as to what the feature does.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Go to `/start/plans` and Verify copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
