### PR TITLE
Sites: Scroll to the top when the page or selected item of dataviews is changed

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from '@automattic/components';
+import { usePrevious } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode } from 'react';
+import { ReactNode, useRef, useLayoutEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { DataViews } from 'calypso/components/dataviews';
 import { ItemsDataViewsType, DataViewsColumn } from './interfaces';
@@ -54,6 +55,8 @@ export type ItemsDataViewsProps = {
 
 const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsProps ) => {
 	const translate = useTranslate();
+	const scrollContainerRef = useRef< HTMLElement >();
+	const previousDataViewsState = usePrevious( data.dataViewsState );
 
 	// Until the DataViews package is updated to support the spinner, we need to manually add the (loading) spinner to the table wrapper for now.
 	// todo: The DataViews v0.9 has the spinner support. Remove this once we upgrade the package.
@@ -77,6 +80,29 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 		// Render the SpinnerWrapper component inside the spinner wrapper
 		ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
 	}
+
+	useLayoutEffect( () => {
+		if (
+			! scrollContainerRef.current ||
+			previousDataViewsState?.type !== data.dataViewsState.type
+		) {
+			scrollContainerRef.current = document.querySelector(
+				'.dataviews-view-list, .dataviews-view-table-wrapper'
+			) as HTMLElement;
+		}
+
+		if ( ! previousDataViewsState?.selectedItem && data.dataViewsState.selectedItem ) {
+			window.setTimeout(
+				() => scrollContainerRef.current?.querySelector( 'li.is-selected' )?.scrollIntoView(),
+				300
+			);
+			return;
+		}
+
+		if ( previousDataViewsState?.page !== data.dataViewsState.page ) {
+			scrollContainerRef.current?.scrollTo( 0, 0 );
+		}
+	}, [ data.dataViewsState.type, data.dataViewsState.page ] );
 
 	return (
 		<div className={ className }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7352

## Proposed Changes

* Scroll to the top when the page is changed
* Scroll to the selected item when opening the GSV

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Scroll down
* Go to the next page
* Make sure the list scrolls to the top
* Scroll down and select any site
* Make sure the list scrolls to the selected item after the GSV opens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
