### PR TITLE
Nav redesign: bring back external link icon on Hosting -> Overview

### DIFF
--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -98,7 +98,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 		}
 		return (
 			( item?.parent === 'jetpack' && item?.url?.startsWith( 'https://jetpack.com' ) ) ||
-			( item?.parent === 'wpcom-hosting-menu' && item?.url?.startsWith( '/hosting/' ) )
+			( item?.parent === 'wpcom-hosting-menu' && item?.url?.startsWith( '/overview/' ) )
 		);
 	};
 


### PR DESCRIPTION
Related to pfsHM7-13k-p2

> Hosting > “Overview” menu item is missing external link icon in Calypso (if it should be there). 

## Proposed Changes

This PR fixes a regression to:

- https://github.com/Automattic/wp-calypso/pull/90562

introduced by:

- https://github.com/Automattic/wp-calypso/pull/90762,

which unintentionally made the external link icon for Hosting -> Overview submenu not show when in Calypso. This PR fixes this by fixing the route.

## Why are these changes being made?

It fixes a regression.

## Testing Instructions

1. Go to `/home/:site` of an Atomic Early Classic site.
2. Verify that you can see the external link icon on Hosting -> Overview:

<img width="136" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/349575f5-b8b6-4d04-ba51-c02d553e07b2">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?