### PR TITLE
A4A:  Add Product marketplace brand navigation tab.

### DIFF
--- a/client/a8c-for-agencies/components/layout/nav.tsx
+++ b/client/a8c-for-agencies/components/layout/nav.tsx
@@ -15,6 +15,7 @@ type LayoutNavigationProps = {
 export type LayoutNavigationItemProps = {
 	key?: string;
 	label: string;
+	icon?: ReactNode;
 	compactCount?: boolean;
 	onClick?: () => void;
 	path?: string;
@@ -53,18 +54,23 @@ export function LayoutNavigationTabs( {
 }: LayoutNavigationTabsProps ) {
 	return (
 		<NavTabs selectedText={ selectedText } selectedCount={ selectedCount }>
-			{ items.map( ( { label, onClick, selected, count, path, compactCount = true } ) => (
-				<NavItem
-					key={ label.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
-					compactCount={ compactCount }
-					count={ count }
-					path={ path }
-					onClick={ onClick }
-					selected={ selected }
-				>
-					{ label }
-				</NavItem>
-			) ) }
+			{ items.map(
+				( { key, icon, label, onClick, selected, count, path, compactCount = true } ) => (
+					<NavItem
+						key={ key ?? label.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
+						compactCount={ compactCount }
+						count={ count }
+						path={ path }
+						onClick={ onClick }
+						selected={ selected }
+					>
+						<div className="content">
+							{ icon }
+							{ label }
+						</div>
+					</NavItem>
+				)
+			) }
 		</NavTabs>
 	);
 }

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -248,6 +248,12 @@ html,
 .section-nav.a4a-layout__navigation {
 	margin-block-start: 16px;
 
+	&.section-nav-updated .count {
+		border-radius: 4px;
+		border: 1px solid var(--color-neutral-5);
+		background: var(--color-surface);
+	}
+
 	.section-nav__mobile-header-text .count {
 		margin-inline-start: 8px;
 	}
@@ -295,6 +301,16 @@ html,
 	@include breakpoint-deprecated( ">1040px" ) {
 		margin-block-start: 32px;
 		margin-inline: -16px;
+	}
+
+	.section-nav-tab__text {
+		&,
+		.content {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 8px;
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/constants.ts
@@ -5,3 +5,7 @@ export const PRODUCT_FILTER_PRESSABLE_PLANS = 'pressable-plans';
 export const PRODUCT_FILTER_WPCOM_PLANS = 'wpcom-plans';
 export const PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS = 'woocommerce-extensions';
 export const PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS = 'vaultpress-backup-addons';
+
+export const PRODUCT_BRAND_FILTER_ALL = 'all';
+export const PRODUCT_BRAND_FILTER_WOOCOMMERCE = 'woocommerce';
+export const PRODUCT_BRAND_FILTER_JETPACK = 'jetpack';

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -6,6 +6,7 @@ import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
 import HostingOverview from './hosting-overview';
+import { getValidBrand } from './lib/product-brand';
 import PressableOverview from './pressable-overview';
 import DownloadProducts from './primary/download-products';
 import ProductsOverview from './products-overview';
@@ -17,11 +18,17 @@ export const marketplaceContext: Callback = () => {
 
 export const marketplaceProductsContext: Callback = ( context, next ) => {
 	const { site_id, product_slug } = context.query;
+	const productBrand = context.params.brand;
+
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Products" path={ context.path } />
-			<ProductsOverview siteId={ site_id } suggestedProduct={ product_slug } />
+			<ProductsOverview
+				siteId={ site_id }
+				suggestedProduct={ product_slug }
+				productBrand={ getValidBrand( productBrand ) }
+			/>
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -10,6 +10,7 @@ import { useSelector } from 'calypso/state';
 import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
+	PRODUCT_BRAND_FILTER_ALL,
 	PRODUCT_FILTER_ALL,
 	PRODUCT_FILTER_PLANS,
 	PRODUCT_FILTER_PRESSABLE_PLANS,
@@ -29,6 +30,7 @@ type Props = {
 	selectedBundleSize?: number;
 	selectedSite?: SiteDetails | null;
 	selectedProductFilter?: string | null;
+	selectedProductBrandFilter?: string | null;
 	productSearchQuery?: string;
 	usePublicQuery?: boolean;
 };
@@ -129,6 +131,7 @@ export default function useProductAndPlans( {
 	selectedBundleSize = 1,
 	selectedSite,
 	selectedProductFilter = PRODUCT_FILTER_ALL,
+	selectedProductBrandFilter = PRODUCT_BRAND_FILTER_ALL,
 	productSearchQuery,
 	usePublicQuery = false,
 }: Props ) {
@@ -139,14 +142,20 @@ export default function useProductAndPlans( {
 	);
 
 	return useMemo( () => {
+		// List only products that matches the selected product brand filter.
+		const filteredProductBrand =
+			! selectedProductBrandFilter || selectedProductBrandFilter === PRODUCT_BRAND_FILTER_ALL
+				? data
+				: data?.filter( ( { slug } ) => slug.startsWith( selectedProductBrandFilter ) );
+
 		// List only products that is compatible with current bundle size.
 		const supportedProducts =
 			selectedBundleSize > 1
-				? data?.filter(
+				? filteredProductBrand?.filter(
 						( { supported_bundles } ) =>
 							supported_bundles?.some?.( ( { quantity } ) => selectedBundleSize === quantity )
 				  )
-				: data;
+				: filteredProductBrand;
 
 		// We pre-filter the list by current selected filter
 		let filteredProductsAndBundles = getProductsAndPlansByFilter(
@@ -199,12 +208,13 @@ export default function useProductAndPlans( {
 			suggestedProductSlugs,
 		};
 	}, [
-		addedPlanAndProducts,
+		selectedProductBrandFilter,
 		data,
-		isLoadingProducts,
 		selectedBundleSize,
-		productSearchQuery,
 		selectedProductFilter,
+		productSearchQuery,
 		selectedSite,
+		addedPlanAndProducts,
+		isLoadingProducts,
 	] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -25,7 +25,7 @@ import {
 export default function () {
 	page( A4A_MARKETPLACE_LINK, requireAccessContext, marketplaceContext, makeLayout, clientRender );
 	page(
-		A4A_MARKETPLACE_PRODUCTS_LINK,
+		`${ A4A_MARKETPLACE_PRODUCTS_LINK }/:brand?`,
 		requireAccessContext,
 		marketplaceProductsContext,
 		makeLayout,

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-brand.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-brand.tsx
@@ -5,7 +5,7 @@ import {
 } from '../constants';
 
 export function getValidBrand( brand: string ) {
-	return brand === PRODUCT_BRAND_FILTER_JETPACK || brand === PRODUCT_BRAND_FILTER_WOOCOMMERCE
-		? brand
-		: PRODUCT_BRAND_FILTER_ALL;
+	const validBrands = [ PRODUCT_BRAND_FILTER_JETPACK, PRODUCT_BRAND_FILTER_WOOCOMMERCE ];
+
+	return validBrands.includes( brand ) ? brand : PRODUCT_BRAND_FILTER_ALL;
 }

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-brand.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-brand.tsx
@@ -1,0 +1,11 @@
+import {
+	PRODUCT_BRAND_FILTER_ALL,
+	PRODUCT_BRAND_FILTER_JETPACK,
+	PRODUCT_BRAND_FILTER_WOOCOMMERCE,
+} from '../constants';
+
+export function getValidBrand( brand: string ) {
+	return brand === PRODUCT_BRAND_FILTER_JETPACK || brand === PRODUCT_BRAND_FILTER_WOOCOMMERCE
+		? brand
+		: PRODUCT_BRAND_FILTER_ALL;
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -22,6 +22,7 @@ import { ShoppingCartContext } from '../context';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import ProductListing from './product-listing';
+import ProductNavigation from './product-navigation';
 import type { AssignLicenseProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -76,7 +77,7 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 			withBorder
 			compact
 		>
-			<LayoutTop>
+			<LayoutTop withNavigation>
 				<LayoutHeader showStickyContent={ showStickyContent }>
 					<Breadcrumb
 						items={ [
@@ -105,6 +106,8 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 						/>
 					</Actions>
 				</LayoutHeader>
+
+				<ProductNavigation />
 			</LayoutTop>
 
 			<LayoutBody>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -23,12 +23,17 @@ import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import ProductListing from './product-listing';
 import ProductNavigation from './product-navigation';
-import type { AssignLicenseProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
-export default function ProductsOverview( { siteId, suggestedProduct }: AssignLicenseProps ) {
+type Props = {
+	siteId?: string;
+	suggestedProduct?: string;
+	productBrand: string;
+};
+
+export default function ProductsOverview( { siteId, suggestedProduct, productBrand }: Props ) {
 	const translate = useTranslate();
 
 	const {
@@ -107,12 +112,16 @@ export default function ProductsOverview( { siteId, suggestedProduct }: AssignLi
 					</Actions>
 				</LayoutHeader>
 
-				<ProductNavigation />
+				<ProductNavigation selectedTab={ productBrand } />
 			</LayoutTop>
 
 			<LayoutBody>
 				<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
-					<ProductListing selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
+					<ProductListing
+						selectedSite={ selectedSite }
+						suggestedProduct={ suggestedProduct }
+						productBrand={ productBrand }
+					/>
 				</ShoppingCartContext.Provider>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -28,9 +28,14 @@ import './style.scss';
 interface ProductListingProps {
 	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;
+	productBrand: string;
 }
 
-export default function ProductListing( { selectedSite, suggestedProduct }: ProductListingProps ) {
+export default function ProductListing( {
+	selectedSite,
+	suggestedProduct,
+	productBrand,
+}: ProductListingProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -56,6 +61,7 @@ export default function ProductListing( { selectedSite, suggestedProduct }: Prod
 	} = useProductAndPlans( {
 		selectedSite,
 		selectedBundleSize: quantity,
+		selectedProductBrandFilter: productBrand,
 		productSearchQuery,
 	} );
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-navigation/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-navigation/index.tsx
@@ -1,0 +1,78 @@
+import { JetpackLogo, WooLogo } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import LayoutNavigation, {
+	LayoutNavigationItemProps,
+	LayoutNavigationTabs,
+} from 'calypso/a8c-for-agencies/components/layout/nav';
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import useProductAndPlans from '../../hooks/use-product-and-plans';
+
+export default function ProductNavigation() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const { data } = useProductAndPlans( {} );
+
+	const totalJetpackProducts =
+		data?.filter( ( product ) => product.slug.startsWith( 'jetpack' ) ).length ?? 0;
+
+	const totalWooCommerceProducts =
+		data?.filter( ( product ) => product.slug.startsWith( 'woocommerce' ) ).length ?? 0;
+
+	const navItems = useMemo( () => {
+		const items: LayoutNavigationItemProps[] = [
+			{
+				key: 'all',
+				label: translate( 'All' ),
+				count: totalWooCommerceProducts + totalJetpackProducts,
+			},
+		];
+
+		if ( totalJetpackProducts ) {
+			items.push( {
+				key: 'jetpack',
+				label: translate( 'Jetpack' ),
+				icon: <JetpackLogo size={ 18 } />,
+				count: totalJetpackProducts,
+			} );
+		}
+
+		if ( totalWooCommerceProducts ) {
+			items.push( {
+				key: 'woocommerce',
+				label: translate( 'Woo' ),
+				icon: <WooLogo />,
+				count: totalWooCommerceProducts,
+			} );
+		}
+
+		return items.map( ( navItem ) => ( {
+			...navItem,
+			selected: navItem.key === 'all',
+			path: `${ A4A_MARKETPLACE_PRODUCTS_LINK }/${ navItem.key }`,
+			onClick: () => {
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_product_brand_navigation_click', {
+						status: navItem.key,
+					} )
+				);
+			},
+			children: navItem.label,
+		} ) );
+	}, [ dispatch, totalJetpackProducts, totalWooCommerceProducts, translate ] );
+
+	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
+	const selectedItemProps = {
+		selectedText: selectedItem.label,
+		selectedCount: selectedItem.count,
+	};
+
+	return (
+		<LayoutNavigation { ...selectedItemProps }>
+			<LayoutNavigationTabs { ...selectedItemProps } items={ navItems } />
+		</LayoutNavigation>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-navigation/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-navigation/index.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import LayoutNavigation, {
 	LayoutNavigationItemProps,
 	LayoutNavigationTabs,
+	buildNavItems,
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
@@ -58,22 +59,18 @@ export default function ProductNavigation( { selectedTab }: Props ) {
 			} );
 		}
 
-		return items.map( ( navItem ) => ( {
-			...navItem,
-			selected: navItem.key === selectedTab,
-			path:
-				navItem.key === PRODUCT_BRAND_FILTER_ALL
-					? A4A_MARKETPLACE_PRODUCTS_LINK
-					: `${ A4A_MARKETPLACE_PRODUCTS_LINK }/${ navItem.key }`,
-			onClick: () => {
+		return buildNavItems( {
+			items,
+			basePath: A4A_MARKETPLACE_PRODUCTS_LINK,
+			selectedKey: selectedTab ?? '',
+			onItemClick: () => {
 				dispatch(
 					recordTracksEvent( 'calypso_a4a_product_brand_navigation_click', {
-						status: navItem.key,
+						status: selectedTab,
 					} )
 				);
 			},
-			children: navItem.label,
-		} ) );
+		} );
 	}, [ dispatch, selectedTab, totalJetpackProducts, totalWooCommerceProducts, translate ] );
 
 	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-navigation/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-navigation/index.tsx
@@ -8,9 +8,18 @@ import LayoutNavigation, {
 import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	PRODUCT_BRAND_FILTER_ALL,
+	PRODUCT_BRAND_FILTER_JETPACK,
+	PRODUCT_BRAND_FILTER_WOOCOMMERCE,
+} from '../../constants';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
 
-export default function ProductNavigation() {
+type Props = {
+	selectedTab?: string;
+};
+
+export default function ProductNavigation( { selectedTab }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -25,34 +34,37 @@ export default function ProductNavigation() {
 	const navItems = useMemo( () => {
 		const items: LayoutNavigationItemProps[] = [
 			{
-				key: 'all',
+				key: PRODUCT_BRAND_FILTER_ALL,
 				label: translate( 'All' ),
 				count: totalWooCommerceProducts + totalJetpackProducts,
 			},
 		];
 
-		if ( totalJetpackProducts ) {
-			items.push( {
-				key: 'jetpack',
-				label: translate( 'Jetpack' ),
-				icon: <JetpackLogo size={ 18 } />,
-				count: totalJetpackProducts,
-			} );
-		}
-
 		if ( totalWooCommerceProducts ) {
 			items.push( {
-				key: 'woocommerce',
+				key: PRODUCT_BRAND_FILTER_WOOCOMMERCE,
 				label: translate( 'Woo' ),
 				icon: <WooLogo />,
 				count: totalWooCommerceProducts,
 			} );
 		}
 
+		if ( totalJetpackProducts ) {
+			items.push( {
+				key: PRODUCT_BRAND_FILTER_JETPACK,
+				label: translate( 'Jetpack' ),
+				icon: <JetpackLogo size={ 18 } />,
+				count: totalJetpackProducts,
+			} );
+		}
+
 		return items.map( ( navItem ) => ( {
 			...navItem,
-			selected: navItem.key === 'all',
-			path: `${ A4A_MARKETPLACE_PRODUCTS_LINK }/${ navItem.key }`,
+			selected: navItem.key === selectedTab,
+			path:
+				navItem.key === PRODUCT_BRAND_FILTER_ALL
+					? A4A_MARKETPLACE_PRODUCTS_LINK
+					: `${ A4A_MARKETPLACE_PRODUCTS_LINK }/${ navItem.key }`,
 			onClick: () => {
 				dispatch(
 					recordTracksEvent( 'calypso_a4a_product_brand_navigation_click', {
@@ -62,7 +74,7 @@ export default function ProductNavigation() {
 			},
 			children: navItem.label,
 		} ) );
-	}, [ dispatch, totalJetpackProducts, totalWooCommerceProducts, translate ] );
+	}, [ dispatch, selectedTab, totalJetpackProducts, totalWooCommerceProducts, translate ] );
 
 	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
 	const selectedItemProps = {

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -4,6 +4,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import Offering from 'calypso/a8c-for-agencies/components/offering';
 import { OfferingItemProps } from 'calypso/a8c-for-agencies/components/offering/types';
+import {
+	PRODUCT_BRAND_FILTER_JETPACK,
+	PRODUCT_BRAND_FILTER_WOOCOMMERCE,
+} from 'calypso/a8c-for-agencies/sections/marketplace/constants';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -48,7 +52,7 @@ const OverviewBodyProducts = () => {
 		expanded: true,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'jetpack' );
-			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }#jetpack-plans` );
+			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }/${ PRODUCT_BRAND_FILTER_JETPACK }` );
 		},
 	};
 
@@ -77,7 +81,7 @@ const OverviewBodyProducts = () => {
 		expanded: true,
 		actionHandler: () => {
 			actionHandlerCallback( 'products', 'woocommerce' );
-			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }#woocommerce-extensions` );
+			page( `${ A4A_PRODUCTS_MARKETPLACE_LINK }/${ PRODUCT_BRAND_FILTER_WOOCOMMERCE }` );
 		},
 	};
 


### PR DESCRIPTION
This PR adds a Navigation tab to the Marketplace products page to filter by **'Brand'**.

<img width="1054" alt="Screenshot 2024-05-22 at 3 34 21 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8c19b0f8-df70-402d-af67-7303f4e1c048">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/522

## Proposed Changes

* Implement a Product Navigation Tab based on Brand filtering. The navigation tab is URL accessible `/marketplace/products/:brand`.
* Update the Overview page to use the correct URL when redirecting the user to the product brand-specific page.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/products`.
* Confirm that the navigation tab is working as expected.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
